### PR TITLE
Removal of automatically added 'query' parameter for entries subpath

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/link/externalsources/ExternalSourceHalLinkFactory.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/link/externalsources/ExternalSourceHalLinkFactory.java
@@ -12,6 +12,8 @@ import java.util.LinkedList;
 import org.dspace.app.rest.ExternalSourcesRestController;
 import org.dspace.app.rest.link.HalLinkFactory;
 import org.dspace.app.rest.model.hateoas.ExternalSourceResource;
+import org.dspace.services.ConfigurationService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.hateoas.Link;
 import org.springframework.stereotype.Component;
@@ -21,14 +23,18 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class ExternalSourceHalLinkFactory extends
-                                          HalLinkFactory<ExternalSourceResource, ExternalSourcesRestController> {
+        HalLinkFactory<ExternalSourceResource, ExternalSourcesRestController> {
+    @Autowired
+    ConfigurationService configurationService;
 
     @Override
     protected void addLinks(ExternalSourceResource halResource, Pageable pageable, LinkedList<Link> list)
-        throws Exception {
+            throws Exception {
 
-        list.add(buildLink("entries", getMethodOn()
-            .getExternalSourceEntries(halResource.getContent().getName(), "", null, null, null)));
+        String dspaceServerUrl = configurationService.getProperty("dspace.server.url");
+        list.add(
+                buildLink("entries", dspaceServerUrl + "/api/integration/externalsources/" +
+                        halResource.getContent().getName() + "/entries"));
 
     }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/ExternalSourceMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/ExternalSourceMatcher.java
@@ -8,6 +8,7 @@
 package org.dspace.app.rest.matcher;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.dspace.app.rest.test.AbstractControllerIntegrationTest.REST_SERVER_URL;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.is;
 
@@ -22,7 +23,9 @@ public class ExternalSourceMatcher {
         return allOf(
             hasJsonPath("$.id", is(id)),
             hasJsonPath("$.name", is(name)),
-            hasJsonPath("$.hierarchical", is(hierarchical))
+            hasJsonPath("$.hierarchical", is(hierarchical)),
+            hasJsonPath("$._links.entries.href", is(REST_SERVER_URL +
+                                                            "integration/externalsources/" + name + "/entries"))
         );
     }
 }


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes [#2954](https://github.com/DSpace/DSpace/issues/2954)

## Description
This PR removes the automatically added "query" parameter that is prepended on the REST API's link to the entries. This makes sure that the related Angular UI doesn't add it's own 'query' parameter, resulting in two query params -> Breaking the functionality
## Instructions for Reviewers

* In the [ExternalSourceHalLinkFactory](https://github.com/DSpace/DSpace/compare/main...atmire:74271-External-sources-query-param-issue?expand=1#diff-b5b52aa15f3babdf9b5b5d98f6a2b8118e21d8ae830371cc9b81c403890b1337R34), the link was created using the buildLink method rather than the previously used getMethodOn() method
    * The reason for this is that the link generated by spring getMethod on and will add the mandatory param automatically
* The tests were added to make sure that the JSON path contains the entries link without the query parameter

To reproduce this, go to an externalsources endpoint (ie, `server/api/integration/externalsources/orcidV2`), and check out the entries link returned by that response. This should NOT include the query parameter


**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
