### PR TITLE
Refactor existing Metadata Schema & Field pagination tests to determine pagination dynamically

### DIFF
--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataSchemaRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataSchemaRestRepositoryIT.java
@@ -29,6 +29,7 @@ import org.dspace.app.rest.projection.Projection;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
 import org.dspace.builder.MetadataSchemaBuilder;
 import org.dspace.content.MetadataSchema;
+import org.dspace.content.factory.ContentServiceFactory;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -271,74 +272,85 @@ public class MetadataSchemaRestRepositoryIT extends AbstractControllerIntegratio
     @Test
     public void findAllPaginationTest() throws Exception {
 
+        // Determine number of schemas from database
+        int numberOfSchema = ContentServiceFactory.getInstance()
+                                                   .getMetadataSchemaService().findAll(context).size();
+        // If we return 6 schema per page, determine number of pages we expect
+        int pageSize = 6;
+        int numberOfPages = (int) Math.ceil((double) numberOfSchema / pageSize);
+
+        // In these tests we just validate the first 3 pages, as we currently have at least that many schema
         getClient().perform(get("/api/core/metadataschemas")
-                   .param("size", "6")
+                   .param("size", String.valueOf(pageSize))
                    .param("page", "0"))
                    .andExpect(status().isOk())
                    .andExpect(content().contentType(contentType))
                    .andExpect(jsonPath("$._embedded.metadataschemas", Matchers.hasItem(matchEntry())))
                    .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
                            Matchers.containsString("/api/core/metadataschemas?"),
-                           Matchers.containsString("page=0"), Matchers.containsString("size=6"))))
+                           Matchers.containsString("page=0"), Matchers.containsString("size=" + pageSize))))
                    .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
                            Matchers.containsString("/api/core/metadataschemas?"),
-                           Matchers.containsString("page=0"), Matchers.containsString("size=6"))))
+                           Matchers.containsString("page=0"), Matchers.containsString("size=" + pageSize))))
                    .andExpect(jsonPath("$._links.next.href", Matchers.allOf(
                            Matchers.containsString("/api/core/metadataschemas?"),
-                           Matchers.containsString("page=1"), Matchers.containsString("size=6"))))
+                           Matchers.containsString("page=1"), Matchers.containsString("size=" + pageSize))))
                    .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
                            Matchers.containsString("/api/core/metadataschemas?"),
-                           Matchers.containsString("page=2"), Matchers.containsString("size=6"))))
-                   .andExpect(jsonPath("$.page.totalElements", is(16)))
-                   .andExpect(jsonPath("$.page.totalPages", is(3)))
-                   .andExpect(jsonPath("$.page.size", is(6)));
+                           Matchers.containsString("page=" + (numberOfPages - 1)),
+                           Matchers.containsString("size=" + pageSize))))
+                   .andExpect(jsonPath("$.page.totalElements", is(numberOfSchema)))
+                   .andExpect(jsonPath("$.page.totalPages", is(numberOfPages)))
+                   .andExpect(jsonPath("$.page.size", is(pageSize)));
 
         getClient().perform(get("/api/core/metadataschemas")
-                   .param("size", "6")
+                   .param("size", String.valueOf(pageSize))
                    .param("page", "1"))
                    .andExpect(status().isOk())
                    .andExpect(content().contentType(contentType))
                    .andExpect(jsonPath("$._embedded.metadataschemas", Matchers.hasItem(matchEntry())))
                    .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
                            Matchers.containsString("/api/core/metadataschemas?"),
-                           Matchers.containsString("page=0"), Matchers.containsString("size=6"))))
+                           Matchers.containsString("page=0"), Matchers.containsString("size=" + pageSize))))
                    .andExpect(jsonPath("$._links.prev.href", Matchers.allOf(
                            Matchers.containsString("/api/core/metadataschemas?"),
-                           Matchers.containsString("page=0"), Matchers.containsString("size=6"))))
+                           Matchers.containsString("page=0"), Matchers.containsString("size=" + pageSize))))
                    .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
                            Matchers.containsString("/api/core/metadataschemas?"),
-                           Matchers.containsString("page=1"), Matchers.containsString("size=6"))))
+                           Matchers.containsString("page=1"), Matchers.containsString("size=" + pageSize))))
                    .andExpect(jsonPath("$._links.next.href", Matchers.allOf(
                            Matchers.containsString("/api/core/metadataschemas?"),
-                           Matchers.containsString("page=2"), Matchers.containsString("size=6"))))
+                           Matchers.containsString("page=2"), Matchers.containsString("size=" + pageSize))))
                    .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
                            Matchers.containsString("/api/core/metadataschemas?"),
-                           Matchers.containsString("page=2"), Matchers.containsString("size=6"))))
-                   .andExpect(jsonPath("$.page.totalElements", is(16)))
-                   .andExpect(jsonPath("$.page.totalPages", is(3)))
-                   .andExpect(jsonPath("$.page.size", is(6)));
+                           Matchers.containsString("page=" + (numberOfPages - 1)),
+                           Matchers.containsString("size=" + pageSize))))
+                   .andExpect(jsonPath("$.page.totalElements", is(numberOfSchema)))
+                   .andExpect(jsonPath("$.page.totalPages", is(numberOfPages)))
+                   .andExpect(jsonPath("$.page.size", is(pageSize)));
 
         getClient().perform(get("/api/core/metadataschemas")
-                   .param("size", "6")
+                   .param("size", String.valueOf(pageSize))
                    .param("page", "2"))
                    .andExpect(status().isOk())
                    .andExpect(content().contentType(contentType))
                    .andExpect(jsonPath("$._embedded.metadataschemas", Matchers.hasItem(matchEntry())))
                    .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
                            Matchers.containsString("/api/core/metadataschemas?"),
-                           Matchers.containsString("page=0"), Matchers.containsString("size=6"))))
+                           Matchers.containsString("page=0"), Matchers.containsString("size=" + pageSize))))
                    .andExpect(jsonPath("$._links.prev.href", Matchers.allOf(
                            Matchers.containsString("/api/core/metadataschemas?"),
-                           Matchers.containsString("page=1"), Matchers.containsString("size=6"))))
+                           Matchers.containsString("page=1"), Matchers.containsString("size=" + pageSize))))
                    .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
                            Matchers.containsString("/api/core/metadataschemas?"),
-                           Matchers.containsString("page=2"), Matchers.containsString("size=6"))))
+                           Matchers.containsString("page=2"), Matchers.containsString("size=" + pageSize))))
                    .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
                            Matchers.containsString("/api/core/metadataschemas?"),
-                           Matchers.containsString("page=2"), Matchers.containsString("size=6"))))
-                   .andExpect(jsonPath("$.page.totalElements", is(16)))
-                   .andExpect(jsonPath("$.page.totalPages", is(3)))
-                   .andExpect(jsonPath("$.page.size", is(6)));
+                           Matchers.containsString("page=" + (numberOfPages - 1)),
+                           Matchers.containsString("size=" + pageSize))))
+                   .andExpect(jsonPath("$.page.totalElements", is(numberOfSchema)))
+                   .andExpect(jsonPath("$.page.totalPages", is(numberOfPages)))
+                   .andExpect(jsonPath("$.page.size", is(pageSize)));
 
     }
 


### PR DESCRIPTION
Fixes randomish errors that are occurring around the number of schema installed in our test database. This is affecting a number of PRs, including 

* https://github.com/DSpace/DSpace/pull/3170#issuecomment-811197822
* https://github.com/DSpace/DSpace/pull/3200#issuecomment-811040486

To fix the test errors, I've refactored the problematic tests to now:
1. (First commit) Determine number of schema in DB prior to checking pagination returned from the REST endpoint.  Previously we were checking for a hardcoded number of schema.  However, as the number of schema is configurable (see `registry.metadata.load` configuration), hardcoding the number of schema is a flawed approach to this test.
2. (Second commit) Determine number of metadata fields in the same dynamic manner. Again, number of metadata fields can easily change alongside schema, so hardcoding this value is a flawed approach to this test.