### PR TITLE
Addressing issue #3074

### DIFF
--- a/dspace/config/crosswalks/oai/transformers/openaire4.xsl
+++ b/dspace/config/crosswalks/oai/transformers/openaire4.xsl
@@ -54,7 +54,7 @@
                 <xsl:text>ita</xsl:text>
             </xsl:when>
             <xsl:when test="$lc_value = 'ja'">
-                <xsl:text>jap</xsl:text>
+                <xsl:text>jpn</xsl:text>
             </xsl:when>
             <xsl:when test="$lc_value = 'zh'">
                 <xsl:text>zho</xsl:text>


### PR DESCRIPTION
## References
* Fixes #3074

## Description
This PR fixes the wrong defined ISO for Japanese language as reported in issue #3074 .

## Instructions for Reviewers
This is a minor fix, just replacing `jap` with the correct `jpn` ISO 639-3.