### PR TITLE
Create Shibboleth Docker Scripts using samltest.id for easier development

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -51,7 +51,12 @@ RUN ant init_installation update_configs update_code update_webapps
 # Create a new tomcat image that does not retain the the build directory contents
 FROM tomcat:8-jdk11
 ENV DSPACE_INSTALL=/dspace
+ENV TOMCAT_INSTALL=/usr/local/tomcat
 COPY --from=ant_build /dspace $DSPACE_INSTALL
+# Enable the AJP connector in Tomcat's server.xml
+# NOTE: secretRequired="false" should only be used when AJP is NOT accessible from an external network. But, secretRequired="true" isn't supported by mod_proxy_ajp until Apache 2.5
+RUN sed -i '/Service name="Catalina".*/a \\n    <Connector protocol="AJP/1.3" port="8009" address="0.0.0.0" redirectPort="8443" URIEncoding="UTF-8" secretRequired="false" />' $TOMCAT_INSTALL/conf/server.xml
+# Expose Tomcat port and AJP port
 EXPOSE 8080 8009
 
 ENV JAVA_OPTS=-Xmx2000m

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
     ports:
     - published: 8080
       target: 8080
+    - published: 8009
+      target: 8009
     stdin_open: true
     tty: true
     volumes:

--- a/dspace/src/main/docker-compose/README.md
+++ b/dspace/src/main/docker-compose/README.md
@@ -64,7 +64,7 @@ The remainder of these instructions assume you are using ngrok (though other pro
    ```
    # NOTE: dspace.server.url MUST be available externally to use with https://samltest.id/.
    # In this example we are assuming you are using ngrok.
-   dspace.server.url=https://[random-string].ngrok.io/server
+   dspace.server.url=https://[subdomain].ngrok.io/server
 
    # Enable both Password auth & Shibboleth
    plugin.sequence.org.dspace.authenticate.AuthenticationMethod = org.dspace.authenticate.PasswordAuthentication
@@ -86,17 +86,17 @@ The remainder of these instructions assume you are using ngrok (though other pro
 
 4. Start all containers, passing your public hostname as the `DSPACE_HOSTNAME` environment variable:
    ```
-   DSPACE_HOSTNAME=[random-string].ngrok.io docker-compose -p d7 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-shibboleth.yml up -d
+   DSPACE_HOSTNAME=[subdomain].ngrok.io docker-compose -p d7 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-shibboleth.yml up -d
    ```
    NOTE: For Windows you MUST either set the environment variable separately, or use the 'env' command provided with Git/Cygwin
    (you may already have this command if you are running Git for Windows). See https://superuser.com/a/1079563
    ```
-   env DSPACE_HOSTNAME=[random-string].ngrok.io docker-compose -p d7 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-shibboleth.yml up -d
+   env DSPACE_HOSTNAME=[subdomain].ngrok.io docker-compose -p d7 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-shibboleth.yml up -d
    ```
 
 5. Finally, for https://samltest.id/, you need to upload your Shibboleth Metadata for the site to "trust" you.
    Using the form at https://samltest.id/upload.php, enter in
-   `https://[random-string].ngrok.io/Shibboleth.sso/Metadata` and click "Fetch!"
+   `https://[subdomain].ngrok.io/Shibboleth.sso/Metadata` and click "Fetch!"
       * Note: If samltest.id still says you are untrusted, restart your Shibboleth daemon! (This may be necessary to download the IdP Metadata from samltest.id)
         ```
         docker exec -it dspace-shibboleth /bin/bash
@@ -105,8 +105,22 @@ The remainder of these instructions assume you are using ngrok (though other pro
         ```
 
 6. At this point, if all went well, your site should work!  Try it at
-   https://[random-string].ngrok.io/server/
-
+   https://[subdomain].ngrok.io/server/
+7. If you want to include Angular UI as well, then you'll need a few extra steps:
+      * Update `environment.dev.ts` in this directory as follows:
+        ```
+        rest: {
+          ssl: true,
+          host: '[subdomain].ngrok.io',
+          port: 443,
+          // NOTE: Space is capitalized because 'namespace' is a reserved string in TypeScript
+          nameSpace: '/server'
+        }
+        ```
+      * Spin up the `dspace-angular` container alongside the others, e.g.
+        ```
+        DSPACE_HOSTNAME=[subdomain].ngrok.io docker-compose -p d7 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-angular.yml -f dspace/src/main/docker-compose/docker-compose-shibboleth.yml up -d
+        ```
 
 ## Run DSpace 7 REST and Angular from local branches
 

--- a/dspace/src/main/docker-compose/README.md
+++ b/dspace/src/main/docker-compose/README.md
@@ -49,7 +49,7 @@ docker-compose -p d7 -f docker-compose.yml -f dspace/src/main/docker-compose/doc
 
 *Only useful for testing Shibboleth in a development environment*
 
-This Shibboleth container uses https://samltest.id/ by default (see ../docker/dspace-shibboleth/).
+This Shibboleth container uses https://samltest.id/ as an IdP (see `../docker/dspace-shibboleth/`).
 Therefore, for Shibboleth login to work properly, you MUST make your DSpace site available to the external web.
 
 One option is to use a development proxy service like https://ngrok.com/, which creates a temporary public proxy for your localhost.
@@ -78,7 +78,13 @@ The remainder of these instructions assume you are using ngrok (though other pro
    authentication-shibboleth.role-header = role
    ```
 
-3. Start all containers, passing your public hostname as the `DSPACE_HOSTNAME` environment variable:
+3. Build the Shibboleth container (if you haven't built or pulled it before):
+   ```
+   cd [dspace-src]
+   docker-compose -p d7 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-shibboleth.yml build
+   ```
+
+4. Start all containers, passing your public hostname as the `DSPACE_HOSTNAME` environment variable:
    ```
    DSPACE_HOSTNAME=[random-string].ngrok.io docker-compose -p d7 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-shibboleth.yml up -d
    ```
@@ -88,11 +94,17 @@ The remainder of these instructions assume you are using ngrok (though other pro
    env DSPACE_HOSTNAME=[random-string].ngrok.io docker-compose -p d7 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-shibboleth.yml up -d
    ```
 
-4. Finally, for https://samltest.id/, you need to upload your Metadata for the site to "trust" you.
+5. Finally, for https://samltest.id/, you need to upload your Shibboleth Metadata for the site to "trust" you.
    Using the form at https://samltest.id/upload.php, enter in
-   `https://[random-string].ngrok.io/Shibboleth.sso/Metadata`
+   `https://[random-string].ngrok.io/Shibboleth.sso/Metadata` and click "Fetch!"
+      * Note: If samltest.id still says you are untrusted, restart your Shibboleth daemon! (This may be necessary to download the IdP Metadata from samltest.id)
+        ```
+        docker exec -it dspace-shibboleth /bin/bash
+        service shibd stop
+        service shibd start
+        ```
 
-5. At this point, if all went well, your site should work!  Try it at
+6. At this point, if all went well, your site should work!  Try it at
    https://[random-string].ngrok.io/server/
 
 

--- a/dspace/src/main/docker-compose/README.md
+++ b/dspace/src/main/docker-compose/README.md
@@ -52,34 +52,48 @@ docker-compose -p d7 -f docker-compose.yml -f dspace/src/main/docker-compose/doc
 This Shibboleth container uses https://samltest.id/ by default (see ../docker/dspace-shibboleth/).
 Therefore, for Shibboleth login to work properly, you MUST make your DSpace site available to the external web.
 
-One option is to use a development proxy service like https://ngrok.com/ (which creates a temporary public proxy for your localhost)
-If you use ngrok, start it first (in order to obtain a random URL that looks like https://a6eb2e55ad17.ngrok.io):
-```
-./ngrok http 443
-```
+One option is to use a development proxy service like https://ngrok.com/, which creates a temporary public proxy for your localhost.
+The remainder of these instructions assume you are using ngrok (though other proxies may be used).
 
-Then, update `local.cfg` in this directory to use that ngrok URL & enable Shibboleth:
-```
-# NOTE: dspace.server.url MUST be available externally to use with https://samltest.id/.
-# In this example we are assuming you are using ngrok.
-dspace.server.url=https://[random-string].ngrok.io/server
+1. If you use ngrok, start it first (in order to obtain a random URL that looks like https://a6eb2e55ad17.ngrok.io):
+   ```
+   ./ngrok http 443
+   ```
 
-# Enable both Password auth & Shibboleth
-plugin.sequence.org.dspace.authenticate.AuthenticationMethod = org.dspace.authenticate.PasswordAuthentication
-plugin.sequence.org.dspace.authenticate.AuthenticationMethod = org.dspace.authenticate.ShibAuthentication
-```
+2. Then, update `local.cfg` in this directory to use that ngrok URL & configure Shibboleth:
+   ```
+   # NOTE: dspace.server.url MUST be available externally to use with https://samltest.id/.
+   # In this example we are assuming you are using ngrok.
+   dspace.server.url=https://[random-string].ngrok.io/server
 
-Finally, start all containers, passing your public hostname to DSPACE_HOSTNAME environment variable:
-```
-DSPACE_HOSTNAME=[random-string].ngrok.io docker-compose -p d7 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-shibboleth.yml up -d
-```
+   # Enable both Password auth & Shibboleth
+   plugin.sequence.org.dspace.authenticate.AuthenticationMethod = org.dspace.authenticate.PasswordAuthentication
+   plugin.sequence.org.dspace.authenticate.AuthenticationMethod = org.dspace.authenticate.ShibAuthentication
+   
+   # Settings for https://samltest.id/
+   authentication-shibboleth.netid-header = uid
+   authentication-shibboleth.email-header = mail
+   authentication-shibboleth.firstname-header = givenName
+   authentication-shibboleth.lastname-header = sn
+   authentication-shibboleth.role-header = role
+   ```
 
-NOTE: For Windows you MUST either set the environment variable separately, or use the 'env' command provided with Git/Cygwin
-(you may already have this command if you are running Git for Windows). See https://superuser.com/a/1079563
-```
-env DSPACE_HOSTNAME=[random-string].ngrok.io docker-compose -p d7 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-shibboleth.yml up -d
-```
+3. Start all containers, passing your public hostname as the `DSPACE_HOSTNAME` environment variable:
+   ```
+   DSPACE_HOSTNAME=[random-string].ngrok.io docker-compose -p d7 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-shibboleth.yml up -d
+   ```
+   NOTE: For Windows you MUST either set the environment variable separately, or use the 'env' command provided with Git/Cygwin
+   (you may already have this command if you are running Git for Windows). See https://superuser.com/a/1079563
+   ```
+   env DSPACE_HOSTNAME=[random-string].ngrok.io docker-compose -p d7 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-shibboleth.yml up -d
+   ```
 
+4. Finally, for https://samltest.id/, you need to upload your Metadata for the site to "trust" you.
+   Using the form at https://samltest.id/upload.php, enter in
+   `https://[random-string].ngrok.io/Shibboleth.sso/Metadata`
+
+5. At this point, if all went well, your site should work!  Try it at
+   https://[random-string].ngrok.io/server/
 
 
 ## Run DSpace 7 REST and Angular from local branches

--- a/dspace/src/main/docker-compose/README.md
+++ b/dspace/src/main/docker-compose/README.md
@@ -42,6 +42,22 @@ docker-compose -p d7 up -d
 docker-compose -p d7 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-angular.yml up -d
 ```
 
+## Run DSpace 7 REST and Shibboleth SP (in Apache) from your branch
+
+Update `local.cfg` in this directory to include:
+```
+dspace.server.url=https://localhost/server
+plugin.sequence.org.dspace.authenticate.AuthenticationMethod = org.dspace.authenticate.PasswordAuthentication
+plugin.sequence.org.dspace.authenticate.AuthenticationMethod = org.dspace.authenticate.ShibAuthentication
+```
+
+Start all containers:
+```
+docker-compose -p d7 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-shibboleth.yml up -d
+```
+
+Access DSpace REST at: https://localhost/server/
+
 ## Run DSpace 7 REST and Angular from local branches
 
 _The system will be started in 2 steps. Each step shares the same docker network._

--- a/dspace/src/main/docker-compose/docker-compose-shibboleth.yml
+++ b/dspace/src/main/docker-compose/docker-compose-shibboleth.yml
@@ -1,0 +1,26 @@
+#
+# The contents of this file are subject to the license and copyright
+# detailed in the LICENSE and NOTICE files at the root of the source
+# tree and available online at
+#
+# http://www.dspace.org/license/
+#
+
+version: '3.7'
+networks:
+  dspacenet:
+services:
+  dspace-shibboleth:
+    container_name: dspace-shibboleth
+    depends_on:
+      - dspace
+    image: dspace/dspace-shibboleth
+    networks:
+      dspacenet:
+    ports:
+      - published: 80
+        target: 80
+      - published: 443
+        target: 443
+    stdin_open: true
+    tty: true

--- a/dspace/src/main/docker-compose/docker-compose-shibboleth.yml
+++ b/dspace/src/main/docker-compose/docker-compose-shibboleth.yml
@@ -6,6 +6,10 @@
 # http://www.dspace.org/license/
 #
 
+#
+# Test environment for DSpace + Shibboleth (running via mod_shib in Apache). See README for instructions.
+# This should NEVER be used in production scenarios.
+#
 version: '3.7'
 networks:
   dspacenet:
@@ -14,7 +18,9 @@ services:
     container_name: dspace-shibboleth
     depends_on:
       - dspace
-    image: dspace/dspace-shibboleth
+    build:
+      # Must be relative to root, so that it can be built alongside [src]/docker-compose.yml
+      context: ./dspace/src/main/docker/dspace-shibboleth
     networks:
       dspacenet:
     ports:
@@ -24,3 +30,8 @@ services:
         target: 443
     stdin_open: true
     tty: true
+    environment:
+      # Default to using "localhost" for Apache & Shibboleth
+      # However, you can override this via the "DSPACE_HOSTNAME" environment variable.
+      # e.g., if using ngrok.com as a proxy, set to ngrok.io server: "DSPACHE_HOSTNAME=[random-string].ngrok.io"
+      APACHE_SERVER_NAME: '${DSPACE_HOSTNAME:-localhost}"'

--- a/dspace/src/main/docker-compose/docker-compose-shibboleth.yml
+++ b/dspace/src/main/docker-compose/docker-compose-shibboleth.yml
@@ -18,6 +18,7 @@ services:
     container_name: dspace-shibboleth
     depends_on:
       - dspace
+    image: dspace/dspace-shibboleth
     build:
       # Must be relative to root, so that it can be built alongside [src]/docker-compose.yml
       context: ./dspace/src/main/docker/dspace-shibboleth

--- a/dspace/src/main/docker-compose/docker-compose-shibboleth.yml
+++ b/dspace/src/main/docker-compose/docker-compose-shibboleth.yml
@@ -33,5 +33,5 @@ services:
     environment:
       # Default to using "localhost" for Apache & Shibboleth
       # However, you can override this via the "DSPACE_HOSTNAME" environment variable.
-      # e.g., if using ngrok.com as a proxy, set to ngrok.io server: "DSPACHE_HOSTNAME=[random-string].ngrok.io"
-      APACHE_SERVER_NAME: '${DSPACE_HOSTNAME:-localhost}"'
+      # e.g., if using ngrok.com as a proxy, set to ngrok.io server: "DSPACE_HOSTNAME=[random-string].ngrok.io"
+      APACHE_SERVER_NAME: '${DSPACE_HOSTNAME:-localhost}'

--- a/dspace/src/main/docker/README.md
+++ b/dspace/src/main/docker/README.md
@@ -148,6 +148,9 @@ docker build -t dspace/dspace-shibboleth .
 docker run -i -t -d -p 80:80 -p 443:443 dspace/dspace-shibboleth
 ```
 
+This image can also be rebuilt using the `../docker-compose/docker-compose-shibboleth.yml` script.
+
+
 ## local.cfg and test/ folder
 
 These resources are bundled into the `dspace/dspace` image at build time.

--- a/dspace/src/main/docker/README.md
+++ b/dspace/src/main/docker/README.md
@@ -132,6 +132,22 @@ Admins to our DockerHub repo can publish with the following command.
 docker push dspace/dspace-solr
 ```
 
+## dspace/src/main/docker/dspace-shibboleth/Dockerfile
+
+This is a test / demo image which provides an Apache HTTPD proxy (in front of Tomcat)
+with mod_shib & Shibboleth installed.  It is primarily for usage for
+testing DSpace's Shibboleth integration. It uses https://samltest.id/ as the Shibboleth IDP
+
+**This image is built manually.**   It should be rebuilt as needed.
+
+```
+cd dspace/src/main/docker/dspace-shibboleth
+docker build -t dspace/dspace-shibboleth .
+
+# Test running it manually
+docker run -i -t -d -p 80:80 -p 443:443 dspace/dspace-shibboleth
+```
+
 ## local.cfg and test/ folder
 
 These resources are bundled into the `dspace/dspace` image at build time.

--- a/dspace/src/main/docker/dspace-shibboleth/Dockerfile
+++ b/dspace/src/main/docker/dspace-shibboleth/Dockerfile
@@ -1,0 +1,56 @@
+#
+# The contents of this file are subject to the license and copyright
+# detailed in the LICENSE and NOTICE files at the root of the source
+# tree and available online at
+#
+# http://www.dspace.org/license/
+#
+
+# This will be deployed as dspace/dspace-shibboleth:latest
+# Build from Ubuntu as it has easy Apache tooling (e.g. a2enmod script is debian only).
+# Apache & mod_shib are required for DSpace to act as an SP
+# See also https://wiki.lyrasis.org/display/DSDOC7x/Authentication+Plugins#AuthenticationPlugins-ShibbolethAuthentication
+FROM ubuntu:20.04
+
+# Apache ENVs
+ENV APACHE_RUN_USER www-data
+ENV APACHE_RUN_GROUP www-data
+ENV APACHE_LOCK_DIR /var/lock/apache2
+ENV APACHE_LOG_DIR /var/log/apache2
+ENV APACHE_PID_FILE /var/run/apache2/apache2.pid
+ENV APACHE_SERVER_NAME localhost
+
+# Ensure Apache2, mod_shib & shibboleth daemon are installed.
+# Also install ssl-cert to provide a local SSL cert for use with Apache
+# TODO: curl may not be needed here?
+RUN apt-get update \
+      && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+           apache2 \
+           curl \
+           ca-certificates \
+           ssl-cert \
+           libapache2-mod-shib2 \
+      && apt-get clean \
+      && rm -rf /var/lib/apt/lists/* \
+      && rm -rf /tmp/*
+
+# Setup Apache configs & enable mod-shib
+RUN a2enmod ssl rewrite shib && \
+    a2ensite default-ssl.conf
+    #a2dissite 000-default.conf default-ssl.conf
+
+# TODO: NEED to copy over VirtualHost configs specific to Shibboleth!!
+
+# Setup Shibboleth configs
+COPY shibboleth2.xml /etc/shibboleth/
+RUN cd /etc/shibboleth/ \
+    && shib-keygen
+
+# Copy over our startup script
+COPY httpd-shibd-foreground.sh /usr/local/bin/
+
+# Expose HTTP and HTTPS ports for Apache
+EXPOSE 80 443
+
+# Launch Shib & Apache
+CMD ["httpd-shibd-foreground.sh"]

--- a/dspace/src/main/docker/dspace-shibboleth/Dockerfile
+++ b/dspace/src/main/docker/dspace-shibboleth/Dockerfile
@@ -22,11 +22,9 @@ ENV APACHE_SERVER_NAME localhost
 
 # Ensure Apache2, mod_shib & shibboleth daemon are installed.
 # Also install ssl-cert to provide a local SSL cert for use with Apache
-# TODO: curl may not be needed here?
 RUN apt-get update \
       && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
            apache2 \
-           curl \
            ca-certificates \
            ssl-cert \
            libapache2-mod-shib2 \
@@ -34,12 +32,12 @@ RUN apt-get update \
       && rm -rf /var/lib/apt/lists/* \
       && rm -rf /tmp/*
 
-# Setup Apache configs & enable mod-shib
-RUN a2enmod ssl rewrite shib && \
-    a2ensite default-ssl.conf
-    #a2dissite 000-default.conf default-ssl.conf
-
-# TODO: NEED to copy over VirtualHost configs specific to Shibboleth!!
+# Setup Apache configs & enable mod-shib & dspace vhost
+# TODO: AJP Connector must be installed/enabled in Tomcat!!!  Need to update core DSpace image
+COPY dspace-vhost.conf /etc/apache2/sites-available/
+RUN a2enmod ssl headers proxy proxy_ajp proxy_http shib && \
+    a2dissite 000-default.conf default-ssl.conf && \
+    a2ensite dspace-vhost.conf
 
 # Setup Shibboleth configs
 COPY shibboleth2.xml /etc/shibboleth/

--- a/dspace/src/main/docker/dspace-shibboleth/Dockerfile
+++ b/dspace/src/main/docker/dspace-shibboleth/Dockerfile
@@ -12,7 +12,7 @@
 # See also https://wiki.lyrasis.org/display/DSDOC7x/Authentication+Plugins#AuthenticationPlugins-ShibbolethAuthentication
 FROM ubuntu:20.04
 
-# Apache ENVs
+# Apache ENVs (default values)
 ENV APACHE_RUN_USER www-data
 ENV APACHE_RUN_GROUP www-data
 ENV APACHE_LOCK_DIR /var/lock/apache2
@@ -33,7 +33,6 @@ RUN apt-get update \
       && rm -rf /tmp/*
 
 # Setup Apache configs & enable mod-shib & dspace vhost
-# TODO: AJP Connector must be installed/enabled in Tomcat!!!  Need to update core DSpace image
 COPY dspace-vhost.conf /etc/apache2/sites-available/
 RUN a2enmod ssl headers proxy proxy_ajp proxy_http shib && \
     a2dissite 000-default.conf default-ssl.conf && \

--- a/dspace/src/main/docker/dspace-shibboleth/Dockerfile
+++ b/dspace/src/main/docker/dspace-shibboleth/Dockerfile
@@ -40,6 +40,7 @@ RUN a2enmod ssl headers proxy proxy_ajp proxy_http shib && \
 
 # Setup Shibboleth configs
 COPY shibboleth2.xml /etc/shibboleth/
+COPY attribute-map.xml /etc/shibboleth/
 RUN cd /etc/shibboleth/ \
     && shib-keygen
 

--- a/dspace/src/main/docker/dspace-shibboleth/attribute-map.xml
+++ b/dspace/src/main/docker/dspace-shibboleth/attribute-map.xml
@@ -1,4 +1,13 @@
 <!--
+
+    The contents of this file are subject to the license and copyright
+    detailed in the LICENSE and NOTICE files at the root of the source
+    tree and available online at
+
+    http://www.dspace.org/license/
+
+-->
+<!--
     A custom attribute-map.xml file for DSpace
     This configuration adds additional attributes based on the attributes provided by samltest.id.
     See first set of attributes below & docs at https://samltest.id/download/
@@ -64,116 +73,4 @@
     <Attribute name="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent" id="persistent-id">
         <AttributeDecoder xsi:type="NameIDAttributeDecoder" formatter="$NameQualifier!$SPNameQualifier!$Name" defaultQualifiers="true"/>
     </Attribute>
-
-    <!-- Other eduPerson attributes (SAML 2 names followed by SAML 1 names)... -->
-    <!--
-    <Attribute name="urn:oid:1.3.6.1.4.1.5923.1.1.1.11" id="assurance"/>
-    <Attribute name="urn:oid:1.3.6.1.4.1.5923.1.5.1.1" id="member"/>
-    <Attribute name="urn:oid:1.3.6.1.4.1.5923.1.6.1.1" id="eduCourseOffering"/>
-    <Attribute name="urn:oid:1.3.6.1.4.1.5923.1.6.1.2" id="eduCourseMember"/>
-
-    <Attribute name="urn:oid:1.3.6.1.4.1.5923.1.1.1.1" id="unscoped-affiliation">
-        <AttributeDecoder xsi:type="StringAttributeDecoder" caseSensitive="false"/>
-    </Attribute>
-    <Attribute name="urn:oid:1.3.6.1.4.1.5923.1.1.1.5" id="primary-affiliation">
-        <AttributeDecoder xsi:type="StringAttributeDecoder" caseSensitive="false"/>
-    </Attribute>
-    <Attribute name="urn:oid:1.3.6.1.4.1.5923.1.1.1.2" id="nickname"/>
-    <Attribute name="urn:oid:1.3.6.1.4.1.5923.1.1.1.8" id="primary-orgunit-dn"/>
-    <Attribute name="urn:oid:1.3.6.1.4.1.5923.1.1.1.4" id="orgunit-dn"/>
-    <Attribute name="urn:oid:1.3.6.1.4.1.5923.1.1.1.3" id="org-dn"/>
-
-    <Attribute name="urn:mace:dir:attribute-def:eduPersonAffiliation" id="unscoped-affiliation">
-        <AttributeDecoder xsi:type="StringAttributeDecoder" caseSensitive="false"/>
-    </Attribute>
-    <Attribute name="urn:mace:dir:attribute-def:eduPersonPrimaryAffiliation" id="primary-affiliation">
-        <AttributeDecoder xsi:type="StringAttributeDecoder" caseSensitive="false"/>
-    </Attribute>
-    <Attribute name="urn:mace:dir:attribute-def:eduPersonNickname" id="nickname"/>
-    <Attribute name="urn:mace:dir:attribute-def:eduPersonPrimaryOrgUnitDN" id="primary-orgunit-dn"/>
-    <Attribute name="urn:mace:dir:attribute-def:eduPersonOrgUnitDN" id="orgunit-dn"/>
-    <Attribute name="urn:mace:dir:attribute-def:eduPersonOrgDN" id="org-dn"/>
-    -->
-
-    <!-- Older LDAP-defined attributes (SAML 2.0 names followed by SAML 1 names)... -->
-    <!--
-    <Attribute name="urn:oid:2.5.4.3" id="cn"/>
-    <Attribute name="urn:oid:2.5.4.4" id="sn"/>
-    <Attribute name="urn:oid:2.5.4.42" id="givenName"/>
-    <Attribute name="urn:oid:2.16.840.1.113730.3.1.241" id="displayName"/>
-    <Attribute name="urn:oid:0.9.2342.19200300.100.1.1" id="uid"/>
-    <Attribute name="urn:oid:0.9.2342.19200300.100.1.3" id="mail"/>
-    <Attribute name="urn:oid:2.5.4.20" id="telephoneNumber"/>
-    <Attribute name="urn:oid:2.5.4.12" id="title"/>
-    <Attribute name="urn:oid:2.5.4.43" id="initials"/>
-    <Attribute name="urn:oid:2.5.4.13" id="description"/>
-    <Attribute name="urn:oid:2.16.840.1.113730.3.1.1" id="carLicense"/>
-    <Attribute name="urn:oid:2.16.840.1.113730.3.1.2" id="departmentNumber"/>
-    <Attribute name="urn:oid:2.16.840.1.113730.3.1.3" id="employeeNumber"/>
-    <Attribute name="urn:oid:2.16.840.1.113730.3.1.4" id="employeeType"/>
-    <Attribute name="urn:oid:2.16.840.1.113730.3.1.39" id="preferredLanguage"/>
-    <Attribute name="urn:oid:0.9.2342.19200300.100.1.10" id="manager"/>
-    <Attribute name="urn:oid:2.5.4.34" id="seeAlso"/>
-    <Attribute name="urn:oid:2.5.4.23" id="facsimileTelephoneNumber"/>
-    <Attribute name="urn:oid:2.5.4.9" id="street"/>
-    <Attribute name="urn:oid:2.5.4.18" id="postOfficeBox"/>
-    <Attribute name="urn:oid:2.5.4.17" id="postalCode"/>
-    <Attribute name="urn:oid:2.5.4.8" id="st"/>
-    <Attribute name="urn:oid:2.5.4.7" id="l"/>
-    <Attribute name="urn:oid:2.5.4.10" id="o"/>
-    <Attribute name="urn:oid:2.5.4.11" id="ou"/>
-    <Attribute name="urn:oid:2.5.4.15" id="businessCategory"/>
-    <Attribute name="urn:oid:2.5.4.19" id="physicalDeliveryOfficeName"/>
-
-    <Attribute name="urn:mace:dir:attribute-def:cn" id="cn"/>
-    <Attribute name="urn:mace:dir:attribute-def:sn" id="sn"/>
-    <Attribute name="urn:mace:dir:attribute-def:givenName" id="givenName"/>
-    <Attribute name="urn:mace:dir:attribute-def:displayName" id="displayName"/>
-    <Attribute name="urn:mace:dir:attribute-def:uid" id="uid"/>
-    <Attribute name="urn:mace:dir:attribute-def:mail" id="mail"/>
-    <Attribute name="urn:mace:dir:attribute-def:telephoneNumber" id="telephoneNumber"/>
-    <Attribute name="urn:mace:dir:attribute-def:title" id="title"/>
-    <Attribute name="urn:mace:dir:attribute-def:initials" id="initials"/>
-    <Attribute name="urn:mace:dir:attribute-def:description" id="description"/>
-    <Attribute name="urn:mace:dir:attribute-def:carLicense" id="carLicense"/>
-    <Attribute name="urn:mace:dir:attribute-def:departmentNumber" id="departmentNumber"/>
-    <Attribute name="urn:mace:dir:attribute-def:employeeNumber" id="employeeNumber"/>
-    <Attribute name="urn:mace:dir:attribute-def:employeeType" id="employeeType"/>
-    <Attribute name="urn:mace:dir:attribute-def:preferredLanguage" id="preferredLanguage"/>
-    <Attribute name="urn:mace:dir:attribute-def:manager" id="manager"/>
-    <Attribute name="urn:mace:dir:attribute-def:seeAlso" id="seeAlso"/>
-    <Attribute name="urn:mace:dir:attribute-def:facsimileTelephoneNumber" id="facsimileTelephoneNumber"/>
-    <Attribute name="urn:mace:dir:attribute-def:street" id="street"/>
-    <Attribute name="urn:mace:dir:attribute-def:postOfficeBox" id="postOfficeBox"/>
-    <Attribute name="urn:mace:dir:attribute-def:postalCode" id="postalCode"/>
-    <Attribute name="urn:mace:dir:attribute-def:st" id="st"/>
-    <Attribute name="urn:mace:dir:attribute-def:l" id="l"/>
-    <Attribute name="urn:mace:dir:attribute-def:o" id="o"/>
-    <Attribute name="urn:mace:dir:attribute-def:ou" id="ou"/>
-    <Attribute name="urn:mace:dir:attribute-def:businessCategory" id="businessCategory"/>
-    <Attribute name="urn:mace:dir:attribute-def:physicalDeliveryOfficeName" id="physicalDeliveryOfficeName"/>
-    -->
-
-    <!-- SCHAC attributes... -->
-    <!--
-    <Attribute name="urn:oid:1.3.6.1.4.1.25178.1.2.9" id="schacHomeOrganization">
-        <AttributeDecoder xsi:type="StringAttributeDecoder" caseSensitive="false"/>
-    </Attribute>
-    <Attribute name="urn:oid:1.3.6.1.4.1.25178.1.2.10" id="schacHomeOrganizationType">
-        <AttributeDecoder xsi:type="StringAttributeDecoder" caseSensitive="false"/>
-    </Attribute>
-    <Attribute name="urn:oid:1.3.6.1.4.1.25178.1.2.14" id="schacPersonalUniqueCode">
-        <AttributeDecoder xsi:type="StringAttributeDecoder" caseSensitive="false"/>
-    </Attribute>
-    <Attribute name="urn:oid:1.3.6.1.4.1.25178.1.2.15" id="schacPersonalUniqueID"/>
-    <Attribute name="urn:oid:1.3.6.1.4.1.25178.1.2.19" id="schacUserStatus">
-        <AttributeDecoder xsi:type="StringAttributeDecoder" caseSensitive="false"/>
-    </Attribute>
-    <Attribute name="urn:oid:1.3.6.1.4.1.25178.1.2.20" id="schacProjectMembership">
-        <AttributeDecoder xsi:type="StringAttributeDecoder" caseSensitive="false"/>
-    </Attribute>
-    <Attribute name="urn:oid:1.3.6.1.4.1.25178.1.2.21" id="schacProjectSpecificRole">
-        <AttributeDecoder xsi:type="StringAttributeDecoder" caseSensitive="false"/>
-    </Attribute>
-    -->
 </Attributes>

--- a/dspace/src/main/docker/dspace-shibboleth/attribute-map.xml
+++ b/dspace/src/main/docker/dspace-shibboleth/attribute-map.xml
@@ -1,0 +1,179 @@
+<!--
+    A custom attribute-map.xml file for DSpace
+    This configuration adds additional attributes based on the attributes provided by samltest.id.
+    See first set of attributes below & docs at https://samltest.id/download/
+-->
+<Attributes xmlns="urn:mace:shibboleth:2.0:attribute-map" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <!-- Attributes for samltest.id -->
+    <Attribute name="urn:oid:0.9.2342.19200300.100.1.1" id="uid"/>
+    <Attribute name="urn:oid:0.9.2342.19200300.100.1.3" id="mail"/>
+    <Attribute name="urn:oid:2.5.4.4" id="sn"/>
+    <Attribute name="urn:oid:2.16.840.1.113730.3.1.241" id="displayName"/>
+    <Attribute name="urn:oid:2.5.4.20" id="telephoneNumber"/>
+    <Attribute name="urn:oid:2.5.4.42" id="givenName"/>
+    <Attribute name="https://samltest.id/attributes/role" id="role"/>
+
+    <!--
+    The mappings are a mix of SAML 1.1 and SAML 2.0 attribute names agreed to within the Shibboleth
+    community. The non-OID URNs are SAML 1.1 names and most of the OIDs are SAML 2.0 names, with a
+    few exceptions for newer attributes where the name is the same for both versions. You will
+    usually want to uncomment or map the names for both SAML versions as a unit.
+    -->
+
+    <!-- New standard identifier attributes for SAML. -->
+
+    <Attribute name="urn:oasis:names:tc:SAML:attribute:subject-id" id="subject-id">
+        <AttributeDecoder xsi:type="ScopedAttributeDecoder" caseSensitive="false"/>
+    </Attribute>
+
+    <Attribute name="urn:oasis:names:tc:SAML:attribute:pairwise-id" id="pairwise-id">
+        <AttributeDecoder xsi:type="ScopedAttributeDecoder" caseSensitive="false"/>
+    </Attribute>
+
+    <!-- The most typical eduPerson attributes. -->
+
+    <Attribute name="urn:oid:1.3.6.1.4.1.5923.1.1.1.6" id="eppn">
+        <AttributeDecoder xsi:type="ScopedAttributeDecoder" caseSensitive="false"/>
+    </Attribute>
+    <Attribute name="urn:mace:dir:attribute-def:eduPersonPrincipalName" id="eppn">
+        <AttributeDecoder xsi:type="ScopedAttributeDecoder" caseSensitive="false"/>
+    </Attribute>
+
+    <Attribute name="urn:oid:1.3.6.1.4.1.5923.1.1.1.9" id="affiliation">
+        <AttributeDecoder xsi:type="ScopedAttributeDecoder" caseSensitive="false"/>
+    </Attribute>
+    <Attribute name="urn:mace:dir:attribute-def:eduPersonScopedAffiliation" id="affiliation">
+        <AttributeDecoder xsi:type="ScopedAttributeDecoder" caseSensitive="false"/>
+    </Attribute>
+
+    <Attribute name="urn:oid:1.3.6.1.4.1.5923.1.1.1.7" id="entitlement"/>
+    <Attribute name="urn:mace:dir:attribute-def:eduPersonEntitlement" id="entitlement"/>
+
+    <!--
+    Legacy pairwise identifier attribute / NameID format, intended to be replaced by the
+    simpler pairwise-id attribute (see top of file).
+    -->
+
+    <!-- The eduPerson attribute version (note the OID-style name): -->
+    <Attribute name="urn:oid:1.3.6.1.4.1.5923.1.1.1.10" id="persistent-id">
+        <AttributeDecoder xsi:type="NameIDAttributeDecoder" formatter="$NameQualifier!$SPNameQualifier!$Name" defaultQualifiers="true"/>
+    </Attribute>
+
+    <!-- The SAML 2.0 NameID Format: -->
+    <Attribute name="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent" id="persistent-id">
+        <AttributeDecoder xsi:type="NameIDAttributeDecoder" formatter="$NameQualifier!$SPNameQualifier!$Name" defaultQualifiers="true"/>
+    </Attribute>
+
+    <!-- Other eduPerson attributes (SAML 2 names followed by SAML 1 names)... -->
+    <!--
+    <Attribute name="urn:oid:1.3.6.1.4.1.5923.1.1.1.11" id="assurance"/>
+    <Attribute name="urn:oid:1.3.6.1.4.1.5923.1.5.1.1" id="member"/>
+    <Attribute name="urn:oid:1.3.6.1.4.1.5923.1.6.1.1" id="eduCourseOffering"/>
+    <Attribute name="urn:oid:1.3.6.1.4.1.5923.1.6.1.2" id="eduCourseMember"/>
+
+    <Attribute name="urn:oid:1.3.6.1.4.1.5923.1.1.1.1" id="unscoped-affiliation">
+        <AttributeDecoder xsi:type="StringAttributeDecoder" caseSensitive="false"/>
+    </Attribute>
+    <Attribute name="urn:oid:1.3.6.1.4.1.5923.1.1.1.5" id="primary-affiliation">
+        <AttributeDecoder xsi:type="StringAttributeDecoder" caseSensitive="false"/>
+    </Attribute>
+    <Attribute name="urn:oid:1.3.6.1.4.1.5923.1.1.1.2" id="nickname"/>
+    <Attribute name="urn:oid:1.3.6.1.4.1.5923.1.1.1.8" id="primary-orgunit-dn"/>
+    <Attribute name="urn:oid:1.3.6.1.4.1.5923.1.1.1.4" id="orgunit-dn"/>
+    <Attribute name="urn:oid:1.3.6.1.4.1.5923.1.1.1.3" id="org-dn"/>
+
+    <Attribute name="urn:mace:dir:attribute-def:eduPersonAffiliation" id="unscoped-affiliation">
+        <AttributeDecoder xsi:type="StringAttributeDecoder" caseSensitive="false"/>
+    </Attribute>
+    <Attribute name="urn:mace:dir:attribute-def:eduPersonPrimaryAffiliation" id="primary-affiliation">
+        <AttributeDecoder xsi:type="StringAttributeDecoder" caseSensitive="false"/>
+    </Attribute>
+    <Attribute name="urn:mace:dir:attribute-def:eduPersonNickname" id="nickname"/>
+    <Attribute name="urn:mace:dir:attribute-def:eduPersonPrimaryOrgUnitDN" id="primary-orgunit-dn"/>
+    <Attribute name="urn:mace:dir:attribute-def:eduPersonOrgUnitDN" id="orgunit-dn"/>
+    <Attribute name="urn:mace:dir:attribute-def:eduPersonOrgDN" id="org-dn"/>
+    -->
+
+    <!-- Older LDAP-defined attributes (SAML 2.0 names followed by SAML 1 names)... -->
+    <!--
+    <Attribute name="urn:oid:2.5.4.3" id="cn"/>
+    <Attribute name="urn:oid:2.5.4.4" id="sn"/>
+    <Attribute name="urn:oid:2.5.4.42" id="givenName"/>
+    <Attribute name="urn:oid:2.16.840.1.113730.3.1.241" id="displayName"/>
+    <Attribute name="urn:oid:0.9.2342.19200300.100.1.1" id="uid"/>
+    <Attribute name="urn:oid:0.9.2342.19200300.100.1.3" id="mail"/>
+    <Attribute name="urn:oid:2.5.4.20" id="telephoneNumber"/>
+    <Attribute name="urn:oid:2.5.4.12" id="title"/>
+    <Attribute name="urn:oid:2.5.4.43" id="initials"/>
+    <Attribute name="urn:oid:2.5.4.13" id="description"/>
+    <Attribute name="urn:oid:2.16.840.1.113730.3.1.1" id="carLicense"/>
+    <Attribute name="urn:oid:2.16.840.1.113730.3.1.2" id="departmentNumber"/>
+    <Attribute name="urn:oid:2.16.840.1.113730.3.1.3" id="employeeNumber"/>
+    <Attribute name="urn:oid:2.16.840.1.113730.3.1.4" id="employeeType"/>
+    <Attribute name="urn:oid:2.16.840.1.113730.3.1.39" id="preferredLanguage"/>
+    <Attribute name="urn:oid:0.9.2342.19200300.100.1.10" id="manager"/>
+    <Attribute name="urn:oid:2.5.4.34" id="seeAlso"/>
+    <Attribute name="urn:oid:2.5.4.23" id="facsimileTelephoneNumber"/>
+    <Attribute name="urn:oid:2.5.4.9" id="street"/>
+    <Attribute name="urn:oid:2.5.4.18" id="postOfficeBox"/>
+    <Attribute name="urn:oid:2.5.4.17" id="postalCode"/>
+    <Attribute name="urn:oid:2.5.4.8" id="st"/>
+    <Attribute name="urn:oid:2.5.4.7" id="l"/>
+    <Attribute name="urn:oid:2.5.4.10" id="o"/>
+    <Attribute name="urn:oid:2.5.4.11" id="ou"/>
+    <Attribute name="urn:oid:2.5.4.15" id="businessCategory"/>
+    <Attribute name="urn:oid:2.5.4.19" id="physicalDeliveryOfficeName"/>
+
+    <Attribute name="urn:mace:dir:attribute-def:cn" id="cn"/>
+    <Attribute name="urn:mace:dir:attribute-def:sn" id="sn"/>
+    <Attribute name="urn:mace:dir:attribute-def:givenName" id="givenName"/>
+    <Attribute name="urn:mace:dir:attribute-def:displayName" id="displayName"/>
+    <Attribute name="urn:mace:dir:attribute-def:uid" id="uid"/>
+    <Attribute name="urn:mace:dir:attribute-def:mail" id="mail"/>
+    <Attribute name="urn:mace:dir:attribute-def:telephoneNumber" id="telephoneNumber"/>
+    <Attribute name="urn:mace:dir:attribute-def:title" id="title"/>
+    <Attribute name="urn:mace:dir:attribute-def:initials" id="initials"/>
+    <Attribute name="urn:mace:dir:attribute-def:description" id="description"/>
+    <Attribute name="urn:mace:dir:attribute-def:carLicense" id="carLicense"/>
+    <Attribute name="urn:mace:dir:attribute-def:departmentNumber" id="departmentNumber"/>
+    <Attribute name="urn:mace:dir:attribute-def:employeeNumber" id="employeeNumber"/>
+    <Attribute name="urn:mace:dir:attribute-def:employeeType" id="employeeType"/>
+    <Attribute name="urn:mace:dir:attribute-def:preferredLanguage" id="preferredLanguage"/>
+    <Attribute name="urn:mace:dir:attribute-def:manager" id="manager"/>
+    <Attribute name="urn:mace:dir:attribute-def:seeAlso" id="seeAlso"/>
+    <Attribute name="urn:mace:dir:attribute-def:facsimileTelephoneNumber" id="facsimileTelephoneNumber"/>
+    <Attribute name="urn:mace:dir:attribute-def:street" id="street"/>
+    <Attribute name="urn:mace:dir:attribute-def:postOfficeBox" id="postOfficeBox"/>
+    <Attribute name="urn:mace:dir:attribute-def:postalCode" id="postalCode"/>
+    <Attribute name="urn:mace:dir:attribute-def:st" id="st"/>
+    <Attribute name="urn:mace:dir:attribute-def:l" id="l"/>
+    <Attribute name="urn:mace:dir:attribute-def:o" id="o"/>
+    <Attribute name="urn:mace:dir:attribute-def:ou" id="ou"/>
+    <Attribute name="urn:mace:dir:attribute-def:businessCategory" id="businessCategory"/>
+    <Attribute name="urn:mace:dir:attribute-def:physicalDeliveryOfficeName" id="physicalDeliveryOfficeName"/>
+    -->
+
+    <!-- SCHAC attributes... -->
+    <!--
+    <Attribute name="urn:oid:1.3.6.1.4.1.25178.1.2.9" id="schacHomeOrganization">
+        <AttributeDecoder xsi:type="StringAttributeDecoder" caseSensitive="false"/>
+    </Attribute>
+    <Attribute name="urn:oid:1.3.6.1.4.1.25178.1.2.10" id="schacHomeOrganizationType">
+        <AttributeDecoder xsi:type="StringAttributeDecoder" caseSensitive="false"/>
+    </Attribute>
+    <Attribute name="urn:oid:1.3.6.1.4.1.25178.1.2.14" id="schacPersonalUniqueCode">
+        <AttributeDecoder xsi:type="StringAttributeDecoder" caseSensitive="false"/>
+    </Attribute>
+    <Attribute name="urn:oid:1.3.6.1.4.1.25178.1.2.15" id="schacPersonalUniqueID"/>
+    <Attribute name="urn:oid:1.3.6.1.4.1.25178.1.2.19" id="schacUserStatus">
+        <AttributeDecoder xsi:type="StringAttributeDecoder" caseSensitive="false"/>
+    </Attribute>
+    <Attribute name="urn:oid:1.3.6.1.4.1.25178.1.2.20" id="schacProjectMembership">
+        <AttributeDecoder xsi:type="StringAttributeDecoder" caseSensitive="false"/>
+    </Attribute>
+    <Attribute name="urn:oid:1.3.6.1.4.1.25178.1.2.21" id="schacProjectSpecificRole">
+        <AttributeDecoder xsi:type="StringAttributeDecoder" caseSensitive="false"/>
+    </Attribute>
+    -->
+</Attributes>

--- a/dspace/src/main/docker/dspace-shibboleth/dspace-vhost.conf
+++ b/dspace/src/main/docker/dspace-shibboleth/dspace-vhost.conf
@@ -1,6 +1,6 @@
 <VirtualHost _default_:443>
-  ServerName localhost
-  ServerAdmin webmaster@localhost
+  ServerName ${APACHE_SERVER_NAME}
+  ServerAdmin webmaster@${APACHE_SERVER_NAME}
 
   DocumentRoot /var/www/html
 

--- a/dspace/src/main/docker/dspace-shibboleth/dspace-vhost.conf
+++ b/dspace/src/main/docker/dspace-shibboleth/dspace-vhost.conf
@@ -66,7 +66,6 @@
           # Here's a good guide to configuring Apache + Tomcat when this setting is "Off":
           # https://www.switch.ch/de/aai/support/serviceproviders/sp-access-rules.html#javaapplications
           ShibUseHeaders On
-          #require shibboleth
        </Location>
 
        # Ensure /Shibboleth.sso path (in Apache) can be accessed
@@ -85,10 +84,6 @@
        ProxyPass /Shibboleth.sso !
    </IfModule>
 
-  # Adding SSL Proxy Engine On
-  #SSLProxyEngine on
-  #ProxyRequests off
-  #ProxyPreserveHost On
   ## Proxy / Forwarding Settings ##
   <Proxy *>
       AddDefaultCharset Off
@@ -97,12 +92,12 @@
   </Proxy>
 
   # Proxy all requests to /server to Tomcat via AJP
-  # NOTE: Host matches Docker container name of Tomcat container
+  # NOTE: Host (dspace) matches Docker container name of Tomcat container
   ProxyPass /server ajp://dspace:8009/server
   ProxyPassReverse /server ajp://dspace:8009/server
 
   # A specific proxypass configuration for Angular
-  # NOTE: Host matches Docker container name of Angular container
+  # NOTE: Host (dspace-angular) matches Docker container name of Angular container
   ProxyPass / http://dspace-angular:4000/
   ProxyPassReverse / http://dspace-angular:4000/
 </VirtualHost>

--- a/dspace/src/main/docker/dspace-shibboleth/dspace-vhost.conf
+++ b/dspace/src/main/docker/dspace-shibboleth/dspace-vhost.conf
@@ -1,0 +1,106 @@
+<VirtualHost _default_:443>
+  ServerName localhost
+  ServerAdmin webmaster@localhost
+
+  DocumentRoot /var/www/html
+
+  # Possible values include: debug, info, notice, warn, error, crit,
+  # alert, emerg.
+  LogLevel warn
+  ErrorLog ${APACHE_LOG_DIR}/dspace.error.log
+  CustomLog ${APACHE_LOG_DIR}/dspace.access.log combined
+
+  # Required when running DSpace REST API and Angular UI from separate hostnames
+  # This ensures all headers can be passed between frontend and backend
+  Header set Access-Control-Expose-Headers: "Authorization, expires, Location, Content-Disposition, WWW-Authenticate, Set-Cookie, X-Requested-With"
+
+  #   SSL Engine Switch:
+  #   Enable/Disable SSL for this virtual host.
+  SSLEngine on
+  #   A self-signed (snakeoil) certificate can be created by installing the ssl-cert package.
+  SSLCertificateFile    /etc/ssl/certs/ssl-cert-snakeoil.pem
+  SSLCertificateKeyFile /etc/ssl/private/ssl-cert-snakeoil.key
+
+   <IfModule mod_shib>
+       # Shibboleth recommends turning on UseCanonicalName
+       # See "Prepping Apache" in https://wiki.shibboleth.net/confluence/display/SHIB2/NativeSPApacheConfig
+       UseCanonicalName On
+
+       # Most DSpace instances will want to use Shibboleth "Lazy Session", which ensures that users
+       # can access DSpace without first authenticating via Shibboleth.
+       # This section turns on Shibboleth "Lazy Session". Also ensures that once they have authenticated
+       # (by accessing /Shibboleth.sso/Login path), then their Shib session is kept alive
+       <Location />
+          AuthType shibboleth
+          ShibRequireSession Off
+          require shibboleth
+          # If your "shibboleth2.xml" file specifies an <ApplicationOverride> setting for your
+          # DSpace Service Provider, then you may need to tell Apache which "id" to redirect Shib requests to.
+          # Just uncomment this and change the value "my-dspace-id" to the associated @id attribute value.
+          #ShibRequestSetting applicationId my-dspace-id
+       </Location>
+
+       # If a user attempts to access the DSpace shibboleth login page, force them to authenticate via Shib
+       <Location "/server/api/authn/shibboleth">
+          Order deny,allow
+          Allow from all
+          AuthType shibboleth
+          ShibRequireSession On
+          # Please note that setting ShibUseHeaders to "On" is a potential security risk.
+          # You may wish to set it to "Off". See the mod_shib docs for details about this setting:
+          # https://wiki.shibboleth.net/confluence/display/SHIB2/NativeSPApacheConfig#NativeSPApacheConfig-AuthConfigOptions
+          # Here's a good guide to configuring Apache + Tomcat when this setting is "Off":
+          # https://www.switch.ch/de/aai/support/serviceproviders/sp-access-rules.html#javaapplications
+          ShibUseHeaders On
+          require shibboleth
+       </Location>
+       <Location "/server/api/authn/login">
+          Order deny,allow
+          Allow from all
+          AuthType shibboleth
+          # For DSpace, this is required to be off otherwise the available auth methods will be not visible
+          ShibRequireSession Off
+          # Please note that setting ShibUseHeaders to "On" is a potential security risk.
+          # You may wish to set it to "Off". See the mod_shib docs for details about this setting:
+          # https://wiki.shibboleth.net/confluence/display/SHIB2/NativeSPApacheConfig#NativeSPApacheConfig-AuthConfigOptions
+          # Here's a good guide to configuring Apache + Tomcat when this setting is "Off":
+          # https://www.switch.ch/de/aai/support/serviceproviders/sp-access-rules.html#javaapplications
+          ShibUseHeaders On
+          #require shibboleth
+       </Location>
+
+       # Ensure /Shibboleth.sso path (in Apache) can be accessed
+       # By default it may be inaccessible if your Apache security is tight.
+       <Location "/Shibboleth.sso">
+          Order deny,allow
+          Allow from all
+          # Also ensure Shibboleth/mod_shib responds to this path
+          SetHandler shib
+       </Location>
+
+       # Finally, you may need to ensure requests to /Shibboleth.sso are NOT redirected
+       # to Tomcat (as they need to be handled by mod_shib instead).
+       # NOTE: THIS SETTING IS LIKELY ONLY NEEDED IF YOU ARE USING mod_proxy TO REDIRECT
+       # ALL REQUESTS TO TOMCAT (e.g. ProxyPass / ajp://localhost:8009/)
+       ProxyPass /Shibboleth.sso !
+   </IfModule>
+
+  # Adding SSL Proxy Engine On
+  #SSLProxyEngine on
+  #ProxyRequests off
+  #ProxyPreserveHost On
+  ## Proxy / Forwarding Settings ##
+  <Proxy *>
+      AddDefaultCharset Off
+      Order allow,deny
+      Allow from all
+  </Proxy>
+
+  # Proxy all requests to /server to Tomcat via AJP
+  ProxyPass /server ajp://localhost:8009/server
+  ProxyPassReverse /server ajp://localhost:8009/server
+
+  # A specific proxypass configuration for Angular
+  ProxyPass / http://localhost:3000/
+  ProxyPassReverse / http://localhost:3000/
+</VirtualHost>

--- a/dspace/src/main/docker/dspace-shibboleth/dspace-vhost.conf
+++ b/dspace/src/main/docker/dspace-shibboleth/dspace-vhost.conf
@@ -97,10 +97,12 @@
   </Proxy>
 
   # Proxy all requests to /server to Tomcat via AJP
-  ProxyPass /server ajp://localhost:8009/server
-  ProxyPassReverse /server ajp://localhost:8009/server
+  # NOTE: Host matches Docker container name of Tomcat container
+  ProxyPass /server ajp://dspace:8009/server
+  ProxyPassReverse /server ajp://dspace:8009/server
 
   # A specific proxypass configuration for Angular
-  ProxyPass / http://localhost:3000/
-  ProxyPassReverse / http://localhost:3000/
+  # NOTE: Host matches Docker container name of Angular container
+  ProxyPass / http://dspace-angular:4000/
+  ProxyPassReverse / http://dspace-angular:4000/
 </VirtualHost>

--- a/dspace/src/main/docker/dspace-shibboleth/dspace-vhost.conf
+++ b/dspace/src/main/docker/dspace-shibboleth/dspace-vhost.conf
@@ -1,3 +1,6 @@
+#
+# A custom/sample Apache VirtualHost for running DSpace behind Apache with Shibboleth enabled
+#
 <VirtualHost _default_:443>
   ServerName ${APACHE_SERVER_NAME}
   ServerAdmin webmaster@${APACHE_SERVER_NAME}

--- a/dspace/src/main/docker/dspace-shibboleth/httpd-shibd-foreground.sh
+++ b/dspace/src/main/docker/dspace-shibboleth/httpd-shibd-foreground.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
+# Replace the ${APACHE_SERVER_NAME} placeholder in our shibboleth2.xml with the current value of the
+# $APACHE_SERVER_NAME environment variable.
+sed -i "s/\${APACHE_SERVER_NAME}/$APACHE_SERVER_NAME/g" /etc/shibboleth/shibboleth2.xml
+
 # Start the Shibboleth daemon
 /etc/init.d/shibd start
 

--- a/dspace/src/main/docker/dspace-shibboleth/httpd-shibd-foreground.sh
+++ b/dspace/src/main/docker/dspace-shibboleth/httpd-shibd-foreground.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Start the Shibboleth daemon
+/etc/init.d/shibd start
+
+# Remove existing Apache PID files (if any)
+rm -f /var/run/apache2/apache2.pid
+
+# Start Apache (in foreground)
+exec /usr/sbin/apache2ctl -DFOREGROUND

--- a/dspace/src/main/docker/dspace-shibboleth/httpd-shibd-foreground.sh
+++ b/dspace/src/main/docker/dspace-shibboleth/httpd-shibd-foreground.sh
@@ -1,4 +1,13 @@
 #!/bin/bash
+#
+# The contents of this file are subject to the license and copyright
+# detailed in the LICENSE and NOTICE files at the root of the source
+# tree and available online at
+#
+# http://www.dspace.org/license/
+#
+
+# This script simply starts up the Shibboleth Daemon & Apache in the foreground
 set -e
 
 # Replace the ${APACHE_SERVER_NAME} placeholder in our shibboleth2.xml with the current value of the

--- a/dspace/src/main/docker/dspace-shibboleth/shibboleth2.xml
+++ b/dspace/src/main/docker/dspace-shibboleth/shibboleth2.xml
@@ -45,7 +45,7 @@
         -->
         <!-- DSPACE 7 requires Shibboleth to use "SameSite=None" property for its Cookies -->
         <Sessions lifetime="28800" timeout="3600" relayState="ss:mem"
-                  checkAddress="false" handlerSSL="false" cookieProps="; path=/; SameSite=None; Secure; HttpOnly">
+                  checkAddress="false" handlerSSL="true" cookieProps="; path=/; SameSite=None; secure; HttpOnly">
 
             <!--
             Configures SSO for a default IdP. To allow for >1 IdP, remove
@@ -129,7 +129,7 @@
         -->
         <!--
         <ApplicationOverride id="admin" entityID="https://admin.example.org/shibboleth"/>
-	-->
+	    -->
 
     </ApplicationDefaults>
 

--- a/dspace/src/main/docker/dspace-shibboleth/shibboleth2.xml
+++ b/dspace/src/main/docker/dspace-shibboleth/shibboleth2.xml
@@ -20,14 +20,14 @@
     -->
     <RequestMapper type="Native">
         <RequestMap applicationId="default">
-            <!-- Default to localhost. Change this if you change your ServerName -->
-            <Host name="localhost"></Host>
+            <!-- Placeholder is replaced by value of $APACHE_SERVER_NAME env var when http-shibd-foreground.sh runs -->
+            <Host name="${APACHE_SERVER_NAME}"></Host>
         </RequestMap>
     </RequestMapper>
 
     <!-- The ApplicationDefaults element is where most of Shibboleth's SAML bits are defined. -->
-    <!-- Default to localhost. Change this if you change your ServerName -->
-    <ApplicationDefaults entityID="https://localhost/shibboleth"
+    <!-- Placeholder is replaced by value of $APACHE_SERVER_NAME env var when http-shibd-foreground.sh runs -->
+    <ApplicationDefaults entityID="https://${APACHE_SERVER_NAME}/shibboleth"
                          REMOTE_USER="eppn persistent-id targeted-id">
 
         <!--

--- a/dspace/src/main/docker/dspace-shibboleth/shibboleth2.xml
+++ b/dspace/src/main/docker/dspace-shibboleth/shibboleth2.xml
@@ -1,0 +1,138 @@
+<SPConfig xmlns="urn:mace:shibboleth:2.0:native:sp:config"
+          xmlns:conf="urn:mace:shibboleth:2.0:native:sp:config"
+          xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+          xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+          xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+          clockSkew="180">
+
+    <!--
+    By default, in-memory StorageService, ReplayCache, ArtifactMap, and SessionCache
+    are used. See example-shibboleth2.xml for samples of explicitly configuring them.
+    -->
+
+    <!--
+    To customize behavior for specific resources on Apache, and to link vhosts or
+    resources to ApplicationOverride settings below, use web server options/commands.
+    See https://wiki.shibboleth.net/confluence/display/SHIB2/NativeSPConfigurationElements for help.
+
+    For examples with the RequestMap XML syntax instead, see the example-shibboleth2.xml
+    file, and the https://wiki.shibboleth.net/confluence/display/SHIB2/NativeSPRequestMapHowTo topic.
+    -->
+    <RequestMapper type="Native">
+        <RequestMap applicationId="default">
+            <!-- Default to localhost. Change this if you change your ServerName -->
+            <Host name="localhost"></Host>
+        </RequestMap>
+    </RequestMapper>
+
+    <!-- The ApplicationDefaults element is where most of Shibboleth's SAML bits are defined. -->
+    <!-- Default to localhost. Change this if you change your ServerName -->
+    <ApplicationDefaults entityID="https://localhost/shibboleth"
+                         REMOTE_USER="eppn persistent-id targeted-id">
+
+        <!--
+        Controls session lifetimes, address checks, cookie handling, and the protocol handlers.
+        You MUST supply an effectively unique handlerURL value for each of your applications.
+        The value defaults to /Shibboleth.sso, and should be a relative path, with the SP computing
+        a relative value based on the virtual host. Using handlerSSL="true", the default, will force
+        the protocol to be https. You should also set cookieProps to "https" for SSL-only sites.
+        Note that while we default checkAddress to "false", this has a negative impact on the
+        security of your site. Stealing sessions via cookie theft is much easier with this disabled.
+        -->
+        <!-- DSPACE 7 requires Shibboleth to use "SameSite=None" property for its Cookies -->
+        <Sessions lifetime="28800" timeout="3600" relayState="ss:mem"
+                  checkAddress="false" handlerSSL="false" cookieProps="; path=/; SameSite=None; Secure; HttpOnly">
+
+            <!--
+            Configures SSO for a default IdP. To allow for >1 IdP, remove
+            entityID property and adjust discoveryURL to point to discovery service.
+            (Set discoveryProtocol to "WAYF" for legacy Shibboleth WAYF support.)
+            You can also override entityID on /Login query string, or in RequestMap/htaccess.
+            -->
+            <SSO entityID="https://samltest.id/saml/idp"
+                 discoveryProtocol="SAMLDS" discoveryURL="https://ds.example.org/DS/WAYF">
+                SAML2 SAML1
+            </SSO>
+
+            <!-- SAML and local-only logout. -->
+            <Logout>SAML2 Local</Logout>
+
+            <!-- Extension service that generates "approximate" metadata based on SP configuration. -->
+            <Handler type="MetadataGenerator" Location="/Metadata" signing="false"/>
+
+            <!-- Status reporting service. -->
+            <Handler type="Status" Location="/Status" acl="127.0.0.1 ::1"/>
+
+            <!-- Session diagnostic service. -->
+            <Handler type="Session" Location="/Session" showAttributeValues="false"/>
+
+            <!-- JSON feed of discovery information. -->
+            <Handler type="DiscoveryFeed" Location="/DiscoFeed"/>
+        </Sessions>
+
+        <!--
+        Allows overriding of error template information/filenames. You can
+        also add attributes with values that can be plugged into the templates.
+        -->
+        <Errors supportContact="sample@email.com"
+                helpLocation="/about.html"
+                styleSheet="/shibboleth-sp/main.css"/>
+
+        <!-- Example of remotely supplied batch of signed metadata. -->
+        <!--
+        <MetadataProvider type="XML" validate="true"
+	      uri="http://example.org/federation-metadata.xml"
+              backingFilePath="federation-metadata.xml" reloadInterval="7200">
+            <MetadataFilter type="RequireValidUntil" maxValidityInterval="2419200"/>
+            <MetadataFilter type="Signature" certificate="fedsigner.pem"/>
+            <DiscoveryFilter type="Blacklist" matcher="EntityAttributes" trimTags="true"
+              attributeName="http://macedir.org/entity-category"
+              attributeNameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"
+              attributeValue="http://refeds.org/category/hide-from-discovery" />
+        </MetadataProvider>
+        -->
+
+        <MetadataProvider type="XML" uri="https://samltest.id/saml/idp"
+                          backingFilePath="samltest-metadata.xml" reloadInterval="7200">
+        </MetadataProvider>
+
+        <!-- Example of locally maintained metadata. -->
+        <!--
+        <MetadataProvider type="XML" validate="true" file="partner-metadata.xml"/>
+        -->
+
+        <!-- Map to extract attributes from SAML assertions. -->
+        <AttributeExtractor type="XML" validate="true" reloadChanges="false" path="attribute-map.xml"/>
+
+        <!-- Use a SAML query if no attributes are supplied during SSO. -->
+        <AttributeResolver type="Query" subjectMatch="true"/>
+
+        <!-- Default filtering policy for recognized attributes, lets other data pass. -->
+        <AttributeFilter type="XML" validate="true" path="attribute-policy.xml"/>
+
+        <!-- Simple file-based resolver for using a single keypair. -->
+        <!-- These can be generated on Ubuntu via 'shib-keygen' -->
+        <CredentialResolver type="File" key="sp-key.pem" certificate="sp-cert.pem"/>
+
+        <!--
+        The default settings can be overridden by creating ApplicationOverride elements (see
+        the https://wiki.shibboleth.net/confluence/display/SHIB2/NativeSPApplicationOverride topic).
+        Resource requests are mapped by web server commands, or the RequestMapper, to an
+        applicationId setting.
+
+        Example of a second application (for a second vhost) that has a different entityID.
+        Resources on the vhost would map to an applicationId of "admin":
+        -->
+        <!--
+        <ApplicationOverride id="admin" entityID="https://admin.example.org/shibboleth"/>
+	-->
+
+    </ApplicationDefaults>
+
+    <!-- Policies that determine how to process and authenticate runtime messages. -->
+    <SecurityPolicyProvider type="XML" validate="true" path="security-policy.xml"/>
+
+    <!-- Low-level configuration about protocols and bindings available for use. -->
+    <ProtocolProvider type="XML" validate="true" reloadChanges="false" path="protocols.xml"/>
+
+</SPConfig>

--- a/dspace/src/main/docker/dspace-shibboleth/shibboleth2.xml
+++ b/dspace/src/main/docker/dspace-shibboleth/shibboleth2.xml
@@ -1,4 +1,13 @@
 <!--
+
+    The contents of this file are subject to the license and copyright
+    detailed in the LICENSE and NOTICE files at the root of the source
+    tree and available online at
+
+    http://www.dspace.org/license/
+
+-->
+<!--
     A custom shibboleth2.xml file for DSpace
     This configuration uses https://samltest.id/saml/idp as an IDP
 -->

--- a/dspace/src/main/docker/dspace-shibboleth/shibboleth2.xml
+++ b/dspace/src/main/docker/dspace-shibboleth/shibboleth2.xml
@@ -1,3 +1,7 @@
+<!--
+    A custom shibboleth2.xml file for DSpace
+    This configuration uses https://samltest.id/saml/idp as an IDP
+-->
 <SPConfig xmlns="urn:mace:shibboleth:2.0:native:sp:config"
           xmlns:conf="urn:mace:shibboleth:2.0:native:sp:config"
           xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"

--- a/pom.xml
+++ b/pom.xml
@@ -413,6 +413,7 @@
                         <exclude>**/readme*</exclude>
                         <exclude>**/.gitignore</exclude>
                         <exclude>**/*.cfg</exclude>
+                        <exclude>**/*.conf</exclude>
                     </excludes>
                     <mapping>
                         <!-- Custom DSpace file extensions which are not recognized by license-maven-plugin:


### PR DESCRIPTION
Fixes: https://github.com/DSpace-Labs/DSpace-Docker-Images/issues/60

## Description
This PR allows developers to easily spin up DSpace 7 configured with Shibboleth and with https://samltest.id/ as the IdP.  It makes it much easier to develop & test with Shibboleth. _This PR only touches Docker scripts & configuration. It makes no code changes._

The following changes are included:
* Minor updates to existing `./Dockerfile.test` test/dev Docker setup -- adds/enables the Tomcat AJP connector by default.  This allows Apache to forward requests to DSpace 7 running on Tomcat in Docker.
* Adds a new `./dspace/src/main/docker/dspace-shibboleth/Dockerfile` which defines a new Docker container that runs an Apache web server, with `mod_shib` installed and the `shibd` (Shibboleth daemon) running locally.  Also added necessary Apache and Shibboleth configurations to `./dspace/src/main/docker/dspace-shibboleth/` to support running a Shibboleth SP pointing at https://samltest.id/ as the IdP. See [README](https://github.com/DSpace/DSpace/pull/3091/files#diff-7825a238af629ac5b8fcff411601d0e7d7d6f82c25365694364b10bfe282db59) for more details.
* Adds a new `./dspace/src/main/docker-compose/docker-compose-shibboleth.yml` Docker Compose script which can be used to easily spin up that `dspace-shibboleth` container alongside the rest of DSpace 7.  See [README](https://github.com/DSpace/DSpace/pull/3091/files#diff-6c9b6f658ca3f421a4537edbf7a657798ab38592886cdeaab1a7c1d4a570a5c6) for all the details.

## Instructions for Reviewers

* Take a look at the code/configuration
* Spin up the `dspace-shibboleth` container using the instructions in the README.  (NOTE: I've thoroughly tested this and feel it is working properly, but a second set of eyes is always welcome!)
    * NOTE: As the instructions note, currently I'm requiring you to use a public proxy service like https://ngrok.com/ (which is free).  So, anyone wanting to these this would need to signup for ngrok or find another way to ensure Docker containers running on their `localhost` are available at a public URL.