### PR TITLE
REST API changes to embed size

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/indexobject/CollectionIndexFactoryImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/indexobject/CollectionIndexFactoryImpl.java
@@ -124,6 +124,7 @@ public class CollectionIndexFactoryImpl extends DSpaceObjectIndexFactoryImpl<Ind
         addContainerMetadataField(doc, highlightedMetadataFields, toIgnoreMetadataFields, "dc.rights.license",
                                   rights_license);
         addContainerMetadataField(doc, highlightedMetadataFields, toIgnoreMetadataFields, "dc.title", title);
+        doc.addField("dc.title_sort", title);
 
         return doc;
     }

--- a/dspace-api/src/main/java/org/dspace/discovery/indexobject/CommunityIndexFactoryImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/indexobject/CommunityIndexFactoryImpl.java
@@ -101,6 +101,7 @@ public class CommunityIndexFactoryImpl extends DSpaceObjectIndexFactoryImpl<Inde
                                   "dc.description.tableofcontents", description_table);
         addContainerMetadataField(doc, highlightedMetadataFields, toIgnoreMetadataFields, "dc.rights", rights);
         addContainerMetadataField(doc, highlightedMetadataFields, toIgnoreMetadataFields, "dc.title", title);
+        doc.addField("dc.title_sort", title);
         return doc;
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/projection/AbstractProjection.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/projection/AbstractProjection.java
@@ -48,7 +48,8 @@ public abstract class AbstractProjection implements Projection {
     }
 
     @Override
-    public PageRequest getPagingOptions(String rel) {
+    public PageRequest getPagingOptions(String rel, HALResource<? extends RestAddressableModel> resource,
+                                        Link... oldLinks) {
         return null;
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/projection/AbstractProjection.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/projection/AbstractProjection.java
@@ -11,6 +11,7 @@ import org.dspace.app.rest.model.LinkRest;
 import org.dspace.app.rest.model.RestAddressableModel;
 import org.dspace.app.rest.model.RestModel;
 import org.dspace.app.rest.model.hateoas.HALResource;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.hateoas.Link;
 
 /**
@@ -45,4 +46,10 @@ public abstract class AbstractProjection implements Projection {
     public boolean allowLinking(HALResource halResource, LinkRest linkRest) {
         return true;
     }
+
+    @Override
+    public PageRequest getPagingOptions(String rel) {
+        return null;
+    }
+
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/projection/CompositeProjection.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/projection/CompositeProjection.java
@@ -13,6 +13,7 @@ import org.dspace.app.rest.model.LinkRest;
 import org.dspace.app.rest.model.RestAddressableModel;
 import org.dspace.app.rest.model.RestModel;
 import org.dspace.app.rest.model.hateoas.HALResource;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.hateoas.Link;
 
 /**
@@ -80,5 +81,10 @@ public class CompositeProjection implements Projection {
             }
         }
         return true;
+    }
+
+    @Override
+    public PageRequest getPagingOptions(String rel) {
+        return null;
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/projection/CompositeProjection.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/projection/CompositeProjection.java
@@ -13,7 +13,6 @@ import org.dspace.app.rest.model.LinkRest;
 import org.dspace.app.rest.model.RestAddressableModel;
 import org.dspace.app.rest.model.RestModel;
 import org.dspace.app.rest.model.hateoas.HALResource;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.hateoas.Link;
 
 /**
@@ -23,7 +22,7 @@ import org.springframework.hateoas.Link;
  * the constructor. Embedding will be allowed if any of the given projections allow them. Linking will
  * be allowed if all of the given projections allow them.
  */
-public class CompositeProjection implements Projection {
+public class CompositeProjection extends AbstractProjection {
 
     public final static String NAME = "composite";
 
@@ -81,10 +80,5 @@ public class CompositeProjection implements Projection {
             }
         }
         return true;
-    }
-
-    @Override
-    public PageRequest getPagingOptions(String rel) {
-        return null;
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/projection/EmbedRelsProjection.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/projection/EmbedRelsProjection.java
@@ -93,10 +93,29 @@ public class EmbedRelsProjection extends AbstractProjection {
     }
 
     @Override
-    public PageRequest getPagingOptions(String rel) {
-        Integer size = embedSizes.get(rel);
+    public PageRequest getPagingOptions(String rel, HALResource<? extends RestAddressableModel> resource,
+                                        Link... oldLinks) {
+        Integer size = getPaginationSize(rel, resource, oldLinks);
         if (size != null && size > 0) {
             return PageRequest.of(0, size);
+        }
+        return null;
+    }
+
+    private Integer getPaginationSize(String rel, HALResource<? extends RestAddressableModel> resource,
+                                      Link... oldLinks) {
+        if (resource.getContent().getEmbedLevel() == 0 && embedSizes.containsKey(rel)) {
+            return embedSizes.get(rel);
+        }
+        StringBuilder fullName = new StringBuilder();
+        for (Link oldLink : oldLinks) {
+            fullName.append(oldLink.getRel().value()).append("/");
+        }
+        fullName.append(rel);
+
+        // If the full name matches, the link can be embedded (e.g. mappedItems/owningCollection on a collection page)
+        if (embedSizes.containsKey(fullName.toString())) {
+            return embedSizes.get(fullName.toString());
         }
         return null;
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/projection/EmbedRelsProjection.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/projection/EmbedRelsProjection.java
@@ -36,6 +36,17 @@ public class EmbedRelsProjection extends AbstractProjection {
      */
     private Map<String, Integer> embedSizes;
 
+    /**
+     * The EmbedRelsProjection will take a set of embed relations and embed sizes as a parameter that will be added to
+     * the projection.
+     * The set of embedRels contains strings representing the embedded relation.
+     * The set of embedSizes contains a string containing the embedded relation followed by a "=" and the size of the
+     * embedded relation.
+     * Example: embed=collections&embed.size=collections=5 - These parameters will ensure that the embedded collections
+     * size will be limited to 5
+     * @param embedRels     The embedded relations
+     * @param embedSizes    The sizes of the embedded relations defined as {relation}={size}
+     */
     public EmbedRelsProjection(Set<String> embedRels, Set<String> embedSizes) {
         this.embedRels = embedRels;
         this.embedSizes = embedSizes.stream()

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/projection/EmbedRelsProjection.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/projection/EmbedRelsProjection.java
@@ -29,6 +29,11 @@ public class EmbedRelsProjection extends AbstractProjection {
     public final static String NAME = "embedrels";
 
     private final Set<String> embedRels;
+
+    /**
+     * This variable contains a map with the key being the rel as a String and the value being the size of the embed
+     * as an Integer
+     */
     private Map<String, Integer> embedSizes;
 
     public EmbedRelsProjection(Set<String> embedRels, Set<String> embedSizes) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/projection/Projection.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/projection/Projection.java
@@ -141,7 +141,10 @@ public interface Projection {
     /**
      * This method will return the {@link PageRequest} object for a specific given rel
      * @param rel   The rel for which the {@link PageRequest} object will be made
+     * @param resource the resource from which the embed may or may not be made.
+     * @param oldLinks    The previously traversed links
      * @return      The {@link PageRequest} object for the given rel
      */
-    PageRequest getPagingOptions(String rel);
+    PageRequest getPagingOptions(String rel, HALResource<? extends RestAddressableModel> resource,
+                                 Link... oldLinks);
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/projection/Projection.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/projection/Projection.java
@@ -15,6 +15,7 @@ import org.dspace.app.rest.model.RestModel;
 import org.dspace.app.rest.model.hateoas.HALResource;
 import org.dspace.app.rest.repository.DSpaceRestRepository;
 import org.dspace.app.rest.utils.Utils;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.hateoas.Link;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.RestController;
@@ -136,4 +137,6 @@ public interface Projection {
      * @return true if allowed, false otherwise.
      */
     boolean allowLinking(HALResource halResource, LinkRest linkRest);
+
+    PageRequest getPagingOptions(String rel);
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/projection/Projection.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/projection/Projection.java
@@ -138,5 +138,10 @@ public interface Projection {
      */
     boolean allowLinking(HALResource halResource, LinkRest linkRest);
 
+    /**
+     * This method will return the {@link PageRequest} object for a specific given rel
+     * @param rel   The rel for which the {@link PageRequest} object will be made
+     * @return      The {@link PageRequest} object for the given rel
+     */
     PageRequest getPagingOptions(String rel);
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CommunityCollectionLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CommunityCollectionLinkRepository.java
@@ -71,6 +71,7 @@ public class CommunityCollectionLinkRepository extends AbstractDSpaceRestReposit
             discoverQuery.addFilterQueries("location.parent:" + communityId);
             discoverQuery.setStart(Math.toIntExact(pageable.getOffset()));
             discoverQuery.setMaxResults(pageable.getPageSize());
+            discoverQuery.setSortField("dc.title_sort", DiscoverQuery.SORT_ORDER.asc);
             DiscoverResult resp = searchService.search(context, scopeObject, discoverQuery);
             long tot = resp.getTotalSearchResults();
             for (IndexableObject solrCol : resp.getIndexableObjects()) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CommunitySubcommunityLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CommunitySubcommunityLinkRepository.java
@@ -67,6 +67,7 @@ public class CommunitySubcommunityLinkRepository extends AbstractDSpaceRestRepos
             discoverQuery.addFilterQueries("location.parent:" + communityId);
             discoverQuery.setStart(Math.toIntExact(pageable.getOffset()));
             discoverQuery.setMaxResults(pageable.getPageSize());
+            discoverQuery.setSortField("dc.title_sort", DiscoverQuery.SORT_ORDER.asc);
             DiscoverResult resp = searchService.search(context, scopeObject, discoverQuery);
             long tot = resp.getTotalSearchResults();
             for (IndexableObject solrCommunities : resp.getIndexableObjects()) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/Utils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/Utils.java
@@ -547,8 +547,10 @@ public class Utils {
             projections.add(converter.getProjection(projectionName));
         }
 
+
         if (!embedRels.isEmpty()) {
-            projections.add(new EmbedRelsProjection(embedRels));
+            Set<String> embedSizes = new HashSet<>(getValues(servletRequest, "embed.size"));
+            projections.add(new EmbedRelsProjection(embedRels, embedSizes));
         }
 
         if (projections.isEmpty()) {
@@ -676,7 +678,8 @@ public class Utils {
             Method method = requireMethod(linkRepository.getClass(), linkRest.method());
             Object contentId = getContentIdForLinkMethod(resource.getContent(), method);
             try {
-                Object linkedObject = method.invoke(linkRepository, null, contentId, null, projection);
+                Object linkedObject = method
+                        .invoke(linkRepository, null, contentId, projection.getPagingOptions(rel), projection);
                 resource.embedResource(rel, wrapForEmbedding(resource, linkedObject, link, oldLinks));
             } catch (InvocationTargetException e) {
                 // This will be thrown from the LinkRepository if a Resource has been requested that'll try to embed

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/Utils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/Utils.java
@@ -678,8 +678,8 @@ public class Utils {
             Method method = requireMethod(linkRepository.getClass(), linkRest.method());
             Object contentId = getContentIdForLinkMethod(resource.getContent(), method);
             try {
-                Object linkedObject = method
-                        .invoke(linkRepository, null, contentId, projection.getPagingOptions(rel), projection);
+                Object linkedObject = method.invoke(linkRepository, null, contentId,
+                                                    projection.getPagingOptions(rel, resource, oldLinks), projection);
                 resource.embedResource(rel, wrapForEmbedding(resource, linkedObject, link, oldLinks));
             } catch (InvocationTargetException e) {
                 // This will be thrown from the LinkRepository if a Resource has been requested that'll try to embed

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CollectionRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CollectionRestRepositoryIT.java
@@ -33,6 +33,7 @@ import org.dspace.app.rest.converter.CollectionConverter;
 import org.dspace.app.rest.matcher.CollectionMatcher;
 import org.dspace.app.rest.matcher.CommunityMatcher;
 import org.dspace.app.rest.matcher.HalMatcher;
+import org.dspace.app.rest.matcher.ItemMatcher;
 import org.dspace.app.rest.matcher.MetadataMatcher;
 import org.dspace.app.rest.matcher.PageMatcher;
 import org.dspace.app.rest.model.CollectionRest;
@@ -47,9 +48,12 @@ import org.dspace.builder.CollectionBuilder;
 import org.dspace.builder.CommunityBuilder;
 import org.dspace.builder.EPersonBuilder;
 import org.dspace.builder.GroupBuilder;
+import org.dspace.builder.ItemBuilder;
 import org.dspace.builder.ResourcePolicyBuilder;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
+import org.dspace.content.Item;
+import org.dspace.content.service.CollectionService;
 import org.dspace.core.Constants;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
@@ -72,6 +76,9 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
 
     @Autowired
     GroupService groupService;
+
+    @Autowired
+    CollectionService collectionService;
 
     @Test
     public void findAllTest() throws Exception {
@@ -2157,5 +2164,197 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
                 .andExpect(jsonPath("$.page.number", is(2)))
                 .andExpect(jsonPath("$.page.totalElements", is(5)));
     }
+
+    @Test
+    public void findOneTestWithEmbedsNoPageSize() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+
+        Collection collection = CollectionBuilder.createCollection(context, parentCommunity)
+                                                 .withName("Collection")
+                                                 .build();
+
+        Collection mappedCollection = CollectionBuilder.createCollection(context, parentCommunity)
+                                                       .withName("Mapped Collection")
+                                                       .build();
+
+        Item item0 = ItemBuilder.createItem(context, collection).withTitle("Item 0").build();
+        Item item1 = ItemBuilder.createItem(context, collection).withTitle("Item 1").build();
+        Item item2 = ItemBuilder.createItem(context, collection).withTitle("Item 2").build();
+        Item item3 = ItemBuilder.createItem(context, collection).withTitle("Item 3").build();
+        Item item4 = ItemBuilder.createItem(context, collection).withTitle("Item 4").build();
+        Item item5 = ItemBuilder.createItem(context, collection).withTitle("Item 5").build();
+        Item item6 = ItemBuilder.createItem(context, collection).withTitle("Item 6").build();
+        Item item7 = ItemBuilder.createItem(context, collection).withTitle("Item 7").build();
+        Item item8 = ItemBuilder.createItem(context, collection).withTitle("Item 8").build();
+        Item item9 = ItemBuilder.createItem(context, collection).withTitle("Item 9").build();
+
+        collectionService.addItem(context, mappedCollection, item0);
+        collectionService.addItem(context, mappedCollection, item1);
+        collectionService.addItem(context, mappedCollection, item2);
+        collectionService.addItem(context, mappedCollection, item3);
+        collectionService.addItem(context, mappedCollection, item4);
+        collectionService.addItem(context, mappedCollection, item5);
+        collectionService.addItem(context, mappedCollection, item6);
+        collectionService.addItem(context, mappedCollection, item7);
+        collectionService.addItem(context, mappedCollection, item8);
+        collectionService.addItem(context, mappedCollection, item9);
+
+        collectionService.update(context, mappedCollection);
+
+        context.restoreAuthSystemState();
+
+        getClient().perform(get("/api/core/collections/" + mappedCollection.getID())
+                                    .param("embed", "mappedItems"))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$", CollectionMatcher.matchCollection(mappedCollection)))
+                   .andExpect(jsonPath("$._embedded.mappedItems._embedded.mappedItems", Matchers.containsInAnyOrder(
+                           ItemMatcher.matchItemProperties(item0),
+                           ItemMatcher.matchItemProperties(item1),
+                           ItemMatcher.matchItemProperties(item2),
+                           ItemMatcher.matchItemProperties(item3),
+                           ItemMatcher.matchItemProperties(item4),
+                           ItemMatcher.matchItemProperties(item5),
+                           ItemMatcher.matchItemProperties(item6),
+                           ItemMatcher.matchItemProperties(item7),
+                           ItemMatcher.matchItemProperties(item8),
+                           ItemMatcher.matchItemProperties(item9)
+                   )))
+                   .andExpect(jsonPath("$._links.self.href",
+                                       Matchers.containsString("/api/core/collections/" + mappedCollection.getID())))
+                   .andExpect(jsonPath("$._embedded.mappedItems.page.size", is(20)))
+                   .andExpect(jsonPath("$._embedded.mappedItems.page.totalElements", is(10)));
+    }
+
+
+    @Test
+    public void findOneTestWithEmbedsWithPageSize() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+
+        Collection collection = CollectionBuilder.createCollection(context, parentCommunity)
+                                                 .withName("Collection")
+                                                 .build();
+
+        Collection mappedCollection = CollectionBuilder.createCollection(context, parentCommunity)
+                                                       .withName("Mapped Collection")
+                                                       .build();
+
+        Item item0 = ItemBuilder.createItem(context, collection).withTitle("Item 0").build();
+        Item item1 = ItemBuilder.createItem(context, collection).withTitle("Item 1").build();
+        Item item2 = ItemBuilder.createItem(context, collection).withTitle("Item 2").build();
+        Item item3 = ItemBuilder.createItem(context, collection).withTitle("Item 3").build();
+        Item item4 = ItemBuilder.createItem(context, collection).withTitle("Item 4").build();
+        Item item5 = ItemBuilder.createItem(context, collection).withTitle("Item 5").build();
+        Item item6 = ItemBuilder.createItem(context, collection).withTitle("Item 6").build();
+        Item item7 = ItemBuilder.createItem(context, collection).withTitle("Item 7").build();
+        Item item8 = ItemBuilder.createItem(context, collection).withTitle("Item 8").build();
+        Item item9 = ItemBuilder.createItem(context, collection).withTitle("Item 9").build();
+
+        collectionService.addItem(context, mappedCollection, item0);
+        collectionService.addItem(context, mappedCollection, item1);
+        collectionService.addItem(context, mappedCollection, item2);
+        collectionService.addItem(context, mappedCollection, item3);
+        collectionService.addItem(context, mappedCollection, item4);
+        collectionService.addItem(context, mappedCollection, item5);
+        collectionService.addItem(context, mappedCollection, item6);
+        collectionService.addItem(context, mappedCollection, item7);
+        collectionService.addItem(context, mappedCollection, item8);
+        collectionService.addItem(context, mappedCollection, item9);
+
+        collectionService.update(context, mappedCollection);
+
+        context.restoreAuthSystemState();
+
+        getClient().perform(get("/api/core/collections/" + mappedCollection.getID())
+                                    .param("embed", "mappedItems")
+                                    .param("embed.size", "mappedItems=5"))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$", CollectionMatcher.matchCollection(mappedCollection)))
+                   .andExpect(jsonPath("$._embedded.mappedItems._embedded.mappedItems", Matchers.containsInAnyOrder(
+                           ItemMatcher.matchItemProperties(item0),
+                           ItemMatcher.matchItemProperties(item1),
+                           ItemMatcher.matchItemProperties(item2),
+                           ItemMatcher.matchItemProperties(item3),
+                           ItemMatcher.matchItemProperties(item4)
+                   )))
+                   .andExpect(jsonPath("$._links.self.href",
+                                       Matchers.containsString("/api/core/collections/" + mappedCollection.getID())))
+                   .andExpect(jsonPath("$._embedded.mappedItems.page.size", is(5)))
+                   .andExpect(jsonPath("$._embedded.mappedItems.page.totalElements", is(10)));
+    }
+
+
+    @Test
+    public void findOneTestWithEmbedsWithInvalidPageSize() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+
+        Collection collection = CollectionBuilder.createCollection(context, parentCommunity)
+                                                 .withName("Collection")
+                                                 .build();
+
+        Collection mappedCollection = CollectionBuilder.createCollection(context, parentCommunity)
+                                                       .withName("Mapped Collection")
+                                                       .build();
+
+        Item item0 = ItemBuilder.createItem(context, collection).withTitle("Item 0").build();
+        Item item1 = ItemBuilder.createItem(context, collection).withTitle("Item 1").build();
+        Item item2 = ItemBuilder.createItem(context, collection).withTitle("Item 2").build();
+        Item item3 = ItemBuilder.createItem(context, collection).withTitle("Item 3").build();
+        Item item4 = ItemBuilder.createItem(context, collection).withTitle("Item 4").build();
+        Item item5 = ItemBuilder.createItem(context, collection).withTitle("Item 5").build();
+        Item item6 = ItemBuilder.createItem(context, collection).withTitle("Item 6").build();
+        Item item7 = ItemBuilder.createItem(context, collection).withTitle("Item 7").build();
+        Item item8 = ItemBuilder.createItem(context, collection).withTitle("Item 8").build();
+        Item item9 = ItemBuilder.createItem(context, collection).withTitle("Item 9").build();
+
+        collectionService.addItem(context, mappedCollection, item0);
+        collectionService.addItem(context, mappedCollection, item1);
+        collectionService.addItem(context, mappedCollection, item2);
+        collectionService.addItem(context, mappedCollection, item3);
+        collectionService.addItem(context, mappedCollection, item4);
+        collectionService.addItem(context, mappedCollection, item5);
+        collectionService.addItem(context, mappedCollection, item6);
+        collectionService.addItem(context, mappedCollection, item7);
+        collectionService.addItem(context, mappedCollection, item8);
+        collectionService.addItem(context, mappedCollection, item9);
+
+        collectionService.update(context, mappedCollection);
+
+        context.restoreAuthSystemState();
+
+        getClient().perform(get("/api/core/collections/" + mappedCollection.getID())
+                                    .param("embed", "mappedItems")
+                                    .param("embed.size", "mappedItems=invalidPage"))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$", CollectionMatcher.matchCollection(mappedCollection)))
+                   .andExpect(jsonPath("$._embedded.mappedItems._embedded.mappedItems", Matchers.containsInAnyOrder(
+                           ItemMatcher.matchItemProperties(item0),
+                           ItemMatcher.matchItemProperties(item1),
+                           ItemMatcher.matchItemProperties(item2),
+                           ItemMatcher.matchItemProperties(item3),
+                           ItemMatcher.matchItemProperties(item4),
+                           ItemMatcher.matchItemProperties(item5),
+                           ItemMatcher.matchItemProperties(item6),
+                           ItemMatcher.matchItemProperties(item7),
+                           ItemMatcher.matchItemProperties(item8),
+                           ItemMatcher.matchItemProperties(item9)
+                   )))
+                   .andExpect(jsonPath("$._links.self.href",
+                                       Matchers.containsString("/api/core/collections/" + mappedCollection.getID())))
+                   .andExpect(jsonPath("$._embedded.mappedItems.page.size", is(20)))
+                   .andExpect(jsonPath("$._embedded.mappedItems.page.totalElements", is(10)));
+    }
+
 
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
@@ -368,6 +368,202 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
     }
 
     @Test
+    public void findOneTestWithEmbedsNoPageSize() throws Exception {
+        //We turn off the authorization system in order to create the structure as defined below
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+        //1. A community-collection structure with one parent community with 10 sub-communities
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+        Community child0 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community 0")
+                                           .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community 1")
+                                           .build();
+        Community child2 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community 2")
+                                           .build();
+        Community child3 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community 3")
+                                           .build();
+        Community child4 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community 4")
+                                           .build();
+        Community child5 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community 5")
+                                           .build();
+        Community child6 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community 6")
+                                           .build();
+        Community child7 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community 7")
+                                           .build();
+        Community child8 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community 8")
+                                           .build();
+        Community child9 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community 9")
+                                           .build();
+
+
+        context.restoreAuthSystemState();
+
+        getClient().perform(get("/api/core/communities/" + parentCommunity.getID())
+                                    .param("embed", "subcommunities"))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$", CommunityMatcher.matchCommunity(parentCommunity)))
+                   .andExpect(
+                           jsonPath("$._embedded.subcommunities._embedded.subcommunities", Matchers.containsInAnyOrder(
+                                   CommunityMatcher.matchCommunity(child0),
+                                   CommunityMatcher.matchCommunity(child1),
+                                   CommunityMatcher.matchCommunity(child2),
+                                   CommunityMatcher.matchCommunity(child3),
+                                   CommunityMatcher.matchCommunity(child4),
+                                   CommunityMatcher.matchCommunity(child5),
+                                   CommunityMatcher.matchCommunity(child6),
+                                   CommunityMatcher.matchCommunity(child7),
+                                   CommunityMatcher.matchCommunity(child8),
+                                   CommunityMatcher.matchCommunity(child9)
+                           )))
+                   .andExpect(jsonPath("$._links.self.href",
+                                       Matchers.containsString("/api/core/communities/" + parentCommunity.getID())))
+                   .andExpect(jsonPath("$._embedded.subcommunities.page.size", is(20)))
+                   .andExpect(jsonPath("$._embedded.subcommunities.page.totalElements", is(10)));
+    }
+
+    @Test
+    public void findOneTestWithEmbedsWithPageSize() throws Exception {
+        //We turn off the authorization system in order to create the structure as defined below
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+        //1. A community-collection structure with one parent community with 10 sub-communities
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+        Community child0 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community 0")
+                                           .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community 1")
+                                           .build();
+        Community child2 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community 2")
+                                           .build();
+        Community child3 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community 3")
+                                           .build();
+        Community child4 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community 4")
+                                           .build();
+        Community child5 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community 5")
+                                           .build();
+        Community child6 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community 6")
+                                           .build();
+        Community child7 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community 7")
+                                           .build();
+        Community child8 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community 8")
+                                           .build();
+        Community child9 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community 9")
+                                           .build();
+
+        context.restoreAuthSystemState();
+
+        getClient().perform(get("/api/core/communities/" + parentCommunity.getID())
+                                    .param("embed", "subcommunities")
+                                    .param("embed.size", "subcommunities=5"))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$", CommunityMatcher.matchCommunity(parentCommunity)))
+                   .andExpect(
+                           jsonPath("$._embedded.subcommunities._embedded.subcommunities", Matchers.containsInAnyOrder(
+                                   CommunityMatcher.matchCommunity(child0),
+                                   CommunityMatcher.matchCommunity(child1),
+                                   CommunityMatcher.matchCommunity(child2),
+                                   CommunityMatcher.matchCommunity(child3),
+                                   CommunityMatcher.matchCommunity(child4)
+                           )))
+                   .andExpect(jsonPath("$._links.self.href",
+                                       Matchers.containsString("/api/core/communities/" + parentCommunity.getID())))
+                   .andExpect(jsonPath("$._embedded.subcommunities.page.size", is(5)))
+                   .andExpect(jsonPath("$._embedded.subcommunities.page.totalElements", is(10)));
+    }
+
+    @Test
+    public void findOneTestWithEmbedsWithInvalidPageSize() throws Exception {
+        //We turn off the authorization system in order to create the structure as defined below
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+        //1. A community-collection structure with one parent community with 10 sub-communities
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+        Community child0 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community 0")
+                                           .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community 1")
+                                           .build();
+        Community child2 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community 2")
+                                           .build();
+        Community child3 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community 3")
+                                           .build();
+        Community child4 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community 4")
+                                           .build();
+        Community child5 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community 5")
+                                           .build();
+        Community child6 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community 6")
+                                           .build();
+        Community child7 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community 7")
+                                           .build();
+        Community child8 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community 8")
+                                           .build();
+        Community child9 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community 9")
+                                           .build();
+
+        context.restoreAuthSystemState();
+
+        getClient().perform(get("/api/core/communities/" + parentCommunity.getID())
+                                    .param("embed", "subcommunities")
+                                    .param("embed.size", "subcommunities=invalidPage"))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$", CommunityMatcher.matchCommunity(parentCommunity)))
+                   .andExpect(
+                           jsonPath("$._embedded.subcommunities._embedded.subcommunities", Matchers.containsInAnyOrder(
+                                   CommunityMatcher.matchCommunity(child0),
+                                   CommunityMatcher.matchCommunity(child1),
+                                   CommunityMatcher.matchCommunity(child2),
+                                   CommunityMatcher.matchCommunity(child3),
+                                   CommunityMatcher.matchCommunity(child4),
+                                   CommunityMatcher.matchCommunity(child5),
+                                   CommunityMatcher.matchCommunity(child6),
+                                   CommunityMatcher.matchCommunity(child7),
+                                   CommunityMatcher.matchCommunity(child8),
+                                   CommunityMatcher.matchCommunity(child9)
+                           )))
+                   .andExpect(jsonPath("$._links.self.href",
+                                       Matchers.containsString("/api/core/communities/" + parentCommunity.getID())))
+                   .andExpect(jsonPath("$._embedded.subcommunities.page.size", is(20)))
+                   .andExpect(jsonPath("$._embedded.subcommunities.page.totalElements", is(10)));
+    }
+
+    @Test
     public void findAllNoDuplicatesOnMultipleCommunityTitlesTest() throws Exception {
         context.turnOffAuthorisationSystem();
         List<String> titles = Arrays.asList("First title", "Second title", "Third title", "Fourth title");

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
@@ -35,6 +35,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.CharEncoding;
 import org.dspace.app.rest.matcher.BitstreamMatcher;
+import org.dspace.app.rest.matcher.BundleMatcher;
 import org.dspace.app.rest.matcher.CollectionMatcher;
 import org.dspace.app.rest.matcher.HalMatcher;
 import org.dspace.app.rest.matcher.ItemMatcher;
@@ -46,6 +47,7 @@ import org.dspace.app.rest.model.patch.ReplaceOperation;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
 import org.dspace.app.rest.test.MetadataPatchSuite;
 import org.dspace.builder.BitstreamBuilder;
+import org.dspace.builder.BundleBuilder;
 import org.dspace.builder.CollectionBuilder;
 import org.dspace.builder.CommunityBuilder;
 import org.dspace.builder.EPersonBuilder;
@@ -54,6 +56,7 @@ import org.dspace.builder.ItemBuilder;
 import org.dspace.builder.ResourcePolicyBuilder;
 import org.dspace.builder.WorkspaceItemBuilder;
 import org.dspace.content.Bitstream;
+import org.dspace.content.Bundle;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.Item;
@@ -2739,6 +2742,149 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
                         .andExpect(jsonPath("$.metadata", matchMetadataDoesNotExist("dc.description.provenance")));
 
     }
+
+    @Test
+    public void findOneTestWithEmbedsWithNoPageSize() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+
+        Collection collection = CollectionBuilder.createCollection(context, parentCommunity)
+                                                 .withName("Collection")
+                                                 .build();
+
+        Item item = ItemBuilder.createItem(context, collection).withTitle("Item").build();
+
+        Bundle bundle0 = BundleBuilder.createBundle(context, item).withName("Bundle 0").build();
+        Bundle bundle1 = BundleBuilder.createBundle(context, item).withName("Bundle 1").build();
+        Bundle bundle2 = BundleBuilder.createBundle(context, item).withName("Bundle 2").build();
+        Bundle bundle3 = BundleBuilder.createBundle(context, item).withName("Bundle 3").build();
+        Bundle bundle4 = BundleBuilder.createBundle(context, item).withName("Bundle 4").build();
+        Bundle bundle5 = BundleBuilder.createBundle(context, item).withName("Bundle 5").build();
+        Bundle bundle6 = BundleBuilder.createBundle(context, item).withName("Bundle 6").build();
+        Bundle bundle7 = BundleBuilder.createBundle(context, item).withName("Bundle 7").build();
+        Bundle bundle8 = BundleBuilder.createBundle(context, item).withName("Bundle 8").build();
+        Bundle bundle9 = BundleBuilder.createBundle(context, item).withName("Bundle 9").build();
+
+        context.restoreAuthSystemState();
+
+        getClient().perform(get("/api/core/items/" + item.getID())
+                                    .param("embed", "bundles"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$", ItemMatcher.matchItemProperties(item)))
+        .andExpect(jsonPath("$._embedded.bundles._embedded.bundles",Matchers.containsInAnyOrder(
+            BundleMatcher.matchProperties(bundle0.getName(), bundle0.getID(), bundle0.getHandle(), bundle0.getType()),
+            BundleMatcher.matchProperties(bundle1.getName(), bundle1.getID(), bundle1.getHandle(), bundle1.getType()),
+            BundleMatcher.matchProperties(bundle2.getName(), bundle2.getID(), bundle2.getHandle(), bundle2.getType()),
+            BundleMatcher.matchProperties(bundle3.getName(), bundle3.getID(), bundle3.getHandle(), bundle3.getType()),
+            BundleMatcher.matchProperties(bundle4.getName(), bundle4.getID(), bundle4.getHandle(), bundle4.getType()),
+            BundleMatcher.matchProperties(bundle5.getName(), bundle5.getID(), bundle5.getHandle(), bundle5.getType()),
+            BundleMatcher.matchProperties(bundle6.getName(), bundle6.getID(), bundle6.getHandle(), bundle6.getType()),
+            BundleMatcher.matchProperties(bundle7.getName(), bundle7.getID(), bundle7.getHandle(), bundle7.getType()),
+            BundleMatcher.matchProperties(bundle8.getName(), bundle8.getID(), bundle8.getHandle(), bundle8.getType()),
+            BundleMatcher.matchProperties(bundle9.getName(), bundle9.getID(), bundle9.getHandle(), bundle9.getType())
+        )))
+        .andExpect(jsonPath("$._links.self.href", Matchers.containsString("/api/core/items/" + item.getID())))
+        .andExpect(jsonPath("$._embedded.bundles.page.size", is(20)))
+        .andExpect(jsonPath("$._embedded.bundles.page.totalElements", is(10)));
+    }
+
+    @Test
+    public void findOneTestWithEmbedsWithPageSize() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+
+        Collection collection = CollectionBuilder.createCollection(context, parentCommunity)
+                                                 .withName("Collection")
+                                                 .build();
+
+        Item item = ItemBuilder.createItem(context, collection).withTitle("Item").build();
+
+        Bundle bundle0 = BundleBuilder.createBundle(context, item).withName("Bundle 0").build();
+        Bundle bundle1 = BundleBuilder.createBundle(context, item).withName("Bundle 1").build();
+        Bundle bundle2 = BundleBuilder.createBundle(context, item).withName("Bundle 2").build();
+        Bundle bundle3 = BundleBuilder.createBundle(context, item).withName("Bundle 3").build();
+        Bundle bundle4 = BundleBuilder.createBundle(context, item).withName("Bundle 4").build();
+        Bundle bundle5 = BundleBuilder.createBundle(context, item).withName("Bundle 5").build();
+        Bundle bundle6 = BundleBuilder.createBundle(context, item).withName("Bundle 6").build();
+        Bundle bundle7 = BundleBuilder.createBundle(context, item).withName("Bundle 7").build();
+        Bundle bundle8 = BundleBuilder.createBundle(context, item).withName("Bundle 8").build();
+        Bundle bundle9 = BundleBuilder.createBundle(context, item).withName("Bundle 9").build();
+
+        context.restoreAuthSystemState();
+
+        getClient().perform(get("/api/core/items/" + item.getID())
+                                    .param("embed", "bundles")
+                           .param("embed.size", "bundles=5"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$", ItemMatcher.matchItemProperties(item)))
+        .andExpect(jsonPath("$._embedded.bundles._embedded.bundles",Matchers.containsInAnyOrder(
+            BundleMatcher.matchProperties(bundle0.getName(), bundle0.getID(), bundle0.getHandle(), bundle0.getType()),
+            BundleMatcher.matchProperties(bundle1.getName(), bundle1.getID(), bundle1.getHandle(), bundle1.getType()),
+            BundleMatcher.matchProperties(bundle2.getName(), bundle2.getID(), bundle2.getHandle(), bundle2.getType()),
+            BundleMatcher.matchProperties(bundle3.getName(), bundle3.getID(), bundle3.getHandle(), bundle3.getType()),
+            BundleMatcher.matchProperties(bundle4.getName(), bundle4.getID(), bundle4.getHandle(), bundle4.getType())
+        )))
+        .andExpect(jsonPath("$._links.self.href", Matchers.containsString("/api/core/items/" + item.getID())))
+        .andExpect(jsonPath("$._embedded.bundles.page.size", is(5)))
+        .andExpect(jsonPath("$._embedded.bundles.page.totalElements", is(10)));
+    }
+
+
+    @Test
+    public void findOneTestWithEmbedsWithInvalidPageSize() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+
+        Collection collection = CollectionBuilder.createCollection(context, parentCommunity)
+                                                 .withName("Collection")
+                                                 .build();
+
+        Item item = ItemBuilder.createItem(context, collection).withTitle("Item").build();
+
+        Bundle bundle0 = BundleBuilder.createBundle(context, item).withName("Bundle 0").build();
+        Bundle bundle1 = BundleBuilder.createBundle(context, item).withName("Bundle 1").build();
+        Bundle bundle2 = BundleBuilder.createBundle(context, item).withName("Bundle 2").build();
+        Bundle bundle3 = BundleBuilder.createBundle(context, item).withName("Bundle 3").build();
+        Bundle bundle4 = BundleBuilder.createBundle(context, item).withName("Bundle 4").build();
+        Bundle bundle5 = BundleBuilder.createBundle(context, item).withName("Bundle 5").build();
+        Bundle bundle6 = BundleBuilder.createBundle(context, item).withName("Bundle 6").build();
+        Bundle bundle7 = BundleBuilder.createBundle(context, item).withName("Bundle 7").build();
+        Bundle bundle8 = BundleBuilder.createBundle(context, item).withName("Bundle 8").build();
+        Bundle bundle9 = BundleBuilder.createBundle(context, item).withName("Bundle 9").build();
+
+        context.restoreAuthSystemState();
+
+        getClient().perform(get("/api/core/items/" + item.getID())
+                                    .param("embed", "bundles")
+                                    .param("embed.size", "bundles=invalidPage"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$", ItemMatcher.matchItemProperties(item)))
+        .andExpect(jsonPath("$._embedded.bundles._embedded.bundles",Matchers.containsInAnyOrder(
+            BundleMatcher.matchProperties(bundle0.getName(), bundle0.getID(), bundle0.getHandle(), bundle0.getType()),
+            BundleMatcher.matchProperties(bundle1.getName(), bundle1.getID(), bundle1.getHandle(), bundle1.getType()),
+            BundleMatcher.matchProperties(bundle2.getName(), bundle2.getID(), bundle2.getHandle(), bundle2.getType()),
+            BundleMatcher.matchProperties(bundle3.getName(), bundle3.getID(), bundle3.getHandle(), bundle3.getType()),
+            BundleMatcher.matchProperties(bundle4.getName(), bundle4.getID(), bundle4.getHandle(), bundle4.getType()),
+            BundleMatcher.matchProperties(bundle5.getName(), bundle5.getID(), bundle5.getHandle(), bundle5.getType()),
+            BundleMatcher.matchProperties(bundle6.getName(), bundle6.getID(), bundle6.getHandle(), bundle6.getType()),
+            BundleMatcher.matchProperties(bundle7.getName(), bundle7.getID(), bundle7.getHandle(), bundle7.getType()),
+            BundleMatcher.matchProperties(bundle8.getName(), bundle8.getID(), bundle8.getHandle(), bundle8.getType()),
+            BundleMatcher.matchProperties(bundle9.getName(), bundle9.getID(), bundle9.getHandle(), bundle9.getType())
+        )))
+        .andExpect(jsonPath("$._links.self.href", Matchers.containsString("/api/core/items/" + item.getID())))
+        .andExpect(jsonPath("$._embedded.bundles.page.size", is(20)))
+        .andExpect(jsonPath("$._embedded.bundles.page.totalElements", is(10)));
+}
+
 
 
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
@@ -2885,6 +2885,246 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         .andExpect(jsonPath("$._embedded.bundles.page.totalElements", is(10)));
 }
 
+    @Test
+    public void findOneTestWithMultiLevelEmbedsWithNoPageSize() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+
+        Collection collection = CollectionBuilder.createCollection(context, parentCommunity)
+                                                 .withName("Collection")
+                                                 .build();
+
+        Item item = ItemBuilder.createItem(context, collection).withTitle("Item").build();
+
+        Bundle bundle0 = BundleBuilder.createBundle(context, item).withName("Bundle 0").build();
+
+        String bitstreamContent = "ThisIsSomeDummyText";
+
+        Bitstream bitstream0;
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
+            bitstream0 = BitstreamBuilder.createBitstream(context, bundle0, is)
+                                         .withName("Bitstream0")
+                                         .withMimeType("text/plain")
+                                         .build();
+        }
+        Bitstream bitstream1;
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
+            bitstream1 = BitstreamBuilder.createBitstream(context, bundle0, is)
+                                         .withName("Bitstream1")
+                                         .withMimeType("text/plain")
+                                         .build();
+        }
+        Bitstream bitstream2;
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
+            bitstream2 = BitstreamBuilder.createBitstream(context, bundle0, is)
+                                         .withName("Bitstream2")
+                                         .withMimeType("text/plain")
+                                         .build();
+        }
+        Bitstream bitstream3;
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
+            bitstream3 = BitstreamBuilder.createBitstream(context, bundle0, is)
+                                         .withName("Bitstream3")
+                                         .withMimeType("text/plain")
+                                         .build();
+        }
+        Bitstream bitstream4;
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
+            bitstream4 = BitstreamBuilder.createBitstream(context, bundle0, is)
+                                         .withName("Bitstream4")
+                                         .withMimeType("text/plain")
+                                         .build();
+        }
+        Bitstream bitstream5;
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
+            bitstream5 = BitstreamBuilder.createBitstream(context, bundle0, is)
+                                         .withName("Bitstream5")
+                                         .withMimeType("text/plain")
+                                         .build();
+        }
+        Bitstream bitstream6;
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
+            bitstream6 = BitstreamBuilder.createBitstream(context, bundle0, is)
+                                         .withName("Bitstream6")
+                                         .withMimeType("text/plain")
+                                         .build();
+        }
+        Bitstream bitstream7;
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
+            bitstream7 = BitstreamBuilder.createBitstream(context, bundle0, is)
+                                         .withName("Bitstream7")
+                                         .withMimeType("text/plain")
+                                         .build();
+        }
+        Bitstream bitstream8;
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
+            bitstream8 = BitstreamBuilder.createBitstream(context, bundle0, is)
+                                         .withName("Bitstream8")
+                                         .withMimeType("text/plain")
+                                         .build();
+        }
+        Bitstream bitstream9;
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
+            bitstream9 = BitstreamBuilder.createBitstream(context, bundle0, is)
+                                         .withName("Bitstream9")
+                                         .withMimeType("text/plain")
+                                         .build();
+        }
+        context.restoreAuthSystemState();
+
+        getClient().perform(get("/api/core/items/" + item.getID())
+                                    .param("embed", "bundles/bitstreams"))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$", ItemMatcher.matchItemProperties(item)))
+                   .andExpect(jsonPath("$._embedded.bundles._embedded.bundles", Matchers.containsInAnyOrder(
+                           BundleMatcher.matchProperties(bundle0.getName(), bundle0.getID(), bundle0.getHandle(),
+                                                         bundle0.getType())
+                   )))
+                   .andExpect(jsonPath("$._embedded.bundles._embedded.bundles[0]._embedded.bitstreams" +
+                                               "._embedded.bitstreams",
+                                    Matchers.containsInAnyOrder(
+                                            BitstreamMatcher.matchProperties(bitstream0),
+                                            BitstreamMatcher.matchProperties(bitstream1),
+                                            BitstreamMatcher.matchProperties(bitstream2),
+                                            BitstreamMatcher.matchProperties(bitstream3),
+                                            BitstreamMatcher.matchProperties(bitstream4),
+                                            BitstreamMatcher.matchProperties(bitstream5),
+                                            BitstreamMatcher.matchProperties(bitstream6),
+                                            BitstreamMatcher.matchProperties(bitstream7),
+                                            BitstreamMatcher.matchProperties(bitstream8),
+                                            BitstreamMatcher.matchProperties(bitstream9)
+                                    )))
+                   .andExpect(
+                           jsonPath("$._links.self.href", Matchers.containsString("/api/core/items/" + item.getID())))
+                   .andExpect(jsonPath("$._embedded.bundles._embedded.bundles[0]." +
+                                               "_embedded.bitstreams.page.size", is(20)))
+                   .andExpect(jsonPath("$._embedded.bundles._embedded.bundles[0]" +
+                                               "._embedded.bitstreams.page.totalElements",
+                                       is(10)));
+    }
+
+    @Test
+    public void findOneTestWithMultiLevelEmbedsWithPageSize() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+
+        Collection collection = CollectionBuilder.createCollection(context, parentCommunity)
+                                                 .withName("Collection")
+                                                 .build();
+
+        Item item = ItemBuilder.createItem(context, collection).withTitle("Item").build();
+
+        Bundle bundle0 = BundleBuilder.createBundle(context, item).withName("Bundle 0").build();
+
+        String bitstreamContent = "ThisIsSomeDummyText";
+
+        Bitstream bitstream0;
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
+            bitstream0 = BitstreamBuilder.createBitstream(context, bundle0, is)
+                                         .withName("Bitstream0")
+                                         .withMimeType("text/plain")
+                                         .build();
+        }
+        Bitstream bitstream1;
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
+            bitstream1 = BitstreamBuilder.createBitstream(context, bundle0, is)
+                                         .withName("Bitstream1")
+                                         .withMimeType("text/plain")
+                                         .build();
+        }
+        Bitstream bitstream2;
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
+            bitstream2 = BitstreamBuilder.createBitstream(context, bundle0, is)
+                                         .withName("Bitstream2")
+                                         .withMimeType("text/plain")
+                                         .build();
+        }
+        Bitstream bitstream3;
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
+            bitstream3 = BitstreamBuilder.createBitstream(context, bundle0, is)
+                                         .withName("Bitstream3")
+                                         .withMimeType("text/plain")
+                                         .build();
+        }
+        Bitstream bitstream4;
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
+            bitstream4 = BitstreamBuilder.createBitstream(context, bundle0, is)
+                                         .withName("Bitstream4")
+                                         .withMimeType("text/plain")
+                                         .build();
+        }
+        Bitstream bitstream5;
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
+            bitstream5 = BitstreamBuilder.createBitstream(context, bundle0, is)
+                                         .withName("Bitstream5")
+                                         .withMimeType("text/plain")
+                                         .build();
+        }
+        Bitstream bitstream6;
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
+            bitstream6 = BitstreamBuilder.createBitstream(context, bundle0, is)
+                                         .withName("Bitstream6")
+                                         .withMimeType("text/plain")
+                                         .build();
+        }
+        Bitstream bitstream7;
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
+            bitstream7 = BitstreamBuilder.createBitstream(context, bundle0, is)
+                                         .withName("Bitstream7")
+                                         .withMimeType("text/plain")
+                                         .build();
+        }
+        Bitstream bitstream8;
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
+            bitstream8 = BitstreamBuilder.createBitstream(context, bundle0, is)
+                                         .withName("Bitstream8")
+                                         .withMimeType("text/plain")
+                                         .build();
+        }
+        Bitstream bitstream9;
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
+            bitstream9 = BitstreamBuilder.createBitstream(context, bundle0, is)
+                                         .withName("Bitstream9")
+                                         .withMimeType("text/plain")
+                                         .build();
+        }
+        context.restoreAuthSystemState();
+
+        getClient().perform(get("/api/core/items/" + item.getID())
+                                    .param("embed", "bundles/bitstreams")
+                                    .param("embed.size", "bundles/bitstreams=5"))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$", ItemMatcher.matchItemProperties(item)))
+                   .andExpect(jsonPath("$._embedded.bundles._embedded.bundles", Matchers.containsInAnyOrder(
+                           BundleMatcher.matchProperties(bundle0.getName(), bundle0.getID(), bundle0.getHandle(),
+                                                         bundle0.getType())
+                   )))
+                   .andExpect(jsonPath("$._embedded.bundles._embedded.bundles[0]._embedded.bitstreams" +
+                                               "._embedded.bitstreams",
+                                    Matchers.containsInAnyOrder(
+                                            BitstreamMatcher.matchProperties(bitstream0),
+                                            BitstreamMatcher.matchProperties(bitstream1),
+                                            BitstreamMatcher.matchProperties(bitstream2),
+                                            BitstreamMatcher.matchProperties(bitstream3),
+                                            BitstreamMatcher.matchProperties(bitstream4)
+                                    )))
+                   .andExpect(
+                           jsonPath("$._links.self.href", Matchers.containsString("/api/core/items/" + item.getID())))
+                   .andExpect(jsonPath("$._embedded.bundles._embedded.bundles[0]" +
+                                               "._embedded.bitstreams.page.size", is(5)))
+                   .andExpect(jsonPath("$._embedded.bundles._embedded.bundles[0]" +
+                                               "._embedded.bitstreams.page.totalElements",
+                                       is(10)));
+    }
+
+
+
 
 
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/BitstreamMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/BitstreamMatcher.java
@@ -10,6 +10,7 @@ package org.dspace.app.rest.matcher;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static org.dspace.app.rest.matcher.HalMatcher.matchEmbeds;
 import static org.dspace.app.rest.matcher.MetadataMatcher.matchMetadata;
+import static org.dspace.app.rest.matcher.MetadataMatcher.matchMetadataDoesNotExist;
 import static org.dspace.app.rest.test.AbstractControllerIntegrationTest.REST_SERVER_URL;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.empty;
@@ -123,9 +124,11 @@ public class BitstreamMatcher {
                     hasJsonPath("$.name", is(bitstream.getName())),
                     hasJsonPath("$.bundleName", is(bitstream.getBundles().get(0).getName())),
                     hasJsonPath("$.metadata", allOf(
-                            matchMetadata("dc.title", bitstream.getName()),
-                            matchMetadata("dc.description", bitstream.getDescription())
+                            matchMetadata("dc.title", bitstream.getName())
                     )),
+                    bitstream.getDescription() != null ?
+                            hasJsonPath("$.metadata", matchMetadata("dc.description", bitstream.getDescription())) :
+                            hasJsonPath("$.metadata", matchMetadataDoesNotExist("dc.description")),
                     hasJsonPath("$.sizeBytes", is((int) bitstream.getSizeBytes())),
                     hasJsonPath("$.checkSum", matchChecksum())
             );
@@ -139,9 +142,11 @@ public class BitstreamMatcher {
                 hasJsonPath("$.uuid", is(uuid.toString())),
                 hasJsonPath("$.name", is(name)),
                 hasJsonPath("$.metadata", allOf(
-                        matchMetadata("dc.title", name),
-                        matchMetadata("dc.description", description)
+                        matchMetadata("dc.title", name)
                 )),
+                description != null ?
+                        hasJsonPath("$.metadata", matchMetadata("dc.description", description)) :
+                        hasJsonPath("$.metadata", matchMetadataDoesNotExist("dc.description")),
                 hasJsonPath("$.sizeBytes", is((int) size)),
                 hasJsonPath("$.checkSum", matchChecksum())
         );

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/projection/MockProjection.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/projection/MockProjection.java
@@ -15,13 +15,12 @@ import org.dspace.app.rest.model.MockObjectRest;
 import org.dspace.app.rest.model.RestAddressableModel;
 import org.dspace.app.rest.model.RestModel;
 import org.dspace.app.rest.model.hateoas.HALResource;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.hateoas.Link;
 
 /**
  * A projection for use in tests.
  */
-public class MockProjection implements Projection {
+public class MockProjection extends AbstractProjection {
 
     public static final String NAME = "mock";
 
@@ -96,10 +95,5 @@ public class MockProjection implements Projection {
 
     public boolean allowLinking(HALResource halResource, LinkRest linkRest) {
         return false;
-    }
-
-    @Override
-    public PageRequest getPagingOptions(String rel) {
-        return null;
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/projection/MockProjection.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/projection/MockProjection.java
@@ -15,6 +15,7 @@ import org.dspace.app.rest.model.MockObjectRest;
 import org.dspace.app.rest.model.RestAddressableModel;
 import org.dspace.app.rest.model.RestModel;
 import org.dspace.app.rest.model.hateoas.HALResource;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.hateoas.Link;
 
 /**
@@ -95,5 +96,10 @@ public class MockProjection implements Projection {
 
     public boolean allowLinking(HALResource halResource, LinkRest linkRest) {
         return false;
+    }
+
+    @Override
+    public PageRequest getPagingOptions(String rel) {
+        return null;
     }
 }


### PR DESCRIPTION
## References
* Required for: https://github.com/DSpace/dspace-angular/issues/918  (However, a corresponding Angular PR is necessary)

## Description
This PR adds support for paging options in the embedded objects for the REST response. It'll now be possible to specify how large the list of returned embedded objects can be for a specific embed.
For example, it'll now be possible to limit the amount of returned subcommunities when retrieving a community through the DSpace 7 REST API

## Instructions for Reviewers
This PR adds support for paging options in the embeds. This can be done by adding the parameter `embed.size` with the value being `{rel}={size}`. If this is given with the request, it'll make sure that the returned list of embedded {rel} objects will not be larger than the size given.

List of changes in this PR:
* Build and deploy this PR
* Construct a community with more than 5 subcommunities
* perform a findOne on the community with `embed=subcommunities`. Also give it a parameter `embed.size` with value `subcommunities=5`.
* Verify that the list of embedded subcommunities is only 5 objects large and that the page for this embed shows how many there truly are

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
