### PR TITLE
Self links contain embed params

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/RestResourceController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/RestResourceController.java
@@ -1021,7 +1021,7 @@ public class RestResourceController implements InitializingBean {
 
     /**
      * Internal method to convert the parameters provided as a MultivalueMap as a string to use in the self-link.
-     * This function will exclude all "embed" parameters
+     * This function will exclude all "embed" parameters and parameters starting with "embed."
      * @param parameters
      * @return encoded uriString containing request parameters without embed parameter
      */
@@ -1030,7 +1030,7 @@ public class RestResourceController implements InitializingBean {
         UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.newInstance();
 
         for (String key : parameters.keySet()) {
-            if (!StringUtils.equals(key, "embed")) {
+            if (!StringUtils.equals(key, "embed") && !StringUtils.startsWith(key, "embed.")) {
                 uriComponentsBuilder.queryParam(key, parameters.get(key));
             }
         }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/RestResourceController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/RestResourceController.java
@@ -1021,15 +1021,18 @@ public class RestResourceController implements InitializingBean {
 
     /**
      * Internal method to convert the parameters provided as a MultivalueMap as a string to use in the self-link.
+     * This function will exclude all "embed" parameters
      * @param parameters
-     * @return encoded uriString containing request parameters
+     * @return encoded uriString containing request parameters without embed parameter
      */
     private String getEncodedParameterStringFromRequestParams(
             @RequestParam MultiValueMap<String, Object> parameters) {
         UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.newInstance();
 
         for (String key : parameters.keySet()) {
-            uriComponentsBuilder.queryParam(key, parameters.get(key));
+            if (!StringUtils.equals(key, "embed")) {
+                uriComponentsBuilder.queryParam(key, parameters.get(key));
+            }
         }
         return uriComponentsBuilder.encode().build().toString();
     }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/RestResourceControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/RestResourceControllerIT.java
@@ -98,6 +98,11 @@ public class RestResourceControllerIT extends AbstractControllerIntegrationTest 
                    // The self link should contain those same parameters
                    .andExpect(jsonPath("$._links.self.href", endsWith(
                            "/api/core/metadatafields/search/byFieldName?schema=dc&offset=0")));
+
+        getClient().perform(get("/api/core/metadatafields/search/byFieldName?schema=dc&offset=0&embed.size=schema=5"))
+                   // The self link should contain those same parameters
+                   .andExpect(jsonPath("$._links.self.href", endsWith(
+                           "/api/core/metadatafields/search/byFieldName?schema=dc&offset=0")));
     }
 
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/RestResourceControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/RestResourceControllerIT.java
@@ -91,6 +91,15 @@ public class RestResourceControllerIT extends AbstractControllerIntegrationTest 
                                        endsWith("/api/core/metadatafields/search/byFieldName")));
     }
 
+    @Test
+    public void selfLinkContainsRequestParametersAndEmbedsWhenProvided() throws Exception {
+        // When we call a search endpoint with additional parameters and an embed parameter
+        getClient().perform(get("/api/core/metadatafields/search/byFieldName?schema=dc&offset=0&embed=schema"))
+                   // The self link should contain those same parameters
+                   .andExpect(jsonPath("$._links.self.href", endsWith(
+                           "/api/core/metadatafields/search/byFieldName?schema=dc&offset=0")));
+    }
+
 
 
 }


### PR DESCRIPTION
## References
* Fixes #3062
* Problem initially introduced by #3030 

## Description
Currently, self links should include embed parameters when returned, but this is not OK, since they don't affect the resource itself.
This PR avoids the addition of the aforementioned embed parameter
## Instructions for Reviewers

List of changes in this PR:
* RestResourceController -> When creating the self link (And including the actual parameters through the code from #3030), the embed parameter is excluded. The Projection creation is based on a [hardcoded check on the “embed” parameter](https://github.com/atmire/DSpace/blob/w2p-75404_self-links-contain-embeds/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/Utils.java#L542) as well, so this sort of check has been used similarly in this case
* RestResourceControllerIT.java -> A new test has been created that checks the steps mentioned below

**Test case**
* Retrieve any resource with an embed param. e.g. `/api/core/metadatafields/search/byFieldName?schema=dc&offset=0&embed=schema`
* The self link for a HAL resource should contain the parameters that have a (possible) effect on that resource but it shouldn't contain parameters that can't affect it.
    * /api/core/metadatafields/search/byFieldName?schema=dc&offset=0

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
