### PR TITLE
LDAP Authentication: use generic exception instead of special SQLException

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
@@ -141,6 +141,14 @@ public class LDAPAuthentication
         // Prevents anonymous users from being added to this group, and the second check
         // ensures they are LDAP users
         try {
+            // without a logged in user, this method should return an empty list
+            if (context.getCurrentUser() == null) {
+                return Collections.EMPTY_LIST;
+            }
+            // if the logged in user does not have a netid, it's not an LDAP user and this method should return an empty list
+            if (context.getCurrentUser().getNetid() == null) {
+                return Collections.EMPTY_LIST;
+            }
             if (!context.getCurrentUser().getNetid().equals("")) {
                 String groupName = configurationService.getProperty("authentication-ldap.login.specialgroup");
                 if ((groupName != null) && (!groupName.trim().equals(""))) {
@@ -156,7 +164,7 @@ public class LDAPAuthentication
                     }
                 }
             }
-        } catch (Exception ex) {
+        } catch (SQLException ex) {
             // The user is not an LDAP user, so we don't need to worry about them
         }
         return Collections.EMPTY_LIST;

--- a/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
@@ -145,7 +145,8 @@ public class LDAPAuthentication
             if (context.getCurrentUser() == null) {
                 return Collections.EMPTY_LIST;
             }
-            // if the logged in user does not have a netid, it's not an LDAP user and this method should return an empty list
+            // if the logged in user does not have a netid, it's not an LDAP user
+            // and this method should return an empty list
             if (context.getCurrentUser().getNetid() == null) {
                 return Collections.EMPTY_LIST;
             }

--- a/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
@@ -156,7 +156,7 @@ public class LDAPAuthentication
                     }
                 }
             }
-        } catch (SQLException ex) {
+        } catch (Exception ex) {
             // The user is not an LDAP user, so we don't need to worry about them
         }
         return Collections.EMPTY_LIST;


### PR DESCRIPTION
Fixes #3204 

On our DSpace 7 test environment we are using LDAP authentication and for all LDAP authorized epersons we assign a special group with the configuration option `authentication-ldap.login.specialgroup = Login\ Member`. The group exists and everything worked fine until I have applied this commit: https://github.com/DSpace/DSpace/commit/95d0a2bf57e02f544698d6bfbed52c28d2c5fa07
After this commit had been applied, I got this exception when starting the DSpace server:
```
java.lang.NullPointerException: null
        at org.dspace.authenticate.LDAPAuthentication.getSpecialGroups(LDAPAuthentication.java:144) ~[dspace-api-7.0-beta5-SNAPSHOT.jar:7.0-beta5-SNAPSHOT]
        at org.dspace.authenticate.AuthenticationServiceImpl.getSpecialGroups(AuthenticationServiceImpl.java:182) ~[dspace-api-7.0-beta5-SNAPSHOT.jar:7.0-beta5-SNAPSHOT]
        at org.dspace.app.rest.security.AnonymousAdditionalAuthorizationFilter.doFilterInternal(AnonymousAdditionalAuthorizationFilter.java:59) ~[classes/:7.0-beta5-SNAPSHOT]
```
I have traced the reason for that exception back to this change: https://github.com/DSpace/DSpace/commit/95d0a2bf57e02f544698d6bfbed52c28d2c5fa07#diff-1adf3162e20b03f98121c310686b305dff2780bee469b184b2af4522c84c4b75L145 (the generic Exception has been exchanged with an SQLException, thus an NPE is not being cought anymore).

This PR reverts that change and catches a generic exception - with that change LDAP authentication is working fine here again. However, I'm not sure, if this is the best solution after all...