### PR TITLE
Fix ability to run partial migrations (i.e. ./dspace database migrate [version]) during PR testing

### DIFF
--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
@@ -201,14 +201,11 @@ public class DatabaseUtils {
                                 "You've specified to migrate your database ONLY to version " + migrationVersion + " " +
                                     "...");
                             System.out.println(
-                                "\nWARNING: It is highly likely you will see errors in your logs when the Metadata");
-                            System.out.println(
-                                "or Bitstream Format Registry auto-update. This is because you are attempting to");
-                            System.out.println(
-                                "use an OLD version " + migrationVersion + " Database with a newer DSpace API. NEVER " +
-                                    "do this in a");
-                            System.out.println(
-                                "PRODUCTION scenario. The resulting old DB is only useful for migration testing.\n");
+                                "\nWARNING: In this mode, we DISABLE all callbacks, which means that you will need " +
+                                    "to manually update registries and manually run a reindex. This is because you " +
+                                    "are attempting to use an OLD version (" + migrationVersion + ") Database with " +
+                                    "a newer DSpace API. NEVER do this in a PRODUCTION scenario. The resulting " +
+                                    "database is only useful for migration testing.\n");
 
                             System.out.print(
                                 "Are you SURE you only want to migrate your database to version " + migrationVersion
@@ -647,7 +644,7 @@ public class DatabaseUtils {
      * @param datasource    DataSource object (retrieved from DatabaseManager())
      * @param connection    Database connection
      * @param targetVersion If specified, only migrate the database to a particular *version* of DSpace. This is
-     *                      mostly just useful for testing.
+     *                      just useful for testing migrations, and should NOT be used in Production.
      *                      If null, the database is migrated to the latest version.
      * @param outOfOrder    If true, Flyway will run any lower version migrations that were previously "ignored".
      *                      If false, Flyway will only run new migrations with a higher version number.
@@ -661,6 +658,10 @@ public class DatabaseUtils {
             throw new SQLException("The datasource is a null reference -- cannot continue.");
         }
 
+        // Whether to reindex all content in Solr after successfully updating database
+        boolean reindexAfterUpdate = DSpaceServicesFactory.getInstance().getConfigurationService()
+                                                          .getBooleanProperty("discovery.autoReindex", true);
+
         try {
             // Setup Flyway API against our database
             FluentConfiguration flywayConfiguration = setupFlyway(datasource);
@@ -671,8 +672,14 @@ public class DatabaseUtils {
 
             // If a target version was specified, tell Flyway to ONLY migrate to that version
             // (i.e. all later migrations are left as "pending"). By default we always migrate to latest version.
+            // This mode is only useful for testing migrations & should NEVER be used in Production.
             if (!StringUtils.isBlank(targetVersion)) {
                 flywayConfiguration.target(targetVersion);
+                // Disable all callbacks. Most callbacks use the Context object which triggers a full database update,
+                // bypassing this target version.
+                flywayConfiguration.callbacks(new Callback[]{});
+                // Also disable reindex after update for this migration mode (as reindex also uses Context object)
+                reindexAfterUpdate = false;
             }
 
             // Initialized Flyway object (will be created by flywayConfiguration.load() below)
@@ -722,7 +729,7 @@ public class DatabaseUtils {
                 flyway.migrate();
 
                 // Flag that Discovery will need reindexing, since database was updated
-                setReindexDiscovery(true);
+                setReindexDiscovery(reindexAfterUpdate);
             } else {
                 log.info("DSpace database schema is up to date");
             }


### PR DESCRIPTION
## Description
In DSpace 6.x, it was possible to run `./dspace database migrate [version]` to test the Flyway migration process _up to_ a specific migration number.  For example, running `./dspace database migration 5.7.2017.05.05` would update an older 4.x database to 5.x compatibility, while skipping any later migrations.  This is because the last 5.x Flyway migration has a version number of `5.7.2017.05.05`.

This capability is NEVER to be used in Production scenarios (as you must run all migrations). But, it's extremely useful for developers testing individual Flyway migrations in PRs (as it allows you to also run migrations one-by-one, by specifying versions one by one in order).

This PR restores that capability.  It was accidentally broken recently (likely during the last Flyway upgrade) because the Context object is configured to now run *all migrations* when it initializes.  

Therefore, to restore this functionality, I have _disabled all Flyway callbacks & automatic reindexing_ whenever a `[version]` is passed to the `migrate` command, as this ensures a Context object is never called/initialized (this is because the Flyway migration process never needs/uses a Context, whereas Callbacks and reindexing both require a Context.)

I discovered this issue while testing the migration changes in #3144, but the issue is unrelated.


## Instructions for Reviewers
Review the code changes (they are very minor).

If desired, find an older database dump (5.x or older) and run `./dspace database migrate 6.1.2017.01.03`, which will make that database 6.x compatible, but leave _all 7.x migrations_ as "Pending".