### PR TITLE
Bugfix IRUS Integration with Entities

### DIFF
--- a/dspace-api/src/main/java/org/dspace/statistics/export/processor/ExportEventProcessor.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/export/processor/ExportEventProcessor.java
@@ -208,7 +208,7 @@ public abstract class ExportEventProcessor {
             entityTypes.add(ENTITY_TYPE_DEFAULT);
         }
 
-        if (type != null && entityTypes.contains(type.getLabel())) {
+        if (entityTypes.contains(type.getLabel())) {
             return true;
         }
         return false;

--- a/dspace-api/src/main/java/org/dspace/statistics/export/processor/ExportEventProcessor.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/export/processor/ExportEventProcessor.java
@@ -185,6 +185,7 @@ public abstract class ExportEventProcessor {
 
     /**
      * Checks if the item's entity type should be processed
+     * When no entity type is present, the check will not be performed and true will be returned.
      *
      * @param item to be checked
      * @return whether the item should be processed
@@ -193,6 +194,10 @@ public abstract class ExportEventProcessor {
     protected boolean shouldProcessEntityType(Item item) throws SQLException {
         Entity entity = entityService.findByItemId(context, item.getID());
         EntityType type = entityService.getType(context, entity);
+
+        if (type == null) {
+            return true;
+        }
 
         String[] entityTypeStrings = configurationService.getArrayProperty("irus.statistics.tracker.entity-types");
         List<String> entityTypes = new ArrayList<>();

--- a/dspace-api/src/test/java/org/dspace/statistics/export/processor/ExportEventProcessorTest.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/export/processor/ExportEventProcessorTest.java
@@ -241,6 +241,24 @@ public class ExportEventProcessorTest extends AbstractIntegrationTestWithDatabas
 
     }
 
+    @Test
+    /**
+     * Test the ShouldProcessEntityType method where no entityType is present
+     */
+    public void testShouldProcessEntityTypeWhenNotPresent() throws SQLException {
+        context.turnOffAuthorisationSystem();
+        Community community = CommunityBuilder.createCommunity(context).build();
+        Collection collection = CollectionBuilder.createCollection(context, community).build();
+        Item item = ItemBuilder.createItem(context, collection).build();
+        context.restoreAuthSystemState();
+
+        ExportEventProcessor exportEventProcessor = new ItemEventProcessor(context, request, item);
+
+        boolean result = exportEventProcessor.shouldProcessEntityType(item);
+
+        assertTrue(result);
+    }
+
 
     @Test
     /**


### PR DESCRIPTION
# Description
IRUS Integration has recently become a part of DSpace, however it enforced a check on whether the given Item was a given EntityType or not. This was defaulting to the "Publication" EntityType, however if the repository did not choose to actively implement the Entities framework, they would never be able to send the Item information to IRUS because this check is always done and always enforced.
We've changed this check to only be restrictive on the EntityType if the given Item actually has an EntityType. If the item does not have an EntityType, we simply return true for this check

## Instructions for Reviewers

List of changes in this PR:
* Added a nullcheck on the EntityType, allowing the shouldProcessEntityType method to return true if the item has no entity type
* Added a test for this

How to test this PR:
* Create an Item with no EntityType, ensure that the IRUS integration framework will now allow this item to pass
* Create an Item with an EntityType for which it's disallowed to be sent to IRUS (this should be Person by default), verify that it doesn't get sent

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
