### PR TITLE
[DS-4478] Optionally list all values of an array property

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -889,6 +889,14 @@
             <version>20180130</version>
         </dependency>
 
+        <!-- Useful for testing command-line tools -->
+        <dependency>
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-rules</artifactId>
+            <version>1.19.0</version>
+            <scope>test</scope>
+        </dependency>
+
         <!-- Used for Solr core export/import -->
         <dependency>
             <groupId>com.opencsv</groupId>

--- a/dspace-api/src/main/java/org/dspace/app/util/Configuration.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/Configuration.java
@@ -37,6 +37,7 @@ public class Configuration {
      * <li>{@code --property name} prints the value of the DSpace configuration
      * property {@code name} to the standard output.</li>
      * <li>{@code --raw} suppresses parameter substitution in the output.</li>
+     * <li>{@code --first} print only the first of multiple values.</li>
      * <li>{@code --help} describes these options.</li>
      * </ul>
      * If the property does not exist, nothing is written.
@@ -51,8 +52,8 @@ public class Configuration {
                           "optional name of the module in which 'property' exists");
         options.addOption("r", "raw", false,
                           "do not do property substitution on the value");
-        options.addOption("a", "all", false,
-                          "display all values of an array property");
+        options.addOption("f", "first", false,
+                          "display only the first value of an array property");
         options.addOption("?", "Get help");
         options.addOption("h", "help", false, "Get help");
 
@@ -103,8 +104,8 @@ public class Configuration {
                 if (rawValue.getClass().isArray()) {
                     for (Object value : (Object[]) rawValue) {
                         System.out.println(value.toString());
-                        if (!cmd.hasOption('a')) {
-                            break; // Unless --all print only one value
+                        if (cmd.hasOption('f')) {
+                            break; // If --first print only one value
                         }
                     }
                 } else { // Not an array
@@ -115,8 +116,8 @@ public class Configuration {
                 String[] values = cfg.getArrayProperty(propName);
                 for (String value : values) {
                     System.out.println(value);
-                    if (!cmd.hasOption('a')) {
-                        break; // Unless --all print only one value
+                    if (cmd.hasOption('f')) {
+                        break; // If --first print only one value
                     }
                 }
             }

--- a/dspace-api/src/main/java/org/dspace/app/util/Configuration.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/Configuration.java
@@ -51,6 +51,8 @@ public class Configuration {
                           "optional name of the module in which 'property' exists");
         options.addOption("r", "raw", false,
                           "do not do property substitution on the value");
+        options.addOption("a", "all", false,
+                          "display all values of an array property");
         options.addOption("?", "Get help");
         options.addOption("h", "help", false, "Get help");
 
@@ -90,19 +92,36 @@ public class Configuration {
         propNameBuilder.append(cmd.getOptionValue('p'));
         String propName = propNameBuilder.toString();
 
-        // Print the property's value, if it exists
+        // Print the property's value(s), if it exists
         ConfigurationService cfg = DSpaceServicesFactory.getInstance().getConfigurationService();
         if (!cfg.hasProperty(propName)) {
             System.out.println();
         } else {
-            String val;
             if (cmd.hasOption('r')) {
-                val = cfg.getPropertyValue(propName).toString();
+                // Print "raw" values (without property substitutions)
+                Object rawValue = cfg.getPropertyValue(propName);
+                if (rawValue.getClass().isArray()) {
+                    for (Object value : (Object[]) rawValue) {
+                        System.out.println(value.toString());
+                        if (!cmd.hasOption('a')) {
+                            break; // Unless --all print only one value
+                        }
+                    }
+                } else { // Not an array
+                    System.out.println(rawValue.toString());
+                }
             } else {
-                val = cfg.getProperty(propName);
+                // Print values with property substitutions
+                String[] values = cfg.getArrayProperty(propName);
+                for (String value : values) {
+                    System.out.println(value);
+                    if (!cmd.hasOption('a')) {
+                        break; // Unless --all print only one value
+                    }
+                }
             }
-            System.out.println(val);
         }
+
         System.exit(0);
     }
 }

--- a/dspace-api/src/test/java/org/dspace/app/util/ConfigurationIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/util/ConfigurationIT.java
@@ -12,6 +12,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.collection.IsArrayContainingInAnyOrder.arrayContainingInAnyOrder;
+import static org.junit.Assert.assertEquals;
 
 import org.dspace.AbstractDSpaceTest;
 import org.dspace.services.ConfigurationService;
@@ -220,6 +221,46 @@ public class ConfigurationIT
                 String[] output = outputs.split("\n");
                 assertThat(output, arrayWithSize(0)); // Huh?  Shouldn't split() return { "" } ?
             }
+        });
+        systemOutRule.enableLog();
+        Configuration.main(argv);
+    }
+
+    /**
+     * Test fetching only the first value of an array property.
+     */
+    @Test
+    public void testMainFirstArray() {
+        String[] argv = new String[] {
+            "--property", ARRAY_PROPERTY,
+            "--first"
+        };
+        expectedSystemExit.expectSystemExitWithStatus(0);
+        expectedSystemExit.checkAssertionAfterwards(() -> {
+            String outputs = systemOutRule.getLogWithNormalizedLineSeparator();
+            String[] output = outputs.split("\n");
+            assertThat(output, arrayWithSize(1));
+            assertEquals("--first should return first value", output[0], ARRAY_VALUE[0]);
+        });
+        systemOutRule.enableLog();
+        Configuration.main(argv);
+    }
+
+    /**
+     * Test fetching a single-valued property using {@code --first}
+     */
+    @Test
+    public void testMainFirstSingle() {
+        String[] argv = new String[] {
+            "--property", SINGLE_PROPERTY,
+            "--first"
+        };
+        expectedSystemExit.expectSystemExitWithStatus(0);
+        expectedSystemExit.checkAssertionAfterwards(() -> {
+            String outputs = systemOutRule.getLogWithNormalizedLineSeparator();
+            String[] output = outputs.split("\n");
+            assertThat(output, arrayWithSize(1));
+            assertEquals("--first should return only value", output[0], SINGLE_VALUE);
         });
         systemOutRule.enableLog();
         Configuration.main(argv);

--- a/dspace-api/src/test/java/org/dspace/app/util/ConfigurationIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/util/ConfigurationIT.java
@@ -94,7 +94,6 @@ public class ConfigurationIT
     public void testMainAllSingle() {
         String[] argv;
         argv = new String[] {
-            "--all",
             "--property", SINGLE_PROPERTY
         };
         expectedSystemExit.expectSystemExitWithStatus(0);
@@ -123,7 +122,6 @@ public class ConfigurationIT
     public void testMainAllArray() {
         String[] argv;
         argv = new String[] {
-            "--all",
             "--property", ARRAY_PROPERTY
         };
         expectedSystemExit.expectSystemExitWithStatus(0);
@@ -153,7 +151,6 @@ public class ConfigurationIT
     public void testMainAllSubstitution() {
         String[] argv;
         argv = new String[] {
-            "--all",
             "--property", PLACEHOLDER_PROPERTY
         };
         expectedSystemExit.expectSystemExitWithStatus(0);
@@ -184,7 +181,6 @@ public class ConfigurationIT
         // Can it handle a raw property (with substitution placeholders)?
         String[] argv;
         argv = new String[] {
-            "--all",
             "--property", PLACEHOLDER_PROPERTY,
             "--raw"
         };
@@ -215,7 +211,6 @@ public class ConfigurationIT
         // Can it handle an undefined property?
         String[] argv;
         argv = new String[] {
-            "--all",
             "--property", MISSING_PROPERTY
         };
         expectedSystemExit.expectSystemExitWithStatus(0);

--- a/dspace-api/src/test/java/org/dspace/app/util/ConfigurationIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/util/ConfigurationIT.java
@@ -1,0 +1,232 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+
+package org.dspace.app.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.collection.IsArrayContainingInAnyOrder.arrayContainingInAnyOrder;
+
+import org.dspace.AbstractDSpaceTest;
+import org.dspace.services.ConfigurationService;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.Assertion;
+import org.junit.contrib.java.lang.system.ExpectedSystemExit;
+import org.junit.contrib.java.lang.system.SystemErrRule;
+import org.junit.contrib.java.lang.system.SystemOutRule;
+
+/**
+ * Tests for configuration utilities.
+ *
+ * Because our command-line tools call System.exit(), we can't expect any code
+ * (such as assertions) following the call to main() to be executed.  Instead we
+ * set up expectations in advance and attach them to an exit() trapper.
+ *
+ * @author mhwood
+ */
+public class ConfigurationIT
+        extends AbstractDSpaceTest {
+
+    private static ConfigurationService cfg;
+
+    private static final String SINGLE_PROPERTY = "test.single";
+    private static final String SINGLE_VALUE = "value";
+
+    private static final String ARRAY_PROPERTY = "test.array";
+    private static final String[] ARRAY_VALUE = { "one", "two" };
+
+    private static final String PLACEHOLDER_PROPERTY = "test.substituted";
+    private static final String PLACEHOLDER_VALUE = "insert ${test.single} here"; // Keep aligned with SINGLE_NAME
+    private static final String SUBSTITUTED_VALUE = "insert value here"; // Keep aligned with SINGLE_VALUE
+
+    private static final String MISSING_PROPERTY = "test.missing";
+
+    /** Capture standard output. */
+    @Rule
+    public final SystemOutRule systemOutRule = new SystemOutRule();
+
+    /** Capture standard error. */
+    @Rule
+    public final SystemErrRule systemErrRule = new SystemErrRule();
+
+    /** Capture System.exit() value. */
+    @Rule
+    public final ExpectedSystemExit expectedSystemExit = ExpectedSystemExit.none();
+
+    /**
+     * Create some expected properties before all tests.
+     */
+    @BeforeClass
+    public static void setupSuite() {
+        cfg = kernelImpl.getConfigurationService();
+
+        cfg.setProperty(SINGLE_PROPERTY, SINGLE_VALUE);
+        cfg.setProperty(ARRAY_PROPERTY, ARRAY_VALUE);
+        cfg.setProperty(PLACEHOLDER_PROPERTY, PLACEHOLDER_VALUE);
+        cfg.setProperty(MISSING_PROPERTY, null); // Ensure that this one is undefined
+    }
+
+    /**
+     * After all tests, remove the properties that were created at entry.
+     */
+    @AfterClass
+    public static void teardownSuite() {
+        if (null != cfg) {
+            cfg.setProperty(SINGLE_PROPERTY, null);
+            cfg.setProperty(ARRAY_PROPERTY, null);
+            cfg.setProperty(PLACEHOLDER_PROPERTY, null);
+        }
+    }
+
+    /**
+     * Test fetching all values of a single-valued property.
+     */
+    @Test
+    public void testMainAllSingle() {
+        String[] argv;
+        argv = new String[] {
+            "--all",
+            "--property", SINGLE_PROPERTY
+        };
+        expectedSystemExit.expectSystemExitWithStatus(0);
+        expectedSystemExit.checkAssertionAfterwards(new Assertion() {
+            @Override public void checkAssertion() {
+                String[] output = systemOutRule.getLogWithNormalizedLineSeparator()
+                        .split("\n");
+                assertThat(output, arrayWithSize(1));
+            }
+        });
+        expectedSystemExit.checkAssertionAfterwards(new Assertion() {
+            @Override public void checkAssertion() {
+                String[] output = systemOutRule.getLogWithNormalizedLineSeparator()
+                        .split("\n");
+                assertThat(output[0], equalTo(SINGLE_VALUE));
+            }
+        });
+        systemOutRule.enableLog();
+        Configuration.main(argv);
+    }
+
+    /**
+     * Test fetching all values of an array property.
+     */
+    @Test
+    public void testMainAllArray() {
+        String[] argv;
+        argv = new String[] {
+            "--all",
+            "--property", ARRAY_PROPERTY
+        };
+        expectedSystemExit.expectSystemExitWithStatus(0);
+        expectedSystemExit.checkAssertionAfterwards(new Assertion() {
+            @Override public void checkAssertion() {
+                String[] output = systemOutRule.getLogWithNormalizedLineSeparator()
+                        .split("\n");
+                assertThat(output, arrayWithSize(ARRAY_VALUE.length));
+            }
+        });
+        expectedSystemExit.checkAssertionAfterwards(new Assertion() {
+            @Override public void checkAssertion() {
+                String[] output = systemOutRule.getLogWithNormalizedLineSeparator()
+                        .split("\n");
+                assertThat(output, arrayContainingInAnyOrder(ARRAY_VALUE));
+            }
+        });
+        systemOutRule.enableLog();
+        Configuration.main(argv);
+    }
+
+    /**
+     * Test fetching all values of a single-valued property containing property
+     * placeholders.
+     */
+    @Test
+    public void testMainAllSubstitution() {
+        String[] argv;
+        argv = new String[] {
+            "--all",
+            "--property", PLACEHOLDER_PROPERTY
+        };
+        expectedSystemExit.expectSystemExitWithStatus(0);
+        expectedSystemExit.checkAssertionAfterwards(new Assertion() {
+            @Override public void checkAssertion() {
+                String[] output = systemOutRule.getLogWithNormalizedLineSeparator()
+                        .split("\n");
+                assertThat(output, arrayWithSize(1));
+            }
+        });
+        expectedSystemExit.checkAssertionAfterwards(new Assertion() {
+            @Override public void checkAssertion() {
+                String[] output = systemOutRule.getLogWithNormalizedLineSeparator()
+                        .split("\n");
+                assertThat(output[0], equalTo(SUBSTITUTED_VALUE));
+            }
+        });
+        systemOutRule.enableLog();
+        Configuration.main(argv);
+    }
+
+    /**
+     * Test fetching all values of a single-valued property containing property
+     * placeholders, suppressing property substitution.
+     */
+    @Test
+    public void testMainAllRaw() {
+        // Can it handle a raw property (with substitution placeholders)?
+        String[] argv;
+        argv = new String[] {
+            "--all",
+            "--property", PLACEHOLDER_PROPERTY,
+            "--raw"
+        };
+        expectedSystemExit.expectSystemExitWithStatus(0);
+        expectedSystemExit.checkAssertionAfterwards(new Assertion() {
+            @Override public void checkAssertion() {
+                String[] output = systemOutRule.getLogWithNormalizedLineSeparator()
+                        .split("\n");
+                assertThat(output, arrayWithSize(1));
+            }
+        });
+        expectedSystemExit.checkAssertionAfterwards(new Assertion() {
+            @Override public void checkAssertion() {
+                String[] output = systemOutRule.getLogWithNormalizedLineSeparator()
+                        .split("\n");
+                assertThat(output[0], equalTo(PLACEHOLDER_VALUE));
+            }
+        });
+        systemOutRule.enableLog();
+        Configuration.main(argv);
+    }
+
+    /**
+     * Test fetching all values of an undefined property.
+     */
+    @Test
+    public void testMainAllUndefined() {
+        // Can it handle an undefined property?
+        String[] argv;
+        argv = new String[] {
+            "--all",
+            "--property", MISSING_PROPERTY
+        };
+        expectedSystemExit.expectSystemExitWithStatus(0);
+        expectedSystemExit.checkAssertionAfterwards(new Assertion() {
+            @Override public void checkAssertion() {
+                String outputs = systemOutRule.getLogWithNormalizedLineSeparator();
+                String[] output = outputs.split("\n");
+                assertThat(output, arrayWithSize(0)); // Huh?  Shouldn't split() return { "" } ?
+            }
+        });
+        systemOutRule.enableLog();
+        Configuration.main(argv);
+    }
+}


### PR DESCRIPTION
## Description
Fixes #7813
Add an option "-f" / "--first" to request that only the first value of an array property be shown by `bin/dspace dsprop`, and by default show all values.
Ported from dspace-6_x:  #2741

## Instructions for Reviewers
List of changes in this PR:
* New option to `dsprop` as noted above.
* New integration test to demonstrate the correctness of the new option's code.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
