### PR TITLE
Fix dependency convergence issues (for javassist) on main branch

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -848,17 +848,21 @@
             <version>3.0.2</version>
             <exclusions>
                 <exclusion>
-		          <groupId>javax.validation</groupId>
-		          <artifactId>validation-api</artifactId>
-		        </exclusion>
-		        <exclusion>
-		          <groupId>com.fasterxml.jackson.jaxrs</groupId>
-		          <artifactId>jackson-jaxrs-json-provider</artifactId>
-		        </exclusion>
-		        <exclusion>
-		          <groupId>org.yaml</groupId>
-		          <artifactId>snakeyaml</artifactId>
-		        </exclusion>
+                    <groupId>javax.validation</groupId>
+                    <artifactId>validation-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.jaxrs</groupId>
+                    <artifactId>jackson-jaxrs-json-provider</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.yaml</groupId>
+                    <artifactId>snakeyaml</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.javassist</groupId>
+                    <artifactId>javassist</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 


### PR DESCRIPTION
After merging #2780, a dependency convergence issue appeared on `main` ([see build](https://github.com/DSpace/DSpace/runs/1475282242?check_suite_focus=true)):

```
Warning:  
Dependency convergence error for org.javassist:javassist:3.25.0-GA paths to dependency are:
+-org.dspace:dspace-api:7.0-beta5-SNAPSHOT
  +-org.glassfish.jersey.inject:jersey-hk2:2.30.1
    +-org.javassist:javassist:3.25.0-GA
and
+-org.dspace:dspace-api:7.0-beta5-SNAPSHOT
  +-org.orcid:orcid-model:3.0.2
    +-io.swagger:swagger-jersey-jaxrs:1.5.16
      +-io.swagger:swagger-jaxrs:1.5.16
        +-org.reflections:reflections:0.9.11
          +-org.javassist:javassist:3.21.0-GA

Warning:  Rule 0: org.apache.maven.plugins.enforcer.DependencyConvergence failed with message:
Failed while enforcing releasability. See above detailed error message.
```

This PR fixes the above issue by ignoring the older javassist dependency which is being pulled in by the ORCID v3 API.   It also fixes the alignment of other existing exclusions, which were using tabs instead of spaces.