### PR TITLE
Limit externalSources per metadata field

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/DCInput.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/DCInput.java
@@ -145,6 +145,7 @@ public class DCInput {
     private String relationshipType = null;
     private String searchConfiguration = null;
     private String filter;
+    private List<String> externalSources;
 
     /**
      * The scope of the input sets, this restricts hidden metadata fields from
@@ -226,6 +227,15 @@ public class DCInput {
         relationshipType = fieldMap.get("relationship-type");
         searchConfiguration = fieldMap.get("search-configuration");
         filter = fieldMap.get("filter");
+        externalSources = new ArrayList<>();
+        String externalSourcesDef = fieldMap.get("externalsources");
+        if (StringUtils.isNotBlank(externalSourcesDef)) {
+            String[] sources = StringUtils.split(externalSourcesDef, ",");
+            for (String source: sources) {
+                externalSources.add(StringUtils.trim(source));
+            }
+        }
+
     }
 
     /**
@@ -520,6 +530,10 @@ public class DCInput {
 
     public String getFilter() {
         return filter;
+    }
+
+    public List<String> getExternalSources() {
+        return externalSources;
     }
 
     public boolean isQualdropValue() {

--- a/dspace-api/src/test/data/dspaceFolder/config/submission-forms.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/submission-forms.xml
@@ -63,6 +63,7 @@
                         <dc-qualifier>author</dc-qualifier>
                         <input-type>name</input-type>
                     </linked-metadata-field>
+                    <externalsources>orcid,my_staff_db</externalsources>
                     <required></required>
                 </relation-field>
             </row>
@@ -242,6 +243,7 @@ it, please enter the types and the actual numbers or codes.</hint>
          <filter>creativework.publisher:somepublishername</filter>
          <label>Journal</label>
          <hint>Select the journal related to this volume.</hint>
+         <externalsources></externalsources>
        </relation-field>
      </row>
      <row>

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionFormConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionFormConverter.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.dspace.app.rest.model.ScopeEnum;
 import org.dspace.app.rest.model.SubmissionFormFieldRest;
@@ -174,6 +175,9 @@ public class SubmissionFormConverter implements DSpaceConverter<DCInputSet, Subm
         selectableRelationship.setFilter(dcinput.getFilter());
         selectableRelationship.setSearchConfiguration(dcinput.getSearchConfiguration());
         selectableRelationship.setNameVariants(String.valueOf(dcinput.areNameVariantsAllowed()));
+        if (CollectionUtils.isNotEmpty(dcinput.getExternalSources())) {
+            selectableRelationship.setExternalSources(dcinput.getExternalSources());
+        }
         return selectableRelationship;
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/submit/SelectableRelationship.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/submit/SelectableRelationship.java
@@ -7,6 +7,8 @@
  */
 package org.dspace.app.rest.model.submit;
 
+import java.util.List;
+
 /**
  * The SelectableRelationship REST Resource. It is not addressable directly, only
  * used as inline object in the InputForm resource.
@@ -24,6 +26,7 @@ public class SelectableRelationship {
     private String filter;
     private String searchConfiguration;
     private String nameVariants;
+    private List<String> externalSources;
 
     public void setRelationshipType(String relationshipType) {
         this.relationshipType = relationshipType;
@@ -55,5 +58,13 @@ public class SelectableRelationship {
 
     public String getNameVariants() {
         return nameVariants;
+    }
+
+    public List<String> getExternalSources() {
+        return externalSources;
+    }
+
+    public void setExternalSources(List<String> externalSources) {
+        this.externalSources = externalSources;
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionFormsControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionFormsControllerIT.java
@@ -8,9 +8,11 @@
 package org.dspace.app.rest;
 
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -589,6 +591,47 @@ public class SubmissionFormsControllerIT extends AbstractControllerIntegrationTe
                             "Inserisci titolo principale di questo item", "dc.title"))));
 
         resetLocalesConfiguration();
+    }
+
+    @Test
+    public void multipleExternalSourcesTest() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+
+        getClient(token).perform(get("/api/config/submissionforms/traditionalpageone"))
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //We expect the content type to be "application/hal+json;charset=UTF-8"
+                .andExpect(content().contentType(contentType))
+                //Check that the JSON root matches the expected "traditionalpageone" input forms
+                .andExpect(jsonPath("$.id", is("traditionalpageone")))
+                .andExpect(jsonPath("$.name", is("traditionalpageone")))
+                .andExpect(jsonPath("$.type", is("submissionform")))
+                .andExpect(jsonPath("$._links.self.href", Matchers
+                        .startsWith(REST_SERVER_URL + "config/submissionforms/traditionalpageone")))
+                // check the external sources of the first field in the first row
+                .andExpect(jsonPath("$.rows[0].fields[0].selectableRelationship.externalSources",
+                        contains(is("orcid"), is("my_staff_db"))))
+        ;
+    }
+
+    @Test
+    public void noExternalSourcesTest() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+
+        getClient(token).perform(get("/api/config/submissionforms/journalVolumeStep"))
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //We expect the content type to be "application/hal+json;charset=UTF-8"
+                .andExpect(content().contentType(contentType))
+                //Check that the JSON root matches the expected "journalVolumeStep" input forms
+                .andExpect(jsonPath("$.id", is("journalVolumeStep")))
+                .andExpect(jsonPath("$.name", is("journalVolumeStep")))
+                .andExpect(jsonPath("$.type", is("submissionform")))
+                .andExpect(jsonPath("$._links.self.href", Matchers
+                        .startsWith(REST_SERVER_URL + "config/submissionforms/journalVolumeStep")))
+                // check the external sources of the first field in the first row
+                .andExpect(jsonPath("$.rows[0].fields[0].selectableRelationship.externalSources", nullValue()))
+        ;
     }
 
     private void resetLocalesConfiguration() throws DCInputsReaderException {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionFormsControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionFormsControllerIT.java
@@ -8,7 +8,6 @@
 package org.dspace.app.rest;
 
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;

--- a/dspace/config/item-submission.xml
+++ b/dspace/config/item-submission.xml
@@ -18,7 +18,7 @@
     <!-- for handle "default". -->
     <submission-map>
         <name-map collection-handle="default" submission-name="traditional"/>
-        <name-map collection-handle="10673/1623" submission-name="People" />
+        <name-map collection-handle="123456789/1161" submission-name="People" />
     </submission-map>
 
 

--- a/dspace/config/item-submission.xml
+++ b/dspace/config/item-submission.xml
@@ -18,6 +18,7 @@
     <!-- for handle "default". -->
     <submission-map>
         <name-map collection-handle="default" submission-name="traditional"/>
+        <name-map collection-handle="10673/1623" submission-name="People" />
     </submission-map>
 
 

--- a/dspace/config/item-submission.xml
+++ b/dspace/config/item-submission.xml
@@ -18,7 +18,6 @@
     <!-- for handle "default". -->
     <submission-map>
         <name-map collection-handle="default" submission-name="traditional"/>
-        <name-map collection-handle="123456789/1161" submission-name="People" />
     </submission-map>
 
 

--- a/dspace/config/submission-forms.dtd
+++ b/dspace/config/submission-forms.dtd
@@ -60,5 +60,6 @@
 <!ELEMENT relationship-type (#PCDATA) >
 <!ELEMENT search-configuration (#PCDATA) >
 <!ELEMENT filter (#PCDATA) >
-<!ELEMENT relation-field (relationship-type, search-configuration, filter?, repeatable?, name-variants?, label, type-bind?, hint, linked-metadata-field?, required?, visibility?)>
+<!ELEMENT externalsources (#PCDATA) >
+<!ELEMENT relation-field (relationship-type, search-configuration, filter?, repeatable?, name-variants?, label, type-bind?, hint, linked-metadata-field?, externalsources?, required?, visibility?)>
 <!ELEMENT linked-metadata-field (dc-schema, dc-element, dc-qualifier?, input-type)>

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -61,6 +61,7 @@
                         <dc-qualifier>author</dc-qualifier>
                         <input-type>name</input-type>
                     </linked-metadata-field>
+                    <externalsources>orcid</externalsources>
                     <required>At least one author (plain text or relationship) is required</required>
                 </relation-field>
             </row>
@@ -494,6 +495,7 @@
                     <filter>creativework.publisher:somepublishername</filter>
                     <label>Journal</label>
                     <hint>Select the journal related to this volume.</hint>
+                    <externalsources>sherpaJournal</externalsources>
                 </relation-field>
             </row>
             <row>
@@ -625,6 +627,7 @@
                         <dc-qualifier>author</dc-qualifier>
                         <input-type>name</input-type>
                     </linked-metadata-field>
+                    <externalsources>orcid</externalsources>
                     <required>At least one author (plain text or relationship) is required</required>
                 </relation-field>
             </row>
@@ -893,6 +896,7 @@
                         <dc-element>relation</dc-element>
                         <input-type>onebox</input-type>
                     </linked-metadata-field>
+                    <externalsources></externalsources>
                     <required></required>
                 </relation-field>
             </row>
@@ -1043,6 +1047,7 @@
                         <dc-qualifier>name</dc-qualifier>
                         <input-type>onebox</input-type>
                     </linked-metadata-field>
+                    <externalsources></externalsources>
                     <required>One funding agency is required</required>
                 </relation-field>
             </row>

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -248,6 +248,7 @@
                     <search-configuration>publication</search-configuration>
                     <label>Publication</label>
                     <hint>import a publicaton</hint>
+                    <externalsources>pubmed</externalsources>
                 </relation-field>
             </row>
             <row>

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -243,6 +243,14 @@
 
         <form name="peopleStep">
             <row>
+                <relation-field>
+                    <relationship-type>isPublicationOfAuthor</relationship-type>
+                    <search-configuration>publication</search-configuration>
+                    <label>Publication</label>
+                    <hint>import a publicaton</hint>
+                </relation-field>
+            </row>
+            <row>
                 <field>
                     <dc-schema>person</dc-schema>
                     <dc-element>familyName</dc-element>


### PR DESCRIPTION
## References
* Fixes REST side for https://github.com/DSpace/dspace-angular/issues/943
* Related to https://github.com/DSpace/Rest7Contract/pull/153

## Description
This PR will add support for an "externalsources" xml tag for a "relation-field" xml tag in the submission forms. It'll be parsed by the Java code and it'll be set in the REST response so that Angular can use this field to limit their external sources lookup.
This "externalsources" field can be multivalued and can be empty as well, it's currently set to optional in the .dtd file.
We've also added a relation-field tag on the PeopleStep of the submissions with pubmed as externalsource. This will also provide Angular with an easier way of testing/using their fix for this issue

## Instructions for Reviewers

List of changes in this PR:
* Added support for "externalsources" tag for a "relation-field" tag in the submission forms
* Added an isPublicationOfAuthor relation-field for the PeopleStep

How to test this PR:
* Build and deploy the code locally
* Ask the submission forms for the PeopleStep config
* Verify that it shows pubmed in an "externalsources" field

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
