### PR TITLE
Rename / move 'relationship.type' metadata field to 'dspace.entity.type'

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
@@ -890,10 +890,10 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
         Entity relationEntity = getEntity(c, value);
         // Get relationship type of entity and item
         String relationEntityRelationshipType = itemService.getMetadata(relationEntity.getItem(),
-                                                                        "relationship", "type",
-                                                                        null, Item.ANY).get(0).getValue();
-        String itemRelationshipType = itemService.getMetadata(item, "relationship", "type",
-                                                              null, Item.ANY).get(0).getValue();
+                                                                        "dspace", "entity",
+                                                                        "type", Item.ANY).get(0).getValue();
+        String itemRelationshipType = itemService.getMetadata(item, "dspace", "entity",
+                                                              "type", Item.ANY).get(0).getValue();
 
         // Get the correct RelationshipType based on typeName
         List<RelationshipType> relType = relationshipTypeService.findByLeftwardOrRightwardTypeName(c, typeName);
@@ -1651,8 +1651,8 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
                     if (itemService.find(c, UUID.fromString(targetUUID)) != null) {
                         targetItem = itemService.find(c, UUID.fromString(targetUUID));
                         List<MetadataValue> relTypes = itemService.
-                                                                      getMetadata(targetItem, "relationship", "type",
-                                                                                  null, Item.ANY);
+                                                                      getMetadata(targetItem, "dspace", "entity",
+                                                                                  "type", Item.ANY);
                         String relTypeValue = null;
                         if (relTypes.size() > 0) {
                             relTypeValue = relTypes.get(0).getValue();
@@ -1710,8 +1710,8 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
                                     originItem = itemService.find(c, UUID.fromString(originRefererUUID));
                                     if (originItem != null) {
                                         List<MetadataValue> mdv = itemService.getMetadata(originItem,
-                                                                                          "relationship",
-                                                                                          "type", null,
+                                                                                          "dspace",
+                                                                                          "entity", "type",
                                                                                           Item.ANY);
                                         if (!mdv.isEmpty()) {
                                             String relTypeValue = mdv.get(0).getValue();

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
@@ -1487,7 +1487,7 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
                 }
             }
             //Populate entityTypeMap
-            if (key.equalsIgnoreCase("relationship.type") && line.get(key).size() > 0) {
+            if (key.equalsIgnoreCase("dspace.entity.type") && line.get(key).size() > 0) {
                 if (uuid == null) {
                     entityTypeMap.put(new UUID(0, rowCount), line.get(key).get(0));
                 } else {
@@ -1696,9 +1696,9 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
                             if (itemService.find(c, UUID.fromString(targetUUID)) != null) {
                                 DSpaceCSVLine dSpaceCSVLine = this.csv.getCSVLines()
                                                                       .get(Integer.valueOf(originRow) - 1);
-                                List<String> relTypes = dSpaceCSVLine.get("relationship.type");
+                                List<String> relTypes = dSpaceCSVLine.get("dspace.entity.type");
                                 if (relTypes == null || relTypes.isEmpty()) {
-                                    dSpaceCSVLine.get("relationship.type[]");
+                                    dSpaceCSVLine.get("dspace.entity.type[]");
                                 }
 
                                 if (relTypes != null && relTypes.size() > 0) {

--- a/dspace-api/src/main/java/org/dspace/content/EntityServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/EntityServiceImpl.java
@@ -51,7 +51,7 @@ public class EntityServiceImpl implements EntityService {
     @Override
     public EntityType getType(Context context, Entity entity) throws SQLException {
         Item item = entity.getItem();
-        List<MetadataValue> list = itemService.getMetadata(item, "relationship", "type", null, Item.ANY, false);
+        List<MetadataValue> list = itemService.getMetadata(item, "dspace", "entity", "type", Item.ANY, false);
         if (!list.isEmpty()) {
             return entityTypeService.findByEntityType(context, list.get(0).getValue());
         } else {

--- a/dspace-api/src/main/java/org/dspace/content/RelationshipMetadataServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/RelationshipMetadataServiceImpl.java
@@ -63,11 +63,9 @@ public class RelationshipMetadataServiceImpl implements RelationshipMetadataServ
     public String getEntityTypeStringFromMetadata(Item item) {
         List<MetadataValue> list = item.getMetadata();
         for (MetadataValue mdv : list) {
-            if (StringUtils.equals(mdv.getMetadataField().getMetadataSchema().getName(),
-                "relationship")
-                && StringUtils.equals(mdv.getMetadataField().getElement(),
-                "type")) {
-
+            if (StringUtils.equals(mdv.getMetadataField().getMetadataSchema().getName(), "dspace")
+                && StringUtils.equals(mdv.getMetadataField().getElement(), "entity")
+                && StringUtils.equals(mdv.getMetadataField().getQualifier(), "type")) {
                 return mdv.getValue();
             }
         }

--- a/dspace-api/src/main/java/org/dspace/content/RelationshipServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/RelationshipServiceImpl.java
@@ -257,8 +257,8 @@ public class RelationshipServiceImpl implements RelationshipService {
     }
 
     private boolean verifyEntityTypes(Item itemToProcess, EntityType entityTypeToProcess) {
-        List<MetadataValue> list = itemService.getMetadata(itemToProcess, "relationship", "type",
-                null, Item.ANY, false);
+        List<MetadataValue> list = itemService.getMetadata(itemToProcess, "dspace", "entity",
+                "type", Item.ANY, false);
         if (list.isEmpty()) {
             return false;
         }

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/V7.0_2021.03.18__Move_entity_type_to_dspace_schema.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/V7.0_2021.03.18__Move_entity_type_to_dspace_schema.sql
@@ -1,0 +1,56 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+-- ===============================================================
+-- WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
+--
+-- DO NOT MANUALLY RUN THIS DATABASE MIGRATION. IT WILL BE EXECUTED
+-- AUTOMATICALLY (IF NEEDED) BY "FLYWAY" WHEN YOU STARTUP DSPACE.
+-- http://flywaydb.org/
+-- ===============================================================
+
+-------------------------------------------------------------------------------------------------------
+-- Move all 'relationship.type' metadata fields to 'dspace.entity.type'. Remove 'relationship' schema.
+-------------------------------------------------------------------------------------------------------
+-- Special case: we need to the 'dspace' schema to already exist. If users don't already have it we must create it
+-- manually via SQL, as by default it won't be created until database updates are finished.
+INSERT INTO metadataschemaregistry (metadata_schema_id, namespace, short_id)
+  SELECT metadataschemaregistry_seq.nextval, 'http://dspace.org/dspace' as namespace, 'dspace' as short_id FROM dual
+    WHERE NOT EXISTS
+      (SELECT metadata_schema_id,namespace,short_id FROM metadataschemaregistry
+       WHERE namespace = 'http://dspace.org/dspace' AND short_id = 'dspace');
+
+
+-- Add 'dspace.entity.type' field to registry (if missing)
+INSERT INTO metadatafieldregistry (metadata_field_id, metadata_schema_id, element, qualifier)
+  SELECT metadatafieldregistry_seq.nextval,
+    (SELECT metadata_schema_id FROM metadataschemaregistry WHERE short_id='dspace'), 'entity', 'type' FROM dual
+        WHERE NOT EXISTS
+          (SELECT metadata_field_id,element,qualifier FROM metadatafieldregistry
+           WHERE metadata_schema_id = (SELECT metadata_schema_id FROM metadataschemaregistry WHERE short_id='dspace')
+           AND element = 'entitye' AND qualifier='type');
+
+-- Moves all 'relationship.type' field values to a new 'dspace.entity.type' field
+UPDATE metadatavalue
+  SET metadata_field_id =
+     (SELECT metadata_field_id FROM metadatafieldregistry
+      WHERE metadata_schema_id = (SELECT metadata_schema_id FROM metadataschemaregistry WHERE short_id='dspace')
+      AND element = 'entity' AND qualifier='type')
+  WHERE metadata_field_id =
+     (SELECT metadata_field_id FROM metadatafieldregistry
+      WHERE metadata_schema_id = (SELECT metadata_schema_id FROM metadataschemaregistry WHERE short_id='relationship')
+      AND element = 'type' AND qualifier is NULL);
+
+
+-- Delete 'relationship.type' field from registry
+DELETE FROM metadatafieldregistry
+  WHERE metadata_schema_id = (SELECT metadata_schema_id FROM metadataschemaregistry WHERE short_id = 'relationship')
+  AND element = 'type' AND qualifier is NULL;
+
+-- Delete 'relationship' schema (which is now empty)
+DELETE FROM metadataschemaregistry WHERE short_id = 'relationship' AND namespace = 'http://dspace.org/relationship';

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.0_2021.03.18__Move_entity_type_to_dspace_schema.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.0_2021.03.18__Move_entity_type_to_dspace_schema.sql
@@ -1,0 +1,56 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+-- ===============================================================
+-- WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
+--
+-- DO NOT MANUALLY RUN THIS DATABASE MIGRATION. IT WILL BE EXECUTED
+-- AUTOMATICALLY (IF NEEDED) BY "FLYWAY" WHEN YOU STARTUP DSPACE.
+-- http://flywaydb.org/
+-- ===============================================================
+
+-------------------------------------------------------------------------------------------------------
+-- Move all 'relationship.type' metadata fields to 'dspace.entity.type'. Remove 'relationship' schema.
+-------------------------------------------------------------------------------------------------------
+-- Special case: we need to the 'dspace' schema to already exist. If users don't already have it we must create it
+-- manually via SQL, as by default it won't be created until database updates are finished.
+INSERT INTO metadataschemaregistry (namespace, short_id)
+  SELECT 'http://dspace.org/dspace', 'dspace'
+    WHERE NOT EXISTS
+      (SELECT metadata_schema_id,namespace,short_id FROM metadataschemaregistry
+       WHERE namespace = 'http://dspace.org/dspace' AND short_id = 'dspace');
+
+
+-- Add 'dspace.entity.type' field to registry (if missing)
+INSERT INTO metadatafieldregistry (metadata_schema_id, element, qualifier)
+  SELECT (SELECT metadata_schema_id FROM metadataschemaregistry WHERE short_id='dspace'), 'entity', 'type'
+    WHERE NOT EXISTS
+      (SELECT metadata_field_id,element,qualifier FROM metadatafieldregistry
+       WHERE metadata_schema_id = (SELECT metadata_schema_id FROM metadataschemaregistry WHERE short_id='dspace')
+       AND element = 'entity' AND qualifier='type');
+
+
+-- Moves all 'relationship.type' field values to new 'dspace.entity.type' field
+UPDATE metadatavalue
+  SET metadata_field_id =
+     (SELECT metadata_field_id FROM metadatafieldregistry
+      WHERE metadata_schema_id = (SELECT metadata_schema_id FROM metadataschemaregistry WHERE short_id='dspace')
+      AND element = 'entity' AND qualifier='type')
+  WHERE metadata_field_id =
+     (SELECT metadata_field_id FROM metadatafieldregistry
+      WHERE metadata_schema_id = (SELECT metadata_schema_id FROM metadataschemaregistry WHERE short_id='relationship')
+      AND element = 'type' AND qualifier is NULL);
+
+
+-- Delete 'relationship.type' field from registry
+DELETE FROM metadatafieldregistry
+  WHERE metadata_schema_id = (SELECT metadata_schema_id FROM metadataschemaregistry WHERE short_id = 'relationship')
+  AND element = 'type' AND qualifier is NULL;
+
+-- Delete 'relationship' schema (which is now empty)
+DELETE FROM metadataschemaregistry WHERE short_id = 'relationship' AND namespace = 'http://dspace.org/relationship';

--- a/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataImportIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataImportIT.java
@@ -105,7 +105,7 @@ public class MetadataImportIT extends AbstractIntegrationTestWithDatabase {
     @Test
     public void relationshipMetadataImportTest() throws Exception {
         context.turnOffAuthorisationSystem();
-        Item item = ItemBuilder.createItem(context, collection).withRelationshipType("Publication")
+        Item item = ItemBuilder.createItem(context, collection).withEntityType("Publication")
                                .withTitle("Publication1").build();
         EntityType publication = EntityTypeBuilder.createEntityTypeBuilder(context, "Publication").build();
         EntityType person = EntityTypeBuilder.createEntityTypeBuilder(context, "Person").build();
@@ -128,11 +128,11 @@ public class MetadataImportIT extends AbstractIntegrationTestWithDatabase {
     @Test
     public void relationshipMetadataImporAlreadyExistingItemTest() throws Exception {
         context.turnOffAuthorisationSystem();
-        Item personItem = ItemBuilder.createItem(context, collection).withRelationshipType("Person")
+        Item personItem = ItemBuilder.createItem(context, collection).withEntityType("Person")
                                      .withTitle("Person1").build();
         List<Relationship> relationshipList = relationshipService.findByItem(context, personItem);
         assertEquals(0, relationshipList.size());
-        Item publicationItem = ItemBuilder.createItem(context, collection).withRelationshipType("Publication")
+        Item publicationItem = ItemBuilder.createItem(context, collection).withEntityType("Publication")
                                           .withTitle("Publication1").build();
 
         EntityType publication = EntityTypeBuilder.createEntityTypeBuilder(context, "Publication").build();

--- a/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataImportIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataImportIT.java
@@ -113,7 +113,7 @@ public class MetadataImportIT extends AbstractIntegrationTestWithDatabase {
                                                               "isPublicationOfAuthor", 0, 10, 0, 10);
         context.restoreAuthSystemState();
 
-        String[] csv = {"id,collection,dc.title,relation.isPublicationOfAuthor,relationship.type",
+        String[] csv = {"id,collection,dc.title,relation.isPublicationOfAuthor,dspace.entity.type",
             "+," + collection.getHandle() + ",\"Test Import 1\"," + item.getID() + ",Person"};
         performImportScript(csv);
         Item importedItem = findItemByName("Test Import 1");

--- a/dspace-api/src/test/java/org/dspace/app/csv/CSVMetadataImportReferenceIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/csv/CSVMetadataImportReferenceIT.java
@@ -208,7 +208,7 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
                              .withAuthor("Smith, Donald")
                              .withPersonIdentifierLastName("Smith")
                              .withPersonIdentifierFirstName("Donald")
-                             .withRelationshipType("Person")
+                             .withEntityType("Person")
                              .build();
         context.restoreAuthSystemState();
         String[] csv = {"id,dspace.entity.type,relation.isAuthorOfPublication,collection,rowName,dc.identifier.other",
@@ -230,7 +230,7 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
                                  .withAuthor("Smith, Donald")
                                  .withPersonIdentifierLastName("Smith")
                                  .withPersonIdentifierFirstName("Donald")
-                                 .withRelationshipType("Person")
+                                 .withEntityType("Person")
                                  .build();
         Item person2 = ItemBuilder.createItem(context, col1)
                                  .withTitle("Author2")
@@ -238,7 +238,7 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
                                  .withAuthor("Smith, John")
                                  .withPersonIdentifierLastName("Smith")
                                  .withPersonIdentifierFirstName("John")
-                                 .withRelationshipType("Person")
+                                 .withEntityType("Person")
                                  .build();
         String[] csv = {"id,dspace.entity.type,relation.isAuthorOfPublication,collection,rowName,dc.identifier.other",
             "+,Publication," + person.getID().toString() + "||" + person2.getID().toString() + "," +
@@ -261,7 +261,7 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
                                  .withAuthor("Smith, Donald")
                                  .withPersonIdentifierLastName("Smith")
                                  .withPersonIdentifierFirstName("Donald")
-                                 .withRelationshipType("Person")
+                                 .withEntityType("Person")
                                  .build();
         String[] csv = {"id,dc.title,dspace.entity.type,relation.isAuthorOfPublication,collection,rowName," +
             "dc.identifier.other",
@@ -287,7 +287,7 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
                                  .withAuthor("Smith, Donald")
                                  .withPersonIdentifierLastName("Smith")
                                  .withPersonIdentifierFirstName("Donald")
-                                 .withRelationshipType("Person")
+                                 .withEntityType("Person")
                                  .build();
         Item person2 = ItemBuilder.createItem(context, col1)
                                  .withTitle("Person2")
@@ -295,7 +295,7 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
                                  .withAuthor("Smith, John")
                                  .withPersonIdentifierLastName("Smith")
                                  .withPersonIdentifierFirstName("John")
-                                 .withRelationshipType("Person")
+                                 .withEntityType("Person")
                                  .build();
 
         context.restoreAuthSystemState();
@@ -360,7 +360,7 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
                                  .withAuthor("Smith, Donald")
                                  .withPersonIdentifierLastName("Smith")
                                  .withPersonIdentifierFirstName("Donald")
-                                 .withRelationshipType("Person")
+                                 .withEntityType("Person")
                                  .withIdentifierOther("1")
                                  .build();
         Item person2 = ItemBuilder.createItem(context, col1)
@@ -369,7 +369,7 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
                                  .withAuthor("Smith, John")
                                  .withPersonIdentifierLastName("Smith")
                                  .withPersonIdentifierFirstName("John")
-                                 .withRelationshipType("Person")
+                                 .withEntityType("Person")
                                  .withIdentifierOther("1")
                                  .build();
 
@@ -391,7 +391,7 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
                                  .withAuthor("Smith, Donald")
                                  .withPersonIdentifierLastName("Smith")
                                  .withPersonIdentifierFirstName("Donald")
-                                 .withRelationshipType("Person")
+                                 .withEntityType("Person")
                                  .withIdentifierOther("1")
                                  .build();
         context.restoreAuthSystemState();
@@ -454,7 +454,7 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
         Item testItem = ItemBuilder.createItem(context, col1)
                                  .withTitle("OrgUnit")
                                  .withIssueDate("2017-10-17")
-                                 .withRelationshipType("OrgUnit")
+                                 .withEntityType("OrgUnit")
                                  .build();
         context.restoreAuthSystemState();
         String[] csv = {"id,dspace.entity.type,relation.isAuthorOfPublication,collection,rowName",
@@ -472,7 +472,7 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
         Item testItem = ItemBuilder.createItem(context, col1)
                                    .withTitle("OrgUnit")
                                    .withIssueDate("2017-10-17")
-                                   .withRelationshipType("OrgUnit")
+                                   .withEntityType("OrgUnit")
                                    .build();
         context.restoreAuthSystemState();
         String[] csv = {"id,dspace.entity.type,relation.isAuthorOfPublication,collection,rowName",
@@ -494,7 +494,7 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
                                  .withAuthor("Smith, Donald")
                                  .withPersonIdentifierLastName("Smith")
                                  .withPersonIdentifierFirstName("Donald")
-                                 .withRelationshipType("Person")
+                                 .withEntityType("Person")
                                  .withIdentifierOther("testItemOne")
                                  .build();
 
@@ -502,7 +502,7 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
         Item testItem2 = ItemBuilder.createItem(context, col1)
                                  .withTitle("Publication")
                                  .withIssueDate("2017-10-17")
-                                 .withRelationshipType("Publication")
+                                 .withEntityType("Publication")
                                  .withIdentifierOther("testItemTwo")
                                  .build();
 
@@ -510,7 +510,7 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
         Item testItem3 = ItemBuilder.createItem(context, col1)
                                  .withTitle("Project")
                                  .withIssueDate("2017-10-17")
-                                 .withRelationshipType("Project")
+                                 .withEntityType("Project")
                                  .withIdentifierOther("testItemThree")
                                  .build();
 
@@ -548,7 +548,7 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
                                    .withAuthor("Smith, Donald")
                                    .withPersonIdentifierLastName("Smith")
                                    .withPersonIdentifierFirstName("Donald")
-                                   .withRelationshipType("Person")
+                                   .withEntityType("Person")
                                    .withIdentifierOther("testItemOne")
                                    .build();
 
@@ -569,7 +569,7 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
         Item testItem = ItemBuilder.createItem(context, col1)
                                  .withTitle("Publication")
                                  .withIssueDate("2017-10-17")
-                                 .withRelationshipType("Publication")
+                                 .withEntityType("Publication")
                                  .build();
         context.restoreAuthSystemState();
         String[] csv = {"id,collection,dspace.entity.type,dc.title," +

--- a/dspace-api/src/test/java/org/dspace/app/csv/CSVMetadataImportReferenceIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/csv/CSVMetadataImportReferenceIT.java
@@ -128,7 +128,7 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
      */
     @Test
     public void testSingleMdRef() throws Exception {
-        String[] csv = {"id,relationship.type,relation.isAuthorOfPublication,collection,dc.identifier.other",
+        String[] csv = {"id,dspace.entity.type,relation.isAuthorOfPublication,collection,dc.identifier.other",
             "+,Person,," + col1.getHandle() + ",0",
             "+,Publication,dc.identifier.other:0," + col1.getHandle() + ",1"};
         Item[] items = runImport(csv);
@@ -157,7 +157,7 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
      */
     @Test
     public void testSingleRowNameRef() throws Exception {
-        String[] csv = {"id,dc.title,relationship.type,relation.isAuthorOfPublication,collection,rowName," +
+        String[] csv = {"id,dc.title,dspace.entity.type,relation.isAuthorOfPublication,collection,rowName," +
             "dc.identifier.other",
             "+,Test Item 1,Person,," + col1.getHandle() + ",idVal,0",
             "+,Test Item 2,Publication,rowName:idVal," + col1.getHandle() + ",anything,1"};
@@ -171,7 +171,7 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
      */
     @Test
     public void testMultiMdRef() throws Exception {
-        String[] csv = {"id,relationship.type,relation.isAuthorOfPublication,collection,dc.identifier.other",
+        String[] csv = {"id,dspace.entity.type,relation.isAuthorOfPublication,collection,dc.identifier.other",
             "+,Person,," + col1.getHandle() + ",0",
             "+,Person,," + col1.getHandle() + ",1",
             "+,Publication,dc.identifier.other:0||dc.identifier.other:1," + col1.getHandle() + ",2"};
@@ -186,7 +186,7 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
      */
     @Test
     public void testMultiRowNameRef() throws Exception {
-        String[] csv = {"id,relationship.type,relation.isAuthorOfPublication,collection,dc.identifier.other,rowName",
+        String[] csv = {"id,dspace.entity.type,relation.isAuthorOfPublication,collection,dc.identifier.other,rowName",
             "+,Person,," + col1.getHandle() + ",0,val1",
             "+,Person,," + col1.getHandle() + ",1,val2",
             "+,Publication,rowName:val1||rowName:val2," + col1.getHandle() + ",2,val3"};
@@ -211,7 +211,7 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
                              .withRelationshipType("Person")
                              .build();
         context.restoreAuthSystemState();
-        String[] csv = {"id,relationship.type,relation.isAuthorOfPublication,collection,rowName,dc.identifier.other",
+        String[] csv = {"id,dspace.entity.type,relation.isAuthorOfPublication,collection,rowName,dc.identifier.other",
             "+,Publication," + person.getID().toString() + "," + col1.getHandle() + ",anything,0"};
         Item[] items = runImport(csv);
         assertRelationship(items[0], person, 1, "left", 0);
@@ -240,7 +240,7 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
                                  .withPersonIdentifierFirstName("John")
                                  .withRelationshipType("Person")
                                  .build();
-        String[] csv = {"id,relationship.type,relation.isAuthorOfPublication,collection,rowName,dc.identifier.other",
+        String[] csv = {"id,dspace.entity.type,relation.isAuthorOfPublication,collection,rowName,dc.identifier.other",
             "+,Publication," + person.getID().toString() + "||" + person2.getID().toString() + "," +
                 col1.getHandle() + ",anything,0"};
         Item[] items = runImport(csv);
@@ -263,7 +263,7 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
                                  .withPersonIdentifierFirstName("Donald")
                                  .withRelationshipType("Person")
                                  .build();
-        String[] csv = {"id,dc.title,relationship.type,relation.isAuthorOfPublication,collection,rowName," +
+        String[] csv = {"id,dc.title,dspace.entity.type,relation.isAuthorOfPublication,collection,rowName," +
             "dc.identifier.other",
             "+,Person2,Person,," + col1.getHandle() + ",idVal,0",
             "+,Pub1,Publication,dc.title:Person||dc.title:Person2," + col1.getHandle() + ",anything,1"};
@@ -299,7 +299,7 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
                                  .build();
 
         context.restoreAuthSystemState();
-        String[] csv = {"id,dc.title,relationship.type,relation.isAuthorOfPublication,collection,rowName," +
+        String[] csv = {"id,dc.title,dspace.entity.type,relation.isAuthorOfPublication,collection,rowName," +
             "dc.identifier.other",
             "+,Person3,Person,," + col1.getHandle() + ",idVal,0",
             "+,Pub1,Publication," + person.getID() + "||dc.title:Person2||rowName:idVal," +
@@ -316,7 +316,7 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
      */
     @Test
     public void testRefWithSpecialChar() throws Exception {
-        String[] csv = {"id,dc.title,relationship.type,relation.isAuthorOfPublication,collection,rowName," +
+        String[] csv = {"id,dc.title,dspace.entity.type,relation.isAuthorOfPublication,collection,rowName," +
             "dc.identifier.other",
             "+,Person:,Person,," + col1.getHandle() + ",idVal,0",
             "+,Pub1,Publication,dc.title:Person:," + col1.getHandle() + ",anything,1"};
@@ -329,7 +329,7 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
      */
     @Test(expected = MetadataImportException.class)
     public void testNonUniqueMDRefInCsv() throws Exception {
-        String[] csv = {"id,relationship.type,relation.isAuthorOfPublication,collection,dc.identifier.other",
+        String[] csv = {"id,dspace.entity.type,relation.isAuthorOfPublication,collection,dc.identifier.other",
             "+,Person,," + col1.getHandle() + ",1",
             "+,Person,," + col1.getHandle() + ",1",
             "+,Publication,dc.identifier.other:1," + col1.getHandle() + ",2"};
@@ -341,7 +341,7 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
      */
     @Test(expected = MetadataImportException.class)
     public void testNonUniqueRowName() throws Exception {
-        String[] csv = {"id,relationship.type,relation.isAuthorOfPublication,collection,dc.identifier.other,rowName",
+        String[] csv = {"id,dspace.entity.type,relation.isAuthorOfPublication,collection,dc.identifier.other,rowName",
             "+,Person,," + col1.getHandle() + ",1,value",
             "+,Person,," + col1.getHandle() + ",1,value",
             "+,Publication,rowName:value," + col1.getHandle() + ",2"};
@@ -374,7 +374,7 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
                                  .build();
 
         context.restoreAuthSystemState();
-        String[] csv = {"id,relationship.type,relation.isAuthorOfPublication,collection,dc.identifier.other",
+        String[] csv = {"id,dspace.entity.type,relation.isAuthorOfPublication,collection,dc.identifier.other",
             "+,Publication,dc.identifier.other:1," + col1.getHandle() + ",2"};
         performImportScript(csv, true);
     }
@@ -395,7 +395,7 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
                                  .withIdentifierOther("1")
                                  .build();
         context.restoreAuthSystemState();
-        String[] csv = {"id,relationship.type,relation.isAuthorOfPublication,collection,dc.identifier.other",
+        String[] csv = {"id,dspace.entity.type,relation.isAuthorOfPublication,collection,dc.identifier.other",
             "+,Person,," + col1.getHandle() + ",1",
             "+,Publication,dc.identifier.other:1," + col1.getHandle() + ",2"};
         performImportScript(csv, true);
@@ -406,7 +406,7 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
      */
     @Test(expected = Exception.class)
     public void testNonExistMdRef() throws Exception {
-        String[] csv = {"id,relationship.type,relation.isAuthorOfPublication,collection,dc.identifier.other",
+        String[] csv = {"id,dspace.entity.type,relation.isAuthorOfPublication,collection,dc.identifier.other",
             "+,Person,," + col1.getHandle() + ",1",
             "+,Publication,dc.identifier.other:8675309," + col1.getHandle() + ",2"};
         performImportScript(csv, false);
@@ -417,7 +417,7 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
      */
     @Test(expected = Exception.class)
     public void testCSVImportWrongOrder() throws Exception {
-        String[] csv = {"id,relationship.type,relation.isAuthorOfPublication,collection,dc.identifier.other",
+        String[] csv = {"id,dspace.entity.type,relation.isAuthorOfPublication,collection,dc.identifier.other",
             "+,Publication,dc.identifier.other:8675309," + col1.getHandle() + ",2",
             "+,Person,," + col1.getHandle() + ",8675309",};
         performImportScript(csv, false);
@@ -428,7 +428,7 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
      */
     @Test(expected = Exception.class)
     public void testCSVImportWrongOrderRowName() throws Exception {
-        String[] csv = {"id,relationship.type,relation.isAuthorOfPublication,collection,dc.identifier.other,rowName",
+        String[] csv = {"id,dspace.entity.type,relation.isAuthorOfPublication,collection,dc.identifier.other,rowName",
             "+,Publication,rowName:row2," + col1.getHandle() + ",2,row1",
             "+,Person,," + col1.getHandle() + ",8675309,row2",};
         performImportScript(csv, false);
@@ -439,7 +439,7 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
      */
     @Test(expected = MetadataImportException.class)
     public void testCSVImportInvalidRelationship() throws Exception {
-        String[] csv = {"id,relationship.type,relation.isAuthorOfPublication,collection,rowName",
+        String[] csv = {"id,dspace.entity.type,relation.isAuthorOfPublication,collection,rowName",
             "+,Publication,," + col1.getHandle() + ",row1",
             "+,Unit,rowName:row1," + col1.getHandle() + ",row2",};
         performImportScript(csv, true);
@@ -457,7 +457,7 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
                                  .withRelationshipType("OrgUnit")
                                  .build();
         context.restoreAuthSystemState();
-        String[] csv = {"id,relationship.type,relation.isAuthorOfPublication,collection,rowName",
+        String[] csv = {"id,dspace.entity.type,relation.isAuthorOfPublication,collection,rowName",
             "+,Person,," + col1.getHandle() + ",1" +
                 testItem.getID().toString() + ",,rowName:1," + col1.getHandle() + ",2"};
         performImportScript(csv, false);
@@ -475,7 +475,7 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
                                    .withRelationshipType("OrgUnit")
                                    .build();
         context.restoreAuthSystemState();
-        String[] csv = {"id,relationship.type,relation.isAuthorOfPublication,collection,rowName",
+        String[] csv = {"id,dspace.entity.type,relation.isAuthorOfPublication,collection,rowName",
             testItem.getID().toString() + ",Person,," + col1.getHandle() + ",1" +
                 "+,OrgUnit,rowName:1," + col1.getHandle() + ",2"};
         performImportScript(csv, false);
@@ -530,7 +530,7 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
      */
     @Test
     public void testDuplicateRowNameReferences() throws Exception {
-        String[] csv = {"id,relationship.type,relation.isAuthorOfPublication,collection,dc.identifier.other,rowName",
+        String[] csv = {"id,dspace.entity.type,relation.isAuthorOfPublication,collection,dc.identifier.other,rowName",
             "+,Person,," + col1.getHandle() + ",0,value",
             "+,Publication,rowName:value," + col1.getHandle() + ",1,1",
             "+,Publication,rowName:value," + col1.getHandle() + ",2,2"};
@@ -553,7 +553,7 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
                                    .build();
 
 
-        String[] csv = {"id,relationship.type,relation.isAuthorOfPublication,collection,dc.identifier.other,rowName",
+        String[] csv = {"id,dspace.entity.type,relation.isAuthorOfPublication,collection,dc.identifier.other,rowName",
             "+,Publication," + testItem.getID() + "::virtual::4::600," + col1.getHandle() + ",0,1"};
         Item[] items = runImport(csv);
         assertRelationship(items[0], testItem, 1, "left", 0);
@@ -572,7 +572,7 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
                                  .withRelationshipType("Publication")
                                  .build();
         context.restoreAuthSystemState();
-        String[] csv = {"id,collection,relationship.type,dc.title," +
+        String[] csv = {"id,collection,dspace.entity.type,dc.title," +
             "relation.isProjectOfPublication,relation.isPublicationOfProject",
             "+," + col1.getHandle() + ",Project,Title," +
                 testItem.getID().toString() + "," + testItem.getID().toString()};

--- a/dspace-api/src/test/java/org/dspace/builder/ItemBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/ItemBuilder.java
@@ -96,7 +96,7 @@ public class ItemBuilder extends AbstractDSpaceObjectBuilder<Item> {
     }
 
     public ItemBuilder withRelationshipType(final String relationshipType) {
-        return addMetadataValue(item, "relationship", "type", null, relationshipType);
+        return addMetadataValue(item, "dspace", "entity", "type", relationshipType);
     }
 
     public ItemBuilder withType(final String type) {

--- a/dspace-api/src/test/java/org/dspace/builder/ItemBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/ItemBuilder.java
@@ -95,8 +95,8 @@ public class ItemBuilder extends AbstractDSpaceObjectBuilder<Item> {
                                 subject, authority, confidence);
     }
 
-    public ItemBuilder withRelationshipType(final String relationshipType) {
-        return addMetadataValue(item, "dspace", "entity", "type", relationshipType);
+    public ItemBuilder withEntityType(final String entityType) {
+        return addMetadataValue(item, "dspace", "entity", "type", entityType);
     }
 
     public ItemBuilder withType(final String type) {

--- a/dspace-api/src/test/java/org/dspace/builder/WorkspaceItemBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/WorkspaceItemBuilder.java
@@ -181,7 +181,7 @@ public class WorkspaceItemBuilder extends AbstractBuilder<WorkspaceItem, Workspa
     }
 
     public WorkspaceItemBuilder withRelationshipType(final String relationshipType) {
-        return addMetadataValue("relationship", "type", null, relationshipType);
+        return addMetadataValue("dspace", "entity", "type", relationshipType);
     }
 
     public WorkspaceItemBuilder grantLicense() {

--- a/dspace-api/src/test/java/org/dspace/builder/WorkspaceItemBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/WorkspaceItemBuilder.java
@@ -180,8 +180,8 @@ public class WorkspaceItemBuilder extends AbstractBuilder<WorkspaceItem, Workspa
         return addMetadataValue(MetadataSchemaEnum.DC.getName(),"description", "abstract", subject);
     }
 
-    public WorkspaceItemBuilder withRelationshipType(final String relationshipType) {
-        return addMetadataValue("dspace", "entity", "type", relationshipType);
+    public WorkspaceItemBuilder withEntityType(final String entityType) {
+        return addMetadataValue("dspace", "entity", "type", entityType);
     }
 
     public WorkspaceItemBuilder grantLicense() {

--- a/dspace-api/src/test/java/org/dspace/content/EntityServiceImplTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/EntityServiceImplTest.java
@@ -181,7 +181,7 @@ public class EntityServiceImplTest  {
 
         // Mock the state of objects utilized in getLeftRelationshipTypes()
         // to meet the success criteria of the invocation
-        when(itemService.getMetadata(item, "relationship", "type", null, Item.ANY, false)).thenReturn(metsList);
+        when(itemService.getMetadata(item, "dspace", "entity", "type", Item.ANY, false)).thenReturn(metsList);
         when(entity.getItem()).thenReturn(item);
         when(entityService.getType(context, entity)).thenReturn(entityType);
         when(relationshipTypeService.findByEntityType(context, entityService.getType(context, entity), true, -1, -1))
@@ -209,7 +209,7 @@ public class EntityServiceImplTest  {
 
         // Mock the state of objects utilized in getRightRelationshipTypes()
         // to meet the success criteria of the invocation
-        when(itemService.getMetadata(item, "relationship", "type", null, Item.ANY, false)).thenReturn(metsList);
+        when(itemService.getMetadata(item, "dspace", "entity", "type", Item.ANY, false)).thenReturn(metsList);
         when(entity.getItem()).thenReturn(item);
         when(entityService.getType(context, entity)).thenReturn(entityType);
         when(relationshipTypeService.findByEntityType(context, entityService.getType(context, entity), false, -1, -1))

--- a/dspace-api/src/test/java/org/dspace/content/RelationshipMetadataServiceIT.java
+++ b/dspace-api/src/test/java/org/dspace/content/RelationshipMetadataServiceIT.java
@@ -90,8 +90,8 @@ public class RelationshipMetadataServiceIT extends AbstractIntegrationTestWithDa
         context.turnOffAuthorisationSystem();
         EntityType publicationEntityType = EntityTypeBuilder.createEntityTypeBuilder(context, "Publication").build();
         EntityType authorEntityType = EntityTypeBuilder.createEntityTypeBuilder(context, "Author").build();
-        leftItem = ItemBuilder.createItem(context, col).withRelationshipType("Publication").build();
-        rightItem = ItemBuilder.createItem(context, col).withRelationshipType("Author")
+        leftItem = ItemBuilder.createItem(context, col).withEntityType("Publication").build();
+        rightItem = ItemBuilder.createItem(context, col).withEntityType("Author")
                                .withPersonIdentifierLastName("familyName")
                                .withPersonIdentifierFirstName("firstName").build();
         isAuthorOfPublicationRelationshipType =
@@ -114,8 +114,8 @@ public class RelationshipMetadataServiceIT extends AbstractIntegrationTestWithDa
         context.turnOffAuthorisationSystem();
         EntityType publicationEntityType = EntityTypeBuilder.createEntityTypeBuilder(context, "Publication").build();
         EntityType authorEntityType = EntityTypeBuilder.createEntityTypeBuilder(context, "Author").build();
-        leftItem = ItemBuilder.createItem(context, col).withRelationshipType("Publication").build();
-        rightItem = ItemBuilder.createItem(context, col).withRelationshipType("Author")
+        leftItem = ItemBuilder.createItem(context, col).withEntityType("Publication").build();
+        rightItem = ItemBuilder.createItem(context, col).withEntityType("Author")
                                .withPersonIdentifierLastName("familyName")
                                .withPersonIdentifierFirstName("firstName").build();
         RelationshipType isAuthorOfPublication =
@@ -138,9 +138,9 @@ public class RelationshipMetadataServiceIT extends AbstractIntegrationTestWithDa
         EntityType journalIssueEntityType = EntityTypeBuilder.createEntityTypeBuilder(context, "JournalIssue").build();
         EntityType publicationVolumeEntityType =
             EntityTypeBuilder.createEntityTypeBuilder(context, "JournalVolume").build();
-        leftItem = ItemBuilder.createItem(context, col).withRelationshipType("JournalIssue")
+        leftItem = ItemBuilder.createItem(context, col).withEntityType("JournalIssue")
                               .withPublicationIssueNumber("2").build();
-        rightItem = ItemBuilder.createItem(context, col).withRelationshipType("JournalVolume")
+        rightItem = ItemBuilder.createItem(context, col).withEntityType("JournalVolume")
                                .withPublicationVolumeNumber("30").build();
         RelationshipType isIssueOfVolume =
             RelationshipTypeBuilder
@@ -593,7 +593,7 @@ public class RelationshipMetadataServiceIT extends AbstractIntegrationTestWithDa
         Community community = CommunityBuilder.createCommunity(context).build();
 
         Collection col = CollectionBuilder.createCollection(context, community).build();
-        Item secondItem = ItemBuilder.createItem(context, col).withRelationshipType("Publication").build();
+        Item secondItem = ItemBuilder.createItem(context, col).withEntityType("Publication").build();
         RelationshipBuilder.createRelationshipBuilder(context, secondItem, rightItem,
             isAuthorOfPublicationRelationshipType).build();
         context.restoreAuthSystemState();
@@ -612,7 +612,7 @@ public class RelationshipMetadataServiceIT extends AbstractIntegrationTestWithDa
         Community community = CommunityBuilder.createCommunity(context).build();
         Collection col = CollectionBuilder.createCollection(context, community).build();
 
-        Item secondAuthor = ItemBuilder.createItem(context, col).withRelationshipType("Author")
+        Item secondAuthor = ItemBuilder.createItem(context, col).withEntityType("Author")
                                        .withPersonIdentifierFirstName("firstName")
                                        .withPersonIdentifierLastName("familyName").build();
 
@@ -652,13 +652,13 @@ public class RelationshipMetadataServiceIT extends AbstractIntegrationTestWithDa
         Community community = CommunityBuilder.createCommunity(context).build();
         Collection collection = CollectionBuilder.createCollection(context, community).build();
 
-        Item journalIssue = ItemBuilder.createItem(context, collection).withRelationshipType("JournalIssue").build();
+        Item journalIssue = ItemBuilder.createItem(context, collection).withEntityType("JournalIssue").build();
         Item journalVolume = ItemBuilder.createItem(context, collection)
                                         .withPublicationVolumeNumber("30")
-                                        .withRelationshipType("JournalVolume").build();
+                                        .withEntityType("JournalVolume").build();
         Item journal = ItemBuilder.createItem(context, collection)
                                   .withMetadata("creativeworkseries", "issn", null, "issn journal")
-                                  .withRelationshipType("Journal").build();
+                                  .withEntityType("Journal").build();
         RelationshipBuilder.createRelationshipBuilder(context, journalIssue, journalVolume,
             isJournalVolumeOfIssueRelationshipType).build();
         RelationshipBuilder.createRelationshipBuilder(context, journalVolume, journal,
@@ -666,7 +666,7 @@ public class RelationshipMetadataServiceIT extends AbstractIntegrationTestWithDa
 
         Item publication = ItemBuilder.createItem(context, collection)
                                       .withTitle("Pub 1")
-                                      .withRelationshipType("Publication").build();
+                                      .withEntityType("Publication").build();
 
         RelationshipBuilder.createRelationshipBuilder(context, publication, journalIssue,
             isJournalIssueOfPublicationRelationshipType).build();

--- a/dspace-api/src/test/java/org/dspace/content/RelationshipServiceImplPlaceTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/RelationshipServiceImplPlaceTest.java
@@ -77,10 +77,10 @@ public class RelationshipServiceImplPlaceTest extends AbstractUnitTest {
             WorkspaceItem authorIs = workspaceItemService.create(context, col, false);
 
             item = installItemService.installItem(context, is);
-            itemService.addMetadata(context, item, "relationship", "type", null, null, "Publication");
+            itemService.addMetadata(context, item, "dspace", "entity", "type", null, "Publication");
 
             authorItem = installItemService.installItem(context, authorIs);
-            itemService.addMetadata(context, authorItem, "relationship", "type", null, null, "Person");
+            itemService.addMetadata(context, authorItem, "dspace", "entity", "type", null, "Person");
             itemService.addMetadata(context, authorItem, "person", "familyName", null, null, "familyName");
             itemService.addMetadata(context, authorItem, "person", "givenName", null, null, "firstName");
 
@@ -156,7 +156,7 @@ public class RelationshipServiceImplPlaceTest extends AbstractUnitTest {
         // Here we create an Item so that we can create another relationship with this item
         WorkspaceItem authorIs = workspaceItemService.create(context, col, false);
         Item secondAuthorItem = installItemService.installItem(context, authorIs);
-        itemService.addMetadata(context, secondAuthorItem, "relationship", "type", null, null, "Person");
+        itemService.addMetadata(context, secondAuthorItem, "dspace", "entity", "type", null, "Person");
         itemService.addMetadata(context, secondAuthorItem, "person", "familyName", null, null, "familyNameTwo");
         itemService.addMetadata(context, secondAuthorItem, "person", "givenName", null, null, "firstNameTwo");
         Relationship relationshipTwo = relationshipService
@@ -222,7 +222,7 @@ public class RelationshipServiceImplPlaceTest extends AbstractUnitTest {
         // Relationship a specific place as well
         WorkspaceItem authorIs = workspaceItemService.create(context, col, false);
         Item secondAuthorItem = installItemService.installItem(context, authorIs);
-        itemService.addMetadata(context, secondAuthorItem, "relationship", "type", null, null, "Person");
+        itemService.addMetadata(context, secondAuthorItem, "dspace", "entity", "type", null, "Person");
         itemService.addMetadata(context, secondAuthorItem, "person", "familyName", null, null, "familyNameTwo");
         itemService.addMetadata(context, secondAuthorItem, "person", "givenName", null, null, "firstNameTwo");
         Relationship relationshipTwo = relationshipService
@@ -334,7 +334,7 @@ public class RelationshipServiceImplPlaceTest extends AbstractUnitTest {
         // Create an additional item for another relationship
         WorkspaceItem authorIs = workspaceItemService.create(context, col, false);
         Item secondAuthorItem = installItemService.installItem(context, authorIs);
-        itemService.addMetadata(context, secondAuthorItem, "relationship", "type", null, null, "Person");
+        itemService.addMetadata(context, secondAuthorItem, "dspace", "entity", "type", null, "Person");
         itemService.addMetadata(context, secondAuthorItem, "person", "familyName", null, null, "familyNameTwo");
         itemService.addMetadata(context, secondAuthorItem, "person", "givenName", null, null, "firstNameTwo");
         Relationship relationshipTwo = relationshipService

--- a/dspace-api/src/test/java/org/dspace/content/RelationshipServiceImplTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/RelationshipServiceImplTest.java
@@ -227,8 +227,8 @@ public class RelationshipServiceImplTest {
         when(metsList.get(0).getValue()).thenReturn("Entitylabel");
         when(relationshipService
                 .findByItemAndRelationshipType(context, leftItem, testRel, true)).thenReturn(leftTypelist);
-        when(itemService.getMetadata(leftItem, "relationship", "type", null, Item.ANY, false)).thenReturn(metsList);
-        when(itemService.getMetadata(rightItem, "relationship", "type", null, Item.ANY, false)).thenReturn(metsList);
+        when(itemService.getMetadata(leftItem, "dspace", "entity", "type", Item.ANY, false)).thenReturn(metsList);
+        when(itemService.getMetadata(rightItem, "dspace", "entity", "type", Item.ANY, false)).thenReturn(metsList);
         when(relationshipDAO.create(any(), any())).thenReturn(relationship);
 
         // The reported Relationship should match our defined relationship
@@ -305,8 +305,8 @@ public class RelationshipServiceImplTest {
         relationship = getRelationship(leftItem, rightItem, testRel, 0,0);
 
         // Mock the state of objects utilized in update() to meet the success criteria of the invocation
-        when(itemService.getMetadata(leftItem, "relationship", "type", null, Item.ANY, false)).thenReturn(metsList);
-        when(itemService.getMetadata(rightItem, "relationship", "type", null, Item.ANY, false)).thenReturn(metsList);
+        when(itemService.getMetadata(leftItem, "dspace", "entity", "type", Item.ANY, false)).thenReturn(metsList);
+        when(itemService.getMetadata(rightItem, "dspace", "entity", "type", Item.ANY, false)).thenReturn(metsList);
         when(authorizeService.authorizeActionBoolean(context, relationship.getLeftItem(),
                 Constants.WRITE)).thenReturn(true);
 

--- a/dspace-api/src/test/java/org/dspace/content/dao/RelationshipDAOImplTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/dao/RelationshipDAOImplTest.java
@@ -87,8 +87,8 @@ public class RelationshipDAOImplTest extends AbstractIntegrationTest {
             WorkspaceItem workspaceItemTwo = workspaceItemService.create(context, collection, false);
             itemOne = installItemService.installItem(context, workspaceItem);
             itemTwo = installItemService.installItem(context, workspaceItemTwo);
-            itemService.addMetadata(context, itemOne, "relationship", "type", null, Item.ANY, "Publication");
-            itemService.addMetadata(context, itemTwo, "relationship", "type", null, Item.ANY, "Person");
+            itemService.addMetadata(context, itemOne, "dspace", "entity", "type", Item.ANY, "Publication");
+            itemService.addMetadata(context, itemTwo, "dspace", "entity", "type", Item.ANY, "Person");
             itemService.update(context, itemOne);
             itemService.update(context, itemTwo);
             entityTypeOne = entityTypeService.create(context, "Person");

--- a/dspace-api/src/test/java/org/dspace/content/dao/RelationshipTypeDAOImplTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/dao/RelationshipTypeDAOImplTest.java
@@ -82,8 +82,8 @@ public class RelationshipTypeDAOImplTest extends AbstractIntegrationTest {
             WorkspaceItem workspaceItemTwo = workspaceItemService.create(context, collection, false);
             itemOne = installItemService.installItem(context, workspaceItem);
             itemTwo = installItemService.installItem(context, workspaceItemTwo);
-            itemService.addMetadata(context, itemOne, "relationship", "type", null, Item.ANY, "Publication");
-            itemService.addMetadata(context, itemTwo, "relationship", "type", null, Item.ANY, "Person");
+            itemService.addMetadata(context, itemOne, "dspace", "entity", "type", Item.ANY, "Publication");
+            itemService.addMetadata(context, itemTwo, "dspace", "entity", "type", Item.ANY, "Person");
             itemService.update(context, itemOne);
             itemService.update(context, itemTwo);
             entityTypeOne = entityTypeService.create(context, "Person");

--- a/dspace-api/src/test/java/org/dspace/statistics/export/ITIrusExportUsageEventListener.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/export/ITIrusExportUsageEventListener.java
@@ -123,14 +123,14 @@ public class ITIrusExportUsageEventListener extends AbstractIntegrationTestWithD
             community = CommunityBuilder.createCommunity(context).build();
             collection = CollectionBuilder.createCollection(context, community).build();
             item = ItemBuilder.createItem(context, collection)
-                              .withRelationshipType(entityType.getLabel())
+                              .withEntityType(entityType.getLabel())
                               .build();
 
             File f = new File(testProps.get("test.bitstream").toString());
             bitstream = BitstreamBuilder.createBitstream(context, item, new FileInputStream(f)).build();
 
             itemNotToBeProcessed = ItemBuilder.createItem(context, collection)
-                                              .withRelationshipType(entityType.getLabel())
+                                              .withEntityType(entityType.getLabel())
                                               .withType("Excluded type")
                                               .build();
             File itemNotToBeProcessedFile = new File(testProps.get("test.bitstream").toString());

--- a/dspace-api/src/test/java/org/dspace/statistics/export/ITIrusExportUsageEventListener.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/export/ITIrusExportUsageEventListener.java
@@ -263,8 +263,8 @@ public class ITIrusExportUsageEventListener extends AbstractIntegrationTestWithD
         when(usageEvent.getRequest()).thenReturn(request);
         when(usageEvent.getContext()).thenReturn(new Context());
 
-        itemService.clearMetadata(context, item, "relationship", "type", null, Item.ANY);
-        itemService.addMetadata(context, item, "relationship", "type", null, null, "OrgUnit");
+        itemService.clearMetadata(context, item, "dspace", "entity", "type", Item.ANY);
+        itemService.addMetadata(context, item, "dspace", "entity", "type", null, "OrgUnit");
         itemService.update(context, item);
 
         context.restoreAuthSystemState();
@@ -359,8 +359,8 @@ public class ITIrusExportUsageEventListener extends AbstractIntegrationTestWithD
         when(usageEvent.getRequest()).thenReturn(request);
         when(usageEvent.getContext()).thenReturn(new Context());
 
-        itemService.clearMetadata(context, item, "relationship", "type", null, Item.ANY);
-        itemService.addMetadata(context, item, "relationship", "type", null, null, "OrgUnit");
+        itemService.clearMetadata(context, item, "dspace", "entity", "type", Item.ANY);
+        itemService.addMetadata(context, item, "dspace", "entity", "type", null, "OrgUnit");
         itemService.update(context, item);
 
         context.restoreAuthSystemState();

--- a/dspace-api/src/test/java/org/dspace/statistics/export/processor/ExportEventProcessorIT.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/export/processor/ExportEventProcessorIT.java
@@ -135,7 +135,7 @@ public class ExportEventProcessorIT extends AbstractIntegrationTestWithDatabase 
         context.turnOffAuthorisationSystem();
         Community community = CommunityBuilder.createCommunity(context).build();
         Collection collection = CollectionBuilder.createCollection(context, community).build();
-        Item item = ItemBuilder.createItem(context, collection).withRelationshipType(otherEntity.getLabel()).build();
+        Item item = ItemBuilder.createItem(context, collection).withEntityType(otherEntity.getLabel()).build();
         context.restoreAuthSystemState();
 
         context.setCurrentUser(admin);
@@ -157,7 +157,7 @@ public class ExportEventProcessorIT extends AbstractIntegrationTestWithDatabase 
         Collection collection = CollectionBuilder.createCollection(context, community).build();
         Item item = ItemBuilder.createItem(context, collection)
                                .withType("Excluded type")
-                               .withRelationshipType(publication.getLabel())
+                               .withEntityType(publication.getLabel())
                                .build();
 
         context.restoreAuthSystemState();
@@ -177,7 +177,7 @@ public class ExportEventProcessorIT extends AbstractIntegrationTestWithDatabase 
         context.turnOffAuthorisationSystem();
         Community community = CommunityBuilder.createCommunity(context).build();
         Collection collection = CollectionBuilder.createCollection(context, community).build();
-        Item item = ItemBuilder.createItem(context, collection).withRelationshipType(otherEntity.getLabel()).build();
+        Item item = ItemBuilder.createItem(context, collection).withEntityType(otherEntity.getLabel()).build();
         context.restoreAuthSystemState();
 
         ExportEventProcessor exportEventProcessor = new ItemEventProcessor(context, request, item);
@@ -195,7 +195,7 @@ public class ExportEventProcessorIT extends AbstractIntegrationTestWithDatabase 
         context.turnOffAuthorisationSystem();
         Community community = CommunityBuilder.createCommunity(context).build();
         Collection collection = CollectionBuilder.createCollection(context, community).build();
-        Item item = ItemBuilder.createItem(context, collection).withRelationshipType(publication.getLabel()).build();
+        Item item = ItemBuilder.createItem(context, collection).withEntityType(publication.getLabel()).build();
         context.restoreAuthSystemState();
 
         ExportEventProcessor exportEventProcessor = new ItemEventProcessor(context, request, item);
@@ -214,7 +214,7 @@ public class ExportEventProcessorIT extends AbstractIntegrationTestWithDatabase 
         context.turnOffAuthorisationSystem();
         Community community = CommunityBuilder.createCommunity(context).build();
         Collection collection = CollectionBuilder.createCollection(context, community).build();
-        Item item = ItemBuilder.createItem(context, collection).withRelationshipType(publication.getLabel()).build();
+        Item item = ItemBuilder.createItem(context, collection).withEntityType(publication.getLabel()).build();
         context.restoreAuthSystemState();
 
         ExportEventProcessor exportEventProcessor = new ItemEventProcessor(context, request, item);
@@ -232,7 +232,7 @@ public class ExportEventProcessorIT extends AbstractIntegrationTestWithDatabase 
         context.turnOffAuthorisationSystem();
         Community community = CommunityBuilder.createCommunity(context).build();
         Collection collection = CollectionBuilder.createCollection(context, community).build();
-        Item item = ItemBuilder.createItem(context, collection).withRelationshipType(otherEntity.getLabel()).build();
+        Item item = ItemBuilder.createItem(context, collection).withEntityType(otherEntity.getLabel()).build();
         context.restoreAuthSystemState();
 
         ExportEventProcessor exportEventProcessor = new ItemEventProcessor(context, request, item);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ItemConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ItemConverter.java
@@ -51,7 +51,7 @@ public class ItemConverter
         item.setLastModified(obj.getLastModified());
 
         List<MetadataValue> entityTypes =
-            itemService.getMetadata(obj, "relationship", "type", null, Item.ANY, false);
+            itemService.getMetadata(obj, "dspace", "entity", "type", Item.ANY, false);
         if (CollectionUtils.isNotEmpty(entityTypes) && StringUtils.isNotBlank(entityTypes.get(0).getValue())) {
             item.setEntityType(entityTypes.get(0).getValue());
         }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
@@ -2800,7 +2800,7 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
             .withAuthor("Smith, Donald")
             .withPersonIdentifierLastName("Smith")
             .withPersonIdentifierFirstName("Donald")
-            .withRelationshipType("Person")
+            .withEntityType("Person")
             .build();
         context.restoreAuthSystemState();
 
@@ -2834,7 +2834,7 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
             .withTitle("Publication1")
             .withAuthor("Testy, TEst")
             .withIssueDate("2015-01-01")
-            .withRelationshipType("Publication")
+            .withEntityType("Publication")
             .build();
         context.restoreAuthSystemState();
 
@@ -2916,7 +2916,7 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         Map<String, String> value = new HashMap<>();
         value.put("value", "Publication");
         values.add(value);
-        AddOperation addOperation = new AddOperation("/metadata/relationship.type", values);
+        AddOperation addOperation = new AddOperation("/metadata/dspace.entity.type", values);
         ops.add(addOperation);
         String patchBody = getPatchContent(ops);
         getClient(token).perform(patch("/api/core/items/" + item.getID())

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
@@ -3477,21 +3477,21 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
                              .withAuthor("Smith, Donald")
                              .withPersonIdentifierLastName("Smith")
                              .withPersonIdentifierFirstName("Donald")
-                             .withRelationshipType("Person")
+                             .withEntityType("Person")
                              .build();
 
         author2 = ItemBuilder.createItem(context, col1)
                              .withTitle("Author2")
                              .withIssueDate("2016-02-13")
                              .withAuthor("Smith, Maria")
-                             .withRelationshipType("Person")
+                             .withEntityType("Person")
                              .build();
 
         publication1 = ItemBuilder.createItem(context, col1)
                                   .withTitle("Publication1")
                                   .withAuthor("Testy, TEst")
                                   .withIssueDate("2015-01-01")
-                                  .withRelationshipType("Publication")
+                                  .withEntityType("Publication")
                                   .build();
 
         EntityType publication = EntityTypeBuilder.createEntityTypeBuilder(context, "Publication").build();
@@ -3541,21 +3541,21 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
                              .withAuthor("Smith, Donald")
                              .withPersonIdentifierLastName("Smith")
                              .withPersonIdentifierFirstName("Donald")
-                             .withRelationshipType("Person")
+                             .withEntityType("Person")
                              .build();
 
         author2 = ItemBuilder.createItem(context, col1)
                              .withTitle("Author2")
                              .withIssueDate("2016-02-13")
                              .withAuthor("Smith, Maria")
-                             .withRelationshipType("Person")
+                             .withEntityType("Person")
                              .build();
 
         publication1 = ItemBuilder.createItem(context, col1)
                                   .withTitle("Publication1")
                                   .withAuthor("Testy, TEst")
                                   .withIssueDate("2015-01-01")
-                                  .withRelationshipType("Publication")
+                                  .withEntityType("Publication")
                                   .build();
 
         EntityType publication = EntityTypeBuilder.createEntityTypeBuilder(context, "Publication").build();

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/PatchMetadataIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/PatchMetadataIT.java
@@ -139,17 +139,17 @@ public class PatchMetadataIT extends AbstractEntityIntegrationTest {
                 .withTitle("Person 1")
                 .withPersonIdentifierFirstName("Sarah")
                 .withPersonIdentifierLastName("Dahlen")
-                .withRelationshipType("Person")
+                .withEntityType("Person")
                 .build();
         personItem2 = ItemBuilder.createItem(context, collection)
                 .withTitle("Person 2")
                 .withPersonIdentifierFirstName("Oliver")
                 .withPersonIdentifierLastName("Linton")
-                .withRelationshipType("Person")
+                .withEntityType("Person")
                 .build();
         publicationItem = WorkspaceItemBuilder.createWorkspaceItem(context, collection)
                 .withTitle("Publication 1")
-                .withRelationshipType("Publication")
+                .withEntityType("Publication")
                 .build();
         publicationPersonRelationshipType = relationshipTypeService.findbyTypesAndTypeName(context,
                 entityTypeService.findByEntityType(context, "Publication"),
@@ -257,7 +257,7 @@ public class PatchMetadataIT extends AbstractEntityIntegrationTest {
 
         publicationItem = WorkspaceItemBuilder.createWorkspaceItem(context, collection)
                                               .withTitle("Publication 1")
-                                              .withRelationshipType("Publication")
+                                              .withEntityType("Publication")
                                               .build();
 
         String adminToken = getAuthToken(admin.getEmail(), password);

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/RelationshipDeleteRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/RelationshipDeleteRestRepositoryIT.java
@@ -121,11 +121,11 @@ public class RelationshipDeleteRestRepositoryIT extends AbstractEntityIntegratio
 
         leftItem = ItemBuilder.createItem(context, collection)
             .withTitle("Left item")
-            .withRelationshipType("Publication")
+            .withEntityType("Publication")
             .build();
         rightItem = ItemBuilder.createItem(context, collection)
             .withTitle("Right item")
-            .withRelationshipType("Person")
+            .withEntityType("Person")
             .withPersonIdentifierFirstName("firstName")
             .withPersonIdentifierLastName("familyName")
             .build();
@@ -145,12 +145,12 @@ public class RelationshipDeleteRestRepositoryIT extends AbstractEntityIntegratio
 
         leftItem = ItemBuilder.createItem(context, collection)
             .withTitle("Left item")
-            .withRelationshipType("JournalIssue")
+            .withEntityType("JournalIssue")
             .withPublicationIssueNumber("2")
             .build();
         rightItem = ItemBuilder.createItem(context, collection)
             .withTitle("Right item")
-            .withRelationshipType("JournalVolume")
+            .withEntityType("JournalVolume")
             .withPublicationVolumeNumber("30")
             .build();
         relationshipType = relationshipTypeService
@@ -170,15 +170,15 @@ public class RelationshipDeleteRestRepositoryIT extends AbstractEntityIntegratio
             .withTitle("Person 1")
             .withPersonIdentifierFirstName("Donald")
             .withPersonIdentifierLastName("Smith")
-            .withRelationshipType("Person")
+            .withEntityType("Person")
             .build();
         projectItem = ItemBuilder.createItem(context, collection)
             .withTitle("Project 1")
-            .withRelationshipType("Project")
+            .withEntityType("Project")
             .build();
         publicationItem = ItemBuilder.createItem(context, collection)
             .withTitle("Publication 1")
-            .withRelationshipType("Publication")
+            .withEntityType("Publication")
             .build();
         personProjectRelationshipType = relationshipTypeService.findbyTypesAndTypeName(context,
             entityTypeService.findByEntityType(context, "Person"),

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/RelationshipRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/RelationshipRestRepositoryIT.java
@@ -143,14 +143,14 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
                              .withAuthor("Smith, Donald")
                              .withPersonIdentifierLastName("Smith")
                              .withPersonIdentifierFirstName("Donald")
-                             .withRelationshipType("Person")
+                             .withEntityType("Person")
                              .build();
 
         author2 = ItemBuilder.createItem(context, col2)
                              .withTitle("Author2")
                              .withIssueDate("2016-02-13")
                              .withAuthor("Smith, Maria")
-                             .withRelationshipType("Person")
+                             .withEntityType("Person")
                              .build();
 
         author3 = ItemBuilder.createItem(context, col2)
@@ -158,49 +158,49 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
                              .withIssueDate("2016-02-13")
                              .withPersonIdentifierFirstName("Maybe")
                              .withPersonIdentifierLastName("Maybe")
-                             .withRelationshipType("Person")
+                             .withEntityType("Person")
                              .build();
 
         publication1 = ItemBuilder.createItem(context, col3)
                                   .withTitle("Publication1")
                                   .withAuthor("Testy, TEst")
                                   .withIssueDate("2015-01-01")
-                                  .withRelationshipType("Publication")
+                                  .withEntityType("Publication")
                                   .build();
 
         publication2 = ItemBuilder.createItem(context, col3)
                                   .withTitle("Publication2")
                                   .withAuthor("Testy, TEst")
                                   .withIssueDate("2015-01-01")
-                                  .withRelationshipType("Publication")
+                                  .withEntityType("Publication")
                                   .build();
 
         orgUnit1 = ItemBuilder.createItem(context, col3)
                               .withTitle("OrgUnit1")
                               .withAuthor("Testy, TEst")
                               .withIssueDate("2015-01-01")
-                              .withRelationshipType("OrgUnit")
+                              .withEntityType("OrgUnit")
                               .build();
 
         orgUnit2 = ItemBuilder.createItem(context, col3)
                 .withTitle("OrgUnit2")
                 .withAuthor("Testy, TEst")
                 .withIssueDate("2015-01-01")
-                .withRelationshipType("OrgUnit")
+                .withEntityType("OrgUnit")
                 .build();
 
         orgUnit3 = ItemBuilder.createItem(context, col3)
                               .withTitle("OrgUnit3")
                               .withAuthor("Test, Testy")
                               .withIssueDate("2015-02-01")
-                              .withRelationshipType("OrgUnit")
+                              .withEntityType("OrgUnit")
                               .build();
 
         project1 = ItemBuilder.createItem(context, col3)
                               .withTitle("Project1")
                               .withAuthor("Testy, TEst")
                               .withIssueDate("2015-01-01")
-                              .withRelationshipType("Project")
+                              .withEntityType("Project")
                               .build();
 
         isAuthorOfPublicationRelationshipType = relationshipTypeService
@@ -665,7 +665,7 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
                                   .withIssueDate("2017-10-17")
                                   .withPersonIdentifierFirstName("Donald")
                                   .withPersonIdentifierLastName("Smith")
-                                  .withRelationshipType("Person")
+                                  .withEntityType("Person")
                                   .build();
 
         Item author2 = ItemBuilder.createItem(context, col2)
@@ -673,7 +673,7 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
                                   .withIssueDate("2016-02-13")
                                   .withPersonIdentifierFirstName("Maria")
                                   .withPersonIdentifierLastName("Smith")
-                                  .withRelationshipType("Person")
+                                  .withEntityType("Person")
                                   .build();
 
         Item author3 = ItemBuilder.createItem(context, col2)
@@ -681,13 +681,13 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
                                   .withIssueDate("2016-02-13")
                                   .withPersonIdentifierFirstName("Maybe")
                                   .withPersonIdentifierLastName("Maybe")
-                                  .withRelationshipType("Person")
+                                  .withEntityType("Person")
                                   .build();
 
         Item publication1 = ItemBuilder.createItem(context, col3)
                                        .withTitle("Publication1")
                                        .withIssueDate("2015-01-01")
-                                       .withRelationshipType("Publication")
+                                       .withEntityType("Publication")
                                        .build();
 
         RelationshipType isAuthorOfPublicationRelationshipType = relationshipTypeService
@@ -972,7 +972,7 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         Item publication1 = ItemBuilder.createItem(context, col3)
                                        .withTitle("Publication1")
                                        .withIssueDate("2015-01-01")
-                                       .withRelationshipType("Publication")
+                                       .withEntityType("Publication")
                                        .build();
 
         Item author2 = ItemBuilder.createItem(context, col2)
@@ -980,7 +980,7 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
                                   .withIssueDate("2016-02-13")
                                   .withPersonIdentifierFirstName("Maria")
                                   .withPersonIdentifierLastName("Smith")
-                                  .withRelationshipType("Person")
+                                  .withEntityType("Person")
                                   .build();
 
         Item author3 = ItemBuilder.createItem(context, col2)
@@ -988,7 +988,7 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
                                   .withIssueDate("2016-02-13")
                                   .withPersonIdentifierFirstName("Maybe")
                                   .withPersonIdentifierLastName("Maybe")
-                                  .withRelationshipType("Person")
+                                  .withEntityType("Person")
                                   .build();
 
         String adminToken = getAuthToken(admin.getEmail(), password);
@@ -1185,7 +1185,7 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         Item publication1 = ItemBuilder.createItem(context, col3)
                                        .withTitle("Publication1")
                                        .withIssueDate("2015-01-01")
-                                       .withRelationshipType("Publication")
+                                       .withEntityType("Publication")
                                        .build();
 
         Item author2 = ItemBuilder.createItem(context, col2)
@@ -1193,7 +1193,7 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
                                   .withIssueDate("2016-02-13")
                                   .withPersonIdentifierFirstName("Maria")
                                   .withPersonIdentifierLastName("Smith")
-                                  .withRelationshipType("Person")
+                                  .withEntityType("Person")
                                   .build();
 
         Item author3 = ItemBuilder.createItem(context, col2)
@@ -1201,7 +1201,7 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
                                   .withIssueDate("2016-02-13")
                                   .withPersonIdentifierFirstName("Maybe")
                                   .withPersonIdentifierLastName("Maybe")
-                                  .withRelationshipType("Person")
+                                  .withEntityType("Person")
                                   .build();
 
         String adminToken = getAuthToken(admin.getEmail(), password);
@@ -1399,7 +1399,7 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
                                   .withIssueDate("2016-02-13")
                                   .withPersonIdentifierFirstName("Maria")
                                   .withPersonIdentifierLastName("Smith")
-                                  .withRelationshipType("Person")
+                                  .withEntityType("Person")
                                   .build();
 
         String adminToken = getAuthToken(admin.getEmail(), password);
@@ -2389,7 +2389,7 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
                                   .withAuthor("Smith, Donald")
                                   .withPersonIdentifierFirstName("testingFirstName")
                                   .withPersonIdentifierLastName("testingLastName")
-                                  .withRelationshipType("Person")
+                                  .withEntityType("Person")
                                   .build();
 
         Relationship relationship3 = RelationshipBuilder
@@ -2759,15 +2759,15 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
 
         // Create entity items
         Item journal =
-            ItemBuilder.createItem(context, col1).withRelationshipType("Journal").withTitle(journalTitle).build();
+            ItemBuilder.createItem(context, col1).withEntityType("Journal").withTitle(journalTitle).build();
         Item journalVolume =
-            ItemBuilder.createItem(context, col1).withRelationshipType("JournalVolume").withTitle("JournalVolume")
+            ItemBuilder.createItem(context, col1).withEntityType("JournalVolume").withTitle("JournalVolume")
                        .build();
         Item journalIssue =
-            ItemBuilder.createItem(context, col1).withRelationshipType("JournalIssue").withTitle("JournalIssue")
+            ItemBuilder.createItem(context, col1).withEntityType("JournalIssue").withTitle("JournalIssue")
                        .build();
         Item publication =
-            ItemBuilder.createItem(context, col1).withRelationshipType("Publication").withTitle("Publication").build();
+            ItemBuilder.createItem(context, col1).withEntityType("Publication").withTitle("Publication").build();
 
         // Link Publication-Journal Issue
         RelationshipBuilder.createRelationshipBuilder(context, journalIssue, publication, isPublicationOfJournalIssue)

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/RelationshipTypeRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/RelationshipTypeRestControllerIT.java
@@ -118,48 +118,48 @@ public class RelationshipTypeRestControllerIT extends AbstractEntityIntegrationT
                                   .withTitle("Author1")
                                   .withIssueDate("2017-10-17")
                                   .withAuthor("Smith, Donald")
-                                  .withRelationshipType("Person")
+                                  .withEntityType("Person")
                                   .build();
 
         Item author2 = ItemBuilder.createItem(context, col2)
                                   .withTitle("Author2")
                                   .withIssueDate("2016-02-13")
                                   .withAuthor("Smith, Maria")
-                                  .withRelationshipType("Person")
+                                  .withEntityType("Person")
                                   .build();
 
         Item author3 = ItemBuilder.createItem(context, col2)
                                   .withTitle("Author3")
                                   .withIssueDate("2016-02-13")
                                   .withAuthor("Maybe, Maybe")
-                                  .withRelationshipType("Person")
+                                  .withEntityType("Person")
                                   .build();
 
         Item orgUnit1 = ItemBuilder.createItem(context, col3)
                                    .withTitle("OrgUnit1")
                                    .withAuthor("Testy, TEst")
                                    .withIssueDate("2015-01-01")
-                                   .withRelationshipType("OrgUnit")
+                                   .withEntityType("OrgUnit")
                                    .build();
 
         Item project1 = ItemBuilder.createItem(context, col3)
                                    .withTitle("Project1")
                                    .withAuthor("Testy, TEst")
                                    .withIssueDate("2015-01-01")
-                                   .withRelationshipType("Project")
+                                   .withEntityType("Project")
                                    .build();
 
         Item publication = ItemBuilder.createItem(context, col3)
                                       .withTitle("Publication1")
                                       .withAuthor("Testy, TEst")
                                       .withIssueDate("2015-01-01")
-                                      .withRelationshipType("Publication")
+                                      .withEntityType("Publication")
                                       .build();
 
         Item publication2 = ItemBuilder.createItem(context, col3)
                                        .withTitle("Publication2")
                                        .withIssueDate("2015-01-01")
-                                       .withRelationshipType("Publication")
+                                       .withEntityType("Publication")
                                        .build();
 
         RelationshipType isOrgUnitOfPersonRelationshipType = relationshipTypeService

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkspaceItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkspaceItemRestRepositoryIT.java
@@ -4972,19 +4972,19 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
                                   .withAuthor("Smith, Donald")
                                   .withPersonIdentifierLastName("Smith")
                                   .withPersonIdentifierFirstName("Donald")
-                                  .withRelationshipType("Person")
+                                  .withEntityType("Person")
                                   .build();
 
         Item author2 = ItemBuilder.createItem(context, col1)
                                   .withTitle("Author2")
                                   .withIssueDate("2016-02-13")
                                   .withAuthor("Smith, Maria")
-                                  .withRelationshipType("Person")
+                                  .withEntityType("Person")
                                   .build();
 
         //2. One workspace item.
         WorkspaceItem workspaceItem = WorkspaceItemBuilder.createWorkspaceItem(context, col1)
-                                                          .withRelationshipType("Publication")
+                                                          .withEntityType("Publication")
                                                           .build();
 
         EntityType publication = EntityTypeBuilder.createEntityTypeBuilder(context, "Publication").build();

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/csv/CsvExportIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/csv/CsvExportIT.java
@@ -60,7 +60,7 @@ public class CsvExportIT extends AbstractControllerIntegrationTest {
         Item article = ItemBuilder.createItem(context, col1)
                                   .withTitle("Article")
                                   .withIssueDate("2017-10-17")
-                                  .withRelationshipType("Publication")
+                                  .withEntityType("Publication")
                                   .build();
 
         AtomicReference<Integer> idRef = new AtomicReference<>();
@@ -111,7 +111,7 @@ public class CsvExportIT extends AbstractControllerIntegrationTest {
         Item article = ItemBuilder.createItem(context, col1)
                                   .withTitle("Article")
                                   .withIssueDate("2017-10-17")
-                                  .withRelationshipType("Publication")
+                                  .withEntityType("Publication")
                                   .build();
 
         AtomicReference<Integer> idRef = new AtomicReference<>();

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/csv/CsvImportIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/csv/CsvImportIT.java
@@ -9,10 +9,10 @@ package org.dspace.app.rest.csv;
 
 import static com.jayway.jsonpath.JsonPath.read;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.fileUpload;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -88,77 +88,93 @@ public class CsvImportIT extends AbstractEntityIntegrationTest {
         Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
         Collection col3 = CollectionBuilder.createCollection(context, child1).withName("OrgUnits").build();
 
+        // Create a new Publication (which is an Article)
         Item article = ItemBuilder.createItem(context, col1)
                                   .withTitle("Article")
                                   .withIssueDate("2017-10-17")
-                                  .withRelationshipType("Publication")
+                                  .withEntityType("Publication")
                                   .build();
 
-        Item itemB = validateSpecificItemRelationCreationCsvImport(col1, article, "TestItemB", "Person",
+        // Via CSV import, add two Authors to that Publication
+        Item author1 = validateSpecificItemRelationCreationCsvImport(col1, article, "TestAuthor1", "Person",
                                                                    "isPublicationOfAuthor",
                                                                    "Relationship list size is 1", 1, 0, 0);
-        Item itemC = validateSpecificItemRelationCreationCsvImport(col1, article, "TestItemC", "Person",
+        Item author2 = validateSpecificItemRelationCreationCsvImport(col1, article, "TestAuthor2", "Person",
                                                                    "isPublicationOfAuthor",
                                                                    "Relationship list size is 1", 1, 1, 0);
-        Item itemD = validateSpecificItemRelationCreationCsvImport(col1, article, "TestItemD", "Project",
+        // Via CSV import, add a Project related to that Publication
+        Item project = validateSpecificItemRelationCreationCsvImport(col1, article, "TestProject", "Project",
                                                                    "isPublicationOfProject",
                                                                    "Relationship list size is 1", 1, 0, 0);
-        Item itemE = validateSpecificItemRelationCreationCsvImportMultiple(col1, "TestItemE", "Publication",
+        // Via CSV import, add a new Publication related to both author1 & author2
+        Item article2 = validateSpecificItemRelationCreationCsvImportMultiple(col1, "TestArticle2", "Publication",
                                                                            "isAuthorOfPublication",
                                                                            "Relationship list size is 2", 2, 0, 1,
-                                                                           itemC, itemB);
+                                                                           author2, author1);
 
-        List<Relationship> relationships = relationshipService.findByItem(context, itemE);
+        // Verify that the new Publication is related to both author2 and author1 (in that exact order)
+        List<Relationship> relationships = relationshipService.findByItem(context, article2);
+        assertEquals(2, relationships.size());
         getClient().perform(get("/api/core/relationships/" + relationships.get(0).getID()).param("projection", "full"))
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$.leftPlace", is(0)))
-                   .andExpect(jsonPath("$._links.rightItem.href", containsString(itemC.getID().toString())))
+                   .andExpect(jsonPath("$._links.rightItem.href", containsString(author2.getID().toString())))
                    .andExpect(jsonPath("$.rightPlace", is(1)))
                    .andExpect(jsonPath("$", Matchers.is(RelationshipMatcher.matchRelationship(relationships.get(0)))));
         getClient().perform(get("/api/core/relationships/" + relationships.get(1).getID()).param("projection", "full"))
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$.leftPlace", is(1)))
-                   .andExpect(jsonPath("$._links.rightItem.href", containsString(itemB.getID().toString())))
+                   .andExpect(jsonPath("$._links.rightItem.href", containsString(author1.getID().toString())))
                    .andExpect(jsonPath("$.rightPlace", is(1)))
                    .andExpect(jsonPath("$", Matchers.is(RelationshipMatcher.matchRelationship(relationships.get(1)))));
 
-        Item itemF = validateSpecificItemRelationCreationCsvImport(col1, itemE, "TestItemF", "Person",
+        // Via CSV import add a new Author to the new Publication, as the *third* author.
+        // At this point the new Publication has three authors in this order: author2, author1, author3
+        Item author3 = validateSpecificItemRelationCreationCsvImport(col1, article2, "TestAuthor3", "Person",
                                                                    "isPublicationOfAuthor",
                                                                    "Relationship list size is 1", 1, 2, 0);
 
-        UpdateItemEToDeleteRelationshipToC(itemE, itemB, itemF, col1, "TestItemE");
+        // Verify the new Publication now has 3 relationships (3 authors)
+        relationships = relationshipService.findByItem(context, article2);
+        assertEquals(3,relationships.size());
 
-        getClient().perform(get("/api/core/items/" + itemE.getID())).andExpect(status().isOk());
+        // Now, *remove* the first listed author (author2) from this new Publication
+        updateArticle2ToDeleteRelationshipToAuthor2(article2, author1, author3, col1, "TestArticle2");
 
-        assertItemERelationships(itemB, itemE, itemF);
+        // Verify new Publication still exists after author removal
+        getClient().perform(get("/api/core/items/" + article2.getID())).andExpect(status().isOk());
 
-        updateArticleItemToAddAnotherRelationship(col1, article, itemB, itemC, itemF);
+        // Check relationships to new Publication. Verify it's only related to author1 and author3
+        assertArticle2Relationships(article2, author1, author3);
+
+        // Update original Article to now be related to all three authors
+        updateArticleItemToAddAnotherRelationship(col1, article, author1, author2, author3);
 
         getClient().perform(get("/api/core/items/" + article.getID())).andExpect(status().isOk());
 
-        assertArticleRelationships(article, itemB, itemC, itemF);
-
-
+        // Verify original article is now related to all three authors
+        assertArticleRelationships(article, author1, author2, author3);
     }
 
-    private void assertItemERelationships(Item itemB, Item itemE, Item itemF) throws SQLException {
-        List<Relationship> relationshipsForItemE = relationshipService.findByItem(context, itemE);
-        assertThat(relationshipsForItemE.size(), is(2));
-        assertThat(relationshipsForItemE.get(0).getRightItem(), is(itemF));
-        assertThat(relationshipsForItemE.get(1).getRightItem(), is(itemB));
+    private void assertArticle2Relationships(Item article2, Item author1, Item author3) throws SQLException {
+        List<Relationship> relationshipsForArticle2 = relationshipService.findByItem(context, article2);
+        assertEquals(2, relationshipsForArticle2.size());
+        assertEquals(author3, relationshipsForArticle2.get(0).getRightItem());
+        assertEquals(author1, relationshipsForArticle2.get(1).getRightItem());
     }
 
-    private void assertArticleRelationships(Item article, Item itemB, Item itemC, Item itemF) throws SQLException {
+    private void assertArticleRelationships(Item article, Item author1, Item author2, Item author3)
+        throws SQLException {
         List<Relationship> relationshipsForArticle = relationshipService
             .findByItemAndRelationshipType(context, article, relationshipTypeService
                 .findbyTypesAndTypeName(context, entityTypeService.findByEntityType(context, "Publication"),
-                                        entityTypeService.findByEntityType(context, "Person"), "isAuthorOfPublication",
-                                        "isPublicationOfAuthor"));
-        assertThat(relationshipsForArticle.size(), is(3));
+                                        entityTypeService.findByEntityType(context, "Person"),
+                                        "isAuthorOfPublication", "isPublicationOfAuthor"));
+        assertEquals(3, relationshipsForArticle.size());
         List<Item> expectedRelationshipsItemsForArticle = new ArrayList<>();
-        expectedRelationshipsItemsForArticle.add(itemC);
-        expectedRelationshipsItemsForArticle.add(itemF);
-        expectedRelationshipsItemsForArticle.add(itemB);
+        expectedRelationshipsItemsForArticle.add(author2);
+        expectedRelationshipsItemsForArticle.add(author3);
+        expectedRelationshipsItemsForArticle.add(author1);
 
         List<Item> actualRelationshipsItemsForArticle = new ArrayList<>();
         for (Relationship relationship : relationshipsForArticle) {
@@ -168,24 +184,24 @@ public class CsvImportIT extends AbstractEntityIntegrationTest {
                 actualRelationshipsItemsForArticle.add(relationship.getRightItem());
             }
         }
-        assertThat(true, Matchers.is(actualRelationshipsItemsForArticle
-                                         .containsAll(expectedRelationshipsItemsForArticle)));
+        assertTrue(actualRelationshipsItemsForArticle.containsAll(expectedRelationshipsItemsForArticle));
     }
 
-    private void updateArticleItemToAddAnotherRelationship(Collection col1, Item article, Item itemB, Item itemC,
-                                                           Item itemF) throws Exception {
+    private void updateArticleItemToAddAnotherRelationship(Collection col1, Item article, Item author1, Item author2,
+                                                           Item author3) throws Exception {
         String csvLineString = article.getID().toString() + "," + col1
             .getHandle() + "," + "Article" + "," + "Publication" + "," +
-            itemB.getID().toString() + "||" + itemC.getID().toString() + "||" + itemF
+            author1.getID().toString() + "||" + author2.getID().toString() + "||" + author3
             .getID().toString();
         String[] csv = {"id,collection,dc.title,dspace.entity.type,relation." + "isAuthorOfPublication", csvLineString};
         performImportScript(csv);
     }
 
-    private void UpdateItemEToDeleteRelationshipToC(Item itemE, Item itemB, Item itemF, Collection owningCollection,
-                                                    String title) throws Exception {
-        String csvLineString = itemE.getID().toString() + "," + owningCollection
-            .getHandle() + "," + title + "," + "Person" + "," + itemB.getID().toString() + "||" + itemF.getID()
+    private void updateArticle2ToDeleteRelationshipToAuthor2(Item article2, Item author1, Item author3,
+                                                             Collection owningCollection, String title)
+        throws Exception {
+        String csvLineString = article2.getID().toString() + "," + owningCollection
+            .getHandle() + "," + title + "," + "Person" + "," + author1.getID().toString() + "||" + author3.getID()
                                                                                                        .toString();
         String[] csv = {"id,collection,dc.title,dspace.entity.type,relation." + "isAuthorOfPublication", csvLineString};
         performImportScript(csv);
@@ -193,20 +209,21 @@ public class CsvImportIT extends AbstractEntityIntegrationTest {
     }
 
     private Item validateSpecificItemRelationCreationCsvImport(Collection col1, Item relatedItem, String itemTitle,
-                                                               String relationshipType,
+                                                               String entityType,
                                                                String relationshipTypeLabel,
-                                                               String reasonAssertCheck, Integer sizeToCheck,
-                                                               Integer leftPlaceToCheck,
-                                                               Integer rightPlaceToCheck) throws Exception {
-        String csvLineString = "+," + col1.getHandle() + "," + itemTitle + "," + relationshipType + "," + relatedItem
+                                                               String reasonAssertCheck, int sizeToCheck,
+                                                               int leftPlaceToCheck,
+                                                               int rightPlaceToCheck) throws Exception {
+        String csvLineString = "+," + col1.getHandle() + "," + itemTitle + "," + entityType + "," + relatedItem
             .getID().toString();
         String[] csv = {"id,collection,dc.title,dspace.entity.type,relation." + relationshipTypeLabel, csvLineString};
         performImportScript(csv);
+
         Iterator<Item> itemIteratorItem = itemService.findByMetadataField(context, "dc", "title", null, itemTitle);
         Item item = itemIteratorItem.next();
 
         List<Relationship> relationships = relationshipService.findByItem(context, item);
-        assertThat(reasonAssertCheck, relationships.size(), equalTo(sizeToCheck));
+        assertEquals(reasonAssertCheck, sizeToCheck, relationships.size());
         getClient().perform(get("/api/core/items/" + item.getID())).andExpect(status().isOk());
         getClient().perform(get("/api/core/relationships/" + relationships.get(0).getID()).param("projection", "full"))
                    .andExpect(status().isOk())
@@ -218,7 +235,7 @@ public class CsvImportIT extends AbstractEntityIntegrationTest {
     }
 
     private Item validateSpecificItemRelationCreationCsvImportMultiple(Collection col1, String itemTitle,
-                                                                       String relationshipType,
+                                                                       String entityType,
                                                                        String relationshipTypeLabel,
                                                                        String reasonAssertCheck, Integer sizeToCheck,
                                                                        Integer leftPlaceToCheck,
@@ -231,7 +248,7 @@ public class CsvImportIT extends AbstractEntityIntegrationTest {
         }
         idStringRelatedItems = idStringRelatedItems.substring(0, idStringRelatedItems.length() - 2);
         String csvLineString = "+," + col1
-            .getHandle() + "," + itemTitle + "," + relationshipType + "," + idStringRelatedItems;
+            .getHandle() + "," + itemTitle + "," + entityType + "," + idStringRelatedItems;
         String[] csv = {"id,collection,dc.title,dspace.entity.type,relation." + relationshipTypeLabel, csvLineString};
         performImportScript(csv);
         Iterator<Item> itemIteratorItem = itemService.findByMetadataField(context, "dc", "title", null, itemTitle);
@@ -294,7 +311,7 @@ public class CsvImportIT extends AbstractEntityIntegrationTest {
         Item article = ItemBuilder.createItem(context, col1)
                                   .withTitle("Article")
                                   .withIssueDate("2017-10-17")
-                                  .withRelationshipType("Publication")
+                                  .withEntityType("Publication")
                                   .build();
 
         String csvLineString = "+," + col1.getHandle() + ",TestItemB,Person," + article

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/csv/CsvImportIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/csv/CsvImportIT.java
@@ -201,7 +201,7 @@ public class CsvImportIT extends AbstractEntityIntegrationTest {
                                                              Collection owningCollection, String title)
         throws Exception {
         String csvLineString = article2.getID().toString() + "," + owningCollection
-            .getHandle() + "," + title + "," + "Person" + "," + author1.getID().toString() + "||" + author3.getID()
+            .getHandle() + "," + title + "," + "Publication" + "," + author1.getID().toString() + "||" + author3.getID()
                                                                                                        .toString();
         String[] csv = {"id,collection,dc.title,dspace.entity.type,relation." + "isAuthorOfPublication", csvLineString};
         performImportScript(csv);

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/csv/CsvImportIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/csv/CsvImportIT.java
@@ -178,7 +178,7 @@ public class CsvImportIT extends AbstractEntityIntegrationTest {
             .getHandle() + "," + "Article" + "," + "Publication" + "," +
             itemB.getID().toString() + "||" + itemC.getID().toString() + "||" + itemF
             .getID().toString();
-        String[] csv = {"id,collection,dc.title,relationship.type,relation." + "isAuthorOfPublication", csvLineString};
+        String[] csv = {"id,collection,dc.title,dspace.entity.type,relation." + "isAuthorOfPublication", csvLineString};
         performImportScript(csv);
     }
 
@@ -187,7 +187,7 @@ public class CsvImportIT extends AbstractEntityIntegrationTest {
         String csvLineString = itemE.getID().toString() + "," + owningCollection
             .getHandle() + "," + title + "," + "Person" + "," + itemB.getID().toString() + "||" + itemF.getID()
                                                                                                        .toString();
-        String[] csv = {"id,collection,dc.title,relationship.type,relation." + "isAuthorOfPublication", csvLineString};
+        String[] csv = {"id,collection,dc.title,dspace.entity.type,relation." + "isAuthorOfPublication", csvLineString};
         performImportScript(csv);
 
     }
@@ -200,7 +200,7 @@ public class CsvImportIT extends AbstractEntityIntegrationTest {
                                                                Integer rightPlaceToCheck) throws Exception {
         String csvLineString = "+," + col1.getHandle() + "," + itemTitle + "," + relationshipType + "," + relatedItem
             .getID().toString();
-        String[] csv = {"id,collection,dc.title,relationship.type,relation." + relationshipTypeLabel, csvLineString};
+        String[] csv = {"id,collection,dc.title,dspace.entity.type,relation." + relationshipTypeLabel, csvLineString};
         performImportScript(csv);
         Iterator<Item> itemIteratorItem = itemService.findByMetadataField(context, "dc", "title", null, itemTitle);
         Item item = itemIteratorItem.next();
@@ -232,7 +232,7 @@ public class CsvImportIT extends AbstractEntityIntegrationTest {
         idStringRelatedItems = idStringRelatedItems.substring(0, idStringRelatedItems.length() - 2);
         String csvLineString = "+," + col1
             .getHandle() + "," + itemTitle + "," + relationshipType + "," + idStringRelatedItems;
-        String[] csv = {"id,collection,dc.title,relationship.type,relation." + relationshipTypeLabel, csvLineString};
+        String[] csv = {"id,collection,dc.title,dspace.entity.type,relation." + relationshipTypeLabel, csvLineString};
         performImportScript(csv);
         Iterator<Item> itemIteratorItem = itemService.findByMetadataField(context, "dc", "title", null, itemTitle);
         Item item = itemIteratorItem.next();
@@ -299,7 +299,7 @@ public class CsvImportIT extends AbstractEntityIntegrationTest {
 
         String csvLineString = "+," + col1.getHandle() + ",TestItemB,Person," + article
             .getID().toString();
-        String[] csv = {"id,collection,dc.title,relationship.type,relation.isPublicationOfAuthor", csvLineString};
+        String[] csv = {"id,collection,dc.title,dspace.entity.type,relation.isPublicationOfAuthor", csvLineString};
 
         InputStream inputStream = new ByteArrayInputStream(String.join(System.lineSeparator(),
                                                                        Arrays.asList(csv))

--- a/dspace/config/crosswalks/oai/xoai.xml
+++ b/dspace/config/crosswalks/oai/xoai.xml
@@ -177,7 +177,7 @@
             <SchemaLocation>http://irdb.nii.ac.jp/oai/junii2-3-1.xsd</SchemaLocation>
         </Format>
         <!-- Metadata format based on the OpenAIRE 4.0 guidelines
-             https://openaire-guidelines-for-literature-repository-managers.readthedocs.io/en/v4.0.0/use_of_oai_pmh.html 
+             https://openaire-guidelines-for-literature-repository-managers.readthedocs.io/en/v4.0.0/use_of_oai_pmh.html
         -->
         <Format id="oaiopenaire">
             <Prefix>oai_openaire</Prefix>
@@ -323,8 +323,8 @@
              By default, return an Item record:
                 * If it is publicly accessible
                 * * OR it has been withdrawn (in order to display a tombstone record).
-                * AND doesn't have a relationship.type field
-                * * OR the relationship.type is a Publication
+                * AND doesn't have a dspace.entity.type field
+                * * OR the dspace.entity.type is a Publication
                 * limiting the results only to Publications as expected
              This filter is used by the default context ([oai]/request).
         -->
@@ -363,8 +363,8 @@
              By default, return an Item record:
                 * If it is publicly accessible
                 * * OR it has been withdrawn (in order to display a tombstone record).
-                * AND doesn't have a relationship.type field
-                * * OR the relationship.type is a Publication
+                * AND doesn't have a dspace.entity.type field
+                * * OR the dspace.entity.type is a Publication
                 * limiting the results only to Publications as expected
              This filter is used by the default context ([oai]/request).
         -->
@@ -493,20 +493,20 @@
             </Configuration>
         </CustomCondition>
 
-        <!-- This condition determines if an Item has a "relationship.type" -->
+        <!-- This condition determines if an Item has a "dspace.entity.type" -->
         <CustomCondition id="relationshipTypeExistsCondition">
             <Class>org.dspace.xoai.filter.DSpaceMetadataExistsFilter</Class>
             <Configuration>
-                <string name="field">relationship.type</string>
+                <string name="field">dspace.entity.type</string>
             </Configuration>
         </CustomCondition>
 
-        <!-- This condition determines if an Item has a "relationship.type" field
+        <!-- This condition determines if an Item has a "dspace.entity.type" field
              specifying one of the valid DRIVER document types. -->
         <CustomCondition id="isPublicationEntityCondition">
             <Class>org.dspace.xoai.filter.DSpaceAtLeastOneMetadataFilter</Class>
             <Configuration>
-                <string name="field">relationship.type</string>
+                <string name="field">dspace.entity.type</string>
                 <string name="operator">equal</string>
                 <list name="values">
                     <string>Publication</string>

--- a/dspace/config/registries/dspace-types.xml
+++ b/dspace/config/registries/dspace-types.xml
@@ -30,4 +30,11 @@
         <scope_note>Stores the cookie preferences of an EPerson, as selected in last session. Value will be an array of cookieName/boolean pairs, specifying which cookies are allowed or not allowed.</scope_note>
     </dc-type>
 
+    <dc-type>
+        <schema>dspace</schema>
+        <element>entity</element>
+        <qualifier>type</qualifier>
+        <scope_note>Stores the type of Entity that a specific Item represents</scope_note>
+    </dc-type>
+
 </dspace-dc-types>

--- a/dspace/config/registries/relationship-formats.xml
+++ b/dspace/config/registries/relationship-formats.xml
@@ -1,24 +1,13 @@
 <dspace-dc-types>
 
     <dspace-header>
-        <title>DSpace Relationship</title>
+        <title>DSpace Entity Relationships</title>
     </dspace-header>
-
-    <dc-schema>
-        <name>relationship</name>
-        <namespace>http://dspace.org/relationship</namespace>
-    </dc-schema>
 
     <dc-schema>
         <name>relation</name>
         <namespace>http://dspace.org/relation</namespace>
     </dc-schema>
-
-    <dc-type>
-        <schema>relationship</schema>
-        <element>type</element>
-        <scope_note>Metadata field used for the type of entity, stored in the item</scope_note>
-    </dc-type>
 
     <dc-type>
         <schema>relation</schema>
@@ -124,7 +113,7 @@
 
     <!--
       OpenAIRE4 Guidelines
-      required relationships -->  
+      required relationships -->
     <dc-type>
         <schema>relation</schema>
         <element>isContributorOfPublication</element>

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -195,7 +195,7 @@
                             <property name="snippets" value="5"/>
                         </bean>
                         <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="relationship.type"/>
+                            <property name="field" value="dspace.entity.type"/>
                             <property name="snippets" value="5"/>
                         </bean>
                         <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
@@ -337,7 +337,7 @@
                             <property name="snippets" value="5"/>
                         </bean>
                         <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="relationship.type"/>
+                            <property name="field" value="dspace.entity.type"/>
                             <property name="snippets" value="5"/>
                         </bean>
                         <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
@@ -482,7 +482,7 @@
                             <property name="snippets" value="5"/>
                         </bean>
                         <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="relationship.type"/>
+                            <property name="field" value="dspace.entity.type"/>
                             <property name="snippets" value="5"/>
                         </bean>
                         <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
@@ -619,7 +619,7 @@
                             <property name="snippets" value="5"/>
                         </bean>
                         <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="relationship.type"/>
+                            <property name="field" value="dspace.entity.type"/>
                             <property name="snippets" value="5"/>
                         </bean>
                         <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
@@ -1653,7 +1653,7 @@
         <property name="indexFieldName" value="entityType"/>
         <property name="metadataFields">
             <list>
-                <value>relationship.type</value>
+                <value>dspace.entity.type</value>
             </list>
         </property>
         <property name="facetLimit" value="5"/>
@@ -2232,7 +2232,7 @@
     </bean>
 
     <bean id="sortEntityType" class="org.dspace.discovery.configuration.DiscoverySortFieldConfiguration">
-        <property name="metadataField" value="relationship.type"/>
+        <property name="metadataField" value="dspace.entity.type"/>
     </bean>
 
 </beans>


### PR DESCRIPTION
## References
* Fixes #2815
* Must be merged with https://github.com/DSpace/dspace-angular/pull/1055 (Corresponding Angular PR)

## Description
This is a small refactor in our metadata schemas.  It **completely** removes the `relationship.type` field (and the `relationship` schema), and replaces it with a new `dspace.entity.type` metadata field.  This name was chosen as the value of this field is often referred to as the Entity "type" within our codebases.

NOTE: Keep in mind, there are still usages of the phrase "relationship type" or "RelationshipType" in the backend codebase, because there is an actual [`/api/core/relationshiptypes`](https://github.com/DSpace/RestContract/blob/main/relationshiptypes.md)  endpoint. This PR only corrects usages of "relationship type" when they actually refer to the Entity Type retrieved via either `dspace.entity.type` or the separate  [`/api/core/entitytypes`](https://github.com/DSpace/RestContract/blob/main/entitytypes.md)  endpoint.

In summary, Entity Types are things like "Person", "Publication", etc. while Relationship Types are things like "isAuthorOfPublication" or "isProjectOfOrgUnit".  (And this is the reason why the `relationship.type` metadata field was so confusingly named, as it actually stored the Entity Type, not the Relationship Type)

## Instructions for Reviewers

* Review the PR changes. (They were mostly an automated find & replace, but I also tested them with existing Entity data)
* NOTE: This PR includes a small **bug fix** to incorrect code in `CsvImportIT`.
    * In early builds in this PR, strange failures were occurring in `CsvImportIT`.  See for example this failing test: https://github.com/DSpace/DSpace/runs/2097263205#step:5:1271
    * I refactored the code (variable / method renaming) and enhanced comments in `CsvImportIT` in order to find the bug (see https://github.com/DSpace/DSpace/pull/3183/commits/9bf9c3037f7a8d61eb4a6e573d503011fbaa6673).  The bug was an incorrect/invalid Entity Type in the test itself.  It was fixed in this commit:  https://github.com/DSpace/DSpace/pull/3183/commits/cdb59db8f59a9c2a8eebb348285809bf6ba4972e
* Review Flyway Migrations to move existing entity types from `relationship.type` to `dspace.entity.type`  (I've tested these thoroughly on Postgres. The Oracle ones are untested, but are based on [existing Oracle migrations that used similar SQL](https://github.com/DSpace/DSpace/blob/main/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/V4.9_2015.10.26__DS-2818_registry_update.sql))
    * Keep in mind, no H2 database migration exists as H2 is only used for unit testing, and therefore it will never have the `relationship.type` schema/field.
* Verify that Entity type values (e.g. Person, Publication, etc) are now stored/retrieved in `dspace.entity.type` on Items.  This is easiest to verify via HAL Browser or the corresponding Angular UI PR.


~~**NOTE TO SELF:** Once this is merged, minor updates may be needed to https://wiki.lyrasis.org/display/DSDOC7x/Configurable+Entities (especially correcting any place that mentions `relationship.type`)~~ DONE