### PR TITLE
HAL Browser fix: Ensure we check for CSRF changes after login failure.

### DIFF
--- a/dspace-server-webapp/src/main/webapp/login.html
+++ b/dspace-server-webapp/src/main/webapp/login.html
@@ -216,7 +216,9 @@
                     }
                 },
                 success : successHandler,
-                error : function() {
+                error : function(xhr) {
+                    // Check for an update to the CSRF Token & save to a MyHalBrowserCsrfToken cookie (if found)
+                    checkForUpdatedCSRFTokenInResponse(xhr);
                     toastr.error('The credentials you entered are invalid. Please try again.', 'Login Failed');
                 }
             });


### PR DESCRIPTION
## Description
Fixes a tiny (but annoying) bug in the HAL Browser `login.html`, where it wasn't detecting CSRF token changes after a login failure.  This is essentially a one line fix to ensure we make that check.

## Instructions for Reviewers
This issue is easy to reproduce on api7.dspace.org:
1. Go to https://api7.dspace.org/server/login.html
2. Open Chrome DevTools for this site.  Go to the "Applications" tab, and look at the "Cookies".  You'll see two CSRF related cookes. These two cookies *MUST* have the same token for authentication to work:
    * `DSPACE-XSRF-COOKIE` : This is the cookie controlled by the server side...where the currently valid CSRF token is stored
    * `MyHalBrowserCsrfToken`: This is the client-side JS Cookie, whose value the HAL Browser will send to the server side on an auth request
3. Modify one of the cookies, so they no longer match.  This will simulate these cookies getting out of sync (which doesn't happen frequently, but it can happen when jumping from testing the UI to the HAL Browser, as both rely on the `DSPACE-XSRF-COOKIE`)
4. Now, attempt a login. It will fail with a 403 `Access is denied. Invalid CSRF token.`
5. If you look closely in your Chrome DevTools, the `DSPACE-XSRF-COOKIE` will now have a new value.  But, the HAL Browser didn't detect it, so `MyHalBrowserCsrfToken` will still have the old value.  In other words, these two cookies are permanently "out of sync".  Login won't work again until you clear your cookies.

Once you install this PR, the issue is **fixed**.  In Step 5, both Cookies will be updated.  So, even though you triggered a CSRF failure, the cookies "resync" and login will work on your next attempt.