### PR TITLE
Delete item as collection admin & related issues

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/BundleServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BundleServiceImpl.java
@@ -501,10 +501,10 @@ public class BundleServiceImpl extends DSpaceObjectServiceImpl<Bundle> implement
 
         // Remove bitstreams
         List<Bitstream> bitstreams = bundle.getBitstreams();
-        bundle.clearBitstreams();
         for (Bitstream bitstream : bitstreams) {
             removeBitstream(context, bundle, bitstream);
         }
+        bundle.clearBitstreams();
 
         List<Item> items = new LinkedList<>(bundle.getItems());
         bundle.getItems().clear();

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ItemRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ItemRestRepository.java
@@ -147,7 +147,7 @@ public class ItemRestRepository extends DSpaceObjectRestRepository<Item, ItemRes
     }
 
     @Override
-    @PreAuthorize("hasAuthority('ADMIN')")
+    @PreAuthorize("hasPermission(#id, 'ITEM', 'DELETE')")
     protected void delete(Context context, UUID id) throws AuthorizeException {
         String[] copyVirtual =
             requestService.getCurrentRequest().getServletRequest()

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BundleRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BundleRestRepositoryIT.java
@@ -537,11 +537,7 @@ public class BundleRestRepositoryIT extends AbstractControllerIntegrationTest {
                     .build();
         }
 
-        bundle1 = BundleBuilder.createBundle(context, item)
-                .withName("testname")
-                .withBitstream(bitstream1)
-                .withBitstream(bitstream2)
-                .build();
+        bundle1 = item.getBundles("ORIGINAL").get(0);
 
         context.restoreAuthSystemState();
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
@@ -1313,8 +1313,10 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
                    .andExpect(status().is(404));
 
         //Trying to get deleted item bitstream should fail with 404
-        getClient().perform(get("/api/core/bitstreams/" + bitstream.getID()))
-                   .andExpect(status().is(401));
+        // NOTE: it currently does not work without an admin token
+        String adminToken = getAuthToken(admin.getEmail(), password);
+        getClient(adminToken).perform(get("/api/core/bitstreams/" + bitstream.getID()))
+                   .andExpect(status().is(404));
     }
 
     @Test
@@ -1382,8 +1384,10 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
             .andExpect(status().is(404));
 
         //Trying to get deleted item bitstream should fail with 404
-        getClient().perform(get("/api/core/bitstreams/" + bitstream.getID()))
-            .andExpect(status().is(401));
+        // NOTE: it currently does not work without an admin token
+        String adminToken = getAuthToken(admin.getEmail(), password);
+        getClient(adminToken).perform(get("/api/core/bitstreams/" + bitstream.getID()))
+            .andExpect(status().is(404));
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
@@ -1313,8 +1313,8 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
                    .andExpect(status().is(404));
 
         //Trying to get deleted item bitstream should fail with 404
-        getClient().perform(get("/api/core/biststreams/" + bitstream.getID()))
-                   .andExpect(status().is(404));
+        getClient().perform(get("/api/core/bitstreams/" + bitstream.getID()))
+                   .andExpect(status().is(401));
     }
 
     @Test
@@ -1382,8 +1382,91 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
             .andExpect(status().is(404));
 
         //Trying to get deleted item bitstream should fail with 404
-        getClient().perform(get("/api/core/biststreams/" + bitstream.getID()))
-            .andExpect(status().is(404));
+        getClient().perform(get("/api/core/bitstreams/" + bitstream.getID()))
+            .andExpect(status().is(401));
+    }
+
+    @Test
+    public void deleteOneArchivedTestAsOtherCollectionAdmin() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+        // two collection administrators
+        EPerson col1Admin = EPersonBuilder.createEPerson(context)
+            .withCanLogin(true)
+            .withEmail("col1admin@email.com")
+            .withPassword(password)
+            .withNameInMetadata("Col1", "Admin")
+            .build();
+
+        EPerson col2Admin = EPersonBuilder.createEPerson(context)
+            .withCanLogin(true)
+            .withEmail("col2admin@email.com")
+            .withPassword(password)
+            .withNameInMetadata("Col2", "Admin")
+            .build();
+
+        // A community with two collections.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .build();
+        Collection col1 = CollectionBuilder
+            .createCollection(context, parentCommunity)
+            .withName("Collection 1")
+            .withAdminGroup(col1Admin)
+            .build();
+        CollectionBuilder
+            .createCollection(context, parentCommunity)
+            .withName("Collection 2")
+            .withAdminGroup(col2Admin)
+            .build();
+
+        // One public item, one workspace item and one template item in the first collection.
+        Item publicItem = ItemBuilder.createItem(context, col1)
+            .withTitle("Public item 1")
+            .withIssueDate("2017-10-17")
+            .withAuthor("Smith, Donald").withAuthor("Doe, John")
+            .withSubject("ExtraEntry")
+            .build();
+
+        //Add a bitstream to an item in the first collection
+        String bitstreamContent = "ThisIsSomeDummyText";
+        Bitstream bitstream = null;
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
+            bitstream = BitstreamBuilder.
+                createBitstream(context, publicItem, is)
+                .withName("Bitstream1")
+                .withMimeType("text/plain")
+                .build();
+        }
+
+        context.restoreAuthSystemState();
+
+        // Check publicItem creation
+        getClient().perform(get("/api/core/items/" + publicItem.getID()))
+            .andExpect(status().isOk());
+
+        // Check publicItem bitstream creation (should be stored in bundle)
+        getClient().perform(get("/api/core/items/" + publicItem.getID() + "/bundles"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._links.self.href", Matchers
+                .containsString("/api/core/items/" + publicItem.getID() + "/bundles")));
+
+        // the admin of collection 2 will try to delete an item of collection 1
+        String token = getAuthToken(col2Admin.getEmail(), password);
+
+        // trying to delete the public item should fail
+        getClient(token).perform(delete("/api/core/items/" + publicItem.getID()))
+            .andExpect(status().isForbidden());
+
+        // the item should still exist
+        getClient().perform(get("/api/core/items/" + publicItem.getID()))
+            .andExpect(status().isOk());
+
+        // the bitstream should still exist
+        getClient().perform(get("/api/core/bitstreams/" + bitstream.getID()))
+            .andExpect(status().isOk());
     }
 
     @Test


### PR DESCRIPTION
## References
* Fixes #3262 

## Description
- Pre-authorize of `ItemRestRepository#delete` changed to actually check the user's permissions instead of restricting to admins
- IT's added to test functionality of collection admin being able to delete item of collection it is item to (& also items with bitstreams)

Some related issues that popped up:

### Issue - Collection admin can't delete item with bitstreams (resolved)
- Happens on `authorizeService.authorizeAction(context, bitstream, Constants.DELETE);` in `BitstreamServiceImpl#delete`
- => In `BitstreamServiceImpl#getParentObject` the bitstream doesn’t have any bundles anymore, since they’ve already been deleted => Can be fixed by moving `bundle.clearBitstreams()` to after bitstreams have been deleted in `BundleServiceImpl#delete`

### Issue - [BundleRestRepositoryIT#deleteBundle](https://github.com/DSpace/DSpace/blob/main/dspace-server-webapp/src/test/java/org/dspace/app/rest/BundleRestRepositoryIT.java) (resolved)

The above IT created an item with 2 bitstreams and then a separate bundle with those same 2 bitstreams in and then deletes the separate bundle, and assumes the two bitstreams will also be deleted. 
But this is not the case since the item's ORIGINAL bundle still contains the bitstreams, so they in itself should not be deleted, just removed from the separate bundle, see [here](https://github.com/atmire/DSpace/blob/w2p-79369_fix-error-when-permanently-deleting-item-as-collection-admin/dspace-api/src/main/java/org/dspace/content/BundleServiceImpl.java#L207). So the *assumption of this test* that the bitstreams in itself should also be removed, despite still being present in another bundle (ORIGINAL of item), *was false* and has been changed to just deleting the ORIGINAL bundle of the item.

Previously this worked because the `bundle.clearBitstreams()` in `bundleServiceImpl` was done *before* the bitstreams were deleted, so they then were already removed from the alternate bundle, and thus were only attached to 1 bundle (supposedly the one being removed, but in actuality it was ORIGINAL of item), so could be removed permanently.

### Issue - Deleted bitstream access with no auth token

We noticed there is a typo [here](https://github.com/DSpace/DSpace/blob/main/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java#L1316) (biststreams instead of bitstreams) which inaccurately confirmed that a deleted bitstream access with no auth token gives a 404, likely because of the `BitstreamRestRepository#findOne` pre-authorize: `hasPermission(#id, 'BITSTREAM', 'METADATA_READ')`. So previously it returned a 404 not because the bitstream doesn't exist, but because the endpoint doesn't exist.
If a non logged in user access to a deleted/non-existent bitstream should return 404 this can be handled separately to this PR. Currently just checked it returns a 404 with the adminToken, since we just want to verify the bitstream is gone, regardless of access issues.

## Instructions for Reviewers
Check if a collection admin can permanently delete an item:
Backend:
- Make a non-admin user the collection admin of a testing collection => Add an item to that collection => perform `DELETE {{url}}/server/api/core/items/{uuid} with the user/password` of that collection admin user => should succeed
- Try the same with a user that is not the collection admin => Forbidden

Frontend: see steps to reproduce in issue: https://github.com/DSpace/DSpace/issues/3262

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
