### PR TITLE
[DS-4575]  v.7 - Exposed more parameters for DBCP2

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -75,6 +75,7 @@ db.schema = public
 ## Database Connection pool parameters
 # DSpace wraps around the Apache Commons DBCP2 component, to read about its configuration
 # see: https://commons.apache.org/proper/commons-dbcp/configuration.html
+# look at DSPACE/config/spring/api/core-hibernate.xml for more options
 
 # Maximum number of active DB connections in pool (-1 = unlimited)
 # (default = 30)
@@ -100,7 +101,7 @@ db.initialsize = 0
 # (default = -1)
 db.maxconnlifetime = -1
 
-# Remove abandoned connections.
+# Remove abandoned connections. This is documented under "removeAbandonedOnBorrow" in DBCP2.
 # (default = false)
 db.removeabandoned = false
 

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -72,18 +72,41 @@ db.password = dspace
 #      so this may be set to ${db.username} in most scenarios.
 db.schema = public
 
-## Connection pool parameters
+## Database Connection pool parameters
+# DSpace wraps around the Apache Commons DBCP2 component, to read about its configuration
+# see: https://commons.apache.org/proper/commons-dbcp/configuration.html
 
-# Maximum number of DB connections in pool (default = 30)
+# Maximum number of active DB connections in pool (-1 = unlimited)
+# (default = 30)
 db.maxconnections = 30
 
-# Maximum time to wait before giving up if all connections in pool are busy (milliseconds)
+# Maximum time to wait before giving up if all connections in pool are busy (milliseconds), (-1 = unlimited)
 # (default = 5000ms or 5 seconds)
 db.maxwait = 5000
+
+# Minimum number of idle connections in pool
+# (default = 0)
+db.minidle = 0
 
 # Maximum number of idle connections in pool (-1 = unlimited)
 # (default = 10)
 db.maxidle = 10
+
+# The initial number of connections created when the pool is started
+# (default = 0)
+db.initialsize = 0
+
+# The maximum lifetime in milliseconds of a connection.  (-1 = unlimited)
+# (default = -1)
+db.maxconnlifetime = -1
+
+# Remove abandoned connections.
+# (default = false)
+db.removeabandoned = false
+
+# Remove abandoned timeout. Timeout in seconds before an abandoned connection can be removed.
+# (default = 300 or 5 minutes)
+db.removeabandonedtimeout = 300
 
 # Whether or not to allow for an entire 'clean' of the DSpace database.
 # By default, this setting is 'true', which ensures that the 'dspace database clean' command

--- a/dspace/config/spring/api/core-hibernate.xml
+++ b/dspace/config/spring/api/core-hibernate.xml
@@ -43,9 +43,14 @@
         <property name="url" value="${db.url}"/>
         <property name="username" value="${db.username}"/>
         <property name="password" value="${db.password}"/>
+        <property name="initialSize" value="${db.initialsize}"/>
         <property name="maxWaitMillis" value="${db.maxwait}"/>
         <property name="maxIdle" value="${db.maxidle}"/>
+        <property name="minIdle" value="${db.minidle}"/>
         <property name="maxTotal" value="${db.maxconnections}"/>
+        <property name="maxConnLifetimeMillis" value="${db.maxconnlifetime}"/>
+        <property name="removeAbandonedOnBorrow" value="${db.removeabandoned}"/>
+        <property name="removeAbandonedTimeout" value="${db.removeabandonedtimeout}"/>
     </bean>
 
 </beans>


### PR DESCRIPTION
Exposed more parameters for DBCP2 in the DSpace config.

Notably, maxConnLifeTime and removeAbandoned

See:

- #3070 
- #3080 
- #3164 

See also:
http://dspace.2283337.n4.nabble.com/Notes-on-PostgreSQL-connection-pooling-with-a-Tomcat-JNDI-resource-td4687149.html