### PR TITLE
Uri parameters not added for self link

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/RestResourceController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/RestResourceController.java
@@ -83,6 +83,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.util.UriComponentsBuilder;
 
 /**
  * This is the main entry point of the new REST API. Its responsibility is to
@@ -977,8 +978,9 @@ public class RestResourceController implements InitializingBean {
             PagedResourcesAssembler assembler,
             @RequestParam MultiValueMap<String, Object> parameters)
         throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+        String encodedParameterString = getEncodedParameterStringFromRequestParams(parameters);
 
-        Link link = linkTo(this.getClass(), apiCategory, model).slash("search").slash(searchMethodName).withSelfRel();
+        Link link = linkTo(this.getClass(), apiCategory, model).slash("search").slash(searchMethodName).slash(encodedParameterString).withSelfRel();
         DSpaceRestRepository repository = utils.getResourceRepository(apiCategory, model);
         boolean returnPage = false;
         Object searchResult = null;
@@ -1014,6 +1016,21 @@ public class RestResourceController implements InitializingBean {
             return converter.toResource((T) searchResult);
         }
         return result;
+    }
+
+    /**
+     * Internal method to convert the parameters provided as a MultivalueMap as a string to use in the self-link.
+     * @param parameters
+     * @return encoded uriString containing request parameters
+     */
+    private String getEncodedParameterStringFromRequestParams(
+            @RequestParam MultiValueMap<String, Object> parameters) {
+        UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.newInstance();
+
+        for (String key : parameters.keySet()) {
+            uriComponentsBuilder.queryParam(key, parameters.get(key));
+        }
+        return uriComponentsBuilder.encode().build().toString();
     }
 
     @RequestMapping(method = RequestMethod.DELETE, value = REGEX_REQUESTMAPPING_IDENTIFIER_AS_DIGIT)

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/RestResourceController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/RestResourceController.java
@@ -980,7 +980,8 @@ public class RestResourceController implements InitializingBean {
         throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
         String encodedParameterString = getEncodedParameterStringFromRequestParams(parameters);
 
-        Link link = linkTo(this.getClass(), apiCategory, model).slash("search").slash(searchMethodName).slash(encodedParameterString).withSelfRel();
+        Link link = linkTo(this.getClass(), apiCategory, model).slash("search").slash(searchMethodName)
+                                                               .slash(encodedParameterString).withSelfRel();
         DSpaceRestRepository repository = utils.getResourceRepository(apiCategory, model);
         boolean returnPage = false;
         Object searchResult = null;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/RestResourceControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/RestResourceControllerIT.java
@@ -7,7 +7,9 @@
  */
 package org.dspace.app.rest;
 
+import static org.hamcrest.Matchers.endsWith;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.UUID;
@@ -70,5 +72,25 @@ public class RestResourceControllerIT extends AbstractControllerIntegrationTest 
                 // The status has to be 404 Not Found
                 .andExpect(status().isNotFound());
     }
+
+    @Test
+    public void selfLinkContainsRequestParametersWhenProvided() throws Exception {
+        // When we call the root endpoint
+        getClient().perform(get("/api/core/metadatafields/search/byFieldName?schema=dc&offset=0"))
+                   // The status has to be 404 Not Found
+                   .andExpect(jsonPath("$._links.self.href", endsWith(
+                           "/api/core/metadatafields/search/byFieldName?schema=dc&offset=0")));
+    }
+
+    @Test
+    public void selfLinkDevoidOfRequestParametersWhenNoneProvided() throws Exception {
+        // When we call the root endpoint
+        getClient().perform(get("/api/core/metadatafields/search/byFieldName"))
+                   // The status has to be 404 Not Found
+                   .andExpect(jsonPath("$._links.self.href",
+                                       endsWith("/api/core/metadatafields/search/byFieldName")));
+    }
+
+
 
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/RestResourceControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/RestResourceControllerIT.java
@@ -75,18 +75,18 @@ public class RestResourceControllerIT extends AbstractControllerIntegrationTest 
 
     @Test
     public void selfLinkContainsRequestParametersWhenProvided() throws Exception {
-        // When we call the root endpoint
+        // When we call a search endpoint with additional parameters
         getClient().perform(get("/api/core/metadatafields/search/byFieldName?schema=dc&offset=0"))
-                   // The status has to be 404 Not Found
+                   // The self link should contain those same parameters
                    .andExpect(jsonPath("$._links.self.href", endsWith(
                            "/api/core/metadatafields/search/byFieldName?schema=dc&offset=0")));
     }
 
     @Test
     public void selfLinkDevoidOfRequestParametersWhenNoneProvided() throws Exception {
-        // When we call the root endpoint
+        // When we call a search endpoint without additional parameters
         getClient().perform(get("/api/core/metadatafields/search/byFieldName"))
-                   // The status has to be 404 Not Found
+                   // The self link should match the initial request exactly
                    .andExpect(jsonPath("$._links.self.href",
                                        endsWith("/api/core/metadatafields/search/byFieldName")));
     }


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #2919 
* Initially noticed in [this issue](https://github.com/DSpace/DSpace/pull/2782#issuecomment-648078138)
## Description

## Instructions for Reviewers

#### List of changes in this PR:
* The executeSearchMethods method in RestResourceController.java has been extended to now also return the parameters that were initially send in the request back using the self link
* The parameters are passed along to 'getEncodedParameterStringFromRequestParams' which basically takes in the request parameters, and similarly to [SearchFacetValueHalLinkFactory](https://github.com/DSpace/DSpace/blob/main/dspace-server-webapp/src/main/java/org/dspace/app/rest/link/search/SearchFacetValueHalLinkFactory.java#L35) utilises the UriComponentsBuilder to build the URI, with the addition of an encode, to make sure that the link remains exactly the same


#### Steps to test
* Navigate to {url}/api/core/metadatafields/search/bySchema?schema=dc
    * That self link should contain exactly the same {url}/api/core/metadatafields/search/bySchema?schema=dc
* Navigate to {url}/api/core/metadatafields/search/bySchema (So, without parameters)
    * That self link should contain exactly the same {url}/api/core/metadatafields/search/bySchema

The self-links should be the same as the initial request and resolve to a correct endpoint

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
