### PR TITLE
WorkflowItems not indexing their Item's metadata fix

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/indexobject/InprogressSubmissionIndexFactoryImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/indexobject/InprogressSubmissionIndexFactoryImpl.java
@@ -63,6 +63,7 @@ public abstract class InprogressSubmissionIndexFactoryImpl
         List<String> locations = indexableCollectionService.
                 getCollectionLocations(context, inProgressSubmission.getCollection());
 
+        // Add item metadata
         indexableItemService.addDiscoveryFields(doc, context, item, SearchUtils.getAllDiscoveryConfigurations(item));
         indexableCollectionService.storeCommunityCollectionLocations(doc, locations);
     }

--- a/dspace-api/src/main/java/org/dspace/discovery/indexobject/InprogressSubmissionIndexFactoryImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/indexobject/InprogressSubmissionIndexFactoryImpl.java
@@ -15,6 +15,7 @@ import org.apache.solr.common.SolrInputDocument;
 import org.dspace.content.InProgressSubmission;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
+import org.dspace.discovery.SearchUtils;
 import org.dspace.discovery.indexobject.factory.CollectionIndexFactory;
 import org.dspace.discovery.indexobject.factory.InprogressSubmissionIndexFactory;
 import org.dspace.discovery.indexobject.factory.ItemIndexFactory;
@@ -47,7 +48,7 @@ public abstract class InprogressSubmissionIndexFactoryImpl
 
     @Override
     public void storeInprogressItemFields(Context context, SolrInputDocument doc,
-                                          InProgressSubmission inProgressSubmission) throws SQLException {
+                                          InProgressSubmission inProgressSubmission) throws SQLException, IOException {
         final Item item = inProgressSubmission.getItem();
         doc.addField("lastModified", SolrUtils.getDateFormatter().format(item.getLastModified()));
         EPerson submitter = inProgressSubmission.getSubmitter();
@@ -61,6 +62,8 @@ public abstract class InprogressSubmissionIndexFactoryImpl
         // get the location string (for searching by collection & community)
         List<String> locations = indexableCollectionService.
                 getCollectionLocations(context, inProgressSubmission.getCollection());
+
+        indexableItemService.addDiscoveryFields(doc, context, item, SearchUtils.getAllDiscoveryConfigurations(item));
         indexableCollectionService.storeCommunityCollectionLocations(doc, locations);
     }
 }

--- a/dspace-api/src/main/java/org/dspace/discovery/indexobject/WorkflowItemIndexFactoryImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/indexobject/WorkflowItemIndexFactoryImpl.java
@@ -19,8 +19,6 @@ import org.apache.solr.common.SolrInputDocument;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
 import org.dspace.discovery.IndexableObject;
-import org.dspace.discovery.SearchUtils;
-import org.dspace.discovery.configuration.DiscoveryConfiguration;
 import org.dspace.discovery.indexobject.factory.WorkflowItemIndexFactory;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.xmlworkflow.storedcomponents.ClaimedTask;
@@ -75,10 +73,6 @@ public class WorkflowItemIndexFactoryImpl
         final SolrInputDocument doc = super.buildDocument(context, indexableObject);
         final XmlWorkflowItem workflowItem = indexableObject.getIndexedObject();
         final Item item = workflowItem.getItem();
-        // Add the item metadata as configured
-//        List<DiscoveryConfiguration> discoveryConfigurations = SearchUtils
-//                .getAllDiscoveryConfigurations(workflowItem);
-//        indexableItemService.addDiscoveryFields(doc, context, item, discoveryConfigurations);
 
         String acvalue = DSpaceServicesFactory.getInstance().getConfigurationService()
                 .getProperty("discovery.facet.namedtype.workflow.item");

--- a/dspace-api/src/main/java/org/dspace/discovery/indexobject/WorkflowItemIndexFactoryImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/indexobject/WorkflowItemIndexFactoryImpl.java
@@ -76,9 +76,9 @@ public class WorkflowItemIndexFactoryImpl
         final XmlWorkflowItem workflowItem = indexableObject.getIndexedObject();
         final Item item = workflowItem.getItem();
         // Add the item metadata as configured
-        List<DiscoveryConfiguration> discoveryConfigurations = SearchUtils
-                .getAllDiscoveryConfigurations(workflowItem);
-        indexableItemService.addDiscoveryFields(doc, context, item, discoveryConfigurations);
+//        List<DiscoveryConfiguration> discoveryConfigurations = SearchUtils
+//                .getAllDiscoveryConfigurations(workflowItem);
+//        indexableItemService.addDiscoveryFields(doc, context, item, discoveryConfigurations);
 
         String acvalue = DSpaceServicesFactory.getInstance().getConfigurationService()
                 .getProperty("discovery.facet.namedtype.workflow.item");

--- a/dspace-api/src/main/java/org/dspace/discovery/indexobject/WorkspaceItemIndexFactoryImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/indexobject/WorkspaceItemIndexFactoryImpl.java
@@ -74,9 +74,9 @@ public class WorkspaceItemIndexFactoryImpl
         final WorkspaceItem inProgressSubmission = indexableObject.getIndexedObject();
 
         // Add the item metadata as configured
-        List<DiscoveryConfiguration> discoveryConfigurations = SearchUtils
-                .getAllDiscoveryConfigurations(inProgressSubmission);
-        indexableItemService.addDiscoveryFields(doc, context, inProgressSubmission.getItem(), discoveryConfigurations);
+//        List<DiscoveryConfiguration> discoveryConfigurations = SearchUtils
+//                .getAllDiscoveryConfigurations(inProgressSubmission);
+//        indexableItemService.addDiscoveryFields(doc, context, inProgressSubmission.getItem(), discoveryConfigurations);
 
         return doc;
     }

--- a/dspace-api/src/main/java/org/dspace/discovery/indexobject/WorkspaceItemIndexFactoryImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/indexobject/WorkspaceItemIndexFactoryImpl.java
@@ -19,8 +19,6 @@ import org.apache.solr.common.SolrInputDocument;
 import org.dspace.content.WorkspaceItem;
 import org.dspace.content.service.WorkspaceItemService;
 import org.dspace.core.Context;
-import org.dspace.discovery.SearchUtils;
-import org.dspace.discovery.configuration.DiscoveryConfiguration;
 import org.dspace.discovery.indexobject.factory.WorkspaceItemIndexFactory;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -71,12 +69,6 @@ public class WorkspaceItemIndexFactoryImpl
             acvalue = indexableObject.getTypeText();
         }
         addNamedResourceTypeIndex(doc, acvalue);
-        final WorkspaceItem inProgressSubmission = indexableObject.getIndexedObject();
-
-        // Add the item metadata as configured
-//        List<DiscoveryConfiguration> discoveryConfigurations = SearchUtils
-//                .getAllDiscoveryConfigurations(inProgressSubmission);
-//        indexableItemService.addDiscoveryFields(doc, context, inProgressSubmission.getItem(), discoveryConfigurations);
 
         return doc;
     }

--- a/dspace-api/src/main/java/org/dspace/discovery/indexobject/factory/InprogressSubmissionIndexFactory.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/indexobject/factory/InprogressSubmissionIndexFactory.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.discovery.indexobject.factory;
 
+import java.io.IOException;
 import java.sql.SQLException;
 
 import org.apache.solr.common.SolrInputDocument;
@@ -31,5 +32,5 @@ public interface InprogressSubmissionIndexFactory<T extends IndexableInProgressS
      * @throws SQLException         If database error
      */
     void storeInprogressItemFields(Context context, SolrInputDocument doc, InProgressSubmission inProgressSubmission)
-            throws SQLException;
+        throws SQLException, IOException;
 }

--- a/dspace-api/src/test/java/org/dspace/builder/ClaimedTaskBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/ClaimedTaskBuilder.java
@@ -95,8 +95,8 @@ public class ClaimedTaskBuilder extends AbstractBuilder<ClaimedTask, ClaimedTask
             workflowService
                 .doState(context, user, null, task.getWorkflowItem().getID(), workflow,
                     currentActionConfig);
-            context.addEvent(new Event(Event.MODIFY, Constants.ITEM, task.getWorkflowItem().getItem().getID(), null,
-                itemService.getIdentifiers(context, task.getWorkflowItem().getItem())));
+//            context.addEvent(new Event(Event.MODIFY, Constants.ITEM, task.getWorkflowItem().getItem().getID(), null,  todo: see what breaks :s
+//                itemService.getIdentifiers(context, task.getWorkflowItem().getItem())));
             claimedTask = getService().findByWorkflowIdAndEPerson(context, workflowItem, user);
             // restore the submitter as current user
             context.setCurrentUser(submitter);

--- a/dspace-api/src/test/java/org/dspace/builder/ClaimedTaskBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/ClaimedTaskBuilder.java
@@ -16,10 +16,8 @@ import org.dspace.content.Item;
 import org.dspace.content.LicenseUtils;
 import org.dspace.content.MetadataSchemaEnum;
 import org.dspace.content.WorkspaceItem;
-import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
-import org.dspace.event.Event;
 import org.dspace.xmlworkflow.factory.XmlWorkflowServiceFactory;
 import org.dspace.xmlworkflow.state.Step;
 import org.dspace.xmlworkflow.state.Workflow;
@@ -95,8 +93,6 @@ public class ClaimedTaskBuilder extends AbstractBuilder<ClaimedTask, ClaimedTask
             workflowService
                 .doState(context, user, null, task.getWorkflowItem().getID(), workflow,
                     currentActionConfig);
-//            context.addEvent(new Event(Event.MODIFY, Constants.ITEM, task.getWorkflowItem().getItem().getID(), null,  todo: see what breaks :s
-//                itemService.getIdentifiers(context, task.getWorkflowItem().getItem())));
             claimedTask = getService().findByWorkflowIdAndEPerson(context, workflowItem, user);
             // restore the submitter as current user
             context.setCurrentUser(submitter);


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/DSpace/issues/3173

## Description
This PR ensures that ClaimedTasks and PoolTasks will index its Item's metadata and thus it can be searched for through discovery.

## Instructions for Reviewers

List of changes in this PR:
* Added the indexing of Item metadata for the ClaimedTask and PoolTask by adding the `indexableItemService.addDiscoveryFields` to `storeInprogressItemFields` in the `InprogressSubmissionIndexFactoryImpl`
* Removed duplicate calls of this by removing the specific calls made in the Workflow/WorkspaceIndexFactories as they call the `storeInprogressItemFields` method as well

How to test this PR:
* Setup an Angular instance on main and this PR as REST branch
* Create a collection with workflowGroups to which an EPerson is assigned
* Perform a submission in this collection, ensuring that a workflowItem is created for the submission
* Login as the EPerson in the workflowGroups, go to the myDspace section and search for all tasks
* Claim the task at hand, ensure that doing a search with no query results in that Item being returned
* Now perform a search with a query that holds parts of the item's title, ensure that the item is still being returned. (Look at @benbosman 's issue for a video fully explaining this process

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
