### PR TITLE
Corrects reading of configuration options in LDAPAuthentication

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
@@ -681,7 +681,7 @@ public class LDAPAuthentication
         if (StringUtils.isNotBlank(dn)) {
             System.out.println("dn:" + dn);
             int i = 1;
-            String groupMap = configurationService.getProperty("authentication-ldap", "login.groupmap." + i);
+            String groupMap = configurationService.getProperty("authentication-ldap.login.groupmap." + i);
 
             boolean cmp;
 
@@ -721,7 +721,7 @@ public class LDAPAuthentication
                     }
                 }
 
-                groupMap = configurationService.getProperty("authentication-ldap", "login.groupmap." + ++i);
+                groupMap = configurationService.getProperty("authentication-ldap.login.groupmap." + ++i);
             }
         }
     }


### PR DESCRIPTION
fixes #3207

This PR updates the way of reading configuration options for login.groupmap for authentication-ldap.