### PR TITLE
Ensure REST API version is prepended with "DSpace"

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/RootConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/RootConverter.java
@@ -28,7 +28,7 @@ public class RootConverter {
         rootRest.setDspaceName(configurationService.getProperty("dspace.name"));
         rootRest.setDspaceUI(configurationService.getProperty("dspace.ui.url"));
         rootRest.setDspaceServer(configurationService.getProperty("dspace.server.url"));
-        rootRest.setDspaceVersion(getSourceVersion());
+        rootRest.setDspaceVersion("DSpace " + getSourceVersion());
         return rootRest;
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/converter/RootConverterTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/converter/RootConverterTest.java
@@ -52,7 +52,7 @@ public class RootConverterTest {
         assertEquals("dspaceurl", rootRest.getDspaceUI());
         assertEquals("dspacename", rootRest.getDspaceName());
         assertEquals(restUrl, rootRest.getDspaceServer());
-        assertEquals(Util.getSourceVersion(), rootRest.getDspaceVersion());
+        assertEquals("DSpace " + Util.getSourceVersion(), rootRest.getDspaceVersion());
     }
 
     @Test


### PR DESCRIPTION
## Description
Tiny bug which ensures the root REST API returns a `dspaceVersion` property that starts with "DSpace".  

This is necessary to better align with https://github.com/DSpace/dspace-angular/pull/968 , as the Angular UI uses this `dspaceVersion` to populate the `<meta name="Generator">` tag, and we want that tag to report DSpace as the software product.

## Instructions for Reviewers
* Review the changes (includes modifying an IT to verify the change)
* If necessary, deploy and verify that the root path of the REST API has `dspaceVersion` property starting with "DSpace".
