### PR TITLE
Exclude swagger-jersey-jaxrs as it would include old v1 jersey depenies

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -856,6 +856,10 @@
                     <groupId>org.javassist</groupId>
                     <artifactId>javassist</artifactId>
                 </exclusion>
+                <exclusion>
+                	<groupId>io.swagger</groupId>
+                	<artifactId>swagger-jersey-jaxrs</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 


### PR DESCRIPTION
## References
* Fixes #3234 

## Description
This is a bit hard to reproduce and so verify... look to the issue description for more context.
In short, the demo was NOT working but as a final test for this PR I have manually removed the following jar from the build webapp
* jersey-core-1.13.jar
* jersey-multipart-1.13.jar
* jsr311-api-1.1.1.jar

these jar are not necessary as we already have jakarta 2 and jersey-client 2 for the api and implementation of java.ws.rs
Having also this old dependencies seem to cause pseudo-random issue depending on which one is picked first by the JVM.
The only environment where we where able to see it in a stable way was the demo server... (the tomcat version doesn't matter)

## Instructions for Reviewers
Test if the lookup from external providers work well and verify that the ORCID features are still working.

Unfortunately our test cannot help to much on that as this is a runtime dependencies used only when real http request are performed.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [n/a] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [n/a] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [n/a] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
