### PR TITLE
Values escaped in browse and discover links

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/link/BrowseEntryHalLinkFactory.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/link/BrowseEntryHalLinkFactory.java
@@ -42,7 +42,7 @@ public class BrowseEntryHalLinkFactory extends HalLinkFactory<BrowseEntryResourc
             addFilterParams(baseLink, data);
 
             list.add(buildLink(BrowseIndexRest.ITEMS,
-                               baseLink.build().toUriString()));
+                               baseLink.build().encode().toUriString()));
         }
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/link/search/SearchFacetValueHalLinkFactory.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/link/search/SearchFacetValueHalLinkFactory.java
@@ -36,7 +36,7 @@ public class SearchFacetValueHalLinkFactory extends DiscoveryRestHalLinkFactory<
 
             addFilterForFacetValue(builder, halResource.getFacetData(), halResource.getValueData());
 
-            list.add(buildLink("search", builder.build().toUriString()));
+            list.add(buildLink("search", builder.build().encode().toUriString()));
 
         }
     }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.app.rest;
 
+import static com.google.common.net.UrlEscapers.urlPathSegmentEscaper;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
@@ -5764,7 +5765,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                    .andExpect(jsonPath("$._embedded.values[0].label", is("Smith, Donald")))
                    .andExpect(jsonPath("$._embedded.values[0].count", is(1)))
                    .andExpect(jsonPath("$._embedded.values[0]._links.search.href",
-                        containsString("api/discover/search/objects?query=Donald&f.author=Smith, Donald,equals")))
+                        containsString("api/discover/search/objects?query=Donald&f.author=" +
+                                urlPathSegmentEscaper().escape("Smith, Donald,equals")
+                        )))
                    .andExpect(jsonPath("$._embedded.values").value(Matchers.hasSize(1)));
 
     }
@@ -5817,7 +5820,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                    .andExpect(jsonPath("$._embedded.values[0].label", is("2017 - 2020")))
                    .andExpect(jsonPath("$._embedded.values[0].count", is(3)))
                    .andExpect(jsonPath("$._embedded.values[0]._links.search.href",
-                        containsString("api/discover/search/objects?dsoType=Item&f.dateIssued=[2017 TO 2020],equals")))
+                        containsString("api/discover/search/objects?dsoType=Item&f.dateIssued=" +
+                                urlPathSegmentEscaper().escape("[2017 TO 2020],equals")
+                        )))
                    .andExpect(jsonPath("$._embedded.values").value(Matchers.hasSize(1)));
 
     }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -1150,7 +1150,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         parentCommunity = CommunityBuilder.createCommunity(context).build();
         Collection collection = CollectionBuilder.createCollection(context, parentCommunity).build();
         ItemBuilder.createItem(context, collection)
-                .withAuthor("Atmire & friends")
+                .withAuthor("DSpace & friends")
                 .build();
 
         context.restoreAuthSystemState();
@@ -1164,7 +1164,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                 .andExpect(jsonPath("$._embedded.facets", hasItem(allOf(
                         hasJsonPath("$.name", is("author")),
                         hasJsonPath("$._embedded.values", hasItem(
-                                hasJsonPath("$._links.search.href", containsString("Atmire%20%26%20friends"))
+                                hasJsonPath("$._links.search.href", containsString("DSpace%20%26%20friends"))
                         ))
                 ))));
     }
@@ -1177,7 +1177,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         parentCommunity = CommunityBuilder.createCommunity(context).build();
         Collection collection = CollectionBuilder.createCollection(context, parentCommunity).build();
         ItemBuilder.createItem(context, collection)
-                .withAuthor("Atmire & friends")
+                .withAuthor("DSpace & friends")
                 .build();
 
         context.restoreAuthSystemState();
@@ -1189,8 +1189,8 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         .param("size", "20"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$._embedded.entries", hasItem(allOf(
-                        hasJsonPath("$.value", is("Atmire & friends")),
-                        hasJsonPath("$._links.items.href", containsString("Atmire%20%26%20friends"))
+                        hasJsonPath("$.value", is("DSpace & friends")),
+                        hasJsonPath("$._links.items.href", containsString("DSpace%20%26%20friends"))
                 ))));
     }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/FacetValueMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/FacetValueMatcher.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.app.rest.matcher;
 
+import static com.google.common.net.UrlEscapers.urlPathSegmentEscaper;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
@@ -24,7 +25,9 @@ public class FacetValueMatcher {
             hasJsonPath("$.label", is(label)),
             hasJsonPath("$.type", is("discover")),
             hasJsonPath("$._links.search.href", containsString("api/discover/search/objects")),
-            hasJsonPath("$._links.search.href", containsString("f.author=" + label + ",equals"))
+            hasJsonPath("$._links.search.href", containsString(
+                    "f.author=" + urlPathSegmentEscaper().escape(label) + ",equals"
+            ))
         );
     }
 


### PR DESCRIPTION
## References
* Part of fix for https://github.com/DSpace/DSpace/issues/3230 ('Browse by author broken if author name has special character'), but will require an additional Angular fix
* Angular fix: https://github.com/DSpace/dspace-angular/pull/1216 ('Escape browse by author data requests')

## Description
Escapes the links in the browse entries items link and in the discovery search link so that spaces, ampersands, etc are escaped in these links so they correctly resolve with results:
* `{url}/api/discover/search/objects` => `_embedded.facets._embedded.values._links.search.href`
* `{url}/api/discover/browses/author/entries` => `_embedded.entries._links.items.href`

_Example:_ 
Before:
```
"items": {
  "href": "{{url}}/server/api/discover/browses/author/items?filterValue=Biomolecular & Analytical Mass Spectrometry (BAMS)"
```
After: 
```
"items": {
  "href": "{{url}}/server/api/discover/browses/author/items?filterValue=Biomolecular%20%26%20Analytical%20Mass%20Spectrometry%20(BAMS)"
```

## Instructions for Reviewers
- The browse entries request done in the frontend must result in entries with an items link which is escaped.
So for _example_ with https://demo7.dspace.org/browse/author?bbm.rpp=100&startsWith=Biomolecular%20%26
=> Does request https://api7.dspace.org/server/api/discover/browses/author/entries?sort=default,ASC&page=0&size=100&startsWith=Biomolecular%20%26 whose resulting `_embedded.entries._links.items.href` should be escaped like described above.
=> Verify this items link has [results](https://api7.dspace.org/server/api/discover/browses/author/items?filterValue=Biomolecular%20%26%20Analytical%20Mass%20Spectrometry%20(BAMS))

- However the actual author browse page https://demo7.dspace.org/browse/author?bbm.rpp=100&value=Biomolecular%20%26%20Analytical%20Mass%20Spectrometry%20(BAMS) still doesn't show the (4) expected items => Requests https://api7.dspace.org/server/api/discover/browses/author/items?sort=default,ASC&page=0&size=100&filterValue=Biomolecular%20&%20Analytical%20Mass%20Spectrometry%20(BAMS) => Ampersand not escaped
Cause: The frontend builds the link again in `BrowseEntrySearchOptions#getBrowseItemsFor(filterValue, BrowseEntrySearchOptions)` where the filterValue should also be escaped [here](https://github.com/DSpace/dspace-angular/blob/main/src/app/core/browse/browse.service.ts#L133) 
=> Requires additional minor Angular change to fix the original issue

- The discovery search request from the discovery page (ex  https://demo7.dspace.org/search?value=&spc.sf=score&spc.sd=DESC&spc.page=1&query=Test&scope= => https://api7.dspace.org/server/api/discover/search/objects?sort=score,DESC&page=0&size=10&query=Test) in its response in the `_embedded.facets._embedded.values._links.search.href` the values should be escaped
_Before_:
```
                "search": {
                  "href": "https://api7.dspace.org/server/api/discover/search/objects?query=Test&f.author=Simmons, Cameron,equals"
```
_After_:
```
                "search": {
                  "href": "https://api7.dspace.org/server/api/discover/search/objects?query=Test&f.author=Simmons,%20Cameron,equals"
```

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
