### PR TITLE
Fix JAXB build errors by disabling package annotations. 

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -170,6 +170,7 @@
                 </configuration>
             </plugin>
 
+            <!-- Used to create/generate 'org.dspace.workflow' classes from our workflow-curation.xsd via JAXB -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>jaxb2-maven-plugin</artifactId>
@@ -185,6 +186,8 @@
                                 <source>src/main/resources/org/dspace/workflow</source>
                             </sources>
                             <packageName>org.dspace.workflow</packageName>
+                            <addGeneratedAnnotation>true</addGeneratedAnnotation>
+                            <noPackageLevelAnnotations>true</noPackageLevelAnnotations>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
In some environments, after we merged #3157, some people began seeing the following build error (reproducible via a simple `mvn clean package` or `mvn clean install`):

```
[ERROR] /home/corrado/data/gitdata/DSpace/dspace-api/target/generated-sources/jaxb/org/dspace/workflow/package-info.java:[8,38] duplicate element 'namespace' in annotation @javax.xml.bind.annotation.XmlSchema.
[ERROR] /home/corrado/data/gitdata/DSpace/dspace-api/target/generated-sources/jaxb/org/dspace/workflow/package-info.java:[8,90] duplicate element 'elementFormDefault' in annotation @javax.xml.bind.annotation.XmlSchema.
```

I was able to reproduce this error on Windows 10 with the latest `main`, as was @corrad82-4s.  Strangely however this error does NOT appear in GitHub CI builds, so it might be OS or environment specific.

Nonetheless, this PR fixes the issue with a simple configuration change to `jaxb2-maven-plugin` in our POM:
* Disables package level annotations (i.e. the creation of the `package-info.java` class), which was throwing the errors
* I also tweaked the configuration to annotate all these classes as `@Generated`, just to make it clearer they are dynamically generated.

This PR should be very easy to review...and GitHub CI will show us whether this has any issues in another environment.