### PR TITLE
Searches without a scope can trigger "Invalid UUID" error from ScopeResolver

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SearchEventConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SearchEventConverter.java
@@ -34,9 +34,12 @@ public class SearchEventConverter {
                                                                              null);
         usageSearchEvent.setQuery(searchEventRest.getQuery());
         usageSearchEvent.setDsoType(searchEventRest.getDsoType());
-        IndexableObject scopeObject = scopeResolver.resolveScope(context, String.valueOf(searchEventRest.getScope()));
-        if (scopeObject instanceof DSpaceObject) {
-            usageSearchEvent.setScope((DSpaceObject) scopeObject);
+        if (searchEventRest.getScope() != null) {
+            IndexableObject scopeObject =
+                    scopeResolver.resolveScope(context, String.valueOf(searchEventRest.getScope()));
+            if (scopeObject instanceof DSpaceObject) {
+                usageSearchEvent.setScope((DSpaceObject) scopeObject);
+            }
         }
         usageSearchEvent.setConfiguration(searchEventRest.getConfiguration());
         if (searchEventRest.getAppliedFilters() != null) {


### PR DESCRIPTION
## Description
Fixes a tiny bug that I discovered while testing other PRs.  If you perform a search without a scope, the following is logged in the `dspace.log`:

```
2021-06-21 21:36:46,448 WARN  org.dspace.app.rest.utils.ScopeResolver @ The given scope string null is not a UUID
java.lang.IllegalArgumentException: Invalid UUID string: null
        at java.util.UUID.fromString(UUID.java:215) ~[?:?]
        at org.dspace.app.rest.utils.ScopeResolver.resolveScope(ScopeResolver.java:42) [classes/:7.0-beta6-SNAPSHOT]
        at org.dspace.app.rest.converter.SearchEventConverter.convert(SearchEventConverter.java:37) [classes/:7.0-beta6-SNAPSHOT]
        at org.dspace.app.rest.repository.SearchEventRestRepository.createSearchEvent(SearchEventRestRepository.java:52) [classes/:7.0-beta6-SNAPSHOT]
        at org.dspace.app.rest.StatisticsRestController.postSearchEvent(StatisticsRestController.java:101) [classes/:7.0-beta6-SNAPSHOT]
        at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
        at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:?]
        at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
        at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
        ...
```

This Warning doesn't result in any failures or errors, but it's an annoyingly long stacktrace.  The cause is that the `ScopeResolver` simply isn't handling a possible null scope, and this PR fixes that

## Instructions for Reviewers
To reproduce the bug:
* Watch/follow the `dspace.log`
* Perform a search from the UI without a scope.  You'll see the above WARN message (which is triggered via a POSTed searchEvent for that search).

This should be very easy to code review as the bug is rather obvious if you look at the code.  The `null` scope is being turned into a literal string `"null"` which then throws an Invalid UUID exception
