### PR TITLE
Enforce that facet "filter-operator" is a valid value

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/query/RestSearchOperator.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/query/RestSearchOperator.java
@@ -7,6 +7,9 @@
  */
 package org.dspace.app.rest.model.query;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -94,5 +97,20 @@ public enum RestSearchOperator {
 
     public String getDspaceOperator() {
         return dspaceOperator;
+    }
+
+    /**
+     * Returns a list of dspace operators of this enum's values, plus "query" which is also allowed, but will be
+     * transformed in {@link org.dspace.app.rest.converter.query.SearchQueryConverter} to any of the others
+     *
+     * @return List of dspace operators of this enum's values, plus "query"
+     */
+    public static List<String> getListOfAllowedSearchOperatorStrings() {
+        List<String> allowedSearchOperatorStrings = new ArrayList<>();
+        for (RestSearchOperator restSearchOperator: Arrays.asList(RestSearchOperator.values())) {
+            allowedSearchOperatorStrings.add(restSearchOperator.getDspaceOperator());
+        }
+        allowedSearchOperatorStrings.add("query");
+        return allowedSearchOperatorStrings;
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/parameter/resolver/SearchFilterResolver.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/parameter/resolver/SearchFilterResolver.java
@@ -14,6 +14,7 @@ import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 import org.dspace.app.rest.exception.DSpaceBadRequestException;
+import org.dspace.app.rest.exception.UnprocessableEntityException;
 import org.dspace.app.rest.model.query.RestSearchOperator;
 import org.dspace.app.rest.parameter.SearchFilter;
 import org.springframework.core.MethodParameter;
@@ -68,7 +69,7 @@ public class SearchFilterResolver implements HandlerMethodArgumentResolver {
     private void checkIfValidOperator(String filterOperator) {
         if (StringUtils.isNotBlank(filterOperator)) {
             if (!ALLOWED_SEARCH_OPERATORS.contains(filterOperator.trim())) {
-                throw new DSpaceBadRequestException(
+                throw new UnprocessableEntityException(
                     "The operator can't be \"" + filterOperator + "\", must be the of one of: " +
                     String.join(", ", ALLOWED_SEARCH_OPERATORS));
             }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/parameter/resolver/SearchFilterResolver.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/parameter/resolver/SearchFilterResolver.java
@@ -13,7 +13,6 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
-import org.dspace.app.rest.exception.DSpaceBadRequestException;
 import org.dspace.app.rest.exception.UnprocessableEntityException;
 import org.dspace.app.rest.model.query.RestSearchOperator;
 import org.dspace.app.rest.parameter.SearchFilter;
@@ -74,7 +73,7 @@ public class SearchFilterResolver implements HandlerMethodArgumentResolver {
                     String.join(", ", ALLOWED_SEARCH_OPERATORS));
             }
         } else {
-            throw new DSpaceBadRequestException(
+            throw new UnprocessableEntityException(
                 "The operator can't be empty, must be the one of: " + String.join(", ", ALLOWED_SEARCH_OPERATORS));
         }
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/parameter/resolver/SearchFilterResolver.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/parameter/resolver/SearchFilterResolver.java
@@ -13,6 +13,8 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
+import org.dspace.app.rest.exception.DSpaceBadRequestException;
+import org.dspace.app.rest.model.query.RestSearchOperator;
 import org.dspace.app.rest.parameter.SearchFilter;
 import org.springframework.core.MethodParameter;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -29,13 +31,15 @@ public class SearchFilterResolver implements HandlerMethodArgumentResolver {
     public static final String SEARCH_FILTER_PREFIX = "f.";
     public static final String FILTER_OPERATOR_SEPARATOR = ",";
 
+    public static final List<String> ALLOWED_SEARCH_OPERATORS =
+        RestSearchOperator.getListOfAllowedSearchOperatorStrings();
+
     public boolean supportsParameter(final MethodParameter parameter) {
         return parameter.getParameterType().equals(SearchFilter.class) || isSearchFilterList(parameter);
     }
 
     public Object resolveArgument(final MethodParameter parameter, final ModelAndViewContainer mavContainer,
-                                  final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory)
-        throws Exception {
+                                  final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory) {
         List<SearchFilter> result = new LinkedList<>();
 
         Iterator<String> parameterNames = webRequest.getParameterNames();
@@ -48,7 +52,7 @@ public class SearchFilterResolver implements HandlerMethodArgumentResolver {
                 for (String value : webRequest.getParameterValues(parameterName)) {
                     String filterValue = StringUtils.substringBeforeLast(value, FILTER_OPERATOR_SEPARATOR);
                     String filterOperator = StringUtils.substringAfterLast(value, FILTER_OPERATOR_SEPARATOR);
-
+                    this.checkIfValidOperator(filterOperator);
                     result.add(new SearchFilter(filterName, filterOperator, filterValue));
                 }
             }
@@ -58,6 +62,19 @@ public class SearchFilterResolver implements HandlerMethodArgumentResolver {
             return result.isEmpty() ? null : result.get(0);
         } else {
             return result;
+        }
+    }
+
+    private void checkIfValidOperator(String filterOperator) {
+        if (StringUtils.isNotBlank(filterOperator)) {
+            if (!ALLOWED_SEARCH_OPERATORS.contains(filterOperator.trim())) {
+                throw new DSpaceBadRequestException(
+                    "The operator can't be \"" + filterOperator + "\", must be the of one of: " +
+                    String.join(", ", ALLOWED_SEARCH_OPERATORS));
+            }
+        } else {
+            throw new DSpaceBadRequestException(
+                "The operator can't be empty, must be the one of: " + String.join(", ", ALLOWED_SEARCH_OPERATORS));
         }
     }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -3281,8 +3281,8 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         getClient().perform(get("/api/discover/search/objects")
             .param("f.title", "test"))
                    //** THEN **
-                   //Will result in 400 status because of missing filter operator
-                   .andExpect(status().isBadRequest());
+                   //Will result in 422 status because of missing filter operator
+                   .andExpect(status().isUnprocessableEntity());
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -3281,7 +3281,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         getClient().perform(get("/api/discover/search/objects")
             .param("f.title", "test"))
                    //** THEN **
-                   //Will result in 404 status because of missing filter operator
+                   //Will result in 400 status because of missing filter operator
                    .andExpect(status().isBadRequest());
     }
 
@@ -3295,8 +3295,8 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         getClient().perform(get("/api/discover/search/objects")
             .param("f.title", "test,operator"))
                    //** THEN **
-                   //Will result in 404 status because of non-valid filter operator
-                   .andExpect(status().isBadRequest());
+                   //Will result in 422 status because of non-valid filter operator
+                   .andExpect(status().isUnprocessableEntity());
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -2370,7 +2370,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
     }
 
     @Test
-    public void discoverSearchObjectsWithQueryOperatorContains() throws Exception {
+    public void discoverSearchObjectsWithQueryOperatorContains_query() throws Exception {
         //We turn off the authorization system in order to create the structure as defined below
         context.turnOffAuthorisationSystem();
 
@@ -2445,7 +2445,83 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
     }
 
     @Test
-    public void discoverSearchObjectsWithQueryOperatorNotContains() throws Exception {
+    public void discoverSearchObjectsWithQueryOperatorContains() throws Exception {
+        //We turn off the authorization system in order to create the structure as defined below
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+        //1. A community-collection structure with one parent community with sub-community and two collections.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community")
+                                           .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+        Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
+        //2. Three public items that are readable by Anonymous with different subjects
+        Item publicItem1 = ItemBuilder.createItem(context, col1)
+                                      .withTitle("Test")
+                                      .withIssueDate("2010-10-17")
+                                      .withAuthor("Smith, Donald")
+                                      .withSubject("ExtraEntry")
+                                      .build();
+
+        Item publicItem2 = ItemBuilder.createItem(context, col2)
+                                      .withTitle("Test 2")
+                                      .withIssueDate("1990-02-13")
+                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
+                                      .withSubject("TestingForMore").withSubject("ExtraEntry")
+                                      .build();
+
+        Item publicItem3 = ItemBuilder.createItem(context, col2)
+                                      .withTitle("Public item 2")
+                                      .withIssueDate("2010-02-13")
+                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+                                      .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                                      .withSubject("AnotherTest").withSubject("TestingForMore")
+                                      .withSubject("ExtraEntry")
+                                      .build();
+
+        context.restoreAuthSystemState();
+
+        UUID scope = col2.getID();
+        //** WHEN **
+        //An anonymous user browses this endpoint to find the the objects in the system
+        //With the given search filter
+        getClient().perform(get("/api/discover/search/objects")
+            .param("f.title", "test,contains"))
+                   //** THEN **
+                   //The status has to be 200 OK
+                   .andExpect(status().isOk())
+                   //The type has to be 'discover'
+                   .andExpect(jsonPath("$.type", is("discover")))
+                   //The page object needs to look like this
+                   .andExpect(jsonPath("$._embedded.searchResult.page", is(
+                       PageMatcher.pageEntry(0, 20)
+                                                                          )))
+                   //The search results have to contain the items that match the searchFilter
+                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
+                       SearchResultMatcher.matchOnItemName("item", "items", "Test"),
+                       SearchResultMatcher.matchOnItemName("item", "items", "Test 2")
+                                                                                                                )))
+                   //These facets have to show up in the embedded.facets section as well with the given hasMore property
+                   // because we don't exceed their default limit for a hasMore true (the default is 10)
+                   .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
+                       FacetEntryMatcher.authorFacet(false),
+                       FacetEntryMatcher.entityTypeFacet(false),
+                       FacetEntryMatcher.subjectFacet(false),
+                       FacetEntryMatcher.dateIssuedFacet(false),
+                       FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
+                                                                                        )))
+                   //There always needs to be a self link available
+                   .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
+        ;
+
+    }
+
+    @Test
+    public void discoverSearchObjectsWithQueryOperatorNotContains_query() throws Exception {
         //We turn off the authorization system in order to create the structure as defined below
         context.turnOffAuthorisationSystem();
 
@@ -2514,6 +2590,81 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                 )))
                 //There always needs to be a self link available
                 .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
+        ;
+
+    }
+
+    @Test
+    public void discoverSearchObjectsWithQueryOperatorNotContains() throws Exception {
+        //We turn off the authorization system in order to create the structure as defined below
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+        //1. A community-collection structure with one parent community with sub-community and two collections.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community")
+                                           .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+        Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
+        //2. Three public items that are readable by Anonymous with different subjects
+        Item publicItem1 = ItemBuilder.createItem(context, col1)
+                                      .withTitle("Test")
+                                      .withIssueDate("2010-10-17")
+                                      .withAuthor("Smith, Donald")
+                                      .withSubject("ExtraEntry")
+                                      .build();
+
+        Item publicItem2 = ItemBuilder.createItem(context, col2)
+                                      .withTitle("Test 2")
+                                      .withIssueDate("1990-02-13")
+                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
+                                      .withSubject("TestingForMore").withSubject("ExtraEntry")
+                                      .build();
+
+        Item publicItem3 = ItemBuilder.createItem(context, col2)
+                                      .withTitle("Public item 2")
+                                      .withIssueDate("2010-02-13")
+                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+                                      .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                                      .withSubject("AnotherTest").withSubject("TestingForMore")
+                                      .withSubject("ExtraEntry")
+                                      .build();
+
+        context.restoreAuthSystemState();
+
+        UUID scope = col2.getID();
+        //** WHEN **
+        //An anonymous user browses this endpoint to find the the objects in the system
+        //With the given search filter
+        getClient().perform(get("/api/discover/search/objects")
+            .param("f.title", "test,notcontains"))
+                   //** THEN **
+                   //The status has to be 200 OK
+                   .andExpect(status().isOk())
+                   //The type has to be 'discover'
+                   .andExpect(jsonPath("$.type", is("discover")))
+                   //The page object needs to look like this
+                   .andExpect(jsonPath("$._embedded.searchResult.page", is(
+                       PageMatcher.pageEntry(0, 20)
+                                                                          )))
+                   //The search results have to contain the items that match the searchFilter
+                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.hasItem(
+                       SearchResultMatcher.matchOnItemName("item", "items", "Public item 2")
+                                                                                                     )))
+                   //These facets have to show up in the embedded.facets section as well with the given hasMore property
+                   // because we don't exceed their default limit for a hasMore true (the default is 10)
+                   .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
+                       FacetEntryMatcher.authorFacet(false),
+                       FacetEntryMatcher.entityTypeFacet(false),
+                       FacetEntryMatcher.subjectFacet(false),
+                       FacetEntryMatcher.dateIssuedFacet(false),
+                       FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
+                                                                                        )))
+                   //There always needs to be a self link available
+                   .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
         ;
 
     }
@@ -2673,7 +2824,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
     }
 
     @Test
-    public void discoverSearchObjectsWithQueryOperatorEquals() throws Exception {
+    public void discoverSearchObjectsWithQueryOperatorEquals_query() throws Exception {
         //We turn off the authorization system in order to create the structure as defined below
         context.turnOffAuthorisationSystem();
 
@@ -2747,7 +2898,82 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
     }
 
     @Test
-    public void discoverSearchObjectsWithQueryOperatorNotEquals() throws Exception {
+    public void discoverSearchObjectsWithQueryOperatorEquals() throws Exception {
+        //We turn off the authorization system in order to create the structure as defined below
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+        //1. A community-collection structure with one parent community with sub-community and two collections.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community")
+                                           .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+        Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
+        //2. Three public items that are readable by Anonymous with different subjects
+        Item publicItem1 = ItemBuilder.createItem(context, col1)
+                                      .withTitle("Test")
+                                      .withIssueDate("2010-10-17")
+                                      .withAuthor("Smith, Donald")
+                                      .withSubject("ExtraEntry")
+                                      .build();
+
+        Item publicItem2 = ItemBuilder.createItem(context, col2)
+                                      .withTitle("Test 2")
+                                      .withIssueDate("1990-02-13")
+                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
+                                      .withSubject("TestingForMore").withSubject("ExtraEntry")
+                                      .build();
+
+        Item publicItem3 = ItemBuilder.createItem(context, col2)
+                                      .withTitle("Public item 2")
+                                      .withIssueDate("2010-02-13")
+                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+                                      .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                                      .withSubject("AnotherTest").withSubject("TestingForMore")
+                                      .withSubject("ExtraEntry")
+                                      .build();
+
+        context.restoreAuthSystemState();
+
+        UUID scope = col2.getID();
+        //** WHEN **
+        //An anonymous user browses this endpoint to find the the objects in the system
+        //With the given search filter
+        getClient().perform(get("/api/discover/search/objects")
+            .param("f.title", "Test,equals"))
+                   //** THEN **
+                   //The status has to be 200 OK
+                   .andExpect(status().isOk())
+                   //The type has to be 'discover'
+                   .andExpect(jsonPath("$.type", is("discover")))
+                   //The page object needs to look like this
+                   .andExpect(jsonPath("$._embedded.searchResult.page", is(
+                       PageMatcher.pageEntry(0, 20)
+                                                                          )))
+                   //The search results have to contain the items that match the searchFilter
+                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
+                       SearchResultMatcher.matchOnItemName("item", "items", "Test")
+                                                                                                                )))
+                   //These facets have to show up in the embedded.facets section as well with the given hasMore property
+                   // because we don't exceed their default limit for a hasMore true (the default is 10)
+                   .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
+                       FacetEntryMatcher.authorFacet(false),
+                       FacetEntryMatcher.entityTypeFacet(false),
+                       FacetEntryMatcher.subjectFacet(false),
+                       FacetEntryMatcher.dateIssuedFacet(false),
+                       FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
+                                                                                        )))
+                   //There always needs to be a self link available
+                   .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
+        ;
+
+    }
+
+    @Test
+    public void discoverSearchObjectsWithQueryOperatorNotEquals_query() throws Exception {
         //We turn off the authorization system in order to create the structure as defined below
         context.turnOffAuthorisationSystem();
 
@@ -2822,7 +3048,83 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
     }
 
     @Test
-    public void discoverSearchObjectsWithQueryOperatorNotAuthority() throws Exception {
+    public void discoverSearchObjectsWithQueryOperatorNotEquals() throws Exception {
+        //We turn off the authorization system in order to create the structure as defined below
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+        //1. A community-collection structure with one parent community with sub-community and two collections.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community")
+                                           .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+        Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
+        //2. Three public items that are readable by Anonymous with different subjects
+        Item publicItem1 = ItemBuilder.createItem(context, col1)
+                                      .withTitle("Test")
+                                      .withIssueDate("2010-10-17")
+                                      .withAuthor("Smith, Donald")
+                                      .withSubject("ExtraEntry")
+                                      .build();
+
+        Item publicItem2 = ItemBuilder.createItem(context, col2)
+                                      .withTitle("Test 2")
+                                      .withIssueDate("1990-02-13")
+                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
+                                      .withSubject("TestingForMore").withSubject("ExtraEntry")
+                                      .build();
+
+        Item publicItem3 = ItemBuilder.createItem(context, col2)
+                                      .withTitle("Public item 2")
+                                      .withIssueDate("2010-02-13")
+                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+                                      .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                                      .withSubject("AnotherTest").withSubject("TestingForMore")
+                                      .withSubject("ExtraEntry")
+                                      .build();
+
+        context.restoreAuthSystemState();
+
+        UUID scope = col2.getID();
+        //** WHEN **
+        //An anonymous user browses this endpoint to find the the objects in the system
+        //With the given search filter
+        getClient().perform(get("/api/discover/search/objects")
+            .param("f.title", "Test,notequals"))
+                   //** THEN **
+                   //The status has to be 200 OK
+                   .andExpect(status().isOk())
+                   //The type has to be 'discover'
+                   .andExpect(jsonPath("$.type", is("discover")))
+                   //The page object needs to look like this
+                   .andExpect(jsonPath("$._embedded.searchResult.page", is(
+                       PageMatcher.pageEntry(0, 20)
+                                                                          )))
+                   //The search results have to contain the items that match the searchFilter
+                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.hasItems(
+                       SearchResultMatcher.matchOnItemName("item", "items", "Test 2"),
+                       SearchResultMatcher.matchOnItemName("item", "items", "Public item 2")
+                                                                                                      )))
+                   //These facets have to show up in the embedded.facets section as well with the given hasMore property
+                   // because we don't exceed their default limit for a hasMore true (the default is 10)
+                   .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
+                       FacetEntryMatcher.authorFacet(false),
+                       FacetEntryMatcher.entityTypeFacet(false),
+                       FacetEntryMatcher.subjectFacet(false),
+                       FacetEntryMatcher.dateIssuedFacet(false),
+                       FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
+                                                                                        )))
+                   //There always needs to be a self link available
+                   .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
+        ;
+
+    }
+
+    @Test
+    public void discoverSearchObjectsWithQueryOperatorNotAuthority_query() throws Exception {
         //We turn off the authorization system in order to create the structure as defined below
         context.turnOffAuthorisationSystem();
 
@@ -2893,6 +3195,108 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                 .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
         ;
 
+    }
+
+    @Test
+    public void discoverSearchObjectsWithQueryOperatorNotAuthority() throws Exception {
+        //We turn off the authorization system in order to create the structure as defined below
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+        //1. A community-collection structure with one parent community with sub-community and two collections.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community")
+                                           .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+        Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
+        //2. Three public items that are readable by Anonymous with different subjects
+        Item publicItem1 = ItemBuilder.createItem(context, col1)
+                                      .withTitle("Test")
+                                      .withIssueDate("2010-10-17")
+                                      .withAuthor("Smith, Donald")
+                                      .withSubject("ExtraEntry")
+                                      .build();
+
+        Item publicItem2 = ItemBuilder.createItem(context, col2)
+                                      .withTitle("Test 2")
+                                      .withIssueDate("1990-02-13")
+                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
+                                      .withSubject("TestingForMore").withSubject("ExtraEntry")
+                                      .build();
+
+        Item publicItem3 = ItemBuilder.createItem(context, col2)
+                                      .withTitle("Public item 2")
+                                      .withIssueDate("2010-02-13")
+                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+                                      .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+                                      .withSubject("AnotherTest").withSubject("TestingForMore")
+                                      .withSubject("ExtraEntry")
+                                      .build();
+
+        context.restoreAuthSystemState();
+
+        UUID scope = col2.getID();
+        //** WHEN **
+        //An anonymous user browses this endpoint to find the the objects in the system
+        //With the given search filter
+        getClient().perform(get("/api/discover/search/objects")
+            .param("f.title", "test,notauthority"))
+                   //** THEN **
+                   //The status has to be 200 OK
+                   .andExpect(status().isOk())
+                   //The type has to be 'discover'
+                   .andExpect(jsonPath("$.type", is("discover")))
+                   //The page object needs to look like this
+                   .andExpect(jsonPath("$._embedded.searchResult.page", is(
+                       PageMatcher.pageEntry(0, 20)
+                                                                          )))
+                   //The search results have to contain the items that match the searchFilter
+                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.hasItem(
+                       SearchResultMatcher.matchOnItemName("item", "items", "Public item 2")
+                                                                                                     )))
+                   //These facets have to show up in the embedded.facets section as well with the given hasMore property
+                   // because we don't exceed their default limit for a hasMore true (the default is 10)
+                   .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
+                       FacetEntryMatcher.authorFacet(false),
+                       FacetEntryMatcher.entityTypeFacet(false),
+                       FacetEntryMatcher.subjectFacet(false),
+                       FacetEntryMatcher.dateIssuedFacet(false),
+                       FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
+                                                                                        )))
+                   //There always needs to be a self link available
+                   .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
+        ;
+
+    }
+
+    @Test
+    public void discoverSearchObjectsWithMissingQueryOperator() throws Exception {
+        //** WHEN **
+        // An anonymous user browses this endpoint to find the the objects in the system
+        // With the given search filter where there is the filter operator missing in the value (must be of form
+        // <:filter-value>,<:filter-operator>)
+        getClient().perform(get("/api/discover/search/objects")
+            .param("f.title", "test"))
+                   //** THEN **
+                   //Will result in 404 status because of missing filter operator
+                   .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void discoverSearchObjectsWithNotValidQueryOperator() throws Exception {
+        //** WHEN **
+        // An anonymous user browses this endpoint to find the the objects in the system
+        // With the given search filter where there is a non-valid filter operator given (must be of form
+        // <:filter-value>,<:filter-operator> where the filter operator is one of: “contains”, “notcontains”, "equals"
+        // “notequals”, “authority”, “notauthority”, "query”); see enum RestSearchOperator
+        getClient().perform(get("/api/discover/search/objects")
+            .param("f.title", "test,operator"))
+                   //** THEN **
+                   //Will result in 404 status because of non-valid filter operator
+                   .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -4478,7 +4882,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                 .perform(get("/api/discover/search/objects")
                         .param("configuration", "administrativeView")
                         .param("query", "Test")
-                        .param("f.withdrawn", "true")
+                        .param("f.withdrawn", "true,contains")
                 )
 
                 .andExpect(status().isOk())
@@ -4497,7 +4901,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                 .perform(get("/api/discover/search/objects")
                         .param("configuration", "administrativeView")
                         .param("query", "Test")
-                        .param("f.withdrawn", "false")
+                        .param("f.withdrawn", "false,contains")
                 )
 
                 .andExpect(status().isOk())
@@ -4517,7 +4921,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                 .perform(get("/api/discover/search/objects")
                         .param("configuration", "administrativeView")
                         .param("query", "Test")
-                        .param("f.discoverable", "true")
+                        .param("f.discoverable", "true,contains")
                 )
 
                 .andExpect(status().isOk())
@@ -4537,7 +4941,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                 .perform(get("/api/discover/search/objects")
                         .param("configuration", "administrativeView")
                         .param("query", "Test")
-                        .param("f.discoverable", "false")
+                        .param("f.discoverable", "false,contains")
                 )
 
                 .andExpect(status().isOk())


### PR DESCRIPTION
## References
* Fixes #3027

## Description
If no valid operator is passed in a filter query the discovery endpoint will now result in a bad request.

In my original issue above I noted that this shouldn't be checked for dates, but I'm afraid dates will also have to follow these rules (contains is the default), because the java code has no way to tell if the field is a date or not.

## Instructions for Reviewers
Fire of a query similar to: {dspace.url}/api/discover/search/objects?sort=score,DESC&page=0&size=10&f.author=pujari,%20kb

This should result in a bad request since the operator would be "kb". Next use:

 {dspace.url}/api/discover/search/objects?sort=score,DESC&page=0&size=10&f.author=pujari,%20kb,contains

This should work as "contains" is a valid operator.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
