### PR TITLE
Fix issues with OAI accidentally loading the wrong ConfigurationService

### DIFF
--- a/dspace-oai/src/main/java/org/dspace/xoai/services/api/config/ConfigurationService.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/api/config/ConfigurationService.java
@@ -13,4 +13,6 @@ public interface ConfigurationService {
     String getProperty(String module, String key);
 
     boolean getBooleanProperty(String module, String key, boolean defaultValue);
+
+    boolean getBooleanProperty(String key, boolean defaultValue);
 }

--- a/dspace-oai/src/main/java/org/dspace/xoai/services/impl/cache/DSpaceXOAICacheService.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/impl/cache/DSpaceXOAICacheService.java
@@ -27,8 +27,8 @@ import com.lyncode.xoai.dataprovider.xml.XmlOutputContext;
 import com.lyncode.xoai.dataprovider.xml.oaipmh.OAIPMH;
 import com.lyncode.xoai.util.Base64Utils;
 import org.apache.commons.io.FileUtils;
-import org.dspace.services.ConfigurationService;
 import org.dspace.xoai.services.api.cache.XOAICacheService;
+import org.dspace.xoai.services.api.config.ConfigurationService;
 import org.dspace.xoai.util.DateUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 

--- a/dspace-oai/src/main/java/org/dspace/xoai/services/impl/cache/DSpaceXOAILastCompilationCacheService.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/impl/cache/DSpaceXOAILastCompilationCacheService.java
@@ -15,8 +15,8 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 
 import org.apache.commons.io.FileUtils;
-import org.dspace.services.ConfigurationService;
 import org.dspace.xoai.services.api.cache.XOAILastCompilationCacheService;
+import org.dspace.xoai.services.api.config.ConfigurationService;
 import org.springframework.beans.factory.annotation.Autowired;
 
 
@@ -32,7 +32,7 @@ public class DSpaceXOAILastCompilationCacheService implements XOAILastCompilatio
 
     private static File file = null;
 
-    @Autowired(required = true)
+    @Autowired
     ConfigurationService configurationService;
 
     private File getFile() {

--- a/dspace-oai/src/main/java/org/dspace/xoai/services/impl/config/DSpaceConfigurationService.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/impl/config/DSpaceConfigurationService.java
@@ -52,4 +52,9 @@ public class DSpaceConfigurationService implements ConfigurationService {
         // Assume "module" properties are always prefixed with the module name
         return configurationService.getBooleanProperty(module + "." + key, defaultValue);
     }
+
+    @Override
+    public boolean getBooleanProperty(String key, boolean defaultValue) {
+        return configurationService.getBooleanProperty(key, defaultValue);
+    }
 }


### PR DESCRIPTION
This PR fixes a minor bug caused by #2957 where refactors in that PR accidentally loaded the wrong `ConfigurationService` class in `@Autowired` annotations.  Somewhat confusingly, `dspace-oai` has its own `ConfigurationService` class (which wraps the other one). When using `@Autowired` in `dspace-oai`, it must use the `ConfigurationService` defined in `dspace-oai`.

This resulted in errors like this when running `./dspace oai import`:

```
Exception: Error creating bean with name 'xoaiCacheService': Unsatisfied dependency expressed through field 'configurationService'; nested exception is
org.springframework.beans.factory.NoSuchBeanDefinitionException: No qualifying bean of type 'org.dspace.services.ConfigurationService' available: expected at least 1 bean which qualifies as autowire candidate. Dependency annotations: {@org.springframework.beans.factory.annotation.Autowired(required=true)}
org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'xoaiCacheService': Unsatisfied dependency expressed through field 'configurationService'; nested exception is org.springframework.beans.factory.NoSuchBeanDefinitionException: No qualifying bean of type 'org.dspace.services.ConfigurationService' available: expected at least 1 bean which qualifies as autowire candidate. Dependency annotations: {@org.springframework.beans.factory.annotation.Autowired(required=true)}
        at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredFieldElement.inject(AutowiredAnnotationBeanPostProcessor.java:643)
        at org.springframework.beans.factory.annotation.InjectionMetadata.inject(InjectionMetadata.java:130)
        at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor.postProcessProperties(AutowiredAnnotationBeanPostProcessor.java:399)
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.populateBean(AbstractAutowireCapableBeanFactory.java:1422)
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:594)
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:517)
        at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:323)
        at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:222)
        at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:321)
        at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:202)
        at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingletons(DefaultListableBeanFactory.java:882)
        at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:878)
        at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:550)
        at org.springframework.context.annotation.AnnotationConfigApplicationContext.<init>(AnnotationConfigApplicationContext.java:89)
        at org.dspace.xoai.app.XOAI.main(XOAI.java:546)
```

This was discovered in https://github.com/DSpace/dspace-angular/pull/969 as this `NoSuchBeanDefinitionException` was encountered in the e2e testing .

I've tested this thoroughly locally (in Docker) and both `./dspace oai import` and `./dspace oai clean-cache` now work again.  Before this PR they did not.