### PR TITLE
Improve IPv6 support

### DIFF
--- a/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java
@@ -336,7 +336,7 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
                 } else {
                     dns = configurationService.getProperty("anonymize_statistics.dns_mask", "anonymized");
                 }
-                doc1.addField("dns", dns.toLowerCase());
+                doc1.addField("dns", dns.toLowerCase(Locale.ROOT));
             } catch (UnknownHostException e) {
                 log.info("Failed DNS Lookup for IP:  {}", ip);
                 log.debug(e.getMessage(), e);
@@ -422,7 +422,7 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
             } else {
                 dns = configurationService.getProperty("anonymize_statistics.dns_mask", "anonymized");
             }
-            doc1.addField("dns", dns.toLowerCase());
+            doc1.addField("dns", dns.toLowerCase(Locale.ROOT));
         } catch (UnknownHostException e) {
             log.info("Failed DNS Lookup for IP:  {}", ip);
             log.debug(e.getMessage(), e);

--- a/dspace-api/src/main/java/org/dspace/statistics/util/IPTable.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/util/IPTable.java
@@ -12,6 +12,9 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 /**
  * A Spare v4 IPTable implementation that uses nested HashMaps
  * to optimize IP address matching over ranges of IP addresses.
@@ -19,13 +22,23 @@ import java.util.Set;
  * @author mdiggory at atmire.com
  */
 public class IPTable {
+    private static final Logger log = LogManager.getLogger(IPTable.class);
 
     /* A lookup tree for IP addresses and SubnetRanges */
-    private Map<String, Map<String, Map<String, Set<String>>>> map =
-        new HashMap<String, Map<String, Map<String, Set<String>>>>();
+    private final Map<String, Map<String, Map<String, Set<String>>>> map
+            = new HashMap<>();
 
     /**
-     * Can be full v4 IP, subnet or range string
+     * Can be full v4 IP, subnet or range string.
+     * <ul>
+     *   <li>A full address is a complete dotted-quad:  {@code "1.2.3.4".}
+     *   <li>A subnet is a dotted-triplet:  {@code "1.2.3"}.  It means an entire
+     *       Class C subnet:  "1.2.3.0-1.2.3.255".
+     *   <li>A range is two dotted-quad addresses separated by hyphen:
+     *       {@code "1.2.3.4-1.2.3.14"}.  Only the final octet may be different.
+     * </ul>
+     *
+     * Any attempt at CIDR notation is ignored.
      *
      * @param ip IP address(es)
      * @throws IPFormatException Exception Class to deal with IPFormat errors.
@@ -59,7 +72,6 @@ public class IPTable {
 
             if (subnets.length < 3) {
                 throw new IPFormatException(ip + " - require at least three subnet places (255.255.255.0");
-
             }
 
             start = subnets;
@@ -67,27 +79,24 @@ public class IPTable {
         }
 
         if (start.length >= 3) {
-
-
             Map<String, Map<String, Set<String>>> first = map.get(start[0]);
 
             if (first == null) {
-                first = new HashMap<String, Map<String, Set<String>>>();
+                first = new HashMap<>();
                 map.put(start[0], first);
             }
 
             Map<String, Set<String>> second = first.get(start[1]);
 
-
             if (second == null) {
-                second = new HashMap<String, Set<String>>();
+                second = new HashMap<>();
                 first.put(start[1], second);
             }
 
             Set<String> third = second.get(start[2]);
 
             if (third == null) {
-                third = new HashSet<String>();
+                third = new HashSet<>();
                 second.put(start[2], third);
             }
 
@@ -115,14 +124,22 @@ public class IPTable {
      * Check whether a given address is contained in this netblock.
      *
      * @param ip the address to be tested
-     * @return true if {@code ip} is within this table's limits
+     * @return true if {@code ip} is within this table's limits.  Returns false
+     *         if {@link ip} looks like an IPv6 address.
      * @throws IPFormatException Exception Class to deal with IPFormat errors.
      */
     public boolean contains(String ip) throws IPFormatException {
 
         String[] subnets = ip.split("\\.");
 
-        if (subnets.length != 4) {
+        // Does it look like IPv6?
+        if (subnets.length > 4 || ip.contains("::")) {
+            log.warn("Address {} assumed not to match.  IPv6 is not implemented.", ip);
+            return false;
+        }
+
+        // Does it look like a subnet?
+        if (subnets.length < 4) {
             throw new IPFormatException("needs to be a single IP address");
         }
 
@@ -154,7 +171,7 @@ public class IPTable {
      * @return this table's content as a Set
      */
     public Set<String> toSet() {
-        HashSet<String> set = new HashSet<String>();
+        HashSet<String> set = new HashSet<>();
 
         for (Map.Entry<String, Map<String, Map<String, Set<String>>>> first : map.entrySet()) {
             String firstString = first.getKey();

--- a/dspace-api/src/test/java/org/dspace/statistics/util/IPTableTest.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/util/IPTableTest.java
@@ -1,0 +1,78 @@
+package org.dspace.statistics.util;
+
+import org.dspace.statistics.util.IPTable.IPFormatException;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Ignore;
+
+/**
+ *
+ * @author mwood
+ */
+public class IPTableTest {
+
+    public IPTableTest() {
+    }
+
+    @BeforeClass
+    public static void setUpClass() {
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+    }
+
+    @Before
+    public void setUp() {
+    }
+
+    @After
+    public void tearDown() {
+    }
+
+    /**
+     * Test of add method, of class IPTable.
+     * @throws java.lang.Exception passed through.
+     */
+    @Ignore
+    @Test
+    public void testAdd() throws Exception {
+    }
+
+    /**
+     * Test of contains method, of class IPTable.
+     * @throws java.lang.Exception passed through.
+     */
+    @Test(expected=IPFormatException.class)
+    public void testContains() throws Exception {
+        String localhost = "127.0.0.1";
+        IPTable instance = new IPTable();
+        instance.add(localhost);
+        boolean contains;
+
+        contains = instance.contains(localhost);
+        assertTrue("Address that was add()ed should match", contains);
+
+        contains = instance.contains("192.168.1.1");
+        assertFalse("Address that was not add()ed should not match", contains);
+
+        contains = instance.contains("fec0:0:0:1::2");
+        assertFalse("IPv6 address should not match anything.", contains);
+
+        // This should throw an IPFormatException.
+        contains = instance.contains("axolotl");
+        assertFalse("Nonsense string should raise an exception.", contains);
+    }
+
+    /**
+     * Test of toSet method, of class IPTable.
+     */
+    @Ignore
+    @Test
+    public void testToSet() {
+    }
+}

--- a/dspace-api/src/test/java/org/dspace/statistics/util/IPTableTest.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/util/IPTableTest.java
@@ -1,13 +1,22 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package org.dspace.statistics.util;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.dspace.statistics.util.IPTable.IPFormatException;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Test;
-import static org.junit.Assert.*;
 import org.junit.Ignore;
+import org.junit.Test;
 
 /**
  *
@@ -47,7 +56,7 @@ public class IPTableTest {
      * Test of contains method, of class IPTable.
      * @throws java.lang.Exception passed through.
      */
-    @Test(expected=IPFormatException.class)
+    @Test(expected = IPFormatException.class)
     public void testContains() throws Exception {
         String localhost = "127.0.0.1";
         IPTable instance = new IPTable();

--- a/dspace-api/src/test/java/org/dspace/statistics/util/IPTableTest.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/util/IPTableTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
  * @author mwood
  */
 public class IPTableTest {
+    private static final String LOCALHOST = "127.0.0.1";
 
     public IPTableTest() {
     }
@@ -56,14 +57,14 @@ public class IPTableTest {
      * Test of contains method, of class IPTable.
      * @throws java.lang.Exception passed through.
      */
-    @Test(expected = IPFormatException.class)
-    public void testContains() throws Exception {
-        String localhost = "127.0.0.1";
+    @Test
+    public void testContains()
+            throws Exception {
         IPTable instance = new IPTable();
-        instance.add(localhost);
+        instance.add(LOCALHOST);
         boolean contains;
 
-        contains = instance.contains(localhost);
+        contains = instance.contains(LOCALHOST);
         assertTrue("Address that was add()ed should match", contains);
 
         contains = instance.contains("192.168.1.1");
@@ -71,6 +72,18 @@ public class IPTableTest {
 
         contains = instance.contains("fec0:0:0:1::2");
         assertFalse("IPv6 address should not match anything.", contains);
+    }
+
+    /**
+     * Test of contains method when presented with an invalid address.
+     * @throws Exception passed through.
+     */
+    @Test(expected = IPFormatException.class)
+    public void testContainsBadFormat()
+            throws Exception {
+        IPTable instance = new IPTable();
+        instance.add(LOCALHOST);
+        boolean contains;
 
         // This should throw an IPFormatException.
         contains = instance.contains("axolotl");


### PR DESCRIPTION
## References
* Fixes #3094

## Description
Uses IPv6-aware JRE class instead of home-grown IPv4-only class to resolve addresses to names.  Treats IPv6 addresses as valid non-matches, not format errors.

## Instructions for Reviewers

List of changes in this PR:
* Resove IPv6 addresses to names properly, by using InetAddress.
* Avoid logging `NullPointerException`s for logged-out sessions by testing the current-EPerson reference for nullity before asking for its name.
* Work around problem with testing for allowed proxies, by detecting IPv6 addresses and treating them as non-matching instead of throwing an exception.  We should extend IPTable to handle IPv6 addresses as it does IPv4 addresses, but this change solves the immediate problem.

Test by logging on over an IPv6 connection.  This should no longer log NPEs or format errors, and should fail (if at all) further down the code path.  (Login may fail if the authentication token is bound to the client's address with `jwt.login.token.include.ip = true`.  This is a separate issue)

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
