### PR TITLE
Iterate over all language elements when getting metadata values from Solr oai item.compile field

### DIFF
--- a/dspace-oai/src/main/java/org/dspace/xoai/data/DSpaceItem.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/data/DSpaceItem.java
@@ -42,11 +42,19 @@ public abstract class DSpaceItem implements Item
     
     private static List<String> values (List<Element> input) {
     	List<String> elems = new ArrayList<String>();
-    	for (Element e : input)
-    		if (e.getElement() != null && !e.getElement().isEmpty() && e.getElement().get(0).getField() != null)
-    			for (Field f : e.getElement().get(0).getField())
-    				if (f.getName() != null && f.getName().equals("value"))
-    					elems.add(f.getValue());
+    	for (Element e : input) {
+    		if (e.getElement() != null && !e.getElement().isEmpty()) {
+    			for (Element eLang : e.getElement()) {
+    				if (eLang.getField() != null) {
+    					for (Field f : eLang.getField()) {
+    						if (f.getName() != null && f.getName().equals("value")) {
+    							elems.add(f.getValue());
+    						}
+    					}
+    				}
+    			}
+    		}
+    	}
     	return elems;
     }
     


### PR DESCRIPTION
## References
Fixes [DS-4561](https://jira.lyrasis.org/browse/DS-4561)
Fixes #7894 

## Description
DSpaceItem.values() needs to iterate over all language elements from the Solr oai item.compile field instead of just the first one as was done previously with e.getElement().get(0)

## Instructions for Reviewers
Full description in [DS-4561](https://jira.lyrasis.org/browse/DS-4561). This issue was affecting results from OAI filters using DSpaceAtLeastOneMetadataFilter since only the first language variant would be checked. An edge case had an item with multiple dc.rights metadata values and the first dc.rights had an empty value. The OpenAIRE 3 Transformer failed to convert the empty value to a default value of "info:eu-repo/semantics/restrictedAccess" due to the XPath match with text() ([XPath source here](https://github.com/DSpace/DSpace/blob/a72ff50de121c4639eb5cd16dfa17358a66749a0/dspace/config/crosswalks/oai/transformers/openaire.xsl#L47)) failing to match against an element with no text. An attempt to do an OAI GetRecord on the item resulted in "The given id does not exist" because the OpenAIRE 3 filter rejected the item as it was "missing" a valid dc.rights value. With this patch applied, DSpaceAtLeastOneMetadataFilter gets all dc.rights metadata values to check and correctly checks and passes the second dc.rights with the valid OpenAIRE 3 rights code.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
