### PR TITLE
Cleanup unused POM dependencies & minor security updates

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -315,6 +315,13 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-ehcache</artifactId>
+            <exclusions>
+                <!-- Newer version pulled in via Jersey below -->
+                <exclusion>
+                    <groupId>org.javassist</groupId>
+                    <artifactId>javassist</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>
@@ -325,15 +332,15 @@
             <artifactId>hibernate-validator-cdi</artifactId>
             <version>${hibernate-validator.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.hibernate.javax.persistence</groupId>
+            <artifactId>hibernate-jpa-2.1-api</artifactId>
+            <version>1.0.0.Final</version>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-orm</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>javax.el</artifactId>
-            <version>3.0.1-b10</version>
         </dependency>
 
         <dependency>
@@ -358,10 +365,6 @@
         </dependency>
         <dependency>
             <groupId>org.dspace</groupId>
-            <artifactId>jargon</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.dspace</groupId>
             <artifactId>mets</artifactId>
         </dependency>
         <dependency>
@@ -369,14 +372,6 @@
             <artifactId>apache-jena-libs</artifactId>
             <type>pom</type>
         </dependency>
-        <!-- Required to support PubMed API call in "PubmedImportMetadataSourceServiceImpl.GetRecord" -->
-        <!-- Makes runtime operations in Jersey Dependency Injection -->
-        <dependency>
-            <groupId>org.glassfish.jersey.inject</groupId>
-            <artifactId>jersey-hk2</artifactId>
-            <version>${jersey.version}</version>
-        </dependency>
-
         <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
@@ -438,10 +433,6 @@
             <artifactId>jdom</artifactId>
         </dependency>
         <dependency>
-            <groupId>oro</groupId>
-            <artifactId>oro</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>pdfbox</artifactId>
         </dependency>
@@ -454,28 +445,12 @@
             <artifactId>poi-scratchpad</artifactId>
         </dependency>
         <dependency>
-            <groupId>rome</groupId>
-            <artifactId>rome</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>rome</groupId>
-            <artifactId>opensearch</artifactId>
-        </dependency>
-        <dependency>
             <groupId>xalan</groupId>
             <artifactId>xalan</artifactId>
         </dependency>
         <dependency>
             <groupId>xerces</groupId>
             <artifactId>xercesImpl</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>xml-apis</groupId>
-            <artifactId>xml-apis</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>activation</artifactId>
         </dependency>
         <dependency>
             <groupId>com.ibm.icu</groupId>
@@ -514,6 +489,7 @@
             <artifactId>spring-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Used for RSS / ATOM syndication feeds -->
         <dependency>
             <groupId>org.rometools</groupId>
             <artifactId>rome-modules</artifactId>
@@ -729,7 +705,6 @@
             <artifactId>guava</artifactId>
         </dependency>
 
-
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
@@ -820,6 +795,11 @@
                     <groupId>org.apache.geronimo.specs</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
+                <!-- Exclude Woodstox, as later version provided by Solr dependencies -->
+                <exclusion>
+                    <groupId>org.codehaus.woodstox</groupId>
+                    <artifactId>woodstox-core-asl</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -833,14 +813,28 @@
                     <groupId>org.apache.geronimo.specs</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
+                <!-- Exclude Woodstox, as later version provided by Solr dependencies -->
+                <exclusion>
+                    <groupId>org.codehaus.woodstox</groupId>
+                    <artifactId>woodstox-core-asl</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
+        <!-- Jersey / JAX-RS client (javax.ws.rs.*) dependencies needed to integrate with external sources/services -->
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
             <version>${jersey.version}</version>
         </dependency>
+        <!-- Required because Jersey no longer includes a dependency injection provider by default.
+             Needed to support PubMed API call in "PubmedImportMetadataSourceServiceImpl.GetRecord" -->
+        <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
+            <version>${jersey.version}</version>
+        </dependency>
+
         <!-- S3 -->
         <dependency>
             <groupId>com.amazonaws</groupId>
@@ -882,13 +876,7 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.hibernate.javax.persistence</groupId>
-            <artifactId>hibernate-jpa-2.1-api</artifactId>
-            <version>1.0.0.Final</version>
-        </dependency>
-
-        <dependency>
+       <dependency>
             <groupId>org.apache.bcel</groupId>
             <artifactId>bcel</artifactId>
             <version>6.4.0</version>

--- a/dspace-oai/pom.xml
+++ b/dspace-oai/pom.xml
@@ -169,12 +169,6 @@
             <groupId>org.apache.solr</groupId>
             <artifactId>solr-solrj</artifactId>
             <version>${solr.client.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.codehaus.woodstox</groupId>
-                    <artifactId>wstx-asl</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- Web API -->

--- a/dspace-swordv2/pom.xml
+++ b/dspace-swordv2/pom.xml
@@ -143,6 +143,11 @@
                     <groupId>org.apache.geronimo.specs</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
+                <!-- Exclude Woodstox, as later version provided by Solr dependencies -->
+                <exclusion>
+                    <groupId>org.codehaus.woodstox</groupId>
+                    <artifactId>woodstox-core-asl</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
     </dependencies>

--- a/dspace/modules/server/pom.xml
+++ b/dspace/modules/server/pom.xml
@@ -317,6 +317,13 @@ just adding new jar in the classloader</description>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <!-- Newer version is pulled in by hibernate-ehcache -->
+                <exclusion>
+                    <groupId>net.bytebuddy</groupId>
+                    <artifactId>byte-buddy</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.solr</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -671,8 +671,8 @@
                                         <!-- XML Commons claims these licenses, but it's really Apache License: https://xerces.apache.org/xml-commons/licenses.html -->
                                         <licenseMerge>Apache Software License, Version 2.0|The SAX License|The W3C License</licenseMerge>
                                         <licenseMerge>BSD License|The BSD License|BSD licence|BSD license|BSD|BSD-style license|New BSD License|New BSD license|Revised BSD License|BSD 2-Clause license</licenseMerge>
-                                        <!-- DuraSpace uses a BSD License for DSpace -->
-                                        <licenseMerge>BSD License|DuraSpace BSD License|DuraSpace Sourcecode License</licenseMerge>
+                                        <!-- DSpace uses a BSD License -->
+                                        <licenseMerge>BSD License|DSpace BSD License|DSpace Sourcecode License</licenseMerge>
                                         <!-- Coverity uses modified BSD: https://github.com/coverity/coverity-security-library -->
                                         <licenseMerge>BSD License|BSD style modified by Coverity</licenseMerge>
                                         <!-- Jaxen claims this license, but it's really BSD: http://jaxen.codehaus.org/license.html -->
@@ -1278,11 +1278,6 @@
             </dependency>
             <dependency>
                 <groupId>org.dspace</groupId>
-                <artifactId>jargon</artifactId>
-                <version>1.4.25</version>
-            </dependency>
-            <dependency>
-                <groupId>org.dspace</groupId>
                 <artifactId>mets</artifactId>
                 <version>1.5.2</version>
             </dependency>
@@ -1327,11 +1322,6 @@
                 <version>2.1.1</version>
             </dependency>
             <dependency>
-                <groupId>commons-discovery</groupId>
-                <artifactId>commons-discovery</artifactId>
-                <version>0.5</version>
-            </dependency>
-            <dependency>
                 <groupId>commons-fileupload</groupId>
                 <artifactId>commons-fileupload</artifactId>
                 <version>1.3.3</version>
@@ -1346,6 +1336,8 @@
                 <artifactId>commons-lang3</artifactId>
                 <version>3.7</version>
             </dependency>
+            <!-- NOTE: We don't use commons-logging directly, but many dependencies rely on it.
+                 So, we specify the version to use to avoid dependency convergence issues. -->
             <dependency>
                 <groupId>commons-logging</groupId>
                 <artifactId>commons-logging</artifactId>
@@ -1431,11 +1423,6 @@
             </dependency>
 
             <dependency>
-                <groupId>oro</groupId>
-                <artifactId>oro</artifactId>
-                <version>2.0.8</version>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.pdfbox</groupId>
                 <artifactId>pdfbox</artifactId>
                 <version>${pdfbox-version}</version>
@@ -1466,16 +1453,6 @@
                 <version>${poi-version}</version>
             </dependency>
             <dependency>
-                <groupId>rome</groupId>
-                <artifactId>rome</artifactId>
-                <version>1.0</version>
-            </dependency>
-            <dependency>
-                <groupId>rome</groupId>
-                <artifactId>opensearch</artifactId>
-                <version>0.1</version>
-            </dependency>
-            <dependency>
                 <groupId>xalan</groupId>
                 <artifactId>xalan</artifactId>
                 <version>2.7.0</version>
@@ -1483,45 +1460,14 @@
             <dependency>
                 <groupId>xerces</groupId>
                 <artifactId>xercesImpl</artifactId>
-                <version>2.11.0</version>
+                <version>2.12.0</version>
             </dependency>
             <dependency>
                 <groupId>xml-apis</groupId>
                 <artifactId>xml-apis</artifactId>
                 <version>1.4.01</version>
             </dependency>
-            <dependency>
-                <groupId>javax.activation</groupId>
-                <artifactId>activation</artifactId>
-                <version>1.1.1</version>
-            </dependency>
 
-            <dependency>
-                <groupId>wsdl4j</groupId>
-                <artifactId>wsdl4j</artifactId>
-                <version>1.6.3</version>
-            </dependency>
-            <dependency>
-                <groupId>javax.xml</groupId>
-                <artifactId>jaxrpc-api</artifactId>
-                <version>1.3</version>
-            </dependency>
-            <dependency>
-                <groupId>axis</groupId>
-                <artifactId>axis</artifactId>
-                <version>1.4</version>
-            </dependency>
-            <dependency>
-                <groupId>axis</groupId>
-                <artifactId>axis-ant</artifactId>
-                <version>1.4</version>
-                <scope>compile</scope>
-            </dependency>
-            <dependency>
-                <groupId>axis</groupId>
-                <artifactId>axis-saaj</artifactId>
-                <version>1.4</version>
-            </dependency>
             <!-- Keep icu4j synced with version used by lucene-analyzers-icu (Solr) -->
             <dependency>
                 <groupId>com.ibm.icu</groupId>
@@ -1532,16 +1478,6 @@
                 <groupId>com.oracle</groupId>
                 <artifactId>ojdbc6</artifactId>
                 <version>11.2.0.4.0</version>
-            </dependency>
-            <dependency>
-                <groupId>com.sun.media</groupId>
-                <artifactId>jai_imageio</artifactId>
-                <version>1.1</version>
-            </dependency>
-            <dependency>
-                <groupId>javax.media</groupId>
-                <artifactId>jai_core</artifactId>
-                <version>1.1.3</version>
             </dependency>
             <dependency>
                 <groupId>org.dspace</groupId>
@@ -1706,21 +1642,6 @@
                 <version>1.0.2</version>
             </dependency>
             <dependency>
-                <groupId>org.javassist</groupId>
-                <artifactId>javassist</artifactId>
-                <version>3.20.0-GA</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.logging</groupId>
-                <artifactId>jboss-logging</artifactId>
-                <version>3.3.0.Final</version>
-            </dependency>
-            <dependency>
-                <groupId>org.codehaus.woodstox</groupId>
-                <artifactId>woodstox-core-asl</artifactId>
-                <version>4.4.1</version>
-            </dependency>
-            <dependency>
                 <groupId>xom</groupId>
                 <artifactId>xom</artifactId>
                 <version>1.2.5</version>
@@ -1747,7 +1668,7 @@
 
     <licenses>
         <license>
-            <name>DuraSpace BSD License</name>
+            <name>DSpace BSD License</name>
             <url>https://raw.github.com/DSpace/DSpace/main/LICENSE</url>
             <distribution>repo</distribution>
             <comments>
@@ -1757,8 +1678,8 @@
     </licenses>
 
     <issueManagement>
-        <system>JIRA</system>
-        <url>https://jira.duraspace.org/browse/DS</url>
+        <system>GitHub</system>
+        <url>https://github.com/DSpace/DSpace/issues</url>
     </issueManagement>
 
     <mailingLists>
@@ -1819,7 +1740,7 @@
         <developer>
            <name>DSpace Committers</name>
            <email>dspace-devel@googlegroups.com</email>
-           <url>https://wiki.duraspace.org/display/DSPACE/DSpace+Committers</url>
+           <url>https://wiki.lyrasis.org/display/DSPACE/DSpace+Committers</url>
            <roles>
              <role>committer</role>
            </roles>
@@ -1830,7 +1751,7 @@
         <contributor>
            <name>DSpace Contributors</name>
            <email>dspace-tech@googlegroups.com</email>
-           <url>https://wiki.duraspace.org/display/DSPACE/DSpaceContributors</url>
+           <url>https://wiki.lyrasis.org/display/DSPACE/DSpaceContributors</url>
            <roles>
              <role>developer</role>
            </roles>

--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,8 @@
         <jaxb-api.version>2.3.1</jaxb-api.version>
         <jaxb-runtime.version>2.3.1</jaxb-runtime.version>
         <!-- NOTE: Jetty needed for Handle Server & tests -->
-        <jetty.version>9.4.15.v20190215</jetty.version>
-        <log4j.version>2.11.2</log4j.version>
+        <jetty.version>9.4.17.v20190418</jetty.version>
+        <log4j.version>2.13.3</log4j.version>
         <pdfbox-version>2.0.15</pdfbox-version>
         <poi-version>3.17</poi-version>
         <slf4j.version>1.7.25</slf4j.version>
@@ -1269,6 +1269,21 @@
                 <groupId>net.cnri</groupId>
                 <artifactId>cnri-servlet-container</artifactId>
                 <version>3.0.0</version>
+                <exclusions>
+                    <!-- A later version of Jetty is pulled in below -->
+                    <exclusion>
+                        <groupId>org.eclipse.jetty</groupId>
+                        <artifactId>jetty-http</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.eclipse.jetty</groupId>
+                        <artifactId>jetty-io</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.eclipse.jetty</groupId>
+                        <artifactId>jetty-util</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <!-- Jetty is needed to run Handle Server (and tests in some modules) -->
             <dependency>


### PR DESCRIPTION
## References
Fixes four GitHub security alerts
 
* Removes `axis` which was found to be unused. Fixes https://github.com/DSpace/DSpace/network/alert/pom.xml/axis:axis/open
* Updates `xerces` to fix: https://github.com/DSpace/DSpace/network/alert/pom.xml/xerces:xercesImpl/open 
* Updates `log4j` to fix: https://github.com/DSpace/DSpace/network/alert/pom.xml/org.apache.logging.log4j:log4j-core/open
* Updates `jetty` to fix: https://github.com/DSpace/DSpace/network/alert/pom.xml/org.eclipse.jetty:jetty-server/open

## Description
General POM cleanup to remove a lot of unused/unnecessary dependencies.  

As I was fixing the security alerts noted above, I noticed several very old dependencies which I found were not used in our codebase (likely they were needed by either the XMLUI or JSPUI, but no longer necessary).  Therefore, I did a more thorough comb of the Parent POM to search for usages of each dependency, removing any which are unused & making minor tweaks (where needed) to solve any resulting dependency convergence issues.

Finally, I cleaned up references to "DuraSpace" in our Parent POM.

## Instructions for Reviewers

* Review changes in PR
* Verify all tests still succeed
* Optionally, download, build & tests backend still works.  (I've done this test in Docker and have found no issues.)