### PR TITLE
Community admin should also be considered a Collection admin

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authorize/AuthorizeServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/AuthorizeServiceImpl.java
@@ -460,7 +460,7 @@ public class AuthorizeServiceImpl implements AuthorizeService {
                                                                        groupService.allMemberGroups(c, e),
                                                                        Constants.ADMIN, Constants.COLLECTION);
 
-            if (CollectionUtils.isNotEmpty(policies)) {
+            if (CollectionUtils.isNotEmpty(policies) || isCommunityAdmin(c, e)) {
                 return true;
             }
         }

--- a/dspace-api/src/test/java/org/dspace/authorize/AuthorizeServiceTest.java
+++ b/dspace-api/src/test/java/org/dspace/authorize/AuthorizeServiceTest.java
@@ -8,6 +8,7 @@
 
 package org.dspace.authorize;
 
+import java.io.IOException;
 import java.sql.SQLException;
 
 import org.dspace.AbstractUnitTest;
@@ -130,37 +131,68 @@ public class AuthorizeServiceTest extends AbstractUnitTest {
     }
 
     @Test
-    public void testIsCollectionAdmin() throws SQLException, AuthorizeException {
+    public void testIsCollectionAdmin() throws SQLException, AuthorizeException, IOException {
 
-        context.turnOffAuthorisationSystem();
+        Community community = null;
+        EPerson eperson = null;
 
-        Community community = communityService.create(null, context);
-        Collection collection = collectionService.create(context, community);
-        EPerson eperson = ePersonService.create(context);
+        try {
 
-        Group administrators = collectionService.createAdministrators(context, collection);
-        groupService.addMember(context, administrators, eperson);
+            context.turnOffAuthorisationSystem();
 
-        context.restoreAuthSystemState();
-        context.commit();
+            community = communityService.create(null, context);
+            Collection collection = collectionService.create(context, community);
+            eperson = ePersonService.create(context);
 
-        Assert.assertTrue(authorizeService.isCollectionAdmin(context, eperson));
+            Group administrators = collectionService.createAdministrators(context, collection);
+            groupService.addMember(context, administrators, eperson);
+            context.commit();
+
+            Assert.assertTrue(authorizeService.isCollectionAdmin(context, eperson));
+
+        } finally {
+
+            if (community != null) {
+                communityService.delete(context, context.reloadEntity(community));
+            }
+            if (eperson != null) {
+                ePersonService.delete(context, context.reloadEntity(eperson));
+            }
+
+            context.restoreAuthSystemState();
+        }
     }
 
     @Test
-    public void testIsCollectionAdminReturnsTrueIfTheUserIsCommunityAdmin() throws SQLException, AuthorizeException {
+    public void testIsCollectionAdminReturnsTrueIfTheUserIsCommunityAdmin()
+        throws SQLException, AuthorizeException, IOException {
 
-        context.turnOffAuthorisationSystem();
+        Community community = null;
+        EPerson eperson = null;
 
-        Community community = communityService.create(null, context);
-        EPerson eperson = ePersonService.create(context);
+        try {
 
-        Group administrators = communityService.createAdministrators(context, community);
-        groupService.addMember(context, administrators, eperson);
+            context.turnOffAuthorisationSystem();
 
-        context.restoreAuthSystemState();
-        context.commit();
+            community = communityService.create(null, context);
+            eperson = ePersonService.create(context);
 
-        Assert.assertTrue(authorizeService.isCollectionAdmin(context, eperson));
+            Group administrators = communityService.createAdministrators(context, community);
+            groupService.addMember(context, administrators, eperson);
+            context.commit();
+
+            Assert.assertTrue(authorizeService.isCollectionAdmin(context, eperson));
+
+        } finally {
+
+            if (community != null) {
+                communityService.delete(context, context.reloadEntity(community));
+            }
+            if (eperson != null) {
+                ePersonService.delete(context, context.reloadEntity(eperson));
+            }
+
+            context.restoreAuthSystemState();
+        }
     }
 }


### PR DESCRIPTION
## Description
The Community admins should also be considered a Collection admins. Currently, however, if a user is a community admin he is not also considered as a collection admin.

## Instructions for Reviewers
I changed the implementation of the method org.dspace.authorize.AuthorizeServiceImpl.isCollectionAdmin(Context, EPerson) to return true even if the user is a Community admin.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
