### PR TITLE
Update/Correct default Submission Configurations for Testathon & Final release

### DIFF
--- a/dspace-api/src/test/data/dspaceFolder/config/submission-forms.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/submission-forms.xml
@@ -46,9 +46,11 @@
 	         <required></required>
 	       </field>
        </row>
-   </form>      
-   
+   </form>
+
    <form name="traditionalpageone">
+            <!-- NOTE: this Author <row> is customized from the default submission-forms.xml in order to make it
+                 easier to test Entity functionality -->
             <row>
                 <relation-field>
                     <relationship-type>isAuthorOfPublication</relationship-type>
@@ -182,7 +184,7 @@ it, please enter the types and the actual numbers or codes.</hint>
        </field>
      </row>
 	</form>
-	
+
 	<form name="traditionalpagetwo">
      <row>
        <field>
@@ -310,7 +312,7 @@ it, please enter the types and the actual numbers or codes.</hint>
         </field>
       </row>
    </form>
-    
+
    <form name="sampleauthority">
      <row>
 		<field>
@@ -347,7 +349,7 @@ it, please enter the types and the actual numbers or codes.</hint>
             <required></required>
         </field>
      </row>
-  </form>   
+  </form>
  </form-definitions>
 
 

--- a/dspace/config/item-submission.xml
+++ b/dspace/config/item-submission.xml
@@ -17,7 +17,36 @@
     <!-- which does not appear in this map will be associated with the mapping -->
     <!-- for handle "default". -->
     <submission-map>
+        <!-- Default submission process -->
         <name-map collection-handle="default" submission-name="traditional"/>
+
+        <!-- Sample Entities Collection configuration based on the demo Entities dataset available at:
+             https://github.com/DSpace-Labs/AIP-Files/releases/tag/demo-entities-data
+             This sets up the following Entity-based Collections in that dataset:
+                "Publication" Collections = "Publications" -> "Articles", "Books", "Publications 2", & "Theses"
+                "OrgUnit" Collection = "Related Objects" -> "OrgUnits"
+                "Person" Collections = "Related Objects" -> "People" & "People 2"
+                "Project" Collections = "Related Objects" -> "Projects" & "Projects 2"
+                "Journal" Collection = "Compound Journals" -> "Journals"
+                "Journal Volume" Collection = "Compound Journals" -> "Journal Volumes"
+                "Journal Issue" Collection = "Compound Journals" ->  "Journal Issues"
+             If you are using that demo dataset, you can simply uncomment the below configuration to enable Entity
+             submission into all of the above Collections.
+        -->
+        <!--
+        <name-map collection-handle="123456789/3" submission-name="Publication"/>
+        <name-map collection-handle="123456789/4" submission-name="Publication"/>
+        <name-map collection-handle="123456789/281" submission-name="Publication"/>
+        <name-map collection-handle="123456789/5" submission-name="Publication"/>
+        <name-map collection-handle="123456789/8" submission-name="OrgUnit"/>
+        <name-map collection-handle="123456789/6" submission-name="Person"/>
+        <name-map collection-handle="123456789/279" submission-name="Person"/>
+        <name-map collection-handle="123456789/7" submission-name="Project"/>
+        <name-map collection-handle="123456789/280" submission-name="Project"/>
+        <name-map collection-handle="123456789/28" submission-name="Journal"/>
+        <name-map collection-handle="123456789/29" submission-name="JournalVolume"/>
+        <name-map collection-handle="123456789/30" submission-name="JournalIssue"/>
+        -->
     </submission-map>
 
 
@@ -44,7 +73,7 @@
     <!-- -->
     <step-definitions>
         <!-- The "collection" step is a "special step" which is *REQUIRED* -->
-        <!-- In DSpace, all submitted items must be immediately assigned --> 
+        <!-- In DSpace, all submitted items must be immediately assigned -->
         <!-- to a collection. This step ensures that a collection is always selected. -->
         <step-definition id="collection">
             <heading></heading>
@@ -52,6 +81,9 @@
             <type>collection</type>
             <scope visibility="hidden" visibilityOutside="hidden">submission</scope>
         </step-definition>
+
+        <!-- The following set of DescribeStep <step-definition>s all point to forms (of the same name) which are
+             defined in submission-forms.xml -->
         <step-definition id="traditionalpageone" mandatory="true">
             <heading>submit.progressbar.describe.stepone</heading>
             <processing-class>org.dspace.app.rest.submit.step.DescribeStep</processing-class>
@@ -62,8 +94,12 @@
             <processing-class>org.dspace.app.rest.submit.step.DescribeStep</processing-class>
             <type>submission-form</type>
         </step-definition>
-
-        <step-definition id="peopleStep" mandatory="true">
+        <step-definition id="publicationStep" mandatory="true">
+            <heading>submit.progressbar.describe.stepone</heading>
+            <processing-class>org.dspace.app.rest.submit.step.DescribeStep</processing-class>
+            <type>submission-form</type>
+        </step-definition>
+        <step-definition id="personStep" mandatory="true">
             <heading>submit.progressbar.describe.stepone</heading>
             <processing-class>org.dspace.app.rest.submit.step.DescribeStep</processing-class>
             <type>submission-form</type>
@@ -106,38 +142,26 @@
             <scope visibilityOutside="read-only">submission</scope>
         </step-definition>
 
-        <!-- Step Upload Item with Embargo Features to enable this step, please 
-            make sure to comment-out the previous step "UploadStep" <step-definition id="upload-with-embargo">
-            <heading>submit.progressbar.upload</heading> <processing-class>org.dspace.submit.step.UploadWithEmbargoStep</processing-class> 
-            <type>uploadWithEmbargo</type> </step-definition> -->
-
-
-        <!--Step will be to select a Creative Commons License -->
-        <!-- Uncomment this step to allow the user to select a Creative Commons 
-            license -->
-         <!-- <step-definition id="cclicense"> <heading>submit.progressbar.CClicense</heading>
+        <!-- This optional step may allow the user to select a Creative Commons license -->
+        <step-definition id="cclicense" mandatory="false">
+            <heading>submit.progressbar.CClicense</heading>
             <processing-class>org.dspace.app.rest.submit.step.CCLicenseStep</processing-class>
-	       <type>cclicense</type> </step-definition> -->
+	        <type>cclicense</type>
+        </step-definition>
 
-        <!--Step will be to enrich the current submission querying external providers or processing the uploaded file -->
-        <!-- Uncomment this step to enrich the current submission using information extracted
-            from uploaded files or metadata. Please note that this step will be triggered only when a request is performed that mean
-            the file to be uploaded or the metadata saved. Angular allows to configure an autosave feature based on a timer or the input
-            of specific metadata such as identifiers used by this step, see the submission.autosave settings in the environment.common.ts
-            Check also config/spring/api/step-processing-listener.xml for further server side configuration
+        <!-- This optional step may enrich the current submission using information extracted
+             from uploaded files or metadata.  -->
+        <!-- Please note that this step will be triggered only when a request is performed,
+             e.g. when a file is uploaded or the form is saved. The Angular UI also supports an
+             autosave feature based on a timer, or the input of specific metadata such as identifiers,
+             see the 'submission.autosave' settings in the 'environment.common.ts'.
+             See also 'config/spring/api/step-processing-listener.xml' for further server side configuration
              -->
-        <!-- <step-definition id="extractionstep"> 
+        <step-definition id="extractionstep">
             <heading>submit.progressbar.ExtractMetadataStep</heading>
             <processing-class>org.dspace.app.rest.submit.step.ExtractMetadataStep</processing-class>
-            <type>extract</type> 
-        </step-definition> -->
-
-        <!-- Fake Steps to test parsing of all options -->
-        <!-- <step-definition mandatory="false"> <heading>fake.submission.readonly</heading>
-            <processing-class>org.dspace.submit.step.SampleStep</processing-class> <type>sample</type> 
-            <scope visibility="read-only">submission</scope> </step-definition> <step-definition mandatory="false">
-            <heading>fake.workflow.readonly</heading> <processing-class>org.dspace.submit.step.SampleStep</processing-class> 
-            <type>sample</type> <scope visibility="read-only">workflow</scope> </step-definition> -->
+            <type>extract</type>
+        </step-definition>
 
         <!-- OpenAIRE submission steps/forms -->
         <step-definition id="openAIREProjectForm" mandatory="true">
@@ -166,7 +190,7 @@
             <type>submission-form</type>
         </step-definition>
 
-        <!-- This is the Sample Step which utilizes the JSPSampleStep class -->
+        <!-- This is the Sample/Fake Step which is used for testing only -->
         <step-definition id="sample">
             <heading>Sample</heading>
             <processing-class>org.dspace.submit.step.SampleStep</processing-class>
@@ -192,7 +216,6 @@
 
         <!--This "traditional" process defines the DEFAULT item submission process -->
         <submission-process name="traditional">
-
             <!--Uncommment to display the SAMPLE step as your first step -->
             <!--<step id="sample"/> -->
 
@@ -204,26 +227,45 @@
 
             <!--Step will be to Upload the item -->
             <step id="upload"/>
-            <!-- <step id="upload-with-embargo"/> -->
             <!-- <step id="extractionstep"/> -->
 
-            <!--Step will be to select a Creative Commons License -->
-            <!-- Uncomment this step to allow the user to select a Creative Commons -->
+            <!-- Uncomment this step to allow the user to select a Creative Commons License -->
             <!-- <step id="cclicense"/> -->
 
-            <!--Step will be to Sign off on the License -->
+            <!--Step will be to Sign off on the required DSpace License agreement -->
             <step id="license"/>
-            <!-- <step id="creative-commons"/> -->
-            <!-- <step id="verify"/> -->
         </submission-process>
 
-        <submission-process name="People">
+        <!--
+        Submission Process for 'Publication' Entities.
+        These are not to be confused with default Items, as Publications may be linked with other Entities
+        (e.g. Person, JournalIssue, etc).
+        To enable: create a collection for Publications and add it to the <submission-map> tag linking to this process
+         -->
+        <submission-process name="Publication">
             <step id="collection"/>
-            <step id="peopleStep"/>
+            <!-- Publications use a custom first step, but share page 2 with "traditional" Item form -->
+            <step id="publicationStep"/>
+            <step id="traditionalpagetwo"/>
             <step id="upload"/>
             <step id="license"/>
         </submission-process>
 
+        <!--
+        Submission Process for 'Person' Entities
+        To enable: create a collection for Persons and add it to the <submission-map> tag linking to this process
+         -->
+        <submission-process name="Person">
+            <step id="collection"/>
+            <step id="personStep"/>
+            <step id="upload"/>
+            <step id="license"/>
+        </submission-process>
+
+        <!--
+        Submission Process for 'Pproject' Entities
+        To enable: create a collection for Projects and add it to the <submission-map> tag linking to this process
+         -->
         <submission-process name="Project">
             <step id="collection"/>
             <step id="projectStep"/>
@@ -231,25 +273,44 @@
             <step id="license"/>
         </submission-process>
 
+        <!--
+        Submission Process for 'OrgUnit' Entities
+        To enable: create a collection for OrgUnits and add it to the <submission-map> tag linking to this process
+         -->
         <submission-process name="OrgUnit">
             <step id="collection"/>
             <step id="orgUnitStep"/>
             <step id="upload"/>
             <step id="license"/>
         </submission-process>
-        <submission-process name="Journals">
+
+        <!--
+        Submission Process for 'Journal' Entities
+        To enable: create a collection for Journals and add it to the <submission-map> tag linking to this process
+         -->
+        <submission-process name="Journal">
             <step id="collection"/>
             <step id="journalStep"/>
             <step id="upload"/>
             <step id="license"/>
         </submission-process>
-        <submission-process name="JournalVolumes">
+
+        <!--
+        Submission Process for 'JournalVolume' Entities
+        To enable: create a collection for JournalVolumes and add it to the <submission-map> tag linking to this process
+         -->
+        <submission-process name="JournalVolume">
             <step id="collection"/>
             <step id="journalVolumeStep"/>
             <step id="upload"/>
             <step id="license"/>
         </submission-process>
-        <submission-process name="JournalIssues">
+
+        <!--
+        Submission Process for 'JournalIssues' Entities
+        To enable: create a collection for JournalIssues and add it to the <submission-map> tag linking to this process
+         -->
+        <submission-process name="JournalIssue">
             <step id="collection"/>
             <step id="journalIssueStep"/>
             <step id="upload"/>

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -21,6 +21,7 @@
     <!-- serves as a 'this field is required' flag.                           -->
 
     <form-definitions>
+        <!-- Form used for entering in Bitstream/File metadata after uploading a file -->
         <form name="bitstream-metadata">
             <row>
                 <field>
@@ -47,7 +48,203 @@
             </row>
         </form>
 
+        <!-- Form which defines the first page/section of the "traditional" DSpace submission process,
+             often used when depositing normal Items (i.e. Items which are not Entities). -->
         <form name="traditionalpageone">
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>contributor</dc-element>
+                    <dc-qualifier>author</dc-qualifier>
+                    <repeatable>true</repeatable>
+                    <label>Author</label>
+                    <input-type>onebox</input-type>
+                    <hint>Enter the author's name (Family name, Given names).</hint>
+                    <required></required>
+                </field>
+            </row>
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>title</dc-element>
+                    <dc-qualifier></dc-qualifier>
+                    <repeatable>false</repeatable>
+                    <label>Title</label>
+                    <input-type>onebox</input-type>
+                    <hint>Enter the main title of the item.</hint>
+                    <required>You must enter a main title for this item.</required>
+                </field>
+            </row>
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>title</dc-element>
+                    <dc-qualifier>alternative</dc-qualifier>
+                    <repeatable>true</repeatable>
+                    <label>Other Titles</label>
+                    <input-type>onebox</input-type>
+                    <hint>If the item has any alternative titles, please enter them here.</hint>
+                    <required></required>
+                </field>
+            </row>
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>date</dc-element>
+                    <dc-qualifier>issued</dc-qualifier>
+                    <repeatable>false</repeatable>
+                    <label>Date of Issue</label>
+                    <style>col-sm-4</style>
+                    <input-type>date</input-type>
+                    <hint>Please give the date of previous publication or public distribution.
+                        You can leave out the day and/or month if they aren't applicable.
+                    </hint>
+                    <required>You must enter at least the year.</required>
+                </field>
+
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>publisher</dc-element>
+                    <dc-qualifier></dc-qualifier>
+                    <repeatable>false</repeatable>
+                    <label>Publisher</label>
+                    <style>col-sm-8</style>
+                    <input-type>onebox</input-type>
+                    <hint>Enter the name of the publisher of the previously issued instance of this item.</hint>
+                    <required></required>
+                </field>
+            </row>
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>identifier</dc-element>
+                    <dc-qualifier>citation</dc-qualifier>
+                    <repeatable>false</repeatable>
+                    <label>Citation</label>
+                    <input-type>onebox</input-type>
+                    <hint>Enter the standard citation for the previously issued instance of this item.</hint>
+                    <required></required>
+                </field>
+            </row>
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>relation</dc-element>
+                    <dc-qualifier>ispartofseries</dc-qualifier>
+                    <repeatable>true</repeatable>
+                    <label>Series/Report No.</label>
+                    <input-type>series</input-type>
+                    <hint>Enter the series and number assigned to this item by your community.</hint>
+                    <required></required>
+                </field>
+            </row>
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>identifier</dc-element>
+                    <dc-qualifier></dc-qualifier>
+                    <!-- An input-type of qualdrop_value MUST be marked as repeatable -->
+                    <repeatable>true</repeatable>
+                    <label>Identifiers</label>
+                    <input-type value-pairs-name="common_identifiers">qualdrop_value</input-type>
+                    <hint>If the item has any identification numbers or codes associated with
+                        it, please enter the types and the actual numbers or codes.
+                    </hint>
+                    <required></required>
+                </field>
+            </row>
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>type</dc-element>
+                    <dc-qualifier></dc-qualifier>
+                    <repeatable>true</repeatable>
+                    <label>Type</label>
+                    <input-type value-pairs-name="common_types">dropdown</input-type>
+                    <hint>Select the type(s) of content of the item. To select more than one value in the list, you may
+                        have to hold down the "CTRL" or "Shift" key.
+                    </hint>
+                    <required></required>
+                </field>
+            </row>
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>language</dc-element>
+                    <dc-qualifier>iso</dc-qualifier>
+                    <repeatable>false</repeatable>
+                    <label>Language</label>
+                    <input-type value-pairs-name="common_iso_languages">dropdown</input-type>
+                    <hint>Select the language of the main content of the item. If the language does not appear in the
+                        list, please select 'Other'. If the content does not really have a language (for example, if it
+                        is a dataset or an image) please select 'N/A'.
+                    </hint>
+                    <required></required>
+                </field>
+            </row>
+        </form>
+
+        <!-- Form which defines the second page/section of the "traditional" DSpace submission process,
+             often used when depositing normal Items. -->
+        <form name="traditionalpagetwo">
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>subject</dc-element>
+                    <dc-qualifier></dc-qualifier>
+                    <!-- An input-type of tag MUST be marked as repeatable -->
+                    <repeatable>true</repeatable>
+                    <label>Subject Keywords</label>
+                    <input-type>tag</input-type>
+                    <hint>Enter appropriate subject keywords or phrases.</hint>
+                    <required></required>
+                    <vocabulary>srsc</vocabulary>
+                </field>
+            </row>
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>description</dc-element>
+                    <dc-qualifier>abstract</dc-qualifier>
+                    <repeatable>false</repeatable>
+                    <label>Abstract</label>
+                    <input-type>textarea</input-type>
+                    <hint>Enter the abstract of the item.</hint>
+                    <required></required>
+                </field>
+            </row>
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>description</dc-element>
+                    <dc-qualifier>sponsorship</dc-qualifier>
+                    <repeatable>false</repeatable>
+                    <label>Sponsors</label>
+                    <input-type>textarea</input-type>
+                    <hint>Enter the names of any sponsors and/or funding codes in the box.</hint>
+                    <required></required>
+                </field>
+            </row>
+            <row>
+                <field>
+                    <dc-schema>dc</dc-schema>
+                    <dc-element>description</dc-element>
+                    <dc-qualifier></dc-qualifier>
+                    <repeatable>false</repeatable>
+                    <label>Description</label>
+                    <input-type>textarea</input-type>
+                    <hint>Enter any other description or comments in this box.</hint>
+                    <required></required>
+                </field>
+            </row>
+        </form>
+
+
+        <!-- Form which defines the *first* metadata page/section for depositing Publication Entities.
+             Since Publication Entities are very similar to normal Items, this is nearly identical to the
+             'traditionalpageone' form. The only difference is the Author field can be used to link the
+             Publication Entity to a Person Entity. -->
+        <form name="publicationStep">
             <row>
                 <relation-field>
                     <relationship-type>isAuthorOfPublication</relationship-type>
@@ -190,60 +387,8 @@
             </row>
         </form>
 
-        <form name="traditionalpagetwo">
-            <row>
-                <field>
-                    <dc-schema>dc</dc-schema>
-                    <dc-element>subject</dc-element>
-                    <dc-qualifier></dc-qualifier>
-                    <!-- An input-type of tag MUST be marked as repeatable -->
-                    <repeatable>true</repeatable>
-                    <label>Subject Keywords</label>
-                    <input-type>tag</input-type>
-                    <hint>Enter appropriate subject keywords or phrases.</hint>
-                    <required></required>
-                    <vocabulary>srsc</vocabulary>
-                </field>
-            </row>
-            <row>
-                <field>
-                    <dc-schema>dc</dc-schema>
-                    <dc-element>description</dc-element>
-                    <dc-qualifier>abstract</dc-qualifier>
-                    <repeatable>false</repeatable>
-                    <label>Abstract</label>
-                    <input-type>textarea</input-type>
-                    <hint>Enter the abstract of the item.</hint>
-                    <required></required>
-                </field>
-            </row>
-            <row>
-                <field>
-                    <dc-schema>dc</dc-schema>
-                    <dc-element>description</dc-element>
-                    <dc-qualifier>sponsorship</dc-qualifier>
-                    <repeatable>false</repeatable>
-                    <label>Sponsors</label>
-                    <input-type>textarea</input-type>
-                    <hint>Enter the names of any sponsors and/or funding codes in the box.</hint>
-                    <required></required>
-                </field>
-            </row>
-            <row>
-                <field>
-                    <dc-schema>dc</dc-schema>
-                    <dc-element>description</dc-element>
-                    <dc-qualifier></dc-qualifier>
-                    <repeatable>false</repeatable>
-                    <label>Description</label>
-                    <input-type>textarea</input-type>
-                    <hint>Enter any other description or comments in this box.</hint>
-                    <required></required>
-                </field>
-            </row>
-        </form>
-
-        <form name="peopleStep">
+        <!-- Form which defines the metadata page/section for depositing Person Entities -->
+        <form name="personStep">
             <row>
                 <relation-field>
                     <relationship-type>isPublicationOfAuthor</relationship-type>
@@ -320,6 +465,7 @@
             </row>
         </form>
 
+        <!-- Form which defines the metadata page/section for depositing Project Entities -->
         <form name="projectStep">
             <row>
                 <field>
@@ -390,6 +536,7 @@
             </row>
         </form>
 
+        <!-- Form which defines the metadata page/section for depositing OrgUnit Entities -->
         <form name="orgUnitStep">
             <row>
                 <field>
@@ -449,6 +596,7 @@
             </row>
         </form>
 
+        <!-- Form which defines the metadata page/section for depositing Journal Entities -->
         <form name="journalStep">
             <row>
                 <field>
@@ -498,6 +646,7 @@
 
         </form>
 
+        <!-- Form which defines the metadata page/section for depositing JournalVolume Entities -->
         <form name="journalVolumeStep">
             <row>
                 <relation-field>
@@ -548,6 +697,7 @@
             </row>
         </form>
 
+        <!-- Form which defines the metadata page/section for depositing JournalIssue Entities -->
         <form name="journalIssueStep">
             <row>
                 <relation-field>


### PR DESCRIPTION
## Description

This PR updates our existing `item-submission.xml` and `submission-form.xml` configurations as follows:

* Ensure Entities/relationships are **disabled by default**, which involves removing them from the `traditional` submission configuration.
* Create a new form/submission configuration for `Publication` entities. Previously they shared the `traditional` submission configuration, but they need their own configs
* Add a (commented out) sample Entities collection mapping based on the demo Entities data at https://github.com/DSpace-Labs/AIP-Files/releases/tag/demo-entities-data  This is useful for anyone who wants to quickly test the Entities submission forms & also useful for our demo site for Testathon.
* Remove ununsed/unsupported steps.
* Uncommented all `step-definition` tags, as they are unused until a corresponding `step` references them.  This simply makes it easier to use/enable those steps when needed.
* Enhanced comments & some renaming of steps to make more consistent (e.g. `peopleStep` named to `personStep` to match entity name)

## Instructions for Reviewers
* Review the changes
* The easiest way to test these changes is using the sample Entities dataset at https://github.com/DSpace-Labs/AIP-Files/releases/tag/demo-entities-data
* Then, you can simply uncomment all the sample `<name-map>` tags in the `item-submission.xml`, and verify that a different (Entity-specific) Submission form is available for each Entity-specific Collection. (NOTE: In that same dataset, there's also a "Sample Collection" which will default to using the "traditional" form, so that you can test submission of a simple Item)

I've tested this locally using the same Entities dataset & it's all working as expected.
