### PR TITLE
Fix #3211 by depending directly on tika-parsers

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -632,7 +632,7 @@
         <!-- Used for full-text indexing with Solr -->
         <dependency>
             <groupId>org.apache.tika</groupId>
-            <artifactId>tika-core</artifactId>
+            <artifactId>tika-parsers</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1196,6 +1196,29 @@
                 <groupId>org.apache.tika</groupId>
                 <artifactId>tika-parsers</artifactId>
                 <version>1.24.1</version>
+                <!-- Exclude a few tika-parsers dependencies that we already use, with slightly different versions -->
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.protobuf</groupId>
+                        <artifactId>protobuf-java</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>net.sf.ehcache</groupId>
+                        <artifactId>ehcache-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>jakarta.ws.rs</groupId>
+                        <artifactId>jakarta.ws.rs-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>javax.xml.soap</groupId>
+                        <artifactId>javax.xml.soap-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.jvnet.staxex</groupId>
+                        <artifactId>stax-ex</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <!-- Reminder: Keep icu4j (in Parent POM) synced with version used by lucene-analyzers-icu below,
              otherwise ICUFoldingFilterFactory may throw errors in tests.  -->

--- a/pom.xml
+++ b/pom.xml
@@ -1194,7 +1194,7 @@
             <!-- Used for full-text indexing with Solr. Should be synced with version of Tika in solr-cell -->
             <dependency>
                 <groupId>org.apache.tika</groupId>
-                <artifactId>tika-core</artifactId>
+                <artifactId>tika-parsers</artifactId>
                 <version>1.24.1</version>
             </dependency>
             <!-- Reminder: Keep icu4j (in Parent POM) synced with version used by lucene-analyzers-icu below,


### PR DESCRIPTION
Fixes #3211

## Description

This small PR changes the `tika-core` dependency of `dspace-api` to `tika-parsers`. When applied, full text indexing works from the discovery consumer again without error.

Note: The reason this probably went unnoticed is that `solr-cell`'s scope is set to `test` in `dspace-server-webapp`'s `pom.xml`. It appears this may have been done because because `solr-cell` brings in a lot of other dependencies that were unwanted in that context. However, for full text indexing to work in the context of the webapp, we do currently require `tika-parsers` to be deployed with it.