### PR TITLE
UI/REST linkage configuration is too sensitive to details that should be insignificant.  #3282

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -20,11 +20,15 @@
 dspace.dir = /dspace
 
 # URL of DSpace backend ('server' webapp). Include port number etc.
-# This is where REST API and all enabled server modules (OAI-PMH, SWORD, SWORDv2, RDF, etc) will respond
+# DO NOT end it with '/'.
+# This is where REST API and all enabled server modules (OAI-PMH, SWORD,
+# SWORDv2, RDF, etc) will respond.
 dspace.server.url = http://localhost:8080/server
 
-# URL of DSpace frontend (Angular UI). Include port number etc
-# This is used by the backend to provide links in emails, RSS feeds, Sitemaps, etc.
+# URL of DSpace frontend (Angular UI). Include port number etc.
+# DO NOT end it with '/'.
+# This is used by the backend to provide links in emails, RSS feeds, Sitemaps,
+# etc.
 dspace.ui.url = http://localhost:4000
 
 # Name of the site

--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -33,11 +33,15 @@
 dspace.dir=/dspace
 
 # URL of DSpace backend ('server' webapp). Include port number etc.
-# This is where REST API and all enabled server modules (OAI-PMH, SWORD, SWORDv2, RDF, etc) will respond
+# DO NOT end it with '/'.
+# This is where REST API and all enabled server modules (OAI-PMH, SWORD,
+# SWORDv2, RDF, etc) will respond.
 dspace.server.url = http://localhost:8080/server
 
-# URL of DSpace frontend (Angular UI). Include port number etc
-# This is used by the backend to provide links in emails, RSS feeds, Sitemaps, etc.
+# URL of DSpace frontend (Angular UI). Include port number etc.
+# DO NOT end it with '/'.
+# This is used by the backend to provide links in emails, RSS feeds, Sitemaps,
+# etc.
 dspace.ui.url = http://localhost:4000
 
 # Name of the site


### PR DESCRIPTION
## References
* Related to #3282

## Description
Document requirements for UI and REST URI configuration:  no trailing slashes.

## Instructions for Reviewers
List of changes in this PR:
* `local.cfg.EXAMPLE` updated to warn about slashes.
* `dspace.cfg` updated to warn about slashes.

Please do not close the issue.  This is a work-around.  The problem should be addressed by making the code more forgiving.

You should expect no change in behavior.  This is documentation only.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
