### PR TITLE
Switch Author field to "onebox" to allow first/last name in single entry box.

### DIFF
--- a/dspace/config/submission-forms.dtd
+++ b/dspace/config/submission-forms.dtd
@@ -7,19 +7,19 @@
  <!ELEMENT form (row)+ >
  <!ELEMENT row (field|relation-field)+ >
  <!ATTLIST form name NMTOKEN #REQUIRED>
- 
+
  <!ELEMENT field (dc-schema, dc-element, dc-qualifier?, language?, repeatable?, label, style?, type-bind?, input-type, hint, required?, regex?, vocabulary?, visibility?, readonly?) >
  <!ELEMENT dc-schema (#PCDATA) >
  <!ELEMENT dc-element (#PCDATA) >
  <!ELEMENT dc-qualifier (#PCDATA) >
  <!ELEMENT language (#PCDATA)>
  <!ELEMENT type-bind (#PCDATA) >
- 
+
  <!ELEMENT repeatable (#PCDATA) >
  <!ELEMENT label (#PCDATA) >
  <!ELEMENT style (#PCDATA) >
  <!ELEMENT input-type (#PCDATA)>
-  
+
  <!ELEMENT hint (#PCDATA) >
  <!ELEMENT required (#PCDATA)>
  <!ELEMENT name-variants (#PCDATA)>
@@ -40,7 +40,7 @@
  <!ATTLIST value-pairs value-pairs-name CDATA #REQUIRED
                             dc-term   CDATA #REQUIRED
  >
-  
+
  <!ELEMENT pair (displayed-value,stored-value) >
  <!ELEMENT displayed-value (#PCDATA)>
  <!ELEMENT stored-value (#PCDATA)>
@@ -49,11 +49,11 @@
 
  <!ELEMENT vocabulary (#PCDATA) >
 
- <!ATTLIST vocabulary closed (true|false) "false"> 
+ <!ATTLIST vocabulary closed (true|false) "false">
 
  <!ELEMENT visibility (#PCDATA) >
 
- <!ATTLIST language value-pairs-name CDATA  #IMPLIED>  
+ <!ATTLIST language value-pairs-name CDATA  #IMPLIED>
 
  <!ELEMENT readonly (#PCDATA) >
 
@@ -61,5 +61,5 @@
 <!ELEMENT search-configuration (#PCDATA) >
 <!ELEMENT filter (#PCDATA) >
 <!ELEMENT externalsources (#PCDATA) >
-<!ELEMENT relation-field (relationship-type, search-configuration, filter?, repeatable?, name-variants?, label, type-bind?, hint, linked-metadata-field?, externalsources?, required?, visibility?)>
+<!ELEMENT relation-field (relationship-type, search-configuration, filter?, repeatable?, name-variants?, label, type-bind?, hint, linked-metadata-field?, externalsources?, required?, regex?, visibility?)>
 <!ELEMENT linked-metadata-field (dc-schema, dc-element, dc-qualifier?, input-type)>

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -31,7 +31,7 @@
                     <label>Title</label>
                     <input-type>onebox</input-type>
                     <hint>Enter the name of the file.</hint>
-                    <required>You must enter a main title for this item.</required>
+                    <required>You must enter a name for this file</required>
                 </field>
             </row>
             <row>
@@ -54,15 +54,19 @@
                     <search-configuration>person</search-configuration>
                     <repeatable>true</repeatable>
                     <label>Author</label>
-                    <hint>Add an author</hint>
+                    <hint>Enter the author's name (Family name, Given names).</hint>
                     <linked-metadata-field>
                         <dc-schema>dc</dc-schema>
                         <dc-element>contributor</dc-element>
                         <dc-qualifier>author</dc-qualifier>
-                        <input-type>name</input-type>
+                        <input-type>onebox</input-type>
                     </linked-metadata-field>
                     <externalsources>orcid</externalsources>
-                    <required>At least one author (plain text or relationship) is required</required>
+                    <required></required>
+                    <!-- You may choose to validate author names via a Regular Expression if it's appropriate for
+                         your institution. The below regex requires a comma to be present in the author field.
+                         However, this is disabled by default to support organizations as authors, etc. -->
+                    <!--<regex>\w+(,)+\w+</regex>-->
                 </relation-field>
             </row>
             <row>
@@ -75,7 +79,6 @@
                     <input-type>onebox</input-type>
                     <hint>Enter the main title of the item.</hint>
                     <required>You must enter a main title for this item.</required>
-                    <!--    <language value-pairs-name="common_iso_languages">true</language> -->
                 </field>
             </row>
             <row>
@@ -100,8 +103,7 @@
                     <style>col-sm-4</style>
                     <input-type>date</input-type>
                     <hint>Please give the date of previous publication or public distribution.
-                        You can leave out the day and/or month if they aren't
-                        applicable.
+                        You can leave out the day and/or month if they aren't applicable.
                     </hint>
                     <required>You must enter at least the year.</required>
                 </field>
@@ -864,7 +866,7 @@
             </row>
 
             <!-- Additional Subject with specific taxonomy (like mesh, fos, ...) -->
-            
+
             <!-- example for FOS -->
             <!-- <row>
                 <field>
@@ -1067,14 +1069,14 @@
                     <label>Name of the Funding Stream</label>
                     <input-type>onebox</input-type>
                     <hint>Enter the name of the funding stream of the project</hint>
-                </field>            
+                </field>
                 <field>
                     <dc-schema>dc</dc-schema>
                     <dc-element>identifier</dc-element>
                     <label>Award number</label>
                     <input-type>onebox</input-type>
                     <hint>Enter the identifier of the project</hint>
-                </field>            
+                </field>
             </row>
         </form>
 
@@ -1355,9 +1357,9 @@
 
         </value-pairs>
 
-        <!-- OpenAIRE document types 
-             https://openaire-guidelines-for-literature-repository-managers.readthedocs.io/en/v4.0.0/field_publicationtype.html 
-             Based on COAR Vocabularies -> Controlled Vocabulary for Resource Type Genres (Version 2.0): 
+        <!-- OpenAIRE document types
+             https://openaire-guidelines-for-literature-repository-managers.readthedocs.io/en/v4.0.0/field_publicationtype.html
+             Based on COAR Vocabularies -> Controlled Vocabulary for Resource Type Genres (Version 2.0):
              http://vocabularies.coar-repositories.org/documentation/resource_types/
         -->
         <value-pairs value-pairs-name="openaire_types" dc-term="type">


### PR DESCRIPTION
## References
Workaround for https://github.com/DSpace/dspace-angular/issues/847 (not a full solution though as issues still occur when the Author field uses the `name` input-type.)

## Description
This PR simply changes the Submission configuration to default to using a `onebox` type for the Author field.  Also makes the following minor changes:
* Updates `submission-forms.dtd` to allow `<regex>` tag to appear in `<relation-field>`.  This tag is supported in that field already but was not listed in the DTD
* Provides a sample, commented-out `<regex>` for the Author field to validate if the name includes a comma (e.g. [Family name],[Given names]).  However, this is disabled to support organization names as authors. Also see https://www.kalzumeus.com/2010/06/17/falsehoods-programmers-believe-about-names/
* Minor cleanup/fixes to `submission-forms.xml` discovered while testing.

## Instructions for Reviewers
* Review changes in this PR
* Test by deploying locally.  Optionally test uncommenting the `<regex>` for field validation. However, please be aware that https://github.com/DSpace/dspace-angular/issues/971 means that validation errors sometimes do not appear as expected (they sometimes appear on multiple values in the field or on the wrong value in the field).
