### PR TITLE
DS-4588: fix case-insensitive spiderdetector test

### DIFF
--- a/dspace-api/src/test/java/org/dspace/statistics/util/SpiderDetectorServiceImplTest.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/util/SpiderDetectorServiceImplTest.java
@@ -80,7 +80,7 @@ public class SpiderDetectorServiceImplTest extends AbstractDSpaceTest
         req.setAgent("msnboT Is WaTching you");
         assertTrue("'msnbot' didn't match pattern", spiderDetectorService.isSpider(req));
 
-        req.setAgent("FirefOx");
+        req.setAgent("mozilla/5.0 (x11; linux x86_64; rv:91.0) gecko/20100101 firefox/91.0");
         assertFalse("'Firefox' matched a pattern", spiderDetectorService.isSpider(req));
 
         // Test IP patterns


### PR DESCRIPTION
We should not use the string "FirefOx" to test the validity of included spider user agent patterns because it is not a valid user agent in the first place. The Mozilla Firefox browser uses patterns such as this:

> Mozilla/5.0 (X11; Linux x86_64; rv:91.0) Gecko/20100101 Firefox/91.0

The test currently matches the following regular expression:

> ^firefox$

In this case, if a client *did* connect with a single-word string such as "Firefox" or "firefox" it would definitely be a non-human user and we should not log a statistics hit.

If the goal of the test is to check *valid* human user agents against case-insensitive regular expression matching, then we should use the following:

> mozilla/5.0 (x11; linux x86_64; rv:91.0) gecko/20100101 firefox/91.0

## References
* Should be merged before #3333