### PR TITLE
Metadata identifier for Communities and Collections

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
@@ -142,8 +142,8 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
             } else {
                 identifierService.register(context, newCollection, handle);
             }
-        } catch (IdentifierException e) {
-            throw new RuntimeException("Can't create an Identifier!");
+        } catch (IllegalStateException | IdentifierException ex) {
+            throw new IllegalStateException(ex);
         }
 
         // create the default authorization policy for collections

--- a/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
@@ -55,6 +55,8 @@ import org.dspace.eperson.service.SubscribeService;
 import org.dspace.event.Event;
 import org.dspace.harvest.HarvestedCollection;
 import org.dspace.harvest.service.HarvestedCollectionService;
+import org.dspace.identifier.IdentifierException;
+import org.dspace.identifier.service.IdentifierService;
 import org.dspace.workflow.factory.WorkflowServiceFactory;
 import org.dspace.xmlworkflow.WorkflowConfigurationException;
 import org.dspace.xmlworkflow.factory.XmlWorkflowFactory;
@@ -92,6 +94,8 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
     protected CommunityService communityService;
     @Autowired(required = true)
     protected GroupService groupService;
+    @Autowired(required = true)
+    protected IdentifierService identifierService;
 
     @Autowired(required = true)
     protected LicenseService licenseService;
@@ -131,11 +135,15 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
         //Add our newly created collection to our community, authorization checks occur in THIS method
         communityService.addCollection(context, community, newCollection);
 
-        //Update our community so we have a collection identifier
-        if (handle == null) {
-            handleService.createHandle(context, newCollection);
-        } else {
-            handleService.createHandle(context, newCollection, handle);
+        //Update our collection so we have a collection identifier
+        try {
+            if (handle == null) {
+                identifierService.register(context, newCollection);
+            } else {
+                identifierService.register(context, newCollection, handle);
+            }
+        } catch (IdentifierException e) {
+            throw new RuntimeException("Can't create an Identifier!");
         }
 
         // create the default authorization policy for collections

--- a/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
@@ -135,17 +135,6 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
         //Add our newly created collection to our community, authorization checks occur in THIS method
         communityService.addCollection(context, community, newCollection);
 
-        //Update our collection so we have a collection identifier
-        try {
-            if (handle == null) {
-                identifierService.register(context, newCollection);
-            } else {
-                identifierService.register(context, newCollection, handle);
-            }
-        } catch (IllegalStateException | IdentifierException ex) {
-            throw new IllegalStateException(ex);
-        }
-
         // create the default authorization policy for collections
         // of 'anonymous' READ
         Group anonymousGroup = groupService.findByName(context, Group.ANONYMOUS);
@@ -158,6 +147,18 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
         authorizeService
             .createResourcePolicy(context, newCollection, anonymousGroup, null, Constants.DEFAULT_BITSTREAM_READ, null);
 
+        collectionDAO.save(context, newCollection);
+
+        //Update our collection so we have a collection identifier
+        try {
+            if (handle == null) {
+                identifierService.register(context, newCollection);
+            } else {
+                identifierService.register(context, newCollection, handle);
+            }
+        } catch (IllegalStateException | IdentifierException ex) {
+            throw new IllegalStateException(ex);
+        }
 
         context.addEvent(new Event(Event.CREATE, Constants.COLLECTION,
                                    newCollection.getID(), newCollection.getHandle(),
@@ -167,7 +168,6 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
                                       "collection_id=" + newCollection.getID())
                      + ",handle=" + newCollection.getHandle());
 
-        collectionDAO.save(context, newCollection);
         return newCollection;
     }
 

--- a/dspace-api/src/main/java/org/dspace/content/CommunityServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CommunityServiceImpl.java
@@ -100,9 +100,10 @@ public class CommunityServiceImpl extends DSpaceObjectServiceImpl<Community> imp
             } else {
                 identifierService.register(context, newCommunity, handle);
             }
-        } catch (IdentifierException e) {
-            throw new RuntimeException("Can't create an Identifier!");
+        }  catch (IllegalStateException | IdentifierException ex) {
+            throw new IllegalStateException(ex);
         }
+
 
         if (parent != null) {
             parent.addSubCommunity(newCommunity);

--- a/dspace-api/src/main/java/org/dspace/content/CommunityServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CommunityServiceImpl.java
@@ -94,17 +94,6 @@ public class CommunityServiceImpl extends DSpaceObjectServiceImpl<Community> imp
 
         Community newCommunity = communityDAO.create(context, new Community());
 
-        try {
-            if (handle == null) {
-                identifierService.register(context, newCommunity);
-            } else {
-                identifierService.register(context, newCommunity, handle);
-            }
-        }  catch (IllegalStateException | IdentifierException ex) {
-            throw new IllegalStateException(ex);
-        }
-
-
         if (parent != null) {
             parent.addSubCommunity(newCommunity);
             newCommunity.addParentCommunity(parent);
@@ -127,6 +116,16 @@ public class CommunityServiceImpl extends DSpaceObjectServiceImpl<Community> imp
             context.addEvent(new Event(Event.ADD, Constants.SITE, siteService.findSite(context).getID(),
                                        Constants.COMMUNITY, newCommunity.getID(), newCommunity.getHandle(),
                                        getIdentifiers(context, newCommunity)));
+        }
+
+        try {
+            if (handle == null) {
+                identifierService.register(context, newCommunity);
+            } else {
+                identifierService.register(context, newCommunity, handle);
+            }
+        }  catch (IllegalStateException | IdentifierException ex) {
+            throw new IllegalStateException(ex);
         }
 
         log.info(LogManager.getHeader(context, "create_community",

--- a/dspace-api/src/main/java/org/dspace/content/CommunityServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CommunityServiceImpl.java
@@ -37,6 +37,8 @@ import org.dspace.core.LogManager;
 import org.dspace.eperson.Group;
 import org.dspace.eperson.service.GroupService;
 import org.dspace.event.Event;
+import org.dspace.identifier.IdentifierException;
+import org.dspace.identifier.service.IdentifierService;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -69,6 +71,8 @@ public class CommunityServiceImpl extends DSpaceObjectServiceImpl<Community> imp
     protected BitstreamService bitstreamService;
     @Autowired(required = true)
     protected SiteService siteService;
+    @Autowired(required = true)
+    protected IdentifierService identifierService;
 
     protected CommunityServiceImpl() {
         super();
@@ -92,13 +96,12 @@ public class CommunityServiceImpl extends DSpaceObjectServiceImpl<Community> imp
 
         try {
             if (handle == null) {
-                handleService.createHandle(context, newCommunity);
+                identifierService.register(context, newCommunity);
             } else {
-                handleService.createHandle(context, newCommunity, handle);
+                identifierService.register(context, newCommunity, handle);
             }
-        } catch (IllegalStateException ie) {
-            //If an IllegalStateException is thrown, then an existing object is already using this handle
-            throw ie;
+        } catch (IdentifierException e) {
+            throw new RuntimeException("Can't create an Identifier!");
         }
 
         if (parent != null) {

--- a/dspace-api/src/main/java/org/dspace/content/CommunityServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CommunityServiceImpl.java
@@ -108,16 +108,6 @@ public class CommunityServiceImpl extends DSpaceObjectServiceImpl<Community> imp
 
         communityDAO.save(context, newCommunity);
 
-        context.addEvent(new Event(Event.CREATE, Constants.COMMUNITY, newCommunity.getID(), newCommunity.getHandle(),
-                                   getIdentifiers(context, newCommunity)));
-
-        // if creating a top-level Community, simulate an ADD event at the Site.
-        if (parent == null) {
-            context.addEvent(new Event(Event.ADD, Constants.SITE, siteService.findSite(context).getID(),
-                                       Constants.COMMUNITY, newCommunity.getID(), newCommunity.getHandle(),
-                                       getIdentifiers(context, newCommunity)));
-        }
-
         try {
             if (handle == null) {
                 identifierService.register(context, newCommunity);
@@ -126,6 +116,16 @@ public class CommunityServiceImpl extends DSpaceObjectServiceImpl<Community> imp
             }
         }  catch (IllegalStateException | IdentifierException ex) {
             throw new IllegalStateException(ex);
+        }
+
+        context.addEvent(new Event(Event.CREATE, Constants.COMMUNITY, newCommunity.getID(), newCommunity.getHandle(),
+                getIdentifiers(context, newCommunity)));
+
+        // if creating a top-level Community, simulate an ADD event at the Site.
+        if (parent == null) {
+            context.addEvent(new Event(Event.ADD, Constants.SITE, siteService.findSite(context).getID(),
+                    Constants.COMMUNITY, newCommunity.getID(), newCommunity.getHandle(),
+                    getIdentifiers(context, newCommunity)));
         }
 
         log.info(LogManager.getHeader(context, "create_community",

--- a/dspace-api/src/main/java/org/dspace/identifier/DOIIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/DOIIdentifierProvider.java
@@ -169,6 +169,9 @@ public class DOIIdentifierProvider
     @Override
     public String register(Context context, DSpaceObject dso)
         throws IdentifierException {
+        if (!(dso instanceof Item)) {
+            return null;
+        }
         String doi = mint(context, dso);
         // register tries to reserve doi if it's not already.
         // So we don't have to reserve it here.
@@ -179,6 +182,9 @@ public class DOIIdentifierProvider
     @Override
     public void register(Context context, DSpaceObject dso, String identifier)
         throws IdentifierException {
+        if (!(dso instanceof Item)) {
+            return;
+        }
         String doi = doiService.formatIdentifier(identifier);
         DOI doiRow = null;
 

--- a/dspace-api/src/main/java/org/dspace/identifier/DOIIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/DOIIdentifierProvider.java
@@ -170,6 +170,7 @@ public class DOIIdentifierProvider
     public String register(Context context, DSpaceObject dso)
         throws IdentifierException {
         if (!(dso instanceof Item)) {
+            // DOI are currently assigned only to Item
             return null;
         }
         String doi = mint(context, dso);
@@ -183,6 +184,7 @@ public class DOIIdentifierProvider
     public void register(Context context, DSpaceObject dso, String identifier)
         throws IdentifierException {
         if (!(dso instanceof Item)) {
+            // DOI are currently assigned only to Item
             return;
         }
         String doi = doiService.formatIdentifier(identifier);

--- a/dspace-api/src/main/java/org/dspace/identifier/EZIDIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/EZIDIdentifierProvider.java
@@ -147,7 +147,9 @@ public class EZIDIdentifierProvider
     public String register(Context context, DSpaceObject dso)
         throws IdentifierException {
         log.debug("register {}", dso);
-
+        if (!(dso instanceof Item)) {
+            return null;
+        }
         DSpaceObjectService<DSpaceObject> dsoService = contentServiceFactory.getDSpaceObjectService(dso);
         List<MetadataValue> identifiers = dsoService.getMetadata(dso, MD_SCHEMA, DOI_ELEMENT, DOI_QUALIFIER, null);
         for (MetadataValue identifier : identifiers) {

--- a/dspace-api/src/main/java/org/dspace/identifier/EZIDIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/EZIDIdentifierProvider.java
@@ -149,6 +149,7 @@ public class EZIDIdentifierProvider
         log.debug("register {}", dso);
 
         if (!(dso instanceof Item)) {
+            // DOI are currently assigned only to Item
             return null;
         }
         DSpaceObjectService<DSpaceObject> dsoService = contentServiceFactory.getDSpaceObjectService(dso);
@@ -175,6 +176,7 @@ public class EZIDIdentifierProvider
         log.debug("register {} as {}", object, identifier);
 
         if (!(object instanceof Item)) {
+            // DOI are currently assigned only to Item
             return;
         }
         EZIDResponse response;

--- a/dspace-api/src/main/java/org/dspace/identifier/EZIDIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/EZIDIdentifierProvider.java
@@ -147,6 +147,7 @@ public class EZIDIdentifierProvider
     public String register(Context context, DSpaceObject dso)
         throws IdentifierException {
         log.debug("register {}", dso);
+
         if (!(dso instanceof Item)) {
             return null;
         }
@@ -173,6 +174,9 @@ public class EZIDIdentifierProvider
     public void register(Context context, DSpaceObject object, String identifier) {
         log.debug("register {} as {}", object, identifier);
 
+        if (!(object instanceof Item)) {
+            return;
+        }
         EZIDResponse response;
         try {
             EZIDRequest request = requestFactory.getInstance(loadAuthority(),

--- a/dspace-api/src/main/java/org/dspace/identifier/IdentifierServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/IdentifierServiceImpl.java
@@ -94,16 +94,8 @@ public class IdentifierServiceImpl implements IdentifierService {
         throws AuthorizeException, SQLException, IdentifierException {
         //We need to commit our context because one of the providers might require the handle created above
         // Next resolve all other services
-        boolean registered = false;
         for (IdentifierProvider service : providers) {
-            String identifier = service.register(context, dso);
-            if (identifier != null) {
-                registered = true;
-            }
-        }
-        if (!registered) {
-            throw new IdentifierException("Cannot register identifier: Didn't "
-                                              + "find a provider that supports this identifier.");
+            service.register(context, dso);
         }
         //Update our item / collection / community
         contentServiceFactory.getDSpaceObjectService(dso).update(context, dso);

--- a/dspace-api/src/main/java/org/dspace/identifier/IdentifierServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/IdentifierServiceImpl.java
@@ -94,10 +94,18 @@ public class IdentifierServiceImpl implements IdentifierService {
         throws AuthorizeException, SQLException, IdentifierException {
         //We need to commit our context because one of the providers might require the handle created above
         // Next resolve all other services
+        boolean registered = false;
         for (IdentifierProvider service : providers) {
-            service.register(context, dso);
+            String identifier = service.register(context, dso);
+            if (identifier != null) {
+                registered = true;
+            }
         }
-        //Update our item
+        if (!registered) {
+            throw new IdentifierException("Cannot register identifier: Didn't "
+                                              + "find a provider that supports this identifier.");
+        }
+        //Update our item / collection / community
         contentServiceFactory.getDSpaceObjectService(dso).update(context, dso);
     }
 
@@ -117,7 +125,7 @@ public class IdentifierServiceImpl implements IdentifierService {
             throw new IdentifierException("Cannot register identifier: Didn't "
                                               + "find a provider that supports this identifier.");
         }
-        //Update our item
+        //Update our item / collection / community
         contentServiceFactory.getDSpaceObjectService(object).update(context, object);
     }
 

--- a/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProvider.java
@@ -25,7 +25,6 @@ import org.dspace.content.MetadataSchemaEnum;
 import org.dspace.content.MetadataValue;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.DSpaceObjectService;
-import org.dspace.content.service.ItemService;
 import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
@@ -67,9 +66,6 @@ public class VersionedHandleIdentifierProvider extends IdentifierProvider {
 
     @Autowired(required = true)
     private HandleService handleService;
-
-    @Autowired(required = true)
-    private ItemService itemService;
 
     @Autowired(required = true)
     protected ContentServiceFactory contentServiceFactory;
@@ -114,11 +110,8 @@ public class VersionedHandleIdentifierProvider extends IdentifierProvider {
     public String register(Context context, DSpaceObject dso) {
         String id = mint(context, dso);
         try {
-            if (dso instanceof Item) {
-                populateHandleMetadata(context, (Item) dso, id);
-            }
-            if (dso instanceof Collection || dso instanceof Community) {
-                populateNotVersionedHandleMetadata(context, dso, id);
+            if (dso instanceof Item || dso instanceof Collection || dso instanceof Community) {
+                populateHandleMetadata(context, dso, id);
             }
         } catch (Exception e) {
             log.error(LogManager.getHeader(context, "Error while attempting to create handle",
@@ -132,7 +125,6 @@ public class VersionedHandleIdentifierProvider extends IdentifierProvider {
     @Override
     public void register(Context context, DSpaceObject dso, String identifier)
         throws IdentifierException {
-        // FIXME are Collections and Communities to be handled here?
         if (dso instanceof Item && identifier != null) {
             Item item = (Item) dso;
 
@@ -421,16 +413,17 @@ public class VersionedHandleIdentifierProvider extends IdentifierProvider {
         return identifier;
     }
 
-    protected void populateHandleMetadata(Context context, Item item, String handle)
+    protected void populateHandleMetadata(Context context, DSpaceObject dso, String handle)
         throws SQLException, IOException, AuthorizeException {
         String handleref = handleService.getCanonicalForm(handle);
         // we want to remove the old handle and insert the new. To do so, we
         // load all identifiers, clear the metadata field, re add all
         // identifiers which are not from type handle and add the new handle.
-        List<MetadataValue> identifiers = itemService.getMetadata(item,
+        DSpaceObjectService<DSpaceObject> dsoService = contentServiceFactory.getDSpaceObjectService(dso);
+        List<MetadataValue> identifiers = dsoService.getMetadata(dso,
                                                                   MetadataSchemaEnum.DC.getName(), "identifier", "uri",
                                                                   Item.ANY);
-        itemService.clearMetadata(context, item, MetadataSchemaEnum.DC.getName(),
+        dsoService.clearMetadata(context, dso, MetadataSchemaEnum.DC.getName(),
                                   "identifier", "uri", Item.ANY);
         for (MetadataValue identifier : identifiers) {
             if (this.supports(identifier.getValue())) {
@@ -439,8 +432,8 @@ public class VersionedHandleIdentifierProvider extends IdentifierProvider {
                 continue;
             }
             log.debug("Preserving identifier " + identifier.getValue());
-            itemService.addMetadata(context,
-                                    item,
+            dsoService.addMetadata(context,
+                                    dso,
                                     identifier.getMetadataField(),
                                     identifier.getLanguage(),
                                     identifier.getValue(),
@@ -450,32 +443,9 @@ public class VersionedHandleIdentifierProvider extends IdentifierProvider {
 
         // Add handle as identifier.uri DC value.
         if (StringUtils.isNotBlank(handleref)) {
-            itemService.addMetadata(context, item, MetadataSchemaEnum.DC.getName(),
+            dsoService.addMetadata(context, dso, MetadataSchemaEnum.DC.getName(),
                                     "identifier", "uri", null, handleref);
         }
-        itemService.update(context, item);
-    }
-
-    protected void populateNotVersionedHandleMetadata(Context context, DSpaceObject dso, String handle)
-            throws SQLException, IOException, AuthorizeException {
-        String handleref = handleService.getCanonicalForm(handle);
-
-        DSpaceObjectService<DSpaceObject> dsoService = contentServiceFactory.getDSpaceObjectService(dso);
-
-        // Add handle as identifier.uri DC value.
-        // First check that identifier doesn't already exist.
-        boolean identifierExists = false;
-        // List<MetadataValue> identifiers = dsoObjectService
-        List<MetadataValue> identifiers = dsoService
-                .getMetadata(dso, MetadataSchemaEnum.DC.getName(), "identifier", "uri", Item.ANY);
-        for (MetadataValue identifier : identifiers) {
-            if (handleref.equals(identifier.getValue())) {
-                identifierExists = true;
-            }
-        }
-        if (!identifierExists) {
-            dsoService.addMetadata(context, dso, MetadataSchemaEnum.DC.getName(),
-                    "identifier", "uri", null, handleref);
-        }
+        dsoService.update(context, dso);
     }
 }

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V7_0_2020_10_31__CollectionCommunity_Metadata_Handle.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V7_0_2020_10_31__CollectionCommunity_Metadata_Handle.java
@@ -1,0 +1,90 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.storage.rdbms.migration;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+import org.dspace.handle.service.HandleService;
+import org.dspace.services.factory.DSpaceServicesFactory;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.PreparedStatementSetter;
+import org.springframework.jdbc.datasource.SingleConnectionDataSource;
+
+/**
+ * This class automatically adding rptype to the resource policy created with a migration into XML-based Configurable
+ * Workflow system
+ *
+ * @author Alessandro Martelli (alessandro.martelli at 4science.it)
+ */
+public class V7_0_2020_10_31__CollectionCommunity_Metadata_Handle extends BaseJavaMigration {
+    // Size of migration script run
+    protected Integer migration_file_size = -1;
+
+    @Override
+    public void migrate(Context context) throws Exception {
+
+        HandleService handleService = DSpaceServicesFactory
+                .getInstance().getServiceManager().getServicesByType(HandleService.class).get(0);
+
+        final String prefix = handleService.getCanonicalPrefix();
+
+        final String SQL_INSERT = "insert into metadatavalue "
+                + " (metadata_field_id, text_value, text_lang, place, authority, confidence, dspace_object_id) "
+
+                + " select distinct T1.metadata_field_id as metadata_field_id, concat(?, h.handle) as text_value, "
+                + "  null as text_lang, 0 as place, null as authority, -1 as confidence, c.uuid as dspace_object_id  "
+
+                + "  from %s c "
+                + "  left outer join handle h on h.resource_id = c.uuid "
+                + "  left outer join metadatavalue mv on mv.dspace_object_id = c.uuid "
+                + "  left outer join metadatafieldregistry mfr on mv.metadata_field_id = mfr.metadata_field_id "
+                + "  left outer join metadataschemaregistry msr on mfr.metadata_schema_id = msr.metadata_schema_id "
+
+                + "  cross join (select mfr.metadata_field_id as metadata_field_id from metadatafieldregistry mfr "
+                + "     left outer join metadataschemaregistry msr on mfr.metadata_schema_id = msr.metadata_schema_id "
+                + "     where msr.short_id = 'dc' "
+                + "      and mfr.element = 'identifier' "
+                + "      and mfr.qualifier = 'uri') T1 "
+                + ";";
+
+        final String COLLECTIONS_SQL_INDEX = String.format(SQL_INSERT, "collection");
+        final String COMMUNITIES_SQL_INDEX = String.format(SQL_INSERT, "community");
+
+        try {
+            new JdbcTemplate(new SingleConnectionDataSource(context.getConnection(), true))
+                .update(COLLECTIONS_SQL_INDEX, new PreparedStatementSetter() {
+                    @Override
+                    public void setValues(PreparedStatement ps) throws SQLException {
+                        ps.setString(1, prefix);
+                    }
+                });
+
+            new JdbcTemplate(new SingleConnectionDataSource(context.getConnection(), true))
+                .update(COMMUNITIES_SQL_INDEX, new PreparedStatementSetter() {
+                    @Override
+                    public void setValues(PreparedStatement ps) throws SQLException {
+                        ps.setString(1, prefix);
+                    }
+                });
+        } catch (DataAccessException dae) {
+            throw new SQLException("Flyway executeSql() error occurred", dae);
+        }
+
+        migration_file_size = COLLECTIONS_SQL_INDEX.length() + COMMUNITIES_SQL_INDEX.length();
+
+    }
+
+    @Override
+    public Integer getChecksum() {
+        return migration_file_size;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V7_0_2020_10_31__CollectionCommunity_Metadata_Handle.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/migration/V7_0_2020_10_31__CollectionCommunity_Metadata_Handle.java
@@ -20,8 +20,9 @@ import org.springframework.jdbc.core.PreparedStatementSetter;
 import org.springframework.jdbc.datasource.SingleConnectionDataSource;
 
 /**
- * This class automatically adding rptype to the resource policy created with a migration into XML-based Configurable
- * Workflow system
+ * Insert a 'dc.idendifier.uri' metadata record for each Community and Collection in the database.
+ * The value is calculated concatenating the canonicalPrefix extracted from the configuration
+ * (default is "http://hdl.handle.net/) and the object's handle suffix stored inside the handle table.
  *
  * @author Alessandro Martelli (alessandro.martelli at 4science.it)
  */

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/metadata/h2/V7.0_2020.10.31__CollectionCommunity_Metadata_Handle.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/metadata/h2/V7.0_2020.10.31__CollectionCommunity_Metadata_Handle.sql
@@ -21,7 +21,7 @@
 insert into metadatavalue (metadata_field_id, text_value, text_lang, place, authority, confidence, dspace_object_id) 
   select distinct 
   	T1.metadata_field_id as metadata_field_id, 
-  	concat(T2.handleprefix, h.handle) as text_value, 
+  	concat('${handle.canonical.prefix}', h.handle) as text_value, 
   	null as text_lang, 0 as place, 
   	null as authority, 
   	-1 as confidence, 
@@ -38,8 +38,6 @@ insert into metadatavalue (metadata_field_id, text_value, text_lang, place, auth
 	 	where msr.short_id = 'dc' 
 	  		and mfr.element = 'identifier'
 	  		and mfr.qualifier = 'uri') T1
-
-   	cross join tmp_handleprefix T2
 	  
   	where uuid not in (
 		select c.uuid as uuid from community c 
@@ -60,7 +58,7 @@ insert into metadatavalue (metadata_field_id, text_value, text_lang, place, auth
 insert into metadatavalue (metadata_field_id, text_value, text_lang, place, authority, confidence, dspace_object_id) 
   select distinct 
   	T1.metadata_field_id as metadata_field_id, 
-  	concat(T2.handleprefix, h.handle) as text_value, 
+  	concat('${handle.canonical.prefix}', h.handle) as text_value, 
   	null as text_lang, 0 as place, 
   	null as authority, 
   	-1 as confidence, 
@@ -77,8 +75,6 @@ insert into metadatavalue (metadata_field_id, text_value, text_lang, place, auth
 	 	where msr.short_id = 'dc' 
 	  		and mfr.element = 'identifier'
 	  		and mfr.qualifier = 'uri') T1
-
-   	cross join tmp_handleprefix T2
 	  
   	where uuid not in (
 		select c.uuid as uuid from collection c 
@@ -90,10 +86,5 @@ insert into metadatavalue (metadata_field_id, text_value, text_lang, place, auth
 	  		and mfr.element = 'identifier'
 	  		and mfr.qualifier = 'uri'
 	)
-;  	
+;
 
--------------------------------------------------------------
--- This will DROP the temporary table
--------------------------------------------------------------
-
-DROP TABLE tmp_handleprefix;

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/metadata/h2/V7.0_2020.10.31__CollectionCommunity_Metadata_Handle.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/metadata/h2/V7.0_2020.10.31__CollectionCommunity_Metadata_Handle.sql
@@ -1,0 +1,99 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+-- ===============================================================
+-- WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
+--
+-- DO NOT MANUALLY RUN THIS DATABASE MIGRATION. IT WILL BE EXECUTED
+-- AUTOMATICALLY (IF NEEDED) BY "FLYWAY" WHEN YOU STARTUP DSPACE.
+-- http://flywaydb.org/
+-- ===============================================================
+
+-------------------------------------------------------------
+-- This will create COMMUNITY handle metadata
+-------------------------------------------------------------
+
+insert into metadatavalue (metadata_field_id, text_value, text_lang, place, authority, confidence, dspace_object_id) 
+  select distinct 
+  	T1.metadata_field_id as metadata_field_id, 
+  	concat(T2.handleprefix, h.handle) as text_value, 
+  	null as text_lang, 0 as place, 
+  	null as authority, 
+  	-1 as confidence, 
+  	c.uuid as dspace_object_id
+  	
+  	from community c 
+  	left outer join handle h on h.resource_id = c.uuid 
+  	left outer join metadatavalue mv on mv.dspace_object_id = c.uuid 
+  	left outer join metadatafieldregistry mfr on mv.metadata_field_id = mfr.metadata_field_id
+  	left outer join metadataschemaregistry msr on mfr.metadata_schema_id = msr.metadata_schema_id
+  
+  	cross join (select mfr.metadata_field_id as metadata_field_id from metadatafieldregistry mfr 
+	 	left outer join metadataschemaregistry msr on mfr.metadata_schema_id = msr.metadata_schema_id
+	 	where msr.short_id = 'dc' 
+	  		and mfr.element = 'identifier'
+	  		and mfr.qualifier = 'uri') T1
+
+   	cross join tmp_handleprefix T2
+	  
+  	where uuid not in (
+		select c.uuid as uuid from community c 
+	 	left outer join handle h on h.resource_id = c.uuid 
+	 	left outer join metadatavalue mv on mv.dspace_object_id = c.uuid 
+	 	left outer join metadatafieldregistry mfr on mv.metadata_field_id = mfr.metadata_field_id
+	 	left outer join metadataschemaregistry msr on mfr.metadata_schema_id = msr.metadata_schema_id
+	 	where msr.short_id = 'dc' 
+	  		and mfr.element = 'identifier'
+	  		and mfr.qualifier = 'uri'
+	)
+;  
+
+-------------------------------------------------------------
+-- This will create COLLECTION handle metadata
+-------------------------------------------------------------	
+	
+insert into metadatavalue (metadata_field_id, text_value, text_lang, place, authority, confidence, dspace_object_id) 
+  select distinct 
+  	T1.metadata_field_id as metadata_field_id, 
+  	concat(T2.handleprefix, h.handle) as text_value, 
+  	null as text_lang, 0 as place, 
+  	null as authority, 
+  	-1 as confidence, 
+  	c.uuid as dspace_object_id
+  	
+  	from collection c 
+  	left outer join handle h on h.resource_id = c.uuid 
+  	left outer join metadatavalue mv on mv.dspace_object_id = c.uuid 
+  	left outer join metadatafieldregistry mfr on mv.metadata_field_id = mfr.metadata_field_id
+  	left outer join metadataschemaregistry msr on mfr.metadata_schema_id = msr.metadata_schema_id
+  
+  	cross join (select mfr.metadata_field_id as metadata_field_id from metadatafieldregistry mfr 
+	 	left outer join metadataschemaregistry msr on mfr.metadata_schema_id = msr.metadata_schema_id
+	 	where msr.short_id = 'dc' 
+	  		and mfr.element = 'identifier'
+	  		and mfr.qualifier = 'uri') T1
+
+   	cross join tmp_handleprefix T2
+	  
+  	where uuid not in (
+		select c.uuid as uuid from collection c 
+	 	left outer join handle h on h.resource_id = c.uuid 
+	 	left outer join metadatavalue mv on mv.dspace_object_id = c.uuid 
+	 	left outer join metadatafieldregistry mfr on mv.metadata_field_id = mfr.metadata_field_id
+	 	left outer join metadataschemaregistry msr on mfr.metadata_schema_id = msr.metadata_schema_id
+	 	where msr.short_id = 'dc' 
+	  		and mfr.element = 'identifier'
+	  		and mfr.qualifier = 'uri'
+	)
+;  	
+
+-------------------------------------------------------------
+-- This will DROP the temporary table
+-------------------------------------------------------------
+
+DROP TABLE tmp_handleprefix;

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/metadata/oracle/V7.0_2020.10.31__CollectionCommunity_Metadata_Handle.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/metadata/oracle/V7.0_2020.10.31__CollectionCommunity_Metadata_Handle.sql
@@ -21,7 +21,7 @@
 insert into metadatavalue (metadata_field_id, text_value, text_lang, place, authority, confidence, dspace_object_id) 
   select distinct 
   	T1.metadata_field_id as metadata_field_id, 
-  	concat(T2.handleprefix, h.handle) as text_value, 
+  	concat('${handle.canonical.prefix}', h.handle) as text_value, 
   	null as text_lang, 0 as place, 
   	null as authority, 
   	-1 as confidence, 
@@ -38,8 +38,6 @@ insert into metadatavalue (metadata_field_id, text_value, text_lang, place, auth
 	 	where msr.short_id = 'dc' 
 	  		and mfr.element = 'identifier'
 	  		and mfr.qualifier = 'uri') T1
-
-   	cross join tmp_handleprefix T2
 	  
   	where uuid not in (
 		select c.uuid as uuid from community c 
@@ -60,7 +58,7 @@ insert into metadatavalue (metadata_field_id, text_value, text_lang, place, auth
 insert into metadatavalue (metadata_field_id, text_value, text_lang, place, authority, confidence, dspace_object_id) 
   select distinct 
   	T1.metadata_field_id as metadata_field_id, 
-  	concat(T2.handleprefix, h.handle) as text_value, 
+  	concat('${handle.canonical.prefix}', h.handle) as text_value, 
   	null as text_lang, 0 as place, 
   	null as authority, 
   	-1 as confidence, 
@@ -77,8 +75,6 @@ insert into metadatavalue (metadata_field_id, text_value, text_lang, place, auth
 	 	where msr.short_id = 'dc' 
 	  		and mfr.element = 'identifier'
 	  		and mfr.qualifier = 'uri') T1
-
-   	cross join tmp_handleprefix T2
 	  
   	where uuid not in (
 		select c.uuid as uuid from collection c 
@@ -92,8 +88,3 @@ insert into metadatavalue (metadata_field_id, text_value, text_lang, place, auth
 	)
 ;  	
 
--------------------------------------------------------------
--- This will DROP the temporary table
--------------------------------------------------------------
-
-DROP TABLE tmp_handleprefix;

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/metadata/oracle/V7.0_2020.10.31__CollectionCommunity_Metadata_Handle.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/metadata/oracle/V7.0_2020.10.31__CollectionCommunity_Metadata_Handle.sql
@@ -1,0 +1,99 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+-- ===============================================================
+-- WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
+--
+-- DO NOT MANUALLY RUN THIS DATABASE MIGRATION. IT WILL BE EXECUTED
+-- AUTOMATICALLY (IF NEEDED) BY "FLYWAY" WHEN YOU STARTUP DSPACE.
+-- http://flywaydb.org/
+-- ===============================================================
+
+-------------------------------------------------------------
+-- This will create COMMUNITY handle metadata
+-------------------------------------------------------------
+
+insert into metadatavalue (metadata_field_id, text_value, text_lang, place, authority, confidence, dspace_object_id) 
+  select distinct 
+  	T1.metadata_field_id as metadata_field_id, 
+  	concat(T2.handleprefix, h.handle) as text_value, 
+  	null as text_lang, 0 as place, 
+  	null as authority, 
+  	-1 as confidence, 
+  	c.uuid as dspace_object_id
+  	
+  	from community c 
+  	left outer join handle h on h.resource_id = c.uuid 
+  	left outer join metadatavalue mv on mv.dspace_object_id = c.uuid 
+  	left outer join metadatafieldregistry mfr on mv.metadata_field_id = mfr.metadata_field_id
+  	left outer join metadataschemaregistry msr on mfr.metadata_schema_id = msr.metadata_schema_id
+  
+  	cross join (select mfr.metadata_field_id as metadata_field_id from metadatafieldregistry mfr 
+	 	left outer join metadataschemaregistry msr on mfr.metadata_schema_id = msr.metadata_schema_id
+	 	where msr.short_id = 'dc' 
+	  		and mfr.element = 'identifier'
+	  		and mfr.qualifier = 'uri') T1
+
+   	cross join tmp_handleprefix T2
+	  
+  	where uuid not in (
+		select c.uuid as uuid from community c 
+	 	left outer join handle h on h.resource_id = c.uuid 
+	 	left outer join metadatavalue mv on mv.dspace_object_id = c.uuid 
+	 	left outer join metadatafieldregistry mfr on mv.metadata_field_id = mfr.metadata_field_id
+	 	left outer join metadataschemaregistry msr on mfr.metadata_schema_id = msr.metadata_schema_id
+	 	where msr.short_id = 'dc' 
+	  		and mfr.element = 'identifier'
+	  		and mfr.qualifier = 'uri'
+	)
+;  
+
+-------------------------------------------------------------
+-- This will create COLLECTION handle metadata
+-------------------------------------------------------------	
+	
+insert into metadatavalue (metadata_field_id, text_value, text_lang, place, authority, confidence, dspace_object_id) 
+  select distinct 
+  	T1.metadata_field_id as metadata_field_id, 
+  	concat(T2.handleprefix, h.handle) as text_value, 
+  	null as text_lang, 0 as place, 
+  	null as authority, 
+  	-1 as confidence, 
+  	c.uuid as dspace_object_id
+  	
+  	from collection c 
+  	left outer join handle h on h.resource_id = c.uuid 
+  	left outer join metadatavalue mv on mv.dspace_object_id = c.uuid 
+  	left outer join metadatafieldregistry mfr on mv.metadata_field_id = mfr.metadata_field_id
+  	left outer join metadataschemaregistry msr on mfr.metadata_schema_id = msr.metadata_schema_id
+  
+  	cross join (select mfr.metadata_field_id as metadata_field_id from metadatafieldregistry mfr 
+	 	left outer join metadataschemaregistry msr on mfr.metadata_schema_id = msr.metadata_schema_id
+	 	where msr.short_id = 'dc' 
+	  		and mfr.element = 'identifier'
+	  		and mfr.qualifier = 'uri') T1
+
+   	cross join tmp_handleprefix T2
+	  
+  	where uuid not in (
+		select c.uuid as uuid from collection c 
+	 	left outer join handle h on h.resource_id = c.uuid 
+	 	left outer join metadatavalue mv on mv.dspace_object_id = c.uuid 
+	 	left outer join metadatafieldregistry mfr on mv.metadata_field_id = mfr.metadata_field_id
+	 	left outer join metadataschemaregistry msr on mfr.metadata_schema_id = msr.metadata_schema_id
+	 	where msr.short_id = 'dc' 
+	  		and mfr.element = 'identifier'
+	  		and mfr.qualifier = 'uri'
+	)
+;  	
+
+-------------------------------------------------------------
+-- This will DROP the temporary table
+-------------------------------------------------------------
+
+DROP TABLE tmp_handleprefix;

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/metadata/postgres/V7.0_2020.10.31__CollectionCommunity_Metadata_Handle.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/metadata/postgres/V7.0_2020.10.31__CollectionCommunity_Metadata_Handle.sql
@@ -21,7 +21,7 @@
 insert into metadatavalue (metadata_field_id, text_value, text_lang, place, authority, confidence, dspace_object_id) 
   select distinct 
   	T1.metadata_field_id as metadata_field_id, 
-  	concat(T2.handleprefix, h.handle) as text_value, 
+  	concat('${handle.canonical.prefix}', h.handle) as text_value, 
   	null as text_lang, 0 as place, 
   	null as authority, 
   	-1 as confidence, 
@@ -38,8 +38,6 @@ insert into metadatavalue (metadata_field_id, text_value, text_lang, place, auth
 	 	where msr.short_id = 'dc' 
 	  		and mfr.element = 'identifier'
 	  		and mfr.qualifier = 'uri') T1
-
-   	cross join tmp_handleprefix T2
 	  
   	where uuid not in (
 		select c.uuid as uuid from community c 
@@ -60,7 +58,7 @@ insert into metadatavalue (metadata_field_id, text_value, text_lang, place, auth
 insert into metadatavalue (metadata_field_id, text_value, text_lang, place, authority, confidence, dspace_object_id) 
   select distinct 
   	T1.metadata_field_id as metadata_field_id, 
-  	concat(T2.handleprefix, h.handle) as text_value, 
+  	concat('${handle.canonical.prefix}', h.handle) as text_value, 
   	null as text_lang, 0 as place, 
   	null as authority, 
   	-1 as confidence, 
@@ -77,8 +75,6 @@ insert into metadatavalue (metadata_field_id, text_value, text_lang, place, auth
 	 	where msr.short_id = 'dc' 
 	  		and mfr.element = 'identifier'
 	  		and mfr.qualifier = 'uri') T1
-
-   	cross join tmp_handleprefix T2
 	  
   	where uuid not in (
 		select c.uuid as uuid from collection c 
@@ -92,8 +88,3 @@ insert into metadatavalue (metadata_field_id, text_value, text_lang, place, auth
 	)
 ;  	
 
--------------------------------------------------------------
--- This will DROP the temporary table
--------------------------------------------------------------
-
-DROP TABLE tmp_handleprefix;

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/metadata/postgres/V7.0_2020.10.31__CollectionCommunity_Metadata_Handle.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/metadata/postgres/V7.0_2020.10.31__CollectionCommunity_Metadata_Handle.sql
@@ -1,0 +1,99 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+-- ===============================================================
+-- WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
+--
+-- DO NOT MANUALLY RUN THIS DATABASE MIGRATION. IT WILL BE EXECUTED
+-- AUTOMATICALLY (IF NEEDED) BY "FLYWAY" WHEN YOU STARTUP DSPACE.
+-- http://flywaydb.org/
+-- ===============================================================
+
+-------------------------------------------------------------
+-- This will create COMMUNITY handle metadata
+-------------------------------------------------------------
+
+insert into metadatavalue (metadata_field_id, text_value, text_lang, place, authority, confidence, dspace_object_id) 
+  select distinct 
+  	T1.metadata_field_id as metadata_field_id, 
+  	concat(T2.handleprefix, h.handle) as text_value, 
+  	null as text_lang, 0 as place, 
+  	null as authority, 
+  	-1 as confidence, 
+  	c.uuid as dspace_object_id
+  	
+  	from community c 
+  	left outer join handle h on h.resource_id = c.uuid 
+  	left outer join metadatavalue mv on mv.dspace_object_id = c.uuid 
+  	left outer join metadatafieldregistry mfr on mv.metadata_field_id = mfr.metadata_field_id
+  	left outer join metadataschemaregistry msr on mfr.metadata_schema_id = msr.metadata_schema_id
+  
+  	cross join (select mfr.metadata_field_id as metadata_field_id from metadatafieldregistry mfr 
+	 	left outer join metadataschemaregistry msr on mfr.metadata_schema_id = msr.metadata_schema_id
+	 	where msr.short_id = 'dc' 
+	  		and mfr.element = 'identifier'
+	  		and mfr.qualifier = 'uri') T1
+
+   	cross join tmp_handleprefix T2
+	  
+  	where uuid not in (
+		select c.uuid as uuid from community c 
+	 	left outer join handle h on h.resource_id = c.uuid 
+	 	left outer join metadatavalue mv on mv.dspace_object_id = c.uuid 
+	 	left outer join metadatafieldregistry mfr on mv.metadata_field_id = mfr.metadata_field_id
+	 	left outer join metadataschemaregistry msr on mfr.metadata_schema_id = msr.metadata_schema_id
+	 	where msr.short_id = 'dc' 
+	  		and mfr.element = 'identifier'
+	  		and mfr.qualifier = 'uri'
+	)
+;  
+
+-------------------------------------------------------------
+-- This will create COLLECTION handle metadata
+-------------------------------------------------------------	
+	
+insert into metadatavalue (metadata_field_id, text_value, text_lang, place, authority, confidence, dspace_object_id) 
+  select distinct 
+  	T1.metadata_field_id as metadata_field_id, 
+  	concat(T2.handleprefix, h.handle) as text_value, 
+  	null as text_lang, 0 as place, 
+  	null as authority, 
+  	-1 as confidence, 
+  	c.uuid as dspace_object_id
+  	
+  	from collection c 
+  	left outer join handle h on h.resource_id = c.uuid 
+  	left outer join metadatavalue mv on mv.dspace_object_id = c.uuid 
+  	left outer join metadatafieldregistry mfr on mv.metadata_field_id = mfr.metadata_field_id
+  	left outer join metadataschemaregistry msr on mfr.metadata_schema_id = msr.metadata_schema_id
+  
+  	cross join (select mfr.metadata_field_id as metadata_field_id from metadatafieldregistry mfr 
+	 	left outer join metadataschemaregistry msr on mfr.metadata_schema_id = msr.metadata_schema_id
+	 	where msr.short_id = 'dc' 
+	  		and mfr.element = 'identifier'
+	  		and mfr.qualifier = 'uri') T1
+
+   	cross join tmp_handleprefix T2
+	  
+  	where uuid not in (
+		select c.uuid as uuid from collection c 
+	 	left outer join handle h on h.resource_id = c.uuid 
+	 	left outer join metadatavalue mv on mv.dspace_object_id = c.uuid 
+	 	left outer join metadatafieldregistry mfr on mv.metadata_field_id = mfr.metadata_field_id
+	 	left outer join metadataschemaregistry msr on mfr.metadata_schema_id = msr.metadata_schema_id
+	 	where msr.short_id = 'dc' 
+	  		and mfr.element = 'identifier'
+	  		and mfr.qualifier = 'uri'
+	)
+;  	
+
+-------------------------------------------------------------
+-- This will DROP the temporary table
+-------------------------------------------------------------
+
+DROP TABLE tmp_handleprefix;

--- a/dspace-api/src/test/java/org/dspace/content/CollectionTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/CollectionTest.java
@@ -38,6 +38,8 @@ import org.dspace.core.factory.CoreServiceFactory;
 import org.dspace.core.service.LicenseService;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
+import org.dspace.services.ConfigurationService;
+import org.dspace.utils.DSpace;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -159,6 +161,7 @@ public class CollectionTest extends AbstractDSpaceObjectTest {
     public void testCreate() throws Exception {
         // Allow Community ADD perms
         doNothing().when(authorizeServiceSpy).authorizeAction(context, owningCommunity, Constants.ADD);
+        doNothing().when(authorizeServiceSpy).authorizeAction(context, owningCommunity, Constants.ADD, true);
 
         Collection created = collectionService.create(context, owningCommunity);
         assertThat("testCreate 0", created, notNullValue());
@@ -172,6 +175,14 @@ public class CollectionTest extends AbstractDSpaceObjectTest {
     public void testCreateWithValidHandle() throws Exception {
         // Allow Community ADD perms
         doNothing().when(authorizeServiceSpy).authorizeAction(context, owningCommunity, Constants.ADD);
+        doNothing().when(authorizeServiceSpy).authorizeAction(context, owningCommunity, Constants.ADD, true);
+
+        // provide additional prefixes to the configuration in order to support them
+        final ConfigurationService configurationService = new DSpace().getConfigurationService();
+        String handleAdditionalPrefixes = configurationService.getProperty("handle.additional.prefixes");
+
+        try {
+        configurationService.setProperty("handle.additional.prefixes", "987654321");
 
         // test creating collection with a specified handle which is NOT already in use
         // (this handle should not already be used by system, as it doesn't start with "1234567689" prefix)
@@ -180,6 +191,10 @@ public class CollectionTest extends AbstractDSpaceObjectTest {
         // check that collection was created, and that its handle was set to proper value
         assertThat("testCreateWithValidHandle 0", created, notNullValue());
         assertThat("testCreateWithValidHandle 1", created.getHandle(), equalTo("987654321/100"));
+
+        } finally {
+            configurationService.setProperty("handle.additional.prefixes", handleAdditionalPrefixes);
+        }
     }
 
 

--- a/dspace-api/src/test/java/org/dspace/content/CommunityTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/CommunityTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -35,7 +36,10 @@ import org.dspace.authorize.factory.AuthorizeServiceFactory;
 import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
+import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
+import org.dspace.services.ConfigurationService;
+import org.dspace.utils.DSpace;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -169,6 +173,7 @@ public class CommunityTest extends AbstractDSpaceObjectTest {
         // Below settings default to Full Admin Rights (but not Community Admin rights)
         // Allow full Admin perms
         when(authorizeServiceSpy.isAdmin(context)).thenReturn(true);
+        when(authorizeServiceSpy.isAdmin(context, eperson)).thenReturn(true);
 
         //Test that a full Admin can create a Community without a parent (Top-Level Community)
         Community created = communityService.create(null, context);
@@ -206,6 +211,14 @@ public class CommunityTest extends AbstractDSpaceObjectTest {
     public void testCreateWithValidHandle() throws Exception {
         // Allow full Admin perms
         when(authorizeServiceSpy.isAdmin(context)).thenReturn(true);
+        doReturn(true).when(authorizeServiceSpy).isAdmin(eq(context), any(EPerson.class));
+
+        // provide additional prefixes to the configuration in order to support them
+        final ConfigurationService configurationService = new DSpace().getConfigurationService();
+        String handleAdditionalPrefixes = configurationService.getProperty("handle.additional.prefixes");
+
+        try {
+        configurationService.setProperty("handle.additional.prefixes", "987654321");
 
         // test creating community with a specified handle which is NOT already in use
         // (this handle should not already be used by system, as it doesn't start with "1234567689" prefix)
@@ -214,6 +227,10 @@ public class CommunityTest extends AbstractDSpaceObjectTest {
         // check that community was created, and that its handle was set to proper value
         assertThat("testCreateWithValidHandle 0", created, notNullValue());
         assertThat("testCreateWithValidHandle 1", created.getHandle(), equalTo("987654321/100c"));
+
+        } finally {
+            configurationService.setProperty("handle.additional.prefixes", handleAdditionalPrefixes);
+        }
     }
 
 
@@ -602,6 +619,7 @@ public class CommunityTest extends AbstractDSpaceObjectTest {
     public void testCreateCollectionAuth() throws Exception {
         // Allow current Community ADD perms
         doNothing().when(authorizeServiceSpy).authorizeAction(context, c, Constants.ADD);
+        doNothing().when(authorizeServiceSpy).authorizeAction(context, c, Constants.ADD, true);
 
         Collection result = collectionService.create(context, c);
         assertThat("testCreateCollectionAuth 0", result, notNullValue());
@@ -628,6 +646,7 @@ public class CommunityTest extends AbstractDSpaceObjectTest {
     public void testAddCollectionAuth() throws Exception {
         // Allow current Community ADD perms
         doNothing().when(authorizeServiceSpy).authorizeAction(context, c, Constants.ADD);
+        doNothing().when(authorizeServiceSpy).authorizeAction(context, c, Constants.ADD, true);
 
         Collection col = collectionService.create(context, c);
         c.addCollection(col);
@@ -929,7 +948,8 @@ public class CommunityTest extends AbstractDSpaceObjectTest {
     @SuppressWarnings("ObjectEqualsNull")
     public void testEquals() throws SQLException, AuthorizeException {
         // Allow full Admin perms (just to create top-level community)
-        when(authorizeServiceSpy.isAdmin(context)).thenReturn(true);
+        doReturn(true).when(authorizeServiceSpy).isAdmin(eq(context));
+        doReturn(true).when(authorizeServiceSpy).isAdmin(eq(context), any(EPerson.class));
 
         assertFalse("testEquals 0", c.equals(null));
         assertFalse("testEquals 1", c.equals(communityService.create(null, context)));

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/MetadataConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/MetadataConverter.java
@@ -22,6 +22,7 @@ import org.dspace.app.rest.model.MetadataValueRest;
 import org.dspace.app.rest.projection.Projection;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.DSpaceObject;
+import org.dspace.content.Item;
 import org.dspace.content.MetadataValue;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.DSpaceObjectService;
@@ -85,6 +86,7 @@ public class MetadataConverter implements DSpaceConverter<MetadataValueList, Met
     public <T extends DSpaceObject> void setMetadata(Context context, T dso, MetadataRest metadataRest)
             throws SQLException, AuthorizeException {
         DSpaceObjectService<T> dsoService = contentServiceFactory.getDSpaceObjectService(dso);
+        dsoService.clearMetadata(context, dso, Item.ANY, Item.ANY, Item.ANY, Item.ANY);
         persistMetadataRest(context, dso, metadataRest, dsoService);
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/MetadataConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/MetadataConverter.java
@@ -75,6 +75,7 @@ public class MetadataConverter implements DSpaceConverter<MetadataValueList, Met
 
     /**
      * Sets a DSpace object's domain metadata values from a rest representation.
+     * Any existing metadata values are deleted or overwritten.
      *
      * @param context the context to use.
      * @param dso the DSpace object.
@@ -84,8 +85,31 @@ public class MetadataConverter implements DSpaceConverter<MetadataValueList, Met
      */
     public void setMetadata(Context context, DSpaceObject dso, MetadataRest metadataRest)
             throws SQLException, AuthorizeException {
-        DSpaceObjectService dsoService = contentServiceFactory.getDSpaceObjectService(dso);
-        dsoService.clearMetadata(context, dso, Item.ANY, Item.ANY, Item.ANY, Item.ANY);
+        addMetadataImpl(context, dso, metadataRest, true);
+    }
+
+    /**
+     * Sets a DSpace object's domain metadata values from a rest representation.
+     * Any existing metadata values are preserved.
+     *
+     * @param context the context to use.
+     * @param dso the DSpace object.
+     * @param metadataRest the rest representation of the new metadata.
+     * @throws SQLException if a database error occurs.
+     * @throws AuthorizeException if an authorization error occurs.
+     */
+    public <T extends DSpaceObject> void addMetadata(Context context, T dso, MetadataRest metadataRest)
+            throws SQLException, AuthorizeException {
+        addMetadataImpl(context, dso, metadataRest, false);
+    }
+
+    public <T extends DSpaceObject> void addMetadataImpl(Context context, T dso, MetadataRest metadataRest,
+            boolean clearMetadata)
+            throws SQLException, AuthorizeException {
+        DSpaceObjectService<T> dsoService = contentServiceFactory.getDSpaceObjectService(dso);
+        if (clearMetadata) {
+            dsoService.clearMetadata(context, dso, Item.ANY, Item.ANY, Item.ANY, Item.ANY);
+        }
         for (Map.Entry<String, List<MetadataValueRest>> entry: metadataRest.getMap().entrySet()) {
             String[] seq = entry.getKey().split("\\.");
             String schema = seq[0];
@@ -98,4 +122,5 @@ public class MetadataConverter implements DSpaceConverter<MetadataValueList, Met
         }
         dsoService.update(context, dso);
     }
+
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CollectionRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CollectionRestRepository.java
@@ -236,11 +236,6 @@ public class CollectionRestRepository extends DSpaceObjectRestRepository<Collect
             throw new UnprocessableEntityException("Error parsing request body.", e1);
         }
 
-        if (collectionRest.getMetadata().getMap().containsKey("dc.identifier.uri")) {
-            throw new UnprocessableEntityException("Handle identifier cannot be passed "
-                    + "as metadata during collection creation.");
-        }
-
         Collection collection;
         try {
             Community parent = communityService.find(context, id);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CollectionRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CollectionRestRepository.java
@@ -245,7 +245,7 @@ public class CollectionRestRepository extends DSpaceObjectRestRepository<Collect
             }
             collection = cs.create(context, parent);
             cs.update(context, collection);
-            metadataConverter.setMetadata(context, collection, collectionRest.getMetadata());
+            metadataConverter.addMetadata(context, collection, collectionRest.getMetadata());
         } catch (SQLException e) {
             throw new RuntimeException("Unable to create new Collection under parent Community " + id, e);
         }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CollectionRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CollectionRestRepository.java
@@ -236,6 +236,11 @@ public class CollectionRestRepository extends DSpaceObjectRestRepository<Collect
             throw new UnprocessableEntityException("Error parsing request body.", e1);
         }
 
+        if (collectionRest.getMetadata().getMap().containsKey("dc.identifier.uri")) {
+            throw new UnprocessableEntityException("Handle identifier cannot be passed "
+                    + "as metadata during collection creation.");
+        }
+
         Collection collection;
         try {
             Community parent = communityService.find(context, id);
@@ -245,7 +250,7 @@ public class CollectionRestRepository extends DSpaceObjectRestRepository<Collect
             }
             collection = cs.create(context, parent);
             cs.update(context, collection);
-            metadataConverter.addMetadata(context, collection, collectionRest.getMetadata());
+            metadataConverter.mergeMetadata(context, collection, collectionRest.getMetadata());
         } catch (SQLException e) {
             throw new RuntimeException("Unable to create new Collection under parent Community " + id, e);
         }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CommunityRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CommunityRestRepository.java
@@ -135,11 +135,6 @@ public class CommunityRestRepository extends DSpaceObjectRestRepository<Communit
             throw new UnprocessableEntityException("Error parsing request body.", e1);
         }
 
-        if (communityRest.getMetadata().getMap().containsKey("dc.identifier.uri")) {
-            throw new UnprocessableEntityException("Handle identifier cannot be passed "
-                    + "as metadata during community creation.");
-        }
-
         Community community;
 
         try {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CommunityRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CommunityRestRepository.java
@@ -135,12 +135,17 @@ public class CommunityRestRepository extends DSpaceObjectRestRepository<Communit
             throw new UnprocessableEntityException("Error parsing request body.", e1);
         }
 
+        if (communityRest.getMetadata().getMap().containsKey("dc.identifier.uri")) {
+            throw new UnprocessableEntityException("Handle identifier cannot be passed "
+                    + "as metadata during community creation.");
+        }
+
         Community community;
 
         try {
             community = cs.create(parent, context);
             cs.update(context, community);
-            metadataConverter.addMetadata(context, community, communityRest.getMetadata());
+            metadataConverter.mergeMetadata(context, community, communityRest.getMetadata());
         } catch (SQLException e) {
             throw new RuntimeException(e.getMessage(), e);
         }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CommunityRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CommunityRestRepository.java
@@ -140,7 +140,7 @@ public class CommunityRestRepository extends DSpaceObjectRestRepository<Communit
         try {
             community = cs.create(parent, context);
             cs.update(context, community);
-            metadataConverter.setMetadata(context, community, communityRest.getMetadata());
+            metadataConverter.addMetadata(context, community, communityRest.getMetadata());
         } catch (SQLException e) {
             throw new RuntimeException(e.getMessage(), e);
         }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CollectionRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CollectionRestRepositoryIT.java
@@ -12,7 +12,7 @@ import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static org.dspace.app.rest.matcher.MetadataMatcher.matchMetadata;
 import static org.dspace.app.rest.matcher.MetadataMatcher.matchMetadataDoesNotExist;
 import static org.dspace.app.rest.matcher.MetadataMatcher.matchMetadataNotEmpty;
-import static org.dspace.app.rest.matcher.MetadataMatcher.matchMetadataStringContains;
+import static org.dspace.app.rest.matcher.MetadataMatcher.matchMetadataStringEndsWith;
 import static org.dspace.core.Constants.WRITE;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
@@ -1130,7 +1130,7 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
                             .andExpect(jsonPath("$",
                                 hasJsonPath("$.metadata", Matchers.allOf(
                                     matchMetadataNotEmpty("dc.identifier.uri"),
-                                    matchMetadataStringContains("dc.identifier.uri", handle.get())
+                                    matchMetadataStringEndsWith("dc.identifier.uri", handle.get())
                                 )
                             )))
                             .andDo(result -> idRef

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CollectionRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CollectionRestRepositoryIT.java
@@ -11,6 +11,8 @@ import static com.jayway.jsonpath.JsonPath.read;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static org.dspace.app.rest.matcher.MetadataMatcher.matchMetadata;
 import static org.dspace.app.rest.matcher.MetadataMatcher.matchMetadataDoesNotExist;
+import static org.dspace.app.rest.matcher.MetadataMatcher.matchMetadataNotEmpty;
+import static org.dspace.app.rest.matcher.MetadataMatcher.matchMetadataStringContains;
 import static org.dspace.core.Constants.WRITE;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
@@ -1074,6 +1076,7 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
 
         AtomicReference<UUID> idRef = new AtomicReference<>();
         AtomicReference<UUID> idRefNoEmbeds = new AtomicReference<>();
+        AtomicReference<String> handle = new AtomicReference<>();
         try {
 
         ObjectMapper mapper = new ObjectMapper();
@@ -1121,6 +1124,15 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
                                     MetadataMatcher.matchMetadata("dc.title",
                                             "Title Text")
                                 )))))
+                            // capture "handle" returned in JSON response and check against the metadata
+                            .andDo(result -> handle.set(
+                                    read(result.getResponse().getContentAsString(), "$.handle")))
+                            .andExpect(jsonPath("$",
+                                hasJsonPath("$.metadata", Matchers.allOf(
+                                    matchMetadataNotEmpty("dc.identifier.uri"),
+                                    matchMetadataStringContains("dc.identifier.uri", handle.get())
+                                )
+                            )))
                             .andDo(result -> idRef
                                     .set(UUID.fromString(read(result.getResponse().getContentAsString(), "$.id"))));;
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
@@ -11,6 +11,8 @@ import static com.jayway.jsonpath.JsonPath.read;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static junit.framework.TestCase.assertEquals;
 import static org.dspace.app.rest.matcher.MetadataMatcher.matchMetadata;
+import static org.dspace.app.rest.matcher.MetadataMatcher.matchMetadataNotEmpty;
+import static org.dspace.app.rest.matcher.MetadataMatcher.matchMetadataStringContains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -117,6 +119,8 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
         // Capture the UUID of the created Community (see andDo() below)
         AtomicReference<UUID> idRef = new AtomicReference<>();
         AtomicReference<UUID> idRefNoEmbeds = new AtomicReference<>();
+        AtomicReference<String> handle = new AtomicReference<>();
+
         try {
             getClient(authToken).perform(post("/api/core/communities")
                                         .content(mapper.writeValueAsBytes(comm))
@@ -136,15 +140,26 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
                                     hasJsonPath("$._links.subcommunities.href", not(empty())),
                                     hasJsonPath("$._links.self.href", not(empty())),
                                     hasJsonPath("$.metadata", Matchers.allOf(
-                                        matchMetadata("dc.description", "<p>Some cool HTML code here</p>"),
-                                        matchMetadata("dc.description.abstract",
-                                               "Sample top-level community created via the REST API"),
-                                        matchMetadata("dc.description.tableofcontents", "<p>HTML News</p>"),
-                                        matchMetadata("dc.rights", "Custom Copyright Text"),
-                                        matchMetadata("dc.title", "Title Text")
+                                            matchMetadata("dc.description", "<p>Some cool HTML code here</p>"),
+                                            matchMetadata("dc.description.abstract",
+                                                   "Sample top-level community created via the REST API"),
+                                            matchMetadata("dc.description.tableofcontents", "<p>HTML News</p>"),
+                                            matchMetadata("dc.rights", "Custom Copyright Text"),
+                                            matchMetadata("dc.title", "Title Text")
+                                            )
                                         )
-                                    )
                                 )))
+
+                                // capture "handle" returned in JSON response and check against the metadata
+                                .andDo(result -> handle.set(
+                                        read(result.getResponse().getContentAsString(), "$.handle")))
+                                .andExpect(jsonPath("$",
+                                    hasJsonPath("$.metadata", Matchers.allOf(
+                                        matchMetadataNotEmpty("dc.identifier.uri"),
+                                        matchMetadataStringContains("dc.identifier.uri", handle.get())
+                                        )
+                                    )))
+
                                 // capture "id" returned in JSON response
                                 .andDo(result -> idRef
                                     .set(UUID.fromString(read(result.getResponse().getContentAsString(), "$.id"))));
@@ -233,8 +248,9 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
             .put("dc.title",
                 new MetadataValueRest("Title Text")));
 
-        // Capture the UUID of the created Community (see andDo() below)
+        // Capture the UUID and Handle of the created Community (see andDo() below)
         AtomicReference<UUID> idRef = new AtomicReference<>();
+        AtomicReference<String> handle = new AtomicReference<>();
         try {
             getClient(authToken).perform(post("/api/core/communities")
                 .content(mapper.writeValueAsBytes(comm))
@@ -253,17 +269,26 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
                                     hasJsonPath("$._links.subcommunities.href", not(empty())),
                                     hasJsonPath("$._links.self.href", not(empty())),
                                     hasJsonPath("$.metadata", Matchers.allOf(
-                                        MetadataMatcher.matchMetadata("dc.description",
-                                            "<p>Some cool HTML code here</p>"),
-                                        MetadataMatcher.matchMetadata("dc.description.abstract",
-                                            "Sample top-level community created via the REST API"),
-                                        MetadataMatcher.matchMetadata("dc.description.tableofcontents",
-                                            "<p>HTML News</p>"),
-                                        MetadataMatcher.matchMetadata("dc.rights",
-                                            "Custom Copyright Text"),
-                                        MetadataMatcher.matchMetadata("dc.title",
-                                            "Title Text")
+                                            MetadataMatcher.matchMetadata("dc.description",
+                                                "<p>Some cool HTML code here</p>"),
+                                            MetadataMatcher.matchMetadata("dc.description.abstract",
+                                                "Sample top-level community created via the REST API"),
+                                            MetadataMatcher.matchMetadata("dc.description.tableofcontents",
+                                                "<p>HTML News</p>"),
+                                            MetadataMatcher.matchMetadata("dc.rights",
+                                                "Custom Copyright Text"),
+                                            MetadataMatcher.matchMetadata("dc.title",
+                                                "Title Text")
+                                            )
                                         )
+                                )))
+                                // capture "handle" returned in JSON response and check against the metadata
+                                .andDo(result -> handle.set(
+                                        read(result.getResponse().getContentAsString(), "$.handle")))
+                                .andExpect(jsonPath("$",
+                                    hasJsonPath("$.metadata", Matchers.allOf(
+                                        matchMetadataNotEmpty("dc.identifier.uri"),
+                                        matchMetadataStringContains("dc.identifier.uri", handle.get())
                                     )
                                 )))
                                 // capture "id" returned in JSON response

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
@@ -12,7 +12,7 @@ import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static junit.framework.TestCase.assertEquals;
 import static org.dspace.app.rest.matcher.MetadataMatcher.matchMetadata;
 import static org.dspace.app.rest.matcher.MetadataMatcher.matchMetadataNotEmpty;
-import static org.dspace.app.rest.matcher.MetadataMatcher.matchMetadataStringContains;
+import static org.dspace.app.rest.matcher.MetadataMatcher.matchMetadataStringEndsWith;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -156,7 +156,7 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
                                 .andExpect(jsonPath("$",
                                     hasJsonPath("$.metadata", Matchers.allOf(
                                         matchMetadataNotEmpty("dc.identifier.uri"),
-                                        matchMetadataStringContains("dc.identifier.uri", handle.get())
+                                        matchMetadataStringEndsWith("dc.identifier.uri", handle.get())
                                         )
                                     )))
 
@@ -288,7 +288,7 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
                                 .andExpect(jsonPath("$",
                                     hasJsonPath("$.metadata", Matchers.allOf(
                                         matchMetadataNotEmpty("dc.identifier.uri"),
-                                        matchMetadataStringContains("dc.identifier.uri", handle.get())
+                                        matchMetadataStringEndsWith("dc.identifier.uri", handle.get())
                                     )
                                 )))
                                 // capture "id" returned in JSON response

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/EPersonRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/EPersonRestRepositoryIT.java
@@ -10,6 +10,7 @@ package org.dspace.app.rest;
 import static com.jayway.jsonpath.JsonPath.read;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static org.dspace.app.rest.matcher.MetadataMatcher.matchMetadata;
+import static org.dspace.app.rest.matcher.MetadataMatcher.matchMetadataDoesNotExist;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
@@ -132,7 +133,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
                                hasJsonPath("$._links.self.href", not(empty())),
                                hasJsonPath("$.metadata", Matchers.allOf(
                                        matchMetadata("eperson.firstname", "John"),
-                                       matchMetadata("eperson.lastname", "Doe")
+                                       matchMetadata("eperson.lastname", "Doe"),
+                                       matchMetadataDoesNotExist("dc.identifier.uri")
                                )))))
                             .andDo(result -> idRef
                                     .set(UUID.fromString(read(result.getResponse().getContentAsString(), "$.id"))));

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/MetadataMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/MetadataMatcher.java
@@ -15,7 +15,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
 import org.hamcrest.Matcher;
-import org.hamcrest.core.StringContains;
+import org.hamcrest.core.StringEndsWith;
 
 /**
  * Utility class to provide convenient matchers for metadata.
@@ -46,14 +46,14 @@ public class MetadataMatcher {
     }
 
     /**
-     * Gets a matcher to ensure that at least one value for a given metadata key contains the given subString.
+     * Gets a matcher to ensure that at least one value for a given metadata key endsWith the given subString.
      * @param key the metadata key.
+     * @param subString the subString which the value must end with
      * @return the matcher
      */
-    public static Matcher<? super Object> matchMetadataStringContains(String key, String subString) {
-        return hasJsonPath("$.['" + key + "'][*].value", hasItem(StringContains.containsString(subString)));
+    public static Matcher<? super Object> matchMetadataStringEndsWith(String key, String subString) {
+        return hasJsonPath("$.['" + key + "'][*].value", hasItem(StringEndsWith.endsWith(subString)));
     }
-
 
     /**
      * Gets a matcher to ensure a given value is present at a specific position in the list of values for a given key.

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/MetadataMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/MetadataMatcher.java
@@ -9,10 +9,13 @@ package org.dspace.app.rest.matcher;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasNoJsonPath;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 
 import org.hamcrest.Matcher;
+import org.hamcrest.core.StringContains;
 
 /**
  * Utility class to provide convenient matchers for metadata.
@@ -32,6 +35,25 @@ public class MetadataMatcher {
     public static Matcher<? super Object> matchMetadata(String key, String value) {
         return hasJsonPath("$.['" + key + "'][*].value", hasItem(value));
     }
+
+    /**
+     * Gets a matcher to ensure a given key contains at least one value.
+     * @param key the metadata key.
+     * @return the matcher
+     */
+    public static Matcher<? super Object> matchMetadataNotEmpty(String key) {
+        return hasJsonPath("$.['" + key + "']", not(empty()));
+    }
+
+    /**
+     * Gets a matcher to ensure that at least one value for a given metadata key contains the given subString.
+     * @param key the metadata key.
+     * @return the matcher
+     */
+    public static Matcher<? super Object> matchMetadataStringContains(String key, String subString) {
+        return hasJsonPath("$.['" + key + "'][*].value", hasItem(StringContains.containsString(subString)));
+    }
+
 
     /**
      * Gets a matcher to ensure a given value is present at a specific position in the list of values for a given key.


### PR DESCRIPTION
## References
* Fixes #[887](https://github.com/DSpace/dspace-angular/issues/887)

## Description
As for items, when we create a new Community or Collection, the handle is saved as a metadata value (dc.identifier.uri) fetching the correct prefix from the configuration.

## Instructions for Reviewers
Tests to prove the metadata value insertion after creation of top community, sub community and collection have been implemented. We prove also that the same logic is not applied to other dso object (Tested for eperson).

List of changes in this PR:
* The handle metadata creation for communities and collection has been deferred after the object creation due to permission errors. In particular the community parents structure must be evaluated before creating the metadata value.
* Previously during the Community and Collection creation the passed rest metadata used to override any existing metadata values for the created object. A merge method as been added to prevent the new handle metadata to be immediately erased. See [here](https://github.com/4Science/DSpace/blob/a0b5cf90751e6fb7e1884ecb00d57713be0303f2/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CollectionRestRepository.java#L248) and [here](https://github.com/4Science/DSpace/blob/a0b5cf90751e6fb7e1884ecb00d57713be0303f2/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CommunityRestRepository.java#L143)
* The common code for top community and sub community creation code in CommunityRestRespository [have been factorized](https://github.com/4Science/DSpace/blob/a0b5cf90751e6fb7e1884ecb00d57713be0303f2/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CommunityRestRepository.java#L127) to avoid code duplication.
* For DOIIdentifierProvider and EZIDIdentifierProvider the process is skipped for DSpaceObjects different from Item.
* HandleIdentifierProvider and VersionHandleIdentifierProvider have been generalized and the process is skipped for DspaceObjects different from Item, Collection or Community.
* Several unit tests of CollectionTest and CommunityTest have been fixed doubling the mocked methods of the AuthorizeService. This is mainly due to some code duplication on the service side.
* A flyway script takes care to populate the dc.identifier.uri metadata for any existing community and collection. Since we needed to retrieve the handlePrefix from the configuration, a java based migration has been implemented, and the value is passed to the query via prepared statement for security reason.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.