### PR TITLE
Enable Customized CSRF Protection in Spring Security for Server Webapp

### DIFF
--- a/dspace-api/src/test/java/org/dspace/builder/util/AbstractBuilderCleanupUtil.java
+++ b/dspace-api/src/test/java/org/dspace/builder/util/AbstractBuilderCleanupUtil.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import org.dspace.builder.AbstractBuilder;
 import org.dspace.builder.BitstreamBuilder;
 import org.dspace.builder.BitstreamFormatBuilder;
+import org.dspace.builder.BundleBuilder;
 import org.dspace.builder.ClaimedTaskBuilder;
 import org.dspace.builder.CollectionBuilder;
 import org.dspace.builder.CommunityBuilder;
@@ -28,6 +29,7 @@ import org.dspace.builder.PoolTaskBuilder;
 import org.dspace.builder.ProcessBuilder;
 import org.dspace.builder.RelationshipBuilder;
 import org.dspace.builder.RelationshipTypeBuilder;
+import org.dspace.builder.ResourcePolicyBuilder;
 import org.dspace.builder.SiteBuilder;
 import org.dspace.builder.WorkflowItemBuilder;
 import org.dspace.builder.WorkspaceItemBuilder;
@@ -43,14 +45,17 @@ public class AbstractBuilderCleanupUtil {
             = new LinkedHashMap<>();
 
     /**
-     * Constructor that will initialize the Map with a predefined order for deletion
+     * Constructor that will initialize the Map with a predefined order for deletion.
+     * <P>
+     * Objects are deleted top-to-bottom in this Map. Objects that need to be removed *first*
+     * should appear at the top. Objects that may be deleted later, appear at the bottom.
      */
     public AbstractBuilderCleanupUtil() {
         initMap();
-
     }
 
     private void initMap() {
+        map.put(ResourcePolicyBuilder.class.getName(), new LinkedList<>());
         map.put(RelationshipBuilder.class.getName(), new LinkedList<>());
         map.put(RelationshipTypeBuilder.class.getName(), new LinkedList<>());
         map.put(EntityTypeBuilder.class.getName(), new LinkedList<>());
@@ -64,6 +69,7 @@ public class AbstractBuilderCleanupUtil {
         map.put(CommunityBuilder.class.getName(), new LinkedList<>());
         map.put(EPersonBuilder.class.getName(), new LinkedList<>());
         map.put(GroupBuilder.class.getName(), new LinkedList<>());
+        map.put(BundleBuilder.class.getName(), new LinkedList<>());
         map.put(ItemBuilder.class.getName(), new LinkedList<>());
         map.put(MetadataFieldBuilder.class.getName(), new LinkedList<>());
         map.put(MetadataSchemaBuilder.class.getName(), new LinkedList<>());

--- a/dspace-server-webapp/pom.xml
+++ b/dspace-server-webapp/pom.xml
@@ -414,6 +414,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <version>${spring-security.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
             <version>${json-path.version}</version>

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/Application.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/Application.java
@@ -152,12 +152,10 @@ public class Application extends SpringBootServletInitializer {
                             // for our Access-Control-Allow-Origin header
                             .allowCredentials(corsAllowCredentials).allowedOrigins(corsAllowedOrigins)
                             // Allow list of request preflight headers allowed to be sent to us from the client
-                            .allowedHeaders("Authorization", "Content-Type", "X-Requested-With", "accept", "Origin",
-                                            "Access-Control-Request-Method", "Access-Control-Request-Headers",
-                                            "X-On-Behalf-Of", "X-XSRF-TOKEN")
-                            // Allow list of response headers allowed to be sent by us (the server)
-                            .exposedHeaders("Access-Control-Allow-Origin", "Access-Control-Allow-Credentials",
-                                            "Authorization");
+                            .allowedHeaders("Accept", "Authorization", "Content-Type", "Origin", "X-On-Behalf-Of",
+                                            "X-Requested-With", "X-XSRF-TOKEN")
+                            // Allow list of response headers allowed to be sent by us (the server) to the client
+                            .exposedHeaders("Authorization", "DSPACE-XSRF-TOKEN", "Location", "WWW-Authenticate");
                 }
             }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/Application.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/Application.java
@@ -154,7 +154,7 @@ public class Application extends SpringBootServletInitializer {
                             // Allow list of request preflight headers allowed to be sent to us from the client
                             .allowedHeaders("Authorization", "Content-Type", "X-Requested-With", "accept", "Origin",
                                             "Access-Control-Request-Method", "Access-Control-Request-Headers",
-                                            "X-On-Behalf-Of")
+                                            "X-On-Behalf-Of", "X-XSRF-TOKEN")
                             // Allow list of response headers allowed to be sent by us (the server)
                             .exposedHeaders("Access-Control-Allow-Origin", "Access-Control-Allow-Credentials",
                                             "Authorization");

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/DSpaceAccessDeniedHandler.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/DSpaceAccessDeniedHandler.java
@@ -1,0 +1,56 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.exception;
+
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.security.web.csrf.InvalidCsrfTokenException;
+import org.springframework.security.web.csrf.MissingCsrfTokenException;
+import org.springframework.stereotype.Component;
+
+/**
+ * This Handler customizes behavior of AccessDeniedException errors thrown by Spring Security/Boot
+ */
+@Component
+public class DSpaceAccessDeniedHandler implements AccessDeniedHandler {
+
+    /**
+     * Override handle() to pass these exceptions over to our DSpaceApiExceptionControllerAdvice handler
+     * @param request request
+     * @param response response
+     * @param ex AccessDeniedException
+     * @throws IOException
+     * @throws ServletException
+     */
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException ex)
+        throws IOException, ServletException {
+
+        // Do nothing if response is already committed
+        if (response.isCommitted()) {
+            return;
+        }
+
+        // Get access to our general exception handler
+        DSpaceApiExceptionControllerAdvice handler = new DSpaceApiExceptionControllerAdvice();
+
+        // If a CSRF Token was passed in but was invalid pass to csrfTokenException()
+        if (ex instanceof InvalidCsrfTokenException || ex instanceof MissingCsrfTokenException) {
+            handler.csrfTokenException(request, response, ex);
+            return;
+        }
+
+        // Otherwise, our handleAuthorizeException method will deal with generic AccessDeniedExceptions
+        handler.handleAuthorizeException(request, response, ex);
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/DSpaceAccessDeniedHandler.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/DSpaceAccessDeniedHandler.java
@@ -19,7 +19,14 @@ import org.springframework.security.web.csrf.MissingCsrfTokenException;
 import org.springframework.stereotype.Component;
 
 /**
- * This Handler customizes behavior of AccessDeniedException errors thrown by Spring Security/Boot
+ * This Handler customizes behavior of AccessDeniedException errors thrown by Spring Security/Boot.
+ * <P>
+ * More specifically, we use this Handler to ensure exceptions related to CSRF Tokens are also sent to our
+ * DSpaceApiExceptionControllerAdvice class, which manages all exceptions for the DSpace backend. Without this
+ * handler, those CSRF exceptions are managed by Spring Security/Boot *before* DSpaceApiExceptionControllerAdvice
+ * is triggered.
+ *
+ * @see DSpaceApiExceptionControllerAdvice
  */
 @Component
 public class DSpaceAccessDeniedHandler implements AccessDeniedHandler {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
@@ -54,8 +54,6 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
     @Autowired
     private RestAuthenticationService restAuthenticationService;
 
-    // NOTE: this method is also called by DSpaceAccessDeniedHandler to handle AccessDeniedExceptions thrown by
-    // Spring Security
     @ExceptionHandler({AuthorizeException.class, RESTAuthorizationException.class, AccessDeniedException.class})
     protected void handleAuthorizeException(HttpServletRequest request, HttpServletResponse response, Exception ex)
         throws IOException {
@@ -66,7 +64,8 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
         }
     }
 
-    // NOTE: this method is also called by DSpaceAccessDeniedHandler to handle CSRF exceptions thrown by Spring Security
+    // NOTE: DSpaceAccessDeniedHandler does some preprocessing of InvalidCsrfTokenException errors (to reset the
+    // CSRF token) before sending error handling to this method.
     @ExceptionHandler({InvalidCsrfTokenException.class, MissingCsrfTokenException.class})
     protected void csrfTokenException(HttpServletRequest request, HttpServletResponse response, Exception ex)
         throws IOException {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/CrossSiteCookieCsrfTokenRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/CrossSiteCookieCsrfTokenRepository.java
@@ -1,0 +1,222 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.security;
+
+import java.util.UUID;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.HttpHeaders;
+
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.security.web.csrf.CsrfTokenRepository;
+import org.springframework.security.web.csrf.DefaultCsrfToken;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+import org.springframework.web.util.WebUtils;
+
+/**
+ * This is a Spring Security CookieCsrfTokenRepository which supports cross-site cookies (i.e. SameSite=None).
+ * PLEASE NOTE: It will NOT support cross-domain CSRF, as Cookies cannot be sent across domains. Therefore, this
+ * CsrfTokenRepository is similar to Spring Security's in that it requires the REST API and UI to be on the same domain.
+ * <P>
+ * This code was mostly borrowed from Spring Security's CookieCsrfTokenRepository
+ * https://github.com/spring-projects/spring-security/blob/5.2.x/web/src/main/java/org/springframework/security/web/csrf/CookieCsrfTokenRepository.java
+ * <P>
+ * Corresponding tests were also copied to CrossSiteCookieCsrfTokenRepositoryTest.
+ * <P>
+ * The only modification were to the saveToken() method below. See that method's JavaDocs.
+ * <P>
+ * NOTE: This class is TEMPORARY and should be REMOVED as soon as the "SameSite" attribute is supported by
+ * Spring Security's CookieCsrfTokenRepository. As soon as the below ticket is resolved & we upgrade Spring Security,
+ * then this custom class can be removed:
+ * https://github.com/spring-projects/spring-security/issues/7537
+ */
+public class CrossSiteCookieCsrfTokenRepository implements CsrfTokenRepository {
+    static final String DEFAULT_CSRF_COOKIE_NAME = "XSRF-TOKEN";
+
+    static final String DEFAULT_CSRF_PARAMETER_NAME = "_csrf";
+
+    static final String DEFAULT_CSRF_HEADER_NAME = "X-XSRF-TOKEN";
+
+    private String parameterName = DEFAULT_CSRF_PARAMETER_NAME;
+
+    private String headerName = DEFAULT_CSRF_HEADER_NAME;
+
+    private String cookieName = DEFAULT_CSRF_COOKIE_NAME;
+
+    private boolean cookieHttpOnly = true;
+
+    private String cookiePath;
+
+    private String cookieDomain;
+
+    public CrossSiteCookieCsrfTokenRepository() {
+    }
+
+    @Override
+    public CsrfToken generateToken(HttpServletRequest request) {
+        return new DefaultCsrfToken(this.headerName, this.parameterName,
+                                    createNewToken());
+    }
+
+    /**
+     * This is the only method modified for DSpace.  We changed this method to use ResponseCookie to build the
+     * cookie, so that we could hardcode the "SameSite" attribute to a value of "None". This allows for cross site
+     * XSRF-TOKEN cookies.
+     * @param token
+     * @param request
+     * @param response
+     */
+    @Override
+    public void saveToken(CsrfToken token, HttpServletRequest request,
+                          HttpServletResponse response) {
+        String tokenValue = token == null ? "" : token.getToken();
+        Cookie cookie = new Cookie(this.cookieName, tokenValue);
+        cookie.setSecure(request.isSecure());
+        if (this.cookiePath != null && !this.cookiePath.isEmpty()) {
+            cookie.setPath(this.cookiePath);
+        } else {
+            cookie.setPath(this.getRequestContext(request));
+        }
+        if (token == null) {
+            cookie.setMaxAge(0);
+        } else {
+            cookie.setMaxAge(-1);
+        }
+        cookie.setHttpOnly(cookieHttpOnly);
+        if (this.cookieDomain != null && !this.cookieDomain.isEmpty()) {
+            cookie.setDomain(this.cookieDomain);
+        }
+
+        // Custom: Turn the above Cookie into a ResponseCookie so that we can set "SameSite" attribute
+        // NOTE: ONLY set "SameSite=None" if cookie is also secure. Most modern browsers will block it otherwise.
+        // This means that DSpace MUST USE HTTPS if the UI is on a different domain then backend.
+        String sameSite = "";
+        if (cookie.getSecure()) {
+            sameSite = "None";
+        }
+        ResponseCookie responseCookie = ResponseCookie.from(cookie.getName(), cookie.getValue())
+                                              .path(cookie.getPath()).maxAge(cookie.getMaxAge())
+                                              .domain(cookie.getDomain()).httpOnly(cookie.isHttpOnly())
+                                              .secure(cookie.getSecure()).sameSite(sameSite).build();
+        // Write the ResponseCookie to the Set-Cookie header
+        response.addHeader(HttpHeaders.SET_COOKIE, responseCookie.toString());
+    }
+
+    @Override
+    public CsrfToken loadToken(HttpServletRequest request) {
+        Cookie cookie = WebUtils.getCookie(request, this.cookieName);
+        if (cookie == null) {
+            return null;
+        }
+        String token = cookie.getValue();
+        if (!StringUtils.hasLength(token)) {
+            return null;
+        }
+        return new DefaultCsrfToken(this.headerName, this.parameterName, token);
+    }
+
+
+    /**
+     * Sets the name of the HTTP request parameter that should be used to provide a token.
+     *
+     * @param parameterName the name of the HTTP request parameter that should be used to
+     * provide a token
+     */
+    public void setParameterName(String parameterName) {
+        Assert.notNull(parameterName, "parameterName is not null");
+        this.parameterName = parameterName;
+    }
+
+    /**
+     * Sets the name of the HTTP header that should be used to provide the token.
+     *
+     * @param headerName the name of the HTTP header that should be used to provide the
+     * token
+     */
+    public void setHeaderName(String headerName) {
+        Assert.notNull(headerName, "headerName is not null");
+        this.headerName = headerName;
+    }
+
+    /**
+     * Sets the name of the cookie that the expected CSRF token is saved to and read from.
+     *
+     * @param cookieName the name of the cookie that the expected CSRF token is saved to
+     * and read from
+     */
+    public void setCookieName(String cookieName) {
+        Assert.notNull(cookieName, "cookieName is not null");
+        this.cookieName = cookieName;
+    }
+
+    /**
+     * Sets the HttpOnly attribute on the cookie containing the CSRF token.
+     * Defaults to <code>true</code>.
+     *
+     * @param cookieHttpOnly <code>true</code> sets the HttpOnly attribute, <code>false</code> does not set it
+     */
+    public void setCookieHttpOnly(boolean cookieHttpOnly) {
+        this.cookieHttpOnly = cookieHttpOnly;
+    }
+
+    private String getRequestContext(HttpServletRequest request) {
+        String contextPath = request.getContextPath();
+        return contextPath.length() > 0 ? contextPath : "/";
+    }
+
+    /**
+     * Factory method to conveniently create an instance that has
+     * {@link #setCookieHttpOnly(boolean)} set to false.
+     *
+     * @return an instance of CookieCsrfTokenRepository with
+     * {@link #setCookieHttpOnly(boolean)} set to false
+     */
+    public static CrossSiteCookieCsrfTokenRepository withHttpOnlyFalse() {
+        CrossSiteCookieCsrfTokenRepository result = new CrossSiteCookieCsrfTokenRepository();
+        result.setCookieHttpOnly(false);
+        return result;
+    }
+
+    private String createNewToken() {
+        return UUID.randomUUID().toString();
+    }
+
+    /**
+     * Set the path that the Cookie will be created with. This will override the default functionality which uses the
+     * request context as the path.
+     *
+     * @param path the path to use
+     */
+    public void setCookiePath(String path) {
+        this.cookiePath = path;
+    }
+
+    /**
+     * Get the path that the CSRF cookie will be set to.
+     *
+     * @return the path to be used.
+     */
+    public String getCookiePath() {
+        return this.cookiePath;
+    }
+
+    /**
+     * Sets the domain of the cookie that the expected CSRF token is saved to and read from.
+     *
+     * @since 5.2
+     * @param cookieDomain the domain of the cookie that the expected CSRF token is saved to
+     * and read from
+     */
+    public void setCookieDomain(String cookieDomain) {
+        this.cookieDomain = cookieDomain;
+    }
+
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/DSpaceCsrfAuthenticationStrategy.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/DSpaceCsrfAuthenticationStrategy.java
@@ -1,0 +1,83 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.security;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.session.SessionAuthenticationException;
+import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.security.web.csrf.CsrfTokenRepository;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * Custom SessionAuthenticationStrategy to be used alongside DSpaceCsrfTokenRepository.
+ * <P>
+ * Because DSpace is Stateless, this class only resets the CSRF Token if the client has attempted to use it (either
+ * successfully or unsuccessfully). This ensures that the Token is not changed on every request (since we are stateless
+ * every request creates a new Authentication object).
+ * <P>
+ * Based on Spring Security's CsrfAuthenticationStrategy:
+ * https://github.com/spring-projects/spring-security/blob/5.2.x/web/src/main/java/org/springframework/security/web/csrf/CsrfAuthenticationStrategy.java
+ */
+public class DSpaceCsrfAuthenticationStrategy implements SessionAuthenticationStrategy {
+
+    private final CsrfTokenRepository csrfTokenRepository;
+
+    /**
+     * Creates a new instance
+     * @param csrfTokenRepository the {@link CsrfTokenRepository} to use
+     */
+    public DSpaceCsrfAuthenticationStrategy(CsrfTokenRepository csrfTokenRepository) {
+        Assert.notNull(csrfTokenRepository, "csrfTokenRepository cannot be null");
+        this.csrfTokenRepository = csrfTokenRepository;
+    }
+
+    /**
+     * This method is triggered anytime a new Authentication occurs. As DSpace uses Stateless authentication,
+     * this method is triggered on _every request_ after an initial login occurs. This is because the Spring Security
+     * Authentication object is recreated on every request.
+     * <P>
+     * Therefore, for DSpace, we've customized this method to ensure a new CSRF Token is NOT generated each time a new
+     * Authentication object is created -- doing so causes the CSRF Token to change with every request. Instead, we
+     * check to see if the client also passed a CSRF token via a header or parameter. If so, this means the client
+     * has used (or attempted to use) the token & it must then be regenerated.
+     */
+    @Override
+    public void onAuthentication(Authentication authentication,
+                                 HttpServletRequest request, HttpServletResponse response)
+        throws SessionAuthenticationException {
+
+        // Check if token returned in server-side cookie
+        CsrfToken token = this.csrfTokenRepository.loadToken(request);
+        // For DSpace, this will only be null if we are forcing CSRF token regeneration (e.g. on initial login)
+        boolean containsToken = token != null;
+
+        if (containsToken) {
+            // Check for header or parameter in request
+            boolean containsHeader = StringUtils.hasLength(request.getHeader(token.getHeaderName()));
+            boolean containsParameter = StringUtils.hasLength(request.getParameter(token.getParameterName()));
+
+            // If token exists & we've also been sent either the header or parameter
+            // then we need to reset our token (as it's been used)
+            if (containsHeader || containsParameter) {
+                this.csrfTokenRepository.saveToken(null, request, response);
+
+                CsrfToken newToken = this.csrfTokenRepository.generateToken(request);
+                this.csrfTokenRepository.saveToken(newToken, request, response);
+
+                request.setAttribute(CsrfToken.class.getName(), newToken);
+                request.setAttribute(newToken.getParameterName(), newToken);
+            }
+        }
+    }
+
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/DSpaceCsrfTokenRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/DSpaceCsrfTokenRepository.java
@@ -138,7 +138,6 @@ public class DSpaceCsrfTokenRepository implements CsrfTokenRepository {
 
     @Override
     public CsrfToken loadToken(HttpServletRequest request) {
-        // First, verify the (server-side) cookie was sent back
         Cookie cookie = WebUtils.getCookie(request, this.cookieName);
         if (cookie == null) {
             return null;
@@ -148,8 +147,6 @@ public class DSpaceCsrfTokenRepository implements CsrfTokenRepository {
             return null;
         }
 
-        // If we got here, we know a token exists in the cookie and *either* the header or the parameter.
-        // So, this just sends the token info back so that it can be validated by Spring Security.
         return new DefaultCsrfToken(this.headerName, this.parameterName, token);
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/DSpaceCsrfTokenRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/DSpaceCsrfTokenRepository.java
@@ -30,9 +30,9 @@ import org.springframework.web.util.WebUtils;
  *
  * How it works:
  *
- *  1. Backend generates XSRF token & stores in a *server-side* cookie named DSPACE-XSRF-COOKIE. This cookie is
- *     only readable to clients on the same domain. But, it is returned (by user's browser) on every subsequent request
- *     to backend. See "saveToken()" method below.
+ *  1. Backend generates XSRF token & stores in a *server-side* cookie named DSPACE-XSRF-COOKIE. By default, this cookie
+ *     is not readable to JS clients (HttpOnly=true). But, it is returned (by user's browser) on every subsequent
+ *     request to backend. See "saveToken()" method below.
  *  2. At the same time, backend also sends the generated XSRF token in a header named DSPACE-XSRF-TOKEN to client.
  *     See "saveToken()" method below.
  *  3. Client MUST look for DSPACE-XSRF-TOKEN header in a response from backend. If found, the client MUST store/save
@@ -147,14 +147,6 @@ public class DSpaceCsrfTokenRepository implements CsrfTokenRepository {
         if (!StringUtils.hasLength(token)) {
             return null;
         }
-
-        // Second, verify either the header or param has been sent. This is a customization for DSpace.
-        // Because the server-side cookie is ALWAYS sent back, we need to verify the client has also sent the token in
-        // some other way. This ensures that we only *change* the Token when it has been used or attempted to be used.
-        //if (!StringUtils.hasLength(request.getHeader(this.headerName)) &&
-        //    !StringUtils.hasLength(request.getParameter(this.parameterName))) {
-        //    return null;
-        // }
 
         // If we got here, we know a token exists in the cookie and *either* the header or the parameter.
         // So, this just sends the token info back so that it can be validated by Spring Security.

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/WebSecurityConfiguration.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/WebSecurityConfiguration.java
@@ -161,7 +161,7 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
      *
      * @return CsrfTokenRepository as described above
      */
-    private CsrfTokenRepository getCsrfTokenRepository() {
+    public CsrfTokenRepository getCsrfTokenRepository() {
         return new DSpaceCsrfTokenRepository();
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/WebSecurityConfiguration.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/WebSecurityConfiguration.java
@@ -114,8 +114,8 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
             .logout()
                 // On logout, clear the "session" salt
                 .addLogoutHandler(customLogoutHandler)
-                // Configure the logout entry point
-                .logoutRequestMatcher(new AntPathRequestMatcher("/api/authn/logout"))
+                // Configure the logout entry point & require POST
+                .logoutRequestMatcher(new AntPathRequestMatcher("/api/authn/logout", HttpMethod.POST.name()))
                 // When logout is successful, return OK (204) status
                 .logoutSuccessHandler(new HttpStatusReturningLogoutSuccessHandler(HttpStatus.NO_CONTENT))
                 // Everyone can call this endpoint
@@ -162,8 +162,7 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
      * @return CsrfTokenRepository as described above
      */
     private CsrfTokenRepository getCsrfTokenRepository() {
-        // NOTE: Created cookie is set to HttpOnly=false to allow Hal Browser (or other local JS clients) to access it.
-        return DSpaceCsrfTokenRepository.withHttpOnlyFalse();
+        return new DSpaceCsrfTokenRepository();
     }
 
     /**

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/WebSecurityConfiguration.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/WebSecurityConfiguration.java
@@ -60,8 +60,10 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     @Override
     public void configure(WebSecurity webSecurity) throws Exception {
+        // Define URL patterns which Spring Security will ignore entirely.
         webSecurity
             .ignoring()
+                // These /login request types are purposefully unsecured, as they all throw errors.
                 .antMatchers(HttpMethod.GET, "/api/authn/login")
                 .antMatchers(HttpMethod.PUT, "/api/authn/login")
                 .antMatchers(HttpMethod.PATCH, "/api/authn/login")
@@ -71,63 +73,57 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
-        http.headers().cacheControl();
-        http
-            //Tell Spring to not create Sessions
+        // Configure authentication requirements for ${dspace.server.url}/api/ URL only
+        // NOTE: REST API is hardcoded to respond on /api/. Other modules (OAI, SWORD, etc) use other root paths.
+        http.antMatcher("/api/**")
+            // Enable Spring Security authorization on these paths
+            .authorizeRequests()
+                // Allow POST by anyone on the login endpoint
+                .antMatchers(HttpMethod.POST,"/api/authn/login").permitAll()
+                // Everyone can call GET on the status endpoint (used to check your authentication status)
+                .antMatchers(HttpMethod.GET, "/api/authn/status").permitAll()
+            .and()
+            // Tell Spring to not create Sessions
             .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS).and()
-            //Anonymous requests should have the "ANONYMOUS" security grant
+            // Anonymous requests should have the "ANONYMOUS" security grant
             .anonymous().authorities(ANONYMOUS_GRANT).and()
-            //Wire up the HttpServletRequest with the current SecurityContext values
+            // Wire up the HttpServletRequest with the current SecurityContext values
             .servletApi().and()
-            //Enable CORS for Spring Security (see CORS settings in Application and ApplicationConfig)
+            // Enable CORS for Spring Security (see CORS settings in Application and ApplicationConfig)
             .cors().and()
-            //Return 401 on authorization failures with a correct WWWW-Authenticate header
+            // Enable CSRF protection with custom CookieCsrfTokenRepository (see below) designed for Angular apps
+            // While we primarily use JWT in headers, CSRF protection is needed because we also support JWT via Cookies
+            .csrf().csrfTokenRepository(this.getCsrfTokenRepository()).and()
+            // Return 401 on authorization failures with a correct WWWW-Authenticate header
             .exceptionHandling().authenticationEntryPoint(
                     new DSpace401AuthenticationEntryPoint(restAuthenticationService))
             .and()
 
-            //Logout configuration
+            // Logout configuration
             .logout()
-                //On logout, clear the "session" salt
+                // On logout, clear the "session" salt
                 .addLogoutHandler(customLogoutHandler)
-                //Configure the logout entry point
+                // Configure the logout entry point
                 .logoutRequestMatcher(new AntPathRequestMatcher("/api/authn/logout"))
-                //When logout is successful, return OK (204) status
+                // When logout is successful, return OK (204) status
                 .logoutSuccessHandler(new HttpStatusReturningLogoutSuccessHandler(HttpStatus.NO_CONTENT))
-                //Everyone can call this endpoint
+                // Everyone can call this endpoint
                 .permitAll()
             .and()
 
-            //Enable CSRF protection (only on /api/ URLs) with the CookieCsrfTokenRepository designed for Angular apps
-            // See https://docs.spring.io/spring-security/site/docs/current/reference/html5/#servlet-csrf
-            // While we primarily use JWT in headers, enabled CSRF protection because we also support JWT via Cookies
-            .antMatcher("/api/**")
-                .csrf().csrfTokenRepository(this.getCsrfTokenRepository())
-            .and()
-
-            //Configure the URL patterns with their authentication requirements
-            //Enable Spring Security authorization on /api/ URLs only
-            .antMatcher("/api/**")
-                .authorizeRequests()
-                //Allow POST by anyone on the login endpoint
-                .antMatchers(HttpMethod.POST,"/api/authn/login").permitAll()
-                //TRACE, CONNECT, OPTIONS, HEAD
-                //Everyone can call GET on the status endpoint
-                .antMatchers(HttpMethod.GET, "/api/authn/status").permitAll()
-            .and()
+            // Add a filter before any request to handle DSpace IP-based authorization/authentication
+            // (e.g. anonymous users may be added to special DSpace groups if they are in a given IP range)
             .addFilterBefore(new AnonymousAdditionalAuthorizationFilter(authenticationManager(), authenticationService),
                              StatelessAuthenticationFilter.class)
-            //Add a filter before our login endpoints to do the authentication based on the data in the HTTP request
+            // Add a filter before our login endpoints to do the authentication based on the data in the HTTP request
             .addFilterBefore(new StatelessLoginFilter("/api/authn/login", authenticationManager(),
                                                       restAuthenticationService),
                              LogoutFilter.class)
-
-            //Add a filter before our shibboleth endpoints to do the authentication based on the data in the
+            // Add a filter before our shibboleth endpoints to do the authentication based on the data in the
             // HTTP request
             .addFilterBefore(new ShibbolethAuthenticationFilter("/api/authn/shibboleth", authenticationManager(),
                                                       restAuthenticationService),
                              LogoutFilter.class)
-
             // Add a custom Token based authentication filter based on the token previously given to the client
             // before each URL
             .addFilterBefore(new StatelessAuthenticationFilter(authenticationManager(), restAuthenticationService,
@@ -141,12 +137,16 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
     }
 
     /**
-     * Override the defaults of CookieCsrfTokenRepository to always set the Path to "/"
+     * Override the defaults of CookieCsrfTokenRepository to always set the Cookie Path to "/"
      * <P>
      * We use the CookieCsrfTokenRepository designed for Angular apps
      * See https://docs.spring.io/spring-security/site/docs/current/reference/html5/#servlet-csrf
      * <P>
-     * However, Angular *requires* the CSR cookie path to always be "/" or it will ignore it.
+     * This CookieCsrfTokenRepository will write a cookie named XSRF-TOKEN and read it from
+     * a header named X-XSRF-TOKEN *or* a URL parameter named "_csrf". Angular apps will respond to
+     * XSRF-TOKEN automatically, see: https://angular.io/guide/http#security-xsrf-protection
+     * <P>
+     * However, currently Angular *requires* the CSR cookie path to always be "/" or it will ignore it.
      * See: https://stackoverflow.com/a/50511663
      * @return CookieCsrfTokenRepository with cookie path="/"
      */

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/jwt/JWTTokenRestAuthenticationServiceImpl.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/jwt/JWTTokenRestAuthenticationServiceImpl.java
@@ -15,6 +15,7 @@ import java.util.List;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.HttpHeaders;
 
 import com.nimbusds.jose.JOSEException;
 import org.apache.commons.lang3.StringUtils;
@@ -32,6 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
 /**
@@ -151,11 +153,12 @@ public class JWTTokenRestAuthenticationServiceImpl implements RestAuthentication
 
     @Override
     public void invalidateAuthenticationCookie(HttpServletResponse response) {
-        Cookie cookie = new Cookie(AUTHORIZATION_COOKIE, "");
-        cookie.setHttpOnly(true);
-        cookie.setMaxAge(0);
-        cookie.setSecure(true);
-        response.addCookie(cookie);
+        // Re-send the same cookie (as addTokenToResponse()) with no value and a Max-Age of 0 seconds
+        ResponseCookie cookie = ResponseCookie.from(AUTHORIZATION_COOKIE, "")
+                                              .maxAge(0).httpOnly(true).secure(true).sameSite("None").build();
+
+        // Write the cookie to the Set-Cookie header in order to send it
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }
 
     @Override
@@ -190,14 +193,28 @@ public class JWTTokenRestAuthenticationServiceImpl implements RestAuthentication
         return wwwAuthenticate.toString();
     }
 
-    private void addTokenToResponse(final HttpServletResponse response, final String token, final Boolean addCookie)
-            throws IOException {
+    /**
+     * Adds the Authentication token (JWT) to the response either in a header (default) or in a cookie.
+     * <P>
+     * If 'addCookie' is true, then the JWT is also added to a response cookie. This is primarily for support of auth
+     * plugins which _require_ cookie-based auth (e.g. Shibboleth). Note that this cookie can be used cross-site
+     * (i.e. SameSite=None), but cannot be used by Javascript (HttpOnly) including the Angular UI. It also will only be
+     * sent via HTTPS (Secure).
+     * <P>
+     * If 'addCookie' is false, then the JWT is only added in the Authorization header. This is recommended behavior
+     * as it is the most secure. For the UI (or any JS clients) the JWT must be sent in the Authorization header.
+     * @param response current response
+     * @param token the authentication token
+     * @param addCookie whether to send token in a cookie (true) or header (false)
+     */
+    private void addTokenToResponse(final HttpServletResponse response, final String token, final Boolean addCookie) {
         // we need authentication cookies because Shibboleth can't use the authentication headers due to the redirects
         if (addCookie) {
-            Cookie cookie = new Cookie(AUTHORIZATION_COOKIE, token);
-            cookie.setHttpOnly(true);
-            cookie.setSecure(true);
-            response.addCookie(cookie);
+            ResponseCookie cookie = ResponseCookie.from(AUTHORIZATION_COOKIE, token)
+                                                  .httpOnly(true).secure(true).sameSite("None").build();
+
+            // Write the cookie to the Set-Cookie header in order to send it
+            response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
         }
         response.setHeader(AUTHORIZATION_HEADER, String.format("%s %s", AUTHORIZATION_TYPE, token));
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/ApplicationConfig.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/ApplicationConfig.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.app.rest.utils;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -48,6 +49,15 @@ public class ApplicationConfig {
     public String[] getCorsAllowedOrigins() {
         // Use "rest.cors.allowed-origins" if configured. Otherwise, default to the "dspace.ui.url" setting.
         if (corsAllowedOrigins != null) {
+            // Ensure no allowed origins end in a trailing slash
+            // Browsers send 'Origin' header without a trailing slash & Spring Security considers
+            // http://example.org and http://example.org/ to be different Origins.
+            for (int i = 0; i < corsAllowedOrigins.length; i++) {
+                if (corsAllowedOrigins[i].endsWith("/")) {
+                    corsAllowedOrigins[i] = StringUtils.removeEnd(corsAllowedOrigins[i], "/");
+                }
+            }
+
             return corsAllowedOrigins;
         } else if (uiURL != null) {
             return new String[] {uiURL};

--- a/dspace-server-webapp/src/main/webapp/index.html
+++ b/dspace-server-webapp/src/main/webapp/index.html
@@ -75,7 +75,7 @@
         <tr>
             <td><strong><%= HAL.truncateIfUrl(rel) %></strong></td>
             <td><%= link.title || '' %></td>
-            <td><%= link.name ? 'name: ' + link.name : 'index: ' + i %></a></td>
+            <td><%= link.name ? 'name: ' + link.name : 'index: ' + i %></td>
             <td>
                 <% if (HAL.isUrl(rel)) { %>
                 <a class="dox" href="<%= HAL.normalizeUrl(HAL.buildUrl(rel)) %>"><i class="icon-book"></i></a>
@@ -250,6 +250,7 @@ Content-Type: application/json
     </div>
 </script>
 
+<!-- Customized (to use WebJars) for DSpace -->
 <script src="webjars/jquery/dist/jquery.min.js"></script>
 <script src="browser/vendor/js/underscore.js"></script>
 <script src="browser/vendor/js/backbone.js"></script>
@@ -260,6 +261,7 @@ Content-Type: application/json
 <script src="browser/js/hal.js"></script>
 <script src="browser/js/hal/browser.js"></script>
 
+<!-- Customized for DSpace -->
 <script src="js/hal/http/client.js"></script>
 <script src="browser/js/hal/resource.js"></script>
 

--- a/dspace-server-webapp/src/main/webapp/index.html
+++ b/dspace-server-webapp/src/main/webapp/index.html
@@ -180,10 +180,10 @@
         <h3>Make a non-GET request</h3>
     </div>
 
-    <form class="non-safe" action="<%= href %>">
+    <form class="non-safe" action="<%= _.escape(href) %>">
         <div class="modal-body">
             <p>Target URI</p>
-            <input name="url" type="text" class="url" value="<%= href %>" />
+            <input name="url" type="text" class="url" value="<%= _.escape(href) %>" />
             <p>Method:</p>
             <input name="method" type="text" class="method" value="POST" />
             <p>Headers:</p>

--- a/dspace-server-webapp/src/main/webapp/js/hal/http/client.js
+++ b/dspace-server-webapp/src/main/webapp/js/hal/http/client.js
@@ -21,10 +21,10 @@ HAL.Http.Client = function(opts) {
 };
 
 /**
- * Get CSRF Token by parsing it out of the XSRF-TOKEN cookie sent by our DSpace server webapp
+ * Get CSRF Token by parsing it out of the DSPACE-XSRF-COOKIE (server-side) cookie set by our DSpace server webapp
  **/
 function getCSRFToken() {
-    var cookie = document.cookie.match('(^|;)\\s*' + 'XSRF-TOKEN' + '\\s*=\\s*([^;]+)');
+    var cookie = document.cookie.match('(^|;)\\s*' + 'DSPACE-XSRF-COOKIE' + '\\s*=\\s*([^;]+)');
     if(cookie != undefined) {
         return cookie.pop();
     } else {

--- a/dspace-server-webapp/src/main/webapp/js/hal/http/client.js
+++ b/dspace-server-webapp/src/main/webapp/js/hal/http/client.js
@@ -12,10 +12,30 @@ HAL.Http.Client = function(opts) {
     this.defaultHeaders = {'Accept': 'application/hal+json, application/json, */*; q=0.01'};
     var authorizationHeader = getAuthorizationHeader();
     authorizationHeader ? this.defaultHeaders.Authorization = authorizationHeader : '';
+    // If we find a CSRF header (in a cookie), send it back in X-XSRF-Token header
+    var csrfToken = getCSRFToken();
+    csrfToken ? this.defaultHeaders['X-XSRF-Token'] = csrfToken : '';
+    // Write all headers to console (for easy debugging)
     console.log(this.defaultHeaders);
     this.headers = this.defaultHeaders;
 };
 
+/**
+ * Get CSRF Token by parsing it out of the XSRF-TOKEN cookie sent by our DSpace server webapp
+ **/
+function getCSRFToken() {
+    var cookie = document.cookie.match('(^|;)\\s*' + 'XSRF-TOKEN' + '\\s*=\\s*([^;]+)');
+    if(cookie != undefined) {
+        return cookie.pop();
+    } else {
+        return undefined;
+    }
+}
+
+/**
+ * Get Authorization Header by parsing it out of the "MyHalBrowserToken" cookie.
+ * This cookie is set in login.html after a successful login occurs.
+ **/
 function getAuthorizationHeader() {
     var cookie = document.cookie.match('(^|;)\\s*' + 'MyHalBrowserToken' + '\\s*=\\s*([^;]+)');
     if(cookie != undefined) {

--- a/dspace-server-webapp/src/main/webapp/login.html
+++ b/dspace-server-webapp/src/main/webapp/login.html
@@ -71,7 +71,13 @@
 <script>
     $(document).ready(function() {
         var successHandler = function(result, status, xhr) {
+            // look for Authorization header & save to a MyHalBrowserToken cookie
             document.cookie = "MyHalBrowserToken=" + xhr.getResponseHeader('Authorization').split(" ")[1];
+            // look for DSpace-XSRF-TOKEN header & save to a MyHalBrowserCsrfToken cookie (if found)
+            var csrfToken = xhr.getResponseHeader('DSPACE-XSRF-TOKEN');
+            if (csrfToken!=null) {
+                document.cookie = "MyHalBrowserCsrfToken=" + csrfToken;
+            }
             toastr.success('You are now logged in. Please wait while we redirect you...', 'Login Successful');
             setTimeout(function() {
                 window.location.href = window.location.pathname.replace("login.html", "");
@@ -101,7 +107,9 @@
           beforeSend: function (xhr, settings) {
                // If CSRF token found in cookie, send it back as X-XSRF-Token header
                var csrfToken = getCSRFToken();
-               xhr.setRequestHeader('X-XSRF-Token', csrfToken ? csrfToken : '');
+               if (csrfToken != null) {
+                   xhr.setRequestHeader('X-XSRF-Token', csrfToken);
+               }
           },
           success : successHandler,
           error : function(result, status, xhr) {
@@ -139,14 +147,15 @@
         }
 
        /**
-        * Get CSRF Token by parsing it out of the DSPACE-XSRF-COOKIE server-side cookie set by our DSpace server webapp
+        * Get CSRF Token by parsing it out of the "MyHalBrowserCsrfToken" cookie.
+        * This cookie is set in login.html after a successful login occurs.
         **/
         function getCSRFToken() {
-            var cookie = document.cookie.match('(^|;)\\s*' + 'DSPACE-XSRF-COOKIE' + '\\s*=\\s*([^;]+)');
-            if(cookie != undefined) {
+            var cookie = document.cookie.match('(^|;)\\s*' + 'MyHalBrowserCsrfToken' + '\\s*=\\s*([^;]+)');
+            if (cookie != null) {
                 return cookie.pop();
             } else {
-                return undefined;
+                return null;
             }
         }
 
@@ -164,7 +173,9 @@
                 beforeSend: function (xhr, settings) {
                     // If CSRF token found in cookie, send it back as X-XSRF-Token header
                     var csrfToken = getCSRFToken();
-                    xhr.setRequestHeader('X-XSRF-Token', csrfToken ? csrfToken : '');
+                    if (csrfToken != null) {
+                       xhr.setRequestHeader('X-XSRF-Token', csrfToken);
+                    }
                 },
                 success : successHandler,
                 error : function() {

--- a/dspace-server-webapp/src/main/webapp/login.html
+++ b/dspace-server-webapp/src/main/webapp/login.html
@@ -98,6 +98,11 @@
         $.ajax({
           url : window.location.href.replace("login.html", "") + 'api/authn/login',
           type : 'POST',
+          beforeSend: function (xhr, settings) {
+               // If CSRF token found in cookie, send it back as X-XSRF-Token header
+               var csrfToken = getCSRFToken();
+               xhr.setRequestHeader('X-XSRF-Token', csrfToken ? csrfToken : '');
+          },
           success : successHandler,
           error : function(result, status, xhr) {
               if (result.status === 401) {
@@ -108,12 +113,11 @@
                       if (realms.length == 1){
                           var loc = /location="([^,]*)"/.exec(authenticate);
                           if (loc !== null && loc.length === 2) {
-                          document.location = loc[1];
+                              document.location = loc[1];
                           }
                       } else if (realms.length > 1){
                           for (var i = 0; i < realms.length; i++){
                               addLocationButton(realms[i], element);
-
                           }
                       }
                   }
@@ -134,6 +138,18 @@
             return string.charAt(0).toUpperCase() + string.slice(1);
         }
 
+       /**
+        * Get CSRF Token by parsing it out of the XSRF-TOKEN cookie sent by our DSpace server webapp
+        **/
+        function getCSRFToken() {
+            var cookie = document.cookie.match('(^|;)\\s*' + 'XSRF-TOKEN' + '\\s*=\\s*([^;]+)');
+            if(cookie != undefined) {
+                return cookie.pop();
+            } else {
+                return undefined;
+            }
+        }
+
         $("#login-form").submit(function(event) {
             event.preventDefault();
             $.ajax({
@@ -144,6 +160,11 @@
                 data: {
                     user: $("#username").val(),
                     password: $("#password").val()
+                },
+                beforeSend: function (xhr, settings) {
+                    // If CSRF token found in cookie, send it back as X-XSRF-Token header
+                    var csrfToken = getCSRFToken();
+                    xhr.setRequestHeader('X-XSRF-Token', csrfToken ? csrfToken : '');
                 },
                 success : successHandler,
                 error : function() {

--- a/dspace-server-webapp/src/main/webapp/login.html
+++ b/dspace-server-webapp/src/main/webapp/login.html
@@ -139,10 +139,10 @@
         }
 
        /**
-        * Get CSRF Token by parsing it out of the XSRF-TOKEN cookie sent by our DSpace server webapp
+        * Get CSRF Token by parsing it out of the DSPACE-XSRF-COOKIE server-side cookie set by our DSpace server webapp
         **/
         function getCSRFToken() {
-            var cookie = document.cookie.match('(^|;)\\s*' + 'XSRF-TOKEN' + '\\s*=\\s*([^;]+)');
+            var cookie = document.cookie.match('(^|;)\\s*' + 'DSPACE-XSRF-COOKIE' + '\\s*=\\s*([^;]+)');
             if(cookie != undefined) {
                 return cookie.pop();
             } else {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/AuthenticationRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/AuthenticationRestControllerIT.java
@@ -401,6 +401,8 @@ public class AuthenticationRestControllerIT extends AbstractControllerIntegratio
                                                     .cookie(cookies))
                    // Should return a 403 Forbidden, for an invalid CSRF token
                    .andExpect(status().isForbidden())
+                   // Verify it includes our custom error reason (from DSpaceApiExceptionControllerAdvice)
+                   .andExpect(status().reason(containsString("Invalid CSRF token")))
                    // And, a new/updated token should be returned (as both server-side cookie and header)
                    // This is handled by DSpaceAccessDeniedHandler
                    .andExpect(cookie().exists("DSPACE-XSRF-COOKIE"))

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/AuthenticationRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/AuthenticationRestControllerIT.java
@@ -19,6 +19,7 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -399,7 +400,12 @@ public class AuthenticationRestControllerIT extends AbstractControllerIntegratio
                                                     .secure(true)
                                                     .cookie(cookies))
                    // Should return a 403 Forbidden, for an invalid CSRF token
-                   .andExpect(status().isForbidden());
+                   .andExpect(status().isForbidden())
+                   // And, a new/updated token should be returned (as both server-side cookie and header)
+                   // This is handled by DSpaceAccessDeniedHandler
+                   .andExpect(cookie().exists("DSPACE-XSRF-COOKIE"))
+                   .andExpect(header().exists("DSPACE-XSRF-TOKEN"));
+
         //Logout
         getClient(token).perform(post("/api/authn/logout"))
                         .andExpect(status().isNoContent());

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/CrossSiteCookieCsrfTokenRepositoryTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/CrossSiteCookieCsrfTokenRepositoryTest.java
@@ -1,0 +1,287 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import javax.servlet.http.Cookie;
+import javax.ws.rs.core.HttpHeaders;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.web.csrf.CsrfToken;
+
+/**
+ * This is almost an exact copy of Spring Security's CookieCsrfTokenRepositoryTests
+ * https://github.com/spring-projects/spring-security/blob/5.2.x/web/src/test/java/org/springframework/security/web/csrf/CookieCsrfTokenRepositoryTests.java
+ *
+ * The only modifications are:
+ *   - Updating these tests to use our custom CrossSiteCookieCsrfTokenRepository
+ *   - Updating the saveTokenSecure() test, where we check for our custom SameSite attribute.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class CrossSiteCookieCsrfTokenRepositoryTest {
+    CrossSiteCookieCsrfTokenRepository repository;
+    MockHttpServletResponse response;
+    MockHttpServletRequest request;
+
+    @Before
+    public void setup() {
+        this.repository = new CrossSiteCookieCsrfTokenRepository();
+        this.request = new MockHttpServletRequest();
+        this.response = new MockHttpServletResponse();
+        this.request.setContextPath("/context");
+    }
+
+    @Test
+    public void generateToken() {
+        CsrfToken generateToken = this.repository.generateToken(this.request);
+
+        assertThat(generateToken).isNotNull();
+        assertThat(generateToken.getHeaderName())
+            .isEqualTo(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_HEADER_NAME);
+        assertThat(generateToken.getParameterName())
+            .isEqualTo(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_PARAMETER_NAME);
+        assertThat(generateToken.getToken()).isNotEmpty();
+    }
+
+    @Test
+    public void generateTokenCustom() {
+        String headerName = "headerName";
+        String parameterName = "paramName";
+        this.repository.setHeaderName(headerName);
+        this.repository.setParameterName(parameterName);
+
+        CsrfToken generateToken = this.repository.generateToken(this.request);
+
+        assertThat(generateToken).isNotNull();
+        assertThat(generateToken.getHeaderName()).isEqualTo(headerName);
+        assertThat(generateToken.getParameterName()).isEqualTo(parameterName);
+        assertThat(generateToken.getToken()).isNotEmpty();
+    }
+
+    @Test
+    public void saveToken() {
+        CsrfToken token = this.repository.generateToken(this.request);
+        this.repository.saveToken(token, this.request, this.response);
+
+        Cookie tokenCookie = this.response
+            .getCookie(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+
+        assertThat(tokenCookie.getMaxAge()).isEqualTo(-1);
+        assertThat(tokenCookie.getName())
+            .isEqualTo(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+        assertThat(tokenCookie.getPath()).isEqualTo(this.request.getContextPath());
+        assertThat(tokenCookie.getSecure()).isEqualTo(this.request.isSecure());
+        assertThat(tokenCookie.getValue()).isEqualTo(token.getToken());
+        assertThat(tokenCookie.isHttpOnly()).isEqualTo(true);
+    }
+
+    @Test
+    public void saveTokenSecure() {
+        this.request.setSecure(true);
+        CsrfToken token = this.repository.generateToken(this.request);
+        this.repository.saveToken(token, this.request, this.response);
+
+        Cookie tokenCookie = this.response
+            .getCookie(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+
+        assertThat(tokenCookie.getSecure()).isTrue();
+        // DSpace Custom assert to verify SameSite attribute is set
+        // The Cookie class doesn't yet support SameSite, so we have to re-read
+        // the cookie from our headers, and check it.
+        List<String> headers = this.response.getHeaders(HttpHeaders.SET_COOKIE);
+        assertThat(headers.size()).isEqualTo(1);
+        assertThat(headers.get(0)).containsIgnoringCase("SameSite=None");
+    }
+
+    @Test
+    public void saveTokenNull() {
+        this.request.setSecure(true);
+        this.repository.saveToken(null, this.request, this.response);
+
+        Cookie tokenCookie = this.response
+            .getCookie(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+
+        assertThat(tokenCookie.getMaxAge()).isZero();
+        assertThat(tokenCookie.getName())
+            .isEqualTo(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+        assertThat(tokenCookie.getPath()).isEqualTo(this.request.getContextPath());
+        assertThat(tokenCookie.getSecure()).isEqualTo(this.request.isSecure());
+        assertThat(tokenCookie.getValue()).isEmpty();
+    }
+
+    @Test
+    public void saveTokenHttpOnlyTrue() {
+        this.repository.setCookieHttpOnly(true);
+        CsrfToken token = this.repository.generateToken(this.request);
+        this.repository.saveToken(token, this.request, this.response);
+
+        Cookie tokenCookie = this.response
+            .getCookie(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+
+        assertThat(tokenCookie.isHttpOnly()).isTrue();
+    }
+
+    @Test
+    public void saveTokenHttpOnlyFalse() {
+        this.repository.setCookieHttpOnly(false);
+        CsrfToken token = this.repository.generateToken(this.request);
+        this.repository.saveToken(token, this.request, this.response);
+
+        Cookie tokenCookie = this.response
+            .getCookie(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+
+        assertThat(tokenCookie.isHttpOnly()).isFalse();
+    }
+
+    @Test
+    public void saveTokenWithHttpOnlyFalse() {
+        this.repository = CrossSiteCookieCsrfTokenRepository.withHttpOnlyFalse();
+        CsrfToken token = this.repository.generateToken(this.request);
+        this.repository.saveToken(token, this.request, this.response);
+
+        Cookie tokenCookie = this.response
+            .getCookie(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+
+        assertThat(tokenCookie.isHttpOnly()).isFalse();
+    }
+
+    @Test
+    public void saveTokenCustomPath() {
+        String customPath = "/custompath";
+        this.repository.setCookiePath(customPath);
+        CsrfToken token = this.repository.generateToken(this.request);
+        this.repository.saveToken(token, this.request, this.response);
+
+        Cookie tokenCookie = this.response
+            .getCookie(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+
+        assertThat(tokenCookie.getPath()).isEqualTo(this.repository.getCookiePath());
+    }
+
+    @Test
+    public void saveTokenEmptyCustomPath() {
+        String customPath = "";
+        this.repository.setCookiePath(customPath);
+        CsrfToken token = this.repository.generateToken(this.request);
+        this.repository.saveToken(token, this.request, this.response);
+
+        Cookie tokenCookie = this.response
+            .getCookie(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+
+        assertThat(tokenCookie.getPath()).isEqualTo(this.request.getContextPath());
+    }
+
+    @Test
+    public void saveTokenNullCustomPath() {
+        String customPath = null;
+        this.repository.setCookiePath(customPath);
+        CsrfToken token = this.repository.generateToken(this.request);
+        this.repository.saveToken(token, this.request, this.response);
+
+        Cookie tokenCookie = this.response
+            .getCookie(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+
+        assertThat(tokenCookie.getPath()).isEqualTo(this.request.getContextPath());
+    }
+
+    @Test
+    public void saveTokenWithCookieDomain() {
+        String domainName = "example.com";
+        this.repository.setCookieDomain(domainName);
+
+        CsrfToken token = this.repository.generateToken(this.request);
+        this.repository.saveToken(token, this.request, this.response);
+
+        Cookie tokenCookie = this.response
+            .getCookie(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+
+        assertThat(tokenCookie.getDomain()).isEqualTo(domainName);
+    }
+
+    @Test
+    public void loadTokenNoCookiesNull() {
+        assertThat(this.repository.loadToken(this.request)).isNull();
+    }
+
+    @Test
+    public void loadTokenCookieIncorrectNameNull() {
+        this.request.setCookies(new Cookie("other", "name"));
+
+        assertThat(this.repository.loadToken(this.request)).isNull();
+    }
+
+    @Test
+    public void loadTokenCookieValueEmptyString() {
+        this.request.setCookies(
+            new Cookie(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME, ""));
+
+        assertThat(this.repository.loadToken(this.request)).isNull();
+    }
+
+    @Test
+    public void loadToken() {
+        CsrfToken generateToken = this.repository.generateToken(this.request);
+
+        this.request
+            .setCookies(new Cookie(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME,
+                                   generateToken.getToken()));
+
+        CsrfToken loadToken = this.repository.loadToken(this.request);
+
+        assertThat(loadToken).isNotNull();
+        assertThat(loadToken.getHeaderName()).isEqualTo(generateToken.getHeaderName());
+        assertThat(loadToken.getParameterName())
+            .isEqualTo(generateToken.getParameterName());
+        assertThat(loadToken.getToken()).isNotEmpty();
+    }
+
+    @Test
+    public void loadTokenCustom() {
+        String cookieName = "cookieName";
+        String value = "value";
+        String headerName = "headerName";
+        String parameterName = "paramName";
+        this.repository.setHeaderName(headerName);
+        this.repository.setParameterName(parameterName);
+        this.repository.setCookieName(cookieName);
+
+        this.request.setCookies(new Cookie(cookieName, value));
+
+        CsrfToken loadToken = this.repository.loadToken(this.request);
+
+        assertThat(loadToken).isNotNull();
+        assertThat(loadToken.getHeaderName()).isEqualTo(headerName);
+        assertThat(loadToken.getParameterName()).isEqualTo(parameterName);
+        assertThat(loadToken.getToken()).isEqualTo(value);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void setCookieNameNullIllegalArgumentException() {
+        this.repository.setCookieName(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void setParameterNameNullIllegalArgumentException() {
+        this.repository.setParameterName(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void setHeaderNameNullIllegalArgumentException() {
+        this.repository.setHeaderName(null);
+    }
+
+
+
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/DSpaceCsrfTokenRepositoryTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/DSpaceCsrfTokenRepositoryTest.java
@@ -26,18 +26,18 @@ import org.springframework.security.web.csrf.CsrfToken;
  * https://github.com/spring-projects/spring-security/blob/5.2.x/web/src/test/java/org/springframework/security/web/csrf/CookieCsrfTokenRepositoryTests.java
  *
  * The only modifications are:
- *   - Updating these tests to use our custom CrossSiteCookieCsrfTokenRepository
+ *   - Updating these tests to use our custom DSpaceCsrfTokenRepository
  *   - Updating the saveTokenSecure() test, where we check for our custom SameSite attribute.
  */
 @RunWith(MockitoJUnitRunner.class)
-public class CrossSiteCookieCsrfTokenRepositoryTest {
-    CrossSiteCookieCsrfTokenRepository repository;
+public class DSpaceCsrfTokenRepositoryTest {
+    DSpaceCsrfTokenRepository repository;
     MockHttpServletResponse response;
     MockHttpServletRequest request;
 
     @Before
     public void setup() {
-        this.repository = new CrossSiteCookieCsrfTokenRepository();
+        this.repository = new DSpaceCsrfTokenRepository();
         this.request = new MockHttpServletRequest();
         this.response = new MockHttpServletResponse();
         this.request.setContextPath("/context");
@@ -49,9 +49,9 @@ public class CrossSiteCookieCsrfTokenRepositoryTest {
 
         assertThat(generateToken).isNotNull();
         assertThat(generateToken.getHeaderName())
-            .isEqualTo(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_HEADER_NAME);
+            .isEqualTo(DSpaceCsrfTokenRepository.DEFAULT_CSRF_HEADER_NAME);
         assertThat(generateToken.getParameterName())
-            .isEqualTo(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_PARAMETER_NAME);
+            .isEqualTo(DSpaceCsrfTokenRepository.DEFAULT_CSRF_PARAMETER_NAME);
         assertThat(generateToken.getToken()).isNotEmpty();
     }
 
@@ -76,11 +76,11 @@ public class CrossSiteCookieCsrfTokenRepositoryTest {
         this.repository.saveToken(token, this.request, this.response);
 
         Cookie tokenCookie = this.response
-            .getCookie(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+            .getCookie(DSpaceCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
 
         assertThat(tokenCookie.getMaxAge()).isEqualTo(-1);
         assertThat(tokenCookie.getName())
-            .isEqualTo(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+            .isEqualTo(DSpaceCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
         assertThat(tokenCookie.getPath()).isEqualTo(this.request.getContextPath());
         assertThat(tokenCookie.getSecure()).isEqualTo(this.request.isSecure());
         assertThat(tokenCookie.getValue()).isEqualTo(token.getToken());
@@ -94,7 +94,7 @@ public class CrossSiteCookieCsrfTokenRepositoryTest {
         this.repository.saveToken(token, this.request, this.response);
 
         Cookie tokenCookie = this.response
-            .getCookie(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+            .getCookie(DSpaceCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
 
         assertThat(tokenCookie.getSecure()).isTrue();
         // DSpace Custom assert to verify SameSite attribute is set
@@ -111,11 +111,11 @@ public class CrossSiteCookieCsrfTokenRepositoryTest {
         this.repository.saveToken(null, this.request, this.response);
 
         Cookie tokenCookie = this.response
-            .getCookie(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+            .getCookie(DSpaceCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
 
         assertThat(tokenCookie.getMaxAge()).isZero();
         assertThat(tokenCookie.getName())
-            .isEqualTo(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+            .isEqualTo(DSpaceCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
         assertThat(tokenCookie.getPath()).isEqualTo(this.request.getContextPath());
         assertThat(tokenCookie.getSecure()).isEqualTo(this.request.isSecure());
         assertThat(tokenCookie.getValue()).isEmpty();
@@ -128,7 +128,7 @@ public class CrossSiteCookieCsrfTokenRepositoryTest {
         this.repository.saveToken(token, this.request, this.response);
 
         Cookie tokenCookie = this.response
-            .getCookie(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+            .getCookie(DSpaceCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
 
         assertThat(tokenCookie.isHttpOnly()).isTrue();
     }
@@ -140,19 +140,19 @@ public class CrossSiteCookieCsrfTokenRepositoryTest {
         this.repository.saveToken(token, this.request, this.response);
 
         Cookie tokenCookie = this.response
-            .getCookie(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+            .getCookie(DSpaceCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
 
         assertThat(tokenCookie.isHttpOnly()).isFalse();
     }
 
     @Test
     public void saveTokenWithHttpOnlyFalse() {
-        this.repository = CrossSiteCookieCsrfTokenRepository.withHttpOnlyFalse();
+        this.repository = DSpaceCsrfTokenRepository.withHttpOnlyFalse();
         CsrfToken token = this.repository.generateToken(this.request);
         this.repository.saveToken(token, this.request, this.response);
 
         Cookie tokenCookie = this.response
-            .getCookie(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+            .getCookie(DSpaceCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
 
         assertThat(tokenCookie.isHttpOnly()).isFalse();
     }
@@ -165,7 +165,7 @@ public class CrossSiteCookieCsrfTokenRepositoryTest {
         this.repository.saveToken(token, this.request, this.response);
 
         Cookie tokenCookie = this.response
-            .getCookie(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+            .getCookie(DSpaceCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
 
         assertThat(tokenCookie.getPath()).isEqualTo(this.repository.getCookiePath());
     }
@@ -178,7 +178,7 @@ public class CrossSiteCookieCsrfTokenRepositoryTest {
         this.repository.saveToken(token, this.request, this.response);
 
         Cookie tokenCookie = this.response
-            .getCookie(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+            .getCookie(DSpaceCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
 
         assertThat(tokenCookie.getPath()).isEqualTo(this.request.getContextPath());
     }
@@ -191,7 +191,7 @@ public class CrossSiteCookieCsrfTokenRepositoryTest {
         this.repository.saveToken(token, this.request, this.response);
 
         Cookie tokenCookie = this.response
-            .getCookie(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+            .getCookie(DSpaceCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
 
         assertThat(tokenCookie.getPath()).isEqualTo(this.request.getContextPath());
     }
@@ -205,7 +205,7 @@ public class CrossSiteCookieCsrfTokenRepositoryTest {
         this.repository.saveToken(token, this.request, this.response);
 
         Cookie tokenCookie = this.response
-            .getCookie(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+            .getCookie(DSpaceCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
 
         assertThat(tokenCookie.getDomain()).isEqualTo(domainName);
     }
@@ -225,7 +225,7 @@ public class CrossSiteCookieCsrfTokenRepositoryTest {
     @Test
     public void loadTokenCookieValueEmptyString() {
         this.request.setCookies(
-            new Cookie(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME, ""));
+            new Cookie(DSpaceCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME, ""));
 
         assertThat(this.repository.loadToken(this.request)).isNull();
     }
@@ -235,7 +235,7 @@ public class CrossSiteCookieCsrfTokenRepositoryTest {
         CsrfToken generateToken = this.repository.generateToken(this.request);
 
         this.request
-            .setCookies(new Cookie(CrossSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME,
+            .setCookies(new Cookie(DSpaceCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME,
                                    generateToken.getToken()));
 
         CsrfToken loadToken = this.repository.loadToken(this.request);

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/test/AbstractControllerIntegrationTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/test/AbstractControllerIntegrationTest.java
@@ -7,6 +7,8 @@
  */
 package org.dspace.app.rest.test;
 
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
@@ -131,11 +133,17 @@ public class AbstractControllerIntegrationTest extends AbstractIntegrationTestWi
             .alwaysDo(MockMvcResultHandlers.print())
             //Add all filter implementations
             .addFilters(new ErrorPageFilter())
-            .addFilters(requestFilters.toArray(new Filter[requestFilters.size()]));
+            .addFilters(requestFilters.toArray(new Filter[requestFilters.size()]))
+            // Enable/Integrate Spring Security with MockMVC
+            .apply(springSecurity());
 
+        // Make sure all MockMvc requests (in all tests) include a valid CSRF token (in header) by default.
+        // If an authToken was passed in, also make sure request sends the authToken in the "Authorization" header
         if (StringUtils.isNotBlank(authToken)) {
             mockMvcBuilder.defaultRequest(
-                get("/").header(AUTHORIZATION_HEADER, AUTHORIZATION_TYPE + authToken));
+                get("/").with(csrf().asHeader()).header(AUTHORIZATION_HEADER, AUTHORIZATION_TYPE + authToken));
+        } else {
+            mockMvcBuilder.defaultRequest(get("/").with(csrf().asHeader()));
         }
 
         return mockMvcBuilder

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -351,6 +351,16 @@ useProxies = true
 # This is necessary because Angular Universal will also behave as a proxy server.
 proxies.trusted.ipranges = 127.0.0.1
 
+# Spring Boot proxy configuration (can be set in local.cfg or in application.properties).
+# By default, Spring Boot does not automatically use X-Forwarded-* Headers when generating links (and similar) in the
+# REST API. When using a proxy in front of the REST API, you may need to modify this setting:
+#   * NATIVE = allows your web server to natively support standard Forwarded headers
+#   * FRAMEWORK = enables Spring Framework's built in filter to manage these headers in Spring Boot
+#   * NONE = default value. Forwarded headers are ignored
+# For more information see
+# https://docs.spring.io/spring-boot/docs/current/reference/html/howto.html#howto-use-behind-a-proxy-server
+#server.forward-headers-strategy=FRAMEWORK
+
 #### Media Filter / Format Filter plugins (through PluginService) ####
 # Media/Format Filters help to full-text index content or
 # perform automated format conversions

--- a/dspace/modules/server/pom.xml
+++ b/dspace/modules/server/pom.xml
@@ -298,6 +298,12 @@ just adding new jar in the classloader</description>
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <version>${spring-security.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path-assert</artifactId>
             <version>${json-path.version}</version>

--- a/dspace/src/main/docker/dspace-shibboleth/Dockerfile
+++ b/dspace/src/main/docker/dspace-shibboleth/Dockerfile
@@ -34,7 +34,7 @@ RUN apt-get update \
 
 # Setup Apache configs & enable mod-shib & dspace vhost
 COPY dspace-vhost.conf /etc/apache2/sites-available/
-RUN a2enmod ssl headers proxy proxy_ajp proxy_http shib && \
+RUN a2enmod ssl proxy proxy_ajp proxy_http shib && \
     a2dissite 000-default.conf default-ssl.conf && \
     a2ensite dspace-vhost.conf
 

--- a/dspace/src/main/docker/dspace-shibboleth/dspace-vhost.conf
+++ b/dspace/src/main/docker/dspace-shibboleth/dspace-vhost.conf
@@ -13,10 +13,6 @@
   ErrorLog ${APACHE_LOG_DIR}/dspace.error.log
   CustomLog ${APACHE_LOG_DIR}/dspace.access.log combined
 
-  # Required when running DSpace REST API and Angular UI from separate hostnames
-  # This ensures all headers can be passed between frontend and backend
-  Header set Access-Control-Expose-Headers: "Authorization, expires, Location, Content-Disposition, WWW-Authenticate, Set-Cookie, X-Requested-With"
-
   #   SSL Engine Switch:
   #   Enable/Disable SSL for this virtual host.
   SSLEngine on

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
         <java.version>11</java.version>
         <spring.version>5.2.5.RELEASE</spring.version>
         <spring-boot.version>2.2.6.RELEASE</spring-boot.version>
+        <spring-security.version>5.2.2.RELEASE</spring-security.version> <!-- sync with version used by spring-boot-->
         <hibernate.version>5.4.10.Final</hibernate.version>
         <hibernate-validator.version>6.0.18.Final</hibernate-validator.version>
         <postgresql.driver.version>42.2.9</postgresql.driver.version>


### PR DESCRIPTION
## References
* Replaces #2922 (Based heavily on this older PR with updates)
* Replaces #3001
* Requires https://github.com/DSpace/dspace-angular/pull/977 when testing Angular UI

## Description
Enables a customized version of Spring Security CSRF (aka XSRF) Protection which works both cross-domain (where client & backend are on separate domains) and via Shibboleth.  The CSRF Protection is custom because, while it still uses Cookies to save CSRF tokens, the CSRF tokens are _always_ sent between the frontend & backend via HTTP Headers (this is what allows it to work cross domain).

As noted in this [LGTM rule](https://lgtm.com/rules/1511220334423/), Spring Security enables this CSRF protection by default and recommends it "for any request that could be processed by a browser client by normal users".  In this PR, I've also made sure to use standard names for XSRF headers/cookies based on [Angular XSRF Protection](https://angular.io/guide/http#security-xsrf-protection) best practices -- this makes the Angular UI implementation a bit easier.

## Detail: How it Works

1. Server Webapp generates CSRF token & stores in a *server-side* cookie named `DSPACE-XSRF-COOKIE`.  By default, this cookie is not readable to JS clients (HttpOnly=true). But, it is returned (by user's browser) on every subsequent request to backend. 
2. At the same time, Server Webapp also sends the generated CSRF token in a header named `DSPACE-XSRF-TOKEN` to client (e.g. Angular UI).
3. Client MUST look for `DSPACE-XSRF-TOKEN` header in a response from backend. If found, the client MUST store/save this token for later request(s).  For Angular UI, this task is/will be performed by a new `XsrfInterceptor`.
4. Whenever the client is making a mutating request (e.g. POST, PUT, DELETE, etc), the CSRF token is REQUIRED to be sent back to the Server Webapp in the `X-XSRF-TOKEN` header.
    * NOTE: non-mutating requests (e.g. GET, HEAD) do not check for an CSRF token. This is default behavior in Spring Security
5. In the Server Webapp, the `X-XSRF-TOKEN` header is received & compared to the current value of the *server-side* cookie named `DSPACE-XSRF-COOKIE`. If tokens match, the request is accepted. If tokens don't match a 403 is returned. This validation is done automatically by Spring Security.

_In summary_, the CSRF token is ALWAYS sent to/from the client & backend via *HTTP headers*. This is what allows the client and backend to be on different domains. The server-side cookie named `DSPACE-XSRF-COOKIE` is (usually) not accessible to the client. It only exists to allow the server-side to remember the currently active CSRF token, so that it can validate the CSRF token sent back (by the client) in the `X-XSRF-TOKEN` header.

## Full List of Changes

* Enables Spring Security's CSRF protection, using a custom `DSpaceCsrfTokenRepository` to send/receive the CSRF token (as described in detail above).
    * Also adds a custom `DSpaceCsrfAuthenticationStrategy` which ensures the CSRF token is only regenerated/changed when it is attempted to be used -- this is needed as the default AuthenticationStrategy ends up regenerating the token on every request when stateless authentication is used.
    * Adds/Updates ITs to prove this is working as expected....including verifying an error is thrown if an invalid CSRF token is sent.
* Updates `/logout` endpoint to ONLY respond to `POST` requests (previously it allowed for `GET` or `POST`).  This aligns with the OWASP principle ["Do not use GET requests for state changing operations"](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#introduction). It also is recommended by Spring Security
* Added custom `DSpaceAccessDeniedHandler` to allow us to customize the error message when an invalid/missing CSRF token is sent.
* Updated all Cookies to use `SameSite=None` attribute. This is necessary to allow Cookies to be passed back and forth (by a user's browser) between client & server when they are on different domains.  Without this, the browser will block (or fail to send) these cookies back whenever the UI and REST API are on a different domain.
* Updated HAL Browser code to support CSRF as described above. This means it now reads the CSRF token from the new `DSPACE-XSRF-TOKEN` header...storing it in a new `MyHalBrowserCsrfToken` cookie (alongside `MyHalBrowserToken` cookie used for the Auth token), and sending it back in a `X-XSRF-TOKEN` header.
* Minor changes to `AbstractBuilderCleanupUtil` to list a few missing Builders.  Without them, I hit some odd IT errors.
* Minor cleanup/reorg of `WebSecurityConfiguration` just to make it more readable. Added some inline comments.
* Minor changes to `ApplicationConfig` to ensure URLs listed in `rest.cors.allowed-origins` configuration _never end in a trailing slash_.  Spring Security treats "http://example.org" and "http://example.org/" as different origins....which causes very odd behavior if you don't notice you added a trailing slash.
* Minor fixes to Docker settings for `dspace-shibboleth` docker image.  This fixes an annoying bug where Apache settings on that image were *overwriting* the HTTP Headers generated by the DSpace REST API, causing odd errors to occur.

## Instructions for Reviewers

* Test HalBrowser (especially login/logout)
* Test Authentication via Shibboleth
* Test Authentication via Password
* Test Angular UI functionality in general (Requires corresponding Angular PR)

## Checklist

- [ ] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
