### PR TITLE
Improve REST Error message for specific errors

### DIFF
--- a/dspace-api/src/main/java/org/dspace/eperson/EPersonServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/EPersonServiceImpl.java
@@ -283,9 +283,7 @@ public class EPersonServiceImpl extends DSpaceObjectServiceImpl<EPerson> impleme
         for (Group group: workFlowGroups) {
             List<EPerson> ePeople = groupService.allMembers(context, group);
             if (ePeople.size() == 1 && ePeople.contains(ePerson)) {
-                throw new IllegalStateException(
-                    "Refused to delete user " + ePerson.getID() + " because it the only member of the workflow group"
-                    + group.getID() + ". Delete the tasks and group first if you want to remove this user.");
+                throw new EmptyWorkflowGroupException(ePerson.getID(), group.getID());
             }
         }
         // check for presence of eperson in tables that

--- a/dspace-api/src/main/java/org/dspace/eperson/EmptyWorkflowGroupException.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/EmptyWorkflowGroupException.java
@@ -24,8 +24,21 @@ public class EmptyWorkflowGroupException extends IllegalStateException {
     public static final String msgFmt = "Refused to delete user %s because it is the only member of the " +
         "workflow group %s. Delete the tasks and group first if you want to remove this user.";
 
+    private final UUID ePersonId;
+    private final UUID groupId;
+
     public EmptyWorkflowGroupException(UUID ePersonId, UUID groupId) {
         super(String.format(msgFmt, ePersonId, groupId));
+        this.ePersonId = ePersonId;
+        this.groupId = groupId;
+    }
+
+    public UUID getEPersonId() {
+        return ePersonId;
+    }
+
+    public UUID getGroupId() {
+        return groupId;
     }
 
 }

--- a/dspace-api/src/main/java/org/dspace/eperson/EmptyWorkflowGroupException.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/EmptyWorkflowGroupException.java
@@ -21,11 +21,11 @@ import java.util.UUID;
  */
 public class EmptyWorkflowGroupException extends IllegalStateException {
 
+    public static final String msgFmt = "Refused to delete user %s because it is the only member of the " +
+        "workflow group %s. Delete the tasks and group first if you want to remove this user.";
+
     public EmptyWorkflowGroupException(UUID ePersonId, UUID groupId) {
-        super(String.format(
-            "Refused to delete user %s because it is the only member of the workflow group %s. " +
-            "Delete the tasks and group first if you want to remove this user.", ePersonId, groupId
-        ));
+        super(String.format(msgFmt, ePersonId, groupId));
     }
 
 }

--- a/dspace-api/src/main/java/org/dspace/eperson/EmptyWorkflowGroupException.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/EmptyWorkflowGroupException.java
@@ -1,0 +1,24 @@
+package org.dspace.eperson;
+
+import java.util.UUID;
+
+/**
+ * <p>This exception class is used to distinguish the following condition:
+ * EPerson cannot be deleted because that would lead to one (or more)
+ * workflow groups being empty.</p>
+ *
+ * <p>The message of this exception can be disclosed in the REST response to
+ * provide more granular feedback to the user.</p>
+ *
+ * @author Bruno Roemers (bruno.roemers at atmire.com)
+ */
+public class EmptyWorkflowGroupException extends IllegalStateException {
+
+    public EmptyWorkflowGroupException(UUID ePersonId, UUID groupId) {
+        super(String.format(
+            "Refused to delete user %s because it is the only member of the workflow group %s. " +
+            "Delete the tasks and group first if you want to remove this user.", ePersonId, groupId
+        ));
+    }
+
+}

--- a/dspace-api/src/main/java/org/dspace/eperson/EmptyWorkflowGroupException.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/EmptyWorkflowGroupException.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package org.dspace.eperson;
 
 import java.util.UUID;

--- a/dspace-api/src/main/resources/Messages.properties
+++ b/dspace-api/src/main/resources/Messages.properties
@@ -1935,3 +1935,9 @@ jsp.dspace-admin.batchimport.itemsimported = Items imported
 jsp.dspace-admin.batchimport.downloadmapfile = Download mapfile
 jsp.dspace-admin.batchimport.deleteitems = Delete uploaded items & remove import
 jsp.dspace-admin.batchimport.resume = Resume upload
+
+# User exposed error messages
+org.dspace.app.rest.exception.RESTEmptyWorkflowGroupException.message = Refused to delete user {0} because it is the only member of the \
+    workflow group {1}. Delete the tasks and group first if you want to remove this user.
+org.dspace.app.rest.exception.EPersonNameNotProvidedException.message = The eperson.firstname and eperson.lastname values need to be filled in
+org.dspace.app.rest.exception.GroupNameNotProvidedException.message = Cannot create group, no group name is provided

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
@@ -17,7 +17,9 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.security.RestAuthenticationService;
+import org.dspace.app.rest.utils.ContextUtil;
 import org.dspace.authorize.AuthorizeException;
+import org.dspace.core.Context;
 import org.springframework.beans.TypeMismatchException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.annotation.AnnotationUtils;
@@ -99,7 +101,9 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
     }
 
     /**
-     * Add an error message to the response body for selected errors.
+     * Add user-friendly error messages to the response body for selected errors.
+     * Since the error messages will be exposed to the API user, the exception classes are expected to implement
+     * {@link TranslatableException} such that the error messages can be translated.
      */
     @ExceptionHandler({
         RESTEmptyWorkflowGroupException.class,
@@ -107,9 +111,10 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
         GroupNameNotProvidedException.class,
     })
     protected void handleCustomUnprocessableEntityException(HttpServletRequest request, HttpServletResponse response,
-                                                            Exception ex) throws IOException {
+                                                            TranslatableException ex) throws IOException {
+        Context context = ContextUtil.obtainContext(request);
         sendErrorResponse(
-            request, response, null, ex.getLocalizedMessage(), HttpStatus.UNPROCESSABLE_ENTITY.value()
+            request, response, null, ex.getLocalizedMessage(context), HttpStatus.UNPROCESSABLE_ENTITY.value()
         );
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
@@ -98,9 +98,14 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
                 HttpStatus.UNPROCESSABLE_ENTITY.value());
     }
 
-    @ExceptionHandler(RESTEmptyWorkflowGroupException.class)
-    protected void handleEmptyWorkflowGroupException(HttpServletRequest request, HttpServletResponse response,
-                                                     Exception ex) throws IOException {
+    @ExceptionHandler({
+        RESTEmptyWorkflowGroupException.class,
+        EPersonNameNotProvidedException.class,
+        GroupNameNotProvidedException.class,
+    })
+    protected void handleCustomUnprocessableEntityException(HttpServletRequest request, HttpServletResponse response,
+                                                            Exception ex) throws IOException {
+        // add error message to response body for selected errors
         sendErrorResponse(
             request, response, null, ex.getLocalizedMessage(), HttpStatus.UNPROCESSABLE_ENTITY.value()
         );

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
@@ -98,6 +98,14 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
                 HttpStatus.UNPROCESSABLE_ENTITY.value());
     }
 
+    @ExceptionHandler(RESTEmptyWorkflowGroupException.class)
+    protected void handleEmptyWorkflowGroupException(HttpServletRequest request, HttpServletResponse response,
+                                                     Exception ex) throws IOException {
+        sendErrorResponse(
+            request, response, null, ex.getLocalizedMessage(), HttpStatus.UNPROCESSABLE_ENTITY.value()
+        );
+    }
+
     @ExceptionHandler(QueryMethodParameterConversionException.class)
     protected void ParameterConversionException(HttpServletRequest request, HttpServletResponse response, Exception ex)
         throws IOException {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
@@ -98,6 +98,9 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
                 HttpStatus.UNPROCESSABLE_ENTITY.value());
     }
 
+    /**
+     * Add an error message to the response body for selected errors.
+     */
     @ExceptionHandler({
         RESTEmptyWorkflowGroupException.class,
         EPersonNameNotProvidedException.class,
@@ -105,7 +108,6 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
     })
     protected void handleCustomUnprocessableEntityException(HttpServletRequest request, HttpServletResponse response,
                                                             Exception ex) throws IOException {
-        // add error message to response body for selected errors
         sendErrorResponse(
             request, response, null, ex.getLocalizedMessage(), HttpStatus.UNPROCESSABLE_ENTITY.value()
         );

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/EPersonNameNotProvidedException.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/EPersonNameNotProvidedException.java
@@ -7,6 +7,8 @@
  */
 package org.dspace.app.rest.exception;
 
+import org.dspace.core.I18nUtil;
+
 /**
  * <p>Extend {@link UnprocessableEntityException} to provide a specific error message
  * in the REST response. The error message is added to the response in
@@ -15,16 +17,20 @@ package org.dspace.app.rest.exception;
  *
  * @author Bruno Roemers (bruno.roemers at atmire.com)
  */
-public class EPersonNameNotProvidedException extends UnprocessableEntityException {
+public class EPersonNameNotProvidedException extends UnprocessableEntityException implements TranslatableException {
 
-    public static final String message = "The eperson.firstname and eperson.lastname values need to be filled in";
+    public static final String MESSAGE_KEY = "org.dspace.app.rest.exception.EPersonNameNotProvidedException.message";
 
     public EPersonNameNotProvidedException() {
-        super(message);
+        super(I18nUtil.getMessage(MESSAGE_KEY));
     }
 
     public EPersonNameNotProvidedException(Throwable cause) {
-        super(message, cause);
+        super(I18nUtil.getMessage(MESSAGE_KEY), cause);
+    }
+
+    public String getMessageKey() {
+        return MESSAGE_KEY;
     }
 
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/EPersonNameNotProvidedException.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/EPersonNameNotProvidedException.java
@@ -17,7 +17,7 @@ package org.dspace.app.rest.exception;
  */
 public class EPersonNameNotProvidedException extends UnprocessableEntityException {
 
-    private static final String message = "The eperson.firstname and eperson.lastname values need to be filled in";
+    public static final String message = "The eperson.firstname and eperson.lastname values need to be filled in";
 
     public EPersonNameNotProvidedException() {
         super(message);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/EPersonNameNotProvidedException.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/EPersonNameNotProvidedException.java
@@ -17,7 +17,7 @@ package org.dspace.app.rest.exception;
  */
 public class EPersonNameNotProvidedException extends UnprocessableEntityException {
 
-    public static final String message = "The eperson.firstname and eperson.lastname values need to be filled in";
+    private static final String message = "The eperson.firstname and eperson.lastname values need to be filled in";
 
     public EPersonNameNotProvidedException() {
         super(message);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/EPersonNameNotProvidedException.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/EPersonNameNotProvidedException.java
@@ -13,18 +13,18 @@ package org.dspace.app.rest.exception;
  * {@link DSpaceApiExceptionControllerAdvice#handleCustomUnprocessableEntityException},
  * hence it should not contain sensitive or security-compromising info.</p>
  *
- * <p>Note there is a similarly named error in the DSpace API module.</p>
- *
  * @author Bruno Roemers (bruno.roemers at atmire.com)
  */
-public class RESTEmptyWorkflowGroupException extends UnprocessableEntityException {
+public class EPersonNameNotProvidedException extends UnprocessableEntityException {
 
-    public RESTEmptyWorkflowGroupException(String message, Throwable cause) {
-        super(message, cause);
+    public static final String message = "The eperson.firstname and eperson.lastname values need to be filled in";
+
+    public EPersonNameNotProvidedException() {
+        super(message);
     }
 
-    public RESTEmptyWorkflowGroupException(String message) {
-        super(message);
+    public EPersonNameNotProvidedException(Throwable cause) {
+        super(message, cause);
     }
 
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/GroupNameNotProvidedException.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/GroupNameNotProvidedException.java
@@ -7,6 +7,8 @@
  */
 package org.dspace.app.rest.exception;
 
+import org.dspace.core.I18nUtil;
+
 /**
  * <p>Extend {@link UnprocessableEntityException} to provide a specific error message
  * in the REST response. The error message is added to the response in
@@ -15,16 +17,19 @@ package org.dspace.app.rest.exception;
  *
  * @author Bruno Roemers (bruno.roemers at atmire.com)
  */
-public class GroupNameNotProvidedException extends UnprocessableEntityException {
+public class GroupNameNotProvidedException extends UnprocessableEntityException implements TranslatableException {
 
-    public static final String message = "cannot create group, no group name is provided";
+    public static final String MESSAGE_KEY = "org.dspace.app.rest.exception.GroupNameNotProvidedException.message";
 
     public GroupNameNotProvidedException() {
-        super(message);
+        super(I18nUtil.getMessage(MESSAGE_KEY));
     }
 
     public GroupNameNotProvidedException(Throwable cause) {
-        super(message, cause);
+        super(I18nUtil.getMessage(MESSAGE_KEY), cause);
     }
 
+    public String getMessageKey() {
+        return MESSAGE_KEY;
+    }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/GroupNameNotProvidedException.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/GroupNameNotProvidedException.java
@@ -17,7 +17,7 @@ package org.dspace.app.rest.exception;
  */
 public class GroupNameNotProvidedException extends UnprocessableEntityException {
 
-    private static final String message = "cannot create group, no group name is provided";
+    public static final String message = "cannot create group, no group name is provided";
 
     public GroupNameNotProvidedException() {
         super(message);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/GroupNameNotProvidedException.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/GroupNameNotProvidedException.java
@@ -13,18 +13,18 @@ package org.dspace.app.rest.exception;
  * {@link DSpaceApiExceptionControllerAdvice#handleCustomUnprocessableEntityException},
  * hence it should not contain sensitive or security-compromising info.</p>
  *
- * <p>Note there is a similarly named error in the DSpace API module.</p>
- *
  * @author Bruno Roemers (bruno.roemers at atmire.com)
  */
-public class RESTEmptyWorkflowGroupException extends UnprocessableEntityException {
+public class GroupNameNotProvidedException extends UnprocessableEntityException {
 
-    public RESTEmptyWorkflowGroupException(String message, Throwable cause) {
-        super(message, cause);
+    private static final String message = "cannot create group, no group name is provided";
+
+    public GroupNameNotProvidedException() {
+        super(message);
     }
 
-    public RESTEmptyWorkflowGroupException(String message) {
-        super(message);
+    public GroupNameNotProvidedException(Throwable cause) {
+        super(message, cause);
     }
 
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/RESTEmptyWorkflowGroupException.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/RESTEmptyWorkflowGroupException.java
@@ -30,7 +30,7 @@ public class RESTEmptyWorkflowGroupException extends UnprocessableEntityExceptio
      * @param cause {@link EmptyWorkflowGroupException}, from which EPerson id and group id are obtained
      * @return message with EPerson id and group id substituted
      */
-    public static String formatMessage(String formatStr, EmptyWorkflowGroupException cause) {
+    private static String formatMessage(String formatStr, EmptyWorkflowGroupException cause) {
         MessageFormat fmt = new MessageFormat(formatStr);
         String[] values = {
             cause.getEPersonId().toString(), // {0} in formatStr

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/RESTEmptyWorkflowGroupException.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/RESTEmptyWorkflowGroupException.java
@@ -7,6 +7,12 @@
  */
 package org.dspace.app.rest.exception;
 
+import java.text.MessageFormat;
+
+import org.dspace.core.Context;
+import org.dspace.core.I18nUtil;
+import org.dspace.eperson.EmptyWorkflowGroupException;
+
 /**
  * <p>Extend {@link UnprocessableEntityException} to provide a specific error message
  * in the REST response. The error message is added to the response in
@@ -17,14 +23,41 @@ package org.dspace.app.rest.exception;
  *
  * @author Bruno Roemers (bruno.roemers at atmire.com)
  */
-public class RESTEmptyWorkflowGroupException extends UnprocessableEntityException {
+public class RESTEmptyWorkflowGroupException extends UnprocessableEntityException implements TranslatableException {
 
-    public RESTEmptyWorkflowGroupException(String message, Throwable cause) {
-        super(message, cause);
+    /**
+     * @param formatStr string with placeholders, ideally obtained using {@link I18nUtil}
+     * @param cause {@link EmptyWorkflowGroupException}, from which EPerson id and group id are obtained
+     * @return message with EPerson id and group id substituted
+     */
+    public static String formatMessage(String formatStr, EmptyWorkflowGroupException cause) {
+        MessageFormat fmt = new MessageFormat(formatStr);
+        String[] values = {
+            cause.getEPersonId().toString(), // {0} in formatStr
+            cause.getGroupId().toString(), // {1} in formatStr
+        };
+        return fmt.format(values);
     }
 
-    public RESTEmptyWorkflowGroupException(String message) {
-        super(message);
+    public static final String MESSAGE_KEY = "org.dspace.app.rest.exception.RESTEmptyWorkflowGroupException.message";
+
+    private final EmptyWorkflowGroupException cause;
+
+    public RESTEmptyWorkflowGroupException(EmptyWorkflowGroupException cause) {
+        super(formatMessage(
+            I18nUtil.getMessage(MESSAGE_KEY), cause
+        ), cause);
+        this.cause = cause;
+    }
+
+    public String getMessageKey() {
+        return MESSAGE_KEY;
+    }
+
+    public String getLocalizedMessage(Context context) {
+        return formatMessage(
+            I18nUtil.getMessage(MESSAGE_KEY, context), cause
+        );
     }
 
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/RESTEmptyWorkflowGroupException.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/RESTEmptyWorkflowGroupException.java
@@ -1,0 +1,29 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.exception;
+
+/**
+ * <p>Extend {@link UnprocessableEntityException} to provide a specific error message
+ * in the REST response. The error message is added to the response in
+ * {@link DSpaceApiExceptionControllerAdvice#handleEmptyWorkflowGroupException}.</p>
+ *
+ * <p>Note there is a similarly named error in the DSpace API module.</p>
+ *
+ * @author Bruno Roemers (bruno.roemers at atmire.com)
+ */
+public class RESTEmptyWorkflowGroupException extends UnprocessableEntityException {
+
+    public RESTEmptyWorkflowGroupException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public RESTEmptyWorkflowGroupException(String message) {
+        super(message);
+    }
+
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/TranslatableException.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/TranslatableException.java
@@ -1,0 +1,52 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+
+package org.dspace.app.rest.exception;
+
+import org.dspace.core.Context;
+import org.dspace.core.I18nUtil;
+
+/**
+ * <p>Implement TranslatableException to make Exceptions or RuntimeExceptions translatable.</p>
+ *
+ * <p>In most cases, only {@link #getMessageKey()} should be implemented;
+ * {@link #getMessage()} and {@link #getLocalizedMessage()} are already provided by {@link Throwable}
+ * and the default implementation of {@link #getLocalizedMessage(Context)} is usually sufficient.</p>
+ *
+ * <p>A locale-aware message can be obtained by calling {@link #getLocalizedMessage(Context)}.</p>
+ *
+ * @author Bruno Roemers (bruno.roemers at atmire.com)
+ */
+public interface TranslatableException {
+
+    /**
+     * @return message key (used for lookup with {@link I18nUtil})
+     */
+    String getMessageKey();
+
+    /**
+     * Already implemented by {@link Throwable}.
+     * @return message for default locale
+     */
+    String getMessage();
+
+    /**
+     * Already implemented by {@link Throwable}.
+     * @return message for default locale
+     */
+    String getLocalizedMessage();
+
+    /**
+     * @param context current DSpace context (used to infer current locale)
+     * @return message for current locale (or default locale if current locale did not yield a result)
+     */
+    default String getLocalizedMessage(Context context) {
+        return I18nUtil.getMessage(getMessageKey(), context);
+    }
+
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/EPersonRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/EPersonRestRepository.java
@@ -316,7 +316,7 @@ public class EPersonRestRepository extends DSpaceObjectRestRepository<EPerson, E
         } catch (SQLException | IOException e) {
             throw new RuntimeException(e.getMessage(), e);
         } catch (EmptyWorkflowGroupException e) {
-            throw new RESTEmptyWorkflowGroupException(e.getLocalizedMessage(), e);
+            throw new RESTEmptyWorkflowGroupException(e);
         } catch (IllegalStateException e) {
             throw new UnprocessableEntityException(e.getMessage(), e);
         }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/EPersonRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/EPersonRestRepository.java
@@ -22,6 +22,7 @@ import org.dspace.app.rest.Parameter;
 import org.dspace.app.rest.SearchRestMethod;
 import org.dspace.app.rest.authorization.AuthorizationFeatureService;
 import org.dspace.app.rest.exception.DSpaceBadRequestException;
+import org.dspace.app.rest.exception.RESTEmptyWorkflowGroupException;
 import org.dspace.app.rest.exception.UnprocessableEntityException;
 import org.dspace.app.rest.model.EPersonRest;
 import org.dspace.app.rest.model.MetadataRest;
@@ -34,6 +35,7 @@ import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.content.service.SiteService;
 import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
+import org.dspace.eperson.EmptyWorkflowGroupException;
 import org.dspace.eperson.RegistrationData;
 import org.dspace.eperson.service.AccountService;
 import org.dspace.eperson.service.EPersonService;
@@ -313,8 +315,10 @@ public class EPersonRestRepository extends DSpaceObjectRestRepository<EPerson, E
             es.delete(context, eperson);
         } catch (SQLException | IOException e) {
             throw new RuntimeException(e.getMessage(), e);
+        } catch (EmptyWorkflowGroupException e) {
+            throw new RESTEmptyWorkflowGroupException(e.getLocalizedMessage(), e);
         } catch (IllegalStateException e) {
-            throw  new UnprocessableEntityException(e.getMessage(), e);
+            throw new UnprocessableEntityException(e.getMessage(), e);
         }
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/EPersonRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/EPersonRestRepository.java
@@ -22,6 +22,7 @@ import org.dspace.app.rest.Parameter;
 import org.dspace.app.rest.SearchRestMethod;
 import org.dspace.app.rest.authorization.AuthorizationFeatureService;
 import org.dspace.app.rest.exception.DSpaceBadRequestException;
+import org.dspace.app.rest.exception.EPersonNameNotProvidedException;
 import org.dspace.app.rest.exception.RESTEmptyWorkflowGroupException;
 import org.dspace.app.rest.exception.UnprocessableEntityException;
 import org.dspace.app.rest.model.EPersonRest;
@@ -201,8 +202,7 @@ public class EPersonRestRepository extends DSpaceObjectRestRepository<EPerson, E
             List<MetadataValueRest> epersonLastName = metadataRest.getMap().get("eperson.lastname");
             if (epersonFirstName == null || epersonLastName == null ||
                 epersonFirstName.isEmpty() || epersonLastName.isEmpty()) {
-                throw new UnprocessableEntityException("The eperson.firstname and eperson.lastname values need to be " +
-                                                    "filled in");
+                throw new EPersonNameNotProvidedException();
             }
         }
         String password = epersonRest.getPassword();

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/GroupRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/GroupRestRepository.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.dspace.app.rest.Parameter;
 import org.dspace.app.rest.SearchRestMethod;
 import org.dspace.app.rest.converter.MetadataConverter;
+import org.dspace.app.rest.exception.GroupNameNotProvidedException;
 import org.dspace.app.rest.exception.RepositoryMethodNotImplementedException;
 import org.dspace.app.rest.exception.UnprocessableEntityException;
 import org.dspace.app.rest.model.GroupRest;
@@ -71,7 +72,7 @@ public class GroupRestRepository extends DSpaceObjectRestRepository<Group, Group
         }
 
         if (isBlank(groupRest.getName())) {
-            throw new UnprocessableEntityException("cannot create group, no group name is provided");
+            throw new GroupNameNotProvidedException();
         }
 
         Group group;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/EPersonRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/EPersonRestRepositoryIT.java
@@ -890,7 +890,7 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
             .andExpect(status().reason(is(plFmt.format(values))))
             .andExpect(status().reason(startsWith("[PL]"))); // verify it did not fall back to default locale
 
-        // make request using Polish locale
+        // make request using default locale
         getClient(getAuthToken(admin.getEmail(), password))
             .perform(delete("/api/eperson/epersons/" + ePerson.getID()))
             .andExpect(status().isUnprocessableEntity())

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/EPersonRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/EPersonRestRepositoryIT.java
@@ -40,6 +40,7 @@ import javax.ws.rs.core.MediaType;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.StringUtils;
+import org.dspace.app.rest.exception.EPersonNameNotProvidedException;
 import org.dspace.app.rest.jackson.IgnoreJacksonWriteOnlyAccess;
 import org.dspace.app.rest.matcher.EPersonMatcher;
 import org.dspace.app.rest.matcher.GroupMatcher;
@@ -2533,7 +2534,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
                                          .param("token", newRegisterToken)
                                          .content(mapper.writeValueAsBytes(ePersonRest))
                                          .contentType(MediaType.APPLICATION_JSON))
-                            .andExpect(status().isUnprocessableEntity());
+                            .andExpect(status().isUnprocessableEntity())
+                            .andExpect(status().reason(is(EPersonNameNotProvidedException.message)));
 
             EPerson createdEPerson = ePersonService.findByEmail(context, newRegisterEmail);
             assertNull(createdEPerson);
@@ -2579,7 +2581,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
                                          .param("token", newRegisterToken)
                                          .content(mapper.writeValueAsBytes(ePersonRest))
                                          .contentType(MediaType.APPLICATION_JSON))
-                            .andExpect(status().isUnprocessableEntity());
+                            .andExpect(status().isUnprocessableEntity())
+                            .andExpect(status().reason(is(EPersonNameNotProvidedException.message)));
 
             EPerson createdEPerson = ePersonService.findByEmail(context, newRegisterEmail);
             assertNull(createdEPerson);

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/GroupRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/GroupRestRepositoryIT.java
@@ -9,6 +9,7 @@ package org.dspace.app.rest;
 
 import static com.jayway.jsonpath.JsonPath.read;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
@@ -32,6 +33,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import javax.ws.rs.core.MediaType;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.dspace.app.rest.exception.GroupNameNotProvidedException;
 import org.dspace.app.rest.matcher.EPersonMatcher;
 import org.dspace.app.rest.matcher.GroupMatcher;
 import org.dspace.app.rest.matcher.HalMatcher;
@@ -194,10 +196,27 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         String authToken = getAuthToken(admin.getEmail(), password);
         getClient(authToken)
-                .perform(post("/api/eperson/groups")
-                        .content(mapper.writeValueAsBytes(groupRest))
-                        .contentType(contentType))
-                .andExpect(status().isUnprocessableEntity());
+            .perform(
+                post("/api/eperson/groups").content("").contentType(contentType)
+            )
+            .andExpect(status().isUnprocessableEntity())
+            .andExpect(status().reason(containsString("Unprocessable")));
+    }
+
+    @Test
+    public void createWithoutNameTest() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        GroupRest groupRest = new GroupRest(); // no name set
+
+        String authToken = getAuthToken(admin.getEmail(), password);
+        getClient(authToken)
+            .perform(
+                post("/api/eperson/groups")
+                    .content(mapper.writeValueAsBytes(groupRest))
+                    .contentType(contentType)
+            )
+            .andExpect(status().isUnprocessableEntity())
+            .andExpect(status().reason(is(GroupNameNotProvidedException.message)));
     }
 
     @Test

--- a/dspace-server-webapp/src/test/resources/Messages_pl.properties
+++ b/dspace-server-webapp/src/test/resources/Messages_pl.properties
@@ -1,0 +1,13 @@
+#
+# The contents of this file are subject to the license and copyright
+# detailed in the LICENSE and NOTICE files at the root of the source
+# tree and available online at
+#
+# http://www.dspace.org/license/
+#
+
+# User exposed error messages
+org.dspace.app.rest.exception.RESTEmptyWorkflowGroupException.message = [PL] Refused to delete user {0} because it is the only member of the \
+    workflow group {1}. Delete the tasks and group first if you want to remove this user.
+org.dspace.app.rest.exception.EPersonNameNotProvidedException.message = [PL] The eperson.firstname and eperson.lastname values need to be filled in
+org.dspace.app.rest.exception.GroupNameNotProvidedException.message = [PL] Cannot create group, no group name is provided


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/DSpace/issues/3101

## Description
This PR delivers us a framework in which we can supply custom Exceptions with a message key and implement the `TranslatabeException` interface. When adding this Exception to the correct method in `DSpaceApiExceptionControllerAdvice`, the message returned in the Response will be translated based on the key that the Exception had. This message key will be retrieved from the appropriate Message.properties file depending on the locale of the Request.
The Locale of the Request can be set with the "Accept-Language" header.

## Instructions for Reviewers

List of changes in this PR:
* Added `TranslatableException` interface which allows us to create Exceptions with a message key. This message key will be looked up in the Messages(-LOCALE).properties file and the String in there will be used for the Response
* Added support for this in the `DSpaceApiExceptionControllerAdvice`
* Added tests to prove that it works

How to test this PR:
* Build and deploy the code locally
* Try to create an EPerson without a name
* Verify that you get a proper error message in the Response
* Add the key for this Exception to a Messages_pl.properties file and repeat the same request with "Accept-Languages" header set to "pl" ( Keep in mind that the `webui.supported.locales` property will need to contain the pl locale as well)
* Verify that the request with the Accept Languages header now returns the polish error message in the Response

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
