### PR TITLE
Added self link to root endpoint

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/link/RootHalLinkFactory.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/link/RootHalLinkFactory.java
@@ -14,6 +14,7 @@ import org.dspace.app.rest.RootRestResourceController;
 import org.dspace.app.rest.model.hateoas.RootResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
+import org.springframework.hateoas.IanaLinkRelations;
 import org.springframework.hateoas.Link;
 import org.springframework.stereotype.Component;
 
@@ -32,6 +33,7 @@ public class RootHalLinkFactory extends HalLinkFactory<RootResource, RootRestRes
                 buildLink(endpointLink.getRel().value(),
                           halResource.getContent().getDspaceServer() + endpointLink.getHref()));
         }
+        list.add(buildLink(IanaLinkRelations.SELF.value(), getMethodOn().listDefinedEndpoint(null)));
     }
 
     protected Class<RootRestResourceController> getControllerClass() {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/RootRestResourceControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/RootRestResourceControllerIT.java
@@ -69,6 +69,7 @@ public class RootRestResourceControllerIT extends AbstractControllerIntegrationT
                    .andExpect(jsonPath("$._links.submissionuploads.href", startsWith(BASE_REST_SERVER_URL)))
                    .andExpect(jsonPath("$._links.workspaceitems.href", startsWith(BASE_REST_SERVER_URL)))
                    .andExpect(jsonPath("$._links.authn.href", startsWith(BASE_REST_SERVER_URL)))
+                   .andExpect(jsonPath("$._links.self.href", startsWith(BASE_REST_SERVER_URL)))
         ;
     }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/RootRestResourceControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/RootRestResourceControllerIT.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.app.rest;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.startsWith;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -24,6 +25,8 @@ import org.junit.Test;
  * @author Tom Desair (tom dot desair at atmire dot com)
  */
 public class RootRestResourceControllerIT extends AbstractControllerIntegrationTest {
+
+    private static final String ROOT_REST_SERVER_URL = "http://localhost/api";
 
     @Test
     public void serverPropertiesTest() throws Exception {
@@ -69,7 +72,7 @@ public class RootRestResourceControllerIT extends AbstractControllerIntegrationT
                    .andExpect(jsonPath("$._links.submissionuploads.href", startsWith(BASE_REST_SERVER_URL)))
                    .andExpect(jsonPath("$._links.workspaceitems.href", startsWith(BASE_REST_SERVER_URL)))
                    .andExpect(jsonPath("$._links.authn.href", startsWith(BASE_REST_SERVER_URL)))
-                   .andExpect(jsonPath("$._links.self.href", startsWith(BASE_REST_SERVER_URL)))
+                   .andExpect(jsonPath("$._links.self.href", equalTo(ROOT_REST_SERVER_URL)))
         ;
     }
 


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/DSpace/issues/3049

## Description
This PR adds the self link to the Root endpoint of the REST api.

## Instructions for Reviewers

List of changes in this PR:
* Added self link to the root endpoint
* Added assertion in IT to prove that it works

How to test this PR:
* Boot up the REST api HAL browser from this branch
* Go to the root endpoint and verify that a "self" link is available that points to the same page when you navigate to it

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
