### PR TITLE
Update links to Entities test data

### DIFF
--- a/dspace/src/main/docker-compose/cli.assetstore.yml
+++ b/dspace/src/main/docker-compose/cli.assetstore.yml
@@ -11,7 +11,8 @@ version: "3.7"
 services:
   dspace-cli:
     environment:
-      - LOADASSETS=https://www.dropbox.com/s/v3ahfcuatklbmi0/assetstore-2019-11-28.tar.gz?dl=1
+      # This assetstore zip is available from https://github.com/DSpace-Labs/AIP-Files/releases/tag/demo-entities-data
+      - LOADASSETS=https://github.com/DSpace-Labs/AIP-Files/releases/download/demo-entities-data/assetstore.tar.gz
     entrypoint:
       - /bin/bash
       - '-c'

--- a/dspace/src/main/docker-compose/db.entities.yml
+++ b/dspace/src/main/docker-compose/db.entities.yml
@@ -13,4 +13,32 @@ services:
     image: dspace/dspace-postgres-pgcrypto:loadsql
     environment:
       # This SQL is available from https://github.com/DSpace-Labs/AIP-Files/releases/tag/demo-entities-data
-      - LOADSQL=https://github.com/DSpace-Labs/AIP-Files/releases/download/demo-entities-data/dspace7-entities-2021-04-07.sql
+      - LOADSQL=https://github.com/DSpace-Labs/AIP-Files/releases/download/demo-entities-data/dspace7-entities-2021-04-14.sql
+  dspace:
+    ### OVERRIDE default 'entrypoint' in 'docker-compose.yml ####
+    # Ensure that the database is ready BEFORE starting tomcat
+    # 1. While a TCP connection to dspacedb port 5432 is not available, continue to sleep
+    # 2. Then, run database migration to init database tables
+    # 3. (Custom for Entities) enable Entity-specific collection submission mappings in item-submission.xml
+    #    This 'sed' command inserts the sample configurations specific to the Entities data set, see:
+    #    https://github.com/DSpace/DSpace/blob/main/dspace/config/item-submission.xml#L36-L49
+    # 4. Finally, start Tomcat
+    entrypoint:
+      - /bin/bash
+      - '-c'
+      - |
+        while (!</dev/tcp/dspacedb/5432) > /dev/null 2>&1; do sleep 1; done;
+        /dspace/bin/dspace database migrate
+        sed -i '/name-map collection-handle="default".*/a \\n <name-map collection-handle="123456789/3" submission-name="Publication"/> \
+          <name-map collection-handle="123456789/4" submission-name="Publication"/> \
+          <name-map collection-handle="123456789/281" submission-name="Publication"/> \
+          <name-map collection-handle="123456789/5" submission-name="Publication"/> \
+          <name-map collection-handle="123456789/8" submission-name="OrgUnit"/> \
+          <name-map collection-handle="123456789/6" submission-name="Person"/> \
+          <name-map collection-handle="123456789/279" submission-name="Person"/> \
+          <name-map collection-handle="123456789/7" submission-name="Project"/> \
+          <name-map collection-handle="123456789/280" submission-name="Project"/> \
+          <name-map collection-handle="123456789/28" submission-name="Journal"/> \
+          <name-map collection-handle="123456789/29" submission-name="JournalVolume"/> \
+          <name-map collection-handle="123456789/30" submission-name="JournalIssue"/>' /dspace/config/item-submission.xml
+        catalina.sh run

--- a/dspace/src/main/docker-compose/db.entities.yml
+++ b/dspace/src/main/docker-compose/db.entities.yml
@@ -12,5 +12,5 @@ services:
   dspacedb:
     image: dspace/dspace-postgres-pgcrypto:loadsql
     environment:
-      # Double underbars in env names will be replaced with periods for apache commons
-      - LOADSQL=https://www.dropbox.com/s/4ap1y6deseoc8ws/dspace7-entities-2019-11-28.sql?dl=1
+      # This SQL is available from https://github.com/DSpace-Labs/AIP-Files/releases/tag/demo-entities-data
+      - LOADSQL=https://github.com/DSpace-Labs/AIP-Files/releases/download/demo-entities-data/dspace7-entities-2021-04-07.sql


### PR DESCRIPTION
This is a small PR to update our Docker scripts to link to the new Configurable Entities sample data set & to enable the `item-submission.xml` Entities collection mapping corresponding to this data set.

This new sample data set has been made available at: 
https://github.com/DSpace-Labs/AIP-Files/releases/tag/demo-entities-data

I've fully tested this locally using my own Docker instance & the scripts are working.  So, once GitHub CI approves, I'll merge these immediately in preparation for Testathon.