### PR TITLE
Disable stacktrace in error responses by default. Document how to enable for development

### DIFF
--- a/dspace-server-webapp/src/main/resources/application.properties
+++ b/dspace-server-webapp/src/main/resources/application.properties
@@ -67,20 +67,15 @@ spring.http.encoding.enabled=true
 spring.http.encoding.force=true
 
 ###########################
-# Embedded Tomcat Settings
+# Server Properties
 #
-# Change application port (for embedded Tomcat)
-# Spring Boot app will be available at http://localhost:[server.port]/
-server.port=8080
-
-# Context path where application should be made available
-# (Optional, defaults to root context)
-#server.context-path=/spring-data-rest
-
 # Error handling settings
-# Always include the fullstacktrace in error pages
-# Can be set to "never" if you don't want it.
-server.error.include-stacktrace = always
+# Whether to include the full Java stacktrace in error responses (in the "trace" property).
+# Valid values include "always" and "never".
+# Spring Boot & DSpace default to "never" as this is more secure for Production (as stacktraces may include info
+# or hints that hackers can use to attack your site).
+# However, you may wish to set this to "always" in your 'local.cfg' for development or debugging purposes.
+server.error.include-stacktrace = never
 
 ######################
 # Spring Boot Autoconfigure


### PR DESCRIPTION
Discovered via discussion in https://github.com/DSpace/DSpace/issues/3045

By default, DSpace should set `server.error.include-stacktrace = never` (which is the default setting for Spring Boot).  This ensures that the `trace` property is never returned in error responses.  This behavior is necessary to avoid "[Information Exposure through a stack trace](https://lgtm.com/rules/6780073/)" security issues.

If a developer wants to see the stack trace, they can simply add this to their `local.cfg` file:
`server.error.include-stacktrace = always`
(That setting in your `local.cfg` will override the defaults in our `application.properties` file)

When set to `always`, any error response will include the full Java stack trace (in the `trace` property in the response).  However, as noted above, this setting is not recommended for Production.