### PR TITLE
Issue 3055 some renaming

### DIFF
--- a/dspace-api/src/test/java/org/dspace/curate/CurationIT.java
+++ b/dspace-api/src/test/java/org/dspace/curate/CurationIT.java
@@ -20,7 +20,7 @@ import org.dspace.scripts.factory.ScriptServiceFactory;
 import org.dspace.scripts.service.ScriptService;
 import org.junit.Test;
 
-public class CurationTest extends AbstractIntegrationTestWithDatabase {
+public class CurationIT extends AbstractIntegrationTestWithDatabase {
 
     @Test(expected = ParseException.class)
     public void curationWithoutEPersonParameterTest() throws Exception {

--- a/dspace-api/src/test/java/org/dspace/curate/CuratorReportTest.java
+++ b/dspace-api/src/test/java/org/dspace/curate/CuratorReportTest.java
@@ -35,11 +35,11 @@ import org.slf4j.LoggerFactory;
  *
  * @author mhwood
  */
-public class ITCurator
+public class CuratorReportTest
         extends AbstractUnitTest {
-    Logger LOG = LoggerFactory.getLogger(ITCurator.class);
+    Logger LOG = LoggerFactory.getLogger(CuratorReportTest.class);
 
-    public ITCurator() {
+    public CuratorReportTest() {
     }
 
     @BeforeClass

--- a/dspace-api/src/test/java/org/dspace/eperson/GroupServiceImplTest.java
+++ b/dspace-api/src/test/java/org/dspace/eperson/GroupServiceImplTest.java
@@ -21,9 +21,9 @@ import org.junit.Test;
  *
  * @author mwood
  */
-public class GroupServiceImplIT
+public class GroupServiceImplTest
     extends AbstractUnitTest {
-    public GroupServiceImplIT() {
+    public GroupServiceImplTest() {
         super();
     }
 

--- a/dspace-api/src/test/java/org/dspace/statistics/export/processor/BitstreamEventProcessorIT.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/export/processor/BitstreamEventProcessorIT.java
@@ -9,15 +9,21 @@ package org.dspace.statistics.export.processor;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.mock;
 
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.codec.CharEncoding;
 import org.dspace.AbstractIntegrationTestWithDatabase;
+import org.dspace.builder.BitstreamBuilder;
 import org.dspace.builder.CollectionBuilder;
 import org.dspace.builder.CommunityBuilder;
 import org.dspace.builder.ItemBuilder;
+import org.dspace.content.Bitstream;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.Item;
@@ -27,23 +33,22 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
- * Test class for the ItemEventProcessor
+ * Test class for the BitstreamEventProcessor
  */
-public class ItemEventProcessorTest extends AbstractIntegrationTestWithDatabase {
+public class BitstreamEventProcessorIT extends AbstractIntegrationTestWithDatabase {
 
+    private ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
 
-    private final ConfigurationService configurationService
-            = DSpaceServicesFactory.getInstance().getConfigurationService();
 
     private String encodedUrl;
 
+
     @Before
-    @Override
     public void setUp() throws Exception {
         super.setUp();
         configurationService.setProperty("irus.statistics.tracker.enabled", true);
 
-        String dspaceUrl = configurationService.getProperty("dspace.ui.url");
+        String dspaceUrl = configurationService.getProperty("dspace.server.url");
         try {
             encodedUrl = URLEncoder.encode(dspaceUrl, CharEncoding.UTF_8);
         } catch (UnsupportedEncodingException e) {
@@ -56,23 +61,27 @@ public class ItemEventProcessorTest extends AbstractIntegrationTestWithDatabase 
     /**
      * Test the method that adds data based on the object types
      */
-    public void testAddObectSpecificData() throws UnsupportedEncodingException {
+    public void testAddObectSpecificData() throws Exception {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+
         context.turnOffAuthorisationSystem();
         Community community = CommunityBuilder.createCommunity(context).build();
         Collection collection = CollectionBuilder.createCollection(context, community).build();
         Item item = ItemBuilder.createItem(context, collection).build();
+
+        File f = new File(testProps.get("test.bitstream").toString());
+        Bitstream bitstream = BitstreamBuilder.createBitstream(context, item, new FileInputStream(f)).build();
+
         context.restoreAuthSystemState();
 
-        String encodedHandle = URLEncoder.encode(item.getHandle(), CharEncoding.UTF_8);
+        BitstreamEventProcessor bitstreamEventProcessor = new BitstreamEventProcessor(context, request, bitstream);
 
-        ItemEventProcessor itemEventProcessor = new ItemEventProcessor(context, null, item);
-        String result = itemEventProcessor.addObjectSpecificData("existing-string", item);
+        String result = bitstreamEventProcessor.addObjectSpecificData("existing-string", bitstream);
 
         assertThat(result,
-                   is("existing-string&svc_dat=" + encodedUrl + "%2Fhandle%2F" + encodedHandle +
-                              "&rft_dat=Investigation"));
+                   is("existing-string&svc_dat=" + encodedUrl + "%2Fapi%2Fcore%2Fbitstreams%2F" + bitstream.getID()
+                              + "%2Fcontent&rft_dat=Request"));
 
     }
-
 
 }

--- a/dspace-api/src/test/java/org/dspace/statistics/export/processor/ExportEventProcessorIT.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/export/processor/ExportEventProcessorIT.java
@@ -41,7 +41,7 @@ import org.mockito.Mock;
 /**
  * Test for the ExportEventProcessor class
  */
-public class ExportEventProcessorTest extends AbstractIntegrationTestWithDatabase {
+public class ExportEventProcessorIT extends AbstractIntegrationTestWithDatabase {
 
     @Mock
     private final HttpServletRequest request = mock(HttpServletRequest.class);

--- a/dspace-api/src/test/java/org/dspace/statistics/export/processor/ItemEventProcessorIT.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/export/processor/ItemEventProcessorIT.java
@@ -9,21 +9,15 @@ package org.dspace.statistics.export.processor;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.mockito.Mockito.mock;
 
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
-import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.codec.CharEncoding;
 import org.dspace.AbstractIntegrationTestWithDatabase;
-import org.dspace.builder.BitstreamBuilder;
 import org.dspace.builder.CollectionBuilder;
 import org.dspace.builder.CommunityBuilder;
 import org.dspace.builder.ItemBuilder;
-import org.dspace.content.Bitstream;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.Item;
@@ -33,22 +27,23 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
- * Test class for the BitstreamEventProcessor
+ * Test class for the ItemEventProcessor
  */
-public class BitstreamEventProcessorTest extends AbstractIntegrationTestWithDatabase {
+public class ItemEventProcessorIT extends AbstractIntegrationTestWithDatabase {
 
-    private ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
 
+    private final ConfigurationService configurationService
+            = DSpaceServicesFactory.getInstance().getConfigurationService();
 
     private String encodedUrl;
 
-
     @Before
+    @Override
     public void setUp() throws Exception {
         super.setUp();
         configurationService.setProperty("irus.statistics.tracker.enabled", true);
 
-        String dspaceUrl = configurationService.getProperty("dspace.server.url");
+        String dspaceUrl = configurationService.getProperty("dspace.ui.url");
         try {
             encodedUrl = URLEncoder.encode(dspaceUrl, CharEncoding.UTF_8);
         } catch (UnsupportedEncodingException e) {
@@ -61,27 +56,23 @@ public class BitstreamEventProcessorTest extends AbstractIntegrationTestWithData
     /**
      * Test the method that adds data based on the object types
      */
-    public void testAddObectSpecificData() throws Exception {
-        HttpServletRequest request = mock(HttpServletRequest.class);
-
+    public void testAddObectSpecificData() throws UnsupportedEncodingException {
         context.turnOffAuthorisationSystem();
         Community community = CommunityBuilder.createCommunity(context).build();
         Collection collection = CollectionBuilder.createCollection(context, community).build();
         Item item = ItemBuilder.createItem(context, collection).build();
-
-        File f = new File(testProps.get("test.bitstream").toString());
-        Bitstream bitstream = BitstreamBuilder.createBitstream(context, item, new FileInputStream(f)).build();
-
         context.restoreAuthSystemState();
 
-        BitstreamEventProcessor bitstreamEventProcessor = new BitstreamEventProcessor(context, request, bitstream);
+        String encodedHandle = URLEncoder.encode(item.getHandle(), CharEncoding.UTF_8);
 
-        String result = bitstreamEventProcessor.addObjectSpecificData("existing-string", bitstream);
+        ItemEventProcessor itemEventProcessor = new ItemEventProcessor(context, null, item);
+        String result = itemEventProcessor.addObjectSpecificData("existing-string", item);
 
         assertThat(result,
-                   is("existing-string&svc_dat=" + encodedUrl + "%2Fapi%2Fcore%2Fbitstreams%2F" + bitstream.getID()
-                              + "%2Fcontent&rft_dat=Request"));
+                   is("existing-string&svc_dat=" + encodedUrl + "%2Fhandle%2F" + encodedHandle +
+                              "&rft_dat=Investigation"));
 
     }
+
 
 }


### PR DESCRIPTION
## References
This is a replacement for https://github.com/DSpace/DSpace/pull/3135 and a partial workaround for issue #3055 

## Description
Please check the previous PR for details. This one is just a reduced version where I have only renamed test that extends `org.dspace.AbstractIntegrationTest` according to the IT naming convention and the ones that extends only `org.dspace.AbstractUnitTest` according to the unit test name convention.

## Instructions for Reviewers
There is no really way to proof that these changes work all the times... you can merge in your own branch and verify that you are able to run the CI multiple times without issue

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [N/A] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [HOPE SO :) ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [N/A] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [N/A] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
