### PR TITLE
Exceptions in DSpace 7 REST API producing log entries in DSpace log files

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
@@ -11,6 +11,7 @@ import static org.springframework.web.servlet.DispatcherServlet.EXCEPTION_ATTRIB
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.Set;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -52,6 +53,11 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 @ControllerAdvice
 public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionHandler {
     private static final Logger log = LogManager.getLogger(DSpaceApiExceptionControllerAdvice.class);
+
+    /**
+     * Set of HTTP error codes to log as ERROR with full stacktrace.
+     */
+    private static final Set<Integer> LOG_AS_ERROR = Set.of(422);
 
     @Autowired
     private RestAuthenticationService restAuthenticationService;
@@ -180,7 +186,10 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
     }
 
     /**
-     * Send the error to the response. Some errors may also be logged.
+     * Send the error to the response.
+     * 5xx errors will be logged as ERROR with a full stack trace, 4xx errors will be logged as WARN without a
+     * stacktrace. Specific 4xx errors where an ERROR log with full stacktrace is more appropriate are configured in
+     * {@link #LOG_AS_ERROR}
      * @param request current request
      * @param response current response
      * @param ex Exception thrown
@@ -193,11 +202,13 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
         //Make sure Spring picks up this exception
         request.setAttribute(EXCEPTION_ATTRIBUTE, ex);
 
-        // For now, just logging server errors.
         // We don't want to fill logs with bad/invalid REST API requests.
-        if (statusCode == HttpServletResponse.SC_INTERNAL_SERVER_ERROR) {
+        if (HttpStatus.valueOf(statusCode).is5xxServerError() || LOG_AS_ERROR.contains(statusCode)) {
             // Log the full error and status code
             log.error("{} (status:{})", message, statusCode, ex);
+        } else if (HttpStatus.valueOf(statusCode).is4xxClientError()) {
+            // Log the error as a single-line WARN
+            log.warn("{} (status:{})", message, statusCode);
         }
 
         //Exception properties will be set by org.springframework.boot.web.support.ErrorPageFilter


### PR DESCRIPTION
## References
* Fixes #3139

## Description
This PR introduces the logging of 5xx errors with a full stacktrace and the logging of 4xx errors with just the message.
An exception has been made for the 422 status code, those will be logged as an ERROR with the full stacktrace as well.

## Instructions for Reviewers

List of changes in this PR:
* Introduced the logging of 5xx errors as ERROR with full stacktrace
* Introduced the logging of 4xx errors as WARN with just the message
* Introduces a set of Status codes that can be appended to to provide logging of the specific errors as ERROR with full stacktrace

How to test this PR:
* Please build and deploy the code
* Produce a 5xx error, ensure that the full error is logged as an ERROR
* Produce a 422 error, ensure that the full error is logged as an ERROR
* Produce a different 4xx error, ensure that the error is logged as WARN with just the message

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
