### PR TITLE
Proper Bean-like initialization of SherpaService

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -461,6 +461,10 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>jaxen</groupId>
             <artifactId>jaxen</artifactId>
             <exclusions>

--- a/dspace-api/src/main/java/org/dspace/app/sherpa/SHERPAService.java
+++ b/dspace-api/src/main/java/org/dspace/app/sherpa/SHERPAService.java
@@ -12,6 +12,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import javax.annotation.PostConstruct;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -23,12 +24,12 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.sherpa.v2.SHERPAPublisherResponse;
 import org.dspace.app.sherpa.v2.SHERPAResponse;
 import org.dspace.app.sherpa.v2.SHERPAUtils;
 import org.dspace.services.ConfigurationService;
-import org.dspace.services.factory.DSpaceServicesFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -47,11 +48,11 @@ public class SHERPAService {
     private int maxNumberOfTries;
     private long sleepBetweenTimeouts;
     private int timeout = 5000;
-    private String endpoint = "https://v2.sherpa.ac.uk/cgi/retrieve";
+    private String endpoint = null;
     private String apiKey = null;
 
     /** log4j category */
-    private static Logger log = org.apache.logging.log4j.LogManager.getLogger(SHERPAService.class);
+    private static final Logger log = LogManager.getLogger(SHERPAService.class);
 
     @Autowired
     ConfigurationService configurationService;
@@ -60,14 +61,6 @@ public class SHERPAService {
      * Create a new HTTP builder with sensible defaults in constructor
      */
     public SHERPAService() {
-        // Set configuration service
-        configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
-
-        // Get endoint and API key from configuration
-        endpoint = configurationService.getProperty("sherpa.romeo.url",
-            "https://v2.sherpa.ac.uk/cgi/retrieve");
-        apiKey = configurationService.getProperty("sherpa.romeo.apikey");
-
         HttpClientBuilder builder = HttpClientBuilder.create();
         // httpclient 4.3+ doesn't appear to have any sensible defaults any more. Setting conservative defaults as
         // not to hammer the SHERPA service too much.
@@ -75,6 +68,17 @@ public class SHERPAService {
             .disableAutomaticRetries()
             .setMaxConnTotal(5)
             .build();
+    }
+
+    /**
+     * Complete initialization of the Bean.
+     */
+    @PostConstruct
+    private void init() {
+        // Get endoint and API key from configuration
+        endpoint = configurationService.getProperty("sherpa.romeo.url",
+            "https://v2.sherpa.ac.uk/cgi/retrieve");
+        apiKey = configurationService.getProperty("sherpa.romeo.apikey");
     }
 
     /**


### PR DESCRIPTION
## References
* Fixes #3217

## Description
Reorganize construction to avoid redundant initialization and premature dependence on injected field values.

## Instructions for Reviewers
Difficult to test, since the issue seems to be dependent on the environment.

List of changes in this PR:
* Removed initialization of `configurationService` in constructor, since it is injected (`@Autowired`).
* Moved initializations which depend on `configurationService` to a new `@PostConstruct` method.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
