### PR TITLE
Metadata field caching hibernate performance

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/MetadataFieldDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/MetadataFieldDAOImpl.java
@@ -8,8 +8,10 @@
 package org.dspace.content.dao.impl;
 
 import java.sql.SQLException;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import javax.persistence.Query;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
@@ -17,6 +19,7 @@ import javax.persistence.criteria.Join;
 import javax.persistence.criteria.Root;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.Logger;
 import org.dspace.content.MetadataField;
 import org.dspace.content.MetadataField_;
 import org.dspace.content.MetadataSchema;
@@ -24,6 +27,7 @@ import org.dspace.content.MetadataSchema_;
 import org.dspace.content.dao.MetadataFieldDAO;
 import org.dspace.core.AbstractHibernateDAO;
 import org.dspace.core.Context;
+import org.hibernate.Session;
 
 /**
  * Hibernate implementation of the Database Access Object interface class for the MetadataField object.
@@ -33,6 +37,13 @@ import org.dspace.core.Context;
  * @author kevinvandevelde at atmire.com
  */
 public class MetadataFieldDAOImpl extends AbstractHibernateDAO<MetadataField> implements MetadataFieldDAO {
+    /**
+     * log4j logger
+     */
+    private static Logger log = org.apache.logging.log4j.LogManager.getLogger(MetadataFieldDAOImpl.class);
+
+    private static Map<String, Integer> cachedFields = new HashMap();
+
     protected MetadataFieldDAOImpl() {
         super();
     }
@@ -79,6 +90,30 @@ public class MetadataFieldDAOImpl extends AbstractHibernateDAO<MetadataField> im
     @Override
     public MetadataField findByElement(Context context, String metadataSchema, String element, String qualifier)
         throws SQLException {
+        String key = metadataSchema + "." + element + "." + qualifier;
+        if (cachedFields.containsKey(key)) {
+            Session session = getHibernateSession(context);
+            MetadataField metadataField = null;
+            try {
+                metadataField = session.load(MetadataField.class, cachedFields.get(key));
+            } catch (Throwable e) {
+                log.error("Failed to load metadata field " + key + " using ID " + cachedFields.get(key));
+            }
+            try {
+                if (metadataField != null &&
+                        (metadataField.getMetadataSchema().getName() + "." + metadataField.getElement() +
+                                "." + metadataField.getQualifier()).equals(key)) {
+                    return metadataField;
+                } else {
+                    cachedFields.remove(key);
+                }
+            } catch (Throwable e) {
+                log.error("Failed to verify consistence of metadata field " + key +
+                        " using ID " + cachedFields.get(key));
+                cachedFields.clear();
+            }
+        }
+
         Query query;
 
         if (StringUtils.isNotBlank(qualifier)) {
@@ -103,7 +138,11 @@ public class MetadataFieldDAOImpl extends AbstractHibernateDAO<MetadataField> im
         }
         query.setHint("org.hibernate.cacheable", Boolean.TRUE);
 
-        return singleResult(query);
+        MetadataField metadataField = singleResult(query);
+        if (metadataField != null) {
+            cachedFields.put(key, metadataField.getID());
+        }
+        return metadataField;
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/MetadataFieldDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/MetadataFieldDAOImpl.java
@@ -42,6 +42,10 @@ public class MetadataFieldDAOImpl extends AbstractHibernateDAO<MetadataField> im
      */
     private static Logger log = org.apache.logging.log4j.LogManager.getLogger(MetadataFieldDAOImpl.class);
 
+    /**
+     * Cache for improvement the performance of searching metadata fields
+     * This cache only stores IDs, the actual MetadataField is retrieved from hibernate
+     */
     private static Map<String, Integer> cachedFields = new HashMap();
 
     protected MetadataFieldDAOImpl() {

--- a/dspace-api/src/test/java/org/dspace/content/MetadataFieldPerformanceTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/MetadataFieldPerformanceTest.java
@@ -43,7 +43,7 @@ public class MetadataFieldPerformanceTest extends AbstractUnitTest {
 
         long duration = (endTime - startTime);
 
-        double maxDurationPerCall = 0.02;
+        double maxDurationPerCall = 0.01;
         double maxDuration = maxDurationPerCall * amount;
         //Duration is 0.05798 without performance improvements
         //Duration is 0.0022 with performance improvements
@@ -74,7 +74,7 @@ public class MetadataFieldPerformanceTest extends AbstractUnitTest {
 
         long duration = (endTime - startTime);
 
-        double maxDurationPerCall = 1;
+        double maxDurationPerCall = .3;
         double maxDuration = maxDurationPerCall * amount;
         //Duration is 1.542 without performance improvements
         //Duration is 0.0538 with performance improvements

--- a/dspace-api/src/test/java/org/dspace/content/MetadataFieldPerformanceTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/MetadataFieldPerformanceTest.java
@@ -1,0 +1,98 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content;
+
+import java.sql.SQLException;
+
+import org.dspace.AbstractUnitTest;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.CollectionService;
+import org.dspace.content.service.CommunityService;
+import org.dspace.content.service.MetadataFieldService;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit Tests for Performance of class MetadataField
+ *
+ * @author ben @ atmire . com
+ */
+public class MetadataFieldPerformanceTest extends AbstractUnitTest {
+
+    private final MetadataFieldService metadataFieldService =
+            ContentServiceFactory.getInstance().getMetadataFieldService();
+    private final CommunityService communityService = ContentServiceFactory.getInstance().getCommunityService();
+    private final CollectionService collectionService = ContentServiceFactory.getInstance().getCollectionService();
+
+    @Test
+    public void testManyQueries() throws SQLException {
+
+        long startTime = System.currentTimeMillis();
+
+        int amount = 50000;
+        for (int i = 0; i < amount; i++) {
+            metadataFieldService.findByElement(context, "dc", "description", null);
+        }
+        long endTime = System.currentTimeMillis();
+
+        long duration = (endTime - startTime);
+
+        double maxDurationPerCall = 0.02;
+        double maxDuration = maxDurationPerCall * amount;
+        //Duration is 0.05798 without performance improvements
+        Assert.assertTrue("Duration (" + duration + ") should be smaller than " + maxDuration +
+                " for " + amount + " tests." +
+                " Max of " + maxDurationPerCall + " ms per operation exceeded: " +
+                (((double) (duration)) / amount) + " ms.", duration < maxDuration);
+    }
+
+    @Test
+    public void testManyMetadataAdds() throws SQLException, AuthorizeException {
+        context.turnOffAuthorisationSystem();
+        Community owningCommunity = communityService.create(null, context);
+        Collection collection = collectionService.create(context, owningCommunity);
+        //we need to commit the changes so we don't block the table for testing
+        context.restoreAuthSystemState();
+
+        long startTime = System.currentTimeMillis();
+
+        int amount = 5000;
+        for (int i = 0; i < amount; i++) {
+            collectionService.addMetadata(context, collection,
+                    "dc", "description", null, null, "Test " + i);
+            collectionService.clearMetadata(context, collection,
+                    "dc", "description", null, null);
+        }
+        long endTime = System.currentTimeMillis();
+
+        long duration = (endTime - startTime);
+
+        double maxDurationPerCall = 1;
+        double maxDuration = maxDurationPerCall * amount;
+        //Duration is 1.542 without performance improvements
+        Assert.assertTrue("Duration (" + duration + ") should be smaller than " + maxDuration +
+                " for " + amount + " tests." +
+                " Max of " + maxDurationPerCall + " ms per operation exceeded: " +
+                (((double) (duration)) / amount) + " ms.", duration < maxDuration);
+
+        context.turnOffAuthorisationSystem();
+        // Delete community & collection created in init()
+        try {
+            collectionService.delete(context, collection);
+        } catch (Exception e) {
+            // ignore
+        }
+        try {
+            communityService.delete(context, owningCommunity);
+        } catch (Exception e) {
+            // ignore
+        }
+        context.restoreAuthSystemState();
+    }
+}

--- a/dspace-api/src/test/java/org/dspace/content/MetadataFieldPerformanceTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/MetadataFieldPerformanceTest.java
@@ -46,6 +46,7 @@ public class MetadataFieldPerformanceTest extends AbstractUnitTest {
         double maxDurationPerCall = 0.02;
         double maxDuration = maxDurationPerCall * amount;
         //Duration is 0.05798 without performance improvements
+        //Duration is 0.0022 with performance improvements
         Assert.assertTrue("Duration (" + duration + ") should be smaller than " + maxDuration +
                 " for " + amount + " tests." +
                 " Max of " + maxDurationPerCall + " ms per operation exceeded: " +
@@ -76,6 +77,7 @@ public class MetadataFieldPerformanceTest extends AbstractUnitTest {
         double maxDurationPerCall = 1;
         double maxDuration = maxDurationPerCall * amount;
         //Duration is 1.542 without performance improvements
+        //Duration is 0.0538 with performance improvements
         Assert.assertTrue("Duration (" + duration + ") should be smaller than " + maxDuration +
                 " for " + amount + " tests." +
                 " Max of " + maxDurationPerCall + " ms per operation exceeded: " +

--- a/dspace-api/src/test/java/org/dspace/content/service/MetadataFieldServiceTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/service/MetadataFieldServiceTest.java
@@ -45,6 +45,22 @@ public class MetadataFieldServiceTest extends AbstractUnitTest {
                 metadataFieldService.findByElement(context, "dspace", "identifier", "issn")
         );
 
+        // The dspace.subject and dspace.identifier.issn metadatafields should now reference the 'dspace' metadataschema
+        assertEquals(
+                "dspace",
+                metadataFieldService
+                        .findByElement(context, "dspace", "subject", null)
+                        .getMetadataSchema()
+                        .getName()
+        );
+        assertEquals(
+                "dspace",
+                metadataFieldService
+                        .findByElement(context, "dspace", "identifier", "issn")
+                        .getMetadataSchema()
+                        .getName()
+        );
+
         // Metadatafields dc.subject and dc.identifier.issn should no longer be found
         assertNull(
                 metadataFieldService.findByElement(context, "dc", "subject", null)
@@ -65,6 +81,20 @@ public class MetadataFieldServiceTest extends AbstractUnitTest {
         assertEquals(
                 issnField,
                 metadataFieldService.findByElement(context, "dspace", "identifier", "issn")
+        );
+        assertEquals(
+                "dspace",
+                metadataFieldService
+                        .findByElement(context, "dspace", "subject", null)
+                        .getMetadataSchema()
+                        .getName()
+        );
+        assertEquals(
+                "dspace",
+                metadataFieldService
+                        .findByElement(context, "dspace", "identifier", "issn")
+                        .getMetadataSchema()
+                        .getName()
         );
         assertNull(
                 metadataFieldService.findByElement(context, "dc", "subject", null)

--- a/dspace-api/src/test/java/org/dspace/content/service/MetadataFieldServiceTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/service/MetadataFieldServiceTest.java
@@ -1,0 +1,76 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.dspace.AbstractUnitTest;
+import org.dspace.content.MetadataField;
+import org.dspace.content.MetadataSchema;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.core.Context;
+import org.junit.Test;
+
+public class MetadataFieldServiceTest extends AbstractUnitTest {
+
+    private MetadataFieldService metadataFieldService =
+            ContentServiceFactory.getInstance().getMetadataFieldService();
+    private MetadataSchemaService metadataSchemaService =
+            ContentServiceFactory.getInstance().getMetadataSchemaService();
+
+    @Test
+    public void testMetadataFieldCaching() throws Exception {
+
+        MetadataField subjectField = metadataFieldService.findByElement(context, "dc", "subject", null);
+        MetadataField issnField = metadataFieldService.findByElement(context, "dc", "identifier", "issn");
+
+        MetadataSchema dspaceSchema = metadataSchemaService.find(context, "dspace");
+
+        subjectField.setMetadataSchema(dspaceSchema);
+        issnField.setMetadataSchema(dspaceSchema);
+
+        // Searching for dspace.subject and dspace.identifier.issn should return the already stored metadatafields
+        assertEquals(
+                subjectField,
+                metadataFieldService.findByElement(context, "dspace", "subject", null)
+        );
+        assertEquals(
+                issnField,
+                metadataFieldService.findByElement(context, "dspace", "identifier", "issn")
+        );
+
+        // Metadatafields dc.subject and dc.identifier.issn should no longer be found
+        assertNull(
+                metadataFieldService.findByElement(context, "dc", "subject", null)
+        );
+        assertNull(
+                metadataFieldService.findByElement(context, "dc", "identifier", "issn")
+        );
+
+        // Same tests, new context
+
+        context.complete();
+        context = new Context();
+
+        assertEquals(
+                subjectField,
+                metadataFieldService.findByElement(context, "dspace", "subject", null)
+        );
+        assertEquals(
+                issnField,
+                metadataFieldService.findByElement(context, "dspace", "identifier", "issn")
+        );
+        assertNull(
+                metadataFieldService.findByElement(context, "dc", "subject", null)
+        );
+        assertNull(
+                metadataFieldService.findByElement(context, "dc", "identifier", "issn")
+        );
+    }
+}


### PR DESCRIPTION
## Description
We noticed the hibernate cache is not working well when searching for a metadata field. When using org.dspace.content.service.[MetadataFieldService#findByElement](https://github.com/DSpace/DSpace/blob/main/dspace-api/src/main/java/org/dspace/content/service/MetadataFieldService.java#L71)(org.dspace.core.Context, java.lang.String, java.lang.String, java.lang.String), a large amount of time is spent querying the database for the field

## Instructions for Reviewers
This is a very technical problem.
The hibernate implementation did use the level 2 hibernate cache. This is not the fastest cache, and does in fact still query the database.
This implementation will use the hibernate level 1 cache (when possible). This is done by storing the ID of the metadata field in a Java cache (only the ID), and retrieving the MetadataField from the hibernate cache (which is always up-to-date). This passes all tests, including the tests where new fields are made, all the flyway resets, …

I was able to use the GitHub runners to verify the current performance:
* https://github.com/atmire/DSpace/runs/1934911128#step:5:737 displays the duration of finding a metadata field is 0.06188 ms per operation
* https://github.com/atmire/DSpace/runs/1934911128#step:5:694 displays the duration of adding a metadata value is 1.5202 ms per operation

Hereafter I've included the actual performance improvement https://github.com/atmire/DSpace/commit/4f821ca417673067673c31160232bc53695611a0 :
* https://github.com/atmire/DSpace/runs/1934914170#step:5:692 simply succeeds, and complies to the max durations

Hereafter I've reduced the max duration to see how much faster it really is (no longer in a branch, just to check the amount)
* https://github.com/atmire/DSpace/runs/1934948108#step:5:737 displays the duration of finding a metadata field is now 0.0022 ms per operation => only 3.5% of the duration
* https://github.com/atmire/DSpace/runs/1934948108#step:5:898 displays the duration of adding a metadata value is now 0.0538 ms per operation => only 3.5% of the duration

I've now set the expected durations relatively midway the current master performance and the new performance, which is an expectancy margin of roughly a factor 5 on either side

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
