### PR TITLE
DS-4580 Update confidence when editing record

### DIFF
--- a/dspace-xmlui-mirage2/src/main/webapp/scripts/person-lookup.js
+++ b/dspace-xmlui-mirage2/src/main/webapp/scripts/person-lookup.js
@@ -176,6 +176,27 @@ function AuthorLookup(url, authorityInput, collectionID) {
                         var oldAuthority = $('input[name=' + authorityInput + '_authority]');
                         oldAuthority.val(vcard.data('authorityID'));
                         $('textarea[name='+ authorityInput+']').val(vcard.data('name'));
+
+                        /*
+
+                        Manually setting confidence hidden value and class of graphic
+                        confidence indicator as onchange event handler won't do the trick.
+
+                         */
+
+                        var elem = document.getElementById('aspect_administrative_item_EditItemMetadataForm_field_' + authorityInput + '_authority')
+                        var conf = 'aspect_administrative_item_EditItemMetadataForm_field_' + authorityInput + '_confidence';
+                        var ind = conf + '_indicator';
+
+                        DSpaceAuthorityOnChange(elem, conf, ind);
+
+                        var ind_elem = $('#' + ind)[0];
+                        var ind_classes = ind_elem.className;
+                        ind_elem.title = 'This authority value has been confirmed as accurate by an interactive user';
+                        var new_classes = ind_classes.replace(new RegExp(" glyphicon-.* "), '');
+
+                        ind_elem.className = new_classes + " glyphicon-thumbs-up";
+
                     } else {
                         // submission
                         var lastName = $('input[name=' + authorityInput + '_last]');


### PR DESCRIPTION
Fixes #7913 

This is a bug when using the Authority Control mechanism in the XMLUI UI.

When updating a metadatafield when +editing+ a record (as opposed to submitting a new record), the associated confidence value field which is a hidden input isn't updated.

The confidence indicator (a glyphicon) isn't updated either which is not- a serious issue.

This is because the authority control relies on obsolete jQuery vcard/datatables library that changes the text input value of the confidence id which is supposed to trigger an onchance event handler that then changes the confidence value and the indicator. Onchange does not fire when the value of the input is changed programmatically (see for example: https://stackoverflow.com/questions/11218553/onchange-event-is-not-working-well)

This error was already reported back in 2018 on the mailing list but got no response:
http://dspace.2283337.n4.nabble.com/ORCID-Confidence-td4688898.html

To reproduce you can log onto http://demo.dspace.org, edit an item and manually change the html code to set the hidden confidence value to anything other than "accepted", then click the lookup button and select a value. The confidence value should now be set to accepted as it has been selected interactively by a user, but it is not, because the onchange does not trigger.