### PR TITLE
DS-4589: Update Node.js to version 12 LTS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,19 +32,18 @@ jobs:
         with:
           ruby-version: 2.4
 
-      - name: Install Node.js v6.5 (for Mirage 2)
+      - name: Install Node.js v12 (for Mirage 2)
         shell: bash -l {0}
-        run: nvm install 6.5.0
+        run: nvm install 12.22.4
 
       # Install prerequisites for building Mirage2 more rapidly
-      # Includes NPM, Bower, Grunt, Ruby, Sass, Compass
+      # Includes NPM, Bower, Ruby, Sass, Compass
       # These versions should be kept in sync with ./dspace/modules/xml-mirage2/pom.xml
       - name: Install Mirage 2 prerequisites
         run: |
-          sudo npm install -g npm@3.10.8
+          sudo npm install -g npm@6.14.14
           npm --version
           sudo npm install -g bower
-          sudo npm install -g grunt && sudo npm install -g grunt-cli
           grunt --version
           gem install sass -v 3.4.25
           sass -v

--- a/dspace-xmlui-mirage2/readme.md
+++ b/dspace-xmlui-mirage2/readme.md
@@ -33,12 +33,12 @@ If you don't have git installed, go to the [git downloads page](http://git-scm.c
 
 ### Node ###
 
-We recommend using [nvm](https://github.com/creationix/nvm) (Node Version Manager) to install [Node.js](http://nodejs.org/), because it makes it easy to install, use and upgrade node without super user rights.
+We recommend using [nvm](https://github.com/nvm-sh/nvm) (Node Version Manager) to install [Node.js](http://nodejs.org/), because it makes it easy to install, use and upgrade node without super user rights.
 
 First download and install nvm:
 
 ```bash
-    curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.31.7/install.sh | bash 
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
 ```
 
 Then, close and reopen your terminal, and install a node version. We used v6.5.0 during the development of the theme, but it builds successfully with current [long-term support version](https://github.com/nodejs/Release#release-schedule) 12.x as well.

--- a/dspace-xmlui-mirage2/readme.md
+++ b/dspace-xmlui-mirage2/readme.md
@@ -41,16 +41,16 @@ First download and install nvm:
     curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.31.7/install.sh | bash 
 ```
 
-Then, close and reopen your terminal, and install a node version. We’ve been using v6.5.0 during the development of the theme, but it may very well work on other versions
+Then, close and reopen your terminal, and install a node version. We used v6.5.0 during the development of the theme, but it builds successfully with current [long-term support version](https://github.com/nodejs/Release#release-schedule) 12.x as well.
 
 ```bash
-    nvm install 6.5.0 
+    nvm install 12
 ```
 
 Set the node version you installed as the default version.
 
 ```bash
-    nvm alias default 6.5.0
+    nvm alias default 12
 ```
 
 

--- a/dspace/modules/xmlui-mirage2/pom.xml
+++ b/dspace/modules/xmlui-mirage2/pom.xml
@@ -26,8 +26,8 @@
         <!-- These versions should be kept in sync with ./.travis.yml -->
         <sass.version>3.4.25</sass.version>
         <compass.version>1.0.1</compass.version>
-        <node.version>8.10.0</node.version>
-        <npm.version>6.5.0</npm.version>
+        <node.version>12.22.4</node.version>
+        <npm.version>6.14.14</npm.version>
         <!-- Override version of JRuby that gem-maven-plugin installs when "mirage2.deps.included=true" -->
         <jruby.version>9.1.17.0</jruby.version>
     </properties>


### PR DESCRIPTION
We currently build Mirage 2 with Node.js version 8, which stopped receiving support in 2019-12. We should use a currently supported Node.js LTS version. Mirage 2 builds successfully with version 10 and 12, but version 10 also stopped receiving support as of early 2021, which leaves only version 12 as an option.

In addition, I use the version of npm that ships with the latest Node.js LTS (not necessarily the latest npm version).

See: https://nodejs.org/en/about/releases
See: https://en.wikipedia.org/wiki/Node.js#Releases

## References
* Fixes https://jira.lyrasis.org/browse/DS-4589
* Fixes #7922