### PR TITLE
Deeper membership don't work due to group2groupcache be out of sync

### DIFF
--- a/dspace-api/src/main/java/org/dspace/eperson/service/GroupService.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/service/GroupService.java
@@ -60,7 +60,9 @@ public interface GroupService extends DSpaceObjectService<Group>, DSpaceObjectLe
     public void addMember(Context context, Group group, EPerson e);
 
     /**
-     * add group to this group
+     * add group to this group. Be sure to call the {@link #update(Context, Group)}
+     * method once that all the membership are set to trigger the rebuild of the
+     * group2group cache table
      *
      * @param context     DSpace context object
      * @param groupParent parent group
@@ -80,7 +82,9 @@ public interface GroupService extends DSpaceObjectService<Group>, DSpaceObjectLe
 
 
     /**
-     * remove group from this group
+     * remove group from this group. Be sure to call the {@link #update(Context, Group)}
+     * method once that all the membership are set to trigger the rebuild of the
+     * group2group cache table
      *
      * @param context     DSpace context object
      * @param groupParent parent group

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/GroupRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/GroupRestController.java
@@ -95,7 +95,8 @@ public class GroupRestController {
         for (Group childGroup : childGroups) {
             groupService.addMember(context, parentGroup, childGroup);
         }
-
+        // this is required to trigger the rebuild of the group2group cache
+        groupService.update(context, parentGroup);
         context.complete();
 
         response.setStatus(SC_NO_CONTENT);
@@ -203,7 +204,8 @@ public class GroupRestController {
         }
 
         groupService.removeMember(context, parentGroup, childGroup);
-
+        // this is required to trigger the rebuild of the group2group cache
+        groupService.update(context, parentGroup);
         context.complete();
 
         response.setStatus(SC_NO_CONTENT);


### PR DESCRIPTION
## References
* Fixes #3130 

## Description
This PR improves the existing test to demonstrate the bug reported in #3130 and it subsequent fix

## Instructions for Reviewers
Please check the issue description if you want to reproduce the bug manually, otherwise review the added tests.

Please note that I made two separate commits so that the first one show how the enhanced tests fail
https://github.com/4Science/DSpace/runs/1873503683
and the second one show that the bug is fixed
https://github.com/4Science/DSpace/actions/runs/555451752

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
