### PR TITLE
fixes restlet's blocked repository - dspace 5.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1629,10 +1629,10 @@
             <url>https://oss.sonatype.org/content/repositories/releases/</url>
         </repository>
         <!--Nor sonatype nor maven central appear to still contain org.restlet.jee:org.restlet.ext.servlet:jar:2.1.1 any more. No problem if it is in your local repo. Build fail if it isn't-->
+        <!-- Add mirror for restlet - maven-default-http-blocker fix -->
         <repository>
-            <id>restlet</id>
-            <name>restlet</name>
-            <url>http://maven.restlet.org</url>
+            <id>restlet-mirror</id>
+            <url>https://maven.restlet.talend.com</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
## References
* Fixes #3247 for DSpace 5.x

## Description
This PR adds talend's restlet https repository (https://maven.restlet.talend.com) in order to skip the blocked http repository of restlet (http://maven.restlet.org)

List of changes in this PR:
* Adds a new maven repository - https://maven.restlet.talend.com

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
