### PR TITLE
OAI OpenAIRE: addressing issue 3097 with access rights

### DIFF
--- a/dspace/config/crosswalks/oai/metadataFormats/oai_openaire.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/oai_openaire.xsl
@@ -525,8 +525,8 @@
 
    <!-- datacite:rights -->
    <!-- https://openaire-guidelines-for-literature-repository-managers.readthedocs.io/en/v4.0.0/field_accessrights.html -->
-    <xsl:template match="doc:element[@name='dc']/doc:element[@name='rights']/doc:element" mode="datacite">
-        <xsl:variable name="rightsValue" select="doc:field[@name='value']/text()"/>
+    <xsl:template match="doc:element[@name='dc']/doc:element[@name='rights']/doc:element/doc:field[@name='value']" mode="datacite">
+        <xsl:variable name="rightsValue" select="text()"/>
         <xsl:variable name="rightsURI">
             <xsl:call-template name="resolveRightsURI">
                 <xsl:with-param name="field" select="$rightsValue"/>
@@ -537,9 +537,9 @@
                 <xsl:with-param name="value" select="$rightsValue"/>
             </xsl:call-template>
         </xsl:variable>
-        <!-- this conditions ensures what is referred in issue: #3097 -->
-        <!-- it's a solution to ensure that only values ended with "access" -->
-        <!-- can be used as datacite:rights -->
+		<!-- We are checking to ensure that only values ending in "access" can be used as datacite:rights. 
+		This is a valid solution as we pre-normalize dc.rights values in openaire4.xsl to end in the term 
+		"access" according to COAR Controlled Vocabulary -->
         <xsl:if test="ends-with($lc_rightsValue,'access')">
             <datacite:rights>
                 <xsl:if test="$rightsURI">

--- a/dspace/config/crosswalks/oai/metadataFormats/oai_openaire.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/oai_openaire.xsl
@@ -526,19 +526,30 @@
    <!-- datacite:rights -->
    <!-- https://openaire-guidelines-for-literature-repository-managers.readthedocs.io/en/v4.0.0/field_accessrights.html -->
     <xsl:template match="doc:element[@name='dc']/doc:element[@name='rights']/doc:element" mode="datacite">
+        <xsl:variable name="rightsValue" select="doc:field[@name='value']/text()"/>
         <xsl:variable name="rightsURI">
             <xsl:call-template name="resolveRightsURI">
-                <xsl:with-param name="field" select="doc:field[@name='value']/text()"/>
+                <xsl:with-param name="field" select="$rightsValue"/>
             </xsl:call-template>
         </xsl:variable>
-        <datacite:rights>
-            <xsl:if test="$rightsURI">
-                <xsl:attribute name="rightsURI">
-                <xsl:value-of select="$rightsURI"/>
-            </xsl:attribute>
-            </xsl:if>
-            <xsl:value-of select="doc:field[@name='value']/text()"/>
-        </datacite:rights>
+		<xsl:variable name="lc_rightsValue">
+		    <xsl:call-template name="lowercase">
+                <xsl:with-param name="value" select="$rightsValue"/>
+            </xsl:call-template>
+        </xsl:variable>
+		<!-- this conditions ensures what is referred in issue: #3097 -->
+		<!-- it's a solution to ensure that only values ended with "access" -->
+		<!-- can be used as datacite:rights -->		
+        <xsl:if test="ends-with($lc_rightsValue,'access')">
+            <datacite:rights>
+                <xsl:if test="$rightsURI">
+                    <xsl:attribute name="rightsURI">
+                    <xsl:value-of select="$rightsURI"/>
+                </xsl:attribute>
+                </xsl:if>
+                <xsl:value-of select="$rightsValue"/>
+            </datacite:rights>
+        </xsl:if>
     </xsl:template>
 
 

--- a/dspace/config/crosswalks/oai/metadataFormats/oai_openaire.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/oai_openaire.xsl
@@ -532,14 +532,14 @@
                 <xsl:with-param name="field" select="$rightsValue"/>
             </xsl:call-template>
         </xsl:variable>
-		<xsl:variable name="lc_rightsValue">
-		    <xsl:call-template name="lowercase">
+        <xsl:variable name="lc_rightsValue">
+            <xsl:call-template name="lowercase">
                 <xsl:with-param name="value" select="$rightsValue"/>
             </xsl:call-template>
         </xsl:variable>
-		<!-- this conditions ensures what is referred in issue: #3097 -->
-		<!-- it's a solution to ensure that only values ended with "access" -->
-		<!-- can be used as datacite:rights -->		
+        <!-- this conditions ensures what is referred in issue: #3097 -->
+        <!-- it's a solution to ensure that only values ended with "access" -->
+        <!-- can be used as datacite:rights -->
         <xsl:if test="ends-with($lc_rightsValue,'access')">
             <datacite:rights>
                 <xsl:if test="$rightsURI">
@@ -1019,7 +1019,7 @@
     <xsl:template name="getRightsURI">
         <xsl:call-template name="resolveRightsURI">
             <xsl:with-param name="field"
-                select="//doc:element[@name='dc']/doc:element[@name='rights']/doc:element/doc:field[@name='value']/text()"/>
+                select="//doc:element[@name='dc']/doc:element[@name='rights']/doc:element/doc:field[@name='value'and ends-with(translate(text(), $uppercase, $smallcase),'access')]/text()"/>
         </xsl:call-template>
     </xsl:template>
 
@@ -1124,7 +1124,7 @@
    <!-- Other Auxiliary templates -->
    <!--  -->
     <xsl:param name="smallcase" select="'abcdefghijklmnopqrstuvwxyzàèìòùáéíóúýâêîôûãñõäëïöüÿåæœçðø'"/>
-    <xsl:param name="uppercase" select="'ABCDEFGHIJKLMNOPQRSTUVWXYZÀÈÌÒÙÁÉÍÓÚÝÂÊÎÔÛÃÑÕÄËÏÖÜŸÅÆŒÇÐØ'"/>    
+    <xsl:param name="uppercase" select="'ABCDEFGHIJKLMNOPQRSTUVWXYZÀÈÌÒÙÁÉÍÓÚÝÂÊÎÔÛÃÑÕÄËÏÖÜŸÅÆŒÇÐØ'"/>
 
    <!-- to retrieve a string in uppercase -->
     <xsl:template name="uppercase">


### PR DESCRIPTION
## References
* Fixes #3097

## Description
This pull request addresses issue 3097 by ensuring that only values ending with "access" can be considered for datacite:rights.

## Instructions for Reviewers
This is a simple change of openaire4.xls file that validates if the value ends with "access" keyword. It's not a perfect solution, but intends to address cases where dc:rights have multiple values and has at least one "open access" (as an example).

In order to test it you first need to ensure you have OAI enabled:
`oai.enabled = true`

also ensure you have content on your OAI interface, you can index it using:
`[/dspace/bin/]dspace oai import -c`

then access any item on your OAI interface within the openaire context:
https://yourserver.com/server/oai/openaire4?verb=GetRecord&metadataPrefix=oai_openaire&identifier=oai:dev5.rcaap.pt:123456789/1