### PR TITLE
Add better support for http proxying to Spring Boot

### DIFF
--- a/dspace-server-webapp/src/main/resources/application.properties
+++ b/dspace-server-webapp/src/main/resources/application.properties
@@ -77,6 +77,18 @@ spring.http.encoding.force=true
 # However, you may wish to set this to "always" in your 'local.cfg' for development or debugging purposes.
 server.error.include-stacktrace = never
 
+# Spring Boot proxy configuration (can be overridden in local.cfg).
+# By default, Spring Boot does not automatically use X-Forwarded-* Headers when generating links (and similar) in the
+# DSpace REST API. Three options are currently supported by Spring Boot:
+#   * NATIVE = allows your web server to natively support standard Forwarded headers
+#   * FRAMEWORK = (DSpace default) enables Spring Framework's built in filter to manage these headers in Spring Boot.
+#                 This setting is used by default to support all X-Forwarded-* headers, as the DSpace backend is often
+#                 installed behind Apache HTTPD or Nginx proxy (both of which pass those headers to Tomcat).
+#   * NONE = (Spring default) Forwarded headers are ignored
+# For more information see
+# https://docs.spring.io/spring-boot/docs/current/reference/html/howto.html#howto-use-behind-a-proxy-server
+server.forward-headers-strategy=FRAMEWORK
+
 ######################
 # Spring Boot Autoconfigure
 #
@@ -107,6 +119,9 @@ spring.main.allow-bean-definition-overriding = true
 # Log4J configuration
 logging.config = ${dspace.dir}/config/log4j2.xml
 
+##################################
+# Spring MVC file upload settings
+#
 # Maximum size of a single uploaded file (default = 1MB)
 spring.servlet.multipart.max-file-size = 512MB
 

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -371,16 +371,6 @@ useProxies = true
 # (Requires reboot of servlet container, e.g. Tomcat, to reload)
 #proxies.trusted.include_ui_ip = true
 
-# Spring Boot proxy configuration (can be set in local.cfg or in application.properties).
-# By default, Spring Boot does not automatically use X-Forwarded-* Headers when generating links (and similar) in the
-# REST API. When using a proxy in front of the REST API, you may need to modify this setting:
-#   * NATIVE = allows your web server to natively support standard Forwarded headers
-#   * FRAMEWORK = enables Spring Framework's built in filter to manage these headers in Spring Boot
-#   * NONE = default value. Forwarded headers are ignored
-# For more information see
-# https://docs.spring.io/spring-boot/docs/current/reference/html/howto.html#howto-use-behind-a-proxy-server
-#server.forward-headers-strategy=FRAMEWORK
-
 #### Media Filter / Format Filter plugins (through PluginService) ####
 # Media/Format Filters help to full-text index content or
 # perform automated format conversions


### PR DESCRIPTION
This PR makes one small change to how Spring Boot is configured by default for our REST API:

* Sets `server.forward-headers-strategy=FRAMEWORK` by default, and moves it to Spring Boot's `application.properties` file alongside all our other Spring default settings.
    * I decided to move this setting to `application.properties` just to ensure it's sitting alongside all our other Spring Boot default settings. That said, it can still be overridden in `local.cfg`, just like other settings in `application.properties`.

The reason for this change is that Spring Boot defaults to `server.forward-headers-strategy=NONE`, which ignores ALL `X-Forwarded-*` headers, see https://docs.spring.io/spring-boot/docs/current/reference/html/howto.html#howto-use-behind-a-proxy-server

This default setting (`NONE`) works fine for the DSpace backend as long as you are running under HTTP only **or** only proxying via AJP (e.g. using Tomcat's AJP connector).  However, it does NOT work for any scenario where you are doing http proxying to the DSpace Backend (e.g. using Tomcat's mod_proxy_http or Nginx's proxy_pass settings, or any other http proxy).  The reason is that http proxy servers send `X-Forwarded-*` headers to provide information to DSpace, and DSpace uses that information to build its REST API "link" URLs (as we use Spring HATEOAS to build most links, and it depends on X-Forwarded-* headers when running behind an HTTP proxy).

Changing to `FRAMEWORK` ensures we support all `X-Forwarded` headers, which makes setting up the DSpace backend behind an HTTP proxy much easier.