### PR TITLE
Discovery event consumer throwing ClassCastException on WorkspaceItem creation fix

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/indexobject/AbstractIndexableObject.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/indexobject/AbstractIndexableObject.java
@@ -27,10 +27,10 @@ public abstract class AbstractIndexableObject<T extends ReloadableEntity<PK>, PK
     @Override
     public boolean equals(Object obj) {
         //Two IndexableObjects of the same DSpaceObject are considered equal
-        if (!(obj instanceof AbstractIndexableObject)) {
+        if (!(obj instanceof IndexableObject)) {
             return false;
         }
-        IndexableDSpaceObject other = (IndexableDSpaceObject) obj;
+        IndexableObject other = (IndexableObject) obj;
         return other.getIndexedObject().equals(getIndexedObject());
     }
 


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/DSpace/issues/2989

## Description
This PR fixes the Discovery even consumer ClassCastException upon the creation of a WorkspaceItem. This was due to a cast in the equals method of the AbstractIndexableObject which wasn't necessarily always correct, like the error pointed out. This was fixed by loosening the cast to something that does always hold true and doesn't change the actual implementation.

## Instructions for Reviewers

List of changes in this PR:
* Fixed the incorrect cast in AbstractIndexableObject#equals

How to test this PR:
* Build and deploy the branch
* Create a new WorkspaceItem and verify that the Discovery event consumer no longer throws the ClassCastException

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
