### PR TITLE
[DS-4452] Porting correct instantiation of default ignore fields (CSV…

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/DSpaceCSV.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/DSpaceCSV.java
@@ -306,7 +306,7 @@ public class DSpaceCSV implements Serializable {
         // Specify default values
         String[] defaultValues =
             new String[] {
-                "dc.date.accessioned, dc.date.available, dc.date.updated, dc.description.provenance"
+                "dc.date.accessioned", "dc.date.available", "dc.date.updated", "dc.description.provenance"
             };
         String[] toIgnoreArray =
             DSpaceServicesFactory.getInstance()


### PR DESCRIPTION
Porting correct instantiation of default ignore fields in DSpaceCSV from #2661 

## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes [DS-4452](https://jira.lyrasis.org/browse/DS-4452)

## Description
This is a simple port of the very simple patch in #2661 that correctly instantiates the `String[] defaultValues` array with the default field names as an array of string, not a single concatenated string. It's already been merged in dspace-6_x
