### PR TITLE
handle redirect for items not working - REST Implementation

### DIFF
--- a/dspace-api/src/main/java/org/dspace/handle/HandleServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/handle/HandleServiceImpl.java
@@ -10,6 +10,8 @@ package org.dspace.handle;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -56,6 +58,13 @@ public class HandleServiceImpl implements HandleService {
 
     @Autowired
     protected SiteService siteService;
+
+    private static final Pattern[] IDENTIFIER_PATTERNS = {
+        Pattern.compile("^hdl:(.*)$"),
+        Pattern.compile("^info:hdl/(.*)$"),
+        Pattern.compile("^https?://hdl\\.handle\\.net/(.*)$"),
+        Pattern.compile("^https?://.+/handle/(.*)$")
+    };
 
     /**
      * Public Constructor
@@ -375,5 +384,39 @@ public class HandleServiceImpl implements HandleService {
     @Override
     public int countTotal(Context context) throws SQLException {
         return handleDAO.countRows(context);
+    }
+
+    public String formatHandle(String identifier) {
+        if (identifier == null) {
+            return null;
+        }
+        if (identifier.startsWith(getPrefix() + "/")) {
+            // prefix is the equivalent of 123456789 in 123456789/???; don't strip
+            return identifier;
+        }
+
+        String canonicalPrefix = configurationService.getProperty("handle.canonical.prefix");
+        if (identifier.startsWith(canonicalPrefix + "/")) {
+            // prefix is the equivalent of https://hdl.handle.net/ in https://hdl.handle.net/123456789/???; strip
+            return StringUtils.stripStart(identifier, canonicalPrefix);
+        }
+
+        for (Pattern pattern : IDENTIFIER_PATTERNS) {
+            Matcher matcher = pattern.matcher(identifier);
+            if (matcher.matches()) {
+                return matcher.group(1);
+            }
+        }
+
+        // Check additional prefixes supported in the config file
+        String[] additionalPrefixes = configurationService.getArrayProperty("handle.additional.prefixes");
+        for (String additionalPrefix : additionalPrefixes) {
+            if (identifier.startsWith(additionalPrefix + "/")) {
+                // prefix is the equivalent of 123456789 in 123456789/???; don't strip
+                return identifier;
+            }
+        }
+
+        return null;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/handle/HandleServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/handle/HandleServiceImpl.java
@@ -386,7 +386,8 @@ public class HandleServiceImpl implements HandleService {
         return handleDAO.countRows(context);
     }
 
-    public String formatHandle(String identifier) {
+    @Override
+    public String parseHandle(String identifier) {
         if (identifier == null) {
             return null;
         }

--- a/dspace-api/src/main/java/org/dspace/handle/service/HandleService.java
+++ b/dspace-api/src/main/java/org/dspace/handle/service/HandleService.java
@@ -191,5 +191,5 @@ public interface HandleService {
      * @param identifier
      * @return
      */
-    String formatHandle(String identifier);
+    String parseHandle(String identifier);
 }

--- a/dspace-api/src/main/java/org/dspace/handle/service/HandleService.java
+++ b/dspace-api/src/main/java/org/dspace/handle/service/HandleService.java
@@ -181,4 +181,15 @@ public interface HandleService {
     public void modifyHandleDSpaceObject(Context context, String handle, DSpaceObject newOwner) throws SQLException;
 
     int countTotal(Context context) throws SQLException;
+
+    /**
+     * Format a handle ~
+     *   - hdl:123456789/1                     -> 123456789/1
+     *   - info:hdl/123456789/1                -> 123456789/1
+     *   - https://hdl.handle.net/123456789/1  -> 123456789/1
+     *
+     * @param identifier
+     * @return
+     */
+    String formatHandle(String identifier);
 }

--- a/dspace-api/src/main/java/org/dspace/identifier/HandleIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/HandleIdentifierProvider.java
@@ -60,32 +60,7 @@ public class HandleIdentifierProvider extends IdentifierProvider {
 
     @Override
     public boolean supports(String identifier) {
-        String prefix = handleService.getPrefix();
-        String canonicalPrefix = DSpaceServicesFactory.getInstance().getConfigurationService()
-                                                      .getProperty("handle.canonical.prefix");
-        if (identifier == null) {
-            return false;
-        }
-        // return true if handle has valid starting pattern
-        if (identifier.startsWith(prefix + "/")
-            || identifier.startsWith(canonicalPrefix)
-            || identifier.startsWith("hdl:")
-            || identifier.startsWith("info:hdl")
-            || identifier.matches("^https?://hdl\\.handle\\.net/.*")
-            || identifier.matches("^https?://.+/handle/.*")) {
-            return true;
-        }
-
-        //Check additional prefixes supported in the config file
-        String[] additionalPrefixes = DSpaceServicesFactory.getInstance().getConfigurationService()
-                                                           .getArrayProperty("handle.additional.prefixes");
-        for (String additionalPrefix : additionalPrefixes) {
-            if (identifier.startsWith(additionalPrefix + "/")) {
-                return true;
-            }
-        }
-
-        return false;
+        return handleService.formatHandle(identifier) != null;
     }
 
     @Override
@@ -161,6 +136,7 @@ public class HandleIdentifierProvider extends IdentifierProvider {
     public DSpaceObject resolve(Context context, String identifier, String... attributes) {
         // We can do nothing with this, return null
         try {
+            identifier = handleService.formatHandle(identifier);
             return handleService.resolveToObject(context, identifier);
         } catch (IllegalStateException | SQLException e) {
             log.error(LogManager.getHeader(context, "Error while resolving handle to item", "handle: " + identifier),

--- a/dspace-api/src/main/java/org/dspace/identifier/HandleIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/HandleIdentifierProvider.java
@@ -60,7 +60,7 @@ public class HandleIdentifierProvider extends IdentifierProvider {
 
     @Override
     public boolean supports(String identifier) {
-        return handleService.formatHandle(identifier) != null;
+        return handleService.parseHandle(identifier) != null;
     }
 
     @Override
@@ -136,7 +136,7 @@ public class HandleIdentifierProvider extends IdentifierProvider {
     public DSpaceObject resolve(Context context, String identifier, String... attributes) {
         // We can do nothing with this, return null
         try {
-            identifier = handleService.formatHandle(identifier);
+            identifier = handleService.parseHandle(identifier);
             return handleService.resolveToObject(context, identifier);
         } catch (IllegalStateException | SQLException e) {
             log.error(LogManager.getHeader(context, "Error while resolving handle to item", "handle: " + identifier),

--- a/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProvider.java
@@ -78,33 +78,7 @@ public class VersionedHandleIdentifierProvider extends IdentifierProvider {
 
     @Override
     public boolean supports(String identifier) {
-        String prefix = handleService.getPrefix();
-        String canonicalPrefix = DSpaceServicesFactory.getInstance().getConfigurationService()
-                                                      .getProperty("handle.canonical.prefix");
-        if (identifier == null) {
-            return false;
-        }
-        // return true if handle has valid starting pattern
-        if (identifier.startsWith(prefix + "/")
-            || identifier.startsWith(canonicalPrefix)
-            || identifier.startsWith("hdl:")
-            || identifier.startsWith("info:hdl")
-            || identifier.matches("^https?://hdl\\.handle\\.net/.*")
-            || identifier.matches("^https?://.+/handle/.*")) {
-            return true;
-        }
-
-        //Check additional prefixes supported in the config file
-        String[] additionalPrefixes = DSpaceServicesFactory.getInstance().getConfigurationService()
-                                                           .getArrayProperty("handle.additional.prefixes");
-        for (String additionalPrefix : additionalPrefixes) {
-            if (identifier.startsWith(additionalPrefix + "/")) {
-                return true;
-            }
-        }
-
-        // otherwise, assume invalid handle
-        return false;
+        return handleService.formatHandle(identifier) != null;
     }
 
     @Override
@@ -310,6 +284,7 @@ public class VersionedHandleIdentifierProvider extends IdentifierProvider {
     public DSpaceObject resolve(Context context, String identifier, String... attributes) {
         // We can do nothing with this, return null
         try {
+            identifier = handleService.formatHandle(identifier);
             return handleService.resolveToObject(context, identifier);
         } catch (IllegalStateException | SQLException e) {
             log.error(LogManager.getHeader(context, "Error while resolving handle to item", "handle: " + identifier),

--- a/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProvider.java
@@ -78,7 +78,7 @@ public class VersionedHandleIdentifierProvider extends IdentifierProvider {
 
     @Override
     public boolean supports(String identifier) {
-        return handleService.formatHandle(identifier) != null;
+        return handleService.parseHandle(identifier) != null;
     }
 
     @Override
@@ -284,7 +284,7 @@ public class VersionedHandleIdentifierProvider extends IdentifierProvider {
     public DSpaceObject resolve(Context context, String identifier, String... attributes) {
         // We can do nothing with this, return null
         try {
-            identifier = handleService.formatHandle(identifier);
+            identifier = handleService.parseHandle(identifier);
             return handleService.resolveToObject(context, identifier);
         } catch (IllegalStateException | SQLException e) {
             log.error(LogManager.getHeader(context, "Error while resolving handle to item", "handle: " + identifier),

--- a/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProviderWithCanonicalHandles.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProviderWithCanonicalHandles.java
@@ -72,33 +72,7 @@ public class VersionedHandleIdentifierProviderWithCanonicalHandles extends Ident
 
     @Override
     public boolean supports(String identifier) {
-        String prefix = handleService.getPrefix();
-        String canonicalPrefix = DSpaceServicesFactory.getInstance().getConfigurationService()
-                                                      .getProperty("handle.canonical.prefix");
-        if (identifier == null) {
-            return false;
-        }
-        // return true if handle has valid starting pattern
-        if (identifier.startsWith(prefix + "/")
-            || identifier.startsWith(canonicalPrefix)
-            || identifier.startsWith("hdl:")
-            || identifier.startsWith("info:hdl")
-            || identifier.matches("^https?://hdl\\.handle\\.net/.*")
-            || identifier.matches("^https?://.+/handle/.*")) {
-            return true;
-        }
-
-        //Check additional prefixes supported in the config file
-        String[] additionalPrefixes = DSpaceServicesFactory.getInstance().getConfigurationService()
-                                                           .getArrayProperty("handle.additional.prefixes");
-        for (String additionalPrefix : additionalPrefixes) {
-            if (identifier.startsWith(additionalPrefix + "/")) {
-                return true;
-            }
-        }
-
-        // otherwise, assume invalid handle
-        return false;
+        return handleService.formatHandle(identifier) != null;
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProviderWithCanonicalHandles.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProviderWithCanonicalHandles.java
@@ -72,7 +72,7 @@ public class VersionedHandleIdentifierProviderWithCanonicalHandles extends Ident
 
     @Override
     public boolean supports(String identifier) {
-        return handleService.formatHandle(identifier) != null;
+        return handleService.parseHandle(identifier) != null;
     }
 
     @Override

--- a/dspace-api/src/test/java/org/dspace/handle/HandleServiceTest.java
+++ b/dspace-api/src/test/java/org/dspace/handle/HandleServiceTest.java
@@ -1,0 +1,66 @@
+package org.dspace.handle;
+
+import static org.junit.Assert.*;
+
+import org.dspace.AbstractUnitTest;
+import org.dspace.handle.factory.HandleServiceFactory;
+import org.dspace.handle.service.HandleService;
+import org.dspace.services.ConfigurationService;
+import org.dspace.utils.DSpace;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class HandleServiceTest extends AbstractUnitTest {
+    protected HandleService handleService = HandleServiceFactory.getInstance().getHandleService();
+    protected ConfigurationService configurationService = new DSpace().getConfigurationService();
+
+    @Before
+    @Override
+    public void init() {
+        super.init();
+
+        configurationService.setProperty("handle.prefix", "123456789");
+        configurationService.setProperty("handle.canonical.prefix", "https://fake.canonical.prefix");
+        configurationService.setProperty("handle.additional.prefixes", "987654321, 654321987");
+    }
+
+    @Test
+    public void testParseHandleInvalid() {
+        assertNull(handleService.parseHandle(null));
+        assertNull(handleService.parseHandle("123456789"));
+        assertNull(handleService.parseHandle("/123456789"));
+        assertNull(handleService.parseHandle("https://duraspace.org/dspace/"));
+        assertNull(handleService.parseHandle("10.70131/test_doi_5d2be995d35b6"));
+        assertNull(handleService.parseHandle("not a handle"));
+    }
+
+    @Test
+    public void testParseHandleByPrefix() {
+        // note: handle pattern after prefix is not checked
+        assertEquals("123456789/111", handleService.parseHandle("123456789/111"));
+    }
+
+    @Test
+    public void testParseHandleByCanonicalPrefix() {
+        // note: handle pattern after prefix is not checked
+        assertEquals("111222333/111", handleService.parseHandle("https://fake.canonical.prefix/111222333/111"));
+    }
+
+    @Test
+    public void testParseHandleByAdditionalPrefix() {
+        // note: handle pattern after prefix is not checked
+        assertEquals("987654321/111", handleService.parseHandle("987654321/111"));
+        assertEquals("654321987/111", handleService.parseHandle("654321987/111"));
+    }
+
+    @Test
+    public void testParseHandleByPattern() {
+        assertEquals("111222333/111", handleService.parseHandle("hdl:111222333/111"));
+        assertEquals("111222333/111", handleService.parseHandle("info:hdl/111222333/111"));
+        assertEquals("111222333/111", handleService.parseHandle("https://hdl.handle.net/111222333/111"));
+        assertEquals("111222333/111", handleService.parseHandle("http://hdl.handle.net/111222333/111"));
+        assertEquals("111222333/111", handleService.parseHandle("https://whatever/handle/111222333/111"));
+        assertEquals("111222333/111", handleService.parseHandle("http://whatever/handle/111222333/111"));
+    }
+}

--- a/dspace-api/src/test/java/org/dspace/handle/HandleServiceTest.java
+++ b/dspace-api/src/test/java/org/dspace/handle/HandleServiceTest.java
@@ -7,7 +7,8 @@
  */
 package org.dspace.handle;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import org.dspace.AbstractUnitTest;
 import org.dspace.handle.factory.HandleServiceFactory;
@@ -15,7 +16,6 @@ import org.dspace.handle.service.HandleService;
 import org.dspace.services.ConfigurationService;
 import org.dspace.utils.DSpace;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class HandleServiceTest extends AbstractUnitTest {

--- a/dspace-api/src/test/java/org/dspace/handle/HandleServiceTest.java
+++ b/dspace-api/src/test/java/org/dspace/handle/HandleServiceTest.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package org.dspace.handle;
 
 import static org.junit.Assert.*;


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/DSpace/issues/3113

## Description
This PR fixes the REST side for the above mentioned issue.
It'll take the identifier given in all the handleProviders and it'll remove any known prefixes like "hdl:". This will ensure that the actual handle is used in each resolve method.

## Instructions for Reviewers

List of changes in this PR:
* Added a method in the HandleService to strip the prefixes from the handles
* Used this method in each of the three HandleProviders in both the supports and resolve methods

How to test this PR:
* Build and deploy the code
* Call the `/api/pid/find?id=hdl:{handle}` endpoint
* Verify that a "Location" header is present in the response with the Item's location in it

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
