### PR TITLE
Entities performance improvement in RelationshipServiceImpl

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/RelationshipServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/RelationshipServiceImpl.java
@@ -244,6 +244,10 @@ public class RelationshipServiceImpl implements RelationshipService {
                                          Integer maxCardinality,
                                          RelationshipType relationshipType,
                                          boolean isLeft) throws SQLException {
+        if (maxCardinality == null) {
+            //no need to check the relationships
+            return true;
+        }
         List<Relationship> rightRelationships = findByItemAndRelationshipType(context, itemToProcess, relationshipType,
                                                                               isLeft);
         if (maxCardinality != null && rightRelationships.size() >= maxCardinality) {
@@ -253,7 +257,8 @@ public class RelationshipServiceImpl implements RelationshipService {
     }
 
     private boolean verifyEntityTypes(Item itemToProcess, EntityType entityTypeToProcess) {
-        List<MetadataValue> list = itemService.getMetadata(itemToProcess, "relationship", "type", null, Item.ANY);
+        List<MetadataValue> list = itemService.getMetadata(itemToProcess, "relationship", "type",
+                null, Item.ANY, false);
         if (list.isEmpty()) {
             return false;
         }

--- a/dspace-api/src/test/java/org/dspace/content/RelationshipServiceImplTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/RelationshipServiceImplTest.java
@@ -227,8 +227,8 @@ public class RelationshipServiceImplTest {
         when(metsList.get(0).getValue()).thenReturn("Entitylabel");
         when(relationshipService
                 .findByItemAndRelationshipType(context, leftItem, testRel, true)).thenReturn(leftTypelist);
-        when(itemService.getMetadata(leftItem, "relationship", "type", null, Item.ANY)).thenReturn(metsList);
-        when(itemService.getMetadata(rightItem, "relationship", "type", null, Item.ANY)).thenReturn(metsList);
+        when(itemService.getMetadata(leftItem, "relationship", "type", null, Item.ANY, false)).thenReturn(metsList);
+        when(itemService.getMetadata(rightItem, "relationship", "type", null, Item.ANY, false)).thenReturn(metsList);
         when(relationshipDAO.create(any(), any())).thenReturn(relationship);
 
         // The reported Relationship should match our defined relationship
@@ -305,8 +305,8 @@ public class RelationshipServiceImplTest {
         relationship = getRelationship(leftItem, rightItem, testRel, 0,0);
 
         // Mock the state of objects utilized in update() to meet the success criteria of the invocation
-        when(itemService.getMetadata(leftItem, "relationship", "type", null, Item.ANY)).thenReturn(metsList);
-        when(itemService.getMetadata(rightItem, "relationship", "type", null, Item.ANY)).thenReturn(metsList);
+        when(itemService.getMetadata(leftItem, "relationship", "type", null, Item.ANY, false)).thenReturn(metsList);
+        when(itemService.getMetadata(rightItem, "relationship", "type", null, Item.ANY, false)).thenReturn(metsList);
         when(authorizeService.authorizeActionBoolean(context, relationship.getLeftItem(),
                 Constants.WRITE)).thenReturn(true);
 


### PR DESCRIPTION
## References
* Relates to https://github.com/DSpace/DSpace/issues/3125, but is not the fix yet

## Description
This PR includes two very small changes which improve performance when creating a relationship. This was discovered while investigating https://github.com/DSpace/DSpace/issues/3125 without fixing it:
* If there's no max on the relationships, this code will no longer bother trying to verify whether the max would be exceeded
* This code won't get virtual metadata for retrieving the relationship type

## Instructions for Reviewers
Nothing has changed regarding the behavior, but the performance has changed.
I've verified the performance with the following use case:
* I've created a publication linked to 2 people
* I have a third person, already linked to 99 publication
* I'm creating a link to these 2 items (a third person for the publication, and a 100th publication for the person)
* This new code on average only needs 64% of the time to create the relationship vs the current main code

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
