### PR TITLE
Speed up Docker image rebuilds with BuildKit and better layer reuse

### DIFF
--- a/Dockerfile.jdk8-test
+++ b/Dockerfile.jdk8-test
@@ -8,50 +8,106 @@
 # - note: expose /solr to any host; provide /rest over http
 # - default tag for branch: dspace/dspace: dspace/dspace:dspace-6_x-jdk8
 
+# Step 0 - Get Maven dependencies
+FROM maven:3-jdk-8 as mvndeps
+
+RUN mkdir -p /code/dspace/modules/{additions,rest,xmlui-mirage2,xmlui,solr,jspui,oai,swordv2,sword,rdf} \
+    && mkdir -p /code/{dspace-jspui,dspace-swordv2,dspace-xmlui-mirage2,dspace-oai,dspace-rest,dspace-xmlui,dspace-api,dspace-solr,dspace-sword,dspace-services}
+
+COPY ./pom.xml /code
+COPY ./dspace/pom.xml /code/dspace/
+COPY ./dspace/modules/pom.xml /code/dspace/modules/
+COPY ./dspace/modules/additions/pom.xml /code/dspace/modules/additions/
+COPY ./dspace/modules/rest/pom.xml /code/dspace/modules/rest/
+COPY ./dspace/modules/xmlui-mirage2/pom.xml /code/dspace/modules/xmlui-mirage2/
+COPY ./dspace/modules/xmlui/pom.xml /code/dspace/modules/xmlui/
+COPY ./dspace/modules/solr/pom.xml /code/dspace/modules/solr/
+COPY ./dspace/modules/jspui/pom.xml /code/dspace/modules/jspui/
+COPY ./dspace/modules/oai/pom.xml /code/dspace/modules/oai/
+COPY ./dspace/modules/swordv2/pom.xml /code/dspace/modules/swordv2/
+COPY ./dspace/modules/sword/pom.xml /code/dspace/modules/sword/
+COPY ./dspace/modules/rdf/pom.xml /code/dspace/modules/rdf/
+COPY ./dspace-jspui/pom.xml /code/dspace-jspui/
+COPY ./dspace-rdf/pom.xml /code/dspace-rdf/
+COPY ./dspace-swordv2/pom.xml /code/dspace-swordv2/
+COPY ./dspace-xmlui-mirage2/pom.xml /code/dspace-xmlui-mirage2/
+COPY ./dspace-oai/pom.xml /code/dspace-oai/
+COPY ./dspace-rest/pom.xml /code/dspace-rest/
+COPY ./dspace-xmlui/pom.xml /code/dspace-xmlui/
+COPY ./dspace-api/pom.xml /code/dspace-api/
+COPY ./dspace-solr/pom.xml /code/dspace-solr/
+COPY ./dspace-sword/pom.xml /code/dspace-sword/
+COPY ./dspace-services/pom.xml /code/dspace-services/
+
+WORKDIR /code
+RUN mvn -Dmirage2.on=true de.qaware.maven:go-offline-maven-plugin:1.2.6:resolve-dependencies
+
 # Step 1 - Run Maven Build
 FROM dspace/dspace-dependencies:dspace-6_x as build
 ARG TARGET_DIR=dspace-installer
-WORKDIR /app
+
+# Install node, npm, bower, grunt, and compass (for reuse in layers)
+WORKDIR /opt
+RUN (wget -O- https://nodejs.org/dist/v8.10.0/node-v8.10.0-linux-x64.tar.gz | tar xzf -) \
+    && mv node-v8.10.0-linux-x64/ node \
+    && cd /usr/local/bin \
+    && ln -s /opt/node/bin/node \
+    && ln -s /opt/node/bin/npm \
+    && npm install npm@6.5.0 -g \
+    && npm install bower@1.7.9 -g \
+    && ln -s /opt/node/bin/bower \
+    && npm install grunt -g \
+    && ln -s /opt/node/bin/grunt \
+    && apt-get update \
+    && apt-get install -yq --no-install-recommends ruby ruby-dev build-essential \
+    && gem install compass \
+    && apt-get purge -yq build-essential ruby-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 # The dspace-install directory will be written to /install
 RUN mkdir /install \
     && chown -Rv dspace: /install
 
+WORKDIR /app
 USER dspace
+
+ENV GEM_PATH "/var/lib/gems/2.3.0:/root/.gem/ruby/2.3.0:/usr/lib/x86_64-linux-gnu/rubygems-integration/2.3.0:/usr/share/rubygems-integration/2.3.0:/usr/share/rubygems-integration/all:/home/dspace/.gem/ruby/2.3.0"
+ENV GEM_HOME "/home/dspace/.gem/ruby/2.3.0"
+
+COPY --from=mvndeps --chown=dspace /root/.m2 /home/dspace/.m2
 
 # Copy the DSpace source code into the workdir (excluding .dockerignore contents)
 ADD --chown=dspace . /app/
 COPY dspace/src/main/docker/local.cfg /app/local.cfg
 
 # Build DSpace.  Copy the dspace-install directory to /install.  Clean up the build to keep the docker image small
-RUN mvn package -Dmirage2.on=true && \
+RUN mvn package -Dmirage2.on=true -Dmirage2.deps.included=false && \
   mv /app/dspace/target/${TARGET_DIR}/* /install && \
   mvn clean
 
 # Step 2 - Run Ant Deploy
 FROM tomcat:8-jre8 as ant_build
 ARG TARGET_DIR=dspace-installer
-COPY --from=build /install /dspace-src
-WORKDIR /dspace-src
 
 # Create the initial install deployment using ANT
 ENV ANT_VERSION 1.10.7
 ENV ANT_HOME /tmp/ant-$ANT_VERSION
 ENV PATH $ANT_HOME/bin:$PATH
-
 RUN mkdir $ANT_HOME && \
     wget -qO- "https://archive.apache.org/dist/ant/binaries/apache-ant-$ANT_VERSION-bin.tar.gz" | tar -zx --strip-components=1 -C $ANT_HOME
 
+COPY --from=build /install /dspace-src
+WORKDIR /dspace-src
 RUN ant init_installation update_configs update_code update_webapps update_solr_indexes
 
 # Step 3 - Run tomcat
 # Create a new tomcat image that does not retain the the build directory contents
 FROM tomcat:8-jre8
 ENV DSPACE_INSTALL=/dspace
-COPY --from=ant_build /dspace $DSPACE_INSTALL
+ENV JAVA_OPTS=-Xmx2000m
 EXPOSE 8080 8009
 
-ENV JAVA_OPTS=-Xmx2000m
+COPY --from=ant_build /dspace $DSPACE_INSTALL
 
 RUN ln -s $DSPACE_INSTALL/webapps/solr    /usr/local/tomcat/webapps/solr    && \
     ln -s $DSPACE_INSTALL/webapps/xmlui   /usr/local/tomcat/webapps/xmlui   && \

--- a/compose.sh
+++ b/compose.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Use BuildKit, which uses more aggressive parallelism and
+# caching of intermediate stages
+export COMPOSE_DOCKER_CLI_BUILD=1
+export DOCKER_BUILDKIT=1
+
+if test -w /var/run/docker.sock; then
+    COMPOSE="docker-compose"
+else
+    COMPOSE="sudo docker-compose"
+fi
+
+${COMPOSE} -p d6 -f docker-compose.yml "$@"
+
+if [ $? -ne 0 ]; then
+    echo
+    echo To pull the latest DSpace docker container, please run ./compose.sh pull
+    echo To build DSpace, please run ./compose.sh build
+    echo To run DSpace and make it available on http://127.0.0.1:8080/xmlui please run: ./compose.sh up
+    echo For any other docker-compose command, please run ./compose.sh COMMAND
+    echo
+fi


### PR DESCRIPTION
Using BuildKit, we can parallelize the build of the multi-stage Dockerfile by moving the things that do not require the DSpace
source code to the beginning of each stage. This includes the installation of the basic build tools, such as Node, npm, or Grunt.

This commit speeds up the rebuild of Docker images by reordering the various stages, using layers to preinstall the frontend tools, and using a new stage to cache the Maven dependencies in its own layer. Due to limitations in the Dockerfile format, this requires listing each and every POM file in the project, but hopefully this shouldn't require changing very often.

The commit also adds a convenience compose.sh script for using Docker compose, so you can simply do this:

    ./compose.sh build
    ./compose.sh up

The commit needs to explicitly set up the GEM_HOME and GEM_PATH environment variables, because the Grunt execution is given those variables and the build fails with an empty GEM_PATH. Alternatively, we could drop the mention of GEM_HOME and GEM_PATH in the dspace/modules/xmlui-mirage2/pom.xml file.

## Description

Speeds up rebuilds of the Docker image with BuildKit and reordering of steps.

## Instructions for Reviewers

To test this PR, use the `compose.sh` script to run the build. Please see above instructions.

## Checklist

_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.