### PR TITLE
Fix bugs in default Journal Hierarchy submission configuration

### DIFF
--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -503,7 +503,8 @@
                 <relation-field>
                     <relationship-type>isJournalOfVolume</relationship-type>
                     <search-configuration>journal</search-configuration>
-                    <filter>creativework.publisher:somepublishername</filter>
+                    <!-- example of filtering Discovery search for Journal by a specific publisher -->
+                    <!--<filter>creativework.publisher:somepublishername</filter>-->
                     <label>Journal</label>
                     <hint>Select the journal related to this volume.</hint>
                     <externalsources>sherpaJournal</externalsources>
@@ -520,7 +521,7 @@
             </row>
             <row>
                 <field>
-                    <dc-schema>publicationVolume</dc-schema>
+                    <dc-schema>publicationvolume</dc-schema>
                     <dc-element>volumeNumber</dc-element>
                     <label>Volume</label>
                     <input-type>onebox</input-type>
@@ -548,6 +549,14 @@
         </form>
 
         <form name="journalIssueStep">
+            <row>
+                <relation-field>
+                    <relationship-type>isJournalVolumeOfIssue</relationship-type>
+                    <search-configuration>journalvolume</search-configuration>
+                    <label>Journal Volume</label>
+                    <hint>Select the journal volume related to this issue.</hint>
+                </relation-field>
+            </row>
             <row>
                 <field>
                     <dc-schema>dc</dc-schema>


### PR DESCRIPTION
## References
Discovered while testing https://github.com/DSpace/DSpace/pull/3003 (though these bugs are not related directly to that PR)

## Description
Two bugs exist in the current Journal Hierarchy configurations in `submission-forms.xml`
1. `publicationvolume` schema is wrongly camel cased in the configuration (referenced as `publicationVolume`).  As you can see it's supposed to be all lowercase: https://github.com/DSpace/DSpace/blob/main/dspace/config/registries/schema-publicationVolume-types.xml#L14  This results in errors when attempting to create a new JournalVolume on `main`.
2. The `journalIssueStep` is missing a `relation-field` configuration to link it back to a JournalVolume.  This means that currently on `main`, while you can create a new JournalIssue, you cannot link it to a JournalVolume.
3. I also commented out the example `<filter>` setting in `isJournalOfVolume` simply because it doesn't do anything right now.  It's just an example of how to limit by publisher.

## Instructions for Reviewers
* Review the code changes
* If desired, install this configuration & attempt to create a new Journal, Journal Volume and Journal Issue (as three separate Items) with relationships between them.  (I've successfully done this test with this new configuration)