### PR TITLE
[3116] Security issue in discovery

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceResourceRestrictionPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceResourceRestrictionPlugin.java
@@ -84,17 +84,19 @@ public class SolrServiceResourceRestrictionPlugin implements SolrServiceIndexPlu
             try {
                 List<ResourcePolicy> policies = authorizeService.getPoliciesActionFilter(context, dso, Constants.READ);
                 for (ResourcePolicy resourcePolicy : policies) {
-                    String fieldValue;
-                    if (resourcePolicy.getGroup() != null) {
-                        //We have a group add it to the value
-                        fieldValue = "g" + resourcePolicy.getGroup().getID();
-                    } else {
-                        //We have an eperson add it to the value
-                        fieldValue = "e" + resourcePolicy.getEPerson().getID();
+                    if (resourcePolicyService.isDateValid(resourcePolicy)) {
+                        String fieldValue;
+                        if (resourcePolicy.getGroup() != null) {
+                            //We have a group add it to the value
+                            fieldValue = "g" + resourcePolicy.getGroup().getID();
+                        } else {
+                            //We have an eperson add it to the value
+                            fieldValue = "e" + resourcePolicy.getEPerson().getID();
 
+                        }
+
+                        document.addField("read", fieldValue);
                     }
-
-                    document.addField("read", fieldValue);
 
                     //remove the policy from the cache to save memory
                     context.uncacheEntity(resourcePolicy);
@@ -106,15 +108,17 @@ public class SolrServiceResourceRestrictionPlugin implements SolrServiceIndexPlu
                         List<ResourcePolicy> policiesAdmin = authorizeService
                                      .getPoliciesActionFilter(context, dso, Constants.ADMIN);
                         for (ResourcePolicy resourcePolicy : policiesAdmin) {
-                            String fieldValue;
-                            if (resourcePolicy.getGroup() != null) {
-                                // We have a group add it to the value
-                                fieldValue = "g" + resourcePolicy.getGroup().getID();
-                            } else {
-                                // We have an eperson add it to the value
-                                fieldValue = "e" + resourcePolicy.getEPerson().getID();
+                            if (resourcePolicyService.isDateValid(resourcePolicy)) {
+                                String fieldValue;
+                                if (resourcePolicy.getGroup() != null) {
+                                    // We have a group add it to the value
+                                    fieldValue = "g" + resourcePolicy.getGroup().getID();
+                                } else {
+                                    // We have an eperson add it to the value
+                                    fieldValue = "e" + resourcePolicy.getEPerson().getID();
+                                }
+                                document.addField("read", fieldValue);
                             }
-                            document.addField("read", fieldValue);
 
                             // remove the policy from the cache to save memory
                             context.uncacheEntity(resourcePolicy);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/DiscoverResultConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/DiscoverResultConverter.java
@@ -38,6 +38,10 @@ public class DiscoverResultConverter {
 
     @Autowired
     private List<IndexableObjectConverter> converters;
+
+    @Autowired
+    protected ConverterService converter;
+
     @Autowired
     private DiscoverFacetsConverter facetConverter;
     @Autowired
@@ -93,12 +97,7 @@ public class DiscoverResultConverter {
 
     private RestAddressableModel convertDSpaceObject(final IndexableObject indexableObject,
                                                      final Projection projection) {
-        for (IndexableObjectConverter<Object, RestAddressableModel> converter : converters) {
-            if (converter.supportsModel(indexableObject)) {
-                return converter.convert(indexableObject.getIndexedObject(), projection);
-            }
-        }
-        return null;
+        return converter.toRest(indexableObject.getIndexedObject(), projection);
     }
 
     private void setRequestInformation(final Context context, final String query, final List<String> dsoTypes,

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -1924,7 +1924,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                 .build();
 
         Item publicItem3 = ItemBuilder.createItem(context, col2)
-                .withTitle("Public item 2")
+                .withTitle("Embargoed item 2")
                 .withIssueDate("2010-02-13")
                 .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
                 .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
@@ -1946,7 +1946,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                 .andExpect(jsonPath("$.type", is("discover")))
                 //The page object needs to look like this
                 .andExpect(jsonPath("$._embedded.searchResult.page", is(
-                        PageMatcher.pageEntry(0, 20)
+                        PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 6)
                 )))
                 //These are the items that aren't set to private
                 .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.hasItems(
@@ -1955,12 +1955,16 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         //Collections are specified like this because they don't have any special properties
                         SearchResultMatcher.match(),
                         SearchResultMatcher.match(),
-                        SearchResultMatcher.matchOnItemName("item", "items", "Test"),
-                        SearchResultMatcher.matchOnItemName("item", "items", "Public item 2")
+                        SearchResultMatcher.matchOnItemName("item", "items", "Test")
                 )))
                 //This is a private item, this shouldn't show up in the result
                 .andExpect(jsonPath("$._embedded.searchResult._embedded.objects",
-                        Matchers.not(SearchResultMatcher.matchOnItemName("item", "items", "Test 2"))))
+                        Matchers.not(
+                                Matchers.anyOf(
+                                SearchResultMatcher.matchOnItemName("item", "items", "Test 2"),
+                                SearchResultMatcher.matchOnItemName("item", "items", "Embargoed item 2")
+                                )
+                        )))
                 //These facets have to show up in the embedded.facets section as well with the given hasMore
                 // property because we don't exceed their default limit for a hasMore true (the default is 10)
                 .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -1946,7 +1946,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                 .andExpect(jsonPath("$.type", is("discover")))
                 //The page object needs to look like this
                 .andExpect(jsonPath("$._embedded.searchResult.page", is(
-                        PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 6)
+                        PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 5)
                 )))
                 //These are the items that aren't set to private
                 .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.hasItems(


### PR DESCRIPTION
Fix in PreAuthorize (making sure it's not ignored)

## References
* Fixes https://github.com/DSpace/DSpace/issues/3116

## Description
Items under embargo (not the bitstreams) are exposed via Discovery.
There's even an IT proving it's broken.

## Instructions for Reviewers
https://github.com/DSpace/DSpace/pull/3146/commits/7515fb2075201b2855e5059b7561ebbda75a1e9c solves:
* Discovery ignores the [PreAuthorize permissions check](https://github.com/DSpace/DSpace/blob/main/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ConverterService.java#L122) which should ensure the item cannot be returned, not even when it's embedded
And it proves it now works

https://github.com/DSpace/DSpace/pull/3146/commits/994062b69136911368639c6f6240c7c12cfd9186 solves:
* The [SolrServiceResourceRestrictionPlugin](https://github.com/DSpace/DSpace/blob/main/dspace-api/src/main/java/org/dspace/discovery/SolrServiceResourceRestrictionPlugin.java) doesn't check for dates on permissions, causing the embargoed items to be returned
And it proves it now works

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
