### PR TITLE
Export metadata script (-i) param accepts UUID

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExport.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExport.java
@@ -8,9 +8,12 @@
 package org.dspace.app.bulkedit;
 
 import java.sql.SQLException;
+import java.util.UUID;
 
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.lang3.StringUtils;
+import org.dspace.app.util.factory.UtilServiceFactory;
+import org.dspace.app.util.service.DSpaceObjectUtils;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.MetadataDSpaceCsvExportService;
@@ -30,7 +33,7 @@ public class MetadataExport extends DSpaceRunnable<MetadataExportScriptConfigura
 
     private boolean help = false;
     private String filename = null;
-    private String handle = null;
+    private String identifier = null;
     private boolean exportAllMetadata = false;
     private boolean exportAllItems = false;
 
@@ -40,6 +43,8 @@ public class MetadataExport extends DSpaceRunnable<MetadataExportScriptConfigura
                 .getServicesByType(MetadataDSpaceCsvExportService.class).get(0);
 
     private EPersonService ePersonService = EPersonServiceFactory.getInstance().getEPersonService();
+
+    private DSpaceObjectUtils dSpaceObjectUtils = UtilServiceFactory.getInstance().getDSpaceObjectUtils();
 
     @Override
     public void internalRun() throws Exception {
@@ -57,7 +62,7 @@ public class MetadataExport extends DSpaceRunnable<MetadataExportScriptConfigura
             handler.handleException(e);
         }
         DSpaceCSV dSpaceCSV = metadataDSpaceCsvExportService
-            .handleExport(context, exportAllItems, exportAllMetadata, handle,
+            .handleExport(context, exportAllItems, exportAllMetadata, identifier,
                           handler);
         handler.writeFilestream(context, filename, dSpaceCSV.getInputStream(), EXPORT_CSV);
         context.restoreAuthSystemState();
@@ -66,7 +71,7 @@ public class MetadataExport extends DSpaceRunnable<MetadataExportScriptConfigura
 
     protected void logHelpInfo() {
         handler.logInfo("\nfull export: metadata-export");
-        handler.logInfo("partial export: metadata-export -i handle");
+        handler.logInfo("partial export: metadata-export -i handle/UUID");
     }
 
     @Override
@@ -86,7 +91,7 @@ public class MetadataExport extends DSpaceRunnable<MetadataExportScriptConfigura
         if (!commandLine.hasOption('i')) {
             exportAllItems = true;
         }
-        handle = commandLine.getOptionValue('i');
+        identifier = commandLine.getOptionValue('i');
         filename = getFileNameForExportFile();
 
         exportAllMetadata = commandLine.hasOption('a');
@@ -97,17 +102,20 @@ public class MetadataExport extends DSpaceRunnable<MetadataExportScriptConfigura
         Context context = new Context();
         try {
             DSpaceObject dso = null;
-            if (StringUtils.isNotBlank(handle)) {
-                dso = HandleServiceFactory.getInstance().getHandleService().resolveToObject(context, handle);
+            if (StringUtils.isNotBlank(identifier)) {
+                dso = HandleServiceFactory.getInstance().getHandleService().resolveToObject(context, identifier);
+                if (dso == null) {
+                    dso = dSpaceObjectUtils.findDSpaceObject(context, UUID.fromString(identifier));
+                }
             } else {
                 dso = ContentServiceFactory.getInstance().getSiteService().findSite(context);
             }
             if (dso == null) {
-                throw new ParseException("A handle got given that wasn't able to be parsed to a DSpaceObject");
+                throw new ParseException("An identifier was given that wasn't able to be parsed to a DSpaceObject");
             }
             return dso.getID().toString() + ".csv";
         } catch (SQLException e) {
-            handler.handleException("Something went wrong trying to retrieve DSO for handle: " + handle, e);
+            handler.handleException("Something went wrong trying to retrieve DSO for identifier: " + identifier, e);
         }
         return null;
     }

--- a/dspace-api/src/main/java/org/dspace/app/util/DSpaceObjectUtilsImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/DSpaceObjectUtilsImpl.java
@@ -1,0 +1,47 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.util;
+
+import java.sql.SQLException;
+import java.util.UUID;
+
+import org.dspace.app.util.service.DSpaceObjectUtils;
+import org.dspace.content.DSpaceObject;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.DSpaceObjectService;
+import org.dspace.core.Context;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class DSpaceObjectUtilsImpl implements DSpaceObjectUtils {
+
+    @Autowired
+    private ContentServiceFactory contentServiceFactory;
+
+    /**
+     * Retrieve a DSpaceObject from its uuid. As this method need to iterate over all the different services that
+     * support concrete class of DSpaceObject it has poor performance. Please consider the use of the direct service
+     * (ItemService, CommunityService, etc.) if you know in advance the type of DSpaceObject that you are looking for
+     *
+     * @param context
+     *            DSpace context
+     * @param uuid
+     *            the uuid to lookup
+     * @return the DSpaceObject if any with the supplied uuid
+     * @throws SQLException
+     */
+    public DSpaceObject findDSpaceObject(Context context, UUID uuid) throws SQLException {
+        for (DSpaceObjectService<? extends DSpaceObject> dSpaceObjectService :
+            contentServiceFactory.getDSpaceObjectServices()) {
+            DSpaceObject dso = dSpaceObjectService.find(context, uuid);
+            if (dso != null) {
+                return dso;
+            }
+        }
+        return null;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/app/util/factory/UtilServiceFactory.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/factory/UtilServiceFactory.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.app.util.factory;
 
+import org.dspace.app.util.service.DSpaceObjectUtils;
 import org.dspace.app.util.service.MetadataExposureService;
 import org.dspace.app.util.service.OpenSearchService;
 import org.dspace.app.util.service.WebAppService;
@@ -24,6 +25,8 @@ public abstract class UtilServiceFactory {
     public abstract OpenSearchService getOpenSearchService();
 
     public abstract MetadataExposureService getMetadataExposureService();
+
+    public abstract DSpaceObjectUtils getDSpaceObjectUtils();
 
     public static UtilServiceFactory getInstance() {
         return DSpaceServicesFactory.getInstance().getServiceManager()

--- a/dspace-api/src/main/java/org/dspace/app/util/factory/UtilServiceFactoryImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/factory/UtilServiceFactoryImpl.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.app.util.factory;
 
+import org.dspace.app.util.service.DSpaceObjectUtils;
 import org.dspace.app.util.service.MetadataExposureService;
 import org.dspace.app.util.service.OpenSearchService;
 import org.dspace.app.util.service.WebAppService;
@@ -26,6 +27,8 @@ public class UtilServiceFactoryImpl extends UtilServiceFactory {
     private OpenSearchService openSearchService;
     @Autowired(required = true)
     private WebAppService webAppService;
+    @Autowired(required = true)
+    private DSpaceObjectUtils dSpaceObjectUtils;
 
     @Override
     public WebAppService getWebAppService() {
@@ -40,5 +43,10 @@ public class UtilServiceFactoryImpl extends UtilServiceFactory {
     @Override
     public MetadataExposureService getMetadataExposureService() {
         return metadataExposureService;
+    }
+
+    @Override
+    public DSpaceObjectUtils getDSpaceObjectUtils() {
+        return dSpaceObjectUtils;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/app/util/service/DSpaceObjectUtils.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/service/DSpaceObjectUtils.java
@@ -1,0 +1,33 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.util.service;
+
+import java.sql.SQLException;
+import java.util.UUID;
+
+import org.dspace.content.DSpaceObject;
+import org.dspace.core.Context;
+
+/**
+ * Utility class providing methods to deal with generic DSpace Object of unknown type
+ */
+public interface DSpaceObjectUtils {
+    /**
+     * Retrieve a DSpaceObject from its uuid. As this method need to iterate over all the different services that
+     * support concrete class of DSpaceObject it has poor performance. Please consider the use of the direct service
+     * (ItemService, CommunityService, etc.) if you know in advance the type of DSpaceObject that you are looking for
+     *
+     * @param context
+     *            DSpace context
+     * @param uuid
+     *            the uuid to lookup
+     * @return the DSpaceObject if any with the supplied uuid
+     * @throws SQLException
+     */
+    public DSpaceObject findDSpaceObject(Context context, UUID uuid) throws SQLException;
+}

--- a/dspace-api/src/main/java/org/dspace/content/MetadataDSpaceCsvExportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/MetadataDSpaceCsvExportServiceImpl.java
@@ -12,9 +12,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.UUID;
 
 import com.google.common.collect.Iterators;
 import org.dspace.app.bulkedit.DSpaceCSV;
+import org.dspace.app.util.service.DSpaceObjectUtils;
 import org.dspace.content.service.ItemService;
 import org.dspace.content.service.MetadataDSpaceCsvExportService;
 import org.dspace.core.Constants;
@@ -31,8 +33,11 @@ public class MetadataDSpaceCsvExportServiceImpl implements MetadataDSpaceCsvExpo
     @Autowired
     private ItemService itemService;
 
+    @Autowired
+    private DSpaceObjectUtils dSpaceObjectUtils;
+
     @Override
-    public DSpaceCSV handleExport(Context context, boolean exportAllItems, boolean exportAllMetadata, String handle,
+    public DSpaceCSV handleExport(Context context, boolean exportAllItems, boolean exportAllMetadata, String identifier,
                                   DSpaceRunnableHandler handler) throws Exception {
         Iterator<Item> toExport = null;
 
@@ -40,26 +45,30 @@ public class MetadataDSpaceCsvExportServiceImpl implements MetadataDSpaceCsvExpo
             handler.logInfo("Exporting whole repository WARNING: May take some time!");
             toExport = itemService.findAll(context);
         } else {
-            DSpaceObject dso = HandleServiceFactory.getInstance().getHandleService().resolveToObject(context, handle);
+            DSpaceObject dso = HandleServiceFactory.getInstance().getHandleService()
+                .resolveToObject(context, identifier);
+            if (dso == null) {
+                dso = dSpaceObjectUtils.findDSpaceObject(context, UUID.fromString(identifier));
+            }
             if (dso == null) {
                 throw new IllegalArgumentException(
-                    "Item '" + handle + "' does not resolve to an item in your repository!");
+                    "Item '" + identifier + "' does not resolve to an item in your repository!");
             }
 
             if (dso.getType() == Constants.ITEM) {
-                handler.logInfo("Exporting item '" + dso.getName() + "' (" + handle + ")");
+                handler.logInfo("Exporting item '" + dso.getName() + "' (" + identifier + ")");
                 List<Item> item = new ArrayList<>();
                 item.add((Item) dso);
                 toExport = item.iterator();
             } else if (dso.getType() == Constants.COLLECTION) {
-                handler.logInfo("Exporting collection '" + dso.getName() + "' (" + handle + ")");
+                handler.logInfo("Exporting collection '" + dso.getName() + "' (" + identifier + ")");
                 Collection collection = (Collection) dso;
                 toExport = itemService.findByCollection(context, collection);
             } else if (dso.getType() == Constants.COMMUNITY) {
-                handler.logInfo("Exporting community '" + dso.getName() + "' (" + handle + ")");
+                handler.logInfo("Exporting community '" + dso.getName() + "' (" + identifier + ")");
                 toExport = buildFromCommunity(context, (Community) dso);
             } else {
-                throw new IllegalArgumentException("Error identifying '" + handle + "'");
+                throw new IllegalArgumentException("Error identifying '" + identifier + "'");
             }
         }
 

--- a/dspace-api/src/main/java/org/dspace/content/MetadataDSpaceCsvExportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/MetadataDSpaceCsvExportServiceImpl.java
@@ -52,7 +52,7 @@ public class MetadataDSpaceCsvExportServiceImpl implements MetadataDSpaceCsvExpo
             }
             if (dso == null) {
                 throw new IllegalArgumentException(
-                    "Item '" + identifier + "' does not resolve to an item in your repository!");
+                    "DSO '" + identifier + "' does not resolve to a DSpace Object in your repository!");
             }
 
             if (dso.getType() == Constants.ITEM) {
@@ -68,7 +68,9 @@ public class MetadataDSpaceCsvExportServiceImpl implements MetadataDSpaceCsvExpo
                 handler.logInfo("Exporting community '" + dso.getName() + "' (" + identifier + ")");
                 toExport = buildFromCommunity(context, (Community) dso);
             } else {
-                throw new IllegalArgumentException("Error identifying '" + identifier + "'");
+                throw new IllegalArgumentException(
+                    String.format("DSO with id '%s' (type: %s) can't be exported. Supported types: %s", identifier,
+                        Constants.typeText[dso.getType()], "Item | Collection | Community"));
             }
         }
 

--- a/dspace-api/src/main/java/org/dspace/content/service/MetadataDSpaceCsvExportService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/MetadataDSpaceCsvExportService.java
@@ -28,12 +28,13 @@ public interface MetadataDSpaceCsvExportService {
      * @param context           The relevant DSpace context
      * @param exportAllItems    A boolean indicating whether or not the entire repository should be exported
      * @param exportAllMetadata Defines if all metadata should be exported or only the allowed ones
-     * @param handle            The handle for the DSpaceObject to be exported, can be a Community, Collection or Item
+     * @param identifier        The handle or UUID for the DSpaceObject to be exported, can be a Community,
+     *                          Collection or Item
      * @return                  A DSpaceCSV object containing the exported information
      * @throws Exception        If something goes wrong
      */
     public DSpaceCSV handleExport(Context context, boolean exportAllItems, boolean exportAllMetadata,
-                                  String handle, DSpaceRunnableHandler dSpaceRunnableHandler) throws Exception;
+                                  String identifier, DSpaceRunnableHandler dSpaceRunnableHandler) throws Exception;
 
     /**
      * This method will export all the Items in the given toExport iterator to a DSpaceCSV

--- a/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataExportIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataExportIT.java
@@ -12,9 +12,11 @@ import static junit.framework.TestCase.assertTrue;
 import java.io.File;
 import java.io.FileInputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.UUID;
 
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.dspace.AbstractIntegrationTestWithDatabase;
 import org.dspace.app.launcher.ScriptLauncher;
 import org.dspace.app.scripts.handler.impl.TestDSpaceRunnableHandler;
@@ -24,6 +26,7 @@ import org.dspace.builder.ItemBuilder;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.Item;
+import org.dspace.core.Constants;
 import org.dspace.scripts.DSpaceRunnable;
 import org.dspace.scripts.configuration.ScriptConfiguration;
 import org.dspace.scripts.factory.ScriptServiceFactory;
@@ -183,5 +186,65 @@ public class MetadataExportIT
         String fileContent = IOUtils.toString(new FileInputStream(file), StandardCharsets.UTF_8);
         assertTrue(fileContent.contains("Donald, Smith"));
         assertTrue(fileContent.contains(String.valueOf(item.getID())));
+    }
+
+    @Test
+    public void metadataExportToCsvTest_NonValidIdentifier() throws Exception {
+        String fileLocation = configurationService.getProperty("dspace.dir")
+                              + testProps.get("test.exportcsv").toString();
+
+        String nonValidUUID = String.valueOf(UUID.randomUUID());
+        String[] args = new String[] {"metadata-export", "-i", nonValidUUID, "-f", fileLocation};
+        TestDSpaceRunnableHandler testDSpaceRunnableHandler
+            = new TestDSpaceRunnableHandler();
+
+        ScriptService scriptService = ScriptServiceFactory.getInstance().getScriptService();
+        ScriptConfiguration scriptConfiguration = scriptService.getScriptConfiguration(args[0]);
+
+        DSpaceRunnable script = null;
+        if (scriptConfiguration != null) {
+            script = scriptService.createDSpaceRunnableForScriptConfiguration(scriptConfiguration);
+        }
+        if (script != null) {
+            script.initialize(args, testDSpaceRunnableHandler, null);
+            script.run();
+        }
+
+        Exception exceptionDuringTestRun = testDSpaceRunnableHandler.getException();
+        assertTrue("Random UUID caused IllegalArgumentException",
+            exceptionDuringTestRun instanceof IllegalArgumentException);
+        assertTrue("IllegalArgumentException contains mention of the non-valid UUID",
+            StringUtils.contains(exceptionDuringTestRun.getMessage(), nonValidUUID));
+    }
+
+    @Test
+    public void metadataExportToCsvTest_NonValidDSOType() throws Exception {
+        String fileLocation = configurationService.getProperty("dspace.dir")
+                              + testProps.get("test.exportcsv").toString();
+
+        String uuidNonValidDSOType = String.valueOf(eperson.getID());
+        String[] args = new String[] {"metadata-export", "-i", uuidNonValidDSOType, "-f", fileLocation};
+        TestDSpaceRunnableHandler testDSpaceRunnableHandler
+            = new TestDSpaceRunnableHandler();
+
+        ScriptService scriptService = ScriptServiceFactory.getInstance().getScriptService();
+        ScriptConfiguration scriptConfiguration = scriptService.getScriptConfiguration(args[0]);
+
+        DSpaceRunnable script = null;
+        if (scriptConfiguration != null) {
+            script = scriptService.createDSpaceRunnableForScriptConfiguration(scriptConfiguration);
+        }
+        if (script != null) {
+            script.initialize(args, testDSpaceRunnableHandler, null);
+            script.run();
+        }
+
+        Exception exceptionDuringTestRun = testDSpaceRunnableHandler.getException();
+        assertTrue("UUID of non-supported dsoType IllegalArgumentException",
+            exceptionDuringTestRun instanceof IllegalArgumentException);
+        assertTrue("IllegalArgumentException contains mention of the UUID of non-supported dsoType",
+            StringUtils.contains(exceptionDuringTestRun.getMessage(), uuidNonValidDSOType));
+        assertTrue("IllegalArgumentException contains mention of the non-supported dsoType",
+            StringUtils.contains(exceptionDuringTestRun.getMessage(), Constants.typeText[eperson.getType()]));
     }
 }

--- a/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataExportIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataExportIT.java
@@ -100,4 +100,85 @@ public class MetadataExportIT
             script.run();
         }
     }
+
+    @Test(expected = ParseException.class)
+    public void metadataExportToCsvTestUUID() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Community community = CommunityBuilder.createCommunity(context)
+            .build();
+        Collection collection = CollectionBuilder.createCollection(context, community)
+            .build();
+        Item item = ItemBuilder.createItem(context, collection)
+            .withAuthor("Donald, Smith")
+            .build();
+        context.restoreAuthSystemState();
+        String fileLocation = configurationService.getProperty("dspace.dir")
+            + testProps.get("test.exportcsv").toString();
+
+        String[] args = new String[] {"metadata-export",
+            "-i", String.valueOf(item.getID())};
+        TestDSpaceRunnableHandler testDSpaceRunnableHandler
+            = new TestDSpaceRunnableHandler();
+
+        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl),
+            testDSpaceRunnableHandler, kernelImpl);
+        File file = new File(fileLocation);
+        String fileContent = IOUtils.toString(new FileInputStream(file), StandardCharsets.UTF_8);
+        assertTrue(fileContent.contains("Donald, Smith"));
+        assertTrue(fileContent.contains(String.valueOf(item.getID())));
+    }
+
+    @Test(expected = ParseException.class)
+    public void metadataExportToCsvTestUUIDParent() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Community community = CommunityBuilder.createCommunity(context)
+            .build();
+        Collection collection = CollectionBuilder.createCollection(context, community)
+            .build();
+        Item item = ItemBuilder.createItem(context, collection)
+            .withAuthor("Donald, Smith")
+            .build();
+        context.restoreAuthSystemState();
+        String fileLocation = configurationService.getProperty("dspace.dir")
+            + testProps.get("test.exportcsv").toString();
+
+        String[] args = new String[] {"metadata-export",
+            "-i", String.valueOf(collection.getID())};
+        TestDSpaceRunnableHandler testDSpaceRunnableHandler
+            = new TestDSpaceRunnableHandler();
+
+        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl),
+            testDSpaceRunnableHandler, kernelImpl);
+        File file = new File(fileLocation);
+        String fileContent = IOUtils.toString(new FileInputStream(file), StandardCharsets.UTF_8);
+        assertTrue(fileContent.contains("Donald, Smith"));
+        assertTrue(fileContent.contains(String.valueOf(item.getID())));
+    }
+
+    @Test(expected = ParseException.class)
+    public void metadataExportToCsvTestUUIDGrandParent() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Community community = CommunityBuilder.createCommunity(context)
+            .build();
+        Collection collection = CollectionBuilder.createCollection(context, community)
+            .build();
+        Item item = ItemBuilder.createItem(context, collection)
+            .withAuthor("Donald, Smith")
+            .build();
+        context.restoreAuthSystemState();
+        String fileLocation = configurationService.getProperty("dspace.dir")
+            + testProps.get("test.exportcsv").toString();
+
+        String[] args = new String[] {"metadata-export",
+            "-i", String.valueOf(community.getID())};
+        TestDSpaceRunnableHandler testDSpaceRunnableHandler
+            = new TestDSpaceRunnableHandler();
+
+        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl),
+            testDSpaceRunnableHandler, kernelImpl);
+        File file = new File(fileLocation);
+        String fileContent = IOUtils.toString(new FileInputStream(file), StandardCharsets.UTF_8);
+        assertTrue(fileContent.contains("Donald, Smith"));
+        assertTrue(fileContent.contains(String.valueOf(item.getID())));
+    }
 }

--- a/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataExportIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataExportIT.java
@@ -101,7 +101,7 @@ public class MetadataExportIT
         }
     }
 
-    @Test(expected = ParseException.class)
+    @Test
     public void metadataExportToCsvTestUUID() throws Exception {
         context.turnOffAuthorisationSystem();
         Community community = CommunityBuilder.createCommunity(context)
@@ -116,7 +116,8 @@ public class MetadataExportIT
             + testProps.get("test.exportcsv").toString();
 
         String[] args = new String[] {"metadata-export",
-            "-i", String.valueOf(item.getID())};
+            "-i", String.valueOf(item.getID()),
+            "-f", fileLocation};
         TestDSpaceRunnableHandler testDSpaceRunnableHandler
             = new TestDSpaceRunnableHandler();
 
@@ -128,7 +129,7 @@ public class MetadataExportIT
         assertTrue(fileContent.contains(String.valueOf(item.getID())));
     }
 
-    @Test(expected = ParseException.class)
+    @Test
     public void metadataExportToCsvTestUUIDParent() throws Exception {
         context.turnOffAuthorisationSystem();
         Community community = CommunityBuilder.createCommunity(context)
@@ -143,7 +144,8 @@ public class MetadataExportIT
             + testProps.get("test.exportcsv").toString();
 
         String[] args = new String[] {"metadata-export",
-            "-i", String.valueOf(collection.getID())};
+            "-i", String.valueOf(collection.getID()),
+            "-f", fileLocation};
         TestDSpaceRunnableHandler testDSpaceRunnableHandler
             = new TestDSpaceRunnableHandler();
 
@@ -155,7 +157,7 @@ public class MetadataExportIT
         assertTrue(fileContent.contains(String.valueOf(item.getID())));
     }
 
-    @Test(expected = ParseException.class)
+    @Test
     public void metadataExportToCsvTestUUIDGrandParent() throws Exception {
         context.turnOffAuthorisationSystem();
         Community community = CommunityBuilder.createCommunity(context)
@@ -170,7 +172,8 @@ public class MetadataExportIT
             + testProps.get("test.exportcsv").toString();
 
         String[] args = new String[] {"metadata-export",
-            "-i", String.valueOf(community.getID())};
+            "-i", String.valueOf(community.getID()),
+            "-f", fileLocation};
         TestDSpaceRunnableHandler testDSpaceRunnableHandler
             = new TestDSpaceRunnableHandler();
 

--- a/dspace/config/spring/api/core-services.xml
+++ b/dspace/config/spring/api/core-services.xml
@@ -22,6 +22,7 @@
     <bean class="org.dspace.app.util.MetadataExposureServiceImpl"/>
     <bean class="org.dspace.app.util.OpenSearchServiceImpl"/>
     <bean class="org.dspace.app.util.WebAppServiceImpl"/>
+    <bean class="org.dspace.app.util.DSpaceObjectUtilsImpl"/>
 
     <bean class="org.dspace.authenticate.AuthenticationServiceImpl"/>
 


### PR DESCRIPTION
## References
* Backend support for: https://github.com/DSpace/dspace-angular/issues/1132

## Description
The identifier parameter of the export-metadata script can also now accepts UUID's (in addition to handles). Additional ITs have been added to test this for item/collection/community UUID.

To fix the original issue, an additional frontend change is required, so that no `-f {fileName}` param is included in the script call.

## Instructions for Reviewers
You should be able to use a UUID of a DSO (Item, Collection or Community) for the -i param in the export-metadata script call:
`POST {{url}}/api/system/scripts/metadata-export/processes?` with body form-date properties => `[{\"name\": \"-i\", \"value\": \"UUID\"}]`

Starting the script directly via processes at `{ui-url}/processes/new?script=metadata-export` should also allow for a UUID in in the `-i {id}` parameter.

To test the original issue, an additional frontend change is required, so that no `-f {fileName}` param is included in the script call at Admin sidebar -> "Export" -> "Metadata"

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
