### PR TITLE
 [DS-4562] - Change maxwait default to 10 seconds

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -92,8 +92,8 @@ db.schema = public
 db.maxconnections = 30
 
 # Maximum time to wait before giving up if all connections in pool are busy (milliseconds)
-# (default = 5000ms or 5 seconds)
-db.maxwait = 5000
+# (default = 10000ms or 10 seconds)
+db.maxwait = 10000
 
 # Maximum number of idle connections in pool (-1 = unlimited)
 # (default = 10)

--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -100,8 +100,8 @@ db.schema = public
 #db.maxconnections = 30
 
 # Maximum time to wait before giving up if all connections in pool are busy (milliseconds)
-# (default = 5000ms or 5 seconds)
-#db.maxwait = 5000
+# (default = 10000ms or 10 seconds)
+#db.maxwait = 10000
 
 # Maximum number of idle connections in pool (-1 = unlimited)
 # (default = 10)


### PR DESCRIPTION
Fixes #7895 

The default DBCP2 configuration has remained unchanged since 2015.

It is unclear what reasoning is behind the currently default values.

db.maxwait (maxWaitMillis) is passed on to the DBCP2 bean which has a default value of -1 or indefinate.

Tomcat 8 documentation recommends setting at least 10-15 seconds to accomadate for potential freezes during garbage collection (see https://tomcat.apache.org/tomcat-8.0-doc/jndi-datasource-examples-howto.html#Intermittent_Database_Connection_Failures)

Google also indicates that common values are higher than 5000, often 10000.

See related discussion:
https://github.com/DSpace/DSpace/issues/3070