### PR TITLE
Update IP-based security configurations to more sane defaults (now that CORS + CSRF are enabled)

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -523,8 +523,15 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <artifactId>mockito-inline</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <!-- Different version provided by hibernate-ehcache -->
+                <exclusion>
+                    <groupId>net.bytebuddy</groupId>
+                    <artifactId>byte-buddy</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
@@ -545,6 +552,11 @@
                 <exclusion>
                     <groupId>net.bytebuddy</groupId>
                     <artifactId>byte-buddy</artifactId>
+                </exclusion>
+                <!-- We use a later version of mockito -->
+                <exclusion>
+                    <groupId>org.mockito</groupId>
+                    <artifactId>mockito-core</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/dspace-api/src/main/java/org/dspace/core/Utils.java
+++ b/dspace-api/src/main/java/org/dspace/core/Utils.java
@@ -13,10 +13,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.math.BigInteger;
+import java.net.InetAddress;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.UnknownHostException;
 import java.rmi.dgc.VMID;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -452,6 +454,33 @@ public final class Utils {
             return null;
         }
     }
+
+    /**
+     * Retrieve the IP address(es) of a given URI string
+     * @param uriString URI string
+     * @return IP address(es) in a String array (or null if not found)
+     */
+    public static String[] getIPAddresses(String uriString) {
+        String[] ipAddresses = null;
+
+        // First, get the hostname
+        String hostname = getHostName(uriString);
+
+        if (StringUtils.isNotEmpty(hostname)) {
+            try {
+                // Then, get the list of all IPs for that hostname
+                InetAddress[] inetAddresses = InetAddress.getAllByName(hostname);
+
+                // Convert array of InetAddress objects to array of Strings by calling getHostAddress() for each
+                ipAddresses = Arrays.stream(inetAddresses).map(InetAddress::getHostAddress).toArray(String[]::new);
+            } catch (UnknownHostException ex) {
+                return null;
+            }
+        }
+
+        return ipAddresses;
+    }
+
 
     /**
      * Replaces configuration placeholders within a String with the corresponding value

--- a/dspace-api/src/main/java/org/dspace/core/Utils.java
+++ b/dspace-api/src/main/java/org/dspace/core/Utils.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.math.BigInteger;
+import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -456,7 +457,9 @@ public final class Utils {
     }
 
     /**
-     * Retrieve the IP address(es) of a given URI string
+     * Retrieve the IP address(es) of a given URI string.
+     * <P>
+     * At this time, DSpace only supports IPv4, so this method will only return IPv4 addresses.
      * @param uriString URI string
      * @return IP address(es) in a String array (or null if not found)
      */
@@ -471,8 +474,13 @@ public final class Utils {
                 // Then, get the list of all IPs for that hostname
                 InetAddress[] inetAddresses = InetAddress.getAllByName(hostname);
 
-                // Convert array of InetAddress objects to array of Strings by calling getHostAddress() for each
-                ipAddresses = Arrays.stream(inetAddresses).map(InetAddress::getHostAddress).toArray(String[]::new);
+                // Convert array of InetAddress objects to array of IP address Strings
+                ipAddresses = Arrays.stream(inetAddresses)
+                                    // Filter our array to ONLY include IPv4 addresses
+                                    .filter((address) -> address instanceof Inet4Address)
+                                    // Call getHostAddress() on each to get the IPv4 address as a string
+                                    .map((address) -> ((Inet4Address) address).getHostAddress())
+                                    .toArray(String[]::new);
             } catch (UnknownHostException ex) {
                 return null;
             }

--- a/dspace-api/src/main/java/org/dspace/service/impl/ClientInfoServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/service/impl/ClientInfoServiceImpl.java
@@ -11,6 +11,7 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.dspace.core.Utils;
 import org.dspace.service.ClientInfoService;
 import org.dspace.services.ConfigurationService;
 import org.dspace.statistics.util.IPTable;
@@ -41,8 +42,7 @@ public class ClientInfoServiceImpl implements ClientInfoService {
     @Autowired(required = true)
     public ClientInfoServiceImpl(ConfigurationService configurationService) {
         this.configurationService = configurationService;
-        this.trustedProxies = parseTrustedProxyRanges(
-                configurationService.getArrayProperty("proxies.trusted.ipranges"));
+        this.trustedProxies = parseTrustedProxyRanges();
     }
 
     @Override
@@ -74,40 +74,86 @@ public class ClientInfoServiceImpl implements ClientInfoService {
     public boolean isUseProxiesEnabled() {
         if (useProxiesEnabled == null) {
             useProxiesEnabled = configurationService.getBooleanProperty("useProxies", true);
-            log.info("useProxies=" + useProxiesEnabled);
+            log.info("Proxies (useProxies) enabled? " + useProxiesEnabled);
         }
 
         return useProxiesEnabled;
     }
 
-    private IPTable parseTrustedProxyRanges(String[] proxyProperty) {
-        if (ArrayUtils.isEmpty(proxyProperty)) {
-            return null;
-        } else {
-            //Load all supplied proxy IP ranges into the IP table
-            IPTable ipTable = new IPTable();
+    /**
+     * Parse / Determine trusted proxies based on configuration. "Trusted" proxies are the IP addresses from which we'll
+     * allow the X-FORWARDED-FOR header. We don't accept that header from any IP address, as the header could be used
+     * to spoof/fake your IP address.
+     * <P>
+     * If "proxies.trusted.ipranges" configuration is specified, we trust ONLY those IP addresses.
+     * <P>
+     * If "proxies.trusted.ipranges" is UNSPECIFIED, we only trust the IP address(es) associated with ${dspace.ui.url}.
+     * This is necessary to allow the Angular UI server-side rendering (SSR) to send us the X-FORWARDED-FOR header,
+     * which it usually uses to specify the original client IP address.
+     * @return IPTable of trusted IP addresses/ranges, or null if none could be found.
+     */
+    private IPTable parseTrustedProxyRanges() {
+        IPTable ipTable = null;
+        // Whether we had to look up the UI's IP address (based on its URL), or not
+        boolean uiUrlLookup = false;
+
+        String[] ipAddresses = configurationService.getArrayProperty("proxies.trusted.ipranges");
+        String uiUrl = configurationService.getProperty("dspace.ui.url");
+
+        // If configuration is empty, determine IPs of ${dspace.ui.url} as the default trusted proxy
+        if (ArrayUtils.isEmpty(ipAddresses)) {
+            // Get any IP address(es) associated with our UI
+            ipAddresses = Utils.getIPAddresses(uiUrl);
+            uiUrlLookup = true;
+        }
+
+        // Only continue if we have IPs to trust.
+        if (ArrayUtils.isNotEmpty(ipAddresses)) {
+            ipTable = new IPTable();
             try {
-                for (String proxyRange : proxyProperty) {
-                    ipTable.add(proxyRange);
+                // Load all IPs into our IP Table
+                for (String ipAddress : ipAddresses) {
+                    ipTable.add(ipAddress);
                 }
             } catch (IPTable.IPFormatException e) {
-                log.error("Property proxies.trusted.ipranges contains an invalid IP range", e);
+                if (uiUrlLookup) {
+                    log.error("IP address found for dspace.ui.url={} was invalid", uiUrl, e);
+                } else {
+                    log.error("Property 'proxies.trusted.ipranges' contains an invalid IP range", e);
+                }
                 ipTable = null;
             }
-
-            return ipTable;
         }
+
+        if (ipTable != null) {
+            log.info("Trusted proxy IP ranges/addresses: {}" + ipTable.toSet().toString());
+        }
+
+        return ipTable;
     }
 
+    /**
+     * Whether a request is from a trusted proxy or not. Only returns true if trusted proxies are specified
+     * and the ipAddress is contained in those proxies. False in all other cases
+     * @param ipAddress IP address to check for
+     * @return true if trusted, false otherwise
+     */
     private boolean isRequestFromTrustedProxy(String ipAddress) {
         try {
-            return trustedProxies == null || trustedProxies.contains(ipAddress);
+            return trustedProxies != null && trustedProxies.contains(ipAddress);
         } catch (IPTable.IPFormatException e) {
             log.error("Request contains invalid remote address", e);
             return false;
         }
     }
 
+    /**
+     * Get the first X-FORWARDED-FOR header value which does not match the IP or another proxy IP. This is the most
+     * likely client IP address when proxies are in use.
+     * @param remoteIp remote IP address
+     * @param xForwardedForValue X-FORWARDED-FOR header value passed by that address
+     * @return likely client IP address from X-FORWARDED-FOR header
+     */
     private String getXForwardedForIpValue(String remoteIp, String xForwardedForValue) {
         String ip = null;
 
@@ -119,9 +165,8 @@ public class ClientInfoServiceImpl implements ClientInfoService {
                not equal to the proxy
             */
             if (!StringUtils.equals(remoteIp, xfip) && StringUtils.isNotBlank(xfip)
-                    //if we have trusted proxies, we'll assume that they are not the client IP
-                    && (trustedProxies == null || !isRequestFromTrustedProxy(xfip))) {
-
+                    // if we have trusted proxies, we'll assume that they are not the client IP
+                    && !isRequestFromTrustedProxy(xfip)) {
                 ip = xfip.trim();
             }
         }

--- a/dspace-api/src/main/java/org/dspace/service/impl/ClientInfoServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/service/impl/ClientInfoServiceImpl.java
@@ -178,6 +178,7 @@ public class ClientInfoServiceImpl implements ClientInfoService {
         /* This header is a comma delimited list */
         String headerValue = StringUtils.trimToEmpty(xForwardedForValue);
         for (String xfip : headerValue.split(",")) {
+            xfip = xfip.trim();
             /* proxy itself will sometime populate this header with the same value in
                remote address. ordering in spec is vague, we'll just take the last
                not equal to the proxy
@@ -185,7 +186,7 @@ public class ClientInfoServiceImpl implements ClientInfoService {
             if (!StringUtils.equals(remoteIp, xfip) && StringUtils.isNotBlank(xfip)
                     // if we have trusted proxies, we'll assume that they are not the client IP
                     && !isRequestFromTrustedProxy(xfip)) {
-                ip = xfip.trim();
+                ip = xfip;
             }
         }
 

--- a/dspace-api/src/main/java/org/dspace/service/impl/ClientInfoServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/service/impl/ClientInfoServiceImpl.java
@@ -62,9 +62,8 @@ public class ClientInfoServiceImpl implements ClientInfoService {
             }
 
         } else if (StringUtils.isNotBlank(xForwardedForHeaderValue)) {
-            log.warn(
-                    "X-Forwarded-For header detected but useProxiesEnabled is not enabled. " +
-                            "If your dspace is behind a proxy set it to true");
+            log.warn("X-Forwarded-For header sent from client, but useProxies is not enabled. " +
+                         "To trust X-Forwarded-For headers, set useProxies=true.");
         }
 
         return ip;
@@ -126,7 +125,7 @@ public class ClientInfoServiceImpl implements ClientInfoService {
         }
 
         if (ipTable != null) {
-            log.info("Trusted proxy IP ranges/addresses: {}" + ipTable.toSet().toString());
+            log.info("Trusted proxies (configure via 'proxies.trusted.ipranges'): {}", ipTable.toSet().toString());
         }
 
         return ipTable;

--- a/dspace-api/src/main/java/org/dspace/service/impl/ClientInfoServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/service/impl/ClientInfoServiceImpl.java
@@ -7,7 +7,6 @@
  */
 package org.dspace.service.impl;
 
-import java.lang.reflect.Array;
 import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.lang3.ArrayUtils;

--- a/dspace-api/src/main/java/org/dspace/statistics/util/IPTable.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/util/IPTable.java
@@ -200,6 +200,13 @@ public class IPTable {
         return set;
     }
 
+    /**
+     * Return whether IPTable is empty (having no entries)
+     * @return true if empty, false otherwise
+     */
+    public boolean isEmpty() {
+        return map.isEmpty();
+    }
 
     /**
      * Exception Class to deal with IPFormat errors.

--- a/dspace-api/src/test/java/org/dspace/core/UtilsTest.java
+++ b/dspace-api/src/test/java/org/dspace/core/UtilsTest.java
@@ -7,13 +7,19 @@
  */
 package org.dspace.core;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mockStatic;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 
 import org.dspace.AbstractUnitTest;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.junit.Test;
+import org.mockito.MockedStatic;
 
 /**
  * Perform some basic unit tests for Utils Class
@@ -71,6 +77,31 @@ public class UtilsTest extends AbstractUnitTest {
 
         // This uses a bunch of reserved URI characters
         assertNull("Test invalid URI returns null", Utils.getHostName("&+,?/@="));
+    }
+
+    /**
+     * Test of getIPAddresses method, of class Utils
+     */
+    @Test
+    public void testGetIPAddresses() throws UnknownHostException {
+        // Fake a URL & two fake corresponding IP addresses as an InetAddress
+        String fakeUrl = "https://dspace.org";
+        String fakeHostname = "dspace.org";
+        InetAddress[] fakeInetAddresses =
+            new InetAddress[] { InetAddress.getByName("1.2.3.4"), InetAddress.getByName("5.6.7.8") };
+
+        // Mock responses from InetAddress
+        try (MockedStatic<InetAddress> mockedInetAddress = mockStatic(InetAddress.class)) {
+            // When fakeHostname is passed to InetAddress, return fakeInetAddresses
+            mockedInetAddress.when(() -> InetAddress.getAllByName(fakeHostname)).thenReturn(fakeInetAddresses);
+
+            assertNull("Test invalid URL returns null",
+                       Utils.getIPAddresses("not/a-real;url"));
+
+            assertArrayEquals("Test fake URL returns fake IPs converted to String Array",
+                              new String[] {"1.2.3.4", "5.6.7.8"},
+                              Utils.getIPAddresses(fakeUrl));
+        }
     }
 
     /**

--- a/dspace-api/src/test/java/org/dspace/service/impl/ClientInfoServiceImplTest.java
+++ b/dspace-api/src/test/java/org/dspace/service/impl/ClientInfoServiceImplTest.java
@@ -97,13 +97,13 @@ public class ClientInfoServiceImplTest extends AbstractDSpaceTest {
         clientInfoService = new ClientInfoServiceImpl(configurationService);
 
         String remoteIp = "1.2.3.4";
-        String xForwardedFor = "10.24.64.14,192.168.1.24";
+        String xForwardedFor = "10.24.64.14, 192.168.1.24";
 
         // Ensure first X-Forwarded-For value is returned
         assertEquals("10.24.64.14",
                 clientInfoService.getClientIp(remoteIp, xForwardedFor));
 
-        xForwardedFor = "192.168.1.24,10.24.64.14";
+        xForwardedFor = "192.168.1.24, 10.24.64.14";
 
         // Ensure second X-Forwarded-For value is returned (as first is listed as a trusted proxy & is ignored)
         assertEquals("10.24.64.14",

--- a/dspace-api/src/test/java/org/dspace/service/impl/ClientInfoServiceImplTest.java
+++ b/dspace-api/src/test/java/org/dspace/service/impl/ClientInfoServiceImplTest.java
@@ -42,29 +42,35 @@ public class ClientInfoServiceImplTest extends AbstractDSpaceTest {
     @Test
     public void getClientIpFromRequest() {
         configurationService.setProperty("useProxies", true);
-        configurationService.setProperty("proxies.trusted.ipranges", "127.0.0");
+        configurationService.setProperty("proxies.trusted.ipranges", "1.2.3");
 
         clientInfoService = new ClientInfoServiceImpl(configurationService);
 
         DummyHttpServletRequest req = new DummyHttpServletRequest();
-        req.setAddress("127.0.0.1");
+        req.setAddress("1.2.3.4");
         req.addHeader("X-Forwarded-For", "192.168.1.24");
 
+        // Ensure X-Forwarded-For trusted from an IP in that trusted range
         assertEquals("192.168.1.24", clientInfoService.getClientIp(req));
     }
 
     @Test
     public void getClientIpWithTrustedProxy() {
         configurationService.setProperty("useProxies", true);
-        configurationService.setProperty("proxies.trusted.ipranges", "127.0.0");
+        configurationService.setProperty("proxies.trusted.ipranges", "1.2.3");
 
         clientInfoService = new ClientInfoServiceImpl(configurationService);
 
-        String remoteIp = "127.0.0.1";
+        String remoteIp = "1.2.3.4";
         String xForwardedFor = "192.168.1.24";
 
+        // Ensure X-Forwarded-For trusted from an IP in that trusted range
         assertEquals("192.168.1.24",
                 clientInfoService.getClientIp(remoteIp, xForwardedFor));
+
+        // Ensure X-Forwarded-For also ALWAYS trusted from localhost
+        assertEquals("192.168.1.24",
+                     clientInfoService.getClientIp("127.0.0.1", xForwardedFor));
     }
 
 
@@ -78,6 +84,7 @@ public class ClientInfoServiceImplTest extends AbstractDSpaceTest {
         String remoteIp = "10.24.64.14";
         String xForwardedFor = "192.168.1.24";
 
+        // Ensure X-Forwarded-For value is NOT trusted & instead remote IP is used
         assertEquals("10.24.64.14",
                 clientInfoService.getClientIp(remoteIp, xForwardedFor));
     }
@@ -85,27 +92,30 @@ public class ClientInfoServiceImplTest extends AbstractDSpaceTest {
     @Test
     public void getClientIpWithMultipleTrustedProxies() {
         configurationService.setProperty("useProxies", true);
-        configurationService.setProperty("proxies.trusted.ipranges", "127.0.0,192.168.1");
+        configurationService.setProperty("proxies.trusted.ipranges", "1.2.3,192.168.1");
 
         clientInfoService = new ClientInfoServiceImpl(configurationService);
 
-        String remoteIp = "127.0.0.1";
+        String remoteIp = "1.2.3.4";
         String xForwardedFor = "10.24.64.14,192.168.1.24";
 
+        // Ensure first X-Forwarded-For value is returned
         assertEquals("10.24.64.14",
                 clientInfoService.getClientIp(remoteIp, xForwardedFor));
 
         xForwardedFor = "192.168.1.24,10.24.64.14";
 
+        // Ensure second X-Forwarded-For value is returned (as first is listed as a trusted proxy & is ignored)
         assertEquals("10.24.64.14",
                 clientInfoService.getClientIp(remoteIp, xForwardedFor));
     }
 
     @Test
-    public void getClientIpWithoutTrustedProxies() {
-        // Ensure proxies are on, but no trusted proxies defined
+    public void getClientIpWithoutTrustedProxiesAndTrustedUI() {
+        // Ensure proxies are on, but no trusted proxies defined & our UI is trusted
         configurationService.setProperty("useProxies", true);
         configurationService.setProperty("proxies.trusted.ipranges", "");
+        configurationService.setProperty("proxies.trusted.include_ui_ip", true);
 
         // Set a URL for our UI, and a fake IP address associated with that url
         String fakeUI_URL = "https://mydspace.edu/";
@@ -137,8 +147,43 @@ public class ClientInfoServiceImplTest extends AbstractDSpaceTest {
             assertEquals("10.24.64.14",
                          clientInfoServiceMock.getClientIp(fakeUI_IP, xForwardedFor));
 
-        }
+            // Ensure X-Forwarded-For also ALWAYS trusted from localhost
+            assertEquals("10.24.64.14",
+                         clientInfoServiceMock.getClientIp("127.0.0.1", xForwardedFor));
 
+        }
+    }
+
+    @Test
+    public void getClientIpWithoutTrustedProxiesAndUntrustedUI() {
+        // Ensure proxies are on, but no trusted proxies defined & our UI is trusted
+        configurationService.setProperty("useProxies", true);
+        configurationService.setProperty("proxies.trusted.ipranges", "");
+        configurationService.setProperty("proxies.trusted.include_ui_ip", false);
+
+        // Set a URL for our UI, and a fake IP address associated with that url
+        String fakeUI_URL = "https://mydspace.edu/";
+        String fakeUI_IP  = "1.2.3.4";
+        configurationService.setProperty("dspace.ui.url", fakeUI_URL);
+
+        try (MockedStatic<Utils> mockedUtils = mockStatic(Utils.class)) {
+            // Mock an IP address for mydspace.edu (have it return 1.2.3.4 as the IP address)
+            mockedUtils.when(() -> Utils.getIPAddresses(fakeUI_URL))
+                       .thenReturn(new String[]{fakeUI_IP});
+
+            ClientInfoService clientInfoServiceMock = new ClientInfoServiceImpl(configurationService);
+
+            // Define a fake X-FORWARDED-FOR value returned by our UI
+            String xForwardedFor = "10.24.64.14";
+
+            // UI is not trusted, so it's IP address is returned
+            assertEquals(fakeUI_IP,
+                         clientInfoServiceMock.getClientIp(fakeUI_IP, xForwardedFor));
+
+            // Ensure X-Forwarded-For also ALWAYS trusted from localhost
+            assertEquals("10.24.64.14",
+                         clientInfoServiceMock.getClientIp("127.0.0.1", xForwardedFor));
+        }
     }
 
     @Test

--- a/dspace-api/src/test/java/org/dspace/statistics/util/IPTableTest.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/util/IPTableTest.java
@@ -7,8 +7,11 @@
  */
 package org.dspace.statistics.util;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
+import java.util.Set;
 
 import org.dspace.statistics.util.IPTable.IPFormatException;
 import org.junit.After;
@@ -48,9 +51,47 @@ public class IPTableTest {
      * Test of add method, of class IPTable.
      * @throws java.lang.Exception passed through.
      */
-    @Ignore
     @Test
     public void testAdd() throws Exception {
+        IPTable instance = new IPTable();
+        // Add IP address
+        instance.add(LOCALHOST);
+        // Add IP range
+        instance.add("192.168.1");
+
+        // Make sure both exist
+        Set<String> ipSet = instance.toSet();
+        assertEquals(2, ipSet.size());
+        assertTrue(ipSet.contains(LOCALHOST));
+        assertTrue(ipSet.contains("192.168.1"));
+    }
+
+    @Test
+    public void testAddSameIPTwice() throws Exception {
+        IPTable instance = new IPTable();
+        // Add same IP twice
+        instance.add(LOCALHOST);
+        instance.add(LOCALHOST);
+        // Verify it only exists once
+        assertEquals(1, instance.toSet().size());
+
+        instance = new IPTable();
+        // Add IP range & then add an IP from within that range
+        instance.add("192.168.1");
+        instance.add("192.168.1.1");
+        // Verify only the range exists
+        Set<String> ipSet = instance.toSet();
+        assertEquals(1, ipSet.size());
+        assertTrue(ipSet.contains("192.168.1"));
+
+        instance = new IPTable();
+        // Now, switch order. Add IP address, then add a range encompassing that IP
+        instance.add("192.168.1.1");
+        instance.add("192.168.1");
+        // Verify only the range exists
+        ipSet = instance.toSet();
+        assertEquals(1, ipSet.size());
+        assertTrue(ipSet.contains("192.168.1"));
     }
 
     /**
@@ -72,6 +113,23 @@ public class IPTableTest {
 
         contains = instance.contains("fec0:0:0:1::2");
         assertFalse("IPv6 address should not match anything.", contains);
+
+        // Now test contains() finds an IP within a range of IPs
+        instance.add("192.168.1");
+        contains = instance.contains("192.168.1.1");
+        assertTrue("IP within an add()ed range should match", contains);
+    }
+
+    /**
+     * Test of isEmpty method, of class IPTable.
+     * @throws java.lang.Exception passed through.
+     */
+    @Test
+    public void testisEmpty() throws Exception {
+        IPTable instance = new IPTable();
+        assertTrue(instance.isEmpty());
+        instance.add(LOCALHOST);
+        assertFalse(instance.isEmpty());
     }
 
     /**

--- a/dspace-oai/pom.xml
+++ b/dspace-oai/pom.xml
@@ -210,7 +210,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <artifactId>mockito-inline</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/dspace-server-webapp/pom.xml
+++ b/dspace-server-webapp/pom.xml
@@ -443,7 +443,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <artifactId>mockito-inline</artifactId>
             <scope>test</scope>
         </dependency>
         <!-- Solr Core is needed for Integration Tests (to run a MockSolrServer)     -->

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/jwt/LoginJWTTokenHandler.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/jwt/LoginJWTTokenHandler.java
@@ -31,11 +31,6 @@ public class LoginJWTTokenHandler extends JWTTokenHandler {
     }
 
     @Override
-    protected String getTokenIncludeIPConfigurationKey() {
-        return "jwt.login.token.include.ip";
-    }
-
-    @Override
     protected String getEncryptionEnabledConfigurationKey() {
         return "jwt.login.encryption.enabled";
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/jwt/ShortLivedJWTTokenHandler.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/jwt/ShortLivedJWTTokenHandler.java
@@ -45,7 +45,7 @@ public class ShortLivedJWTTokenHandler extends JWTTokenHandler {
         if (ePerson == null || StringUtils.isBlank(ePerson.getSessionSalt())) {
             return false;
         } else {
-            JWSVerifier verifier = new MACVerifier(buildSigningKey(request, ePerson));
+            JWSVerifier verifier = new MACVerifier(buildSigningKey(ePerson));
 
             //If token is valid and not expired return eperson in token
             Date expirationTime = jwtClaimsSet.getExpirationTime();
@@ -80,11 +80,6 @@ public class ShortLivedJWTTokenHandler extends JWTTokenHandler {
     @Override
     protected String getTokenExpirationConfigurationKey() {
         return "jwt.shortLived.token.expiration";
-    }
-
-    @Override
-    protected String getTokenIncludeIPConfigurationKey() {
-        return "jwt.shortLived.token.include.ip";
     }
 
     @Override

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/AnonymousAdditionalAuthorizationFilterIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/AnonymousAdditionalAuthorizationFilterIT.java
@@ -82,13 +82,22 @@ public class AnonymousAdditionalAuthorizationFilterIT extends AbstractController
                    .andExpect(status().isUnauthorized());
 
         // Test that we can access the item using the IP that's configured for the Staff group
+        // (in our test environment's local.cfg)
+        getClient().perform(get("/api/core/items/" + staffAccessItem1.getID()).with(ip("5.5.5.5")))
+                   .andExpect(status().isOk());
+
+        // Test that we also can access the item using that same IP via a proxy
         getClient().perform(get("/api/core/items/" + staffAccessItem1.getID())
                                 .header("X-Forwarded-For", "5.5.5.5"))
                    .andExpect(status().isOk());
 
         // Test that we can't access the item using the IP that's configured for the Students group
+        getClient().perform(get("/api/core/items/" + staffAccessItem1.getID()).with(ip("6.6.6.6")))
+                   .andExpect(status().isUnauthorized());
+
+        // Test that we also can't also access the item using that same IP via a proxy
         getClient().perform(get("/api/core/items/" + staffAccessItem1.getID())
-                                .header("X-FORWARDED-FOR", "6.6.6.6"))
+                                .header("X-Forwarded-For", "6.6.6.6"))
                    .andExpect(status().isUnauthorized());
     }
 
@@ -103,11 +112,20 @@ public class AnonymousAdditionalAuthorizationFilterIT extends AbstractController
                    .andExpect(status().isUnauthorized());
 
         // Test that we can access the item using the IP that's configured for the Staff group
+        // (in our test environment's local.cfg)
+        getClient().perform(get("/api/core/items/" + staffAccessItem1.getID()).with(ip("5.5.5.5")))
+                   .andExpect(status().isOk());
+
+        // Test that we can also access the item using that same IP via a proxy
         getClient().perform(get("/api/core/items/" + staffAccessItem1.getID())
                                 .header("X-Forwarded-For", "5.5.5.5"))
                    .andExpect(status().isOk());
 
         // Test that we can't access the item using the IP that's configured for the Students group
+        getClient().perform(get("/api/core/items/" + staffAccessItem1.getID()).with(ip("6.6.6.6")))
+                   .andExpect(status().isUnauthorized());
+
+        // Test that we also can't also access the item using that same IP via a proxy
         getClient().perform(get("/api/core/items/" + staffAccessItem1.getID())
                                 .header("X-Forwarded-For", "6.6.6.6"))
                    .andExpect(status().isUnauthorized());

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/AuthenticationRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/AuthenticationRestControllerIT.java
@@ -451,7 +451,7 @@ public class AuthenticationRestControllerIT extends AbstractControllerIntegratio
     }
 
     @Test
-    // This test is verifying that Spring Security's CORS settings are working as we expect
+    // This test (and next) is verifying that Spring Security's CORS settings are working as we expect
     public void testCannotReuseTokenFromUntrustedOrigin() throws Exception {
         // First, get a valid login token
         String token = getAuthToken(eperson.getEmail(), password);
@@ -473,6 +473,17 @@ public class AuthenticationRestControllerIT extends AbstractControllerIntegratio
         //Logout
         getClient(token).perform(post("/api/authn/logout"))
                         .andExpect(status().isNoContent());
+    }
+
+    @Test
+    // This test (and previous) is verifying that Spring Security's CORS settings are working as we expect
+    public void testCannotAuthenticateFromUntrustedOrigin() throws Exception {
+        // Post a valid username & password from an *untrusted* Origin
+        getClient().perform(post("/api/authn/login").header("Origin", "https://example.org")
+                                .param("user", eperson.getEmail())
+                                .param("password", password))
+                   // should result in a 403 error as Spring Security returns that for untrusted origins
+                   .andExpect(status().isForbidden());
     }
 
     @Test

--- a/dspace-services/pom.xml
+++ b/dspace-services/pom.xml
@@ -109,7 +109,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <artifactId>mockito-inline</artifactId>
             <scope>test</scope>
         </dependency>
         <!-- SPECIAL CASE - need JUNIT at build time and testing time -->

--- a/dspace-services/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/dspace-services/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-inline

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -357,15 +357,19 @@ useProxies = true
 # If "useProxies" is enabled, the authentication and statistics logging code will read the X-Forwarded-For header in
 # order to determine the correct client IP address. But they will only use that header value when the request is coming
 # from a trusted proxy server location.
-# By default, ONLY requests from the IP address of ${dspace.ui.url} will be trusted. However, you can use this setting
-# to override that default and specify additional IP addresses (or ranges) whose X-Forwarded-For header values will
-# also be trusted.
+# By default, ONLY requests from localhost (127.0.0.1) will be trusted. However, you can use this setting to specify
+# additional IP addresses (or ranges) whose X-Forwarded-For header values will also be trusted.
 # You can specify a range by only listing the first three ip-address blocks, e.g. 128.177.243
 # You can list multiple IP addresses or ranges by comma-separating them.
-# WARNING: If you customize this setting, be sure to include the IP address of ${dspace.ui.url}, otherwise
-# authentication and other features may not work from the Angular UI.
 # (Requires reboot of servlet container, e.g. Tomcat, to reload)
 #proxies.trusted.ipranges = 127.0.0.1
+
+# Whether or not to automatically include the IP address of ${dspace.ui.url} in the list of trusted ip ranges.
+# This defaults to "true", as some features in the Angular UI (like authentication) require sending an X-Forwarded-For
+# header. Therefore, only disable this if you are not using the Angular UI, or you wish to specify its IP manually
+# in the "proxies.trusted.ipranges" configuration.
+# (Requires reboot of servlet container, e.g. Tomcat, to reload)
+#proxies.trusted.include_ui_ip = true
 
 # Spring Boot proxy configuration (can be set in local.cfg or in application.properties).
 # By default, Spring Boot does not automatically use X-Forwarded-* Headers when generating links (and similar) in the

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -348,21 +348,24 @@ http.proxy.host =
 # port number of proxy server
 http.proxy.port =
 
-# If enabled, the logging and the Solr statistics system will look for
-# an X-Forwarded-For header. If it finds it, it will use this for the user IP address
-# Note that server-side rendered Angular UI requests always present the X-Forwarded-For header
-# with the original client IP address.
+# If enabled, the logging and the Solr statistics system will look for an X-Forwarded-For header.
+# If it finds it, it will use this for the user IP address.
+# NOTE: This is required to be enabled if you plan to use the Angular UI, as the server-side rendering provided in
+# Angular always passes the original client IP Address to the REST API via the X-Forwarded-For header.
 useProxies = true
 
 # If "useProxies" is enabled, the authentication and statistics logging code will read the X-Forwarded-For header in
 # order to determine the correct client IP address. But they will only use that header value when the request is coming
-# from a trusted proxy server location (e.g. HTTPD on localhost). Leave this property empty to trust X-Forwarded-For
-# values of all requests. You can specify a range by only listing the first three ip-address blocks, e.g. 128.177.243
+# from a trusted proxy server location.
+# By default, ONLY requests from the IP address of ${dspace.ui.url} will be trusted. However, you can use this setting
+# to override that default and specify additional IP addresses (or ranges) whose X-Forwarded-For header values will
+# also be trusted.
+# You can specify a range by only listing the first three ip-address blocks, e.g. 128.177.243
 # You can list multiple IP addresses or ranges by comma-separating them.
-# If you are running REST & UI on different servers, you should add the UI servers (range) as a proxy.
-# For example : proxies.trusted.ipranges = 127.0.0.1, 192.168.2
-# This is necessary because Angular Universal will also behave as a proxy server.
-proxies.trusted.ipranges = 127.0.0.1
+# WARNING: If you customize this setting, be sure to include the IP address of ${dspace.ui.url}, otherwise
+# authentication and other features may not work from the Angular UI.
+# (Requires reboot of servlet container, e.g. Tomcat, to reload)
+#proxies.trusted.ipranges = 127.0.0.1
 
 # Spring Boot proxy configuration (can be set in local.cfg or in application.properties).
 # By default, Spring Boot does not automatically use X-Forwarded-* Headers when generating links (and similar) in the

--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -159,8 +159,9 @@ db.schema = public
 #######################
 # PROXY CONFIGURATION #
 #######################
-# uncomment and specify both properties if proxy server required
-# proxy server for external http requests - use regular hostname without port number
+# Uncomment and specify both properties if proxy server is required for external http requests
+# (e.g. requests from DSpace to third party services like Creative Commons use this setting when enabled)
+# Use regular hostname without port number
 #http.proxy.host =
 
 # port number of proxy server
@@ -196,6 +197,15 @@ db.schema = public
 # Enabled by default in authentication.cfg
 #plugin.sequence.org.dspace.authenticate.AuthenticationMethod = org.dspace.authenticate.PasswordAuthentication
 
+#####################
+# REST API SETTINGS #
+#####################
+# Allowed Cross-Origin-Resource-Sharing (CORS) origins (in "Access-Control-Allow-Origin" header).
+# Only these origins (client URLs) can successfully authenticate with your REST API.
+# Defaults to ${dspace.ui.url} if unspecified (as the UI must have access to the REST API).
+# Multiple allowed origin URLs may be comma separated. Wildcard value (*) is NOT SUPPORTED.
+# (Requires reboot of servlet container, e.g. Tomcat, to reload)
+#rest.cors.allowed-origins = ${dspace.ui.url}
 
 #################################################
 # SPRING BOOT SETTINGS (Used by Server Webapp)  #

--- a/dspace/config/modules/authentication.cfg
+++ b/dspace/config/modules/authentication.cfg
@@ -74,13 +74,6 @@ jwt.login.compression.enabled = true
 # Expiration time of a token in milliseconds
 jwt.login.token.expiration = 1800000
 
-# Restrict tokens to a specific ip-address to prevent theft/session hijacking. This is achieved by making the ip-address
-# a part of the JWT siging key. If this property is set to false then the ip-address won't be used as part of
-# the signing key of a jwt token and tokens can be shared over multiple ip-addresses.
-# For security reasons, this defaults to true
-jwt.login.token.include.ip = true
-
-
 #---------------------------------------------------------------#
 #---Stateless JWT Authentication for downloads of bitstreams----#
 #----------------------among other things-----------------------#
@@ -105,9 +98,3 @@ jwt.shortLived.compression.enabled = true
 
 # Expiration time of a token in milliseconds
 jwt.shortLived.token.expiration = 2000
-
-# Restrict tokens to a specific ip-address to prevent theft/session hijacking. This is achieved by making the ip-address
-# a part of the JWT siging key. If this property is set to false then the ip-address won't be used as part of
-# the signing key of a jwt token and tokens can be shared over multiple ip-addresses.
-# For security reasons, this defaults to true
-jwt.shortLived.token.include.ip = true

--- a/dspace/config/modules/rest.cfg
+++ b/dspace/config/modules/rest.cfg
@@ -3,7 +3,8 @@
 #---------------------------------------------------------------#
 # These configs are used by the RESTv7 module                   #
 #---------------------------------------------------------------#
-# Allowed CORS origins (in "Access-Control-Allow-Origin" header).
+# Allowed Cross-Origin-Resource-Sharing (CORS) origins (in "Access-Control-Allow-Origin" header).
+# Only these origins (client URLs) can successfully authenticate with your REST API.
 # Defaults to ${dspace.ui.url} if unspecified (as the UI must have access to the REST API).
 # Multiple allowed origin URLs may be comma separated. Wildcard value (*) is NOT SUPPORTED.
 # (Requires reboot of servlet container, e.g. Tomcat, to reload)

--- a/dspace/modules/additions/pom.xml
+++ b/dspace/modules/additions/pom.xml
@@ -295,7 +295,7 @@
       </dependency>
       <dependency>
          <groupId>org.mockito</groupId>
-         <artifactId>mockito-core</artifactId>
+         <artifactId>mockito-inline</artifactId>
          <scope>test</scope>
       </dependency>
 

--- a/dspace/modules/server/pom.xml
+++ b/dspace/modules/server/pom.xml
@@ -321,15 +321,8 @@ just adding new jar in the classloader</description>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <artifactId>mockito-inline</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <!-- Newer version is pulled in by hibernate-ehcache -->
-                <exclusion>
-                    <groupId>net.bytebuddy</groupId>
-                    <artifactId>byte-buddy</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.solr</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1174,9 +1174,14 @@
                         <groupId>org.junit.vintage</groupId>
                         <artifactId>junit-vintage-engine</artifactId>
                     </exclusion>
+                    <!-- We use a later version of Mockito -->
                     <exclusion>
                         <groupId>org.mockito</groupId>
                         <artifactId>mockito-junit-jupiter</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.mockito</groupId>
+                        <artifactId>mockito-core</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -1558,8 +1563,8 @@
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
-                <artifactId>mockito-core</artifactId>
-                <version>3.1.0</version>
+                <artifactId>mockito-inline</artifactId>
+                <version>3.8.0</version>
                 <scope>test</scope>
             </dependency>
             <!-- H2 is an in-memory database used for Unit/Integration tests -->


### PR DESCRIPTION
## References
* Fixes #2984  (by defaulting the `proxies.trusted.ipranges` setting to the IP address of `dspace.ui.url`, determined dynamically).  This change also fixes https://github.com/DSpace/dspace-angular/issues/1036
* Fixes #2938 (by removing `jwt.*.token.include.ip` settings)

## Description
This PR includes the following changes:
* `proxies.trusted.ipranges` - This setting has **now been commented out by default**.  When commented out, the ONLY trusted IP is localhost (127.0.0.1), and (possibly) the IP address of `dspace.ui.url` (see next configuration).  Therefore, this setting should ONLY be used or changed if you need to add additional trusted proxies.
* `proxies.trusted.include_ui_ip` - This is a **new configuration** which decides whether to automatically trust the UI as a proxy. When enabled (which is default), the backend determines the IP address of `dspace.ui.url` and adds it to the list of trusted proxies.
* `jwt.*.token.include.ip` - This setting has been **removed entirely**. These settings allowed you to store your IP address in your JWT auth token, therefore disabling token reuse across IP addresses.  However, this has the side-effect of forcing you to login again if your IP changes (and if you have a non-static IP, it's possible your IP could change during your session.
    * When authenticating via the Angular UI, your token is already protected by HTTPS + CORS + CSRF. 
        * Authentication is already blocked from untrustworthy origins by CORS.  See the new `testCannotAuthenticateFromUntrustedOrigin()` test to `AuthenticationRestControllerIT`, alongside the existing test `testCannotReuseTokenFromUntrustedOrigin()`.
        *  CSRF provides extra security here too, as to successfully perform authenticated actions, you must (1) be coming from a trusted origin and (2) have a valid JWT and (3) have a valid CSRF token.
    * When authenticating via the REST API (without a browser), CORS has little effect (as an Origin can be faked in that scenario)... However, you are still kept safe by HTTPS and CSRF.
* Building tests for the above changes required upgrading Mockito & switching to using `mockito-inline` in order to use the new support for [mocking static methods](https://javadoc.io/static/org.mockito/mockito-core/3.8.0/org/mockito/Mockito.html#static_mocks). 
* Finally, I copied the `rest.cors.allowed-origins` setting over into our `local.cfg.EXAMPLE` to make that setting more prominent.

## Instructions for Reviewers

* Review the code changes, including new/updated Tests
* Verify basic actions like authentication, editing, etc still work
* Optionally, test that https://github.com/DSpace/dspace-angular/issues/1036 is fixed.