### PR TITLE
IRUS property in build.xml when updating spiders

### DIFF
--- a/dspace/src/main/config/build.xml
+++ b/dspace/src/main/config/build.xml
@@ -63,6 +63,7 @@ Common usage:
     <property name="local-config" value="config/local.cfg" />
     <!-- Next, the default dspace.cfg -->
     <property name="config" value="config/dspace.cfg" />
+    <property name="irus-config" value="config/modules/irus-statistics.cfg" />
 
     <!-- Give user a chance to override without editing this file
        (and without typing -D each time s/he compiles it) -->
@@ -73,6 +74,7 @@ Common usage:
          we load the local.cfg FIRST, so that its settings are used by default. -->
     <property file="${local-config}" />
     <property file="${config}" />
+    <property file="${irus-config}" />
 
     <!-- Timestamp date used when creating backup directories -->
     <tstamp>


### PR DESCRIPTION
## References
* Related to https://github.com/DSpace/DSpace/pull/3031

## Description
Currently, the update_spiders section in the build.xml is never ran: https://github.com/DSpace/DSpace/blob/main/dspace/src/main/config/build.xml#L864
This is due to the fact that the properties that are defined there, aren't loaded properly for the build.xml at that given time. Since they don't exists, spiders can't be downloaded from the location and the file is never set in the installation for DSpace.

## Instructions for Reviewers

List of changes in this PR:
* Made sure that the spiders file is downloaded properly from the external url if activated in the irus-statistics.cfg file

How to test this PR:
* Start a DSpace instance from the regular main branch
* Uncomment the properties: https://github.com/DSpace/DSpace/blob/main/dspace/config/modules/irus-statistics.cfg#L32-L35
* Run the maven clean package and the ant update
* Verify that the COUNTER_Robots_list.txt file is not present in the {dspace.dir}/config/spiders/agents folder
* Now pull in these changes and rebuild maven clean package and ant update again. Make sure to have the above mentioned properties uncommented
* Verify that the file is present now in that location

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
