### PR TITLE
Mapped Items not visible in Collection browse

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
@@ -612,7 +612,6 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
         // Instead we add the collection to an item which works in the same way.
         if (!item.getCollections().contains(collection)) {
             item.addCollection(collection);
-            item.setModified();
         }
 
         context.addEvent(new Event(Event.ADD, Constants.COLLECTION, collection.getID(),
@@ -633,7 +632,7 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
         } else {
             //Remove the item from the collection if we have multiple collections
             item.removeCollection(collection);
-            item.setModified();
+
         }
 
         context.addEvent(new Event(Event.REMOVE, Constants.COLLECTION,

--- a/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
@@ -612,6 +612,7 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
         // Instead we add the collection to an item which works in the same way.
         if (!item.getCollections().contains(collection)) {
             item.addCollection(collection);
+            item.setModified();
         }
 
         context.addEvent(new Event(Event.ADD, Constants.COLLECTION, collection.getID(),
@@ -632,7 +633,7 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
         } else {
             //Remove the item from the collection if we have multiple collections
             item.removeCollection(collection);
-
+            item.setModified();
         }
 
         context.addEvent(new Event(Event.REMOVE, Constants.COLLECTION,

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexEventConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexEventConsumer.java
@@ -157,6 +157,12 @@ public class IndexEventConsumer implements Consumer {
                 } else {
                     log.debug("consume() adding event to update queue: " + event.toString());
                     objectsToUpdate.addAll(indexObjectServiceFactory.getIndexableObjects(ctx, subject));
+
+                    // If the event subject is a Collection and the event object is an Item,
+                    // also update the object in order to index mapped/unmapped Items
+                    if (subject.getType() == Constants.COLLECTION && object.getType() == Constants.ITEM) {
+                        objectsToUpdate.addAll(indexObjectServiceFactory.getIndexableObjects(ctx, object));
+                    }
                 }
                 break;
 

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexEventConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexEventConsumer.java
@@ -160,7 +160,8 @@ public class IndexEventConsumer implements Consumer {
 
                     // If the event subject is a Collection and the event object is an Item,
                     // also update the object in order to index mapped/unmapped Items
-                    if (subject.getType() == Constants.COLLECTION && object.getType() == Constants.ITEM) {
+                    if (subject != null &&
+                        subject.getType() == Constants.COLLECTION && object.getType() == Constants.ITEM) {
                         objectsToUpdate.addAll(indexObjectServiceFactory.getIndexableObjects(ctx, object));
                     }
                 }


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #3141 
* Related to [Angular feature](https://github.com/DSpace/dspace-angular/pull/983)

## Description
When mapping/unmapping items to a collection, the actual indexes of the items were not updated.
This had the side-effect, that these items couldn't be found in the browse/search of the collection that they were mapped to. (Because the search uses a scope, that can't find the item in solr, since it doesn't have the correct location information in the solr record)
Without any codechanges, this could already be fixed by pushing a metadata edit on the item, which indexes the item (Together with the mapped collection information). Making sure that the collection map / unmap 

## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* As mentioned in the description, the actual indexing of the item fixes this problem.
* Since the code already created a new context event when [adding a new item](https://github.com/DSpace/DSpace/blob/main/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java#L617) or removing a [previous one](https://github.com/DSpace/DSpace/blob/main/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java#L638), the only change that needed to happen is to make sure that the underlying code knew that the item was actually changed
    * Which would turn trigger the discovery indexing consumer.
    * As such, we added a call to the 'setModified' method, to make sure the item was marked as 'updated' 

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

1. This is most easily tested by installing / setting up the latest Angular commit together with this PR
2. Edit a Collection and Map a few items to that Collection.
3. Now, visit the Collection homepage (mapped items will not be listed). Under that Collection, click on Browse "By Title", "By Issue Date", "By Author" or "By Subject"... the Mapped Item will **appear** correctly in those browses.
4. Remove the mapping for the previous items again
5. The items should **not** appear in the aforementioned browses

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
