### PR TITLE
Bitstream format retrieval for restricted files

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamFormatLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamFormatLinkRepository.java
@@ -34,7 +34,7 @@ public class BitstreamFormatLinkRepository extends AbstractDSpaceRestRepository
     @Autowired
     BitstreamService bitstreamService;
 
-    @PreAuthorize("hasPermission(#bitstreamId, 'BITSTREAM', 'READ')")
+    @PreAuthorize("hasPermission(#bitstreamId, 'BITSTREAM', 'METADATA_READ')")
     public BitstreamFormatRest getFormat(@Nullable HttpServletRequest request,
                                          UUID bitstreamId,
                                          @Nullable Pageable optionalPageable,

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
@@ -826,6 +826,7 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
     public void getBitstreamFormatUnauthorized() throws Exception {
 
         resourcePolicyService.removePolicies(context, bitstream, READ);
+        resourcePolicyService.removePolicies(context, bitstream.getBundles().get(0), READ);
 
         getClient()
                 .perform(get("/api/core/bitstreams/" + bitstream.getID() + "/format"))
@@ -836,6 +837,7 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
     public void getBitstreamFormatForbidden() throws Exception {
 
         resourcePolicyService.removePolicies(context, bitstream, READ);
+        resourcePolicyService.removePolicies(context, bitstream.getBundles().get(0), READ);
 
         getClient(getAuthToken(eperson.getEmail(), password))
                 .perform(get("/api/core/bitstreams/" + bitstream.getID() + "/format"))


### PR DESCRIPTION
## References
* Fixes #3090

## Description
We changed the permissions to retrieve the bitstream format from bitstream READ to METADATA_READ, this way the bitstreamformat can be read by the users who can access the file metadata

## Instructions for Reviewers
Create a restricted (or embargoed file) & check that the format can still be requested. After remove the read rights from the owning bundle, this should prevent users from requesting the format.


## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
