### PR TITLE
New authorization feature - canManageGroup

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/ManageGroupFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/ManageGroupFeature.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package org.dspace.app.rest.authorization.impl;
 
 import java.sql.SQLException;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/ManageGroupFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/ManageGroupFeature.java
@@ -9,6 +9,7 @@ package org.dspace.app.rest.authorization.impl;
 
 import java.sql.SQLException;
 
+import org.apache.commons.lang3.StringUtils;
 import org.dspace.app.rest.authorization.AuthorizationFeature;
 import org.dspace.app.rest.authorization.AuthorizationFeatureDocumentation;
 import org.dspace.app.rest.model.BaseObjectRest;
@@ -58,11 +59,9 @@ public class ManageGroupFeature implements AuthorizationFeature {
             return true;
         }
 
-        // community/collection admins cannot manage special groups
-        if (
-            group.equals(groupService.findByName(context, Group.ANONYMOUS)) ||
-            group.equals(groupService.findByName(context, Group.ADMIN))
-        ) {
+        // Community/Collection admins cannot manage special groups (Anonymous or Admin)
+        // This check is required until https://github.com/DSpace/DSpace/issues/3323 is fixed.
+        if (StringUtils.equals(group.getName(), Group.ANONYMOUS) || StringUtils.equals(group.getName(), Group.ADMIN)) {
             return false;
         }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/ManageGroupFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/ManageGroupFeature.java
@@ -59,9 +59,10 @@ public class ManageGroupFeature implements AuthorizationFeature {
             return true;
         }
 
-        // Community/Collection admins cannot manage special groups (Anonymous or Admin)
+        // Community/Collection admins cannot manage groups that are not COMMUNITY/COLLECTION bound
         // This check is required until https://github.com/DSpace/DSpace/issues/3323 is fixed.
-        if (StringUtils.equals(group.getName(), Group.ANONYMOUS) || StringUtils.equals(group.getName(), Group.ADMIN)) {
+        if (!(StringUtils.startsWith(group.getName(), "COLLECTION_")
+              || StringUtils.startsWith(group.getName(), "COMMUNITY_"))) {
             return false;
         }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/ManageGroupFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/ManageGroupFeature.java
@@ -1,0 +1,72 @@
+package org.dspace.app.rest.authorization.impl;
+
+import java.sql.SQLException;
+
+import org.dspace.app.rest.authorization.AuthorizationFeature;
+import org.dspace.app.rest.authorization.AuthorizationFeatureDocumentation;
+import org.dspace.app.rest.model.BaseObjectRest;
+import org.dspace.app.rest.model.GroupRest;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.core.Context;
+import org.dspace.eperson.Group;
+import org.dspace.eperson.service.GroupService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * The Manage Group Feature. It can be used to verify if the current user can manage a specific group.
+ *
+ * Authorization is granted if the current user has site-wide ADMIN permissions or if the current user
+ * is a member of this group in case the group is linked to a community or collection.
+ */
+@Component
+@AuthorizationFeatureDocumentation(name = ManageGroupFeature.NAME, description =
+    "It can be used to verify if the current user can manage a specific group")
+public class ManageGroupFeature implements AuthorizationFeature {
+
+    public final static String NAME = "canManageGroup";
+
+    @Autowired
+    GroupService groupService;
+
+    @Autowired
+    AuthorizeService authorizeService;
+
+    @Override
+    public boolean isAuthorized(Context context, BaseObjectRest object) throws SQLException {
+        // this authorization only applies to GroupRest
+        if (!(object instanceof GroupRest)) {
+            return false;
+        }
+        GroupRest groupRest = (GroupRest) object;
+
+        // get the group
+        Group group = groupService.findByName(context, groupRest.getName());
+        if (group == null) {
+            return false;
+        }
+
+        // admins can manage any group
+        if (authorizeService.isAdmin(context)) {
+            return true;
+        }
+
+        // community/collection admins cannot manage special groups
+        if (
+            group.equals(groupService.findByName(context, Group.ANONYMOUS)) ||
+            group.equals(groupService.findByName(context, Group.ADMIN))
+        ) {
+            return false;
+        }
+
+        return authorizeService.isAdmin(context, group);
+    }
+
+    @Override
+    public String[] getSupportedTypes() {
+        return new String[]{
+            GroupRest.CATEGORY + "." + GroupRest.NAME
+        };
+    }
+
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/ManageGroupFeatureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/ManageGroupFeatureIT.java
@@ -1,0 +1,428 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.authorization;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.dspace.app.rest.authorization.impl.ManageGroupFeature;
+import org.dspace.app.rest.converter.GroupConverter;
+import org.dspace.app.rest.matcher.AuthorizationMatcher;
+import org.dspace.app.rest.model.GroupRest;
+import org.dspace.app.rest.projection.Projection;
+import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.app.rest.utils.Utils;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.EPersonBuilder;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.eperson.EPerson;
+import org.dspace.eperson.Group;
+import org.dspace.eperson.service.GroupService;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class ManageGroupFeatureIT extends AbstractControllerIntegrationTest {
+
+    @Autowired
+    private Utils utils;
+
+    @Autowired
+    private GroupConverter groupConverter;
+
+    @Autowired
+    private GroupService groupService;
+
+    @Autowired
+    private AuthorizationFeatureService authorizationFeatureService;
+
+    /**
+     * Structure:
+     * |_ community 1
+     *    |_ (g) community1AdminGroup
+     *       |_ (e) community1Admin
+     *    |_ collection1
+     *       |_ (g) collection1AdminGroup
+     *          |_ (e) collection1Admin
+     *       |_ (g) collection1SubmitterGroup
+     *          |_ (e) collection1Submitter
+     * |_ community2
+     *    |_ (g) community2AdminGroup
+     *       |_ (no people)
+     *    |_ collection2
+     *       |_ (g) collection2AdminGroup
+     *          |_ (no people)
+     *       |_ (g) collection2SubmitterGroup
+     *          |_ (no people)
+     * |_ community3
+     *    |_ (no groups)
+     *    |_ collection3
+     *       |_ (no groups)
+     */
+
+    protected Community community1;
+    protected Group community1AdminGroup;
+    protected EPerson community1Admin;
+    protected Collection collection1;
+    protected Group collection1AdminGroup;
+    protected EPerson collection1Admin;
+    protected Group collection1SubmitterGroup;
+    protected EPerson collection1Submitter;
+
+    protected Community community2;
+    protected Group community2AdminGroup;
+    protected Collection collection2;
+    protected Group collection2AdminGroup;
+    protected Group collection2SubmitterGroup;
+
+    protected Community community3;
+    protected Collection collection3;
+
+    protected Group anonymousGroup;
+    protected Group administratorGroup;
+
+    private AuthorizationFeature canManageGroupFeature;
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+
+        canManageGroupFeature = authorizationFeatureService.find(ManageGroupFeature.NAME);
+
+        context.turnOffAuthorisationSystem();
+
+
+        community1Admin = EPersonBuilder.createEPerson(context)
+            .withCanLogin(true)
+            .withEmail("community1admin@email.com")
+            .withPassword(password)
+            .withNameInMetadata("Admin", "Community 1")
+            .build();
+
+        community1 = CommunityBuilder.createCommunity(context)
+            .withName("Community 1")
+            .withAdminGroup(community1Admin)
+            .build();
+
+        community1AdminGroup = community1.getAdministrators();
+
+
+        collection1Admin = EPersonBuilder.createEPerson(context)
+            .withCanLogin(true)
+            .withEmail("collection1admin@email.com")
+            .withPassword(password)
+            .withNameInMetadata("Admin", "Collection 1")
+            .build();
+
+        collection1Submitter = EPersonBuilder.createEPerson(context)
+            .withCanLogin(true)
+            .withEmail("collection1submitter@email.com")
+            .withPassword(password)
+            .withNameInMetadata("Submitter", "Collection 1")
+            .build();
+
+        collection1 = CollectionBuilder.createCollection(context, community1)
+            .withName("Collection 1")
+            .withAdminGroup(collection1Admin)
+            .withSubmitterGroup(collection1Submitter)
+            .build();
+
+        collection1AdminGroup = collection1.getAdministrators();
+        collection1SubmitterGroup = collection1.getSubmitters();
+
+
+        community2 = CommunityBuilder.createCommunity(context)
+            .withName("Community 2")
+            .withAdminGroup(eperson)
+            .build();
+
+        community2AdminGroup = community2.getAdministrators();
+
+        collection2 = CollectionBuilder.createCollection(context, community2)
+            .withName("Collection 2")
+            .withAdminGroup(eperson)
+            .withSubmitterGroup(eperson)
+            .build();
+
+        collection2AdminGroup = collection2.getAdministrators();
+        collection2SubmitterGroup = collection2.getSubmitters();
+
+
+        community3 = CommunityBuilder.createCommunity(context)
+            .withName("Community 3")
+            .build();
+
+        collection3 = CollectionBuilder.createCollection(context, community3)
+            .withName("Collection 3")
+            .build();
+
+
+        anonymousGroup = groupService.findByName(context, Group.ANONYMOUS);
+        administratorGroup = groupService.findByName(context, Group.ADMIN);
+
+
+        context.restoreAuthSystemState();
+    }
+
+    /**
+     * Get the REST representation of the given group.
+     * @param group the group.
+     * @return the REST representation of the group.
+     */
+    protected GroupRest getGroupRest(Group group) throws Exception {
+        return groupConverter.convert(context.reloadEntity(group), Projection.DEFAULT);
+    }
+
+    /**
+     * Create an authorization instance for feature canManageGroup.
+     * @param user the user to which the authorization applies.
+     * @param groupRest the resource to which the authorization applies.
+     * @return the authorization.
+     */
+    protected Authorization getCanManageGroupAuthorization(EPerson user, GroupRest groupRest) {
+        return new Authorization(user, canManageGroupFeature, groupRest);
+    }
+
+    /**
+     * Get the uri that points to the provided group.
+     * @param groupRest the REST representation of the group.
+     * @return the uri that points to the group.
+     */
+    protected String getGroupLink(GroupRest groupRest) {
+        return utils.linkToSingleResource(groupRest, "self").getHref();
+    }
+
+    /**
+     * Assert that the provided user has permission to manage the provided group.
+     * @param user the user.
+     * @param group the group.
+     */
+    protected void canManageGroup(EPerson user, Group group) throws Exception {
+        String token = getAuthToken(user.getEmail(), password);
+
+        GroupRest groupRest = getGroupRest(group);
+        Authorization authorization = getCanManageGroupAuthorization(user, groupRest);
+
+        getClient(token).perform(
+            get("/api/authz/authorizations/search/object")
+                .param("uri", getGroupLink(groupRest))
+                .param("feature", "canManageGroup")
+        )
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations", Matchers.containsInAnyOrder(
+                AuthorizationMatcher.matchAuthorization(authorization)
+            )));
+
+        getClient(token).perform(
+            get(
+                "/api/authz/authorizations/{epersonUuid}_canManageGroup_eperson.group_{groupUuid}",
+                user.getID(), group.getID()
+            )
+        )
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", AuthorizationMatcher.matchAuthorization(authorization)));
+    }
+
+    /**
+     * Assert that the provided user does not have permission to manage the provided group.
+     * @param user the user.
+     * @param group the group.
+     */
+    protected void canNotManageGroup(EPerson user, Group group) throws Exception {
+        String token = getAuthToken(user.getEmail(), password);
+
+        GroupRest groupRest = getGroupRest(group);
+        Authorization authorization = getCanManageGroupAuthorization(user, groupRest);
+
+        getClient(token).perform(
+            get("/api/authz/authorizations/search/object")
+                .param("uri", getGroupLink(groupRest))
+                .param("feature", "canManageGroup")
+        )
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.authorizations").doesNotExist());
+
+        getClient(token).perform(
+            get(
+                "/api/authz/authorizations/{epersonUuid}_canManageGroup_eperson.group_{groupUuid}",
+                user.getID(), group.getID()
+            )
+        )
+            .andExpect(status().isNotFound());
+    }
+
+
+
+    ////////////////
+    // site admin //
+    ////////////////
+
+    @Test
+    public void siteAdminCanManageCommunity1AdminGroup() throws Exception {
+        canManageGroup(admin, community1AdminGroup);
+    }
+
+    @Test
+    public void siteAdminCanManageCollection1AdminGroup() throws Exception {
+        canManageGroup(admin, collection1AdminGroup);
+    }
+
+    @Test
+    public void siteAdminCanManageCollection1SubmitterGroup() throws Exception {
+        canManageGroup(admin, collection1SubmitterGroup);
+    }
+
+    @Test
+    public void siteAdminCanManageCollection2AdminGroup() throws Exception {
+        canManageGroup(admin, collection2AdminGroup);
+    }
+
+    @Test
+    public void siteAdminCanManageCollection2SubmitterGroup() throws Exception {
+        canManageGroup(admin, collection2SubmitterGroup);
+    }
+
+    @Test
+    public void siteAdminCanManageAnonymousGroup() throws Exception {
+        canManageGroup(admin, anonymousGroup);
+    }
+
+    @Test
+    public void siteAdminCanManageAdministratorGroup() throws Exception {
+        canManageGroup(admin, administratorGroup);
+    }
+
+
+
+    //////////////////////
+    // community  admin //
+    //////////////////////
+
+    @Test
+    public void community1AdminCanManageCommunity1AdminGroup() throws Exception {
+        canManageGroup(community1Admin, community1AdminGroup);
+    }
+
+    @Test
+    public void community1AdminCanManageCollection1AdminGroup() throws Exception {
+        canManageGroup(community1Admin, collection1AdminGroup);
+    }
+
+    @Test
+    public void community1AdminCanManageCollection1SubmitterGroup() throws Exception {
+        canManageGroup(community1Admin, collection1SubmitterGroup);
+    }
+
+    @Test
+    public void community1AdminCanNotManageCollection2AdminGroup() throws Exception {
+        canNotManageGroup(community1Admin, collection2AdminGroup);
+    }
+
+    @Test
+    public void community1AdminCanNotManageCollection2SubmitterGroup() throws Exception {
+        canNotManageGroup(community1Admin, collection2SubmitterGroup);
+    }
+
+    @Test
+    public void community1AdminCanNotManageAnonymousGroup() throws Exception {
+        canNotManageGroup(community1Admin, anonymousGroup);
+    }
+
+    @Test
+    public void community1AdminCanNotManageAdministratorGroup() throws Exception {
+        canNotManageGroup(community1Admin, administratorGroup);
+    }
+
+
+
+    ////////////////////////
+    // collection 1 admin //
+    ////////////////////////
+
+    @Test
+    public void collection1AdminCanNotManageCommunity1AdminGroup() throws Exception {
+        canNotManageGroup(collection1Admin, community1AdminGroup);
+    }
+
+    @Test
+    public void collection1AdminCanManageCollection1AdminGroup() throws Exception {
+        canManageGroup(collection1Admin, collection1AdminGroup);
+    }
+
+    @Test
+    public void collection1AdminCanManageCollection1SubmitterGroup() throws Exception {
+        canManageGroup(collection1Admin, collection1SubmitterGroup);
+    }
+
+    @Test
+    public void collection1AdminCanNotManageCollection2AdminGroup() throws Exception {
+        canNotManageGroup(collection1Admin, collection2AdminGroup);
+    }
+
+    @Test
+    public void collection1AdminCanNotManageCollection2SubmitterGroup() throws Exception {
+        canNotManageGroup(collection1Admin, collection2SubmitterGroup);
+    }
+
+    @Test
+    public void collection1AdminCanNotManageAnonymousGroup() throws Exception {
+        canNotManageGroup(collection1Admin, anonymousGroup);
+    }
+
+    @Test
+    public void collection1AdminCanNotManageAdministratorGroup() throws Exception {
+        canNotManageGroup(collection1Admin, administratorGroup);
+    }
+
+
+
+    ////////////////////////////
+    // collection 1 submitter //
+    ////////////////////////////
+
+    @Test
+    public void collection1SubmitterCanNotManageCommunity1AdminGroup() throws Exception {
+        canNotManageGroup(collection1Submitter, community1AdminGroup);
+    }
+
+    @Test
+    public void collection1SubmitterCanNotManageCollection1AdminGroup() throws Exception {
+        canNotManageGroup(collection1Submitter, collection1AdminGroup);
+    }
+
+    @Test
+    public void collection1SubmitterCanNotManageCollection1SubmitterGroup() throws Exception {
+        canNotManageGroup(collection1Submitter, collection1SubmitterGroup);
+    }
+
+    @Test
+    public void collection1SubmitterCanNotManageCollection2AdminGroup() throws Exception {
+        canNotManageGroup(collection1Submitter, collection2AdminGroup);
+    }
+
+    @Test
+    public void collection1SubmitterCanNotManageCollection2SubmitterGroup() throws Exception {
+        canNotManageGroup(collection1Submitter, collection2SubmitterGroup);
+    }
+
+    @Test
+    public void collection1SubmitterCanNotManageAnonymousGroup() throws Exception {
+        canNotManageGroup(collection1Submitter, anonymousGroup);
+    }
+
+    @Test
+    public void collection1SubmitterCanNotManageAdministratorGroup() throws Exception {
+        canNotManageGroup(collection1Submitter, administratorGroup);
+    }
+
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/AuthorizationMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/AuthorizationMatcher.java
@@ -32,7 +32,7 @@ public class AuthorizationMatcher {
      *            the authorization, if null only the presence of the generic properties will be verified
      * @return
      */
-    public static Matcher matchAuthorization(Authorization authz) {
+    public static Matcher<? super Object> matchAuthorization(Authorization authz) {
         return allOf(
                 // Check authorization properties
                 matchProperties(authz),


### PR DESCRIPTION
## References
* Backend work for https://github.com/DSpace/dspace-angular/issues/1124 ('Access control section is visible to non admin users')
* Fixes https://github.com/DSpace/dspace-angular/issues/1257
* Fixes https://github.com/DSpace/dspace-angular/issues/1258

## Description
The collection admin is able to see the complete Access Control section (where groups/eperson details can be viewed), even though it can’t edit most groups or epeople. Collection admins must be able to edit groups that are linked to the collection it is the admin of (see https://github.com/DSpace/dspace-angular/issues/927), but currently they can also see all other groups' details, as well as epersons'. To differentiate between groups the user can edit and those it can’t, we’ve implemented a new `/api/authz/authorizations` for Group.

There is already a canManageGroups feature, to check whether or not a user can access groups’ info in general (true for admins and com/col admins), but not yet a feature to check if a user can access/manage a singular given group, which is needed to determine whether or not the edit button in the frontend should be shown for any given group page.

## Instructions for Reviewers

You can test this new feature endpoint with:
* `{{url}}/api/authz/authorizations/search/object?uri={group-link}&feature=canManageGroup`
* `{{url}}/api/authz/authorizations/{eperson-uuid}_canManageGroup_eperson.group_{group-uuid}`

Examples: 
* `{{url}}/api/authz/authorizations/a2b0d77d-7b3c-404f-b77c-426e68a9be8f_canManageGroup_eperson.group740a5be7-1e3a-47d5-a0b0-1e68bd205dca_canManageGroup_eperson.group_90320651-0797-4bfb-9c1e-613d100ba77a`
* `{{url}}/api/authz/authorizations/search/object?feature=canManageGroup&uri={{url}}/api/eperson/groups/44d830f2-9acf-4547-bdb2-643b081dd79f`

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
