### PR TITLE
Update license Bitstream format description

### DIFF
--- a/dspace/config/registries/bitstream-formats.xml
+++ b/dspace/config/registries/bitstream-formats.xml
@@ -45,7 +45,7 @@
   <bitstream-type>
     <mimetype>text/plain; charset=utf-8</mimetype>
     <short_description>License</short_description>
-    <description>Item-specific license agreed upon to submission</description>
+    <description>Item-specific license agreed to upon submission</description>
     <support_level>1</support_level>
     <internal>true</internal>
   </bitstream-type>
@@ -54,7 +54,7 @@
   <bitstream-type>
     <mimetype>text/html; charset=utf-8</mimetype>
     <short_description>CC License</short_description>
-    <description>Item-specific Creative Commons license agreed upon to submission</description>
+    <description>Item-specific Creative Commons license agreed to upon submission</description>
     <support_level>1</support_level>
     <internal>true</internal>
   </bitstream-type>


### PR DESCRIPTION
## Description
Descriptions of license Bitstream formats read "license agreed upon to submission".
This looks like a typo to me, "license agreed to upon submission" makes more sense. Or "agreed upon _during_ submission".



List of changes in this PR:
* Change description of Bitstream formats `License` and `CC_License`

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
