### PR TITLE
Rename test to avoid to mess up the test env for the new clean ITs

### DIFF
--- a/dspace-api/src/test/java/org/dspace/administer/StructBuilderTest.java
+++ b/dspace-api/src/test/java/org/dspace/administer/StructBuilderTest.java
@@ -49,18 +49,23 @@ import org.xmlunit.diff.Difference;
 /**
  * Tests of {@link StructBuilder}.
  *
+ * FIXME Due to a not optimal definition of UnitTest and IntegrationTest in
+ * DSpace see https://github.com/DSpace/DSpace/issues/3055 all the integration
+ * test that inherit from org.dspace.AbstractUnitTest without denying its init()
+ * method behavior MUST BE named as Unit Test
+ *
  * @author Mark H. Wood <mwood@iupui.edu>
  */
-public class StructBuilderIT
+public class StructBuilderTest
         extends AbstractIntegrationTest {
-    private static final Logger log = LoggerFactory.getLogger(StructBuilderIT.class);
+    private static final Logger log = LoggerFactory.getLogger(StructBuilderTest.class);
 
     private static final CommunityService communityService
             = ContentServiceFactory.getInstance().getCommunityService();
     private static final CollectionService collectionService
             = ContentServiceFactory.getInstance().getCollectionService();
 
-    public StructBuilderIT() {
+    public StructBuilderTest() {
     }
 
     @BeforeClass

--- a/dspace-api/src/test/java/org/dspace/authorize/AuthorizeConfigTest.java
+++ b/dspace-api/src/test/java/org/dspace/authorize/AuthorizeConfigTest.java
@@ -17,10 +17,15 @@ import org.junit.Test;
  * This integration test verify that the {@link AuthorizeConfiguration} works
  * properly with the configuration reloading
  * 
+ * FIXME Due to a not optimal definition of UnitTest and IntegrationTest in
+ * DSpace see https://github.com/DSpace/DSpace/issues/3055 all the integration
+ * test that inherit from org.dspace.AbstractUnitTest without denying its init()
+ * method behavior MUST BE named as Unit Test
+ * 
  * @author Andrea Bollini (andrea.bollini at 4science.it)
  *
  */
-public class AuthorizeConfigIT extends AbstractIntegrationTest {
+public class AuthorizeConfigTest extends AbstractIntegrationTest {
 
     @Test
     public void testReloadConfiguration() {

--- a/dspace-api/src/test/java/org/dspace/content/CommunityCollectionTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/CommunityCollectionTest.java
@@ -42,11 +42,16 @@ import org.junit.Test;
  * This is an integration test to ensure collections and communities interact properly.
  *
  * The code below is attached as an example.
+ * 
+ * FIXME Due to a not optimal definition of UnitTest and IntegrationTest in
+ * DSpace see https://github.com/DSpace/DSpace/issues/3055 all the integration
+ * test that inherit from org.dspace.AbstractUnitTest without denying its init()
+ * method behavior MUST BE named as Unit Test
  *
  * @author pvillega
  * @author tdonohue
  */
-public class ITCommunityCollection extends AbstractIntegrationTest {
+public class CommunityCollectionTest extends AbstractIntegrationTest {
     protected CommunityService communityService = ContentServiceFactory.getInstance().getCommunityService();
     protected CollectionService collectionService = ContentServiceFactory.getInstance().getCollectionService();
     protected ItemService itemService = ContentServiceFactory.getInstance().getItemService();

--- a/dspace-api/src/test/java/org/dspace/content/MetadataTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/MetadataTest.java
@@ -33,9 +33,14 @@ import org.junit.Test;
 /**
  * This is an integration test to validate the metadata classes
  *
+ * FIXME Due to a not optimal definition of UnitTest and IntegrationTest in
+ * DSpace see https://github.com/DSpace/DSpace/issues/3055 all the integration
+ * test that inherit from org.dspace.AbstractUnitTest without denying its init()
+ * method behavior MUST BE named as Unit Test
+ *
  * @author pvillega
  */
-public class ITMetadata extends AbstractIntegrationTest {
+public class MetadataTest extends AbstractIntegrationTest {
 
     protected CommunityService communityService = ContentServiceFactory.getInstance().getCommunityService();
     protected CollectionService collectionService = ContentServiceFactory.getInstance().getCollectionService();

--- a/dspace-api/src/test/java/org/dspace/content/crosswalk/QDCCrosswalkTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/crosswalk/QDCCrosswalkTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
  *
  * @author mwood
  */
+@Ignore
 public class QDCCrosswalkTest
         extends AbstractDSpaceTest {
     private static final String PLUGIN_NAME = "qdctest";

--- a/dspace-api/src/test/java/org/dspace/content/crosswalk/QDCCrosswalkTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/crosswalk/QDCCrosswalkTest.java
@@ -26,7 +26,6 @@ import org.junit.Test;
  *
  * @author mwood
  */
-@Ignore
 public class QDCCrosswalkTest
         extends AbstractDSpaceTest {
     private static final String PLUGIN_NAME = "qdctest";

--- a/dspace-api/src/test/java/org/dspace/content/packager/DSpaceAIPTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/packager/DSpaceAIPTest.java
@@ -73,13 +73,18 @@ import org.junit.rules.TemporaryFolder;
  * Basic integration testing for the AIP Backup and Restore feature
  * https://wiki.duraspace.org/display/DSDOC5x/AIP+Backup+and+Restore
  *
+ * FIXME Due to a not optimal definition of UnitTest and IntegrationTest in
+ * DSpace see https://github.com/DSpace/DSpace/issues/3055 all the integration
+ * test that inherit from org.dspace.AbstractUnitTest without denying its init()
+ * method behavior MUST BE named as Unit Test
+ *
  * @author Tim Donohue
  */
-public class ITDSpaceAIP extends AbstractIntegrationTest {
+public class DSpaceAIPTest extends AbstractIntegrationTest {
     /**
      * log4j category
      */
-    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ITDSpaceAIP.class);
+    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(DSpaceAIPTest.class);
 
     protected CommunityService communityService = ContentServiceFactory.getInstance().getCommunityService();
     protected CollectionService collectionService = ContentServiceFactory.getInstance().getCollectionService();

--- a/dspace-api/src/test/java/org/dspace/curate/CurationIT.java
+++ b/dspace-api/src/test/java/org/dspace/curate/CurationIT.java
@@ -20,7 +20,7 @@ import org.dspace.scripts.factory.ScriptServiceFactory;
 import org.dspace.scripts.service.ScriptService;
 import org.junit.Test;
 
-public class CurationTest extends AbstractIntegrationTestWithDatabase {
+public class CurationIT extends AbstractIntegrationTestWithDatabase {
 
     @Test(expected = ParseException.class)
     public void curationWithoutEPersonParameterTest() throws Exception {

--- a/dspace-api/src/test/java/org/dspace/curate/CuratorReportingTest.java
+++ b/dspace-api/src/test/java/org/dspace/curate/CuratorReportingTest.java
@@ -35,11 +35,11 @@ import org.slf4j.LoggerFactory;
  *
  * @author mhwood
  */
-public class ITCurator
+public class CuratorReportingTest
         extends AbstractUnitTest {
-    Logger LOG = LoggerFactory.getLogger(ITCurator.class);
+    Logger LOG = LoggerFactory.getLogger(CuratorReportingTest.class);
 
-    public ITCurator() {
+    public CuratorReportingTest() {
     }
 
     @BeforeClass

--- a/dspace-api/src/test/java/org/dspace/curate/CuratorTest.java
+++ b/dspace-api/src/test/java/org/dspace/curate/CuratorTest.java
@@ -25,6 +25,10 @@ import org.dspace.services.ConfigurationService;
 import org.junit.Test;
 
 /**
+ * FIXME Due to a not optimal definition of UnitTest and IntegrationTest in
+ * DSpace see https://github.com/DSpace/DSpace/issues/3055 all the integration
+ * test that inherit from org.dspace.AbstractUnitTest without denying its init()
+ * method behavior MUST BE named as Unit Test
  * @author mhwood
  */
 public class CuratorTest extends AbstractUnitTest {

--- a/dspace-api/src/test/java/org/dspace/eperson/GroupServiceImplTest.java
+++ b/dspace-api/src/test/java/org/dspace/eperson/GroupServiceImplTest.java
@@ -18,12 +18,17 @@ import org.junit.Test;
 
 /**
  * Test integration of GroupServiceImpl.
+ * 
+ * FIXME Due to a not optimal definition of UnitTest and IntegrationTest in
+ * DSpace see https://github.com/DSpace/DSpace/issues/3055 all the integration
+ * test that inherit from org.dspace.AbstractUnitTest without denying its init()
+ * method behavior MUST BE named as Unit Test
  *
  * @author mwood
  */
-public class GroupServiceImplIT
+public class GroupServiceImplTest
     extends AbstractUnitTest {
-    public GroupServiceImplIT() {
+    public GroupServiceImplTest() {
         super();
     }
 

--- a/dspace-api/src/test/java/org/dspace/statistics/export/RetryFailedOpenUrlTrackerTest.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/export/RetryFailedOpenUrlTrackerTest.java
@@ -28,10 +28,16 @@ import org.junit.Test;
 
 /**
  * Class to test the RetryFailedOpenUrlTracker
+ * 
+ * FIXME Due to a not optimal definition of UnitTest and IntegrationTest in
+ * DSpace see https://github.com/DSpace/DSpace/issues/3055 all the integration
+ * test that inherit from org.dspace.AbstractUnitTest without denying its init()
+ * method behavior MUST BE named as Unit Test
+ * 
  */
-public class ITRetryFailedOpenUrlTracker extends AbstractIntegrationTest {
+public class RetryFailedOpenUrlTrackerTest extends AbstractIntegrationTest {
 
-    private static Logger log = Logger.getLogger(ITRetryFailedOpenUrlTracker.class);
+    private static Logger log = Logger.getLogger(RetryFailedOpenUrlTrackerTest.class);
 
 
     protected FailedOpenURLTrackerService failedOpenURLTrackerService =

--- a/dspace-api/src/test/java/org/dspace/statistics/export/processor/BitstreamEventProcessorIT.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/export/processor/BitstreamEventProcessorIT.java
@@ -9,15 +9,21 @@ package org.dspace.statistics.export.processor;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.mock;
 
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.codec.CharEncoding;
 import org.dspace.AbstractIntegrationTestWithDatabase;
+import org.dspace.builder.BitstreamBuilder;
 import org.dspace.builder.CollectionBuilder;
 import org.dspace.builder.CommunityBuilder;
 import org.dspace.builder.ItemBuilder;
+import org.dspace.content.Bitstream;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.Item;
@@ -27,23 +33,22 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
- * Test class for the ItemEventProcessor
+ * Test class for the BitstreamEventProcessor
  */
-public class ItemEventProcessorTest extends AbstractIntegrationTestWithDatabase {
+public class BitstreamEventProcessorIT extends AbstractIntegrationTestWithDatabase {
 
+    private ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
 
-    private final ConfigurationService configurationService
-            = DSpaceServicesFactory.getInstance().getConfigurationService();
 
     private String encodedUrl;
 
+
     @Before
-    @Override
     public void setUp() throws Exception {
         super.setUp();
         configurationService.setProperty("irus.statistics.tracker.enabled", true);
 
-        String dspaceUrl = configurationService.getProperty("dspace.ui.url");
+        String dspaceUrl = configurationService.getProperty("dspace.server.url");
         try {
             encodedUrl = URLEncoder.encode(dspaceUrl, CharEncoding.UTF_8);
         } catch (UnsupportedEncodingException e) {
@@ -56,23 +61,27 @@ public class ItemEventProcessorTest extends AbstractIntegrationTestWithDatabase 
     /**
      * Test the method that adds data based on the object types
      */
-    public void testAddObectSpecificData() throws UnsupportedEncodingException {
+    public void testAddObectSpecificData() throws Exception {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+
         context.turnOffAuthorisationSystem();
         Community community = CommunityBuilder.createCommunity(context).build();
         Collection collection = CollectionBuilder.createCollection(context, community).build();
         Item item = ItemBuilder.createItem(context, collection).build();
+
+        File f = new File(testProps.get("test.bitstream").toString());
+        Bitstream bitstream = BitstreamBuilder.createBitstream(context, item, new FileInputStream(f)).build();
+
         context.restoreAuthSystemState();
 
-        String encodedHandle = URLEncoder.encode(item.getHandle(), CharEncoding.UTF_8);
+        BitstreamEventProcessor bitstreamEventProcessor = new BitstreamEventProcessor(context, request, bitstream);
 
-        ItemEventProcessor itemEventProcessor = new ItemEventProcessor(context, null, item);
-        String result = itemEventProcessor.addObjectSpecificData("existing-string", item);
+        String result = bitstreamEventProcessor.addObjectSpecificData("existing-string", bitstream);
 
         assertThat(result,
-                   is("existing-string&svc_dat=" + encodedUrl + "%2Fhandle%2F" + encodedHandle +
-                              "&rft_dat=Investigation"));
+                   is("existing-string&svc_dat=" + encodedUrl + "%2Fapi%2Fcore%2Fbitstreams%2F" + bitstream.getID()
+                              + "%2Fcontent&rft_dat=Request"));
 
     }
-
 
 }

--- a/dspace-api/src/test/java/org/dspace/statistics/export/processor/ExportEventProcessorIT.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/export/processor/ExportEventProcessorIT.java
@@ -41,7 +41,7 @@ import org.mockito.Mock;
 /**
  * Test for the ExportEventProcessor class
  */
-public class ExportEventProcessorTest extends AbstractIntegrationTestWithDatabase {
+public class ExportEventProcessorIT extends AbstractIntegrationTestWithDatabase {
 
     @Mock
     private final HttpServletRequest request = mock(HttpServletRequest.class);

--- a/dspace-api/src/test/java/org/dspace/statistics/export/processor/ItemEventProcessorIT.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/export/processor/ItemEventProcessorIT.java
@@ -9,21 +9,15 @@ package org.dspace.statistics.export.processor;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.mockito.Mockito.mock;
 
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
-import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.codec.CharEncoding;
 import org.dspace.AbstractIntegrationTestWithDatabase;
-import org.dspace.builder.BitstreamBuilder;
 import org.dspace.builder.CollectionBuilder;
 import org.dspace.builder.CommunityBuilder;
 import org.dspace.builder.ItemBuilder;
-import org.dspace.content.Bitstream;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.Item;
@@ -33,22 +27,23 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
- * Test class for the BitstreamEventProcessor
+ * Test class for the ItemEventProcessor
  */
-public class BitstreamEventProcessorTest extends AbstractIntegrationTestWithDatabase {
+public class ItemEventProcessorIT extends AbstractIntegrationTestWithDatabase {
 
-    private ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
 
+    private final ConfigurationService configurationService
+            = DSpaceServicesFactory.getInstance().getConfigurationService();
 
     private String encodedUrl;
 
-
     @Before
+    @Override
     public void setUp() throws Exception {
         super.setUp();
         configurationService.setProperty("irus.statistics.tracker.enabled", true);
 
-        String dspaceUrl = configurationService.getProperty("dspace.server.url");
+        String dspaceUrl = configurationService.getProperty("dspace.ui.url");
         try {
             encodedUrl = URLEncoder.encode(dspaceUrl, CharEncoding.UTF_8);
         } catch (UnsupportedEncodingException e) {
@@ -61,27 +56,23 @@ public class BitstreamEventProcessorTest extends AbstractIntegrationTestWithData
     /**
      * Test the method that adds data based on the object types
      */
-    public void testAddObectSpecificData() throws Exception {
-        HttpServletRequest request = mock(HttpServletRequest.class);
-
+    public void testAddObectSpecificData() throws UnsupportedEncodingException {
         context.turnOffAuthorisationSystem();
         Community community = CommunityBuilder.createCommunity(context).build();
         Collection collection = CollectionBuilder.createCollection(context, community).build();
         Item item = ItemBuilder.createItem(context, collection).build();
-
-        File f = new File(testProps.get("test.bitstream").toString());
-        Bitstream bitstream = BitstreamBuilder.createBitstream(context, item, new FileInputStream(f)).build();
-
         context.restoreAuthSystemState();
 
-        BitstreamEventProcessor bitstreamEventProcessor = new BitstreamEventProcessor(context, request, bitstream);
+        String encodedHandle = URLEncoder.encode(item.getHandle(), CharEncoding.UTF_8);
 
-        String result = bitstreamEventProcessor.addObjectSpecificData("existing-string", bitstream);
+        ItemEventProcessor itemEventProcessor = new ItemEventProcessor(context, null, item);
+        String result = itemEventProcessor.addObjectSpecificData("existing-string", item);
 
         assertThat(result,
-                   is("existing-string&svc_dat=" + encodedUrl + "%2Fapi%2Fcore%2Fbitstreams%2F" + bitstream.getID()
-                              + "%2Fcontent&rft_dat=Request"));
+                   is("existing-string&svc_dat=" + encodedUrl + "%2Fhandle%2F" + encodedHandle +
+                              "&rft_dat=Investigation"));
 
     }
+
 
 }

--- a/dspace-api/src/test/java/org/dspace/workflowbasic/BasicWorkflowAuthorizationRolesTest.java
+++ b/dspace-api/src/test/java/org/dspace/workflowbasic/BasicWorkflowAuthorizationRolesTest.java
@@ -57,17 +57,23 @@ import org.junit.Test;
  * This is an integration test to ensure that the basic workflow system
  * -including methods of the collection service dealing with it- works properly
  * together with the authorization service.
- *
+ * 
+ * FIXME Due to a not optimal definition of UnitTest and IntegrationTest in
+ * DSpace see https://github.com/DSpace/DSpace/issues/3055 all the integration
+ * test that inherit from org.dspace.AbstractUnitTest without denying its init()
+ * method behavior MUST BE named as Unit Test
+ * 
  * @author Pascal-Nicolas Becker
  * @author Terry Brady
  */
 @Ignore
-public class BasicWorkflowAuthorizationRolesIT
+public class BasicWorkflowAuthorizationRolesTest
     extends AbstractIntegrationTest {
     /**
      * log4j category
      */
-    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(BasicWorkflowAuthorizationIT.class);
+    private static final Logger log = org.apache.logging.log4j.LogManager
+            .getLogger(BasicWorkflowAuthorizationRolesTest.class);
 
     protected CommunityService communityService = ContentServiceFactory.getInstance().getCommunityService();
     protected CollectionService collectionService = ContentServiceFactory.getInstance().getCollectionService();
@@ -97,7 +103,7 @@ public class BasicWorkflowAuthorizationRolesIT
     protected HashMap<ROLE, Group> roleGroups = new HashMap<>();
     protected HashMap<ROLE, EPerson> roleEPersons = new HashMap<>();
 
-    public BasicWorkflowAuthorizationRolesIT() {
+    public BasicWorkflowAuthorizationRolesTest() {
         owningCommunity = null;
         collection = null;
         item = null;

--- a/dspace-api/src/test/java/org/dspace/workflowbasic/BasicWorkflowAuthorizationTest.java
+++ b/dspace-api/src/test/java/org/dspace/workflowbasic/BasicWorkflowAuthorizationTest.java
@@ -57,16 +57,22 @@ import org.junit.Test;
  * -including methods of the collection service dealing with it- works properly
  * together with the authorization service.
  *
+ * FIXME Due to a not optimal definition of UnitTest and IntegrationTest in
+ * DSpace see https://github.com/DSpace/DSpace/issues/3055 all the integration
+ * test that inherit from org.dspace.AbstractUnitTest without denying its init()
+ * method behavior MUST BE named as Unit Test
+ *
  * @author Pascal-Nicolas Becker
  * @author Terry Brady
  */
 @Ignore
-public class BasicWorkflowAuthorizationIT
+public class BasicWorkflowAuthorizationTest
     extends AbstractIntegrationTest {
     /**
      * log4j category
      */
-    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(BasicWorkflowAuthorizationIT.class);
+    private static final Logger log = org.apache.logging.log4j.LogManager
+            .getLogger(BasicWorkflowAuthorizationTest.class);
 
     protected CommunityService communityService = ContentServiceFactory.getInstance().getCommunityService();
     protected CollectionService collectionService = ContentServiceFactory.getInstance().getCollectionService();
@@ -88,7 +94,7 @@ public class BasicWorkflowAuthorizationIT
     protected Group group;
     protected EPerson member;
 
-    public BasicWorkflowAuthorizationIT() {
+    public BasicWorkflowAuthorizationTest() {
         owningCommunity = null;
         collection = null;
         group = null;

--- a/dspace/modules/additions/src/test/java/org/dspace/example/ExampleTest.java
+++ b/dspace/modules/additions/src/test/java/org/dspace/example/ExampleTest.java
@@ -17,8 +17,14 @@ import org.junit.Test;
 /**
  * This IT serves as an an example of how & where to add integration tests for local customizations to the DSpace API.
  * See {@link Example} and {@link ExampleImpl} for the class of which the functionality is tested.
+ * 
+ * FIXME Due to a not optimal definition of UnitTest and IntegrationTest in
+ * DSpace see https://github.com/DSpace/DSpace/issues/3055 all the integration
+ * test that inherit from org.dspace.AbstractUnitTest without denying its init()
+ * method behavior MUST BE named as Unit Test
+ * 
  */
-public class ExampleIT extends AbstractIntegrationTest {
+public class ExampleTest extends AbstractIntegrationTest {
 
     @Test
     public void testExampleImpl() {


### PR DESCRIPTION
## References
* Workaround for #3055

## Description
We have hit random failure on ITs due to an inconsistent state of the test environment. This is more often the case when solr is involved but I guess that could happen also in other scenarios. The problem is that the cleanup of the test environment is guaranteed only extending `org.dspace.AbstractIntegrationTestWithDatabase` not extending `org.dspace.AbstractIntegrationTest` that is indeed in a completely separate tree.
The test that extends this later class are sometimes named according to the IT convention other time as UnitTest this influence which mvn plugin pick them during CI. Moreover, many dspace named Unit Test extending the previous AbstractIntegrationTest or also only the AbstractUnitTest are technically Integration Test so they have pick the wrong name...
unfortunately, making a complete cleanup of these tests is not possible right now due to the dspace 7 timeline so the best option in my opinion is to "give the wrong name" to the residual buggy IT so that they will not disturb the new IT written cleaner thanks to the new  `org.dspace.AbstractIntegrationTestWithDatabase`  and the `Builder` classes.

Unfortunately, I have had to disable the `org.dspace.content.crosswalk.QDCCrosswalkTest` that once renamed has started to fail due to conflict with other unit test. As this test is related to a minor feature I believe that it is worth to disable it instead than spent more hours (already tried to fix for a couple of hours).

## Instructions for Reviewers
A recent failing PR gives us a very clean way to identify the problem
https://github.com/DSpace/DSpace/pull/3133/checks?check_run_id=1778185064#step:5:591
the failing class that succeed in other run (https://github.com/4Science/DSpace/runs/1777980274?check_suite_focus=true ) and locally if run alone fail in a very initial not controversial check saying that nothing is in SOLR.
The reason for that is that the ITCurator test extending `org.dspace.AbstractIntegrationTest` is triggering this code that will disable completely solr for all the next test
```
    // Ensure all tests run with Solr indexing disabled
    disableSolrIndexing();
```

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [N/A] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [N/A] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [N/A] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
