### PR TITLE
Search page result number bug

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/IndexEventConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexEventConsumer.java
@@ -138,8 +138,9 @@ public class IndexEventConsumer implements Consumer {
                     // became directly an item without giving us the chance to retrieve a
                     // workflowitem... so we need to force the unindex of all the related data
                     // before to index it again to be sure to don't leave any zombie in solr
-                        String detail =
-                                Constants.typeText[event.getSubjectType()] + "-" + event.getSubjectID().toString();
+                        IndexFactory indexableObjectService = IndexObjectFactoryFactory.getInstance()
+                                              .getIndexFactoryByType(Constants.typeText[event.getSubjectType()]);
+                        String detail = indexableObjectService.getType() + "-" + event.getSubjectID().toString();
                         uniqueIdsToDelete.add(detail);
                     }
                     objectsToUpdate.addAll(indexObjectServiceFactory.getIndexableObjects(ctx, subject));
@@ -163,7 +164,9 @@ public class IndexEventConsumer implements Consumer {
                 if (event.getSubjectType() == -1 || event.getSubjectID() == null) {
                     log.warn("got null subject type and/or ID on DELETE event, skipping it.");
                 } else {
-                    String detail = Constants.typeText[event.getSubjectType()] + "-" + event.getSubjectID().toString();
+                    IndexFactory indexableObjectService = IndexObjectFactoryFactory.getInstance()
+                                          .getIndexFactoryByType(Constants.typeText[event.getSubjectType()]);
+                    String detail = indexableObjectService.getType() + "-" + event.getSubjectID().toString();
                     log.debug("consume() adding event to delete queue: " + event.toString());
                     uniqueIdsToDelete.add(detail);
                 }


### PR DESCRIPTION
## References
Fixes https://github.com/DSpace/DSpace/issues/3140

## Description
The bug that caused not correctly pagination was that the IndexEventConsumer,
the deletion of an item did not happen because the id that was built was wrong.
For example, the object's id was ITEM-UUID instead of Item-UUID.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
