### PR TITLE
Private and withdrawn filters in administrative search

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/SearchService.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SearchService.java
@@ -63,7 +63,8 @@ public interface SearchService {
      * @param field    the field of the filter query
      * @param operator equals/notequals/notcontains/authority/notauthority
      * @param value    the filter query value
-     * @param config   the discovery configuration
+     * @param config   (nullable) the discovery configuration (if not null, field's corresponding facet.type checked to
+     *                be standard so suffix is not added for equals operator)
      * @return a filter query
      * @throws SQLException if database error
      *                      An exception that provides information on a database access error or other errors.

--- a/dspace-api/src/main/java/org/dspace/discovery/SearchService.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SearchService.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 import org.dspace.content.Item;
 import org.dspace.core.Context;
+import org.dspace.discovery.configuration.DiscoveryConfiguration;
 import org.dspace.discovery.configuration.DiscoveryMoreLikeThisConfiguration;
 import org.dspace.discovery.configuration.DiscoverySearchFilterFacet;
 
@@ -62,11 +63,13 @@ public interface SearchService {
      * @param field    the field of the filter query
      * @param operator equals/notequals/notcontains/authority/notauthority
      * @param value    the filter query value
+     * @param config   the discovery configuration
      * @return a filter query
      * @throws SQLException if database error
      *                      An exception that provides information on a database access error or other errors.
      */
-    DiscoverFilterQuery toFilterQuery(Context context, String field, String operator, String value) throws SQLException;
+    DiscoverFilterQuery toFilterQuery(Context context, String field, String operator, String value,
+        DiscoveryConfiguration config) throws SQLException;
 
     List<Item> getRelatedItems(Context context, Item item,
                                DiscoveryMoreLikeThisConfiguration moreLikeThisConfiguration);

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -1082,8 +1082,12 @@ public class SolrServiceImpl implements SearchService, IndexingService {
 
 
             if (operator.endsWith("equals")) {
-                final DiscoverySearchFilterFacet facet = config.getSidebarFacet(field);
-                if (facet == null || !facet.getType().equals(DiscoveryConfigurationParameters.TYPE_STANDARD)) {
+                final boolean isStandardField
+                    = Optional.ofNullable(config)
+                              .flatMap(c -> Optional.ofNullable(c.getSidebarFacet(field)))
+                              .map(facet -> facet.getType().equals(DiscoveryConfigurationParameters.TYPE_STANDARD))
+                              .orElse(false);
+                if (!isStandardField) {
                     filterQuery.append("_keyword");
                 }
             } else if (operator.endsWith("authority")) {

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -60,6 +60,7 @@ import org.dspace.core.Context;
 import org.dspace.core.Email;
 import org.dspace.core.I18nUtil;
 import org.dspace.core.LogManager;
+import org.dspace.discovery.configuration.DiscoveryConfiguration;
 import org.dspace.discovery.configuration.DiscoveryConfigurationParameters;
 import org.dspace.discovery.configuration.DiscoveryMoreLikeThisConfiguration;
 import org.dspace.discovery.configuration.DiscoverySearchFilterFacet;
@@ -1069,9 +1070,9 @@ public class SolrServiceImpl implements SearchService, IndexingService {
             return new ArrayList<>(0);
         }
     }
-
     @Override
-    public DiscoverFilterQuery toFilterQuery(Context context, String field, String operator, String value)
+    public DiscoverFilterQuery toFilterQuery(Context context, String field, String operator, String value,
+        DiscoveryConfiguration config)
         throws SQLException {
         DiscoverFilterQuery result = new DiscoverFilterQuery();
 
@@ -1081,7 +1082,10 @@ public class SolrServiceImpl implements SearchService, IndexingService {
 
 
             if (operator.endsWith("equals")) {
-                filterQuery.append("_keyword");
+                final DiscoverySearchFilterFacet facet = config.getSidebarFacet(field);
+                if (facet == null || !facet.getType().equals(DiscoveryConfigurationParameters.TYPE_STANDARD)) {
+                    filterQuery.append("_keyword");
+                }
             } else if (operator.endsWith("authority")) {
                 filterQuery.append("_authority");
             }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataFieldRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataFieldRestRepository.java
@@ -190,22 +190,22 @@ public class MetadataFieldRestRepository extends DSpaceRestRepository<MetadataFi
                                                    "forming schema.element.qualifier metadata field name");
             }
             filterQueries.add(searchService.toFilterQuery(context, MetadataFieldIndexFactoryImpl.FIELD_NAME_VARIATIONS,
-                OPERATOR_EQUALS, query).getFilterQuery() + "*");
+                OPERATOR_EQUALS, query, null).getFilterQuery() + "*");
         }
         if (StringUtils.isNotBlank(schemaName)) {
             filterQueries.add(
                 searchService.toFilterQuery(context, MetadataFieldIndexFactoryImpl.SCHEMA_FIELD_NAME, OPERATOR_EQUALS,
-                    schemaName).getFilterQuery());
+                    schemaName, null).getFilterQuery());
         }
         if (StringUtils.isNotBlank(elementName)) {
             filterQueries.add(
                 searchService.toFilterQuery(context, MetadataFieldIndexFactoryImpl.ELEMENT_FIELD_NAME, OPERATOR_EQUALS,
-                    elementName).getFilterQuery());
+                    elementName, null).getFilterQuery());
         }
         if (StringUtils.isNotBlank(qualifierName)) {
             filterQueries.add(searchService
                 .toFilterQuery(context, MetadataFieldIndexFactoryImpl.QUALIFIER_FIELD_NAME, OPERATOR_EQUALS,
-                    qualifierName).getFilterQuery());
+                    qualifierName, null).getFilterQuery());
         }
 
         DiscoverQuery discoverQuery = new DiscoverQuery();

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/DiscoverQueryBuilder.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/DiscoverQueryBuilder.java
@@ -393,7 +393,8 @@ public class DiscoverQueryBuilder implements InitializingBean {
                 DiscoverFilterQuery filterQuery = searchService.toFilterQuery(context,
                                                                               filter.getIndexFieldName(),
                                                                               searchFilter.getOperator(),
-                                                                              searchFilter.getValue());
+                                                                              searchFilter.getValue(),
+                                                                              discoveryConfiguration);
 
                 if (filterQuery != null) {
                     filterQueries.add(filterQuery.getFilterQuery());

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/utils/DiscoverQueryBuilderTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/utils/DiscoverQueryBuilderTest.java
@@ -113,7 +113,7 @@ public class DiscoverQueryBuilderTest {
                 any(), any(DiscoverQuery.class)))
             .then(invocation -> new FacetYearRange((DiscoverySearchFilterFacet) invocation.getArguments()[2]));
 
-        when(searchService.toFilterQuery(any(Context.class), any(String.class), any(String.class), any(String.class)))
+        when(searchService.toFilterQuery(any(Context.class), any(String.class), any(String.class), any(String.class), any(DiscoveryConfiguration.class)))
             .then(invocation -> new DiscoverFilterQuery((String) invocation.getArguments()[1],
                 invocation.getArguments()[1] + ":\"" + invocation.getArguments()[3] + "\"",
                 (String) invocation.getArguments()[3]));
@@ -291,7 +291,7 @@ public class DiscoverQueryBuilderTest {
 
     @Test(expected = DSpaceBadRequestException.class)
     public void testInvalidSearchFilter2() throws Exception {
-        when(searchService.toFilterQuery(any(Context.class), any(String.class), any(String.class), any(String.class)))
+        when(searchService.toFilterQuery(any(Context.class), any(String.class), any(String.class), any(String.class), any(DiscoveryConfiguration.class)))
             .thenThrow(SQLException.class);
 
         queryBuilder

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/utils/DiscoverQueryBuilderTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/utils/DiscoverQueryBuilderTest.java
@@ -113,7 +113,8 @@ public class DiscoverQueryBuilderTest {
                 any(), any(DiscoverQuery.class)))
             .then(invocation -> new FacetYearRange((DiscoverySearchFilterFacet) invocation.getArguments()[2]));
 
-        when(searchService.toFilterQuery(any(Context.class), any(String.class), any(String.class), any(String.class), any(DiscoveryConfiguration.class)))
+        when(searchService.toFilterQuery(any(Context.class), any(String.class), any(String.class), any(String.class),
+            any(DiscoveryConfiguration.class)))
             .then(invocation -> new DiscoverFilterQuery((String) invocation.getArguments()[1],
                 invocation.getArguments()[1] + ":\"" + invocation.getArguments()[3] + "\"",
                 (String) invocation.getArguments()[3]));
@@ -291,7 +292,8 @@ public class DiscoverQueryBuilderTest {
 
     @Test(expected = DSpaceBadRequestException.class)
     public void testInvalidSearchFilter2() throws Exception {
-        when(searchService.toFilterQuery(any(Context.class), any(String.class), any(String.class), any(String.class), any(DiscoveryConfiguration.class)))
+        when(searchService.toFilterQuery(any(Context.class), any(String.class), any(String.class), any(String.class),
+            any(DiscoveryConfiguration.class)))
             .thenThrow(SQLException.class);
 
         queryBuilder


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/dspace-angular/issues/1115

## Description
Solr fields that are configured as type 'standard' (ex. `withdrawn`, `private`, `discoverable`) when applied as filter in discovery, should not get a suffix when the equals operator is applied (ex. `{{url}}/api/discover/search/objects?configuration=administrativeView&f.withdrawn=true,equals`) since the solr field just gets saved as-is, without any suffixed alternatives.

## Instructions for Reviewers
- Endpoints for these fields, like `{{url}}/api/discover/search/objects?configuration=administrativeView&f.withdrawn=true,equals` should now return search objects which have the `withdrawn:true` solr fied
- In UI - Administrative Search => Private/Withdraws filter should now work
> {ui-url}/admin/search?&spc.page=1&f.withdrawn=true,equals 
> {ui-url}/admin/search?f.discoverable=false,equals&spc.page=1

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
