### PR TITLE
CSV Import error with Virtual Metadata fix

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
@@ -113,14 +113,14 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
      *
      * @see #populateRefAndRowMap(DSpaceCSVLine, UUID)
      */
-    protected static HashMap<UUID, String> entityTypeMap = new HashMap<>();
+    protected HashMap<UUID, String> entityTypeMap = new HashMap<>();
 
     /**
      * Map of UUIDs to their relations that are referenced within any import with their referers.
      *
      * @see #populateEntityRelationMap(String, String, String)
      */
-    protected static HashMap<String, HashMap<String, ArrayList<String>>> entityRelationMap = new HashMap<>();
+    protected HashMap<String, HashMap<String, ArrayList<String>>> entityRelationMap = new HashMap<>();
 
 
     /**
@@ -1517,6 +1517,9 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
                 throw new MetadataImportException("Error in CSV row " + rowCount + ":\n" +
                                                       "Not a UUID or indirect entity reference: '" + reference + "'");
             }
+        }
+        if (reference.contains("::virtual::")) {
+            return UUID.fromString(StringUtils.substringBefore(reference, "::virtual::"));
         } else if (!reference.startsWith("rowName:")) { // Not a rowName ref; so it's a metadata value reference
             MetadataValueService metadataValueService = ContentServiceFactory.getInstance().getMetadataValueService();
             MetadataFieldService metadataFieldService =

--- a/dspace-api/src/test/java/org/dspace/app/csv/CSVMetadataImportReferenceIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/csv/CSVMetadataImportReferenceIT.java
@@ -539,6 +539,26 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
         assertRelationship(items[2], items[0], 1, "left", 0);
     }
 
+    @Test
+    public void testRelationToVirtualDataInReferences() throws Exception {
+
+        Item testItem = ItemBuilder.createItem(context, col1)
+                                   .withTitle("Person")
+                                   .withIssueDate("2017-10-17")
+                                   .withAuthor("Smith, Donald")
+                                   .withPersonIdentifierLastName("Smith")
+                                   .withPersonIdentifierFirstName("Donald")
+                                   .withRelationshipType("Person")
+                                   .withIdentifierOther("testItemOne")
+                                   .build();
+
+
+        String[] csv = {"id,relationship.type,relation.isAuthorOfPublication,collection,dc.identifier.other,rowName",
+            "+,Publication," + testItem.getID() + "::virtual::4::600," + col1.getHandle() + ",0,1"};
+        Item[] items = runImport(csv);
+        assertRelationship(items[0], testItem, 1, "left", 0);
+    }
+
     /**
      * Test relationship validation with invalid relationship definition by incorrect typeName usage
      */


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes https://github.com/DSpace/DSpace/issues/2900

## Description
We've implemented a fix that'll allow us to grab the UUID from the String that contains the ::virtual:: string. The code will grab the String before the ::virtual:: indicator and that String should be the UUID that we'll use to find the Item which we'll use to create a Relationship with.
This ensures that a value of `61f90aa1-5522-4fcb-93fa-444434079230::virtual::4::600` will be parsed to using the UUID `61f90aa1-5522-4fcb-93fa-444434079230` to create the Relationship

## Instructions for Reviewers

List of changes in this PR:
* Made sure that the UUID is parsed correctly
* Added a test to prove that it works as expected
* Also made two variables not static anymore as it caused issues when the MetadataImport was wrongly used

How to test this PR:
* Create a CSV for a new Item, add a String to the CSV with the above mentioned value for a relationship type header
* Inspect the imported Item afterwards, verify that it contains a Relationship with an Item representing the given UUID

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
