### PR TITLE
Fix broken Shibboleth Authentication & enhance tests & comments

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/ShibbolethRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/ShibbolethRestController.java
@@ -14,6 +14,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.lang3.StringUtils;
 import org.dspace.app.rest.model.AuthnRest;
+import org.dspace.authenticate.ShibAuthentication;
 import org.dspace.core.Utils;
 import org.dspace.services.ConfigurationService;
 import org.slf4j.Logger;
@@ -27,10 +28,27 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * Rest controller that handles redirect after shibboleth authentication succeded
+ *  Rest controller that handles redirect *after* shibboleth authentication succeeded.
+ *  <P>
+ *  Shibboleth authentication does NOT occur in this Controller, but occurs before this class is called.
+ *  The general Shibboleth login process is as follows:
+ *    1. When Shibboleth plugin is enabled, client/UI receives Shibboleth's absolute URL in WWW-Authenticate header.
+ *       See {@link org.dspace.authenticate.ShibAuthentication} loginPageURL() method.
+ *    2. Client sends the user to that URL when they select Shibboleth authentication.
+ *    3. User logs in using Shibboleth
+ *    4. If successful, they are redirected by Shibboleth to this Controller (the path of this controller is passed
+ *       to Shibboleth as a URL param in step 1)
+ *    5. NOTE: Prior to hitting this Controller, {@link org.dspace.app.rest.security.ShibbolethAuthenticationFilter}
+ *       briefly intercepts the request in order to check for a valid Shibboleth login (see
+ *       ShibAuthentication.authenticate()) and store that user info in a JWT.
+ *    6. This Controller then gets the request & looks for a "redirectUrl" param (also a part of the original URL from
+ *       step 1), and redirects the user to that location (after verifying it's a trusted URL). Usually this is a
+ *       redirect back to the Client/UI page where the User started.
  *
  * @author Andrea Bollini (andrea dot bollini at 4science dot it)
  * @author Giuseppe Digilio (giuseppe dot digilio at 4science dot it)
+ * @see ShibAuthentication
+ * @see org.dspace.app.rest.security.ShibbolethAuthenticationFilter
  */
 @RequestMapping(value = "/api/" + AuthnRest.CATEGORY + "/shibboleth")
 @RestController
@@ -56,7 +74,11 @@ public class ShibbolethRestController implements InitializingBean {
     @RequestMapping(method = RequestMethod.GET)
     public void shibboleth(HttpServletResponse response,
             @RequestParam(name = "redirectUrl", required = false) String redirectUrl) throws IOException {
-        if (redirectUrl == null) {
+        // NOTE: By the time we get here, we already know that Shibboleth is enabled & authentication succeeded,
+        // as both of those are verified by ShibbolethAuthenticationFilter which runs before this controller
+
+        // If redirectUrl unspecified, default to the configured UI
+        if (StringUtils.isEmpty(redirectUrl)) {
             redirectUrl = configurationService.getProperty("dspace.ui.url");
         }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/RestAuthenticationService.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/RestAuthenticationService.java
@@ -53,10 +53,11 @@ public interface RestAuthenticationService {
      * Checks the current request for a valid authentication token. If found, extracts that token and obtains the
      * currently logged in EPerson.
      * @param request current request
+     * @param request current response
      * @param context current DSpace Context
      * @return EPerson of the logged in user (if auth token found), or null if no auth token is found
      */
-    EPerson getAuthenticatedEPerson(HttpServletRequest request, Context context);
+    EPerson getAuthenticatedEPerson(HttpServletRequest request, HttpServletResponse response, Context context);
 
     /**
      * Checks the current request for a valid authentication token. If found, returns true. If not found, returns false

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/RestAuthenticationService.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/RestAuthenticationService.java
@@ -71,8 +71,7 @@ public interface RestAuthenticationService {
      * existing authentication data/token is destroyed/invalidated and cannot be reused in later requests.
      * <P>
      * In other words, this method invalidates the authentication data created by addAuthenticationDataForUser().
-     * This also should include clearing any Cookie created by that method, usually by calling the separate
-     * invalidateAuthenticationCookie() method in this same class.
+     *
      * @param request current request
      * @param response current response
      * @param context current DSpace Context.
@@ -103,8 +102,9 @@ public interface RestAuthenticationService {
      * addAuthenticationDataForUser()). It's useful for those services to immediately *remove/discard* the Cookie after
      * it has been used. This ensures the auth Cookie is temporary in nature, and is destroyed as soon as it is no
      * longer needed.
+     * @param request current request
      * @param res current response (where Cookie should be destroyed)
      */
-    void invalidateAuthenticationCookie(HttpServletResponse res);
+    void invalidateAuthenticationCookie(HttpServletRequest request, HttpServletResponse res);
 
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/ShibbolethAuthenticationFilter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/ShibbolethAuthenticationFilter.java
@@ -14,14 +14,21 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.dspace.authenticate.ShibAuthentication;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderNotFoundException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 
 /**
- * This class will filter shibboleth requests to try and authenticate them
+ * This class will filter Shibboleth requests to see if the user has been authenticated via Shibboleth.
+ * <P>
+ * This filter runs before the ShibbolethRestController, in order to verify Shibboleth authentication succeeded,
+ * and create the authentication token (JWT).
  *
  * @author Giuseppe Digilio (giuseppe dot digilio at 4science dot it)
+ * @see org.dspace.app.rest.ShibbolethRestController
+ * @see org.dspace.authenticate.ShibAuthentication
  */
 public class ShibbolethAuthenticationFilter extends StatelessLoginFilter {
 
@@ -33,7 +40,16 @@ public class ShibbolethAuthenticationFilter extends StatelessLoginFilter {
     @Override
     public Authentication attemptAuthentication(HttpServletRequest req,
                                                 HttpServletResponse res) throws AuthenticationException {
+        // First, if Shibboleth is not enabled, throw an immediate ProviderNotFoundException
+        // This tells Spring Security that authentication failed
+        if (!ShibAuthentication.isEnabled()) {
+            throw new ProviderNotFoundException("Shibboleth is disabled.");
+        }
 
+        // In the case of Shibboleth, this method does NOT actually authenticate us. The authentication
+        // has already happened in Shibboleth & we are just intercepting the return request in order to check
+        // for a valid Shibboleth login (using ShibAuthentication.authenticate()) & save current user to Context
+        // See org.dspace.app.rest.ShibbolethRestController JavaDocs for an outline of the entire Shib login process.
         return authenticationManager.authenticate(
                 new DSpaceAuthentication(null, null, new ArrayList<>())
         );
@@ -44,8 +60,14 @@ public class ShibbolethAuthenticationFilter extends StatelessLoginFilter {
                                             HttpServletResponse res,
                                             FilterChain chain,
                                             Authentication auth) throws IOException, ServletException {
+        // Once we've gotten here, we know we have a successful login (i.e. attemptAuthentication() succeeded)
 
         DSpaceAuthentication dSpaceAuthentication = (DSpaceAuthentication) auth;
+        // OVERRIDE DEFAULT behavior of StatelessLoginFilter to return a temporary authentication cookie containing
+        // the Auth Token (JWT). This Cookie is required because ShibbolethRestController *redirects* the user
+        // back to the client/UI after a successful Shibboleth login. Headers cannot be sent via a redirect, so a Cookie
+        // must be sent to provide the auth token to the client. On the next request from the client, the cookie is
+        // read and destroyed & the Auth token is only used in the Header from that point forward.
         restAuthenticationService.addAuthenticationDataForUser(req, res, dSpaceAuthentication, true);
         chain.doFilter(req, res);
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/StatelessAuthenticationFilter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/StatelessAuthenticationFilter.java
@@ -39,7 +39,8 @@ import org.springframework.security.web.authentication.www.BasicAuthenticationFi
 
 /**
  * Custom Spring authentication filter for Stateless authentication, intercepts requests to check for valid
- * authentication
+ * authentication. This runs before *every* request in the DSpace backend to see if any authentication data
+ * is passed in that request. If so, it authenticates the EPerson in the current Context.
  *
  * @author Frederic Van Reet (frederic dot vanreet at atmire dot com)
  * @author Tom Desair (tom dot desair at atmire dot com)

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/StatelessAuthenticationFilter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/StatelessAuthenticationFilter.java
@@ -94,9 +94,9 @@ public class StatelessAuthenticationFilter extends BasicAuthenticationFilter {
             log.error("Access is denied (status:{})", HttpServletResponse.SC_FORBIDDEN, e);
             return;
         }
+        // If we have a valid Authentication, save it to Spring Security
         if (authentication != null) {
             SecurityContextHolder.getContext().setAuthentication(authentication);
-            restAuthenticationService.invalidateAuthenticationCookie(res);
         }
         chain.doFilter(req, res);
     }
@@ -123,7 +123,7 @@ public class StatelessAuthenticationFilter extends BasicAuthenticationFilter {
 
             Context context = ContextUtil.obtainContext(request);
 
-            EPerson eperson = restAuthenticationService.getAuthenticatedEPerson(request, context);
+            EPerson eperson = restAuthenticationService.getAuthenticatedEPerson(request, res, context);
             if (eperson != null) {
                 //Pass the eperson ID to the request service
                 requestService.setCurrentUserId(eperson.getID());

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/StatelessLoginFilter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/StatelessLoginFilter.java
@@ -46,6 +46,19 @@ public class StatelessLoginFilter extends AbstractAuthenticationProcessingFilter
         this.restAuthenticationService = restAuthenticationService;
     }
 
+    /**
+     * Attempt to authenticate the user by using Spring Security's AuthenticationManager.
+     * The AuthenticationManager will delegate this task to one or more AuthenticationProvider classes.
+     * <P>
+     * For DSpace, our custom AuthenticationProvider is {@link EPersonRestAuthenticationProvider}, so that
+     * is the authenticate() method which is called below.
+     *
+     * @param req current request
+     * @param res current response
+     * @return a valid Spring Security Authentication object if authentication succeeds
+     * @throws AuthenticationException if authentication fails
+     * @see EPersonRestAuthenticationProvider
+     */
     @Override
     public Authentication attemptAuthentication(HttpServletRequest req,
                                                 HttpServletResponse res) throws AuthenticationException {
@@ -53,12 +66,28 @@ public class StatelessLoginFilter extends AbstractAuthenticationProcessingFilter
         String user = req.getParameter("user");
         String password = req.getParameter("password");
 
+        // Attempt to authenticate by passing user & password (if provided) to AuthenticationProvider class(es)
         return authenticationManager.authenticate(
                 new DSpaceAuthentication(user, password, new ArrayList<>())
         );
     }
 
-
+    /**
+     * If the above attemptAuthentication() call was successful (no authentication error was thrown),
+     * then this method will take the returned {@link DSpaceAuthentication} class (which includes all
+     * the data from the authenticated user) and add the authentication data to the response.
+     * <P>
+     * For DSpace, this is calling our {@link org.dspace.app.rest.security.jwt.JWTTokenRestAuthenticationServiceImpl}
+     * in order to create a JWT based on the authentication data & send that JWT back in the response.
+     *
+     * @param req current request
+     * @param res response
+     * @param chain FilterChain
+     * @param auth Authentication object containing info about user who had a successful authentication
+     * @throws IOException
+     * @throws ServletException
+     * @see org.dspace.app.rest.security.jwt.JWTTokenRestAuthenticationServiceImpl
+     */
     @Override
     protected void successfulAuthentication(HttpServletRequest req,
                                             HttpServletResponse res,
@@ -69,6 +98,16 @@ public class StatelessLoginFilter extends AbstractAuthenticationProcessingFilter
         restAuthenticationService.addAuthenticationDataForUser(req, res, dSpaceAuthentication, false);
     }
 
+    /**
+     * If the above attemptAuthentication() call was unsuccessful, then ensure that the response is a 401 Unauthorized
+     * AND it includes a WWW-Authentication header. We use this header in DSpace to return all the enabled
+     * authentication options available to the UI (along with the path to the login URL for each option)
+     * @param request current request
+     * @param response current response
+     * @param failed exception that was thrown by attemptAuthentication()
+     * @throws IOException
+     * @throws ServletException
+     */
     @Override
     protected void unsuccessfulAuthentication(HttpServletRequest request,
                                               HttpServletResponse response, AuthenticationException failed)

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/StatelessLoginFilter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/StatelessLoginFilter.java
@@ -23,7 +23,10 @@ import org.springframework.security.web.authentication.AbstractAuthenticationPro
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 /**
- * This class will filter login requests to try and authenticate them
+ * This class will filter /api/authn/login requests to try and authenticate them. Keep in mind, this filter runs *after*
+ * StatelessAuthenticationFilter (which looks for authentication data in the request itself). So, in some scenarios
+ * (e.g. after a Shibboleth login) the StatelessAuthenticationFilter does the actual authentication, and this Filter
+ * just ensures the auth token (JWT) is sent back in an Authorization header.
  *
  * @author Frederic Van Reet (frederic dot vanreet at atmire dot com)
  * @author Tom Desair (tom dot desair at atmire dot com)

--- a/dspace-server-webapp/src/main/webapp/login.html
+++ b/dspace-server-webapp/src/main/webapp/login.html
@@ -98,39 +98,62 @@
             "onclick" : function() { toastr.remove(); }
         }
 
+        // When the login page loads, we do *two* AJAX requests.
+        // (1) Call GET /api/authn/status. This call has two purposes. First, it checks to see if you are logged in,
+        //     (if not, WWW-Authenticate will return login options). Second, it retrieves the CSRF token, if a
+        //     new one has been assigned (as a valid CSRF token is required for the POST call).
+        // (2) If that /api/authn/status call finds authentication data, call POST /api/authn/login.
+        //     This scenario occurs when you login via an external authentication system (e.g. Shibboleth)...
+        //     in which case the main role of /api/authn/login is to simply ensure the "Authorization" header
+        //     is sent back to the client (based on your authentication data).
         $.ajax({
-          url : window.location.href.replace("login.html", "") + 'api/authn/login',
-          type : 'POST',
-          beforeSend: function (xhr, settings) {
-               // If CSRF token found in cookie, send it back as X-XSRF-Token header
-               var csrfToken = getCSRFToken();
-               if (csrfToken != null) {
-                   xhr.setRequestHeader('X-XSRF-Token', csrfToken);
-               }
-          },
-          success : successHandler,
-          error : function(xhr, textStatus, errorThrown) {
-              // Check for an update to the CSRF Token & save to a MyHalBrowserCsrfToken cookie (if found)
-              checkForUpdatedCSRFTokenInResponse(xhr);
+          url : window.location.href.replace("login.html", "") + 'api/authn/status',
+          type : 'GET',
+          success : function(result, status, xhr) {
+            // Check for an update to the CSRF Token & save to a MyHalBrowserCsrfToken cookie (if found)
+            checkForUpdatedCSRFTokenInResponse(xhr);
 
-              // If 401 Unauthorized, check WWW-Authenticate for authentication options
-              if (xhr.status === 401) {
-                  var authenticate = xhr.getResponseHeader("WWW-Authenticate");
-                  var element = $('div.other-login-methods');
-                  if(authenticate !== null) {
-                      var realms = authenticate.match(/(\w+ (\w+=((".*?")|[^,]*)(, )?)*)/g);
-                      if (realms.length == 1){
-                          var loc = /location="([^,]*)"/.exec(authenticate);
-                          if (loc !== null && loc.length === 2) {
-                              document.location = loc[1];
-                          }
-                      } else if (realms.length > 1){
-                          for (var i = 0; i < realms.length; i++){
-                              addLocationButton(realms[i], element);
-                          }
-                      }
+            // Check for WWW-Authenticate header. If found, this means we are not yet authenticated, and
+            // therefore we need to display available authentication options.
+            var authenticate = xhr.getResponseHeader("WWW-Authenticate");
+            if (authenticate !== null) {
+                var element = $('div.other-login-methods');
+                var realms = authenticate.match(/(\w+ (\w+=((".*?")|[^,]*)(, )?)*)/g);
+                if (realms.length == 1){
+                    var loc = /location="([^,]*)"/.exec(authenticate);
+                    if (loc !== null && loc.length === 2) {
+                        document.location = loc[1];
+                    }
+                } else if (realms.length > 1){
+                    for (var i = 0; i < realms.length; i++){
+                        addLocationButton(realms[i], element);
+                    }
+                }
+            } else {
+                // If Authentication data was found, do a POST /api/authn/login to ensure that data's JWT
+                // is sent back in the "Authorization" header. This simply completes an external authentication
+                // process (e.g. Shibboleth)
+                $.ajax({
+                  url : window.location.href.replace("login.html", "") + 'api/authn/login',
+                  type : 'POST',
+                  beforeSend: function (xhr, settings) {
+                       // If CSRF token found in cookie, send it back as X-XSRF-Token header
+                       var csrfToken = getCSRFToken();
+                       if (csrfToken != null) {
+                           xhr.setRequestHeader('X-XSRF-Token', csrfToken);
+                       }
+                  },
+                  success : successHandler,
+                  error : function(xhr, textStatus, errorThrown) {
+                      // Check for an update to the CSRF Token & save to a MyHalBrowserCsrfToken cookie (if found)
+                      checkForUpdatedCSRFTokenInResponse(xhr);
+                      toastr.error('Failed to logged in. Please check for errors in Javascript console.', 'Login Failed');
                   }
-              }
+                });
+            }
+          },
+          error : function(xhr, textStatus, errorThrown) {
+            toastr.error('Failed to connect with backend. Please check for errors in Javascript console.', 'Could Not Load');
           }
         });
 
@@ -172,6 +195,8 @@
             }
         }
 
+        // When the Username/Password Login form is submitted, POST that data directly to /api/authn/login.
+        // This logs the user in and ensures the "Authorization" header is set with the JWT.
         $("#login-form").submit(function(event) {
             event.preventDefault();
             $.ajax({

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/AuthenticationRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/AuthenticationRestControllerIT.java
@@ -269,6 +269,8 @@ public class AuthenticationRestControllerIT extends AbstractControllerIntegratio
                    .andExpect(jsonPath("$.okay", is(true)))
                    .andExpect(jsonPath("$.authenticated", is(true)))
                    .andExpect(jsonPath("$.type", is("status")))
+                   // Verify the Auth cookie has been deleted after one usage
+                   .andExpect(cookie().value(AUTHORIZATION_COOKIE, ""))
                    // Verify that the CSRF token has been changed
                    // (as both cookie and header should be sent back)
                    .andExpect(cookie().exists("DSPACE-XSRF-COOKIE"))

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ShibbolethRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ShibbolethRestControllerIT.java
@@ -27,58 +27,96 @@ public class ShibbolethRestControllerIT extends AbstractControllerIntegrationTes
     @Autowired
     ConfigurationService configurationService;
 
+    public static final String[] PASS_ONLY = {"org.dspace.authenticate.PasswordAuthentication"};
+    public static final String[] SHIB_ONLY = {"org.dspace.authenticate.ShibAuthentication"};
 
     @Before
     public void setup() throws Exception {
         super.setUp();
+        // Add a second trusted host for some tests
         configurationService.setProperty("rest.cors.allowed-origins",
                 "${dspace.ui.url}, http://anotherdspacehost:4000");
+
+        // Enable Shibboleth login for all tests
+        configurationService.setProperty("plugin.sequence.org.dspace.authenticate.AuthenticationMethod", SHIB_ONLY);
     }
 
     @Test
     public void testRedirectToDefaultDspaceUrl() throws Exception {
-        String token = getAuthToken(eperson.getEmail(), password);
-
-        getClient(token).perform(get("/api/authn/shibboleth"))
+        // NOTE: The initial call to /shibboleth comes *from* an external Shibboleth site. So, it is always
+        // unauthenticated, but it must include some expected SHIB attributes.
+        // SHIB-MAIL attribute is the default email header sent from Shibboleth after a successful login.
+        // In this test we are simply mocking that behavior by setting it to an existing EPerson.
+        getClient().perform(get("/api/authn/shibboleth").requestAttr("SHIB-MAIL", eperson.getEmail()))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("http://localhost:4000"));
     }
 
     @Test
     public void testRedirectToGivenTrustedUrl() throws Exception {
-
-        String token = getAuthToken(eperson.getEmail(), password);
-
-        getClient(token).perform(get("/api/authn/shibboleth")
-                .param("redirectUrl", "http://localhost:8080/server/api/authn/status"))
+        getClient().perform(get("/api/authn/shibboleth")
+                      .param("redirectUrl", "http://localhost:8080/server/api/authn/status")
+                      .requestAttr("SHIB-MAIL", eperson.getEmail()))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("http://localhost:8080/server/api/authn/status"));
+    }
+
+    @Test
+    public void testNoRedirectIfShibbolethDisabled() throws Exception {
+        // Enable Password authentication ONLY
+        configurationService.setProperty("plugin.sequence.org.dspace.authenticate.AuthenticationMethod", PASS_ONLY);
+
+        // Test redirecting to a trusted URL (same as previous test).
+        // This time we should be unauthorized as Shibboleth is disabled.
+        getClient().perform(get("/api/authn/shibboleth")
+                       .param("redirectUrl", "http://localhost:8080/server/api/authn/status")
+                       .requestAttr("SHIB-MAIL", eperson.getEmail()))
+                .andExpect(status().isUnauthorized());
     }
 
     @Test
     public void testRedirectToAnotherGivenTrustedUrl() throws Exception {
         String token = getAuthToken(eperson.getEmail(), password);
 
-        getClient(token).perform(get("/api/authn/shibboleth")
-                .param("redirectUrl", "http://anotherdspacehost:4000/home"))
+        getClient().perform(get("/api/authn/shibboleth")
+                       .param("redirectUrl", "http://anotherdspacehost:4000/home")
+                       .requestAttr("SHIB-MAIL", eperson.getEmail()))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("http://anotherdspacehost:4000/home"));
     }
 
     @Test
     public void testRedirectToGivenUntrustedUrl() throws Exception {
-        String token = getAuthToken(eperson.getEmail(), password);
+        // Now attempt to redirect to a URL that is NOT trusted (i.e. not in 'rest.cors.allowed-origins').
 
-        // Now attempt to redirect to a URL that is NOT trusted (i.e. not the Server or UI).
         // Should result in a 400 error.
-        getClient(token).perform(get("/api/authn/shibboleth")
-                                     .param("redirectUrl", "http://dspace.org"))
-                        .andExpect(status().isBadRequest());
+        getClient().perform(get("/api/authn/shibboleth")
+                       .param("redirectUrl", "http://dspace.org")
+                       .requestAttr("SHIB-MAIL", eperson.getEmail()))
+                .andExpect(status().isBadRequest());
     }
 
     @Test
-    public void testRedirectRequiresAuth() throws Exception {
+    public void testNoRedirectIfInvalidShibAttributes() throws Exception {
+        // In this request, we use a SHIB-MAIL attribute which does NOT match an EPerson.
+        getClient().perform(get("/api/authn/shibboleth")
+                .requestAttr("SHIB-MAIL", "not-an-eperson@example.com"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void testRedirectRequiresShibAttributes() throws Exception {
+        // Verify this endpoint doesn't work if no SHIB-* attributes are set
         getClient().perform(get("/api/authn/shibboleth"))
-                        .andExpect(status().isUnauthorized());
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void testRedirectRequiresShibAttributes2() throws Exception {
+        String token = getAuthToken(eperson.getEmail(), password);
+
+        // Verify this endpoint also doesn't work using a regular auth token (again if SHIB-* attributes missing)
+        getClient(token).perform(get("/api/authn/shibboleth"))
+                .andExpect(status().isUnauthorized());
     }
 }


### PR DESCRIPTION
## References

* Fixes https://github.com/DSpace/dspace-angular/issues/1108

## Description
This PR fixes Shibboleth authentication after #3168 was applied.  That PR accidentally broke Shibboleth authentication, as Shibboleth authentication relies on a temporary Auth Cookie...and that Auth Cookie process was NOT a refreshing/resetting the CSRF token when it was used.  This resulted in the CSRF token sometimes getting out of sync (the large number of redirects during a Shibboleth authentication caused the frontend & backend to get out of sync).

This PR fixes that issue by ensuring the CSRF token is reset as soon as the Auth Cookie is used (which happens during the login process of Shibboleth).  This is in line with the changes made to #3168, which also reset the CSRF token whenever a login/logout occur.

Additionally, minor changes/improvements to the Shibboleth code were made:
* Enhanced the JavaDocs to better describe the Shibboleth process
* Enhanced the ITs for Shibboleth to better Mock the entire login flow for Shibboleth.
* Updated the ShibbolethAuthenticationFilter to block access to the `/api/authn/shibboleth` endpoint if Shibboleth is not enabled.

## Instructions for Reviewers

* Review the code changes & new tests
    * NOTE: I pushed up the new tests in the first commit to show that a few expectations **currently fail**.  Those tests are then fixed by the code changes in the second commit.
* Test that Shibboleth authentication now works properly without CSRF errors
* Verify that Password-based authentication is not affected (it should not be).
