### PR TITLE
Missing ITs for browse by authority values fix

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/authority/MetadataAuthorityServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/MetadataAuthorityServiceImpl.java
@@ -222,4 +222,13 @@ public class MetadataAuthorityServiceImpl implements MetadataAuthorityService {
         }
         return copy;
     }
+
+    @Override
+    public void clearCache() {
+        controlled.clear();
+        isAuthorityRequired.clear();
+        minConfidence.clear();
+
+        isAuthorityRequired = null;
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/content/authority/MetadataAuthorityServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/MetadataAuthorityServiceImpl.java
@@ -226,7 +226,6 @@ public class MetadataAuthorityServiceImpl implements MetadataAuthorityService {
     @Override
     public void clearCache() {
         controlled.clear();
-        isAuthorityRequired.clear();
         minConfidence.clear();
 
         isAuthorityRequired = null;

--- a/dspace-api/src/main/java/org/dspace/content/authority/service/MetadataAuthorityService.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/service/MetadataAuthorityService.java
@@ -112,4 +112,9 @@ public interface MetadataAuthorityService {
      * @return the list of metadata field with authority control
      */
     public List<String> getAuthorityMetadata();
+
+    /**
+     * This method has been created to have a way of clearing the cache kept inside the service
+     */
+    public void clearCache();
 }

--- a/dspace-api/src/test/java/org/dspace/AbstractIntegrationTestWithDatabase.java
+++ b/dspace-api/src/test/java/org/dspace/AbstractIntegrationTestWithDatabase.java
@@ -19,6 +19,7 @@ import org.dspace.authority.MockAuthoritySolrServiceImpl;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.builder.AbstractBuilder;
 import org.dspace.content.Community;
+import org.dspace.content.authority.MetadataAuthorityServiceImpl;
 import org.dspace.core.Context;
 import org.dspace.core.I18nUtil;
 import org.dspace.discovery.MockSolrSearchCore;
@@ -197,6 +198,8 @@ public class AbstractIntegrationTestWithDatabase extends AbstractDSpaceIntegrati
             // Reload our ConfigurationService (to reset configs to defaults again)
             DSpaceServicesFactory.getInstance().getConfigurationService().reloadConfig();
 
+            cleanupCache(serviceManager);
+
             AbstractBuilder.cleanupBuilderCache();
 
             // NOTE: we explicitly do NOT destroy our default eperson & admin as they
@@ -204,6 +207,16 @@ public class AbstractIntegrationTestWithDatabase extends AbstractDSpaceIntegrati
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * Clean up service caches after tests
+     * @param serviceManager
+     */
+    private void cleanupCache(ServiceManager serviceManager) {
+        MetadataAuthorityServiceImpl metadataAuthorityService = serviceManager
+            .getServiceByName(null, MetadataAuthorityServiceImpl.class);
+        metadataAuthorityService.clearCache();
     }
 
     /**

--- a/dspace-api/src/test/java/org/dspace/AbstractIntegrationTestWithDatabase.java
+++ b/dspace-api/src/test/java/org/dspace/AbstractIntegrationTestWithDatabase.java
@@ -19,7 +19,6 @@ import org.dspace.authority.MockAuthoritySolrServiceImpl;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.builder.AbstractBuilder;
 import org.dspace.content.Community;
-import org.dspace.content.authority.MetadataAuthorityServiceImpl;
 import org.dspace.core.Context;
 import org.dspace.core.I18nUtil;
 import org.dspace.discovery.MockSolrSearchCore;
@@ -198,8 +197,6 @@ public class AbstractIntegrationTestWithDatabase extends AbstractDSpaceIntegrati
             // Reload our ConfigurationService (to reset configs to defaults again)
             DSpaceServicesFactory.getInstance().getConfigurationService().reloadConfig();
 
-            cleanupCache(serviceManager);
-
             AbstractBuilder.cleanupBuilderCache();
 
             // NOTE: we explicitly do NOT destroy our default eperson & admin as they
@@ -207,16 +204,6 @@ public class AbstractIntegrationTestWithDatabase extends AbstractDSpaceIntegrati
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-    }
-
-    /**
-     * Clean up service caches after tests
-     * @param serviceManager
-     */
-    private void cleanupCache(ServiceManager serviceManager) {
-        MetadataAuthorityServiceImpl metadataAuthorityService = serviceManager
-            .getServiceByName(null, MetadataAuthorityServiceImpl.class);
-        metadataAuthorityService.clearCache();
     }
 
     /**

--- a/dspace-api/src/test/java/org/dspace/builder/AbstractDSpaceObjectBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/AbstractDSpaceObjectBuilder.java
@@ -83,6 +83,21 @@ public abstract class AbstractDSpaceObjectBuilder<T extends DSpaceObject>
         return (B) this;
     }
 
+    protected <B extends AbstractDSpaceObjectBuilder<T>> B addMetadataValue(final T dso, final String schema,
+                                                                            final String element,
+                                                                            final String qualifier,
+                                                                            final String language,
+                                                                            final String value,
+                                                                            final String authority,
+                                                                            final int confidence) {
+        try {
+            getService().addMetadata(context, dso, schema, element, qualifier, language, value, authority, confidence);
+        } catch (Exception e) {
+            return handleException(e);
+        }
+        return (B) this;
+    }
+
     protected <B extends AbstractDSpaceObjectBuilder<T>> B setMetadataSingleValue(final T dso, final String schema,
                                                                                   final String element,
                                                                                   final String qualifier,

--- a/dspace-api/src/test/java/org/dspace/builder/ItemBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/ItemBuilder.java
@@ -73,6 +73,10 @@ public class ItemBuilder extends AbstractDSpaceObjectBuilder<Item> {
     public ItemBuilder withAuthor(final String authorName) {
         return addMetadataValue(item, MetadataSchemaEnum.DC.getName(), "contributor", "author", authorName);
     }
+    public ItemBuilder withAuthor(final String authorName, final String authority, final int confidence) {
+        return addMetadataValue(item, MetadataSchemaEnum.DC.getName(), "contributor", "author",
+                                null, authorName, authority, confidence);
+    }
 
     public ItemBuilder withPersonIdentifierFirstName(final String personIdentifierFirstName) {
         return addMetadataValue(item, "person", "givenName", null, personIdentifierFirstName);

--- a/dspace-api/src/test/java/org/dspace/builder/ItemBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/ItemBuilder.java
@@ -86,6 +86,10 @@ public class ItemBuilder extends AbstractDSpaceObjectBuilder<Item> {
         return addMetadataValue(item, MetadataSchemaEnum.DC.getName(), "subject", null, subject);
     }
 
+    public ItemBuilder withSubject(final String subject, final String authority, final int confidence) {
+        return addMetadataValue(item, MetadataSchemaEnum.DC.getName(), "subject", null, null, subject, authority, confidence);
+    }
+
     public ItemBuilder withRelationshipType(final String relationshipType) {
         return addMetadataValue(item, "relationship", "type", null, relationshipType);
     }

--- a/dspace-api/src/test/java/org/dspace/builder/ItemBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/ItemBuilder.java
@@ -87,7 +87,8 @@ public class ItemBuilder extends AbstractDSpaceObjectBuilder<Item> {
     }
 
     public ItemBuilder withSubject(final String subject, final String authority, final int confidence) {
-        return addMetadataValue(item, MetadataSchemaEnum.DC.getName(), "subject", null, null, subject, authority, confidence);
+        return addMetadataValue(item, MetadataSchemaEnum.DC.getName(), "subject", null, null,
+                                subject, authority, confidence);
     }
 
     public ItemBuilder withRelationshipType(final String relationshipType) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/SearchFacetValueRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/SearchFacetValueRest.java
@@ -22,7 +22,6 @@ public class SearchFacetValueRest extends RestAddressableModel {
     @JsonIgnore
     private String filterValue;
     private long count;
-    @JsonIgnore
     private String authorityKey;
     @JsonIgnore
     private String sortValue;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BrowsesResourceControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BrowsesResourceControllerIT.java
@@ -225,9 +225,6 @@ public class BrowsesResourceControllerIT extends AbstractControllerIntegrationTe
 
     @Test
     public void findBrowseBySubjectEntriesWithAuthority() throws Exception {
-        String ogDcSubjectChoices = configurationService.getProperty("choices.plugin.dc.subject");
-        String ogDcSubjectAuthorityControlled = configurationService.getProperty("authority.controlled.dc.subject");
-
         configurationService.setProperty("choices.plugin.dc.subject",
                                          "SolrSubjectAuthority");
         configurationService.setProperty("authority.controlled.dc.subject",
@@ -326,14 +323,6 @@ public class BrowsesResourceControllerIT extends AbstractControllerIntegrationTe
                            )
                        )
                    );
-
-        // Clean up configuration for the following tests
-        configurationService.setProperty("choices.plugin.dc.subject",
-                                         ogDcSubjectChoices);
-        configurationService.setProperty("authority.controlled.dc.subject",
-                                         ogDcSubjectAuthorityControlled);
-
-        metadataAuthorityService.clearCache();
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BrowsesResourceControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BrowsesResourceControllerIT.java
@@ -250,24 +250,24 @@ public class BrowsesResourceControllerIT extends AbstractControllerIntegrationTe
                                       .withTitle("Public item 1")
                                       .withIssueDate("2017-10-17")
                                       .withAuthor("Smith, Donald").withAuthor("Doe, John")
-                                      .withSubject("ExtraEntry", "authority_1", 600)
+                                      .withSubject("History of religion", "VR110102", 600)
                                       .build();
 
         Item publicItem2 = ItemBuilder.createItem(context, col2)
                                       .withTitle("Public item 2")
                                       .withIssueDate("2016-02-13")
                                       .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
-                                      .withSubject("TestingForMore", "authority_2", 600)
-                                      .withSubject("ExtraEntry", "authority_1", 600)
+                                      .withSubject("Church studies", "VR110103", 600)
+                                      .withSubject("History of religion", "VR110102", 600)
                                       .build();
 
         Item publicItem3 = ItemBuilder.createItem(context, col2)
                                       .withTitle("Public item 2")
                                       .withIssueDate("2016-02-13")
                                       .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
-                                      .withSubject("AnotherTest", "authority_3", 600)
-                                      .withSubject("TestingForMore", "authority_2", 600)
-                                      .withSubject("ExtraEntry", "authority_1", 600)
+                                      .withSubject("Missionary studies", "VR110104", 600)
+                                      .withSubject("Church studies", "VR110103", 600)
+                                      .withSubject("History of religion", "VR110102", 600)
                                       .build();
 
         context.restoreAuthSystemState();
@@ -290,9 +290,9 @@ public class BrowsesResourceControllerIT extends AbstractControllerIntegrationTe
                    //Check that the subject matches as expected
                    //Verify that they're sorted alphabetically
                    .andExpect(jsonPath("$._embedded.entries",
-                                       contains(BrowseEntryResourceMatcher.matchBrowseEntry("AnotherTest", "authority_3", 1),
-                                                BrowseEntryResourceMatcher.matchBrowseEntry("ExtraEntry", "authority_1", 3),
-                                                BrowseEntryResourceMatcher.matchBrowseEntry("TestingForMore", "authority_2", 2)
+                                       containsInAnyOrder(BrowseEntryResourceMatcher.matchBrowseEntry("Missionary studies", "VR110104", 1),
+                                                BrowseEntryResourceMatcher.matchBrowseEntry("History of religion", "VR110102", 3),
+                                                BrowseEntryResourceMatcher.matchBrowseEntry("Church studies", "VR110103", 2)
                                        )));
 
         getClient().perform(get("/api/discover/browses/subject/entries")
@@ -311,9 +311,9 @@ public class BrowsesResourceControllerIT extends AbstractControllerIntegrationTe
                    //Check that the subject matches as expected
                    //Verify that they're sorted alphabetically
                    .andExpect(jsonPath("$._embedded.entries",
-                                       contains(BrowseEntryResourceMatcher.matchBrowseEntry("AnotherTest", "authority_3", 1),
-                                                BrowseEntryResourceMatcher.matchBrowseEntry("ExtraEntry", "authority_1", 3),
-                                                BrowseEntryResourceMatcher.matchBrowseEntry("TestingForMore", "authority_2", 2)
+                                       containsInAnyOrder(BrowseEntryResourceMatcher.matchBrowseEntry("Missionary studies", "VR110104", 1),
+                                                BrowseEntryResourceMatcher.matchBrowseEntry("History of religion", "VR110102", 3),
+                                                BrowseEntryResourceMatcher.matchBrowseEntry("Church studies", "VR110103", 2)
                                        )));
     }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BrowsesResourceControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BrowsesResourceControllerIT.java
@@ -225,6 +225,9 @@ public class BrowsesResourceControllerIT extends AbstractControllerIntegrationTe
 
     @Test
     public void findBrowseBySubjectEntriesWithAuthority() throws Exception {
+        String ogDcSubjectChoices = configurationService.getProperty("choices.plugin.dc.subject");
+        String ogDcSubjectAuthorityControlled = configurationService.getProperty("authority.controlled.dc.subject");
+
         configurationService.setProperty("choices.plugin.dc.subject",
                                          "SolrSubjectAuthority");
         configurationService.setProperty("authority.controlled.dc.subject",
@@ -318,11 +321,19 @@ public class BrowsesResourceControllerIT extends AbstractControllerIntegrationTe
                        jsonPath("$._embedded.entries",
                            containsInAnyOrder(
                                BrowseEntryResourceMatcher.matchBrowseEntry("Missionary studies", "VR110104", 1),
-                                BrowseEntryResourceMatcher.matchBrowseEntry("History of religion", "VR110102", 3),
-                                BrowseEntryResourceMatcher.matchBrowseEntry("Church studies", "VR110103", 2)
+                               BrowseEntryResourceMatcher.matchBrowseEntry("History of religion", "VR110102", 3),
+                               BrowseEntryResourceMatcher.matchBrowseEntry("Church studies", "VR110103", 2)
                            )
                        )
                    );
+
+        // Clean up configuration for the following tests
+        configurationService.setProperty("choices.plugin.dc.subject",
+                                         ogDcSubjectChoices);
+        configurationService.setProperty("authority.controlled.dc.subject",
+                                         ogDcSubjectAuthorityControlled);
+
+        metadataAuthorityService.clearCache();
     }
 
     @Test
@@ -1231,6 +1242,4 @@ public class BrowsesResourceControllerIT extends AbstractControllerIntegrationTe
                              .andExpect(jsonPath("$._embedded.items[0]._embedded.owningCollection._embedded.adminGroup",
                                                  nullValue()));
     }
-
-
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BrowsesResourceControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BrowsesResourceControllerIT.java
@@ -289,11 +289,15 @@ public class BrowsesResourceControllerIT extends AbstractControllerIntegrationTe
                    //Check the embedded resources and that they're sorted alphabetically
                    //Check that the subject matches as expected
                    //Verify that they're sorted alphabetically
-                   .andExpect(jsonPath("$._embedded.entries",
-                                       containsInAnyOrder(BrowseEntryResourceMatcher.matchBrowseEntry("Missionary studies", "VR110104", 1),
-                                                BrowseEntryResourceMatcher.matchBrowseEntry("History of religion", "VR110102", 3),
-                                                BrowseEntryResourceMatcher.matchBrowseEntry("Church studies", "VR110103", 2)
-                                       )));
+                   .andExpect(
+                       jsonPath("$._embedded.entries",
+                            containsInAnyOrder(
+                                BrowseEntryResourceMatcher.matchBrowseEntry("Missionary studies", "VR110104", 1),
+                                BrowseEntryResourceMatcher.matchBrowseEntry("History of religion", "VR110102", 3),
+                                BrowseEntryResourceMatcher.matchBrowseEntry("Church studies", "VR110103", 2)
+                            )
+                       )
+                   );
 
         getClient().perform(get("/api/discover/browses/subject/entries")
                                 .param("sort", "value,desc"))
@@ -310,11 +314,15 @@ public class BrowsesResourceControllerIT extends AbstractControllerIntegrationTe
                    //Check the embedded resources and that they're sorted alphabetically
                    //Check that the subject matches as expected
                    //Verify that they're sorted alphabetically
-                   .andExpect(jsonPath("$._embedded.entries",
-                                       containsInAnyOrder(BrowseEntryResourceMatcher.matchBrowseEntry("Missionary studies", "VR110104", 1),
-                                                BrowseEntryResourceMatcher.matchBrowseEntry("History of religion", "VR110102", 3),
-                                                BrowseEntryResourceMatcher.matchBrowseEntry("Church studies", "VR110103", 2)
-                                       )));
+                   .andExpect(
+                       jsonPath("$._embedded.entries",
+                           containsInAnyOrder(
+                               BrowseEntryResourceMatcher.matchBrowseEntry("Missionary studies", "VR110104", 1),
+                                BrowseEntryResourceMatcher.matchBrowseEntry("History of religion", "VR110102", 3),
+                                BrowseEntryResourceMatcher.matchBrowseEntry("Church studies", "VR110103", 2)
+                           )
+                       )
+                   );
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BrowsesResourceControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BrowsesResourceControllerIT.java
@@ -291,10 +291,10 @@ public class BrowsesResourceControllerIT extends AbstractControllerIntegrationTe
                    //Verify that they're sorted alphabetically
                    .andExpect(
                        jsonPath("$._embedded.entries",
-                            containsInAnyOrder(
-                                BrowseEntryResourceMatcher.matchBrowseEntry("Missionary studies", "VR110104", 1),
+                            contains(
+                                BrowseEntryResourceMatcher.matchBrowseEntry("Church studies", "VR110103", 2),
                                 BrowseEntryResourceMatcher.matchBrowseEntry("History of religion", "VR110102", 3),
-                                BrowseEntryResourceMatcher.matchBrowseEntry("Church studies", "VR110103", 2)
+                                BrowseEntryResourceMatcher.matchBrowseEntry("Missionary studies", "VR110104", 1)
                             )
                        )
                    );
@@ -313,10 +313,10 @@ public class BrowsesResourceControllerIT extends AbstractControllerIntegrationTe
                    .andExpect(jsonPath("$.page.totalElements", is(3)))
                    //Check the embedded resources and that they're sorted alphabetically
                    //Check that the subject matches as expected
-                   //Verify that they're sorted alphabetically
+                   //Verify that they're sorted alphabetically descending
                    .andExpect(
                        jsonPath("$._embedded.entries",
-                           containsInAnyOrder(
+                           contains(
                                BrowseEntryResourceMatcher.matchBrowseEntry("Missionary studies", "VR110104", 1),
                                BrowseEntryResourceMatcher.matchBrowseEntry("History of religion", "VR110102", 3),
                                BrowseEntryResourceMatcher.matchBrowseEntry("Church studies", "VR110103", 2)

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BrowsesResourceControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BrowsesResourceControllerIT.java
@@ -34,6 +34,7 @@ import org.dspace.content.Item;
 import org.dspace.content.authority.service.MetadataAuthorityService;
 import org.dspace.eperson.Group;
 import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -323,6 +324,10 @@ public class BrowsesResourceControllerIT extends AbstractControllerIntegrationTe
                            )
                        )
                    );
+        DSpaceServicesFactory.getInstance().getConfigurationService().reloadConfig();
+
+        metadataAuthorityService.clearCache();
+
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BrowsesResourceControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BrowsesResourceControllerIT.java
@@ -31,9 +31,12 @@ import org.dspace.builder.ItemBuilder;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.Item;
+import org.dspace.content.authority.service.MetadataAuthorityService;
 import org.dspace.eperson.Group;
+import org.dspace.services.ConfigurationService;
 import org.hamcrest.Matchers;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
 /**
@@ -44,6 +47,11 @@ import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
  * @author Tom Desair (tom dot desair at atmire dot com)
  */
 public class BrowsesResourceControllerIT extends AbstractControllerIntegrationTest {
+    @Autowired
+    ConfigurationService configurationService;
+
+    @Autowired
+    MetadataAuthorityService metadataAuthorityService;
 
     @Test
     public void findAll() throws Exception {
@@ -212,6 +220,100 @@ public class BrowsesResourceControllerIT extends AbstractControllerIntegrationTe
                                        contains(BrowseEntryResourceMatcher.matchBrowseEntry("TestingForMore", 2),
                                                 BrowseEntryResourceMatcher.matchBrowseEntry("ExtraEntry", 3),
                                                 BrowseEntryResourceMatcher.matchBrowseEntry("AnotherTest", 1)
+                                       )));
+    }
+
+    @Test
+    public void findBrowseBySubjectEntriesWithAuthority() throws Exception {
+        configurationService.setProperty("choices.plugin.dc.subject",
+                                         "SolrSubjectAuthority");
+        configurationService.setProperty("authority.controlled.dc.subject",
+                                         "true");
+
+        metadataAuthorityService.clearCache();
+
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+        //1. A community-collection structure with one parent community with sub-community and two collections.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community")
+                                           .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+        Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
+
+        //2. Three public items that are readable by Anonymous with different subjects
+        Item publicItem1 = ItemBuilder.createItem(context, col1)
+                                      .withTitle("Public item 1")
+                                      .withIssueDate("2017-10-17")
+                                      .withAuthor("Smith, Donald").withAuthor("Doe, John")
+                                      .withSubject("ExtraEntry", "authority_1", 600)
+                                      .build();
+
+        Item publicItem2 = ItemBuilder.createItem(context, col2)
+                                      .withTitle("Public item 2")
+                                      .withIssueDate("2016-02-13")
+                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
+                                      .withSubject("TestingForMore", "authority_2", 600)
+                                      .withSubject("ExtraEntry", "authority_1", 600)
+                                      .build();
+
+        Item publicItem3 = ItemBuilder.createItem(context, col2)
+                                      .withTitle("Public item 2")
+                                      .withIssueDate("2016-02-13")
+                                      .withAuthor("Smith, Maria").withAuthor("Doe, Jane")
+                                      .withSubject("AnotherTest", "authority_3", 600)
+                                      .withSubject("TestingForMore", "authority_2", 600)
+                                      .withSubject("ExtraEntry", "authority_1", 600)
+                                      .build();
+
+        context.restoreAuthSystemState();
+
+        //** WHEN **
+        //An anonymous user browses this endpoint to find which subjects are currently in the repository
+        getClient().perform(get("/api/discover/browses/subject/entries")
+                                .param("projection", "full"))
+
+                   //** THEN **
+                   //The status has to be 200
+                   .andExpect(status().isOk())
+
+                   //We expect the content type to be "application/hal+json;charset=UTF-8"
+                   .andExpect(content().contentType(contentType))
+                   .andExpect(jsonPath("$.page.size", is(20)))
+                   //Check that there are indeed 3 different subjects
+                   .andExpect(jsonPath("$.page.totalElements", is(3)))
+                   //Check the embedded resources and that they're sorted alphabetically
+                   //Check that the subject matches as expected
+                   //Verify that they're sorted alphabetically
+                   .andExpect(jsonPath("$._embedded.entries",
+                                       contains(BrowseEntryResourceMatcher.matchBrowseEntry("AnotherTest", "authority_3", 1),
+                                                BrowseEntryResourceMatcher.matchBrowseEntry("ExtraEntry", "authority_1", 3),
+                                                BrowseEntryResourceMatcher.matchBrowseEntry("TestingForMore", "authority_2", 2)
+                                       )));
+
+        getClient().perform(get("/api/discover/browses/subject/entries")
+                                .param("sort", "value,desc"))
+
+                   //** THEN **
+                   //The status has to be 200
+                   .andExpect(status().isOk())
+                   .andDo(MockMvcResultHandlers.print())
+                   //We expect the content type to be "application/hal+json;charset=UTF-8"
+                   .andExpect(content().contentType(contentType))
+                   .andExpect(jsonPath("$.page.size", is(20)))
+                   //Check that there are indeed 3 different subjects
+                   .andExpect(jsonPath("$.page.totalElements", is(3)))
+                   //Check the embedded resources and that they're sorted alphabetically
+                   //Check that the subject matches as expected
+                   //Verify that they're sorted alphabetically
+                   .andExpect(jsonPath("$._embedded.entries",
+                                       contains(BrowseEntryResourceMatcher.matchBrowseEntry("AnotherTest", "authority_3", 1),
+                                                BrowseEntryResourceMatcher.matchBrowseEntry("ExtraEntry", "authority_1", 3),
+                                                BrowseEntryResourceMatcher.matchBrowseEntry("TestingForMore", "authority_2", 2)
                                        )));
     }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -188,6 +188,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
 
     @Test
     public void discoverFacetsAuthorWithAuthorityWithSizeParameter() throws Exception {
+        String ogDcSubjectChoices = configurationService.getProperty("choices.plugin.dc.subject");
+        String ogDcSubjectAuthorityControlled = configurationService.getProperty("authority.controlled.dc.subject");
+
         configurationService.setProperty("choices.plugin.dc.subject",
                                          "SolrSubjectAuthority");
         configurationService.setProperty("authority.controlled.dc.subject",
@@ -270,8 +273,15 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                    .andExpect(jsonPath("$._embedded.values", containsInAnyOrder(
                        FacetValueMatcher.entrySubject("History of religion", 3),
                        FacetValueMatcher.entrySubject("Church studies", 2)
-                   )))
-        ;
+                   )));
+
+        // Clean up configuration for the following tests
+        configurationService.setProperty("choices.plugin.dc.subject",
+                                         ogDcSubjectChoices);
+        configurationService.setProperty("authority.controlled.dc.subject",
+                                         ogDcSubjectAuthorityControlled);
+
+        metadataAuthorityService.clearCache();
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -55,6 +55,7 @@ import org.dspace.content.authority.service.MetadataAuthorityService;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
 import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.xmlworkflow.storedcomponents.ClaimedTask;
 import org.dspace.xmlworkflow.storedcomponents.XmlWorkflowItem;
 import org.hamcrest.Matchers;
@@ -277,6 +278,11 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                        FacetValueMatcher.entryAuthorWithAuthority("Doe, Jane", "test_authority_4", 2),
                        FacetValueMatcher.entryAuthorWithAuthority("Smith, Maria", "test_authority_3", 2)
                    )));
+
+        DSpaceServicesFactory.getInstance().getConfigurationService().reloadConfig();
+
+        metadataAuthorityService.clearCache();
+
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -188,9 +188,6 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
 
     @Test
     public void discoverFacetsAuthorWithAuthorityWithSizeParameter() throws Exception {
-        String ogDcSubjectChoices = configurationService.getProperty("choices.plugin.dc.subject");
-        String ogDcSubjectAuthorityControlled = configurationService.getProperty("authority.controlled.dc.subject");
-
         configurationService.setProperty("choices.plugin.dc.subject",
                                          "SolrSubjectAuthority");
         configurationService.setProperty("authority.controlled.dc.subject",
@@ -271,17 +268,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                    // up in different items
                    //These subjects are the most used ones. Only two show up because of the size.
                    .andExpect(jsonPath("$._embedded.values", containsInAnyOrder(
-                       FacetValueMatcher.entrySubject("History of religion", 3),
-                       FacetValueMatcher.entrySubject("Church studies", 2)
+                       FacetValueMatcher.entrySubject("History of religion", "VR110102", 3),
+                       FacetValueMatcher.entrySubject("Church studies", "VR110103", 2)
                    )));
-
-        // Clean up configuration for the following tests
-        configurationService.setProperty("choices.plugin.dc.subject",
-                                         ogDcSubjectChoices);
-        configurationService.setProperty("authority.controlled.dc.subject",
-                                         ogDcSubjectAuthorityControlled);
-
-        metadataAuthorityService.clearCache();
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -215,7 +215,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                                       .withIssueDate("2017-10-17")
                                       .withAuthor("Smith, Donald")
                                       .withAuthor("Doe, John")
-                                      .withSubject("ExtraEntry", "authority_1", 600)
+                                      .withSubject("History of religion", "VR110102", 600)
                                       .build();
 
         Item publicItem2 = ItemBuilder.createItem(context, col2)
@@ -223,8 +223,8 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                                       .withIssueDate("2016-02-13")
                                       .withAuthor("Smith, Maria")
                                       .withAuthor("Doe, Jane")
-                                      .withSubject("TestingForMore", "authority_2", 600)
-                                      .withSubject("ExtraEntry", "authority_1", 600)
+                                      .withSubject("Church studies", "VR110103", 600)
+                                      .withSubject("History of religion", "VR110102", 600)
                                       .build();
 
         Item publicItem3 = ItemBuilder.createItem(context, col2)
@@ -235,9 +235,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                                       .withAuthor("test, test")
                                       .withAuthor("test2, test2")
                                       .withAuthor("Maybe, Maybe")
-                                      .withSubject("AnotherTest", "authority_3", 600)
-                                      .withSubject("TestingForMore", "authority_2", 600)
-                                      .withSubject("ExtraEntry", "authority_1", 600)
+                                      .withSubject("Missionary studies", "VR110104", 600)
+                                      .withSubject("Church studies", "VR110103", 600)
+                                      .withSubject("History of religion", "VR110102", 600)
                                       .build();
 
         context.restoreAuthSystemState();
@@ -268,8 +268,8 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                    // up in different items
                    //These subjects are the most used ones. Only two show up because of the size.
                    .andExpect(jsonPath("$._embedded.values", containsInAnyOrder(
-                       FacetValueMatcher.entrySubject("ExtraEntry", 3),
-                       FacetValueMatcher.entrySubject("TestingForMore", 2)
+                       FacetValueMatcher.entrySubject("History of religion", 3),
+                       FacetValueMatcher.entrySubject("Church studies", 2)
                    )))
         ;
     }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/BrowseEntryResourceMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/BrowseEntryResourceMatcher.java
@@ -37,12 +37,8 @@ public class BrowseEntryResourceMatcher {
 
     public static Matcher<? super Object> matchBrowseEntry(String value, String authority, int expectedCount) {
         return allOf(
-            //Check core metadata (the JSON Path expression evaluates to a collection so we have to use contains)
-            hasJsonPath("$.value", is(value)),
             hasJsonPath("$.authority", is(authority)),
-            hasJsonPath("$.count", is(expectedCount)),
-            //Check links
-            matchItemLinks()
+            matchBrowseEntry(value, expectedCount)
         );
     }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/BrowseEntryResourceMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/BrowseEntryResourceMatcher.java
@@ -35,11 +35,11 @@ public class BrowseEntryResourceMatcher {
         );
     }
 
-    public static Matcher<? super Object> matchBrowseEntry(String entryValue, String authorityValue, int expectedCount) {
+    public static Matcher<? super Object> matchBrowseEntry(String value, String authority, int expectedCount) {
         return allOf(
             //Check core metadata (the JSON Path expression evaluates to a collection so we have to use contains)
-            hasJsonPath("$.value", is(entryValue)),
-            hasJsonPath("$.authority", is(authorityValue)),
+            hasJsonPath("$.value", is(value)),
+            hasJsonPath("$.authority", is(authority)),
             hasJsonPath("$.count", is(expectedCount)),
             //Check links
             matchItemLinks()

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/BrowseEntryResourceMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/BrowseEntryResourceMatcher.java
@@ -35,6 +35,17 @@ public class BrowseEntryResourceMatcher {
         );
     }
 
+    public static Matcher<? super Object> matchBrowseEntry(String entryValue, String authorityValue, int expectedCount) {
+        return allOf(
+            //Check core metadata (the JSON Path expression evaluates to a collection so we have to use contains)
+            hasJsonPath("$.value", is(entryValue)),
+            hasJsonPath("$.authority", is(authorityValue)),
+            hasJsonPath("$.count", is(expectedCount)),
+            //Check links
+            matchItemLinks()
+        );
+    }
+
     public static Matcher<? super Object> matchItemLinks() {
         return allOf(
             hasJsonPath("$._links.items.href", startsWith(REST_SERVER_URL))

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/FacetValueMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/FacetValueMatcher.java
@@ -38,6 +38,14 @@ public class FacetValueMatcher {
         );
     }
 
+
+    public static Matcher<? super Object> entrySubject(String label, String authority, int count) {
+        return allOf(
+            hasJsonPath("$.authorityKey", is(authority)),
+            entrySubject(label, count)
+        );
+    }
+
     public static Matcher<? super Object> entryDateIssued() {
         return allOf(
             hasJsonPath("$.label", Matchers.notNullValue()),

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/FacetValueMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/FacetValueMatcher.java
@@ -28,6 +28,16 @@ public class FacetValueMatcher {
         );
     }
 
+    public static Matcher<? super Object> entrySubject(String label, int count) {
+        return allOf(
+            hasJsonPath("$.label", is(label)),
+            hasJsonPath("$.type", is("discover")),
+            hasJsonPath("$.count", is(count)),
+            hasJsonPath("$._links.search.href", containsString("api/discover/search/objects")),
+            hasJsonPath("$._links.search.href", containsString("f.subject=" + label + ",equals"))
+        );
+    }
+
     public static Matcher<? super Object> entryDateIssued() {
         return allOf(
             hasJsonPath("$.label", Matchers.notNullValue()),

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/FacetValueMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/FacetValueMatcher.java
@@ -28,6 +28,17 @@ public class FacetValueMatcher {
         );
     }
 
+    public static Matcher<? super Object> entryAuthorWithAuthority(String label, String authority, int count) {
+        return allOf(
+            hasJsonPath("$.authorityKey", is(authority)),
+            hasJsonPath("$.count", is(count)),
+            hasJsonPath("$.label", is(label)),
+            hasJsonPath("$.type", is("discover")),
+            hasJsonPath("$._links.search.href", containsString("api/discover/search/objects")),
+            hasJsonPath("$._links.search.href", containsString("f.author=" + authority + ",authority"))
+        );
+    }
+
     public static Matcher<? super Object> entrySubject(String label, int count) {
         return allOf(
             hasJsonPath("$.label", is(label)),


### PR DESCRIPTION
## References
* Fixes #2798
* Fixes #3185

## Description
This PR ensures that there are ITs for authority values on the browse endpoint and the facet endpoint

## Instructions for Reviewers

List of changes in this PR:
* Added a way to clear the cache in MetadataAuthorityService as we need to be able to reload the config in those maps during the tests or we won't be able to use specific config in the test cases
* Added a cleanupCache method to the AbstractIntegrationTestWithDatabase class to ensure that the caches of those services are actually cleared properly. The config properties are set to default again, but we had to hard reset the cache of the service as well as to not bring test-specific config to other test cases
* Added the tests, however the Facet test doesn't work as AuthorityValues aren't supported there

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
