### PR TITLE
Restrict /api/system/scripts endpoint to admin-only

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ScriptRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ScriptRestRepository.java
@@ -55,8 +55,11 @@ public class ScriptRestRepository extends DSpaceRestRepository<ScriptRest, Strin
     @Autowired
     private DSpaceRunnableParameterConverter dSpaceRunnableParameterConverter;
 
+    // TODO: findOne() currently requires site ADMIN permissions as all scripts are admin-only at this time.
+    // If scripts ever need to be accessible to Comm/Coll Admins, we would likely need to create a new GrantedAuthority
+    // for Comm/Coll Admins in EPersonRestAuthenticationProvider to use on this endpoint
     @Override
-    @PreAuthorize("permitAll()")
+    @PreAuthorize("hasAuthority('ADMIN')")
     public ScriptRest findOne(Context context, String name) {
 
         ScriptConfiguration scriptConfiguration = scriptService.getScriptConfiguration(name);
@@ -70,7 +73,11 @@ public class ScriptRestRepository extends DSpaceRestRepository<ScriptRest, Strin
         throw new DSpaceBadRequestException("The script with name: " + name + " could not be found");
     }
 
+    // TODO: findAll() currently requires site ADMIN permissions as all scripts are admin-only at this time.
+    // If scripts ever need to be accessible to Comm/Coll Admins, we would likely need to create a new GrantedAuthority
+    // for Comm/Coll Admins in EPersonRestAuthenticationProvider to use on this endpoint
     @Override
+    @PreAuthorize("hasAuthority('ADMIN')")
     public Page<ScriptRest> findAll(Context context, Pageable pageable) {
         List<ScriptConfiguration> scriptConfigurations = scriptService.getScriptConfigurations(context);
         return converter.toRestPage(scriptConfigurations, pageable, utils.obtainProjection());

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ScriptRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ScriptRestRepositoryIT.java
@@ -31,7 +31,6 @@ import com.google.gson.Gson;
 import org.apache.commons.collections4.CollectionUtils;
 import org.dspace.app.rest.converter.DSpaceRunnableParameterConverter;
 import org.dspace.app.rest.matcher.BitstreamMatcher;
-import org.dspace.app.rest.matcher.PageMatcher;
 import org.dspace.app.rest.matcher.ProcessMatcher;
 import org.dspace.app.rest.matcher.ScriptMatcher;
 import org.dspace.app.rest.model.ParameterValueRest;
@@ -106,9 +105,7 @@ public class ScriptRestRepositoryIT extends AbstractControllerIntegrationTest {
         String token = getAuthToken(eperson.getEmail(), password);
 
         getClient(token).perform(get("/api/system/scripts"))
-                        .andExpect(status().isOk())
-                        .andExpect(jsonPath("$.page",
-                                            is(PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 0, 0))));
+                        .andExpect(status().isForbidden());
 
     }
 
@@ -197,7 +194,9 @@ public class ScriptRestRepositoryIT extends AbstractControllerIntegrationTest {
 
     @Test
     public void findOneScriptByInvalidNameBadRequestExceptionTest() throws Exception {
-        getClient().perform(get("/api/system/scripts/mock-script-invalid"))
+        String token = getAuthToken(admin.getEmail(), password);
+
+        getClient(token).perform(get("/api/system/scripts/mock-script-invalid"))
                    .andExpect(status().isBadRequest());
     }
 


### PR DESCRIPTION
Currently, the `/api/system/scripts` endpoint is publicly available, but it only returns scripts which you had access to run.  While this behavior was reasonable, it is inconsistent with similar endpoints (such as `/api/system/processes`) which are access restricted by default.  It's also inconsistent because all scripts currently available via that endpoint are already restricted to Administrators only.

Therefore, this PR restricts the  `/api/system/scripts` endpoint to Admin users only. It now returns 401 to non-Admin users.  Tests were updated to prove this behavior.

Sidenote: I've also added a few TODO notes to remind us that in the future this endpoint might need to be made accessible to Community or Collection Administrators. But, that would require a new `GrantedAuthority` specific to those user roles (possibly based on the work in #3148 which allows us to determine Comm/Coll Admin roles much more easily).