### PR TITLE
Remove sequences which no longer exist from 'updatesequences' command

### DIFF
--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/update-sequences.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/update-sequences.sql
@@ -47,8 +47,6 @@ BEGIN
   updateseq('fileextension_seq', 'fileextension', 'file_extension_id');
   updateseq('resourcepolicy_seq', 'resourcepolicy', 'policy_id');
   updateseq('workspaceitem_seq', 'workspaceitem', 'workspace_item_id');
-  updateseq('workflowitem_seq', 'workflowitem', 'workflow_id');
-  updateseq('tasklistitem_seq', 'tasklistitem', 'tasklist_id');
   updateseq('registrationdata_seq', 'registrationdata',
             'registrationdata_id');
   updateseq('subscription_seq', 'subscription', 'subscription_id');

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/update-sequences.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/update-sequences.sql
@@ -24,8 +24,6 @@ SELECT setval('bitstreamformatregistry_seq', max(bitstream_format_id)) FROM bits
 SELECT setval('fileextension_seq', max(file_extension_id)) FROM fileextension;
 SELECT setval('resourcepolicy_seq', max(policy_id)) FROM resourcepolicy;
 SELECT setval('workspaceitem_seq', max(workspace_item_id)) FROM workspaceitem;
-SELECT setval('workflowitem_seq', max(workflow_id)) FROM workflowitem;
-SELECT setval('tasklistitem_seq', max(tasklist_id)) FROM tasklistitem;
 SELECT setval('registrationdata_seq', max(registrationdata_id)) FROM registrationdata;
 SELECT setval('subscription_seq', max(subscription_id)) FROM subscription;
 SELECT setval('metadatafieldregistry_seq', max(metadata_field_id)) FROM metadatafieldregistry;


### PR DESCRIPTION
## References
Stumbled on while testing Docker fresh install (as it calls updatesequences when adding AIPs).

## Description
Our `update-sequences.sql` scripts still reference old sequences, namely workflowitem_seq and tasklistitem_seq which were both removed in this migration:
https://github.com/DSpace/DSpace/blob/main/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.0_2021.01.22__Remove_basic_workflow.sql

This PR is tiny and obvious, so I'm just going to make sure GitHub CI succeeds.