### PR TITLE
DS-4577 add missing HTML escaping in sidebar facet

### DIFF
--- a/dspace-jspui/src/main/webapp/discovery/static-sidebar-facet.jsp
+++ b/dspace-jspui/src/main/webapp/discovery/static-sidebar-facet.jsp
@@ -23,6 +23,7 @@
 <%@ page import="org.dspace.discovery.DiscoverResult.FacetResult"%>
 <%@ page import="java.util.List"%>
 <%@ page import="java.net.URLEncoder"%>
+<%@ page import="org.apache.commons.lang.StringEscapeUtils" %>
 <%@ page import="org.apache.commons.lang.StringUtils"%>
 
 <%
@@ -98,8 +99,8 @@
 	                + "/simple-search?filterquery="+URLEncoder.encode(fvalue.getAsFilterQuery(),"UTF-8")
 	                + "&amp;filtername="+URLEncoder.encode(f,"UTF-8")
 	                + "&amp;filtertype="+URLEncoder.encode(fvalue.getFilterType(),"UTF-8") %>"
-	                title="<fmt:message key="jsp.search.facet.narrow"><fmt:param><%=fvalue.getDisplayedValue() %></fmt:param></fmt:message>">
-	                <%= StringUtils.abbreviate(fvalue.getDisplayedValue(),36) %></a></li><%
+	                title="<fmt:message key="jsp.search.facet.narrow"><fmt:param><%=StringEscapeUtils.escapeHtml(fvalue.getDisplayedValue())%></fmt:param></fmt:message>">
+	                <%= StringEscapeUtils.escapeHtml(StringUtils.abbreviate(fvalue.getDisplayedValue(),36)) %></a></li><%
 		        }
 		        idx++;
 		    }


### PR DESCRIPTION
## References
* Fixes https://jira.lyrasis.org/browse/DS-4577
* Fixes #7910 

## Description
Use HTML encoding for metadata values in sidebar facets

## Instructions for Reviewers
See sample in DS-4577.
- Create an item and metadata values which includes < > (metadata field must be configured with a sidebar facet)
- Check the HTML code in the sidebar facet for this value
