### PR TITLE
fixes restlet's blocked repository - dspace 6.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1554,11 +1554,11 @@
         </repository>
     </distributionManagement>
 
-    <!-- Enable access to artifacts in Sonatype's snapshot repo for Snapshots ONLY -->
     <repositories>
+        <!-- Enable access to artifacts in Sonatype's snapshot repo for Snapshots ONLY -->
         <repository>
           <id>maven-snapshots</id>
-          <url>http://oss.sonatype.org/content/repositories/snapshots</url>
+          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
           <layout>default</layout>
             <releases>
               <enabled>false</enabled>
@@ -1566,6 +1566,11 @@
           <snapshots>
             <enabled>true</enabled>
           </snapshots>
+        </repository>
+        <!-- Add mirror for restlet - maven-default-http-blocker fix -->
+        <repository>
+            <id>restlet-mirror</id>
+            <url>https://maven.restlet.talend.com</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
## References
* Fixes #3247 for DSpace 6.x

## Description
This PR adds talend's restlet https repository (https://maven.restlet.talend.com) in order to skip the blocked http repository of restlet (http://maven.restlet.org) and changes sonatype's repositroy from http to https

List of changes in this PR:
* Adds a new maven repository - https://maven.restlet.talend.com
* Changes sonatype's repository protocol - from http to https

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
