### PR TITLE
Correct use of Default Discovery configuration

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoveryConfigurationService.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoveryConfigurationService.java
@@ -44,7 +44,7 @@ public class DiscoveryConfigurationService {
     public DiscoveryConfiguration getDiscoveryConfiguration(IndexableObject dso) {
         String name;
         if (dso == null) {
-            name = "site";
+            name = "default";
         } else if (dso instanceof IndexableDSpaceObject) {
             name = ((IndexableDSpaceObject) dso).getIndexedObject().getHandle();
         } else {


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/DSpace/issues/3092

## Description
This PR ensures that the default discovery configuration is chosen when no DSO is given. Previously, the site discovery configuration was used when no DSO was given.

## Instructions for Reviewers
This PR changes the way that the discovery configuration is chosen. It'll now default to the default configuration if no DSO is given, previously it used to select the site configuration

How to test this:
* open op discovery.xml
* delete sidebarfacets from the default configuration
* verify that when calling the /api/discover/search endpoint, the deleted sidebarfacets aren't shown anymore and thus the default configuration is being used instead of the site configuration

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
