### PR TITLE
Fix obvious bug in SiteServiceInitializer

### DIFF
--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/SiteServiceInitializer.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/SiteServiceInitializer.java
@@ -45,8 +45,8 @@ public class SiteServiceInitializer implements Callback {
             context = new Context();
             context.turnOffAuthorisationSystem();
             // Create Site object if it doesn't exist in database
-            Site site = null;
-            if (siteService.findSite(context) == null) {
+            Site site = siteService.findSite(context);
+            if (site == null) {
                 site = siteService.createSite(context);
             }
             context.restoreAuthSystemState();


### PR DESCRIPTION
This was discovered by accident while I was looking at DSpace logs and testing the new Flyway Migration in https://github.com/DSpace/DSpace/pull/3046

Our Flyway Callback `SiteServiceInitializer` has an obvious bug if it runs when the Site object _already exists_ in the database.  Namely, when the Site exists, the `SiteServiceInitializer` returns this stacktrace:
```
2020-11-23 15:01:29,948 ERROR org.dspace.storage.rdbms.SiteServiceInitializer @ Error attempting to add/update default Site object
java.lang.NullPointerException: null
        at org.dspace.authorize.ResourcePolicy.setdSpaceObject(ResourcePolicy.java:182) ~[dspace-api-7.0-beta5-SNAPSHOT.jar:7.0-beta5-SNAPSHOT]
        at org.dspace.authorize.AuthorizeServiceImpl.createResourcePolicy(AuthorizeServiceImpl.java:731) ~[dspace-api-7.0-beta5-SNAPSHOT.jar:7.0-beta5-SNAPSHOT]
        at org.dspace.authorize.AuthorizeServiceImpl.createResourcePolicy(AuthorizeServiceImpl.java:718) ~[dspace-api-7.0-beta5-SNAPSHOT.jar:7.0-beta5-SNAPSHOT]
        at org.dspace.authorize.AuthorizeServiceImpl.addPolicy(AuthorizeServiceImpl.java:490) ~[dspace-api-7.0-beta5-SNAPSHOT.jar:7.0-beta5-SNAPSHOT]
        at org.dspace.storage.rdbms.SiteServiceInitializer.initializeSiteObject(SiteServiceInitializer.java:58) [dspace-api-7.0-beta5-SNAPSHOT.jar:7.0-beta5-SNAPSHOT]
        at org.dspace.storage.rdbms.SiteServiceInitializer.handle(SiteServiceInitializer.java:106) [dspace-api-7.0-beta5-SNAPSHOT.jar:7.0-beta5-SNAPSHOT]
        at org.flywaydb.core.internal.callback.DefaultCallbackExecutor.handleEvent(DefaultCallbackExecutor.java:127) [flyway-core-6.5.5.jar:?]
        at org.flywaydb.core.internal.callback.DefaultCallbackExecutor.execute(DefaultCallbackExecutor.java:122) [flyway-core-6.5.5.jar:?]
        at org.flywaydb.core.internal.callback.DefaultCallbackExecutor.access$000(DefaultCallbackExecutor.java:38) [flyway-core-6.5.5.jar:?]
        at org.flywaydb.core.internal.callback.DefaultCallbackExecutor$1.call(DefaultCallbackExecutor.java:108) [flyway-core-6.5.5.jar:?]
        at org.flywaydb.core.internal.callback.DefaultCallbackExecutor$1.call(DefaultCallbackExecutor.java:105) [flyway-core-6.5.5.jar:?]
        at org.flywaydb.core.internal.jdbc.TransactionalExecutionTemplate.execute(TransactionalExecutionTemplate.java:66) [flyway-core-6.5.5.jar:?]
        at org.flywaydb.core.internal.callback.DefaultCallbackExecutor.execute(DefaultCallbackExecutor.java:105) [flyway-core-6.5.5.jar:?]
        at org.flywaydb.core.internal.callback.DefaultCallbackExecutor.onMigrateOrUndoEvent(DefaultCallbackExecutor.java:67) [flyway-core-6.5.5.jar:?]
        at org.flywaydb.core.internal.command.DbMigrate.migrate(DbMigrate.java:147) [flyway-core-6.5.5.jar:?]
        at org.flywaydb.core.Flyway$1.execute(Flyway.java:206) [flyway-core-6.5.5.jar:?]
        at org.flywaydb.core.Flyway$1.execute(Flyway.java:158) [flyway-core-6.5.5.jar:?]
        at org.flywaydb.core.Flyway.execute(Flyway.java:527) [flyway-core-6.5.5.jar:?]
        at org.flywaydb.core.Flyway.migrate(Flyway.java:158) [flyway-core-6.5.5.jar:?]
        at org.dspace.storage.rdbms.DatabaseUtils.updateDatabase(DatabaseUtils.java:722) [dspace-api-7.0-beta5-SNAPSHOT.jar:7.0-beta5-SNAPSHOT]
        at org.dspace.storage.rdbms.DatabaseUtils.updateDatabase(DatabaseUtils.java:635) [dspace-api-7.0-beta5-SNAPSHOT.jar:7.0-beta5-SNAPSHOT]
        at org.dspace.storage.rdbms.DatabaseUtils.main(DatabaseUtils.java:231) [dspace-api-7.0-beta5-SNAPSHOT.jar:7.0-beta5-SNAPSHOT]
        at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
        at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:?]
        at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
        at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
        at org.dspace.app.launcher.ScriptLauncher.runOneCommand(ScriptLauncher.java:272) [dspace-api-7.0-beta5-SNAPSHOT.jar:7.0-beta5-SNAPSHOT]
        at org.dspace.app.launcher.ScriptLauncher.handleScript(ScriptLauncher.java:128) [dspace-api-7.0-beta5-SNAPSHOT.jar:7.0-beta5-SNAPSHOT]
        at org.dspace.app.launcher.ScriptLauncher.main(ScriptLauncher.java:93) [dspace-api-7.0-beta5-SNAPSHOT.jar:7.0-beta5-SNAPSHOT]
```

The issue is a **very obvious** bug in the code logic, where the `site` object is accidentally set to `null`.  This tiny PR fixes the issue.

# How to Test

**Unfortunately** this is very hard to manually test, as the `SiteServiceInitializer` is ONLY run after migrations are executed.  So, the easiest way to test is to start with a fresh database, run only some migrations, and then run the rest of the migrations.  

For example:

1.  `./dspace database clean` (remove all content)
2. `./dspace database migrate 7.0.2020.01.08`  (Run every migration _up to_ the one with version `7.0.2020.01.08`.  This runs all migrations except for one...so, at this point the Site object will have been created in your database)
3. `./dspace database migrate`  (Run the final migration...verify no errors exist in your DSpace logs)

**Alternatively, if you have not yet run the migration in https://github.com/DSpace/DSpace/pull/3046, then you could install this PR prior to running that migration.**