### PR TITLE
Fix #3269 by logging detail when Service Manager can't find a bean

### DIFF
--- a/dspace-services/src/main/java/org/dspace/servicemanager/DSpaceServiceManager.java
+++ b/dspace-services/src/main/java/org/dspace/servicemanager/DSpaceServiceManager.java
@@ -428,8 +428,7 @@ public final class DSpaceServiceManager implements ServiceManagerSystem {
                     // no luck, try the fall back option
                     log.warn(
                         "Unable to locate bean by name or id={}."
-                                + " Will try to look up bean by type next."
-                                + " BeansException: {}", name, e);
+                                + " Will try to look up bean by type next.", name, e);
                     service = null;
                 }
             } else {
@@ -439,8 +438,7 @@ public final class DSpaceServiceManager implements ServiceManagerSystem {
                 } catch (BeansException e) {
                     // no luck, try the fall back option
                     log.warn("Unable to locate bean by name or id={}."
-                            + " Will try to look up bean by type next."
-                            + " BeansException: {}", type.getName(), e);
+                            + " Will try to look up bean by type next.", type.getName(), e);
                     service = null;
                 }
             }

--- a/dspace-services/src/main/java/org/dspace/servicemanager/DSpaceServiceManager.java
+++ b/dspace-services/src/main/java/org/dspace/servicemanager/DSpaceServiceManager.java
@@ -426,10 +426,10 @@ public final class DSpaceServiceManager implements ServiceManagerSystem {
                     service = (T) applicationContext.getBean(name, type);
                 } catch (BeansException e) {
                     // no luck, try the fall back option
-                    log.info(
+                    log.warn(
                         "Unable to locate bean by name or id={}."
                                 + " Will try to look up bean by type next."
-                                + " BeansException: {}", name, e.getMessage());
+                                + " BeansException: {}", name, e);
                     service = null;
                 }
             } else {
@@ -438,9 +438,9 @@ public final class DSpaceServiceManager implements ServiceManagerSystem {
                     service = (T) applicationContext.getBean(type.getName(), type);
                 } catch (BeansException e) {
                     // no luck, try the fall back option
-                    log.info("Unable to locate bean by name or id={}."
+                    log.warn("Unable to locate bean by name or id={}."
                             + " Will try to look up bean by type next."
-                            + " BeansException: {}", type.getName(), e.getMessage());
+                            + " BeansException: {}", type.getName(), e);
                     service = null;
                 }
             }

--- a/dspace/config/log4j2.xml
+++ b/dspace/config/log4j2.xml
@@ -82,7 +82,7 @@
         <Logger name='org.dspace.services'
                 level='ERROR'/>
         <Logger name='org.dspace.servicemanager'
-                level='ERROR'/>
+                level='WARN'/>
         <Logger name='org.dspace.providers'
                 level='ERROR'/>
         <Logger name='org.dspace.utils'


### PR DESCRIPTION
Fixes https://github.com/DSpace/DSpace/issues/3269 by raising the log level to `WARN`, including the `BeanException` as the cause, and raising the minimum log level for the `servicemanager` package to `WARN` rather than `ERROR`.