### PR TITLE
fix #1067 metadatafield with blank qualifier

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataFieldRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataFieldRestRepository.java
@@ -249,6 +249,10 @@ public class MetadataFieldRestRepository extends DSpaceRestRepository<MetadataFi
             throw new UnprocessableEntityException("metadata element (in request body) cannot be blank");
         }
 
+        if (isBlank(metadataFieldRest.getQualifier())) {
+            metadataFieldRest.setQualifier(null);
+        }
+
         // create
         MetadataField metadataField;
         try {


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes Angular issue [1067](https://github.com/DSpace/dspace-angular/issues/1067)
* REST counterpart to Angular PR: https://github.com/DSpace/dspace-angular/pull/1076 

## Description
When an empty qualifier string is provided, it's automatically transformed to a `null` value, to avoid that empty value ending up in the db.

## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* Similarly to the Angular PR, when an empty qualifier is sent, it's transformed to a `null` value

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

* Setup this REST PR codebase
* Setup the Angular codebase WITHOUT the fix of [this PR](https://github.com/DSpace/dspace-angular/pull/1076) in it
* Use the UI to create a new metadata field. Leave the qualifier blank.
    * Observe that the qualifier being sent to REST is transformed to null

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
