### PR TITLE
Make DOI resolver URL stem configurable

### DIFF
--- a/dspace-api/src/main/java/org/dspace/identifier/DOI.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/DOI.java
@@ -34,8 +34,6 @@ public class DOI
     implements Identifier, ReloadableEntity<Integer> {
     public static final String SCHEME = "doi:";
 
-    public static final String RESOLVER = "http://dx.doi.org";
-
     @Id
     @Column(name = "doi_id")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "doi_seq")

--- a/dspace-api/src/main/java/org/dspace/identifier/DOIIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/DOIIdentifierProvider.java
@@ -769,7 +769,7 @@ public class DOIIdentifierProvider
         Item item = (Item) dso;
 
         List<MetadataValue> metadata = itemService.getMetadata(item, MD_SCHEMA, DOI_ELEMENT, DOI_QUALIFIER, null);
-        String leftPart = DOI.RESOLVER + SLASH + getPrefix() + SLASH + getNamespaceSeparator();
+        String leftPart = doiService.getResolver() + SLASH + getPrefix() + SLASH + getNamespaceSeparator();
         for (MetadataValue id : metadata) {
             if (id.getValue().startsWith(leftPart)) {
                 return doiService.DOIFromExternalFormat(id.getValue());

--- a/dspace-api/src/main/java/org/dspace/identifier/DOIServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/DOIServiceImpl.java
@@ -108,7 +108,7 @@ public class DOIServiceImpl implements DOIService {
         }
 
         Matcher matcher = DOI_URL_PATTERN.matcher(identifier);
-        if (DOI_URL_PATTERN.matcher(identifier).matches()) { // various old URL forms
+        if (matcher.matches()) { // various old URL forms
             return resolver + matcher.group(DOI_URL_PATTERN_PATH_GROUP);
         }
 

--- a/dspace-api/src/main/java/org/dspace/identifier/DOIServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/DOIServiceImpl.java
@@ -17,11 +17,13 @@ import org.dspace.core.Context;
 import org.dspace.identifier.dao.DOIDAO;
 import org.dspace.identifier.doi.DOIIdentifierException;
 import org.dspace.identifier.service.DOIService;
+import org.dspace.services.ConfigurationService;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
- * Service implementation for the DOI object.
- * This class is responsible for all business logic calls for the DOI object and is autowired by spring.
+ * Service implementation for the {@link DOI} object.
+ * This class is responsible for all business logic calls for the DOI object
+ * and is autowired by Spring.
  * This class should never be accessed directly.
  *
  * @author kevinvandevelde at atmire.com
@@ -30,6 +32,14 @@ public class DOIServiceImpl implements DOIService {
 
     @Autowired(required = true)
     protected DOIDAO doiDAO;
+
+    @Autowired(required = true)
+    protected ConfigurationService configurationService;
+
+    private static final Pattern DOI_URL_PATTERN
+            = Pattern.compile("http(s)?://([a-z0-9-.]+)?doi.org(?<path>/.*)",
+                    Pattern.CASE_INSENSITIVE);
+    private static final String DOI_URL_PATTERN_PATH_GROUP = "path";
 
     protected DOIServiceImpl() {
 
@@ -66,17 +76,38 @@ public class DOIServiceImpl implements DOIService {
         if (null == identifier) {
             throw new IllegalArgumentException("Identifier is null.", new NullPointerException());
         }
+
         if (identifier.isEmpty()) {
             throw new IllegalArgumentException("Cannot format an empty identifier.");
         }
-        if (identifier.startsWith(DOI.SCHEME)) {
-            return DOI.RESOLVER + "/" + identifier.substring(DOI.SCHEME.length());
+
+        String resolver = getResolver();
+
+        if (identifier.startsWith(DOI.SCHEME)) { // doi:something
+            StringBuilder result = new StringBuilder(resolver);
+            if (!resolver.endsWith("/")) {
+                result.append('/');
+            }
+            result.append(identifier.substring(DOI.SCHEME.length()));
+            return result.toString();
         }
-        if (identifier.startsWith("10.") && identifier.contains("/")) {
-            return DOI.RESOLVER + "/" + identifier;
+
+        if (identifier.startsWith("10.") && identifier.contains("/")) { // 10.something
+            StringBuilder result = new StringBuilder(resolver);
+            if (!resolver.endsWith("/")) {
+                result.append('/');
+            }
+            result.append(identifier);
+            return result.toString();
         }
-        if (identifier.startsWith(DOI.RESOLVER + "/10.")) {
+
+        if (identifier.startsWith(resolver + "/10.")) { // https://doi.org/10.something
             return identifier;
+        }
+
+        Matcher matcher = DOI_URL_PATTERN.matcher(identifier);
+        if (DOI_URL_PATTERN.matcher(identifier).matches()) { // various old URL forms
+            return resolver + matcher.group(DOI_URL_PATTERN_PATH_GROUP);
         }
 
         throw new IdentifierException(identifier + "does not seem to be a DOI.");
@@ -84,7 +115,7 @@ public class DOIServiceImpl implements DOIService {
 
     @Override
     public String DOIFromExternalFormat(String identifier) throws DOIIdentifierException {
-        Pattern pattern = Pattern.compile("^" + DOI.RESOLVER + "/+(10\\..*)$");
+        Pattern pattern = Pattern.compile("^" + getResolver() + "/+(10\\..*)$");
         Matcher matcher = pattern.matcher(identifier);
         if (matcher.find()) {
             return DOI.SCHEME + matcher.group(1);
@@ -99,18 +130,29 @@ public class DOIServiceImpl implements DOIService {
         if (null == identifier) {
             throw new IllegalArgumentException("Identifier is null.", new NullPointerException());
         }
-        if (identifier.startsWith(DOI.SCHEME)) {
-            return identifier;
-        }
+
         if (identifier.isEmpty()) {
             throw new IllegalArgumentException("Cannot format an empty identifier.");
         }
-        if (identifier.startsWith("10.") && identifier.contains("/")) {
+
+        if (identifier.startsWith(DOI.SCHEME)) { // doi:something
+            return identifier;
+        }
+
+        if (identifier.startsWith("10.") && identifier.contains("/")) { // 10.something
             return DOI.SCHEME + identifier;
         }
-        if (identifier.startsWith(DOI.RESOLVER + "/10.")) {
-            return DOI.SCHEME + identifier.substring(18);
+
+        String resolver = getResolver();
+        if (identifier.startsWith(resolver + "/10.")) { //https://doi.org/10.something
+            return DOI.SCHEME + identifier.substring(resolver.length());
         }
+
+        Matcher matcher = DOI_URL_PATTERN.matcher(identifier);
+        if (matcher.matches()) { // various old URL forms
+            return DOI.SCHEME + matcher.group(DOI_URL_PATTERN_PATH_GROUP).substring(1);
+        }
+
         throw new DOIIdentifierException(identifier + "does not seem to be a DOI.",
                                          DOIIdentifierException.UNRECOGNIZED);
     }
@@ -125,5 +167,14 @@ public class DOIServiceImpl implements DOIService {
                                               boolean dsoIsNotNull)
         throws SQLException {
         return doiDAO.findSimilarNotInState(context, doiPattern, statuses, dsoIsNotNull);
+    }
+
+    @Override
+    public String getResolver() {
+        String resolver = configurationService.getProperty("identifier.doi.resolver", "https://doi.org");
+        if (resolver.endsWith("/")) {
+            resolver = resolver.substring(0, resolver.length() - 1);
+        }
+        return resolver;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/identifier/DOIServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/DOIServiceImpl.java
@@ -40,6 +40,8 @@ public class DOIServiceImpl implements DOIService {
             = Pattern.compile("http(s)?://([a-z0-9-.]+)?doi.org(?<path>/.*)",
                     Pattern.CASE_INSENSITIVE);
     private static final String DOI_URL_PATTERN_PATH_GROUP = "path";
+    
+    private static final String RESOLVER_DEFAULT = "https://doi.org";
 
     protected DOIServiceImpl() {
 
@@ -171,7 +173,8 @@ public class DOIServiceImpl implements DOIService {
 
     @Override
     public String getResolver() {
-        String resolver = configurationService.getProperty("identifier.doi.resolver", "https://doi.org");
+        String resolver = configurationService.getProperty("identifier.doi.resolver", 
+                RESOLVER_DEFAULT);
         if (resolver.endsWith("/")) {
             resolver = resolver.substring(0, resolver.length() - 1);
         }

--- a/dspace-api/src/main/java/org/dspace/identifier/DOIServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/DOIServiceImpl.java
@@ -40,7 +40,7 @@ public class DOIServiceImpl implements DOIService {
             = Pattern.compile("http(s)?://([a-z0-9-.]+)?doi.org(?<path>/.*)",
                     Pattern.CASE_INSENSITIVE);
     private static final String DOI_URL_PATTERN_PATH_GROUP = "path";
-    
+
     private static final String RESOLVER_DEFAULT = "https://doi.org";
 
     protected DOIServiceImpl() {
@@ -173,7 +173,7 @@ public class DOIServiceImpl implements DOIService {
 
     @Override
     public String getResolver() {
-        String resolver = configurationService.getProperty("identifier.doi.resolver", 
+        String resolver = configurationService.getProperty("identifier.doi.resolver",
                 RESOLVER_DEFAULT);
         if (resolver.endsWith("/")) {
             resolver = resolver.substring(0, resolver.length() - 1);

--- a/dspace-api/src/main/java/org/dspace/identifier/service/DOIService.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/service/DOIService.java
@@ -88,8 +88,8 @@ public interface DOIService {
      *
      * @param identifier A DOI that should be returned in external form.
      * @return A String containing a URL to the official DOI resolver.
-     * @throws IllegalArgumentException                  If identifier is null or an empty String.
-     * @throws org.dspace.identifier.IdentifierException If identifier could not be recognized as valid DOI.
+     * @throws IllegalArgumentException If identifier is null or an empty String.
+     * @throws IdentifierException      If identifier could not be recognized as valid DOI.
      */
     public String DOIToExternalForm(String identifier)
         throws IdentifierException;

--- a/dspace-api/src/main/java/org/dspace/identifier/service/DOIService.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/service/DOIService.java
@@ -17,25 +17,64 @@ import org.dspace.identifier.IdentifierException;
 import org.dspace.identifier.doi.DOIIdentifierException;
 
 /**
- * Service interface class for the DOI object.
- * The implementation of this class is responsible for all business logic calls for the DOI object and is autowired
- * by spring
+ * Service interface class for the {@link DOI} object.
+ * The implementation of this class is responsible for all business logic calls
+ * for the {@link DOI} object and is autowired by Spring.
  *
  * @author kevinvandevelde at atmire.com
  */
 public interface DOIService {
 
+    /**
+     * Update a DOI in storage.
+     *
+     * @param context current DSpace session.
+     * @param doi the DOI to persist.
+     * @throws SQLException passed through.
+     */
     public void update(Context context, DOI doi) throws SQLException;
 
+    /**
+     * Create a new DOI in storage.
+     *
+     * @param context current DSpace session.
+     * @return the new DOI.
+     * @throws SQLException passed through.
+     */
     public DOI create(Context context) throws SQLException;
 
+    /**
+     * Find a specific DOI in storage.
+     *
+     * @param context current DSpace session.
+     * @param doi string representation of the DOI.
+     * @return the DOI object found.
+     * @throws SQLException passed through, can mean none found.
+     */
     public DOI findByDoi(Context context, String doi) throws SQLException;
 
+    /**
+     * Find the DOI assigned to a given DSpace Object.
+     *
+     * @param context current DSpace session.
+     * @param dso The DSpace Object.
+     * @return the DSO's DOI.
+     * @throws SQLException passed through.
+     */
     public DOI findDOIByDSpaceObject(Context context, DSpaceObject dso) throws SQLException;
 
+    /**
+     * Find the DOI assigned to a given DSpace Object, unless it has one of a
+     * given set of statuses.
+     *
+     * @param context current DSpace context.
+     * @param dso the DSpace Object.
+     * @param statusToExclude uninteresting statuses.
+     * @return the DSO's DOI.
+     * @throws SQLException passed through.
+     */
     public DOI findDOIByDSpaceObject(Context context, DSpaceObject dso, List<Integer> statusToExclude)
         throws SQLException;
-
 
     /**
      * This method helps to convert a DOI into a URL. It takes DOIs in one of
@@ -55,6 +94,12 @@ public interface DOIService {
     public String DOIToExternalForm(String identifier)
         throws IdentifierException;
 
+    /**
+     * Convert an HTTP DOI URL (https://doi.org/10.something) to a "doi:" URI.
+     * @param identifier HTTP URL
+     * @return DOI URI
+     * @throws DOIIdentifierException if {@link identifier} is not recognizable.
+     */
     public String DOIFromExternalFormat(String identifier)
         throws DOIIdentifierException;
 
@@ -64,16 +109,24 @@ public interface DOIService {
      * @param identifier Identifier to format, following format are accepted:
      *                   f.e. 10.123/456, doi:10.123/456, http://dx.doi.org/10.123/456.
      * @return Given Identifier with DOI-Scheme, f.e. doi:10.123/456.
-     * @throws IllegalArgumentException                         If identifier is empty or null.
-     * @throws org.dspace.identifier.doi.DOIIdentifierException If DOI could not be recognized.
+     * @throws IllegalArgumentException If identifier is empty or null.
+     * @throws DOIIdentifierException   If DOI could not be recognized.
      */
     public String formatIdentifier(String identifier)
         throws DOIIdentifierException;
 
+    /**
+     * Find all DOIs that have one of a given set of statuses.
+     * @param context current DSpace session.
+     * @param statuses desired statuses.
+     * @return all DOIs having any of the given statuses.
+     * @throws SQLException passed through.
+     */
     public List<DOI> getDOIsByStatus(Context context, List<Integer> statuses) throws SQLException;
 
     /**
-     * Find all DOIs that are similar to the specified pattern ant not in the specified states.
+     * Find all DOIs that are similar to the specified pattern and not in the
+     * specified states.
      *
      * @param context      DSpace context
      * @param doiPattern   The pattern, e.g. "10.5072/123.%"

--- a/dspace-api/src/main/java/org/dspace/identifier/service/DOIService.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/service/DOIService.java
@@ -138,4 +138,11 @@ public interface DOIService {
     public List<DOI> getSimilarDOIsNotInState(Context context, String doiPattern, List<Integer> statuses,
                                               boolean dsoIsNotNull)
         throws SQLException;
+
+    /**
+     * Get the URL stem of the DOI resolver, e.g. "https://doi.org/".
+     *
+     * @return URL to the DOI resolver.
+     */
+    public String getResolver();
 }

--- a/dspace-api/src/test/java/org/dspace/identifier/DOIIdentifierProviderTest.java
+++ b/dspace-api/src/test/java/org/dspace/identifier/DOIIdentifierProviderTest.java
@@ -187,7 +187,7 @@ public class DOIIdentifierProviderTest
         List<String> remainder = new ArrayList<>();
 
         for (MetadataValue id : metadata) {
-            if (!id.getValue().startsWith(DOI.RESOLVER)) {
+            if (!id.getValue().startsWith(doiService.getResolver())) {
                 remainder.add(id.getValue());
             }
         }
@@ -274,11 +274,11 @@ public class DOIIdentifierProviderTest
             PREFIX + "/" + NAMESPACE_SEPARATOR + "lkjljasd1234",
             DOI.SCHEME + "10.5072/123abc-lkj/kljl",
             "http://dx.doi.org/10.5072/123abc-lkj/kljl",
-            DOI.RESOLVER + "/10.5072/123abc-lkj/kljl"
+            doiService.getResolver() + "/10.5072/123abc-lkj/kljl"
         };
 
         for (String doi : validDOIs) {
-            assertTrue("DOI should be supported", provider.supports(doi));
+            assertTrue("DOI " + doi + " should be supported", provider.supports(doi));
         }
     }
 

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -219,9 +219,14 @@ logging.server.max-payload-length = 10000
 # Credentials used to authenticate against the registration agency:
 identifier.doi.user = username
 identifier.doi.password = password
+
+# URL for the DOI resolver.  This will be the stem for generated DOIs.
+#identifier.doi.resolver = https://doi.org
+
 # DOI prefix used to mint DOIs. All DOIs minted by DSpace will use this prefix.
 # The Prefix will be assigned by the registration agency.
 identifier.doi.prefix = 10.5072
+
 # If you want to, you can further separate your namespace. Should all the
 # suffixes of all DOIs minted by DSpace start with a special string to separate
 # it from other services also minting DOIs under your prefix?


### PR DESCRIPTION
## References
* Partially addresses #3287

## Description
Make the non-local part of DOI URLs configurable.  We have a hard-coded URL stem that is now deprecated.

## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* First, ...
* Second, ...

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
