### PR TITLE
Increase default thumbnail size to match with UI display settings

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -901,9 +901,11 @@ cc.license.locale = en
 
 ##### Settings for Thumbnail creation #####
 
-# maximum width and height of generated thumbnails
-thumbnail.maxwidth  = 80
-thumbnail.maxheight = 80
+# Maximum width and height (in pixels) of generated thumbnails
+# NOTE: In the UI's base theme, `--ds-thumbnail-max-width` defaults to 175px.
+# So, if you set 'thumbnail.maxwidth' >175, you may wish to modify that UI style variable as well.
+thumbnail.maxwidth  = 175
+thumbnail.maxheight = 175
 
 # Blur before scaling.  A little blur before scaling does wonders for keeping
 # more in check. (Only used by JPEGFilter)


### PR DESCRIPTION
This tiny PR changes our Thumbnail configuration default settings to allow for a maximum of 175px x 175px thumbnails, which matches the default display settings in the Angular UI: https://github.com/DSpace/dspace-angular/blob/main/src/styles/_custom_variables.scss#L48