### PR TITLE
Update build.yml to not limit by branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,12 +3,8 @@
 # https://docs.github.com/en/free-pro-team@latest/actions/guides/building-and-testing-java-with-maven
 name: Build
 
-# Run this Build only for pushes / PRs to main branch
-on:
-  push:
-    branches: main
-  pull_request:
-    branches: main
+# Run this Build for all pushes / PRs to current branch
+on: [push, pull_request]
 
 jobs:
   tests:


### PR DESCRIPTION
* Replaces #3069
* Updates original PR #3060

Based on discussion in Slack & PR #3069 , this just updates our `build.yml` to run on every push/PR to the current branch.  @abollini pointed out (in Slack) that this seems to be the ideal build process, as GitHub is smart enough to only use the `build.yml` for the current branch.

This should also be backported/cherry-picked to `dspace-6_x` and `dspace-5_x` to correct their configurations. 
