### PR TITLE
DS-4563 Signal that the transaction should be committed

### DIFF
--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/CurateServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/admin/CurateServlet.java
@@ -263,6 +263,7 @@ public class CurateServlet extends DSpaceServlet
     {
         String task   = request.getParameter("curate_task");
         Curator curator = getCurator(task);
+        curator.setTransactionScope(Curator.TxScope.CURATION);
         boolean success = false;
         try
         {


### PR DESCRIPTION
Fixes https://jira.lyrasis.org/browse/DS-4563 by setting the curation context to a value that will cause the curator to commit the transaction.

This fix has been tested successfully on a DSpace 5.4 repository.