### PR TITLE
Pin to Postgres 11 in Dockerfiles

### DIFF
--- a/dspace/src/main/docker/dspace-postgres-pgcrypto-curl/Dockerfile
+++ b/dspace/src/main/docker/dspace-postgres-pgcrypto-curl/Dockerfile
@@ -7,7 +7,7 @@
 #
 
 # This will be deployed as dspace/dspace-postgres-pgcrpyto:loadsql
-FROM postgres
+FROM postgres:11
 
 ENV POSTGRES_DB dspace
 ENV POSTGRES_USER dspace

--- a/dspace/src/main/docker/dspace-postgres-pgcrypto/Dockerfile
+++ b/dspace/src/main/docker/dspace-postgres-pgcrypto/Dockerfile
@@ -7,7 +7,7 @@
 #
 
 # This will be deployed as dspace/dspace-postgres-pgcrpyto:latest
-FROM postgres
+FROM postgres:11
 
 ENV POSTGRES_DB dspace
 ENV POSTGRES_USER dspace


### PR DESCRIPTION
## Description
This is a tiny PR to simply pin the version of PostgreSQL used by our Docker files to Postgres v11.x.

This is necessary because Postgres v13 has come out, and it is incompatible with databases created on v11.  So, in updating our Postgres Docker images I was getting this error:
```
021-03-26 19:35:02.055 UTC [1] DETAIL:  The data directory was initialized by PostgreSQL version 11, which is not compatible with this version 13.2 (Debian 13.2-1.pgdg100+1)
```

Pinning Postgres to v11 fixes the problem, and v11 is the version we currently list in our docs: https://wiki.lyrasis.org/display/DSDOC7x/Installing+DSpace#InstallingDSpace-RelationalDatabase(PostgreSQLorOracle)