### PR TITLE
Update our GitHub CI settings to upload all test output to a downloadable artifact whenever a test failure occurs.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,8 +62,10 @@ jobs:
           TEST_FLAGS: ${{ matrix.mvnflags }}
         run: mvn install -B -V -P-assembly -Pcoverage-report $TEST_FLAGS
 
-      # Save results of tests to downloadable artifact for this job
-      - name: Archive Results of ${{ matrix.type }}
+      # If previous step failed, save results of tests to downloadable artifact for this job
+      # (This artifact is downloadable at the bottom of any job's summary page)
+      - name: Upload Results of ${{ matrix.type }} to Artifact
+        if: ${{ failure() }}
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.type }} results

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
           # NOTE: Unit Tests include deprecated REST API v6 (as it has unit tests)
           - type: "Unit Tests"
             mvnflags: "-DskipUnitTests=false -Pdspace-rest"
+            resultsdir: "**/target/surefire-reports/**"
           # NOTE: ITs skip all code validation checks, as they are already done by Unit Test job.
           #  - enforcer.skip     => Skip maven-enforcer-plugin rules
           #  - checkstyle.skip   => Skip all checkstyle checks by maven-checkstyle-plugin
@@ -29,6 +30,7 @@ jobs:
           #  - xml.skip          => Skip all XML/XSLT validation by xml-maven-plugin
           - type: "Integration Tests"
             mvnflags: "-DskipIntegrationTests=false -Denforcer.skip=true -Dcheckstyle.skip=true -Dlicense.skip=true -Dxml.skip=true"
+            resultsdir: "**/target/failsafe-reports/**"
       # Do NOT exit immediately if one matrix job fails
       # This ensures ITs continue running even if Unit Tests fail, or visa versa
       fail-fast: false
@@ -59,6 +61,14 @@ jobs:
         env:
           TEST_FLAGS: ${{ matrix.mvnflags }}
         run: mvn install -B -V -P-assembly -Pcoverage-report $TEST_FLAGS
+
+      # Save results of tests to downloadable artifact for this job
+      - name: Archive Results of ${{ matrix.type }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.type }} results
+          path: ${{ matrix.resultsdir }}
+          retention-days: 7
 
       # https://github.com/codecov/codecov-action
       - name: Upload coverage to Codecov.io


### PR DESCRIPTION
## Description
Updates our GitHub CI to upload all test output to a downloadable artifact whenever a test failure occurs.

In other words, if ITs fail, all the `failsafe-reports` are made available for download (as an "artifact") from the GitHub Job summary page.  Similarly, if Unit Tests fail, all the `surefire-reports` are similarly made available.  For now, I've configured these logs to expire after one week...but, that setting can be increased (it defaults to 90 days).

Here's an example of what this looks like in a build: https://github.com/tdonohue/DSpace/actions/runs/947176257 -- see the new "Artifacts" at the bottom.  (This was an earlier test build where I created the artifacts even though tests succeeded....I've since updated the setting to only create these artifacts if tests *fail*)

This will allow us to more easily debug any random/intermittent test failures that may occur, as we'll have more detailed logs from the CI environment.