### PR TITLE
Add endpoints for Item/Bitstream thumbnails

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
@@ -13,6 +13,8 @@ import java.sql.SQLException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 
 import org.apache.commons.collections4.CollectionUtils;
@@ -406,6 +408,25 @@ public class BitstreamServiceImpl extends DSpaceObjectServiceImpl<Bitstream> imp
                 return bitstreams.get(0);
             }
         }
+        return null;
+    }
+
+    @Override
+    public Bitstream getThumbnail(Context context, Bitstream bitstream) throws SQLException {
+        Pattern pattern = Pattern.compile("^" + bitstream.getName() + ".([^.]+)$");
+
+        for (Bundle bundle : bitstream.getBundles()) {
+            for (Item item : bundle.getItems()) {
+                for (Bundle thumbnails : itemService.getBundles(item, "THUMBNAIL")) {
+                    for (Bitstream thumbnail : thumbnails.getBitstreams()) {
+                        if (pattern.matcher(thumbnail.getName()).matches()) {
+                            return thumbnail;
+                        }
+                    }
+                }
+            }
+        }
+
         return null;
     }
 

--- a/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
@@ -13,7 +13,6 @@ import java.sql.SQLException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 

--- a/dspace-api/src/main/java/org/dspace/content/service/BitstreamService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/BitstreamService.java
@@ -209,6 +209,8 @@ public interface BitstreamService extends DSpaceObjectService<Bitstream>, DSpace
 
     public Bitstream getFirstBitstream(Item item, String bundleName) throws SQLException;
 
+    public Bitstream getThumbnail(Context context, Bitstream bitstream) throws SQLException;
+
     public BitstreamFormat getFormat(Context context, Bitstream bitstream) throws SQLException;
 
     public Iterator<Bitstream> findByStoreNumber(Context context, Integer storeNumber) throws SQLException;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/BitstreamRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/BitstreamRest.java
@@ -23,6 +23,10 @@ import com.fasterxml.jackson.annotation.JsonProperty.Access;
         @LinkRest(
                 name = BitstreamRest.FORMAT,
                 method = "getFormat"
+        ),
+        @LinkRest(
+                name = BitstreamRest.THUMBNAIL,
+                method = "getThumbnail"
         )
 })
 public class BitstreamRest extends DSpaceObjectRest {
@@ -32,6 +36,7 @@ public class BitstreamRest extends DSpaceObjectRest {
 
     public static final String BUNDLE = "bundle";
     public static final String FORMAT = "format";
+    public static final String THUMBNAIL = "thumbnail";
 
     private String bundleName;
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/ItemRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/ItemRest.java
@@ -40,6 +40,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
         @LinkRest(
                 name = ItemRest.TEMPLATE_ITEM_OF,
                 method = "getTemplateItemOf"
+        ),
+        @LinkRest(
+                name = ItemRest.THUMBNAIL,
+                method = "getThumbnail"
         )
 })
 public class ItemRest extends DSpaceObjectRest {
@@ -53,6 +57,7 @@ public class ItemRest extends DSpaceObjectRest {
     public static final String RELATIONSHIPS = "relationships";
     public static final String VERSION = "version";
     public static final String TEMPLATE_ITEM_OF = "templateItemOf";
+    public static final String THUMBNAIL = "thumbnail";
 
     private boolean inArchive = false;
     private boolean discoverable = false;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamThumbnailLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamThumbnailLinkRepository.java
@@ -1,0 +1,55 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+
+package org.dspace.app.rest.repository;
+
+import java.sql.SQLException;
+import java.util.UUID;
+import javax.annotation.Nullable;
+import javax.servlet.http.HttpServletRequest;
+
+import org.dspace.app.rest.model.BitstreamRest;
+import org.dspace.app.rest.projection.Projection;
+import org.dspace.content.Bitstream;
+import org.dspace.content.service.BitstreamService;
+import org.dspace.core.Context;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.rest.webmvc.ResourceNotFoundException;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Component;
+
+/**
+ * Link repository for the thumbnail Bitstream of an Item
+ */
+@Component(BitstreamRest.CATEGORY + "." + BitstreamRest.NAME + "." + BitstreamRest.THUMBNAIL)
+public class BitstreamThumbnailLinkRepository extends AbstractDSpaceRestRepository implements LinkRestRepository {
+    @Autowired
+    BitstreamService bitstreamService;
+
+    @PreAuthorize("hasPermission(#itemId, 'ITEM', 'READ')")
+    public BitstreamRest getThumbnail(@Nullable HttpServletRequest request,
+                                      UUID itemId,
+                                      @Nullable Pageable optionalPageable,
+                                      Projection projection) {
+        try {
+            Context context = obtainContext();
+            Bitstream bitstream = bitstreamService.find(context, itemId);
+            if (bitstream == null) {
+                throw new ResourceNotFoundException("No such item: " + itemId);
+            }
+            Bitstream thumbnail = bitstreamService.getThumbnail(context, bitstream);
+            if (thumbnail == null) {
+                return null;
+            }
+            return converter.toRest(thumbnail, projection);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamThumbnailLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamThumbnailLinkRepository.java
@@ -53,4 +53,3 @@ public class BitstreamThumbnailLinkRepository extends AbstractDSpaceRestReposito
         }
     }
 }
-//

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamThumbnailLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamThumbnailLinkRepository.java
@@ -25,23 +25,23 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Component;
 
 /**
- * Link repository for the thumbnail Bitstream of an Item
+ * Link repository for the thumbnail Bitstream of a Bitstream
  */
 @Component(BitstreamRest.CATEGORY + "." + BitstreamRest.NAME + "." + BitstreamRest.THUMBNAIL)
 public class BitstreamThumbnailLinkRepository extends AbstractDSpaceRestRepository implements LinkRestRepository {
     @Autowired
     BitstreamService bitstreamService;
 
-    @PreAuthorize("hasPermission(#itemId, 'ITEM', 'READ')")
+    @PreAuthorize("hasPermission(#bitstreamId, 'BITSTREAM', 'READ')")
     public BitstreamRest getThumbnail(@Nullable HttpServletRequest request,
-                                      UUID itemId,
+                                      UUID bitstreamId,
                                       @Nullable Pageable optionalPageable,
                                       Projection projection) {
         try {
             Context context = obtainContext();
-            Bitstream bitstream = bitstreamService.find(context, itemId);
+            Bitstream bitstream = bitstreamService.find(context, bitstreamId);
             if (bitstream == null) {
-                throw new ResourceNotFoundException("No such item: " + itemId);
+                throw new ResourceNotFoundException("No such bitstream: " + bitstreamId);
             }
             Bitstream thumbnail = bitstreamService.getThumbnail(context, bitstream);
             if (thumbnail == null) {
@@ -53,3 +53,4 @@ public class BitstreamThumbnailLinkRepository extends AbstractDSpaceRestReposito
         }
     }
 }
+//

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ItemThumbnailLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ItemThumbnailLinkRepository.java
@@ -1,0 +1,58 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+
+package org.dspace.app.rest.repository;
+
+import java.sql.SQLException;
+import java.util.UUID;
+import javax.annotation.Nullable;
+import javax.servlet.http.HttpServletRequest;
+
+import org.dspace.app.rest.model.BitstreamRest;
+import org.dspace.app.rest.model.ItemRest;
+import org.dspace.app.rest.projection.Projection;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Item;
+import org.dspace.content.Thumbnail;
+import org.dspace.content.service.ItemService;
+import org.dspace.core.Context;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.rest.webmvc.ResourceNotFoundException;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Component;
+
+/**
+ * Link repository for the thumbnail Bitstream of an Item
+ */
+@Component(ItemRest.CATEGORY + "." + ItemRest.NAME + "." + ItemRest.THUMBNAIL)
+public class ItemThumbnailLinkRepository extends AbstractDSpaceRestRepository implements LinkRestRepository {
+    @Autowired
+    ItemService itemService;
+
+    @PreAuthorize("hasPermission(#itemId, 'ITEM', 'READ')")
+    public BitstreamRest getThumbnail(@Nullable HttpServletRequest request,
+                                      UUID itemId,
+                                      @Nullable Pageable optionalPageable,
+                                      Projection projection) {
+        try {
+            Context context = obtainContext();
+            Item item = itemService.find(context, itemId);
+            if (item == null) {
+                throw new ResourceNotFoundException("No such item: " + itemId);
+            }
+            Thumbnail thumbnail = itemService.getThumbnail(context, item, false);
+            if (thumbnail == null) {
+                return null;
+            }
+            return converter.toRest(thumbnail.getThumb(), projection);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ItemThumbnailLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ItemThumbnailLinkRepository.java
@@ -16,7 +16,6 @@ import javax.servlet.http.HttpServletRequest;
 import org.dspace.app.rest.model.BitstreamRest;
 import org.dspace.app.rest.model.ItemRest;
 import org.dspace.app.rest.projection.Projection;
-import org.dspace.content.Bitstream;
 import org.dspace.content.Item;
 import org.dspace.content.Thumbnail;
 import org.dspace.content.service.ItemService;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestRepositoryIT.java
@@ -1520,6 +1520,7 @@ public class BitstreamRestRepositoryIT extends AbstractControllerIntegrationTest
 
     @Test
     public void thumbnailEndpointTest() throws Exception {
+        // Given an Item
         context.turnOffAuthorisationSystem();
 
         parentCommunity = CommunityBuilder.createCommunity(context)
@@ -1544,6 +1545,7 @@ public class BitstreamRestRepositoryIT extends AbstractControllerIntegrationTest
 
         InputStream is = IOUtils.toInputStream("dummy", "utf-8");
 
+        // With an ORIGINAL Bitstream & matching THUMBNAIL Bitstream
         Bitstream bitstream = BitstreamBuilder.createBitstream(context, originalBundle, is)
                                               .withName("test.pdf")
                                               .withMimeType("application/pdf")
@@ -1565,6 +1567,7 @@ public class BitstreamRestRepositoryIT extends AbstractControllerIntegrationTest
 
     @Test
     public void thumbnailEndpointMultipleThumbnailsWithPrimaryBitstreamTest() throws Exception {
+        // Given an Item
         context.turnOffAuthorisationSystem();
 
         parentCommunity = CommunityBuilder.createCommunity(context)
@@ -1589,43 +1592,58 @@ public class BitstreamRestRepositoryIT extends AbstractControllerIntegrationTest
 
         InputStream is = IOUtils.toInputStream("dummy", "utf-8");
 
-        BitstreamBuilder.createBitstream(context, originalBundle, is)
-                        .withName("test1.pdf")
-                        .withMimeType("application/pdf")
-                        .build();
-        BitstreamBuilder.createBitstream(context, originalBundle, is)
-                        .withName("test2.pdf")
-                        .withMimeType("application/pdf")
-                        .build();
+        // With multiple ORIGINAL Bitstreams & matching THUMBNAIL Bitstreams
+        Bitstream bitstream1 = BitstreamBuilder.createBitstream(context, originalBundle, is)
+                                               .withName("test1.pdf")
+                                               .withMimeType("application/pdf")
+                                               .build();
+        Bitstream bitstream2 = BitstreamBuilder.createBitstream(context, originalBundle, is)
+                                               .withName("test2.pdf")
+                                               .withMimeType("application/pdf")
+                                               .build();
         Bitstream primaryBitstream = BitstreamBuilder.createBitstream(context, originalBundle, is)
                                                      .withName("test3.pdf")
                                                      .withMimeType("application/pdf")
                                                      .build();
-        originalBundle.setPrimaryBitstreamID(primaryBitstream);
 
-        BitstreamBuilder.createBitstream(context, thumbnailBundle, is)
-                        .withName("test1.pdf.jpg")
-                        .withMimeType("image/jpeg")
-                        .build();
-        BitstreamBuilder.createBitstream(context, thumbnailBundle, is)
-                        .withName("test2.pdf.jpg")
-                        .withMimeType("image/jpeg")
-                        .build();
+        Bitstream thumbnail1 = BitstreamBuilder.createBitstream(context, thumbnailBundle, is)
+                                               .withName("test1.pdf.jpg")
+                                               .withMimeType("image/jpeg")
+                                               .build();
+        Bitstream thumbnail2 = BitstreamBuilder.createBitstream(context, thumbnailBundle, is)
+                                               .withName("test2.pdf.jpg")
+                                               .withMimeType("image/jpeg")
+                                               .build();
         Bitstream primaryThumbnail = BitstreamBuilder.createBitstream(context, thumbnailBundle, is)
                                                      .withName("test3.pdf.jpg")
                                                      .withMimeType("image/jpeg")
                                                      .build();
 
+        // and a primary Bitstream
+        originalBundle.setPrimaryBitstreamID(primaryBitstream);
+
         context.restoreAuthSystemState();
 
+        // Bitstream thumbnail endpoints should link to the right thumbnail Bitstreams
         getClient().perform(get("/api/core/bitstreams/" + primaryBitstream.getID() + "/thumbnail"))
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$.uuid", Matchers.is(primaryThumbnail.getID().toString())))
+                   .andExpect(jsonPath("$.type", is("bitstream")));
+
+        getClient().perform(get("/api/core/bitstreams/" + bitstream1.getID() + "/thumbnail"))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.uuid", Matchers.is(thumbnail1.getID().toString())))
+                   .andExpect(jsonPath("$.type", is("bitstream")));
+
+        getClient().perform(get("/api/core/bitstreams/" + bitstream2.getID() + "/thumbnail"))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.uuid", Matchers.is(thumbnail2.getID().toString())))
                    .andExpect(jsonPath("$.type", is("bitstream")));
     }
 
     @Test
     public void thumbnailEndpointItemWithoutThumbnailsTest() throws Exception {
+        // Given an Item
         context.turnOffAuthorisationSystem();
 
         parentCommunity = CommunityBuilder.createCommunity(context)
@@ -1644,9 +1662,10 @@ public class BitstreamRestRepositoryIT extends AbstractControllerIntegrationTest
         Bundle originalBundle = BundleBuilder.createBundle(context, item)
                                              .withName(Constants.DEFAULT_BUNDLE_NAME)
                                              .build();
-        BundleBuilder.createBundle(context, item)
-                     .withName("THUMBNAIL")
-                     .build();
+        // With an empty THUMBNAIL bundle
+        Bundle thumbnailBundle = BundleBuilder.createBundle(context, item)
+                                              .withName("THUMBNAIL")
+                                              .build();
 
         InputStream is = IOUtils.toInputStream("dummy", "utf-8");
 
@@ -1657,6 +1676,19 @@ public class BitstreamRestRepositoryIT extends AbstractControllerIntegrationTest
 
         context.restoreAuthSystemState();
 
+        // Should fail with HTTP 204
+        getClient().perform(get("/api/core/bitstreams/" + bitstream.getID() + "/thumbnail"))
+                   .andExpect(status().isNoContent());
+
+        // With a THUMBNAIL bitstream that doesn't match the ORIGINAL Bitstream's name
+        context.turnOffAuthorisationSystem();
+        BitstreamBuilder.createBitstream(context, thumbnailBundle, is)
+                        .withName("random.pdf.jpg")
+                        .withMimeType("image/jpeg")
+                        .build();
+        context.restoreAuthSystemState();
+
+        // Should still fail with HTTP 204
         getClient().perform(get("/api/core/bitstreams/" + bitstream.getID() + "/thumbnail"))
                    .andExpect(status().isNoContent());
     }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestRepositoryIT.java
@@ -11,6 +11,7 @@ import static org.dspace.app.rest.matcher.MetadataMatcher.matchMetadata;
 import static org.dspace.app.rest.matcher.MetadataMatcher.matchMetadataDoesNotExist;
 import static org.dspace.core.Constants.WRITE;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -46,6 +47,7 @@ import org.dspace.content.service.BitstreamFormatService;
 import org.dspace.content.service.BitstreamService;
 import org.dspace.core.Constants;
 import org.dspace.eperson.EPerson;
+import org.hamcrest.Matchers;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -1513,6 +1515,150 @@ public class BitstreamRestRepositoryIT extends AbstractControllerIntegrationTest
         //Get bundle should contain an empty response
         getClient().perform(get("/api/core/bitstreams/" + bitstream.getID() + "/bundle"))
                 .andExpect(status().isNoContent());
+    }
+
+
+    @Test
+    public void thumbnailEndpointTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+
+        Collection col1 = CollectionBuilder.createCollection(context, parentCommunity)
+                                           .withName("Collection 1").build();
+
+        Item item = ItemBuilder.createItem(context, col1)
+                               .withTitle("Test item -- thumbnail")
+                               .withIssueDate("2017-10-17")
+                               .withAuthor("Smith, Donald").withAuthor("Doe, John")
+                               .build();
+
+        Bundle originalBundle = BundleBuilder.createBundle(context, item)
+                                             .withName(Constants.DEFAULT_BUNDLE_NAME)
+                                             .build();
+        Bundle thumbnailBundle = BundleBuilder.createBundle(context, item)
+                                              .withName("THUMBNAIL")
+                                              .build();
+
+        InputStream is = IOUtils.toInputStream("dummy", "utf-8");
+
+        Bitstream bitstream = BitstreamBuilder.createBitstream(context, originalBundle, is)
+                                              .withName("test.pdf")
+                                              .withMimeType("application/pdf")
+                                              .build();
+        Bitstream thumbnail = BitstreamBuilder.createBitstream(context, thumbnailBundle, is)
+                                              .withName("test.pdf.jpg")
+                                              .withMimeType("image/jpeg")
+                                              .build();
+
+        context.restoreAuthSystemState();
+
+        String tokenAdmin = getAuthToken(admin.getEmail(), password);
+
+        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream.getID() + "/thumbnail"))
+                             .andExpect(status().isOk())
+                             .andExpect(jsonPath("$.uuid", Matchers.is(thumbnail.getID().toString())))
+                             .andExpect(jsonPath("$.type", is("bitstream")));
+    }
+
+    @Test
+    public void thumbnailEndpointMultipleThumbnailsWithPrimaryBitstreamTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+
+        Collection col1 = CollectionBuilder.createCollection(context, parentCommunity)
+                                           .withName("Collection 1").build();
+
+        Item item = ItemBuilder.createItem(context, col1)
+                               .withTitle("Test item -- thumbnail")
+                               .withIssueDate("2017-10-17")
+                               .withAuthor("Smith, Donald").withAuthor("Doe, John")
+                               .build();
+
+        Bundle originalBundle = BundleBuilder.createBundle(context, item)
+                                             .withName(Constants.DEFAULT_BUNDLE_NAME)
+                                             .build();
+        Bundle thumbnailBundle = BundleBuilder.createBundle(context, item)
+                                              .withName("THUMBNAIL")
+                                              .build();
+
+        InputStream is = IOUtils.toInputStream("dummy", "utf-8");
+
+        BitstreamBuilder.createBitstream(context, originalBundle, is)
+                        .withName("test1.pdf")
+                        .withMimeType("application/pdf")
+                        .build();
+        BitstreamBuilder.createBitstream(context, originalBundle, is)
+                        .withName("test2.pdf")
+                        .withMimeType("application/pdf")
+                        .build();
+        Bitstream primaryBitstream = BitstreamBuilder.createBitstream(context, originalBundle, is)
+                                                     .withName("test3.pdf")
+                                                     .withMimeType("application/pdf")
+                                                     .build();
+        originalBundle.setPrimaryBitstreamID(primaryBitstream);
+
+        BitstreamBuilder.createBitstream(context, thumbnailBundle, is)
+                        .withName("test1.pdf.jpg")
+                        .withMimeType("image/jpeg")
+                        .build();
+        BitstreamBuilder.createBitstream(context, thumbnailBundle, is)
+                        .withName("test2.pdf.jpg")
+                        .withMimeType("image/jpeg")
+                        .build();
+        Bitstream primaryThumbnail = BitstreamBuilder.createBitstream(context, thumbnailBundle, is)
+                                                     .withName("test3.pdf.jpg")
+                                                     .withMimeType("image/jpeg")
+                                                     .build();
+
+        context.restoreAuthSystemState();
+
+        getClient().perform(get("/api/core/bitstreams/" + primaryBitstream.getID() + "/thumbnail"))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.uuid", Matchers.is(primaryThumbnail.getID().toString())))
+                   .andExpect(jsonPath("$.type", is("bitstream")));
+    }
+
+    @Test
+    public void thumbnailEndpointItemWithoutThumbnailsTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+
+        Collection col1 = CollectionBuilder.createCollection(context, parentCommunity)
+                                           .withName("Collection 1").build();
+
+        Item item = ItemBuilder.createItem(context, col1)
+                               .withTitle("Test item -- thumbnail")
+                               .withIssueDate("2017-10-17")
+                               .withAuthor("Smith, Donald").withAuthor("Doe, John")
+                               .build();
+
+        Bundle originalBundle = BundleBuilder.createBundle(context, item)
+                                             .withName(Constants.DEFAULT_BUNDLE_NAME)
+                                             .build();
+        BundleBuilder.createBundle(context, item)
+                     .withName("THUMBNAIL")
+                     .build();
+
+        InputStream is = IOUtils.toInputStream("dummy", "utf-8");
+
+        Bitstream bitstream = BitstreamBuilder.createBitstream(context, originalBundle, is)
+                        .withName("test.pdf")
+                        .withMimeType("application/pdf")
+                        .build();
+
+        context.restoreAuthSystemState();
+
+        getClient().perform(get("/api/core/bitstreams/" + bitstream.getID() + "/thumbnail"))
+                   .andExpect(status().isNoContent());
     }
 
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
@@ -73,6 +73,7 @@ import org.dspace.content.Relationship;
 import org.dspace.content.RelationshipType;
 import org.dspace.content.WorkspaceItem;
 import org.dspace.content.service.CollectionService;
+import org.dspace.core.Constants;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
 import org.hamcrest.Matcher;
@@ -3866,6 +3867,149 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         getClient().perform(get("/api/core/items/" + item.getID() + "/owningCollection"))
                    .andExpect(status().isUnauthorized());
 
+    }
+
+    @Test
+    public void thumbnailEndpointTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+
+        Collection col1 = CollectionBuilder.createCollection(context, parentCommunity)
+                                           .withName("Collection 1").build();
+
+        Item item = ItemBuilder.createItem(context, col1)
+                                      .withTitle("Test item -- thumbnail")
+                                      .withIssueDate("2017-10-17")
+                                      .withAuthor("Smith, Donald").withAuthor("Doe, John")
+                                      .build();
+
+        Bundle originalBundle = BundleBuilder.createBundle(context, item)
+                                             .withName(Constants.DEFAULT_BUNDLE_NAME)
+                                             .build();
+        Bundle thumbnailBundle = BundleBuilder.createBundle(context, item)
+                                              .withName("THUMBNAIL")
+                                              .build();
+
+        InputStream is = IOUtils.toInputStream("dummy", "utf-8");
+
+        BitstreamBuilder.createBitstream(context, originalBundle, is)
+                        .withName("test.pdf")
+                        .withMimeType("application/pdf")
+                        .build();
+        Bitstream thumbnail = BitstreamBuilder.createBitstream(context, thumbnailBundle, is)
+                                              .withName("test.pdf.jpg")
+                                              .withMimeType("image/jpeg")
+                                              .build();
+
+        context.restoreAuthSystemState();
+
+        String tokenAdmin = getAuthToken(admin.getEmail(), password);
+
+        getClient(tokenAdmin).perform(get("/api/core/items/" + item.getID() + "/thumbnail"))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.uuid", Matchers.is(thumbnail.getID().toString())))
+                   .andExpect(jsonPath("$.type", is("bitstream")));
+    }
+
+    @Test
+    public void thumbnailEndpointMultipleThumbnailsWithPrimaryBitstreamTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+
+        Collection col1 = CollectionBuilder.createCollection(context, parentCommunity)
+                                           .withName("Collection 1").build();
+
+        Item item = ItemBuilder.createItem(context, col1)
+                               .withTitle("Test item -- thumbnail")
+                               .withIssueDate("2017-10-17")
+                               .withAuthor("Smith, Donald").withAuthor("Doe, John")
+                               .build();
+
+        Bundle originalBundle = BundleBuilder.createBundle(context, item)
+                                             .withName(Constants.DEFAULT_BUNDLE_NAME)
+                                             .build();
+        Bundle thumbnailBundle = BundleBuilder.createBundle(context, item)
+                                              .withName("THUMBNAIL")
+                                              .build();
+
+        InputStream is = IOUtils.toInputStream("dummy", "utf-8");
+
+        BitstreamBuilder.createBitstream(context, originalBundle, is)
+                        .withName("test1.pdf")
+                        .withMimeType("application/pdf")
+                        .build();
+        BitstreamBuilder.createBitstream(context, originalBundle, is)
+                        .withName("test2.pdf")
+                        .withMimeType("application/pdf")
+                        .build();
+        Bitstream primaryBitstream = BitstreamBuilder.createBitstream(context, originalBundle, is)
+                                                     .withName("test3.pdf")
+                                                     .withMimeType("application/pdf")
+                                                     .build();
+        originalBundle.setPrimaryBitstreamID(primaryBitstream);
+
+        BitstreamBuilder.createBitstream(context, thumbnailBundle, is)
+                                              .withName("test1.pdf.jpg")
+                                              .withMimeType("image/jpeg")
+                                              .build();
+        BitstreamBuilder.createBitstream(context, thumbnailBundle, is)
+                                              .withName("test2.pdf.jpg")
+                                              .withMimeType("image/jpeg")
+                                              .build();
+        Bitstream primaryThumbnail = BitstreamBuilder.createBitstream(context, thumbnailBundle, is)
+                                                     .withName("test3.pdf.jpg")
+                                                     .withMimeType("image/jpeg")
+                                                     .build();
+
+        context.restoreAuthSystemState();
+
+        getClient().perform(get("/api/core/items/" + item.getID() + "/thumbnail"))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.uuid", Matchers.is(primaryThumbnail.getID().toString())))
+                   .andExpect(jsonPath("$.type", is("bitstream")));
+    }
+
+    @Test
+    public void thumbnailEndpointItemWithoutThumbnailsTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+
+        Collection col1 = CollectionBuilder.createCollection(context, parentCommunity)
+                                           .withName("Collection 1").build();
+
+        Item item = ItemBuilder.createItem(context, col1)
+                               .withTitle("Test item -- thumbnail")
+                               .withIssueDate("2017-10-17")
+                               .withAuthor("Smith, Donald").withAuthor("Doe, John")
+                               .build();
+
+        Bundle originalBundle = BundleBuilder.createBundle(context, item)
+                                             .withName(Constants.DEFAULT_BUNDLE_NAME)
+                                             .build();
+        BundleBuilder.createBundle(context, item)
+                                              .withName("THUMBNAIL")
+                                              .build();
+
+        InputStream is = IOUtils.toInputStream("dummy", "utf-8");
+
+        BitstreamBuilder.createBitstream(context, originalBundle, is)
+                        .withName("test.pdf")
+                        .withMimeType("application/pdf")
+                        .build();
+
+        context.restoreAuthSystemState();
+
+        getClient().perform(get("/api/core/items/" + item.getID() + "/thumbnail"))
+                   .andExpect(status().isNoContent());
     }
 
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/BitstreamMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/BitstreamMatcher.java
@@ -101,7 +101,8 @@ public class BitstreamMatcher {
     public static Matcher<? super Object> matchFullEmbeds() {
         return matchEmbeds(
                 "bundle",
-                "format"
+                "format",
+                "thumbnail"
         );
     }
 
@@ -113,7 +114,8 @@ public class BitstreamMatcher {
                 "bundle",
                 "content",
                 "format",
-                "self"
+                "self",
+                "thumbnail"
         );
     }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/ItemMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/ItemMatcher.java
@@ -55,7 +55,8 @@ public class ItemMatcher {
                 "owningCollection",
                 "version",
                 "relationships[]",
-                "templateItemOf"
+                "templateItemOf",
+                "thumbnail"
         );
     }
 
@@ -70,7 +71,8 @@ public class ItemMatcher {
                 "relationships",
                 "self",
                 "version",
-                "templateItemOf"
+                "templateItemOf",
+                "thumbnail"
         );
     }
 


### PR DESCRIPTION


## References

* Fixes #3286
* Related to [REST Contract - Bitstreams - Main Thumbnail]( https://github.com/DSpace/RestContract/blob/main/bitstreams.md#main-thumbnail)
* Related to [REST Contract - Items - Main Thumbnail](https://github.com/DSpace/RestContract/blob/main/items.md#main-thumbnail)

## Description

Implement thumbnail endpoints for Bitstream` and Items

* `/api/core/bitstreams/<:uuid>/thumbnail`
* `/api/core/items/<:uuid>/thumbnail`

## Instructions for Reviewers

List of changes in this PR:

* New method `BitstreamService#getThumbnail`
  * Looks up a matching thumbnail in the "sibling THUMBNAIL Bundles" of the Bundles the  Bitstream is included in
  * `<name>.<ext>` → thumbnail name `<name>.<ext>.jpg`
* `BitstreamThumbnailLinkRepository`
  * Exposes `BitstreamService#getThumbnail` at `/api/core/bitstreams/<:uuid>/thumbnail`
* `ItemThumbnailLinkRepository`
  * Exposes `ItemService#getThumbnail` at `/api/core/items/<:uuid>/thumbnail`

**Reviewing:**

1. Select (or create) an Item with some Bitstreams and corresponding thumbnail Bitstreams
2. Open the Item in the HAL browser
   * [ ] should contain a link `thumbnail`
   * [ ] it should link to the thumbnail of the primary Bitstream (if specified)
   * [ ] otherwise, it should link to the thumbnail of the first Bitstream in the ORIGINAL Bundle
3. Open the Item's ORIGINAL Bitstream(s) in the HAL browser
   * [ ] should contain a link `thumbnail`
   * [ ] it should link to the Bitstream's thumbnail

## Checklist

_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.

