### PR TITLE
CSRF short lived token GET endpoint

### DIFF
--- a/dspace-api/src/main/java/org/dspace/service/ClientInfoService.java
+++ b/dspace-api/src/main/java/org/dspace/service/ClientInfoService.java
@@ -34,4 +34,13 @@ public interface ClientInfoService {
      * @return true if this is the case, false otherwise
      */
     boolean isUseProxiesEnabled();
+
+    /**
+     * Whether a request is from a trusted proxy or not. Only returns true if trusted proxies are specified
+     * and the ipAddress is contained in those proxies. False in all other cases
+     * @param ipAddress IP address to check for
+     * @return true if trusted, false otherwise
+     */
+    boolean isRequestFromTrustedProxy(String ipAddress);
+
 }

--- a/dspace-api/src/main/java/org/dspace/service/impl/ClientInfoServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/service/impl/ClientInfoServiceImpl.java
@@ -152,7 +152,7 @@ public class ClientInfoServiceImpl implements ClientInfoService {
      * @param ipAddress IP address to check for
      * @return true if trusted, false otherwise
      */
-    private boolean isRequestFromTrustedProxy(String ipAddress) {
+    public boolean isRequestFromTrustedProxy(String ipAddress) {
         try {
             return trustedProxies != null && trustedProxies.contains(ipAddress);
         } catch (IPTable.IPFormatException e) {

--- a/dspace-api/src/test/data/dspaceFolder/config/local.cfg
+++ b/dspace-api/src/test/data/dspaceFolder/config/local.cfg
@@ -133,3 +133,9 @@ configuration.exposed.array.value = public_value_1, public_value_2
 # Test config for the authentication ip functionality
 authentication-ip.Staff = 5.5.5.5
 authentication-ip.Student = 6.6.6.6
+
+# Explicitly configure trusted IPs
+# NOTE: 127.0.0.1 (localhost) is always a trusted IP, see ClientInfoServiceImpl#parseTrustedProxyRanges
+useProxies = true
+proxies.trusted.ipranges = 7.7.7.7
+proxies.trusted.include_ui_ip = true

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/AuthenticationRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/AuthenticationRestController.java
@@ -184,9 +184,7 @@ public class AuthenticationRestController implements InitializingBean {
     @PreAuthorize("hasAuthority('AUTHENTICATED')")
     @RequestMapping(value = "/shortlivedtokens", method = RequestMethod.GET)
     public AuthenticationTokenResource shortLivedTokenViaGet(HttpServletRequest request) throws AuthorizeException {
-        String clientIp = clientInfoService.getClientIp(request);
-
-        if (!clientInfoService.isRequestFromTrustedProxy(clientIp)) {
+        if (!clientInfoService.isRequestFromTrustedProxy(request.getRemoteAddr())) {
             throw new AuthorizeException("Requests to this endpoint should be made from a trusted IP address.");
         }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/AuthenticationRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/AuthenticationRestController.java
@@ -157,11 +157,7 @@ public class AuthenticationRestController implements InitializingBean {
     @PreAuthorize("hasAuthority('AUTHENTICATED')")
     @RequestMapping(value = "/shortlivedtokens", method = RequestMethod.POST)
     public AuthenticationTokenResource shortLivedToken(HttpServletRequest request) {
-        Projection projection = utils.obtainProjection();
-        AuthenticationToken shortLivedToken =
-            restAuthenticationService.getShortLivedAuthenticationToken(ContextUtil.obtainContext(request), request);
-        AuthenticationTokenRest authenticationTokenRest = converter.toRest(shortLivedToken, projection);
-        return converter.toResource(authenticationTokenRest);
+        return shortLivedTokenResponse(request);
     }
 
     /**
@@ -184,7 +180,18 @@ public class AuthenticationRestController implements InitializingBean {
     @RequestMapping(value = "/shortlivedtokens", method = RequestMethod.GET)
     public AuthenticationTokenResource shortLivedTokenViaGet(HttpServletRequest request) {
         // TODO: only allow certain ips
-        return shortLivedToken(request);
+        return shortLivedTokenResponse(request);
+    }
+
+    /**
+     * See {@link #shortLivedToken} and {@link #shortLivedTokenViaGet}
+     */
+    private AuthenticationTokenResource shortLivedTokenResponse(HttpServletRequest request) {
+        Projection projection = utils.obtainProjection();
+        AuthenticationToken shortLivedToken =
+                restAuthenticationService.getShortLivedAuthenticationToken(ContextUtil.obtainContext(request), request);
+        AuthenticationTokenRest authenticationTokenRest = converter.toRest(shortLivedToken, projection);
+        return converter.toResource(authenticationTokenRest);
     }
 
     /**

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/AuthenticationRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/AuthenticationRestController.java
@@ -165,6 +165,29 @@ public class AuthenticationRestController implements InitializingBean {
     }
 
     /**
+     * This method will generate a short lived token to be used for bitstream downloads among other things.
+     *
+     * For security reasons, this endpoint only responds to a explicitly defined list of ips.
+     *
+     * curl -v -X GET https://{dspace-server.url}/api/authn/shortlivedtokens -H "Authorization: Bearer eyJhbG...COdbo"
+     *
+     * Example:
+     * <pre>
+     * {@code
+     * curl -v -X GET https://{dspace-server.url}/api/authn/shortlivedtokens -H "Authorization: Bearer eyJhbG...COdbo"
+     * }
+     * </pre>
+     * @param request The StandardMultipartHttpServletRequest
+     * @return        The created short lived token
+     */
+    @PreAuthorize("hasAuthority('AUTHENTICATED')")
+    @RequestMapping(value = "/shortlivedtokens", method = RequestMethod.GET)
+    public AuthenticationTokenResource shortLivedTokenViaGet(HttpServletRequest request) {
+        // TODO: only allow certain ips
+        return shortLivedToken(request);
+    }
+
+    /**
      * Disables GET/PUT/PATCH on the /login endpoint. You must use POST (see above method)
      * @return ResponseEntity
      */

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/AuthenticationRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/AuthenticationRestController.java
@@ -27,7 +27,9 @@ import org.dspace.app.rest.projection.Projection;
 import org.dspace.app.rest.security.RestAuthenticationService;
 import org.dspace.app.rest.utils.ContextUtil;
 import org.dspace.app.rest.utils.Utils;
+import org.dspace.authorize.AuthorizeException;
 import org.dspace.core.Context;
+import org.dspace.service.ClientInfoService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
@@ -68,6 +70,9 @@ public class AuthenticationRestController implements InitializingBean {
 
     @Autowired
     private RestAuthenticationService restAuthenticationService;
+
+    @Autowired
+    private ClientInfoService clientInfoService;
 
     @Autowired
     private Utils utils;
@@ -178,8 +183,13 @@ public class AuthenticationRestController implements InitializingBean {
      */
     @PreAuthorize("hasAuthority('AUTHENTICATED')")
     @RequestMapping(value = "/shortlivedtokens", method = RequestMethod.GET)
-    public AuthenticationTokenResource shortLivedTokenViaGet(HttpServletRequest request) {
-        // TODO: only allow certain ips
+    public AuthenticationTokenResource shortLivedTokenViaGet(HttpServletRequest request) throws AuthorizeException {
+        String clientIp = clientInfoService.getClientIp(request);
+
+        if (!clientInfoService.isRequestFromTrustedProxy(clientIp)) {
+            throw new AuthorizeException("Requests to this endpoint should be made from a trusted IP address.");
+        }
+
         return shortLivedTokenResponse(request);
     }
 


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/dspace-angular/pull/1004

## Description
This endpoint will be provide a GET option on the `/api/authn/shortlivedtokens` endpoint that can be used for server side requests. This endpoint can only be requested from IP's that are in the `proxies.trusted.ipranges` configuration property.

List of changes in this PR:
* Added a GET option on the shortlivedtoken endpoint in the AuthenticationRestController class

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
