### PR TITLE
Fix `/api/core/items` endpoint's `totalElements` count to avoid empty pages at end

### DIFF
--- a/dspace-api/src/test/java/org/dspace/builder/CollectionBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/CollectionBuilder.java
@@ -23,6 +23,7 @@ import org.dspace.core.Context;
 import org.dspace.discovery.SearchServiceException;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
+import org.dspace.xmlworkflow.WorkflowConfigurationException;
 
 /**
  * Builder to construct Collection objects.
@@ -177,7 +178,7 @@ public class CollectionBuilder extends AbstractDSpaceObjectBuilder<Collection> {
 
     /**
      * Generate and populate a workflow group for the Collection.  Obsolete:
-     * the 3-step workflow model has been removed.
+     * the 3-step workflow model has been removed. Use other withWorkflowGroup() method instead
      *
      * @param step number of the workflow step.
      * @param members make these users members of the group.
@@ -189,6 +190,25 @@ public class CollectionBuilder extends AbstractDSpaceObjectBuilder<Collection> {
     @Deprecated
     public CollectionBuilder withWorkflowGroup(int step, EPerson... members) throws SQLException, AuthorizeException {
         Group g = collectionService.createWorkflowGroup(context, collection, step);
+        for (EPerson e : members) {
+            groupService.addMember(context, g, e);
+        }
+        groupService.update(context, g);
+        return this;
+    }
+
+    /**
+     * Generate and populate a role-based workflow group for the Collection.
+     *
+     * @param roleName the rolename for the group
+     * @param members make these users members of the group.
+     * @return this
+     * @throws SQLException passed through.
+     * @throws AuthorizeException passed through.
+     */
+    public CollectionBuilder withWorkflowGroup(String roleName, EPerson... members)
+            throws SQLException, AuthorizeException, IOException, WorkflowConfigurationException {
+        Group g = workflowService.createWorkflowRoleGroup(context, collection, roleName);
         for (EPerson e : members) {
             groupService.addMember(context, g, e);
         }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ItemRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ItemRestRepository.java
@@ -121,7 +121,8 @@ public class ItemRestRepository extends DSpaceObjectRestRepository<Item, ItemRes
     @PreAuthorize("hasAuthority('ADMIN')")
     public Page<ItemRest> findAll(Context context, Pageable pageable) {
         try {
-            long total = itemService.countTotal(context);
+            // This endpoint only returns archived items
+            long total = itemService.countArchivedItems(context);
             Iterator<Item> it = itemService.findAll(context, pageable.getPageSize(),
                 Math.toIntExact(pageable.getOffset()));
             List<Item> items = new ArrayList<>();

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
@@ -62,6 +62,7 @@ import org.dspace.builder.ItemBuilder;
 import org.dspace.builder.RelationshipBuilder;
 import org.dspace.builder.RelationshipTypeBuilder;
 import org.dspace.builder.ResourcePolicyBuilder;
+import org.dspace.builder.WorkflowItemBuilder;
 import org.dspace.builder.WorkspaceItemBuilder;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Bundle;
@@ -76,6 +77,7 @@ import org.dspace.content.service.CollectionService;
 import org.dspace.core.Constants;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
+import org.dspace.workflow.WorkflowItem;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -171,8 +173,17 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
                                            .withName("Sub Community")
                                            .build();
-        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
-        Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
+        // Create one Collection with an enabled "reviewer" Workflow step. This lets us create a WorkflowItem below.
+        Collection col1 = CollectionBuilder.createCollection(context, child1)
+                                           .withName("Collection 1")
+                                           .withWorkflowGroup("reviewer", admin)
+                                           .build();
+        // Create a second Collection with a template Item. This is used to ensure that Template Items are
+        // NOT counted/listed in this endpoint.
+        Collection col2 = CollectionBuilder.createCollection(context, child1)
+                                           .withName("Collection 2")
+                                           .withTemplateItem()
+                                           .build();
 
         //2. Three public items that are readable by Anonymous with different subjects
         Item publicItem1 = ItemBuilder.createItem(context, col1)
@@ -206,6 +217,15 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
                 .build();
         Item itemInWorkspace = workspaceItem.getItem();
 
+        // Also create a Workflow Item (in the workflow-enabled Collection), to ensure WorkflowItems are
+        // NOT counted/listed in this endpoint
+        WorkflowItem workflowItem = WorkflowItemBuilder.createWorkflowItem(context, col1)
+                .withTitle("Item in Workflow")
+                .withIssueDate("2019-06-03")
+                .withAuthor("Smith, Jennifer").withAuthor("Doe, John")
+                .build();
+        Item itemInWorkflow = workflowItem.getItem();
+
         context.restoreAuthSystemState();
         String token = getAuthToken(admin.getEmail(), password);
 
@@ -223,7 +243,10 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
                                ItemMatcher.matchItemWithTitleAndDateIssued(publicItem3,
                                        "Public item 3", "2016-02-13"),
                                ItemMatcher.matchItemWithTitleAndDateIssued(itemInWorkspace,
-                                       "In Progress Item", "2018-02-05")
+                                       "In Progress Item", "2018-02-05"),
+                               ItemMatcher.matchItemWithTitleAndDateIssued(itemInWorkflow,
+                                       "Item in Workflow", "2019-06-03"),
+                               ItemMatcher.matchItemProperties(col2.getTemplateItem())
                            )
                    )))
                    .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
@@ -258,7 +281,10 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
                            ItemMatcher.matchItemWithTitleAndDateIssued(publicItem2,
                                    "Public item 2", "2016-02-13"),
                            ItemMatcher.matchItemWithTitleAndDateIssued(itemInWorkspace,
-                                   "In Progress Item", "2018-02-05")
+                                   "In Progress Item", "2018-02-05"),
+                           ItemMatcher.matchItemWithTitleAndDateIssued(itemInWorkflow,
+                                   "Item in Workflow", "2019-06-03"),
+                           ItemMatcher.matchItemProperties(col2.getTemplateItem())
                        )
                    )))
                    .andExpect(jsonPath("$._links.first.href", Matchers.allOf(

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
@@ -197,6 +197,15 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
                                       .withSubject("ExtraEntry")
                                       .build();
 
+        // Create a Workspace Item (which in turn creates an Item with "in_archive=false")
+        // This is only created to prove that WorkspaceItems are NOT counted/listed in this endpoint
+        WorkspaceItem workspaceItem = WorkspaceItemBuilder.createWorkspaceItem(context, col2)
+                .withTitle("In Progress Item")
+                .withIssueDate("2018-02-05")
+                .withAuthor("Doe, Jane").withAuthor("Smith, Jennifer")
+                .build();
+        Item itemInWorkspace = workspaceItem.getItem();
+
         context.restoreAuthSystemState();
         String token = getAuthToken(admin.getEmail(), password);
 
@@ -212,7 +221,9 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
                    .andExpect(jsonPath("$._embedded.items", Matchers.not(
                            Matchers.contains(
                                ItemMatcher.matchItemWithTitleAndDateIssued(publicItem3,
-                                       "Public item 3", "2016-02-13")
+                                       "Public item 3", "2016-02-13"),
+                               ItemMatcher.matchItemWithTitleAndDateIssued(itemInWorkspace,
+                                       "In Progress Item", "2018-02-05")
                            )
                    )))
                    .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
@@ -245,7 +256,9 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
                            ItemMatcher.matchItemWithTitleAndDateIssued(publicItem1,
                                    "Public item 1", "2017-10-17"),
                            ItemMatcher.matchItemWithTitleAndDateIssued(publicItem2,
-                                   "Public item 2", "2016-02-13")
+                                   "Public item 2", "2016-02-13"),
+                           ItemMatcher.matchItemWithTitleAndDateIssued(itemInWorkspace,
+                                   "In Progress Item", "2018-02-05")
                        )
                    )))
                    .andExpect(jsonPath("$._links.first.href", Matchers.allOf(


### PR DESCRIPTION
## References
* Discovered when analyzing #3317 (see [my comment on that ticket](https://github.com/DSpace/DSpace/issues/3317#issuecomment-878545926)).  _I believe it actually may fix that issue as well, but waiting on response from original reporter._

## Description
Currently, the `totalElements` property returned by `/api/core/items` includes WorkspaceItems, while the actual endpoint only returns archived Items. This can result in pagination working improperly, as the wrong number of pages is listed and last page(s) may be empty.

## Instructions for Reviewers
List of changes in this PR:
1. Prove the broken behavior by creating a WorkspaceItem in the `findAllWithPaginationTest()`. This is in the initial commit https://github.com/DSpace/DSpace/pull/3321/commits/b60b76d29e318ccea362a6c03471122cc6cce739 and results in an IT failure (as the value of `totalElements` will be incorrect, even though the WorkspaceItem is not returned from the endpoint).
2. Fixed the bug in the second commit https://github.com/DSpace/DSpace/pull/3321/commits/025c7a8c78a488df0ee300ed5e6cef0a6c472492

This should be easy to review using the tests.  It also can be easily proven locally by simply ensuring one or more Workspace or Workflow items exist.  This will result in incorrect pagination/total counts from the `/api/core/items` endpoint.

REST Contract PR: https://github.com/DSpace/RestContract/pull/166