### PR TITLE
Issue 2988: EPerson Password Replacement/addition with ADD Patch Operation instead of REPLACE

### DIFF
--- a/dspace-api/src/test/java/org/dspace/builder/EPersonBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/EPersonBuilder.java
@@ -117,6 +117,11 @@ public class EPersonBuilder extends AbstractDSpaceObjectBuilder<EPerson> {
         return this;
     }
 
+    public EPersonBuilder withCanLogin(final boolean canLogin) {
+        ePerson.setCanLogIn(canLogin);
+        return this;
+    }
+
     public static void deleteEPerson(UUID uuid) throws SQLException, IOException {
         try (Context c = new Context()) {
             c.turnOffAuthorisationSystem();

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/PatchOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/PatchOperation.java
@@ -19,12 +19,12 @@ import org.dspace.core.Context;
  */
 public abstract class PatchOperation<M> {
 
-    // All PATCH operations's string (in operation.getOp())
-    protected static final String OPERATION_REPLACE = "replace";
-    protected static final String OPERATION_ADD = "add";
-    protected static final String OPERATION_COPY = "copy";
-    protected static final String OPERATION_MOVE = "move";
-    protected static final String OPERATION_REMOVE = "remove";
+    // All PATCH operations' string (in operation.getOp())
+    public static final String OPERATION_REPLACE = "replace";
+    public static final String OPERATION_ADD = "add";
+    public static final String OPERATION_COPY = "copy";
+    public static final String OPERATION_MOVE = "move";
+    public static final String OPERATION_REMOVE = "remove";
 
     /**
      * Updates the rest model by applying the patch operation.

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/EPersonRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/EPersonRestPermissionEvaluatorPlugin.java
@@ -17,7 +17,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.dspace.app.rest.model.patch.Operation;
 import org.dspace.app.rest.model.patch.Patch;
 import org.dspace.app.rest.repository.patch.operation.DSpaceObjectMetadataPatchUtils;
-import org.dspace.app.rest.repository.patch.operation.EPersonPasswordReplaceOperation;
+import org.dspace.app.rest.repository.patch.operation.EPersonPasswordAddOperation;
+import org.dspace.app.rest.repository.patch.operation.PatchOperation;
 import org.dspace.app.rest.utils.ContextUtil;
 import org.dspace.app.util.AuthorizeUtil;
 import org.dspace.authorize.service.AuthorizeService;
@@ -99,8 +100,10 @@ public class EPersonRestPermissionEvaluatorPlugin extends RestObjectPermissionEv
         Request currentRequest = requestService.getCurrentRequest();
         if (currentRequest != null) {
             HttpServletRequest httpServletRequest = currentRequest.getHttpServletRequest();
-            if (operations.size() > 0 && StringUtils.equalsIgnoreCase(operations.get(0).getOp(), "replace")
-                && StringUtils.equalsIgnoreCase(operations.get(0).getPath(), "/password")
+            if (operations.size() > 0
+                && StringUtils.equalsIgnoreCase(operations.get(0).getOp(), PatchOperation.OPERATION_ADD)
+                && StringUtils.equalsIgnoreCase(operations.get(0).getPath(),
+                EPersonPasswordAddOperation.OPERATION_PASSWORD_CHANGE)
                 && StringUtils.isNotBlank(httpServletRequest.getParameter("token"))) {
                 return true;
             }
@@ -119,7 +122,7 @@ public class EPersonRestPermissionEvaluatorPlugin extends RestObjectPermissionEv
          * update their own password and their own metadata.
          */
         for (Operation op: operations) {
-            if (!(op.getPath().contentEquals(EPersonPasswordReplaceOperation.OPERATION_PASSWORD_CHANGE)
+            if (!(op.getPath().contentEquals(EPersonPasswordAddOperation.OPERATION_PASSWORD_CHANGE)
                 || (op.getPath().startsWith(DSpaceObjectMetadataPatchUtils.OPERATION_METADATA_PATH)))) {
                 return false;
             }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/EPersonRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/EPersonRestRepositoryIT.java
@@ -1411,6 +1411,40 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
     }
 
     @Test
+    public void patchPasswordMissingValue() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        String originalPw = "testpass79bC";
+
+        EPerson ePerson = EPersonBuilder.createEPerson(context)
+                                        .withNameInMetadata("John", "Doe")
+                                        .withEmail("Johndoe@example.com")
+                                        .withPassword(originalPw)
+                                        .build();
+
+        context.restoreAuthSystemState();
+
+        String token = getAuthToken(admin.getEmail(), password);
+
+        List<Operation> ops = new ArrayList<>();
+        AddOperation addOperation = new AddOperation("/password", null);
+        ops.add(addOperation);
+        String patchBody = getPatchContent(ops);
+
+        // adding null pw should return bad request
+        getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
+            .content(patchBody)
+            .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                        .andExpect(status().isBadRequest());
+
+        // login with original password
+        token = getAuthToken(ePerson.getEmail(), originalPw);
+        getClient(token).perform(get("/api/"))
+                        .andExpect(status().isOk());
+
+    }
+
+    @Test
     public void patchPasswordNotInitialised() throws Exception {
 
         context.turnOffAuthorisationSystem();

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/EPersonRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/EPersonRestRepositoryIT.java
@@ -48,6 +48,7 @@ import org.dspace.app.rest.model.EPersonRest;
 import org.dspace.app.rest.model.MetadataRest;
 import org.dspace.app.rest.model.MetadataValueRest;
 import org.dspace.app.rest.model.RegistrationRest;
+import org.dspace.app.rest.model.patch.AddOperation;
 import org.dspace.app.rest.model.patch.Operation;
 import org.dspace.app.rest.model.patch.ReplaceOperation;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
@@ -1232,8 +1233,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         String newPassword = "newpassword";
 
         List<Operation> ops = new ArrayList<Operation>();
-        ReplaceOperation replaceOperation = new ReplaceOperation("/password", newPassword);
-        ops.add(replaceOperation);
+        AddOperation addOperation = new AddOperation("/password", newPassword);
+        ops.add(addOperation);
         String patchBody = getPatchContent(ops);
 
         String token = getAuthToken(admin.getEmail(), password);
@@ -1273,8 +1274,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         String newPassword = "newpassword";
 
         List<Operation> ops = new ArrayList<Operation>();
-        ReplaceOperation replaceOperation = new ReplaceOperation("/password", newPassword);
-        ops.add(replaceOperation);
+        AddOperation addOperation = new AddOperation("/password", newPassword);
+        ops.add(addOperation);
         String patchBody = getPatchContent(ops);
 
         // eperson one
@@ -1308,8 +1309,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         String newPassword = "newpassword";
 
         List<Operation> ops = new ArrayList<Operation>();
-        ReplaceOperation replaceOperation = new ReplaceOperation("/password", newPassword);
-        ops.add(replaceOperation);
+        AddOperation addOperation = new AddOperation("/password", newPassword);
+        ops.add(addOperation);
         String patchBody = getPatchContent(ops);
 
         String token = getAuthToken(ePerson.getEmail(), password);
@@ -1342,8 +1343,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         String newPassword = "newpassword";
 
         List<Operation> ops = new ArrayList<Operation>();
-        ReplaceOperation replaceOperation = new ReplaceOperation("/password", newPassword);
-        ops.add(replaceOperation);
+        AddOperation addOperation = new AddOperation("/password", newPassword);
+        ops.add(addOperation);
         String patchBody = getPatchContent(ops);
 
         String token = getAuthToken(admin.getEmail(), password);
@@ -1410,14 +1411,14 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
     }
 
     @Test
-    public void patchPasswordMissingValue() throws Exception {
+    public void patchPasswordNotInitialised() throws Exception {
 
         context.turnOffAuthorisationSystem();
 
         EPerson ePerson = EPersonBuilder.createEPerson(context)
                                         .withNameInMetadata("John", "Doe")
-                                        .withEmail("Johndoe@example.com")
-                                        .withPassword("testpass79bC")
+                                        .withEmail("userNotInitialised@example.com")
+                                        .withCanLogin(true)
                                         .build();
 
         context.restoreAuthSystemState();
@@ -1427,33 +1428,20 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         String newPassword = "newpass";
 
         List<Operation> ops = new ArrayList<Operation>();
-        ReplaceOperation replaceOperation = new ReplaceOperation("/password", newPassword);
-        ops.add(replaceOperation);
+        AddOperation addOperation = new AddOperation("/password", newPassword);
+        ops.add(addOperation);
         String patchBody = getPatchContent(ops);
 
-        // initialize passwd
+        // initialize password with add operation, not set during creation
         getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
                 .content(patchBody)
                 .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isOk());
 
-
-        List<Operation> ops2 = new ArrayList<Operation>();
-        ReplaceOperation replaceOperation2 = new ReplaceOperation("/password", null);
-        ops2.add(replaceOperation2);
-        patchBody = getPatchContent(ops2);
-
-        // should return bad request
-        getClient(token).perform(patch("/api/eperson/epersons/" + ePerson.getID())
-                .content(patchBody)
-                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
-                        .andExpect(status().isBadRequest());
-
-        // login with original password
+        // login with new password => succeeds
         token = getAuthToken(ePerson.getEmail(), newPassword);
         getClient(token).perform(get("/api/"))
                         .andExpect(status().isOk());
-
     }
 
     @Test
@@ -1866,8 +1854,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.restoreAuthSystemState();
 
         List<Operation> ops = new ArrayList<Operation>();
-        ReplaceOperation replaceOperation = new ReplaceOperation("/password", newPassword);
-        ops.add(replaceOperation);
+        AddOperation addOperation = new AddOperation("/password", newPassword);
+        ops.add(addOperation);
         String patchBody = getPatchContent(ops);
         accountService.sendRegistrationInfo(context, ePerson.getEmail());
         String tokenForEPerson = registrationDataService.findByEmail(context, ePerson.getEmail()).getToken();
@@ -1902,8 +1890,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.restoreAuthSystemState();
 
         List<Operation> ops = new ArrayList<Operation>();
-        ReplaceOperation replaceOperation = new ReplaceOperation("/password", newPassword);
-        ops.add(replaceOperation);
+        AddOperation addOperation = new AddOperation("/password", newPassword);
+        ops.add(addOperation);
         String patchBody = getPatchContent(ops);
         accountService.sendRegistrationInfo(context, ePerson.getEmail());
         String tokenForEPerson = registrationDataService.findByEmail(context, ePerson.getEmail()).getToken();
@@ -1947,8 +1935,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.restoreAuthSystemState();
 
         List<Operation> ops = new ArrayList<Operation>();
-        ReplaceOperation replaceOperation = new ReplaceOperation("/password", newPassword);
-        ops.add(replaceOperation);
+        AddOperation addOperation = new AddOperation("/password", newPassword);
+        ops.add(addOperation);
         String patchBody = getPatchContent(ops);
         accountService.sendRegistrationInfo(context, ePerson.getEmail());
         accountService.sendRegistrationInfo(context, ePersonTwo.getEmail());
@@ -2038,8 +2026,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.restoreAuthSystemState();
 
         List<Operation> ops = new ArrayList<Operation>();
-        ReplaceOperation replaceOperation = new ReplaceOperation("/password", newPassword);
-        ops.add(replaceOperation);
+        AddOperation addOperation = new AddOperation("/password", newPassword);
+        ops.add(addOperation);
         String patchBody = getPatchContent(ops);
         accountService.sendRegistrationInfo(context, ePerson.getEmail());
         String newRegisterToken = registrationDataService.findByEmail(context, newRegisterEmail).getToken();

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/EPersonRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/EPersonRestRepositoryIT.java
@@ -1247,9 +1247,19 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // login with new password
         token = getAuthToken(ePerson.getEmail(), newPassword);
-        getClient(token).perform(get("/api/"))
-                        .andExpect(status().isOk());
+        getClient(token).perform(get("/api/authn/status"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.okay", is(true)))
+                        .andExpect(jsonPath("$.authenticated", is(true)))
+                        .andExpect(jsonPath("$.type", is("status")));
 
+        // can't login with old password
+        token = getAuthToken(ePerson.getEmail(), password);
+        getClient(token).perform(get("/api/authn/status"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.okay", is(true)))
+                        .andExpect(jsonPath("$.authenticated", is(false)))
+                        .andExpect(jsonPath("$.type", is("status")));
     }
 
     @Test
@@ -1289,10 +1299,21 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // login with old password
         token = getAuthToken(ePerson2.getEmail(), password);
-        getClient(token).perform(get("/api/"))
-                        .andExpect(status().isOk());
+        getClient(token).perform(get("/api/authn/status"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.okay", is(true)))
+                        .andExpect(jsonPath("$.authenticated", is(true)))
+                        .andExpect(jsonPath("$.type", is("status")));
 
+        // can't login with new password
+        token = getAuthToken(ePerson2.getEmail(), newPassword);
+        getClient(token).perform(get("/api/authn/status"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.okay", is(true)))
+                        .andExpect(jsonPath("$.authenticated", is(false)))
+                        .andExpect(jsonPath("$.type", is("status")));
     }
+
     @Test
     public void patchPasswordForNonAdminUser() throws Exception {
 
@@ -1323,14 +1344,23 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // login with new password
         token = getAuthToken(ePerson.getEmail(), newPassword);
-        getClient(token).perform(get("/api/"))
-                        .andExpect(status().isOk());
+        getClient(token).perform(get("/api/authn/status"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.okay", is(true)))
+                        .andExpect(jsonPath("$.authenticated", is(true)))
+                        .andExpect(jsonPath("$.type", is("status")));
 
+        // can't login with old password
+        token = getAuthToken(ePerson.getEmail(), password);
+        getClient(token).perform(get("/api/authn/status"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.okay", is(true)))
+                        .andExpect(jsonPath("$.authenticated", is(false)))
+                        .andExpect(jsonPath("$.type", is("status")));
     }
 
     @Test
     public void patchPasswordReplaceOnNonExistentValue() throws Exception {
-
         context.turnOffAuthorisationSystem();
 
         EPerson ePerson = EPersonBuilder.createEPerson(context)
@@ -1354,6 +1384,14 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
                 .content(patchBody)
                 .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                 .andExpect(status().isBadRequest());
+
+        // can't login with new password
+        token = getAuthToken(ePerson.getEmail(), newPassword);
+        getClient(token).perform(get("/api/authn/status"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.okay", is(true)))
+                        .andExpect(jsonPath("$.authenticated", is(false)))
+                        .andExpect(jsonPath("$.type", is("status")));
     }
 
     @Test
@@ -1439,9 +1477,19 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // login with original password
         token = getAuthToken(ePerson.getEmail(), originalPw);
-        getClient(token).perform(get("/api/"))
-                        .andExpect(status().isOk());
+        getClient(token).perform(get("/api/authn/status"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.okay", is(true)))
+                        .andExpect(jsonPath("$.authenticated", is(true)))
+                        .andExpect(jsonPath("$.type", is("status")));
 
+        // can't login with null password
+        token = getAuthToken(ePerson.getEmail(), null);
+        getClient(token).perform(get("/api/authn/status"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.okay", is(true)))
+                        .andExpect(jsonPath("$.authenticated", is(false)))
+                        .andExpect(jsonPath("$.type", is("status")));
     }
 
     @Test
@@ -1474,8 +1522,19 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // login with new password => succeeds
         token = getAuthToken(ePerson.getEmail(), newPassword);
-        getClient(token).perform(get("/api/"))
-                        .andExpect(status().isOk());
+        getClient(token).perform(get("/api/authn/status"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.okay", is(true)))
+                        .andExpect(jsonPath("$.authenticated", is(true)))
+                        .andExpect(jsonPath("$.type", is("status")));
+
+        // can't login with old password
+        token = getAuthToken(ePerson.getEmail(), password);
+        getClient(token).perform(get("/api/authn/status"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.okay", is(true)))
+                        .andExpect(jsonPath("$.authenticated", is(false)))
+                        .andExpect(jsonPath("$.type", is("status")));
     }
 
     @Test
@@ -1509,8 +1568,11 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         // login with new email address
         token = getAuthToken(newEmail, password);
-        getClient(token).perform(get("/api/"))
-                        .andExpect(status().isOk());
+        getClient(token).perform(get("/api/authn/status"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.okay", is(true)))
+                        .andExpect(jsonPath("$.authenticated", is(true)))
+                        .andExpect(jsonPath("$.type", is("status")));
 
     }
 
@@ -1569,11 +1631,13 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
                 .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                         .andExpect(status().isBadRequest());
 
-        // login with original password
+        // login with original email
         token = getAuthToken(ePerson.getEmail(), password);
-        getClient(token).perform(get("/api/"))
-                        .andExpect(status().isOk());
-
+        getClient(token).perform(get("/api/authn/status"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.okay", is(true)))
+                        .andExpect(jsonPath("$.authenticated", is(true)))
+                        .andExpect(jsonPath("$.type", is("status")));
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/EPersonRestPermissionEvaluatorPluginTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/EPersonRestPermissionEvaluatorPluginTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.dspace.app.rest.model.patch.AddOperation;
 import org.dspace.app.rest.model.patch.Operation;
 import org.dspace.app.rest.model.patch.Patch;
 import org.dspace.app.rest.model.patch.ReplaceOperation;
@@ -59,8 +60,8 @@ public class EPersonRestPermissionEvaluatorPluginTest {
     public void testHasPatchPermissionAuthFails() throws Exception {
 
         List<Operation> ops = new ArrayList<Operation>();
-        ReplaceOperation passwordOperation = new ReplaceOperation("/password", "testpass");
-        ops.add(passwordOperation);
+        AddOperation addOperation = new AddOperation("/password", "testpass");
+        ops.add(addOperation);
         ReplaceOperation canLoginOperation = new ReplaceOperation("/canLogin", false);
         ops.add(canLoginOperation);
         Patch patch = new Patch(ops);
@@ -73,8 +74,8 @@ public class EPersonRestPermissionEvaluatorPluginTest {
     public void testHasPatchPermissionAuthOk() throws Exception {
 
         List<Operation> ops = new ArrayList<Operation>();
-        ReplaceOperation passwordOperation = new ReplaceOperation("/password", "testpass");
-        ops.add(passwordOperation);
+        AddOperation addOperation = new AddOperation("/password", "testpass");
+        ops.add(addOperation);
         Patch patch = new Patch(ops);
         assertTrue(ePersonRestPermissionEvaluatorPlugin
                        .hasPatchPermission(authentication, null, null, patch));


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/DSpace/issues/2988

## Description
This PR changes the EPerson Password Replace Patch operation to an Add operation. It also removed the constraint that an EPerson had to have a Password prior to replacing it.
It fixes the issue where an EPerson without a password was never able to be assigned one with this Patch operation
This Add patch will also replace the password for an EPerson if it already had one

## Instructions for Reviewers

List of changes in this PR:
* Changed the EPerson Password Replace from a REPLACE patch operation to an ADD patch operation
* Changed tests and docs to reflect this change

How to test this PR:
* Create an EPerson without password
* Perform the Add Password Patch operation
* Try to login with the newly made password, ensure it works as expected

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
