### PR TITLE
Added script to delete all metadata values

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataDeletion.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataDeletion.java
@@ -10,12 +10,15 @@ package org.dspace.app.bulkedit;
 import java.sql.SQLException;
 
 import org.apache.commons.cli.ParseException;
+import org.apache.commons.lang3.ArrayUtils;
 import org.dspace.content.MetadataField;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.MetadataFieldService;
 import org.dspace.content.service.MetadataValueService;
 import org.dspace.core.Context;
 import org.dspace.scripts.DSpaceRunnable;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.utils.DSpace;
 
 /**
@@ -27,36 +30,63 @@ import org.dspace.utils.DSpace;
  */
 public class MetadataDeletion extends DSpaceRunnable<MetadataDeletionScriptConfiguration<MetadataDeletion>> {
 
+    private MetadataValueService metadataValueService;
+
+    private MetadataFieldService metadataFieldService;
+
+    private ConfigurationService configurationService;
+
     private String metadataField;
+
+    private boolean list;
 
     @Override
     public void internalRun() throws Exception {
-        Context context = new Context();
-        context.turnOffAuthorisationSystem();
 
-        try {
-            performMetadataValuesDeletion(context);
-        } catch (SQLException e) {
-            handler.handleException(e);
+        if (list) {
+            listErasableMetadata();
+            return;
         }
 
-        context.restoreAuthSystemState();
-        context.complete();
+        Context context = new Context();
+
+        try {
+            context.turnOffAuthorisationSystem();
+            performMetadataValuesDeletion(context);
+        } finally {
+            context.restoreAuthSystemState();
+            context.complete();
+        }
+
+    }
+
+    private void listErasableMetadata() {
+        String[] erasableMetadata = getErasableMetadata();
+        if (ArrayUtils.isEmpty(erasableMetadata)) {
+            handler.logInfo("No fields has been configured to be cleared via bulk deletion");
+        } else {
+            handler.logInfo("The fields that can be bulk deleted are: " + String.join(", ", erasableMetadata));
+        }
     }
 
     private void performMetadataValuesDeletion(Context context) throws SQLException {
-        MetadataValueService metadataValueService = ContentServiceFactory.getInstance()
-            .getMetadataValueService();
-
-        MetadataFieldService metadataFieldService = ContentServiceFactory.getInstance()
-            .getMetadataFieldService();
 
         MetadataField field = metadataFieldService.findByString(context, metadataField, '.');
         if (field == null) {
             throw new IllegalArgumentException("No metadata field found with name " + metadataField);
         }
 
+        if (!ArrayUtils.contains(getErasableMetadata(), metadataField)) {
+            throw new IllegalArgumentException("The given metadata field cannot be bulk deleted");
+        }
+
+        handler.logInfo(String.format("Deleting the field '%s' from all objects", metadataField));
+
         metadataValueService.deleteByMetadataField(context, field);
+    }
+
+    private String[] getErasableMetadata() {
+        return configurationService.getArrayProperty("bulkedit.allow-bulk-deletion");
     }
 
     @Override
@@ -68,7 +98,18 @@ public class MetadataDeletion extends DSpaceRunnable<MetadataDeletionScriptConfi
 
     @Override
     public void setup() throws ParseException {
+
+        metadataValueService = ContentServiceFactory.getInstance().getMetadataValueService();
+        metadataFieldService = ContentServiceFactory.getInstance().getMetadataFieldService();
+        configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
+
         metadataField = commandLine.getOptionValue('m');
+        list = commandLine.hasOption('l');
+
+        if (!list && metadataField == null) {
+            throw new ParseException("One of the following parameters is required: -m or -l");
+        }
+
     }
 
 }

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataDeletion.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataDeletion.java
@@ -34,27 +34,29 @@ public class MetadataDeletion extends DSpaceRunnable<MetadataDeletionScriptConfi
         Context context = new Context();
         context.turnOffAuthorisationSystem();
 
-        MetadataValueService metadataValueService = ContentServiceFactory.getInstance()
-            .getMetadataValueService();
-
-        MetadataFieldService metadataFieldService = ContentServiceFactory.getInstance()
-            .getMetadataFieldService();
-
         try {
-
-            MetadataField field = metadataFieldService.findByString(context, metadataField, '.');
-            if (field == null) {
-                throw new IllegalArgumentException("No metadata field found with name " + metadataField);
-            }
-
-            metadataValueService.deleteByMetadataField(context, field);
-
+            performMetadataValuesDeletion(context);
         } catch (SQLException e) {
             handler.handleException(e);
         }
 
         context.restoreAuthSystemState();
         context.complete();
+    }
+
+    private void performMetadataValuesDeletion(Context context) throws SQLException {
+        MetadataValueService metadataValueService = ContentServiceFactory.getInstance()
+            .getMetadataValueService();
+
+        MetadataFieldService metadataFieldService = ContentServiceFactory.getInstance()
+            .getMetadataFieldService();
+
+        MetadataField field = metadataFieldService.findByString(context, metadataField, '.');
+        if (field == null) {
+            throw new IllegalArgumentException("No metadata field found with name " + metadataField);
+        }
+
+        metadataValueService.deleteByMetadataField(context, field);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataDeletion.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataDeletion.java
@@ -1,0 +1,72 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.bulkedit;
+
+import java.sql.SQLException;
+
+import org.apache.commons.cli.ParseException;
+import org.dspace.content.MetadataField;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.MetadataFieldService;
+import org.dspace.content.service.MetadataValueService;
+import org.dspace.core.Context;
+import org.dspace.scripts.DSpaceRunnable;
+import org.dspace.utils.DSpace;
+
+/**
+ * {@link DSpaceRunnable} implementation to delete all the values of the given
+ * metadata field.
+ *
+ * @author Luca Giamminonni (luca.giamminonni at 4science.it)
+ *
+ */
+public class MetadataDeletion extends DSpaceRunnable<MetadataDeletionScriptConfiguration<MetadataDeletion>> {
+
+    private String metadataField;
+
+    @Override
+    public void internalRun() throws Exception {
+        Context context = new Context();
+        context.turnOffAuthorisationSystem();
+
+        MetadataValueService metadataValueService = ContentServiceFactory.getInstance()
+            .getMetadataValueService();
+
+        MetadataFieldService metadataFieldService = ContentServiceFactory.getInstance()
+            .getMetadataFieldService();
+
+        try {
+
+            MetadataField field = metadataFieldService.findByString(context, metadataField, '.');
+            if (field == null) {
+                throw new IllegalArgumentException("No metadata field found with name " + metadataField);
+            }
+
+            metadataValueService.deleteByMetadataField(context, field);
+
+        } catch (SQLException e) {
+            handler.handleException(e);
+        }
+
+        context.restoreAuthSystemState();
+        context.complete();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public MetadataDeletionScriptConfiguration<MetadataDeletion> getScriptConfiguration() {
+        return new DSpace().getServiceManager()
+            .getServiceByName("metadata-deletion", MetadataDeletionScriptConfiguration.class);
+    }
+
+    @Override
+    public void setup() throws ParseException {
+        metadataField = commandLine.getOptionValue('m');
+    }
+
+}

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataDeletionCli.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataDeletionCli.java
@@ -1,0 +1,18 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.bulkedit;
+
+/**
+ * The {@link MetadataDeletion} for CLI.
+ *
+ * @author Luca Giamminonni (luca.giamminonni at 4science.it)
+ *
+ */
+public class MetadataDeletionCli extends MetadataDeletion {
+
+}

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataDeletionCliScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataDeletionCliScriptConfiguration.java
@@ -1,0 +1,18 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.bulkedit;
+
+/**
+ * Script configuration for {@link MetadataDeletionCli}.
+ *
+ * @author Luca Giamminonni (luca.giamminonni at 4science.it)
+ *
+ */
+public class MetadataDeletionCliScriptConfiguration extends MetadataDeletionScriptConfiguration<MetadataDeletionCli> {
+
+}

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataDeletionScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataDeletionScriptConfiguration.java
@@ -1,0 +1,62 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.bulkedit;
+
+import java.sql.SQLException;
+
+import org.apache.commons.cli.Options;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.core.Context;
+import org.dspace.scripts.configuration.ScriptConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * The {@link ScriptConfiguration} for the {@link MetadataDeletion} script.
+ */
+public class MetadataDeletionScriptConfiguration<T extends MetadataDeletion> extends ScriptConfiguration<T> {
+
+    @Autowired
+    private AuthorizeService authorizeService;
+
+    private Class<T> dspaceRunnableClass;
+
+    @Override
+    public boolean isAllowedToExecute(Context context) {
+        try {
+            return authorizeService.isAdmin(context);
+        } catch (SQLException e) {
+            throw new RuntimeException("SQLException occurred when checking if the current user is an admin", e);
+        }
+    }
+
+    @Override
+    public Options getOptions() {
+        if (options == null) {
+            Options options = new Options();
+            options.addOption("m", "metadata", true, "metadata field name");
+            options.getOption("m").setType(String.class);
+            super.options = options;
+        }
+        return options;
+    }
+
+    @Override
+    public Class<T> getDspaceRunnableClass() {
+        return dspaceRunnableClass;
+    }
+
+    /**
+     * Generic setter for the dspaceRunnableClass
+     * @param dspaceRunnableClass   The dspaceRunnableClass to be set on this MetadataDeletionScriptConfiguration
+     */
+    @Override
+    public void setDspaceRunnableClass(Class<T> dspaceRunnableClass) {
+        this.dspaceRunnableClass = dspaceRunnableClass;
+    }
+
+}

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataDeletionScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataDeletionScriptConfiguration.java
@@ -37,9 +37,15 @@ public class MetadataDeletionScriptConfiguration<T extends MetadataDeletion> ext
     @Override
     public Options getOptions() {
         if (options == null) {
+
             Options options = new Options();
+
             options.addOption("m", "metadata", true, "metadata field name");
             options.getOption("m").setType(String.class);
+
+            options.addOption("l", "list", false, "lists the metadata fields that can be deleted");
+            options.getOption("l").setType(boolean.class);
+
             super.options = options;
         }
         return options;

--- a/dspace-api/src/test/data/dspaceFolder/config/spring/api/scripts.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/spring/api/scripts.xml
@@ -34,6 +34,11 @@
         <property name="description" value="Retry all failed commits to the OpenURLTracker"/>
         <property name="dspaceRunnableClass" value="org.dspace.statistics.export.RetryFailedOpenUrlTracker"/>
     </bean>
+    
+    <bean id="metadata-deletion" class="org.dspace.app.bulkedit.MetadataDeletionCliScriptConfiguration">
+        <property name="description" value="Delete all the values of the specified metadata field"/>
+        <property name="dspaceRunnableClass" value="org.dspace.app.bulkedit.MetadataDeletionCli"/>
+    </bean>
 
     <bean id="another-mock-script" class="org.dspace.scripts.MockDSpaceRunnableScriptConfiguration" scope="prototype">
         <property name="description" value="Mocking a script for testing purposes" />

--- a/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataDeletionIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataDeletionIT.java
@@ -1,0 +1,70 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.bulkedit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.dspace.AbstractIntegrationTestWithDatabase;
+import org.dspace.app.launcher.ScriptLauncher;
+import org.dspace.app.scripts.handler.impl.TestDSpaceRunnableHandler;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.ItemBuilder;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.MetadataField;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.MetadataFieldService;
+import org.dspace.content.service.MetadataValueService;
+import org.junit.Test;
+
+/**
+ * Integration tests for {@link MetadataDeletion}.
+ *
+ * @author Luca Giamminonni (luca.giamminonni at 4science.it)
+ *
+ */
+public class MetadataDeletionIT extends AbstractIntegrationTestWithDatabase {
+
+    private MetadataValueService metadataValueService = ContentServiceFactory.getInstance().getMetadataValueService();
+
+    private MetadataFieldService metadataFieldService = ContentServiceFactory.getInstance().getMetadataFieldService();
+
+    @Test
+    public void metadataDeletionTest() throws Exception {
+
+        context.turnOffAuthorisationSystem();
+        Community community = CommunityBuilder.createCommunity(context).build();
+        Collection collection = CollectionBuilder.createCollection(context, community).build();
+        createItem(collection, "My First publication", "Mario Rossi");
+        createItem(collection, "Another publication", "John Smith");
+        context.restoreAuthSystemState();
+
+        MetadataField titleField = metadataFieldService.findByElement(context, "dc", "title", null);
+        MetadataField authorField = metadataFieldService.findByElement(context, "dc", "contributor", "author");
+
+        assertEquals(2, metadataValueService.findByField(context, titleField).size());
+        assertEquals(2, metadataValueService.findByField(context, authorField).size());
+
+        TestDSpaceRunnableHandler testDSpaceRunnableHandler = new TestDSpaceRunnableHandler();
+
+        String[] args = new String[] { "metadata-deletion", "-m", "dc.title" };
+        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), testDSpaceRunnableHandler, kernelImpl);
+
+        assertTrue(metadataValueService.findByField(context, titleField).isEmpty());
+        assertEquals(2, metadataValueService.findByField(context, authorField).size());
+    }
+
+    private void createItem(Collection collection, String title, String author) {
+        ItemBuilder.createItem(context, collection)
+            .withTitle(title)
+            .withAuthor(author)
+            .build();
+    }
+}

--- a/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataDeletionIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataDeletionIT.java
@@ -81,6 +81,8 @@ public class MetadataDeletionIT extends AbstractIntegrationTestWithDatabase {
     @Test
     public void metadataDeletionListWithoutErasableMetadataTest() throws Exception {
 
+        configurationService.setProperty("bulkedit.allow-bulk-deletion", null);
+
         TestDSpaceRunnableHandler testDSpaceRunnableHandler = new TestDSpaceRunnableHandler();
 
         String[] args = new String[] { "metadata-deletion", "-l" };

--- a/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataDeletionIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataDeletionIT.java
@@ -7,8 +7,17 @@
  */
 package org.dspace.app.bulkedit;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+
+import java.util.List;
 
 import org.dspace.AbstractIntegrationTestWithDatabase;
 import org.dspace.app.launcher.ScriptLauncher;
@@ -22,6 +31,9 @@ import org.dspace.content.MetadataField;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.MetadataFieldService;
 import org.dspace.content.service.MetadataValueService;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
+import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -36,15 +48,100 @@ public class MetadataDeletionIT extends AbstractIntegrationTestWithDatabase {
 
     private MetadataFieldService metadataFieldService = ContentServiceFactory.getInstance().getMetadataFieldService();
 
-    @Test
-    public void metadataDeletionTest() throws Exception {
+    private ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
+
+    @Before
+    public void setup() {
 
         context.turnOffAuthorisationSystem();
+
         Community community = CommunityBuilder.createCommunity(context).build();
         Collection collection = CollectionBuilder.createCollection(context, community).build();
         createItem(collection, "My First publication", "Mario Rossi");
         createItem(collection, "Another publication", "John Smith");
+
         context.restoreAuthSystemState();
+    }
+
+    @Test
+    public void metadataDeletionListTest() throws Exception {
+
+        configurationService.setProperty("bulkedit.allow-bulk-deletion", new String[] { "dc.title", "dc.type" });
+
+        TestDSpaceRunnableHandler testDSpaceRunnableHandler = new TestDSpaceRunnableHandler();
+
+        String[] args = new String[] { "metadata-deletion", "-l" };
+        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), testDSpaceRunnableHandler, kernelImpl);
+
+        List<String> infoMessages = testDSpaceRunnableHandler.getInfoMessages();
+        assertThat(infoMessages, hasSize(1));
+        assertThat(infoMessages, hasItem(equalTo("The fields that can be bulk deleted are: dc.title, dc.type")));
+    }
+
+    @Test
+    public void metadataDeletionListWithoutErasableMetadataTest() throws Exception {
+
+        TestDSpaceRunnableHandler testDSpaceRunnableHandler = new TestDSpaceRunnableHandler();
+
+        String[] args = new String[] { "metadata-deletion", "-l" };
+        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), testDSpaceRunnableHandler, kernelImpl);
+
+        List<String> infoMessages = testDSpaceRunnableHandler.getInfoMessages();
+        assertThat(infoMessages, hasSize(1));
+        assertThat(infoMessages, hasItem(equalTo("No fields has been configured to be cleared via bulk deletion")));
+    }
+
+    @Test
+    public void metadataDeletionTest() throws Exception {
+
+        MetadataField titleField = metadataFieldService.findByElement(context, "dc", "title", null);
+        MetadataField authorField = metadataFieldService.findByElement(context, "dc", "contributor", "author");
+
+        assertThat(metadataValueService.findByField(context, titleField), hasSize(2));
+        assertThat(metadataValueService.findByField(context, authorField), hasSize(2));
+
+        configurationService.setProperty("bulkedit.allow-bulk-deletion", "dc.title");
+
+        TestDSpaceRunnableHandler testDSpaceRunnableHandler = new TestDSpaceRunnableHandler();
+
+        String[] args = new String[] { "metadata-deletion", "-m", "dc.title" };
+        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), testDSpaceRunnableHandler, kernelImpl);
+
+        assertThat(metadataValueService.findByField(context, titleField), empty());
+        assertThat(metadataValueService.findByField(context, authorField), hasSize(2));
+
+        List<String> infoMessages = testDSpaceRunnableHandler.getInfoMessages();
+        assertThat(infoMessages, hasSize(1));
+        assertThat(infoMessages, hasItem(equalTo("Deleting the field 'dc.title' from all objects")));
+    }
+
+    @Test
+    public void metadataDeletionNotAllowedTest() throws Exception {
+
+        MetadataField titleField = metadataFieldService.findByElement(context, "dc", "title", null);
+        MetadataField authorField = metadataFieldService.findByElement(context, "dc", "contributor", "author");
+
+        assertEquals(2, metadataValueService.findByField(context, titleField).size());
+        assertEquals(2, metadataValueService.findByField(context, authorField).size());
+
+        configurationService.setProperty("bulkedit.allow-bulk-deletion", "dc.type");
+
+        TestDSpaceRunnableHandler testDSpaceRunnableHandler = new TestDSpaceRunnableHandler();
+
+        String[] args = new String[] { "metadata-deletion", "-m", "dc.title" };
+        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), testDSpaceRunnableHandler, kernelImpl);
+
+        Exception exception = testDSpaceRunnableHandler.getException();
+        assertThat(exception, notNullValue());
+        assertThat(exception, instanceOf(IllegalArgumentException.class));
+        assertThat(exception.getMessage(), is("The given metadata field cannot be bulk deleted"));
+
+        assertEquals(2, metadataValueService.findByField(context, titleField).size());
+        assertEquals(2, metadataValueService.findByField(context, authorField).size());
+    }
+
+    @Test
+    public void metadataDeletionWithUnknownMetadataTest() throws Exception {
 
         MetadataField titleField = metadataFieldService.findByElement(context, "dc", "title", null);
         MetadataField authorField = metadataFieldService.findByElement(context, "dc", "contributor", "author");
@@ -54,10 +151,15 @@ public class MetadataDeletionIT extends AbstractIntegrationTestWithDatabase {
 
         TestDSpaceRunnableHandler testDSpaceRunnableHandler = new TestDSpaceRunnableHandler();
 
-        String[] args = new String[] { "metadata-deletion", "-m", "dc.title" };
+        String[] args = new String[] { "metadata-deletion", "-m", "dc.unknown" };
         ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), testDSpaceRunnableHandler, kernelImpl);
 
-        assertTrue(metadataValueService.findByField(context, titleField).isEmpty());
+        Exception exception = testDSpaceRunnableHandler.getException();
+        assertThat(exception, notNullValue());
+        assertThat(exception, instanceOf(IllegalArgumentException.class));
+        assertThat(exception.getMessage(), is("No metadata field found with name dc.unknown"));
+
+        assertEquals(2, metadataValueService.findByField(context, titleField).size());
         assertEquals(2, metadataValueService.findByField(context, authorField).size());
     }
 

--- a/dspace-api/src/test/java/org/dspace/app/scripts/handler/impl/TestDSpaceRunnableHandler.java
+++ b/dspace-api/src/test/java/org/dspace/app/scripts/handler/impl/TestDSpaceRunnableHandler.java
@@ -7,6 +7,9 @@
  */
 package org.dspace.app.scripts.handler.impl;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.dspace.scripts.handler.impl.CommandLineDSpaceRunnableHandler;
 
 /**
@@ -16,6 +19,12 @@ import org.dspace.scripts.handler.impl.CommandLineDSpaceRunnableHandler;
 public class TestDSpaceRunnableHandler extends CommandLineDSpaceRunnableHandler {
 
     private Exception exception = null;
+
+    private final List<String> infoMessages = new ArrayList<>();
+
+    private final List<String> errorMessages = new ArrayList<>();
+
+    private final List<String> warningMessages = new ArrayList<>();
 
     /**
      * We're overriding this method so that we can stop the script from doing the System.exit() if
@@ -32,5 +41,35 @@ public class TestDSpaceRunnableHandler extends CommandLineDSpaceRunnableHandler 
      */
     public Exception getException() {
         return exception;
+    }
+
+    @Override
+    public void logInfo(String message) {
+        super.logInfo(message);
+        infoMessages.add(message);
+    }
+
+    @Override
+    public void logWarning(String message) {
+        super.logWarning(message);
+        warningMessages.add(message);
+    }
+
+    @Override
+    public void logError(String message) {
+        super.logError(message);
+        errorMessages.add(message);
+    }
+
+    public List<String> getInfoMessages() {
+        return infoMessages;
+    }
+
+    public List<String> getErrorMessages() {
+        return errorMessages;
+    }
+
+    public List<String> getWarningMessages() {
+        return warningMessages;
     }
 }

--- a/dspace-server-webapp/src/test/data/dspaceFolder/config/spring/rest/scripts.xml
+++ b/dspace-server-webapp/src/test/data/dspaceFolder/config/spring/rest/scripts.xml
@@ -22,4 +22,9 @@
         <property name="description" value="Curation tasks"/>
         <property name="dspaceRunnableClass" value="org.dspace.curate.Curation"/>
     </bean>
+    
+     <bean id="metadata-deletion" class="org.dspace.app.bulkedit.MetadataDeletionScriptConfiguration" primary="true">
+        <property name="description" value="Delete all the values of the specified metadata field"/>
+        <property name="dspaceRunnableClass" value="org.dspace.app.bulkedit.MetadataDeletion"/>
+    </bean>
 </beans>

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ScriptRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ScriptRestRepositoryIT.java
@@ -95,7 +95,9 @@ public class ScriptRestRepositoryIT extends AbstractControllerIntegrationTest {
                                 ScriptMatcher.matchScript(scriptConfigurations.get(5).getName(),
                                                       scriptConfigurations.get(5).getDescription()),
                                 ScriptMatcher.matchScript(scriptConfigurations.get(6).getName(),
-                                                          scriptConfigurations.get(6).getDescription())
+                                                          scriptConfigurations.get(6).getDescription()),
+                                ScriptMatcher.matchScript(scriptConfigurations.get(7).getName(),
+                                                          scriptConfigurations.get(7).getDescription())
                         )));
 
     }
@@ -120,12 +122,12 @@ public class ScriptRestRepositoryIT extends AbstractControllerIntegrationTest {
         getClient(token).perform(get("/api/system/scripts").param("size", "1"))
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$._embedded.scripts", Matchers.not(Matchers.hasItem(
-                                ScriptMatcher.matchScript(scriptConfigurations.get(0).getName(),
-                                                          scriptConfigurations.get(0).getDescription())
-                        ))))
-                        .andExpect(jsonPath("$._embedded.scripts", hasItem(
                                 ScriptMatcher.matchScript(scriptConfigurations.get(2).getName(),
                                                           scriptConfigurations.get(2).getDescription())
+                        ))))
+                        .andExpect(jsonPath("$._embedded.scripts", hasItem(
+                                ScriptMatcher.matchScript(scriptConfigurations.get(5).getName(),
+                                                          scriptConfigurations.get(5).getDescription())
                         )))
                         .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
                                 Matchers.containsString("/api/system/scripts?"),
@@ -138,22 +140,22 @@ public class ScriptRestRepositoryIT extends AbstractControllerIntegrationTest {
                                 Matchers.containsString("page=1"), Matchers.containsString("size=1"))))
                         .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
                                 Matchers.containsString("/api/system/scripts?"),
-                                Matchers.containsString("page=6"), Matchers.containsString("size=1"))))
+                                Matchers.containsString("page=7"), Matchers.containsString("size=1"))))
                         .andExpect(jsonPath("$.page.size", is(1)))
                         .andExpect(jsonPath("$.page.number", is(0)))
-                        .andExpect(jsonPath("$.page.totalPages", is(7)))
-                        .andExpect(jsonPath("$.page.totalElements", is(7)));
+                        .andExpect(jsonPath("$.page.totalPages", is(8)))
+                        .andExpect(jsonPath("$.page.totalElements", is(8)));
 
 
         getClient(token).perform(get("/api/system/scripts").param("size", "1").param("page", "1"))
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$._embedded.scripts", hasItem(
-                                ScriptMatcher.matchScript(scriptConfigurations.get(1).getName(),
-                                                          scriptConfigurations.get(1).getDescription())
+                                ScriptMatcher.matchScript(scriptConfigurations.get(2).getName(),
+                                                          scriptConfigurations.get(2).getDescription())
                         )))
                         .andExpect(jsonPath("$._embedded.scripts", Matchers.not(hasItem(
-                                ScriptMatcher.matchScript(scriptConfigurations.get(0).getName(),
-                                                          scriptConfigurations.get(0).getDescription())
+                                ScriptMatcher.matchScript(scriptConfigurations.get(5).getName(),
+                                                          scriptConfigurations.get(5).getDescription())
                         ))))
                         .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
                                 Matchers.containsString("/api/system/scripts?"),
@@ -169,11 +171,11 @@ public class ScriptRestRepositoryIT extends AbstractControllerIntegrationTest {
                                 Matchers.containsString("page=2"), Matchers.containsString("size=1"))))
                         .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
                                 Matchers.containsString("/api/system/scripts?"),
-                                Matchers.containsString("page=6"), Matchers.containsString("size=1"))))
+                                Matchers.containsString("page=7"), Matchers.containsString("size=1"))))
                         .andExpect(jsonPath("$.page.size", is(1)))
                         .andExpect(jsonPath("$.page.number", is(1)))
-                        .andExpect(jsonPath("$.page.totalPages", is(7)))
-                        .andExpect(jsonPath("$.page.totalElements", is(7)));
+                        .andExpect(jsonPath("$.page.totalPages", is(8)))
+                        .andExpect(jsonPath("$.page.totalElements", is(8)));
     }
 
     @Test

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1488,9 +1488,6 @@ mail.helpdesk.name = Help Desk
 # Should all Request Copy emails go to the helpdesk instead of the item submitter?
 request.item.helpdesk.override = false
 
-### metadata-deletion script configuration ###
-bulkedit.allow-bulk-deletion = dspace.agreements.end-user
-
 
 #------------------------------------------------------------------#
 #-------------------MODULE CONFIGURATIONS--------------------------#

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1488,6 +1488,9 @@ mail.helpdesk.name = Help Desk
 # Should all Request Copy emails go to the helpdesk instead of the item submitter?
 request.item.helpdesk.override = false
 
+### metadata-deletion script configuration ###
+bulkedit.allow-bulk-deletion = dspace.agreements.end-user
+
 
 #------------------------------------------------------------------#
 #-------------------MODULE CONFIGURATIONS--------------------------#

--- a/dspace/config/modules/bulkedit.cfg
+++ b/dspace/config/modules/bulkedit.cfg
@@ -26,3 +26,9 @@
 
 # Should the 'action' column allow the 'expunge' method.  By default this is set to false
 # bulkedit.allowexpunge = false
+
+### metadata-deletion script configuration ###
+# Comma separated list of metadata fields which can be deleted (in bulk) by the 'metadata-deletion' script.
+# By default, only 'dspace.agreements.end-user' can be deleted in bulk, as doing so allows
+# an administrator to force all users to re-review the End User Agreement on their next login.
+bulkedit.allow-bulk-deletion = dspace.agreements.end-user

--- a/dspace/config/spring/api/scripts.xml
+++ b/dspace/config/spring/api/scripts.xml
@@ -35,4 +35,9 @@
         <property name="description" value="Script for migrating submission forms to DSpace 7"/>
         <property name="dspaceRunnableClass" value="org.dspace.submit.migration.SubmissionFormsMigration"/>
     </bean>
+
+    <bean id="metadata-deletion" class="org.dspace.app.bulkedit.MetadataDeletionCliScriptConfiguration">
+        <property name="description" value="Delete all the values of the specified metadata field"/>
+        <property name="dspaceRunnableClass" value="org.dspace.app.bulkedit.MetadataDeletionCli"/>
+    </bean>
 </beans>

--- a/dspace/config/spring/rest/scripts.xml
+++ b/dspace/config/spring/rest/scripts.xml
@@ -28,4 +28,9 @@
         <property name="description" value="Script for migrating submission forms to DSpace 7"/>
         <property name="dspaceRunnableClass" value="org.dspace.submit.migration.SubmissionFormsMigration"/>
     </bean>
+    
+    <bean id="metadata-deletion" class="org.dspace.app.bulkedit.MetadataDeletionScriptConfiguration" primary="true">
+        <property name="description" value="Delete all the values of the specified metadata field"/>
+        <property name="dspaceRunnableClass" value="org.dspace.app.bulkedit.MetadataDeletion"/>
+    </bean>
 </beans>


### PR DESCRIPTION
## References
* Fixes #2973 

## Description

Added a new script called metadata-deletion to delete all values of a specific metadata field. This script can be used to clear all dspace.agreements.end-user metadata values as required by https://github.com/DSpace/DSpace/issues/2973

## Instructions for Reviewers

To delete all the values of a specific metadata field, you can invoke the metadata-deletion script with the following options:
- m (metadata): the metadata field to be reset

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
