### PR TITLE
Ensure a REST API running in Docker always trusts requests from the host machine

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,11 @@
 version: '3.7'
 networks:
   dspacenet:
+    ipam:
+      config:
+        # Define a custom subnet for our DSpace network, so that we can easily trust requests from host to container.
+        # If you customize this value, be sure to customize the 'proxies.trusted.ipranges' in your local.cfg.
+        - subnet: 172.23.0.0/16
 services:
   # DSpace (backend) webapp container
   dspace:

--- a/dspace/src/main/docker-compose/local.cfg
+++ b/dspace/src/main/docker-compose/local.cfg
@@ -1,6 +1,11 @@
 dspace.dir=/dspace
-db.url=jdbc:postgresql://dspacedb:5432/dspace
 dspace.server.url=http://localhost:8080/server
 dspace.ui.url=http://localhost:4000
 dspace.name=DSpace Started with Docker Compose
+# Ensure we are using the 'dspacedb' image for our database
+db.url=jdbc:postgresql://dspacedb:5432/dspace
+# Ensure we are using the 'dspacesolr' image for Solr
 solr.server=http://dspacesolr:8983/solr
+# NOTE: This setting is required for a REST API running in Docker to trust requests from the host machine.
+# This IP range MUST correspond to the 'dspacenet' subnet defined in our 'docker-compose.yml'.
+proxies.trusted.ipranges = 172.23.0


### PR DESCRIPTION
## References
* Fixes #3229 

## Description

This involves two simple changes:
* Adding a specific subnet address to our docker-compose.yml for our "dspacenet" network
* Ensuring that subnet (entire range) is trusted in the local.cfg used by Docker

I've been testing this setup locally for some time and run into no problems.  So, assuming GitHub has no issues, I'll move this forward quickly as it will be needed during Testathon by anyone running Docker.