### PR TITLE
Submission forms migration script

### DIFF
--- a/dspace-api/src/main/java/org/dspace/submit/migration/SubmissionFormsMigration.java
+++ b/dspace-api/src/main/java/org/dspace/submit/migration/SubmissionFormsMigration.java
@@ -1,0 +1,156 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.submit.migration;
+
+import java.io.File;
+import javax.xml.transform.Result;
+import javax.xml.transform.Source;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
+
+import org.dspace.scripts.DSpaceRunnable;
+import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.utils.DSpace;
+
+/**
+ * Script (config {@link SubmissionFormsMigrationScriptConfiguration}) to transform the old input-forms.xml and
+ * item-submission.xml via XSLT (xsl files in dspace/config/migration) into respectively the new submission-forms.xsl
+ * and item-submissions.xsl files
+ *
+ * @author Maria Verdonck (Atmire) on 13/11/2020
+ */
+public class SubmissionFormsMigration extends DSpaceRunnable<SubmissionFormsMigrationScriptConfiguration> {
+
+    private boolean help = false;
+    private String inputFormsFilePath = null;
+    private String itemSubmissionsFilePath = null;
+
+    private static final String PATH_OUT_CONFIG =
+        DSpaceServicesFactory.getInstance().getConfigurationService().getProperty("dspace.dir")
+        + File.separator + "config";
+
+    private static final String PATH_XSL_SUBMISSION_FORMS =
+        PATH_OUT_CONFIG + File.separator + "migration" + File.separator + "submission-forms.xsl";
+    private static final String PATH_XSL_ITEM_SUBMISSION =
+        PATH_OUT_CONFIG + File.separator + "migration" + File.separator + "item-submissions.xsl";
+
+    private static final String PATH_OUT_INPUT_FORMS = PATH_OUT_CONFIG + File.separator + "submission-forms.xml";
+    private static final String PATH_OUT_ITEM_SUBMISSION = PATH_OUT_CONFIG + File.separator + "item-submission.xml";
+
+    /**
+     * We need to force this, because some dependency elsewhere interferes.
+     */
+    private static final String TRANSFORMER_FACTORY_CLASS
+        = "org.apache.xalan.processor.TransformerFactoryImpl";
+
+    @Override
+    public void internalRun() throws TransformerException {
+        if (help) {
+            printHelp();
+            return;
+        }
+        if (this.inputFormsFilePath != null) {
+            this.transformToSubmissionForms(this.inputFormsFilePath);
+        }
+        if (this.itemSubmissionsFilePath != null) {
+            this.transformToItemSubmission(this.itemSubmissionsFilePath);
+        }
+    }
+
+    private void transformToSubmissionForms(String inputFormsFilePath) throws TransformerException {
+        this.transform(inputFormsFilePath, PATH_XSL_SUBMISSION_FORMS, PATH_OUT_INPUT_FORMS);
+    }
+
+    private void transformToItemSubmission(String itemSubmissionsFilePath) throws TransformerException {
+        this.transform(itemSubmissionsFilePath, PATH_XSL_ITEM_SUBMISSION, PATH_OUT_ITEM_SUBMISSION);
+    }
+
+    /**
+     * Transforms an input xml file to an output xml file with the given xsl file
+     *
+     * @param sourceFilePath Input XML
+     * @param xsltFilePath   Transforming XSL
+     * @param outputPath     Output XML
+     */
+    private void transform(String sourceFilePath, String xsltFilePath, String outputPath)
+        throws TransformerException {
+        super.handler
+            .logInfo("Transforming " + sourceFilePath + " with xsl: " + xsltFilePath + " to output: " + outputPath);
+
+        Source xmlSource = new StreamSource(new File(sourceFilePath));
+        Source xsltSource = new StreamSource(new File(xsltFilePath));
+        Result result = new StreamResult(new File(outputPath));
+
+        // create an instance of TransformerFactory
+        TransformerFactory transformerFactory = TransformerFactory.newInstance(
+            TRANSFORMER_FACTORY_CLASS, null);
+
+        Transformer trans;
+        try {
+            trans = transformerFactory.newTransformer(xsltSource);
+        } catch (TransformerConfigurationException e) {
+            super.handler.logError("Error: the stylesheet at '" + xsltFilePath + "' couldn't be used");
+            throw e;
+        }
+
+        try {
+            trans.transform(xmlSource, result);
+        } catch (Throwable t) {
+            super.handler.logError("Error: couldn't convert the metadata file at '" + sourceFilePath);
+            throw t;
+        }
+    }
+
+    @Override
+    public void setup() {
+        if (commandLine.hasOption('h')) {
+            help = true;
+            return;
+        }
+        if (commandLine.hasOption('f')) {
+            inputFormsFilePath = commandLine.getOptionValue('f');
+            checkIfValidXMLFile(inputFormsFilePath);
+        }
+        if (commandLine.hasOption('s')) {
+            itemSubmissionsFilePath = commandLine.getOptionValue('s');
+            checkIfValidXMLFile(itemSubmissionsFilePath);
+        }
+        if (!(commandLine.hasOption('s') || commandLine.hasOption('f'))) {
+            this.throwIllegalArgumentException("Please fill in either -f <source-input-forms-path> or -s " +
+                                               "<source-item-submissions-path>; or both.");
+        }
+    }
+
+    private void checkIfValidXMLFile(String filePath) {
+        File file = new File(filePath);
+        if (!file.exists()) {
+            this.throwIllegalArgumentException("There is no file at path: " + filePath);
+        }
+        if (!file.isFile() && file.isDirectory()) {
+            this.throwIllegalArgumentException("This is a dir, not a file: " + filePath);
+        }
+        if (!file.getName().endsWith(".xml")) {
+            this.throwIllegalArgumentException("This is not an XML file (doesn't end in .xml): " + filePath);
+        }
+    }
+
+    private void throwIllegalArgumentException(String message) {
+        super.handler.logError(message);
+        throw new IllegalArgumentException(message);
+    }
+
+    @Override
+    public SubmissionFormsMigrationScriptConfiguration getScriptConfiguration() {
+        return new DSpace().getServiceManager().getServiceByName("submission-forms-migrate",
+            SubmissionFormsMigrationScriptConfiguration.class);
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/submit/migration/SubmissionFormsMigration.java
+++ b/dspace-api/src/main/java/org/dspace/submit/migration/SubmissionFormsMigration.java
@@ -51,8 +51,10 @@ public class SubmissionFormsMigration extends DSpaceRunnable<SubmissionFormsMigr
     private static final String PATH_XSL_ITEM_SUBMISSION =
         PATH_OUT_CONFIG + File.separator + "migration" + File.separator + "item-submissions.xsl";
 
-    private static final String PATH_OUT_INPUT_FORMS = PATH_OUT_CONFIG + File.separator + "submission-forms.xml";
-    private static final String PATH_OUT_ITEM_SUBMISSION = PATH_OUT_CONFIG + File.separator + "item-submission.xml";
+    private static final String PATH_OUT_INPUT_FORMS =
+        PATH_OUT_CONFIG + File.separator + "submission-forms.xml.migrated";
+    private static final String PATH_OUT_ITEM_SUBMISSION =
+        PATH_OUT_CONFIG + File.separator + "item-submission.xml.migrated";
 
     private static final String NAME_DTD_INPUT_FORMS = "input-forms.dtd";
     private static final String NAME_DTD_ITEM_SUBMISSION = "item-submission.dtd";
@@ -98,7 +100,7 @@ public class SubmissionFormsMigration extends DSpaceRunnable<SubmissionFormsMigr
         Source xsltSource = new StreamSource(new File(xsltFilePath));
         Result result = new StreamResult(new File(outputPath));
 
-        // create an instance of TransformerFactory
+        // Create an instance of TransformerFactory
         TransformerFactory transformerFactory = TransformerFactory.newInstance(
             TRANSFORMER_FACTORY_CLASS, null);
 
@@ -128,16 +130,23 @@ public class SubmissionFormsMigration extends DSpaceRunnable<SubmissionFormsMigr
         if (commandLine.hasOption('f')) {
             inputFormsFilePath = commandLine.getOptionValue('f');
             checkIfValidXMLFile(inputFormsFilePath);
+            inputFormsFilePath = getAbsolutePath(inputFormsFilePath);
         }
         if (commandLine.hasOption('s')) {
             itemSubmissionsFilePath = commandLine.getOptionValue('s');
             checkIfValidXMLFile(itemSubmissionsFilePath);
+            itemSubmissionsFilePath = getAbsolutePath(itemSubmissionsFilePath);
         }
         if (!commandLine.hasOption('s') || !commandLine.hasOption('f')) {
             this.throwParseException("Please fill in both -f <source-input-forms-path> and -s " +
                                      "<source-item-submissions-path>");
         }
         createDTDFileDummiesIfNotPresent();
+    }
+
+    private String getAbsolutePath(String relativePath) {
+        File file = new File(relativePath);
+        return file.getAbsolutePath();
     }
 
     private void createDTDFileDummiesIfNotPresent() {

--- a/dspace-api/src/main/java/org/dspace/submit/migration/SubmissionFormsMigration.java
+++ b/dspace-api/src/main/java/org/dspace/submit/migration/SubmissionFormsMigration.java
@@ -89,6 +89,7 @@ public class SubmissionFormsMigration extends DSpaceRunnable<SubmissionFormsMigr
         Transformer trans;
         try {
             trans = transformerFactory.newTransformer(xsltSource);
+            trans.setParameter("inputFormsPath", inputFormsFilePath);
         } catch (TransformerConfigurationException e) {
             handler.logError("Error: the stylesheet at '" + xsltFilePath + "' couldn't be used");
             throw e;
@@ -116,9 +117,9 @@ public class SubmissionFormsMigration extends DSpaceRunnable<SubmissionFormsMigr
             itemSubmissionsFilePath = commandLine.getOptionValue('s');
             checkIfValidXMLFile(itemSubmissionsFilePath);
         }
-        if (!(commandLine.hasOption('s') || commandLine.hasOption('f'))) {
-            this.throwParseException("Please fill in either -f <source-input-forms-path> or -s " +
-                                     "<source-item-submissions-path>; or both.");
+        if (!commandLine.hasOption('s') || !commandLine.hasOption('f')) {
+            this.throwParseException("Please fill in both -f <source-input-forms-path> and -s " +
+                                     "<source-item-submissions-path>");
         }
     }
 

--- a/dspace-api/src/main/java/org/dspace/submit/migration/SubmissionFormsMigration.java
+++ b/dspace-api/src/main/java/org/dspace/submit/migration/SubmissionFormsMigration.java
@@ -28,13 +28,13 @@ import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.utils.DSpace;
 
 /**
- * Script (config {@link SubmissionFormsMigrationScriptConfiguration}) to transform the old input-forms.xml and
+ * Script (config {@link SubmissionFormsMigrationCliScriptConfiguration}) to transform the old input-forms.xml and
  * item-submission.xml via XSLT (xsl files in dspace/config/migration) into respectively the new submission-forms.xsl
  * and item-submissions.xsl files
  *
  * @author Maria Verdonck (Atmire) on 13/11/2020
  */
-public class SubmissionFormsMigration extends DSpaceRunnable<SubmissionFormsMigrationScriptConfiguration> {
+public class SubmissionFormsMigration extends DSpaceRunnable<SubmissionFormsMigrationCliScriptConfiguration> {
 
     private boolean help = false;
     private String inputFormsFilePath = null;
@@ -200,8 +200,8 @@ public class SubmissionFormsMigration extends DSpaceRunnable<SubmissionFormsMigr
     }
 
     @Override
-    public SubmissionFormsMigrationScriptConfiguration getScriptConfiguration() {
+    public SubmissionFormsMigrationCliScriptConfiguration getScriptConfiguration() {
         return new DSpace().getServiceManager().getServiceByName("submission-forms-migrate",
-            SubmissionFormsMigrationScriptConfiguration.class);
+            SubmissionFormsMigrationCliScriptConfiguration.class);
     }
 }

--- a/dspace-api/src/main/java/org/dspace/submit/migration/SubmissionFormsMigration.java
+++ b/dspace-api/src/main/java/org/dspace/submit/migration/SubmissionFormsMigration.java
@@ -76,8 +76,7 @@ public class SubmissionFormsMigration extends DSpaceRunnable<SubmissionFormsMigr
      */
     private void transform(String sourceFilePath, String xsltFilePath, String outputPath)
         throws TransformerException {
-        super.handler
-            .logInfo("Transforming " + sourceFilePath + " with xsl: " + xsltFilePath + " to output: " + outputPath);
+        handler.logInfo("Transforming " + sourceFilePath + " with xsl: " + xsltFilePath + " to output: " + outputPath);
 
         Source xmlSource = new StreamSource(new File(sourceFilePath));
         Source xsltSource = new StreamSource(new File(xsltFilePath));
@@ -91,14 +90,14 @@ public class SubmissionFormsMigration extends DSpaceRunnable<SubmissionFormsMigr
         try {
             trans = transformerFactory.newTransformer(xsltSource);
         } catch (TransformerConfigurationException e) {
-            super.handler.logError("Error: the stylesheet at '" + xsltFilePath + "' couldn't be used");
+            handler.logError("Error: the stylesheet at '" + xsltFilePath + "' couldn't be used");
             throw e;
         }
 
         try {
             trans.transform(xmlSource, result);
         } catch (Throwable t) {
-            super.handler.logError("Error: couldn't convert the metadata file at '" + sourceFilePath);
+            handler.logError("Error: couldn't convert the metadata file at '" + sourceFilePath);
             throw t;
         }
     }
@@ -137,7 +136,7 @@ public class SubmissionFormsMigration extends DSpaceRunnable<SubmissionFormsMigr
     }
 
     private void throwParseException(String message) throws ParseException {
-        super.handler.logError(message);
+        handler.logError(message);
         throw new ParseException(message);
     }
 

--- a/dspace-api/src/main/java/org/dspace/submit/migration/SubmissionFormsMigration.java
+++ b/dspace-api/src/main/java/org/dspace/submit/migration/SubmissionFormsMigration.java
@@ -8,6 +8,10 @@
 package org.dspace.submit.migration;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import javax.xml.transform.Result;
 import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
@@ -18,6 +22,7 @@ import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 
 import org.apache.commons.cli.ParseException;
+import org.apache.commons.lang3.StringUtils;
 import org.dspace.scripts.DSpaceRunnable;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.utils.DSpace;
@@ -47,6 +52,15 @@ public class SubmissionFormsMigration extends DSpaceRunnable<SubmissionFormsMigr
     private static final String PATH_OUT_INPUT_FORMS = PATH_OUT_CONFIG + File.separator + "submission-forms.xml";
     private static final String PATH_OUT_ITEM_SUBMISSION = PATH_OUT_CONFIG + File.separator + "item-submission.xml";
 
+    private static final String NAME_DTD_INPUT_FORMS = "input-forms.dtd";
+    private static final String NAME_DTD_ITEM_SUBMISSION = "item-submission.dtd";
+    private static final String CONTENT_DTD_ITEM_SUBMISSION_DUMMY =
+        "<!ELEMENT item-submission (submission-map, step-definitions, submission-definitions) >";
+    private static final String CONTENT_DTD_INPUT_FORMS_DUMMY =
+        "<!ELEMENT input-forms (form-map, form-definitions, form-value-pairs) >";
+    private File inputFormsDummyDTDTemp;
+    private File itemSubmissionDummyDTDTemp;
+
     /**
      * We need to force this, because some dependency elsewhere interferes.
      */
@@ -65,6 +79,7 @@ public class SubmissionFormsMigration extends DSpaceRunnable<SubmissionFormsMigr
         if (this.itemSubmissionsFilePath != null) {
             this.transform(itemSubmissionsFilePath, PATH_XSL_ITEM_SUBMISSION, PATH_OUT_ITEM_SUBMISSION);
         }
+        deleteDTDFileDummies();
     }
 
     /**
@@ -120,6 +135,49 @@ public class SubmissionFormsMigration extends DSpaceRunnable<SubmissionFormsMigr
         if (!commandLine.hasOption('s') || !commandLine.hasOption('f')) {
             this.throwParseException("Please fill in both -f <source-input-forms-path> and -s " +
                                      "<source-item-submissions-path>");
+        }
+        createDTDFileDummiesIfNotPresent();
+    }
+
+    private void createDTDFileDummiesIfNotPresent() {
+        // Create temporary dummy item-submission.dtd in directory of input item-submission.xml if not present
+        String itemSubmissionDir = StringUtils.substringBeforeLast(itemSubmissionsFilePath, File.separator);
+        File itemSubmissionDTD = new File (itemSubmissionDir + File.separator + NAME_DTD_ITEM_SUBMISSION);
+        if (!itemSubmissionDTD.isFile()) {
+            itemSubmissionDummyDTDTemp = itemSubmissionDTD;
+
+            Path path = Paths.get(itemSubmissionDir + File.separator + NAME_DTD_ITEM_SUBMISSION);
+            byte[] strToBytes = CONTENT_DTD_ITEM_SUBMISSION_DUMMY.getBytes();
+
+            try {
+                Files.write(path, strToBytes);
+            } catch (IOException e) {
+                handler.logError("Error trying to create dummy " + NAME_DTD_ITEM_SUBMISSION);
+            }
+        }
+        // Create temporary dummy input-forms.dtd in directory of input input-forms.xml if not present
+        String inputFormsDir = StringUtils.substringBeforeLast(inputFormsFilePath, File.separator);
+        File inputFormsDTD = new File (inputFormsDir + File.separator + NAME_DTD_INPUT_FORMS);
+        if (!inputFormsDTD.isFile()) {
+            inputFormsDummyDTDTemp = inputFormsDTD;
+
+            Path path = Paths.get(inputFormsDir + File.separator + NAME_DTD_INPUT_FORMS);
+            byte[] strToBytes = CONTENT_DTD_INPUT_FORMS_DUMMY.getBytes();
+
+            try {
+                Files.write(path, strToBytes);
+            } catch (IOException e) {
+                handler.logError("Error trying to create dummy " + NAME_DTD_INPUT_FORMS);
+            }
+        }
+    }
+
+    private void deleteDTDFileDummies() {
+        if (itemSubmissionDummyDTDTemp != null) {
+            itemSubmissionDummyDTDTemp.delete();
+        }
+        if (inputFormsDummyDTDTemp != null) {
+            inputFormsDummyDTDTemp.delete();
         }
     }
 

--- a/dspace-api/src/main/java/org/dspace/submit/migration/SubmissionFormsMigration.java
+++ b/dspace-api/src/main/java/org/dspace/submit/migration/SubmissionFormsMigration.java
@@ -142,11 +142,12 @@ public class SubmissionFormsMigration extends DSpaceRunnable<SubmissionFormsMigr
 
     private void createDTDFileDummiesIfNotPresent() {
         // Create temporary dummy item-submission.dtd in directory of input item-submission.xml if not present
-        this.createDummyFileIfNotPresent(itemSubmissionsFilePath, NAME_DTD_ITEM_SUBMISSION, CONTENT_DTD_ITEM_SUBMISSION_DUMMY);
+        this.createDummyFileIfNotPresent(itemSubmissionsFilePath, NAME_DTD_ITEM_SUBMISSION,
+                                         CONTENT_DTD_ITEM_SUBMISSION_DUMMY);
         // Create temporary dummy input-forms.dtd in directory of input input-forms.xml if not present
         this.createDummyFileIfNotPresent(inputFormsFilePath, NAME_DTD_INPUT_FORMS, CONTENT_DTD_INPUT_FORMS_DUMMY);
     }
-    
+
     private void createDummyFileIfNotPresent(String fileInInputDir, String dummyFileName, String dummyContent) {
         String dir = StringUtils.substringBeforeLast(fileInInputDir, File.separator);
         File dummyFile = new File (dir + File.separator + dummyFileName);

--- a/dspace-api/src/main/java/org/dspace/submit/migration/SubmissionFormsMigration.java
+++ b/dspace-api/src/main/java/org/dspace/submit/migration/SubmissionFormsMigration.java
@@ -17,6 +17,7 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 
+import org.apache.commons.cli.ParseException;
 import org.dspace.scripts.DSpaceRunnable;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.utils.DSpace;
@@ -59,19 +60,11 @@ public class SubmissionFormsMigration extends DSpaceRunnable<SubmissionFormsMigr
             return;
         }
         if (this.inputFormsFilePath != null) {
-            this.transformToSubmissionForms(this.inputFormsFilePath);
+            this.transform(inputFormsFilePath, PATH_XSL_SUBMISSION_FORMS, PATH_OUT_INPUT_FORMS);
         }
         if (this.itemSubmissionsFilePath != null) {
-            this.transformToItemSubmission(this.itemSubmissionsFilePath);
+            this.transform(itemSubmissionsFilePath, PATH_XSL_ITEM_SUBMISSION, PATH_OUT_ITEM_SUBMISSION);
         }
-    }
-
-    private void transformToSubmissionForms(String inputFormsFilePath) throws TransformerException {
-        this.transform(inputFormsFilePath, PATH_XSL_SUBMISSION_FORMS, PATH_OUT_INPUT_FORMS);
-    }
-
-    private void transformToItemSubmission(String itemSubmissionsFilePath) throws TransformerException {
-        this.transform(itemSubmissionsFilePath, PATH_XSL_ITEM_SUBMISSION, PATH_OUT_ITEM_SUBMISSION);
     }
 
     /**
@@ -111,7 +104,7 @@ public class SubmissionFormsMigration extends DSpaceRunnable<SubmissionFormsMigr
     }
 
     @Override
-    public void setup() {
+    public void setup() throws ParseException {
         if (commandLine.hasOption('h')) {
             help = true;
             return;
@@ -125,27 +118,27 @@ public class SubmissionFormsMigration extends DSpaceRunnable<SubmissionFormsMigr
             checkIfValidXMLFile(itemSubmissionsFilePath);
         }
         if (!(commandLine.hasOption('s') || commandLine.hasOption('f'))) {
-            this.throwIllegalArgumentException("Please fill in either -f <source-input-forms-path> or -s " +
-                                               "<source-item-submissions-path>; or both.");
+            this.throwParseException("Please fill in either -f <source-input-forms-path> or -s " +
+                                     "<source-item-submissions-path>; or both.");
         }
     }
 
-    private void checkIfValidXMLFile(String filePath) {
+    private void checkIfValidXMLFile(String filePath) throws ParseException {
         File file = new File(filePath);
         if (!file.exists()) {
-            this.throwIllegalArgumentException("There is no file at path: " + filePath);
+            this.throwParseException("There is no file at path: " + filePath);
         }
         if (!file.isFile() && file.isDirectory()) {
-            this.throwIllegalArgumentException("This is a dir, not a file: " + filePath);
+            this.throwParseException("This is a dir, not a file: " + filePath);
         }
         if (!file.getName().endsWith(".xml")) {
-            this.throwIllegalArgumentException("This is not an XML file (doesn't end in .xml): " + filePath);
+            this.throwParseException("This is not an XML file (doesn't end in .xml): " + filePath);
         }
     }
 
-    private void throwIllegalArgumentException(String message) {
+    private void throwParseException(String message) throws ParseException {
         super.handler.logError(message);
-        throw new IllegalArgumentException(message);
+        throw new ParseException(message);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/submit/migration/SubmissionFormsMigrationCliScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/submit/migration/SubmissionFormsMigrationCliScriptConfiguration.java
@@ -1,0 +1,66 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.submit.migration;
+
+import java.sql.SQLException;
+
+import org.apache.commons.cli.Options;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.core.Context;
+import org.dspace.scripts.configuration.ScriptConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * The {@link ScriptConfiguration} for the {@link SubmissionFormsMigration} script
+ *
+ * @author Maria Verdonck (Atmire) on 13/11/2020
+ */
+public class SubmissionFormsMigrationCliScriptConfiguration<T extends SubmissionFormsMigration>
+    extends ScriptConfiguration<T> {
+
+    @Autowired
+    private AuthorizeService authorizeService;
+
+    private Class<T> dspaceRunnableClass;
+
+    @Override
+    public Class<T> getDspaceRunnableClass() {
+        return this.dspaceRunnableClass;
+    }
+
+    @Override
+    public void setDspaceRunnableClass(Class<T> dspaceRunnableClass) {
+        this.dspaceRunnableClass = dspaceRunnableClass;
+    }
+
+    @Override
+    public boolean isAllowedToExecute(Context context) {
+        try {
+            return authorizeService.isAdmin(context);
+        } catch (SQLException e) {
+            throw new RuntimeException("SQLException occurred when checking if the current user is an admin", e);
+        }
+    }
+
+    @Override
+    public Options getOptions() {
+        if (options == null) {
+            Options options = new Options();
+
+            options.addOption("f", "input-forms", true, "Path to source input-forms.xml file location");
+            options.getOption("f").setType(String.class);
+            options.addOption("s", "item-submission", true, "Path to source item-submission.xml file location");
+            options.getOption("s").setType(String.class);
+            options.addOption("h", "help", false, "help");
+            options.getOption("h").setType(boolean.class);
+
+            super.options = options;
+        }
+        return options;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/submit/migration/SubmissionFormsMigrationScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/submit/migration/SubmissionFormsMigrationScriptConfiguration.java
@@ -1,0 +1,66 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.submit.migration;
+
+import java.sql.SQLException;
+
+import org.apache.commons.cli.Options;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.core.Context;
+import org.dspace.scripts.configuration.ScriptConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * The {@link ScriptConfiguration} for the {@link SubmissionFormsMigration} script
+ *
+ * @author Maria Verdonck (Atmire) on 13/11/2020
+ */
+public class SubmissionFormsMigrationScriptConfiguration<T extends SubmissionFormsMigration>
+    extends ScriptConfiguration<T> {
+
+    @Autowired
+    private AuthorizeService authorizeService;
+
+    private Class<T> dspaceRunnableClass;
+
+    @Override
+    public Class<T> getDspaceRunnableClass() {
+        return this.dspaceRunnableClass;
+    }
+
+    @Override
+    public void setDspaceRunnableClass(Class<T> dspaceRunnableClass) {
+        this.dspaceRunnableClass = dspaceRunnableClass;
+    }
+
+    @Override
+    public boolean isAllowedToExecute(Context context) {
+        try {
+            return authorizeService.isAdmin(context);
+        } catch (SQLException e) {
+            throw new RuntimeException("SQLException occurred when checking if the current user is an admin", e);
+        }
+    }
+
+    @Override
+    public Options getOptions() {
+        if (options == null) {
+            Options options = new Options();
+
+            options.addOption("f", "input-forms", true, "Path to source input-forms.xml file location");
+            options.getOption("f").setType(String.class);
+            options.addOption("s", "item-submission", true, "Path to source item-submission.xml file location");
+            options.getOption("s").setType(String.class);
+            options.addOption("h", "help", false, "help");
+            options.getOption("h").setType(boolean.class);
+
+            super.options = options;
+        }
+        return options;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/submit/migration/SubmissionFormsMigrationScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/submit/migration/SubmissionFormsMigrationScriptConfiguration.java
@@ -7,60 +7,19 @@
  */
 package org.dspace.submit.migration;
 
-import java.sql.SQLException;
-
-import org.apache.commons.cli.Options;
-import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.core.Context;
-import org.dspace.scripts.configuration.ScriptConfiguration;
-import org.springframework.beans.factory.annotation.Autowired;
 
 /**
- * The {@link ScriptConfiguration} for the {@link SubmissionFormsMigration} script
+ * Subclass of {@link SubmissionFormsMigrationCliScriptConfiguration} to be use in rest/scripts.xml configuration so
+ * this script is not runnable from REST
  *
- * @author Maria Verdonck (Atmire) on 13/11/2020
+ * @author Maria Verdonck (Atmire) on 05/01/2021
  */
-public class SubmissionFormsMigrationScriptConfiguration<T extends SubmissionFormsMigration>
-    extends ScriptConfiguration<T> {
-
-    @Autowired
-    private AuthorizeService authorizeService;
-
-    private Class<T> dspaceRunnableClass;
-
-    @Override
-    public Class<T> getDspaceRunnableClass() {
-        return this.dspaceRunnableClass;
-    }
-
-    @Override
-    public void setDspaceRunnableClass(Class<T> dspaceRunnableClass) {
-        this.dspaceRunnableClass = dspaceRunnableClass;
-    }
+public class SubmissionFormsMigrationScriptConfiguration extends SubmissionFormsMigrationCliScriptConfiguration {
 
     @Override
     public boolean isAllowedToExecute(Context context) {
-        try {
-            return authorizeService.isAdmin(context);
-        } catch (SQLException e) {
-            throw new RuntimeException("SQLException occurred when checking if the current user is an admin", e);
-        }
-    }
-
-    @Override
-    public Options getOptions() {
-        if (options == null) {
-            Options options = new Options();
-
-            options.addOption("f", "input-forms", true, "Path to source input-forms.xml file location");
-            options.getOption("f").setType(String.class);
-            options.addOption("s", "item-submission", true, "Path to source item-submission.xml file location");
-            options.getOption("s").setType(String.class);
-            options.addOption("h", "help", false, "help");
-            options.getOption("h").setType(boolean.class);
-
-            super.options = options;
-        }
-        return options;
+        // Script is not allowed to be executed from REST side
+        return false;
     }
 }

--- a/dspace/config/migration/item-submissions.xsl
+++ b/dspace/config/migration/item-submissions.xsl
@@ -12,9 +12,11 @@
       </submission-map>
       <step-definitions>
         <xsl:call-template name="transformSteps"/>
+        <xsl:call-template name="addFormPageSteps"/>
+        <xsl:call-template name="addStaticSteps"/>
       </step-definitions>
       <submission-definitions>
-        <xsl:call-template name="transformSubmissions"/>
+        <xsl:call-template name="transformInputFormsToSubmissions"/>
       </submission-definitions>
     </item-submission>
   </xsl:template>
@@ -53,7 +55,37 @@
     </xsl:for-each>
   </xsl:template>
 
-  <xsl:template name="transformSubmissions">
+  <xsl:template name="addFormPageSteps">
+    <xsl:for-each select="$inputForms/input-forms/form-definitions/form/page">
+      <xsl:variable name="formName" select="../@name"/>
+      <step mandatory="true">
+        <xsl:attribute name="id">
+          <xsl:value-of select="concat($formName,'page',@number)"/>
+        </xsl:attribute>
+        <heading>
+          <xsm:value-of select="concat('submit.progressbar.describe.step',@number)"/>
+        </heading>
+        <processing-class>org.dspace.app.rest.submit.step.DescribeStep</processing-class>
+        <type>submission-form</type>
+      </step>
+    </xsl:for-each>
+  </xsl:template>
+
+  <xsl:template name="addStaticSteps">
+    <step id="upload">
+      <heading>submit.progressbar.upload</heading>
+      <processing-class>org.dspace.app.rest.submit.step.UploadStep</processing-class>
+      <type>upload</type>
+    </step>
+    <step id="license">
+      <heading>submit.progressbar.license</heading>
+      <processing-class>org.dspace.app.rest.submit.step.LicenseStep</processing-class>
+      <type>license</type>
+      <scope visibilityOutside="read-only">submission</scope>
+    </step>
+  </xsl:template>
+
+  <xsl:template name="transformInputFormsToSubmissions">
     <xsl:for-each select="$inputForms/input-forms/form-definitions/form">
       <xsl:variable name="formName" select="@name"/>
       <submission-process>

--- a/dspace/config/migration/item-submissions.xsl
+++ b/dspace/config/migration/item-submissions.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <xsl:stylesheet version="1.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xsm="http://www.w3.org/1999/XSL/Transform">
-  <xsl:output method="xml" doctype-system="submission-forms.dtd" indent="yes"/>
+  <xsl:output method="xml" doctype-system="item-submission.dtd" indent="yes"/>
 
   <xsl:template match="/">
     <item-submission>

--- a/dspace/config/migration/item-submissions.xsl
+++ b/dspace/config/migration/item-submissions.xsl
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <xsl:stylesheet version="1.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xsm="http://www.w3.org/1999/XSL/Transform">
   <xsl:output method="xml" doctype-system="submission-forms.dtd" indent="yes"/>
@@ -20,8 +21,12 @@
         <xsl:attribute name="id">
           <xsl:value-of select="@id"/>
         </xsl:attribute>
-        <heading><xsm:value-of select="./heading"/></heading>
-        <processing-class><xsm:value-of select="./processing-class"/></processing-class>
+        <heading>
+          <xsm:value-of select="./heading"/>
+        </heading>
+        <processing-class>
+          <xsm:value-of select="./processing-class"/>
+        </processing-class>
         <type>
           <xsl:choose>
             <xsl:when test="@id='collection' or @id='upload' or @id='licence' or @id='sample'">
@@ -44,5 +49,3 @@
     </xsl:for-each>
   </xsl:template>
 </xsl:stylesheet>
-
-

--- a/dspace/config/migration/item-submissions.xsl
+++ b/dspace/config/migration/item-submissions.xsl
@@ -2,6 +2,8 @@
 <xsl:stylesheet version="1.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xsm="http://www.w3.org/1999/XSL/Transform">
   <xsl:output method="xml" doctype-system="item-submission.dtd" indent="yes"/>
+  <xsl:param name="inputFormsPath"/>
+  <xsl:variable name="inputForms" select="document($inputFormsPath)"/>
 
   <xsl:template match="/">
     <item-submission>
@@ -11,7 +13,9 @@
       <step-definitions>
         <xsl:call-template name="transformSteps"/>
       </step-definitions>
-      <submission-definitions></submission-definitions>
+      <submission-definitions>
+        <xsl:call-template name="transformSubmissions"/>
+      </submission-definitions>
     </item-submission>
   </xsl:template>
 
@@ -46,6 +50,31 @@
           </xsl:when>
         </xsl:choose>
       </step>
+    </xsl:for-each>
+  </xsl:template>
+
+  <xsl:template name="transformSubmissions">
+    <xsl:for-each select="$inputForms/input-forms/form-definitions/form">
+      <xsl:variable name="formName" select="@name"/>
+      <submission-process>
+        <xsl:attribute name="name">
+          <xsl:value-of select="$formName"/>
+        </xsl:attribute>
+
+        <step id="collection"/>
+
+        <!-- The describe step pages -->
+        <xsl:for-each select="page">
+          <step>
+            <xsl:attribute name="id">
+              <xsl:value-of select="concat($formName,'page',@number)"/>
+            </xsl:attribute>
+          </step>
+        </xsl:for-each>
+
+        <step id="license"/>
+        <step id="upload"/>
+      </submission-process>
     </xsl:for-each>
   </xsl:template>
 </xsl:stylesheet>

--- a/dspace/config/migration/item-submissions.xsl
+++ b/dspace/config/migration/item-submissions.xsl
@@ -1,0 +1,48 @@
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xsm="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output method="xml" doctype-system="submission-forms.dtd" indent="yes"/>
+
+  <xsl:template match="/">
+    <item-submission>
+      <submission-map>
+        <xsl:copy-of select="/item-submission/submission-map/name-map"/>
+      </submission-map>
+      <step-definitions>
+        <xsl:call-template name="transformSteps"/>
+      </step-definitions>
+      <submission-definitions></submission-definitions>
+    </item-submission>
+  </xsl:template>
+
+  <xsl:template name="transformSteps">
+    <xsl:for-each select="/item-submission/step-definitions/step">
+      <step>
+        <xsl:attribute name="id">
+          <xsl:value-of select="@id"/>
+        </xsl:attribute>
+        <heading><xsm:value-of select="./heading"/></heading>
+        <processing-class><xsm:value-of select="./processing-class"/></processing-class>
+        <type>
+          <xsl:choose>
+            <xsl:when test="@id='collection' or @id='upload' or @id='licence' or @id='sample'">
+              <xsl:value-of select="@id"/>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:text>submission-form</xsl:text>
+            </xsl:otherwise>
+          </xsl:choose>
+        </type>
+        <xsl:choose>
+          <xsl:when test="@id='collection'">
+            <scope visibility="hidden" visibilityOutside="hidden">submission</scope>
+          </xsl:when>
+          <xsl:when test="@id='license'">
+            <scope visibilityOutside="read-only">submission</scope>
+          </xsl:when>
+        </xsl:choose>
+      </step>
+    </xsl:for-each>
+  </xsl:template>
+</xsl:stylesheet>
+
+

--- a/dspace/config/migration/item-submissions.xsl
+++ b/dspace/config/migration/item-submissions.xsl
@@ -113,8 +113,8 @@
           </step>
         </xsl:for-each>
 
-        <step id="license"/>
         <step id="upload"/>
+        <step id="license"/>
       </submission-process>
     </xsl:for-each>
   </xsl:template>

--- a/dspace/config/migration/item-submissions.xsl
+++ b/dspace/config/migration/item-submissions.xsl
@@ -8,7 +8,16 @@
   <xsl:template match="/">
     <item-submission>
       <submission-map>
-        <xsl:copy-of select="/item-submission/submission-map/name-map"/>
+        <xsl:for-each select="$inputForms/input-forms/form-map/name-map">
+          <name-map>
+            <xsl:attribute name="collection-handle">
+              <xsl:value-of select="@collection-handle"/>
+            </xsl:attribute>
+            <xsl:attribute name="submission-name">
+              <xsl:value-of select="@form-name"/>
+            </xsl:attribute>
+          </name-map>
+        </xsl:for-each>
       </submission-map>
       <step-definitions>
         <xsl:call-template name="transformSteps"/>

--- a/dspace/config/migration/item-submissions.xsl
+++ b/dspace/config/migration/item-submissions.xsl
@@ -34,7 +34,7 @@ configuration file into a DSpace 7.x (or above) item-submission.xml -->
 
   <xsl:template name="transformSteps">
     <xsl:for-each select="/item-submission/step-definitions/step">
-      <step>
+      <step-definition>
         <xsl:attribute name="id">
           <xsl:value-of select="@id"/>
         </xsl:attribute>
@@ -62,14 +62,14 @@ configuration file into a DSpace 7.x (or above) item-submission.xml -->
             <scope visibilityOutside="read-only">submission</scope>
           </xsl:when>
         </xsl:choose>
-      </step>
+      </step-definition>
     </xsl:for-each>
   </xsl:template>
 
   <xsl:template name="addFormPageSteps">
     <xsl:for-each select="$inputForms/input-forms/form-definitions/form/page">
       <xsl:variable name="formName" select="../@name"/>
-      <step mandatory="true">
+      <step-definition mandatory="true">
         <xsl:attribute name="id">
           <xsl:value-of select="concat($formName,'page',@number)"/>
         </xsl:attribute>
@@ -78,22 +78,22 @@ configuration file into a DSpace 7.x (or above) item-submission.xml -->
         </heading>
         <processing-class>org.dspace.app.rest.submit.step.DescribeStep</processing-class>
         <type>submission-form</type>
-      </step>
+      </step-definition>
     </xsl:for-each>
   </xsl:template>
 
   <xsl:template name="addStaticSteps">
-    <step id="upload">
+    <step-definition id="upload">
       <heading>submit.progressbar.upload</heading>
       <processing-class>org.dspace.app.rest.submit.step.UploadStep</processing-class>
       <type>upload</type>
-    </step>
-    <step id="license">
+    </step-definition>
+    <step-definition id="license">
       <heading>submit.progressbar.license</heading>
       <processing-class>org.dspace.app.rest.submit.step.LicenseStep</processing-class>
       <type>license</type>
       <scope visibilityOutside="read-only">submission</scope>
-    </step>
+    </step-definition>
   </xsl:template>
 
   <xsl:template name="transformInputFormsToSubmissions">

--- a/dspace/config/migration/item-submissions.xsl
+++ b/dspace/config/migration/item-submissions.xsl
@@ -1,4 +1,6 @@
 <?xml version="1.0"?>
+<!-- This XSLT is used by `./dspace submission-forms-migrate` to transform a DSpace 6.x (or below) item-submission.xml
+configuration file into a DSpace 7.x (or above) item-submission.xml -->
 <xsl:stylesheet version="1.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xsm="http://www.w3.org/1999/XSL/Transform">
   <xsl:output method="xml" doctype-system="item-submission.dtd" indent="yes"/>

--- a/dspace/config/migration/submission-forms.xsl
+++ b/dspace/config/migration/submission-forms.xsl
@@ -1,0 +1,73 @@
+<?xml version="1.0"?>
+
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    <xsl:output method="xml" doctype-system="submission-forms.dtd"/>
+
+    <xsl:template match="/">
+<!--        <!DOCTYPE input-forms SYSTEM "submission-forms.dtd">-->
+        <input-forms>
+
+            <form-definitions>
+                <xsl:apply-templates select="input-forms/form-definitions/form/page"/>
+                <xsl:call-template name="predefined-forms"/>
+            </form-definitions>
+
+            <xsl:apply-templates select="input-forms/form-value-pairs"/>
+
+
+        </input-forms>
+    </xsl:template>
+
+    <xsl:template match="page">
+        <form>
+            <xsl:attribute name="name">
+                <xsl:value-of select="../@name"/>
+                <xsl:text>page</xsl:text>
+                <xsl:value-of select="@number"/>
+            </xsl:attribute>
+            <xsl:apply-templates select="field"/>
+        </form>
+    </xsl:template>
+
+    <xsl:template match="field">
+        <row>
+            <xsl:copy-of select="."/>
+        </row>
+    </xsl:template>
+
+    <xsl:template match="form-value-pairs">
+            <xsl:copy-of select="."/>
+    </xsl:template>
+
+    <xsl:template name="predefined-forms">
+        <form name="bitstream-metadata">
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>title</dc-element>
+                    <dc-qualifier></dc-qualifier>
+                    <repeatable>false</repeatable>
+                    <label>Title</label>
+                    <input-type>onebox</input-type>
+                    <hint>Enter the name of the file.</hint>
+                    <required>You must enter a main title for this item.</required>
+                </field>
+            </row>
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>description</dc-element>
+                    <repeatable>true</repeatable>
+                    <label>Description</label>
+                    <input-type>textarea</input-type>
+                    <hint>Enter a description for the file</hint>
+                    <required></required>
+                </field>
+            </row>
+        </form>
+    </xsl:template>
+
+
+
+</xsl:stylesheet>

--- a/dspace/config/migration/submission-forms.xsl
+++ b/dspace/config/migration/submission-forms.xsl
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-
+<!-- This XSLT is used by `./dspace submission-forms-migrate` to transform a DSpace 6.x (or below) input-forms.xml
+configuration file into a DSpace 7.x (or above) submission-forms.xml -->
 <xsl:stylesheet version="1.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
     <xsl:output method="xml" doctype-system="submission-forms.dtd"/>

--- a/dspace/config/migration/submission-forms.xsl
+++ b/dspace/config/migration/submission-forms.xsl
@@ -5,7 +5,6 @@
     <xsl:output method="xml" doctype-system="submission-forms.dtd"/>
 
     <xsl:template match="/">
-<!--        <!DOCTYPE input-forms SYSTEM "submission-forms.dtd">-->
         <input-forms>
 
             <form-definitions>
@@ -14,7 +13,6 @@
             </form-definitions>
 
             <xsl:apply-templates select="input-forms/form-value-pairs"/>
-
 
         </input-forms>
     </xsl:template>
@@ -31,9 +29,31 @@
     </xsl:template>
 
     <xsl:template match="field">
-        <row>
-            <xsl:copy-of select="."/>
-        </row>
+        <xsl:choose>
+            <!-- transform input-type twobox into onebox -->
+            <xsl:when test="input-type/text() = 'twobox'">
+                <row>
+                    <field>
+                        <!-- copy each child tag of field where input-type is twobox, except input-type (order children enforced by submission-forms.dtd) -->
+                        <xsl:for-each select="*">
+                            <xsl:choose>
+                                <xsl:when test="(self::input-type)">
+                                    <input-type>onebox</input-type>
+                                </xsl:when>
+                                <xsl:otherwise>
+                                    <xsl:copy-of select="."/>
+                                </xsl:otherwise>
+                            </xsl:choose>
+                        </xsl:for-each>
+                    </field>
+                </row>
+            </xsl:when>
+            <xsl:otherwise>
+                <row>
+                    <xsl:copy-of select="."/>
+                </row>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
 
     <xsl:template match="form-value-pairs">
@@ -67,7 +87,5 @@
             </row>
         </form>
     </xsl:template>
-
-
 
 </xsl:stylesheet>

--- a/dspace/config/spring/api/scripts.xml
+++ b/dspace/config/spring/api/scripts.xml
@@ -31,7 +31,7 @@
                   value="org.dspace.curate.CurationCli"/>
     </bean>
 
-    <bean id="submission-forms-migrate" class="org.dspace.submit.migration.SubmissionFormsMigrationScriptConfiguration">
+    <bean id="submission-forms-migrate" class="org.dspace.submit.migration.SubmissionFormsMigrationCliScriptConfiguration">
         <property name="description" value="Script for migrating submission forms to DSpace 7"/>
         <property name="dspaceRunnableClass" value="org.dspace.submit.migration.SubmissionFormsMigration"/>
     </bean>

--- a/dspace/config/spring/api/scripts.xml
+++ b/dspace/config/spring/api/scripts.xml
@@ -30,4 +30,9 @@
         <property name="dspaceRunnableClass"
                   value="org.dspace.curate.CurationCli"/>
     </bean>
+
+    <bean id="submission-forms-migrate" class="org.dspace.submit.migration.SubmissionFormsMigrationScriptConfiguration">
+        <property name="description" value="Script for migrating submission forms to DSpace 7"/>
+        <property name="dspaceRunnableClass" value="org.dspace.submit.migration.SubmissionFormsMigration"/>
+    </bean>
 </beans>

--- a/dspace/config/spring/rest/scripts.xml
+++ b/dspace/config/spring/rest/scripts.xml
@@ -22,4 +22,10 @@
         <property name="description" value="Curation tasks"/>
         <property name="dspaceRunnableClass" value="org.dspace.curate.Curation"/>
     </bean>
+
+    <!-- Not runnable from REST -->
+    <bean id="submission-forms-migrate" class="org.dspace.submit.migration.SubmissionFormsMigrationScriptConfiguration">
+        <property name="description" value="Script for migrating submission forms to DSpace 7"/>
+        <property name="dspaceRunnableClass" value="org.dspace.submit.migration.SubmissionFormsMigration"/>
+    </bean>
 </beans>


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/DSpace/issues/2818

## Description
This PR introduces a script that will parse `input-forms.xml` and `item-submission.xml` from DSpace <7 versions into the `submission-forms.xml` and `item-submission.xml` standard for DSpace 7.
This script can be called by using `submission-forms-migrate -s {path-to-config-dir}/item-submission.xml -f {path-to-config-dir}/input-forms.xml`
with the `path-to-config-dir` leading to the config dir for the DSpace <7 instance that you're looking to migrate.
The migrated xml files will be present in the DSpace's install dir in the config folder

## Instructions for Reviewers

List of changes in this PR:
* introduced a script to automatically migrate the old submission xml files to the new ones

How to test this PR:
* Setup this branch
* Call the script using {dspace.dir}/dspace submission-forms-migrate -s {path-to-config-dir}/item-submission.xml -f {path-to-config-dir}/input-forms.xml
* Verify that the new submission xml files are present in the {dspace.dir}/config directory

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
