### PR TITLE
Ensure HAL Browser is checking for CSRF token changes during error responses

### DIFF
--- a/dspace-server-webapp/src/main/webapp/js/hal/http/client.js
+++ b/dspace-server-webapp/src/main/webapp/js/hal/http/client.js
@@ -109,9 +109,11 @@ HAL.Http.Client.prototype.get = function(url) {
                 headers: jqXHR.getAllResponseHeaders()
             });
         },
-        error: function() {
-            self.vent.trigger('fail-response', { jqxhr: jqxhr });
-            var contentTypeResponseHeader = jqxhr.getResponseHeader("content-type");
+        error: function(jqXHR, textStatus, errorThrown) {
+            // Also check for updated token during errors. E.g. when a login failure occurs, token may be changed.
+            checkForUpdatedCSRFTokenInResponse(jqXHR);
+            self.vent.trigger('fail-response', { jqxhr: jqXHR });
+            var contentTypeResponseHeader = jqXHR.getResponseHeader("content-type");
             if (contentTypeResponseHeader != undefined
                     && !contentTypeResponseHeader.startsWith("application/hal")
                     && !contentTypeResponseHeader.startsWith("application/json")) {
@@ -135,6 +137,11 @@ HAL.Http.Client.prototype.request = function(opts) {
     // Also check response to see if CSRF Token has been updated
     opts.success = function(resource, textStatus, jqXHR) {
         checkForUpdatedCSRFTokenInResponse(jqXHR);
+    };
+
+    // Also check error responses to see if CSRF Token has been updated
+    opts.error = function(jqXHR, textStatus, errorThrown) {
+         checkForUpdatedCSRFTokenInResponse(jqXHR);
     };
 
     self.vent.trigger('location-change', { url: opts.url });

--- a/dspace-server-webapp/src/main/webapp/js/hal/http/client.js
+++ b/dspace-server-webapp/src/main/webapp/js/hal/http/client.js
@@ -92,7 +92,7 @@ function downloadFile(url) {
 HAL.Http.Client.prototype.get = function(url) {
     var self = this;
     this.vent.trigger('location-change', { url: url });
-    var jqxhr = $.ajax({
+    $.ajax({
         url: url,
         dataType: 'json',
         xhrFields: {
@@ -119,7 +119,8 @@ HAL.Http.Client.prototype.get = function(url) {
                     && !contentTypeResponseHeader.startsWith("application/json")) {
                 downloadFile(url);
             }
-        }});
+        }
+    });
 };
 
 HAL.Http.Client.prototype.request = function(opts) {

--- a/dspace-server-webapp/src/main/webapp/login.html
+++ b/dspace-server-webapp/src/main/webapp/login.html
@@ -73,11 +73,8 @@
         var successHandler = function(result, status, xhr) {
             // look for Authorization header & save to a MyHalBrowserToken cookie
             document.cookie = "MyHalBrowserToken=" + xhr.getResponseHeader('Authorization').split(" ")[1];
-            // look for DSpace-XSRF-TOKEN header & save to a MyHalBrowserCsrfToken cookie (if found)
-            var csrfToken = xhr.getResponseHeader('DSPACE-XSRF-TOKEN');
-            if (csrfToken!=null) {
-                document.cookie = "MyHalBrowserCsrfToken=" + csrfToken;
-            }
+            // Check for an update to the CSRF Token & save to a MyHalBrowserCsrfToken cookie (if found)
+            checkForUpdatedCSRFTokenInResponse(xhr);
             toastr.success('You are now logged in. Please wait while we redirect you...', 'Login Successful');
             setTimeout(function() {
                 window.location.href = window.location.pathname.replace("login.html", "");
@@ -112,9 +109,13 @@
                }
           },
           success : successHandler,
-          error : function(result, status, xhr) {
-              if (result.status === 401) {
-                  var authenticate = result.getResponseHeader("WWW-Authenticate");
+          error : function(xhr, textStatus, errorThrown) {
+              // Check for an update to the CSRF Token & save to a MyHalBrowserCsrfToken cookie (if found)
+              checkForUpdatedCSRFTokenInResponse(xhr);
+
+              // If 401 Unauthorized, check WWW-Authenticate for authentication options
+              if (xhr.status === 401) {
+                  var authenticate = xhr.getResponseHeader("WWW-Authenticate");
                   var element = $('div.other-login-methods');
                   if(authenticate !== null) {
                       var realms = authenticate.match(/(\w+ (\w+=((".*?")|[^,]*)(, )?)*)/g);
@@ -144,6 +145,18 @@
 
         function capitalizeFirstLetter(string) {
             return string.charAt(0).toUpperCase() + string.slice(1);
+        }
+
+       /**
+        * Check current response headers to see if the CSRF Token has changed. If a new value is found in headers,
+        * save the new value into our "MyHalBrowserCsrfToken" cookie.
+        **/
+        function checkForUpdatedCSRFTokenInResponse(jqxhr) {
+            // look for DSpace-XSRF-TOKEN header & save to our MyHalBrowserCsrfToken cookie (if found)
+            var updatedCsrfToken = jqxhr.getResponseHeader('DSPACE-XSRF-TOKEN');
+            if (updatedCsrfToken != null) {
+               document.cookie = "MyHalBrowserCsrfToken=" + updatedCsrfToken;
+            }
         }
 
        /**


### PR DESCRIPTION
## Description

This fixes a minor bug in the customizations of the HAL Browser shipped with DSpace. This first appeared after merging #3103 , as that PR updated the HAL Browser to support CSRF tokens.

However, in the prior PR, I forgot to ensure the HAL Browser _also_ checks for possible CSRF token updates/changes in **error responses**.  This occurs, for example, during an invalid login...the 401 response will also include an updated CSRF token.

This issue caused odd behavior in the HAL Browser, as CSRF validation would work fine until a login failure (or other error) occurred.  At that point, the CSRF token cached in the HAL Browser would be "out of sync" with the new one stored in the `DSPACE-XSRF-COOKIE`...so, validation would continually fail.

So, this PR just updates the existing code in the HAL Browser to ensure it checks for CSRF token changes both in success and error responses.  (There was also a minor correction to an `error()` methods params in `login.html`, as it listed the params in the wrong order per the JQuery docs at https://api.jquery.com/jQuery.ajax/)

## Instructions for Reviewers
Review the JQuery code changes.

Test the HAL Browser login.  Force an invalid authentication (by entering the wrong password).  Then try again and ensure the authentication succeeds.  

In Chrome DevTools, you should also see the `MyHalBrowseCsrfToken` cookie (where the client-side HAL Browser stores the token) and `DSPACE-XSRF-COOKIE` (where the server webapp stores the token) _synced at all times._  Previously, they were getting unsynced when an authentication error occurred.