### PR TITLE
Add CI to GitHub via Actions (based on Travis CI config)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,6 @@ name: Build
 # Run this Build only for pushes / PRs to main branch
 on:
   push:
-    branches: main
   pull_request:
     branches: main
 


### PR DESCRIPTION
## References
* Related to https://github.com/DSpace/DSpace/pull/3060

## Description
The changes in https://github.com/DSpace/DSpace/pull/3060 caused the test builds to stop working on the source github branch
E.g. https://github.com/atmire/DSpace/tree/w2p-74727_Nullpointer-workflow-item-after-submitter-delete no longer contains a test build prior to creating the PR