### PR TITLE
[DS-4548] Rename DSpace's LogManager to LogHelper.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/administer/RegistryLoader.java
+++ b/dspace-api/src/main/java/org/dspace/administer/RegistryLoader.java
@@ -24,7 +24,7 @@ import org.dspace.content.BitstreamFormat;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.BitstreamFormatService;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -95,7 +95,7 @@ public class RegistryLoader {
 
             System.exit(1);
         } catch (Exception e) {
-            log.fatal(LogManager.getHeader(context, "error_loading_registries",
+            log.fatal(LogHelper.getHeader(context, "error_loading_registries",
                                            ""), e);
 
             System.err.println("Error: \n - " + e.getMessage());
@@ -135,7 +135,7 @@ public class RegistryLoader {
             loadFormat(context, n);
         }
 
-        log.info(LogManager.getHeader(context, "load_bitstream_formats",
+        log.info(LogHelper.getHeader(context, "load_bitstream_formats",
                                       "number_loaded=" + typeNodes.getLength()));
     }
 

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
@@ -53,7 +53,7 @@ import org.dspace.content.service.RelationshipTypeService;
 import org.dspace.content.service.WorkspaceItemService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.handle.factory.HandleServiceFactory;
@@ -640,7 +640,7 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
             all += part + ",";
         }
         all = all.substring(0, all.length());
-        log.debug(LogManager.getHeader(c, "metadata_import",
+        log.debug(LogHelper.getHeader(c, "metadata_import",
                                        "item_id=" + item.getID() + ",fromCSV=" + all));
 
         // Don't compare collections or actions or rowNames
@@ -677,7 +677,7 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
                 qualifier = qualifier.substring(0, qualifier.indexOf('['));
             }
         }
-        log.debug(LogManager.getHeader(c, "metadata_import",
+        log.debug(LogHelper.getHeader(c, "metadata_import",
                                        "item_id=" + item.getID() + ",fromCSV=" + all +
                                            ",looking_for_schema=" + schema +
                                            ",looking_for_element=" + element +
@@ -697,7 +697,7 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
                         .getConfidence() : Choices.CF_ACCEPTED);
                 }
                 i++;
-                log.debug(LogManager.getHeader(c, "metadata_import",
+                log.debug(LogHelper.getHeader(c, "metadata_import",
                                                "item_id=" + item.getID() + ",fromCSV=" + all +
                                                    ",found=" + dcv.getValue()));
             }
@@ -748,7 +748,7 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
             // column "dc.contributor.author" so don't remove it
             if ((value != null) && (!"".equals(value)) && (!contains(value, fromCSV)) && fromAuthority == null) {
                 // Remove it
-                log.debug(LogManager.getHeader(c, "metadata_import",
+                log.debug(LogHelper.getHeader(c, "metadata_import",
                                                "item_id=" + item.getID() + ",fromCSV=" + all +
                                                    ",removing_schema=" + schema +
                                                    ",removing_element=" + element +

--- a/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExportServiceImpl.java
@@ -51,7 +51,7 @@ import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.core.Email;
 import org.dspace.core.I18nUtil;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.core.Utils;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.service.EPersonService;
@@ -936,7 +936,7 @@ public class ItemExportServiceImpl implements ItemExportService {
 
             email.send();
         } catch (Exception e) {
-            log.warn(LogManager.getHeader(context, "emailSuccessMessage", "cannot notify user of export"), e);
+            log.warn(LogHelper.getHeader(context, "emailSuccessMessage", "cannot notify user of export"), e);
         }
     }
 

--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
@@ -82,7 +82,7 @@ import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.core.Email;
 import org.dspace.core.I18nUtil;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
 import org.dspace.eperson.service.EPersonService;
@@ -1689,7 +1689,7 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
 
             email.send();
         } catch (Exception e) {
-            log.warn(LogManager.getHeader(context, "emailSuccessMessage", "cannot notify user of import"), e);
+            log.warn(LogHelper.getHeader(context, "emailSuccessMessage", "cannot notify user of import"), e);
         }
     }
 

--- a/dspace-api/src/main/java/org/dspace/app/sherpa/submit/SHERPASubmitService.java
+++ b/dspace-api/src/main/java/org/dspace/app/sherpa/submit/SHERPASubmitService.java
@@ -18,7 +18,7 @@ import org.dspace.app.sherpa.SHERPAService;
 import org.dspace.app.sherpa.v2.SHERPAResponse;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 
 /**
  * SHERPASubmitService is
@@ -115,7 +115,7 @@ public class SHERPASubmitService {
     public Set<String> getISSNs(Context context, Item item) {
         Set<String> issns = new LinkedHashSet<String>();
         if (configuration.getIssnItemExtractors() == null) {
-            log.warn(LogManager.getHeader(context, "searchRelatedJournals",
+            log.warn(LogHelper.getHeader(context, "searchRelatedJournals",
                                           "no issnItemExtractors defined"));
             return null;
         }

--- a/dspace-api/src/main/java/org/dspace/app/sitemap/GenerateSitemaps.java
+++ b/dspace-api/src/main/java/org/dspace/app/sitemap/GenerateSitemaps.java
@@ -40,7 +40,7 @@ import org.dspace.content.service.CollectionService;
 import org.dspace.content.service.CommunityService;
 import org.dspace.content.service.ItemService;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.discovery.DiscoverQuery;
 import org.dspace.discovery.DiscoverResult;
 import org.dspace.discovery.SearchService;
@@ -284,7 +284,7 @@ public class GenerateSitemaps {
 
         if (makeHTMLMap) {
             int files = html.finish();
-            log.info(LogManager.getHeader(c, "write_sitemap",
+            log.info(LogHelper.getHeader(c, "write_sitemap",
                                           "type=html,num_files=" + files + ",communities="
                                               + comms.size() + ",collections=" + colls.size()
                                               + ",items=" + itemCount));
@@ -292,7 +292,7 @@ public class GenerateSitemaps {
 
         if (makeSitemapOrg) {
             int files = sitemapsOrg.finish();
-            log.info(LogManager.getHeader(c, "write_sitemap",
+            log.info(LogHelper.getHeader(c, "write_sitemap",
                                           "type=html,num_files=" + files + ",communities="
                                               + comms.size() + ",collections=" + colls.size()
                                               + ",items=" + itemCount));

--- a/dspace-api/src/main/java/org/dspace/app/statistics/LogAnalyser.java
+++ b/dspace-api/src/main/java/org/dspace/app/statistics/LogAnalyser.java
@@ -31,7 +31,7 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.core.Utils;
 import org.dspace.discovery.DiscoverQuery;
 import org.dspace.discovery.SearchServiceException;
@@ -1144,17 +1144,17 @@ public class LogAnalyser {
         if (match.matches()) {
             // set up a new log line object
             LogLine logLine = new LogLine(parseDate(match.group(1).trim()),
-                                          LogManager.unescapeLogField(match.group(2)).trim(),
-                                          LogManager.unescapeLogField(match.group(3)).trim(),
-                                          LogManager.unescapeLogField(match.group(4)).trim(),
-                                          LogManager.unescapeLogField(match.group(5)).trim());
+                                          LogHelper.unescapeLogField(match.group(2)).trim(),
+                                          LogHelper.unescapeLogField(match.group(3)).trim(),
+                                          LogHelper.unescapeLogField(match.group(4)).trim(),
+                                          LogHelper.unescapeLogField(match.group(5)).trim());
 
             return logLine;
         } else {
             match = validBase.matcher(line);
             if (match.matches()) {
                 LogLine logLine = new LogLine(parseDate(match.group(1).trim()),
-                                              LogManager.unescapeLogField(match.group(2)).trim(),
+                                              LogHelper.unescapeLogField(match.group(2)).trim(),
                                               null,
                                               null,
                                               null

--- a/dspace-api/src/main/java/org/dspace/authenticate/IPAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/IPAuthentication.java
@@ -19,7 +19,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.logging.log4j.Logger;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.core.factory.CoreServiceFactory;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
@@ -194,7 +194,7 @@ public class IPAuthentication implements AuthenticationMethod {
 
                                 groups.add(group);
                             } else {
-                                log.warn(LogManager.getHeader(context,
+                                log.warn(LogHelper.getHeader(context,
                                                               "configuration_error", "unknown_group="
                                                                   + groupName));
                             }
@@ -202,7 +202,7 @@ public class IPAuthentication implements AuthenticationMethod {
                     }
                 }
             } catch (IPMatcherException ipme) {
-                log.warn(LogManager.getHeader(context, "configuration_error",
+                log.warn(LogHelper.getHeader(context, "configuration_error",
                                               "bad_ip=" + addr), ipme);
             }
         }
@@ -228,7 +228,7 @@ public class IPAuthentication implements AuthenticationMethod {
 
                                 groups.remove(group);
                             } else {
-                                log.warn(LogManager.getHeader(context,
+                                log.warn(LogHelper.getHeader(context,
                                                               "configuration_error", "unknown_group="
                                                                   + groupName));
                             }
@@ -236,7 +236,7 @@ public class IPAuthentication implements AuthenticationMethod {
                     }
                 }
             } catch (IPMatcherException ipme) {
-                log.warn(LogManager.getHeader(context, "configuration_error",
+                log.warn(LogHelper.getHeader(context, "configuration_error",
                                               "bad_ip=" + addr), ipme);
             }
         }
@@ -248,7 +248,7 @@ public class IPAuthentication implements AuthenticationMethod {
                 gsb.append(group.getID()).append(", ");
             }
 
-            log.debug(LogManager.getHeader(context, "authenticated",
+            log.debug(LogHelper.getHeader(context, "authenticated",
                                            "special_groups=" + gsb.toString()
                                            + " (by IP=" + addr + ", useProxies=" + useProxies.toString() + ")"
                                           ));

--- a/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
@@ -36,7 +36,7 @@ import org.dspace.authenticate.factory.AuthenticateServiceFactory;
 import org.dspace.authenticate.service.AuthenticationService;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
 import org.dspace.eperson.factory.EPersonServiceFactory;
@@ -156,7 +156,7 @@ public class LDAPAuthentication
                     Group ldapGroup = groupService.findByName(context, groupName);
                     if (ldapGroup == null) {
                         // Oops - the group isn't there.
-                        log.warn(LogManager.getHeader(context,
+                        log.warn(LogHelper.getHeader(context,
                                                       "ldap_specialgroup",
                                                       "Group defined in login.specialgroup does not exist"));
                         return Collections.EMPTY_LIST;
@@ -211,7 +211,7 @@ public class LDAPAuthentication
                             String realm,
                             HttpServletRequest request)
         throws SQLException {
-        log.info(LogManager.getHeader(context, "auth", "attempting trivial auth of user=" + netid));
+        log.info(LogHelper.getHeader(context, "auth", "attempting trivial auth of user=" + netid));
 
         // Skip out when no netid or password is given.
         if (netid == null || password == null) {
@@ -245,7 +245,7 @@ public class LDAPAuthentication
 
         // Check a DN was found
         if ((dn == null) || (dn.trim().equals(""))) {
-            log.info(LogManager
+            log.info(LogHelper
                          .getHeader(context, "failed_login", "no DN found for user " + netid));
             return BAD_CREDENTIALS;
         }
@@ -265,7 +265,7 @@ public class LDAPAuthentication
                 // assign user to groups based on ldap dn
                 assignGroups(dn, ldap.ldapGroup, context);
 
-                log.info(LogManager
+                log.info(LogHelper
                              .getHeader(context, "authenticate", "type=ldap"));
                 return SUCCESS;
             } else {
@@ -277,7 +277,7 @@ public class LDAPAuthentication
 
             if (ldap.ldapAuthenticate(dn, password, context)) {
                 // Register the new user automatically
-                log.info(LogManager.getHeader(context,
+                log.info(LogHelper.getHeader(context,
                                               "autoregister", "netid=" + netid));
 
                 String email = ldap.ldapEmail;
@@ -290,7 +290,7 @@ public class LDAPAuthentication
                         email = netid + configurationService.getProperty("authentication-ldap.netid_email_domain");
                     } else {
                         // We don't have a valid email address. We'll default it to 'netid' but log a warning
-                        log.warn(LogManager.getHeader(context, "autoregister",
+                        log.warn(LogHelper.getHeader(context, "autoregister",
                                                       "Unable to locate email address for account '" + netid + "', so" +
                                                           " it has been set to '" + netid + "'. " +
                                                           "Please check the LDAP 'email_field' OR consider " +
@@ -303,7 +303,7 @@ public class LDAPAuthentication
                     try {
                         eperson = ePersonService.findByEmail(context, email);
                         if (eperson != null) {
-                            log.info(LogManager.getHeader(context,
+                            log.info(LogHelper.getHeader(context,
                                                           "type=ldap-login", "type=ldap_but_already_email"));
                             context.turnOffAuthorisationSystem();
                             eperson.setNetid(netid.toLowerCase());
@@ -350,12 +350,12 @@ public class LDAPAuthentication
                                     context.restoreAuthSystemState();
                                 }
 
-                                log.info(LogManager.getHeader(context, "authenticate",
+                                log.info(LogHelper.getHeader(context, "authenticate",
                                                               "type=ldap-login, created ePerson"));
                                 return SUCCESS;
                             } else {
                                 // No auto-registration for valid certs
-                                log.info(LogManager.getHeader(context,
+                                log.info(LogHelper.getHeader(context,
                                                               "failed_login", "type=ldap_but_no_record"));
                                 return NO_SUCH_USER;
                             }
@@ -429,7 +429,7 @@ public class LDAPAuthentication
             } catch (NumberFormatException e) {
                 // Log the error if it has been set but is invalid
                 if (ldap_search_scope != null) {
-                    log.warn(LogManager.getHeader(context,
+                    log.warn(LogHelper.getHeader(context,
                                                   "ldap_authentication", "invalid search scope: " + ldap_search_scope));
                 }
             }
@@ -548,19 +548,19 @@ public class LDAPAuthentication
                             // Ambiguous user, can't continue
 
                         } else {
-                            log.debug(LogManager.getHeader(context, "got DN", resultDN));
+                            log.debug(LogHelper.getHeader(context, "got DN", resultDN));
                             return resultDN;
                         }
                     }
                 } catch (NamingException e) {
                     // if the lookup fails go ahead and create a new record for them because the authentication
                     // succeeded
-                    log.warn(LogManager.getHeader(context,
+                    log.warn(LogHelper.getHeader(context,
                                                   "ldap_attribute_lookup", "type=failed_search "
                                                       + e));
                 }
             } catch (NamingException | IOException e) {
-                log.warn(LogManager.getHeader(context,
+                log.warn(LogHelper.getHeader(context,
                                               "ldap_authentication", "type=failed_auth " + e));
             } finally {
                 // Close the context when we're done
@@ -630,7 +630,7 @@ public class LDAPAuthentication
                     }
                 } catch (NamingException | IOException e) {
                     // something went wrong (like wrong password) so return false
-                    log.warn(LogManager.getHeader(context,
+                    log.warn(LogHelper.getHeader(context,
                                                   "ldap_authentication", "type=failed_auth " + e));
                     return false;
                 } finally {
@@ -714,18 +714,18 @@ public class LDAPAuthentication
                             groupService.update(context, ldapGroup);
                         } else {
                             // The group does not exist
-                            log.warn(LogManager.getHeader(context,
+                            log.warn(LogHelper.getHeader(context,
                                                           "ldap_assignGroupsBasedOnLdapDn",
                                                           "Group defined in authentication-ldap.login.groupmap." + i
                                                               + " does not exist :: " + dspaceGroupName));
                         }
                     } catch (AuthorizeException ae) {
-                        log.debug(LogManager.getHeader(context,
+                        log.debug(LogHelper.getHeader(context,
                                                        "assignGroupsBasedOnLdapDn could not authorize addition to " +
                                                            "group",
                                                        dspaceGroupName));
                     } catch (SQLException e) {
-                        log.debug(LogManager.getHeader(context, "assignGroupsBasedOnLdapDn could not find group",
+                        log.debug(LogHelper.getHeader(context, "assignGroupsBasedOnLdapDn could not find group",
                                                        dspaceGroupName));
                     }
                 }

--- a/dspace-api/src/main/java/org/dspace/authenticate/PasswordAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/PasswordAuthentication.java
@@ -17,7 +17,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
 import org.dspace.eperson.factory.EPersonServiceFactory;
@@ -147,7 +147,7 @@ public class PasswordAuthentication
                                                               .findByName(context, groupName);
                     if (specialGroup == null) {
                         // Oops - the group isn't there.
-                        log.warn(LogManager.getHeader(context,
+                        log.warn(LogHelper.getHeader(context,
                                                       "password_specialgroup",
                                                       "Group defined in modules/authentication-password.cfg login" +
                                                           ".specialgroup does not exist"));
@@ -158,7 +158,7 @@ public class PasswordAuthentication
                 }
             }
         } catch (Exception e) {
-            log.error(LogManager.getHeader(context, "getSpecialGroups", ""), e);
+            log.error(LogHelper.getHeader(context, "getSpecialGroups", ""), e);
         }
         return Collections.EMPTY_LIST;
     }
@@ -196,7 +196,7 @@ public class PasswordAuthentication
         throws SQLException {
         if (username != null && password != null) {
             EPerson eperson = null;
-            log.info(LogManager.getHeader(context, "authenticate", "attempting password auth of user=" + username));
+            log.info(LogHelper.getHeader(context, "authenticate", "attempting password auth of user=" + username));
             eperson = EPersonServiceFactory.getInstance().getEPersonService()
                                            .findByEmail(context, username.toLowerCase());
 
@@ -208,7 +208,7 @@ public class PasswordAuthentication
                 return BAD_ARGS;
             } else if (eperson.getRequireCertificate()) {
                 // this user can only login with x.509 certificate
-                log.warn(LogManager.getHeader(context, "authenticate",
+                log.warn(LogHelper.getHeader(context, "authenticate",
                                               "rejecting PasswordAuthentication because " + username + " requires " +
                                                   "certificate."));
                 return CERT_REQUIRED;
@@ -216,7 +216,7 @@ public class PasswordAuthentication
                                             .checkPassword(context, eperson, password)) {
                 // login is ok if password matches:
                 context.setCurrentUser(eperson);
-                log.info(LogManager.getHeader(context, "authenticate", "type=PasswordAuthentication"));
+                log.info(LogHelper.getHeader(context, "authenticate", "type=PasswordAuthentication"));
                 return SUCCESS;
             } else {
                 return BAD_CREDENTIALS;

--- a/dspace-api/src/main/java/org/dspace/authenticate/X509Authentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/X509Authentication.java
@@ -35,7 +35,7 @@ import org.dspace.authenticate.factory.AuthenticateServiceFactory;
 import org.dspace.authenticate.service.AuthenticationService;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
 import org.dspace.eperson.factory.EPersonServiceFactory;
@@ -286,7 +286,7 @@ public class X509Authentication implements AuthenticationMethod {
         try {
             certificate.checkValidity();
         } catch (CertificateException e) {
-            log.info(LogManager.getHeader(context, "authentication",
+            log.info(LogHelper.getHeader(context, "authentication",
                                           "X.509 Certificate is EXPIRED or PREMATURE: "
                                               + e.toString()));
             return false;
@@ -298,7 +298,7 @@ public class X509Authentication implements AuthenticationMethod {
                 certificate.verify(caPublicKey);
                 return true;
             } catch (GeneralSecurityException e) {
-                log.info(LogManager.getHeader(context, "authentication",
+                log.info(LogHelper.getHeader(context, "authentication",
                                               "X.509 Certificate FAILED SIGNATURE check: "
                                                   + e.toString()));
             }
@@ -322,11 +322,11 @@ public class X509Authentication implements AuthenticationMethod {
                     }
                 }
                 log
-                    .info(LogManager
+                    .info(LogHelper
                               .getHeader(context, "authentication",
                                          "Keystore method FAILED SIGNATURE check on client cert."));
             } catch (GeneralSecurityException e) {
-                log.info(LogManager.getHeader(context, "authentication",
+                log.info(LogHelper.getHeader(context, "authentication",
                                               "X.509 Certificate FAILED SIGNATURE check: "
                                                   + e.toString()));
             }
@@ -461,7 +461,7 @@ public class X509Authentication implements AuthenticationMethod {
                         if (group != null) {
                             groups.add(group);
                         } else {
-                            log.warn(LogManager.getHeader(context,
+                            log.warn(LogHelper.getHeader(context,
                                                           "configuration_error", "unknown_group="
                                                               + groupName));
                         }
@@ -513,7 +513,7 @@ public class X509Authentication implements AuthenticationMethod {
             try {
                 if (!isValid(context, certs[0])) {
                     log
-                        .warn(LogManager
+                        .warn(LogHelper
                                   .getHeader(context, "authenticate",
                                              "type=x509certificate, status=BAD_CREDENTIALS (not valid)"));
                     return BAD_CREDENTIALS;
@@ -530,7 +530,7 @@ public class X509Authentication implements AuthenticationMethod {
                     if (email != null
                         && canSelfRegister(context, request, null)) {
                         // Register the new user automatically
-                        log.info(LogManager.getHeader(context, "autoregister",
+                        log.info(LogHelper.getHeader(context, "autoregister",
                                                       "from=x.509, email=" + email));
 
                         // TEMPORARILY turn off authorisation
@@ -549,25 +549,25 @@ public class X509Authentication implements AuthenticationMethod {
                     } else {
                         // No auto-registration for valid certs
                         log
-                            .warn(LogManager
+                            .warn(LogHelper
                                       .getHeader(context, "authenticate",
                                                  "type=cert_but_no_record, cannot auto-register"));
                         return NO_SUCH_USER;
                     }
                 } else if (!eperson.canLogIn()) { // make sure this is a login account
-                    log.warn(LogManager.getHeader(context, "authenticate",
+                    log.warn(LogHelper.getHeader(context, "authenticate",
                                                   "type=x509certificate, email=" + email
                                                       + ", canLogIn=false, rejecting."));
                     return BAD_ARGS;
                 } else {
-                    log.info(LogManager.getHeader(context, "login",
+                    log.info(LogHelper.getHeader(context, "login",
                                                   "type=x509certificate"));
                     context.setCurrentUser(eperson);
                     setSpecialGroupsFlag(request, email);
                     return SUCCESS;
                 }
             } catch (AuthorizeException ce) {
-                log.warn(LogManager.getHeader(context, "authorize_exception",
+                log.warn(LogHelper.getHeader(context, "authorize_exception",
                                               ""), ce);
             }
 

--- a/dspace-api/src/main/java/org/dspace/authority/AuthorityValueServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authority/AuthorityValueServiceImpl.java
@@ -21,7 +21,7 @@ import org.apache.solr.common.SolrDocument;
 import org.dspace.authority.service.AuthorityValueService;
 import org.dspace.content.authority.SolrAuthority;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -220,7 +220,7 @@ public class AuthorityValueServiceImpl implements AuthorityValueService {
                 }
             }
         } catch (Exception e) {
-            log.error(LogManager.getHeader(context, "Error while retrieving AuthorityValue from solr",
+            log.error(LogHelper.getHeader(context, "Error while retrieving AuthorityValue from solr",
                                            "query: " + queryString), e);
         }
 

--- a/dspace-api/src/main/java/org/dspace/browse/BrowseEngine.java
+++ b/dspace-api/src/main/java/org/dspace/browse/BrowseEngine.java
@@ -17,7 +17,7 @@ import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.sort.OrderFormat;
 import org.dspace.sort.SortOption;
 
@@ -85,7 +85,7 @@ public class BrowseEngine {
      */
     public BrowseInfo browse(BrowserScope bs)
         throws BrowseException {
-        log.debug(LogManager.getHeader(context, "browse", ""));
+        log.debug(LogHelper.getHeader(context, "browse", ""));
 
         // first, load the browse scope into the object
         this.scope = bs;
@@ -119,7 +119,7 @@ public class BrowseEngine {
      */
     public BrowseInfo browseMini(BrowserScope bs)
         throws BrowseException {
-        log.info(LogManager.getHeader(context, "browse_mini", ""));
+        log.info(LogHelper.getHeader(context, "browse_mini", ""));
 
         // load the scope into the object
         this.scope = bs;
@@ -198,7 +198,7 @@ public class BrowseEngine {
      */
     private BrowseInfo browseByItem(BrowserScope bs)
         throws BrowseException {
-        log.info(LogManager.getHeader(context, "browse_by_item", ""));
+        log.info(LogHelper.getHeader(context, "browse_by_item", ""));
         try {
             // get the table name that we are going to be getting our data from
             dao.setTable(browseIndex.getTableName());
@@ -374,7 +374,7 @@ public class BrowseEngine {
      */
     private BrowseInfo browseByValue(BrowserScope bs)
         throws BrowseException {
-        log.info(LogManager.getHeader(context, "browse_by_value", "focus=" + bs.getJumpToValue()));
+        log.info(LogHelper.getHeader(context, "browse_by_value", "focus=" + bs.getJumpToValue()));
 
         try {
             // get the table name that we are going to be getting our data from
@@ -518,17 +518,17 @@ public class BrowseEngine {
      */
     private String getJumpToValue()
         throws BrowseException {
-        log.debug(LogManager.getHeader(context, "get_focus_value", ""));
+        log.debug(LogHelper.getHeader(context, "get_focus_value", ""));
 
         // if the focus is by value, just return it
         if (scope.hasJumpToValue()) {
-            log.debug(LogManager.getHeader(context, "get_focus_value_return", "return=" + scope.getJumpToValue()));
+            log.debug(LogHelper.getHeader(context, "get_focus_value_return", "return=" + scope.getJumpToValue()));
             return scope.getJumpToValue();
         }
 
         // if the focus is to start with, then we need to return the value of the starts with
         if (scope.hasStartsWith()) {
-            log.debug(LogManager.getHeader(context, "get_focus_value_return", "return=" + scope.getStartsWith()));
+            log.debug(LogHelper.getHeader(context, "get_focus_value_return", "return=" + scope.getStartsWith()));
             return scope.getStartsWith();
         }
 
@@ -565,7 +565,7 @@ public class BrowseEngine {
         // item (I think)
         String max = dao.doMaxQuery(col, tableName, id);
 
-        log.debug(LogManager.getHeader(context, "get_focus_value_return", "return=" + max));
+        log.debug(LogHelper.getHeader(context, "get_focus_value_return", "return=" + max));
 
         return max;
     }
@@ -671,7 +671,7 @@ public class BrowseEngine {
      */
     private int getTotalResults(boolean distinct)
         throws SQLException, BrowseException {
-        log.debug(LogManager.getHeader(context, "get_total_results", "distinct=" + distinct));
+        log.debug(LogHelper.getHeader(context, "get_total_results", "distinct=" + distinct));
 
         // tell the browse query whether we are distinct
         dao.setDistinct(distinct);
@@ -706,7 +706,7 @@ public class BrowseEngine {
         dao.setOffset(offset);
         dao.setCountValues(null);
 
-        log.debug(LogManager.getHeader(context, "get_total_results_return", "return=" + count));
+        log.debug(LogHelper.getHeader(context, "get_total_results_return", "return=" + count));
 
         return count;
     }

--- a/dspace-api/src/main/java/org/dspace/content/BitstreamFormatServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BitstreamFormatServiceImpl.java
@@ -18,7 +18,7 @@ import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.content.dao.BitstreamFormatDAO;
 import org.dspace.content.service.BitstreamFormatService;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -68,7 +68,7 @@ public class BitstreamFormatServiceImpl implements BitstreamFormatService {
 
         if (bitstreamFormat == null) {
             if (log.isDebugEnabled()) {
-                log.debug(LogManager.getHeader(context,
+                log.debug(LogHelper.getHeader(context,
                                                "find_bitstream_format",
                                                "not_found,bitstream_format_id=" + id));
             }
@@ -78,7 +78,7 @@ public class BitstreamFormatServiceImpl implements BitstreamFormatService {
 
         // not null, return format object
         if (log.isDebugEnabled()) {
-            log.debug(LogManager.getHeader(context, "find_bitstream_format",
+            log.debug(LogHelper.getHeader(context, "find_bitstream_format",
                                            "bitstream_format_id=" + id));
         }
 
@@ -129,7 +129,7 @@ public class BitstreamFormatServiceImpl implements BitstreamFormatService {
         BitstreamFormat bitstreamFormat = bitstreamFormatDAO.create(context, new BitstreamFormat());
 
 
-        log.info(LogManager.getHeader(context, "create_bitstream_format",
+        log.info(LogHelper.getHeader(context, "create_bitstream_format",
                                       "bitstream_format_id="
                                           + bitstreamFormat.getID()));
 
@@ -189,7 +189,7 @@ public class BitstreamFormatServiceImpl implements BitstreamFormatService {
             }
 
             for (BitstreamFormat bitstreamFormat : bitstreamFormats) {
-                log.info(LogManager.getHeader(context, "update_bitstream_format",
+                log.info(LogHelper.getHeader(context, "update_bitstream_format",
                                               "bitstream_format_id=" + bitstreamFormat.getID()));
 
                 bitstreamFormatDAO.save(context, bitstreamFormat);
@@ -218,7 +218,7 @@ public class BitstreamFormatServiceImpl implements BitstreamFormatService {
         // Delete this format from database
         bitstreamFormatDAO.delete(context, bitstreamFormat);
 
-        log.info(LogManager.getHeader(context, "delete_bitstream_format",
+        log.info(LogHelper.getHeader(context, "delete_bitstream_format",
                                       "bitstream_format_id=" + bitstreamFormat.getID() + ",bitstreams_changed="
                                           + numberChanged));
     }

--- a/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
@@ -28,7 +28,7 @@ import org.dspace.content.service.BundleService;
 import org.dspace.content.service.ItemService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.event.Event;
 import org.dspace.storage.bitstore.service.BitstreamStorageService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -73,7 +73,7 @@ public class BitstreamServiceImpl extends DSpaceObjectServiceImpl<Bitstream> imp
 
         if (bitstream == null) {
             if (log.isDebugEnabled()) {
-                log.debug(LogManager.getHeader(context, "find_bitstream",
+                log.debug(LogHelper.getHeader(context, "find_bitstream",
                                                "not_found,bitstream_id=" + id));
             }
 
@@ -82,7 +82,7 @@ public class BitstreamServiceImpl extends DSpaceObjectServiceImpl<Bitstream> imp
 
         // not null, return Bitstream
         if (log.isDebugEnabled()) {
-            log.debug(LogManager.getHeader(context, "find_bitstream",
+            log.debug(LogHelper.getHeader(context, "find_bitstream",
                                            "bitstream_id=" + id));
         }
 
@@ -131,7 +131,7 @@ public class BitstreamServiceImpl extends DSpaceObjectServiceImpl<Bitstream> imp
         // Store the bits
         UUID bitstreamID = bitstreamStorageService.store(context, bitstreamDAO.create(context, new Bitstream()), is);
 
-        log.info(LogManager.getHeader(context, "create_bitstream",
+        log.info(LogHelper.getHeader(context, "create_bitstream",
                                       "bitstream_id=" + bitstreamID));
 
         // Set the format to "unknown"
@@ -191,7 +191,7 @@ public class BitstreamServiceImpl extends DSpaceObjectServiceImpl<Bitstream> imp
         bitstreamStorageService.register(
             context, bitstream, assetstore, bitstreamPath);
 
-        log.info(LogManager.getHeader(context,
+        log.info(LogHelper.getHeader(context,
                                       "create_bitstream",
                                       "bitstream_id=" + bitstream.getID()));
 
@@ -248,7 +248,7 @@ public class BitstreamServiceImpl extends DSpaceObjectServiceImpl<Bitstream> imp
         // Check authorisation
         authorizeService.authorizeAction(context, bitstream, Constants.WRITE);
 
-        log.info(LogManager.getHeader(context, "update_bitstream",
+        log.info(LogHelper.getHeader(context, "update_bitstream",
                                       "bitstream_id=" + bitstream.getID()));
         super.update(context, bitstream);
         if (bitstream.isModified()) {
@@ -273,7 +273,7 @@ public class BitstreamServiceImpl extends DSpaceObjectServiceImpl<Bitstream> imp
         // changed to a check on delete
         // Check authorisation
         authorizeService.authorizeAction(context, bitstream, Constants.DELETE);
-        log.info(LogManager.getHeader(context, "delete_bitstream",
+        log.info(LogHelper.getHeader(context, "delete_bitstream",
                                       "bitstream_id=" + bitstream.getID()));
 
         context.addEvent(new Event(Event.DELETE, Constants.BITSTREAM, bitstream.getID(),

--- a/dspace-api/src/main/java/org/dspace/content/BundleServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BundleServiceImpl.java
@@ -33,7 +33,7 @@ import org.dspace.content.service.BundleService;
 import org.dspace.content.service.ItemService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.event.Event;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -73,14 +73,14 @@ public class BundleServiceImpl extends DSpaceObjectServiceImpl<Bundle> implement
         Bundle bundle = bundleDAO.findByID(context, Bundle.class, id);
         if (bundle == null) {
             if (log.isDebugEnabled()) {
-                log.debug(LogManager.getHeader(context, "find_bundle",
+                log.debug(LogHelper.getHeader(context, "find_bundle",
                                                "not_found,bundle_id=" + id));
             }
 
             return null;
         } else {
             if (log.isDebugEnabled()) {
-                log.debug(LogManager.getHeader(context, "find_bundle",
+                log.debug(LogHelper.getHeader(context, "find_bundle",
                                                "bundle_id=" + id));
             }
 
@@ -105,7 +105,7 @@ public class BundleServiceImpl extends DSpaceObjectServiceImpl<Bundle> implement
         }
 
 
-        log.info(LogManager.getHeader(context, "create_bundle", "bundle_id="
+        log.info(LogHelper.getHeader(context, "create_bundle", "bundle_id="
             + bundle.getID()));
 
         // if we ever use the identifier service for bundles, we should
@@ -136,7 +136,7 @@ public class BundleServiceImpl extends DSpaceObjectServiceImpl<Bundle> implement
         // Check authorisation
         authorizeService.authorizeAction(context, bundle, Constants.ADD);
 
-        log.info(LogManager.getHeader(context, "add_bitstream", "bundle_id="
+        log.info(LogHelper.getHeader(context, "add_bitstream", "bundle_id="
             + bundle.getID() + ",bitstream_id=" + bitstream.getID()));
 
         // First check that the bitstream isn't already in the list
@@ -177,7 +177,7 @@ public class BundleServiceImpl extends DSpaceObjectServiceImpl<Bundle> implement
         // Check authorisation
         authorizeService.authorizeAction(context, bundle, Constants.REMOVE);
 
-        log.info(LogManager.getHeader(context, "remove_bitstream",
+        log.info(LogHelper.getHeader(context, "remove_bitstream",
                                       "bundle_id=" + bundle.getID() + ",bitstream_id=" + bitstream.getID()));
 
 
@@ -362,14 +362,14 @@ public class BundleServiceImpl extends DSpaceObjectServiceImpl<Bundle> implement
             // If we have an invalid Bitstream ID, just ignore it, but log a warning
             if (bitstream == null) {
                 //This should never occur but just in case
-                log.warn(LogManager.getHeader(context, "Invalid bitstream id while changing bitstream order",
+                log.warn(LogHelper.getHeader(context, "Invalid bitstream id while changing bitstream order",
                                               "Bundle: " + bundle.getID() + ", bitstream id: " + bitstreamId));
                 continue;
             }
 
             // If we have a Bitstream not in the current list, log a warning & exit immediately
             if (!currentBitstreams.contains(bitstream)) {
-                log.warn(LogManager.getHeader(context,
+                log.warn(LogHelper.getHeader(context,
                                               "Encountered a bitstream not in this bundle while changing bitstream " +
                                                   "order. Bitstream order will not be changed.",
                                               "Bundle: " + bundle.getID() + ", bitstream id: " + bitstreamId));
@@ -380,7 +380,7 @@ public class BundleServiceImpl extends DSpaceObjectServiceImpl<Bundle> implement
 
         // If our lists are different sizes, exit immediately
         if (updatedBitstreams.size() != currentBitstreams.size()) {
-            log.warn(LogManager.getHeader(context,
+            log.warn(LogHelper.getHeader(context,
                                           "Size of old list and new list do not match. Bitstream order will not be " +
                                               "changed.",
                                           "Bundle: " + bundle.getID()));
@@ -471,7 +471,7 @@ public class BundleServiceImpl extends DSpaceObjectServiceImpl<Bundle> implement
     public void update(Context context, Bundle bundle) throws SQLException, AuthorizeException {
         // Check authorisation
         //AuthorizeManager.authorizeAction(ourContext, this, Constants.WRITE);
-        log.info(LogManager.getHeader(context, "update_bundle", "bundle_id="
+        log.info(LogHelper.getHeader(context, "update_bundle", "bundle_id="
             + bundle.getID()));
 
         super.update(context, bundle);
@@ -491,7 +491,7 @@ public class BundleServiceImpl extends DSpaceObjectServiceImpl<Bundle> implement
 
     @Override
     public void delete(Context context, Bundle bundle) throws SQLException, AuthorizeException, IOException {
-        log.info(LogManager.getHeader(context, "delete_bundle", "bundle_id="
+        log.info(LogHelper.getHeader(context, "delete_bundle", "bundle_id="
             + bundle.getID()));
 
         authorizeService.authorizeAction(context, bundle, Constants.DELETE);

--- a/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
@@ -39,7 +39,7 @@ import org.dspace.content.service.WorkspaceItemService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.core.I18nUtil;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.core.service.LicenseService;
 import org.dspace.discovery.DiscoverQuery;
 import org.dspace.discovery.DiscoverResult;
@@ -167,7 +167,7 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
                                    newCollection.getID(), newCollection.getHandle(),
                                    getIdentifiers(context, newCollection)));
 
-        log.info(LogManager.getHeader(context, "create_collection",
+        log.info(LogHelper.getHeader(context, "create_collection",
                                       "collection_id=" + newCollection.getID())
                      + ",handle=" + newCollection.getHandle());
 
@@ -345,7 +345,7 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
 
         if (is == null) {
             collection.setLogo(null);
-            log.info(LogManager.getHeader(context, "remove_logo",
+            log.info(LogHelper.getHeader(context, "remove_logo",
                                           "collection_id=" + collection.getID()));
         } else {
             Bitstream newLogo = bitstreamService.create(context, is);
@@ -357,7 +357,7 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
                 .getPoliciesActionFilter(context, collection, Constants.READ);
             authorizeService.addPolicies(context, policies, newLogo);
 
-            log.info(LogManager.getHeader(context, "set_logo",
+            log.info(LogHelper.getHeader(context, "set_logo",
                                           "collection_id=" + collection.getID() + "logo_bitstream_id="
                                               + newLogo.getID()));
         }
@@ -393,7 +393,7 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
         try {
             workflow = workflowFactory.getWorkflow(collection);
         } catch (WorkflowConfigurationException e) {
-            log.error(LogManager.getHeader(context, "setWorkflowGroup",
+            log.error(LogHelper.getHeader(context, "setWorkflowGroup",
                     "collection_id=" + collection.getID() + " " + e.getMessage()), e);
         }
         if (!StringUtils.equals(workflowFactory.getDefaultWorkflow().getID(), workflow.getID())) {
@@ -569,7 +569,7 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
             Item template = itemService.createTemplateItem(context, collection);
             collection.setTemplateItem(template);
 
-            log.info(LogManager.getHeader(context, "create_template_item",
+            log.info(LogHelper.getHeader(context, "create_template_item",
                                           "collection_id=" + collection.getID() + ",template_item_id="
                                               + template.getID()));
         }
@@ -584,7 +584,7 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
         Item template = collection.getTemplateItem();
 
         if (template != null) {
-            log.info(LogManager.getHeader(context, "remove_template_item",
+            log.info(LogHelper.getHeader(context, "remove_template_item",
                                           "collection_id=" + collection.getID() + ",template_item_id="
                                               + template.getID()));
             // temporarily turn off auth system, we have already checked the permission on the top of the method
@@ -604,7 +604,7 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
         // Check authorisation
         authorizeService.authorizeAction(context, collection, Constants.ADD);
 
-        log.info(LogManager.getHeader(context, "add_item", "collection_id="
+        log.info(LogHelper.getHeader(context, "add_item", "collection_id="
             + collection.getID() + ",item_id=" + item.getID()));
 
         // Create mapping
@@ -645,7 +645,7 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
         // Check authorisation
         canEdit(context, collection, true);
 
-        log.info(LogManager.getHeader(context, "update_collection",
+        log.info(LogHelper.getHeader(context, "update_collection",
                                       "collection_id=" + collection.getID()));
 
         super.update(context, collection);
@@ -702,7 +702,7 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
 
     @Override
     public void delete(Context context, Collection collection) throws SQLException, AuthorizeException, IOException {
-        log.info(LogManager.getHeader(context, "delete_collection",
+        log.info(LogHelper.getHeader(context, "delete_collection",
                                       "collection_id=" + collection.getID()));
 
         // remove harvested collections.

--- a/dspace-api/src/main/java/org/dspace/content/CommunityServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CommunityServiceImpl.java
@@ -33,7 +33,7 @@ import org.dspace.content.service.SiteService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.core.I18nUtil;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.eperson.Group;
 import org.dspace.eperson.service.GroupService;
 import org.dspace.event.Event;
@@ -128,7 +128,7 @@ public class CommunityServiceImpl extends DSpaceObjectServiceImpl<Community> imp
                     getIdentifiers(context, newCommunity)));
         }
 
-        log.info(LogManager.getHeader(context, "create_community",
+        log.info(LogHelper.getHeader(context, "create_community",
                                       "community_id=" + newCommunity.getID())
                      + ",handle=" + newCommunity.getHandle());
 
@@ -218,7 +218,7 @@ public class CommunityServiceImpl extends DSpaceObjectServiceImpl<Community> imp
         // First, delete any existing logo
         Bitstream oldLogo = community.getLogo();
         if (oldLogo != null) {
-            log.info(LogManager.getHeader(context, "remove_logo",
+            log.info(LogHelper.getHeader(context, "remove_logo",
                                           "community_id=" + community.getID()));
             community.setLogo(null);
             bitstreamService.delete(context, oldLogo);
@@ -234,7 +234,7 @@ public class CommunityServiceImpl extends DSpaceObjectServiceImpl<Community> imp
                 .getPoliciesActionFilter(context, community, Constants.READ);
             authorizeService.addPolicies(context, policies, newLogo);
 
-            log.info(LogManager.getHeader(context, "set_logo",
+            log.info(LogHelper.getHeader(context, "set_logo",
                                           "community_id=" + community.getID() + "logo_bitstream_id="
                                               + newLogo.getID()));
         }
@@ -247,7 +247,7 @@ public class CommunityServiceImpl extends DSpaceObjectServiceImpl<Community> imp
         // Check authorisation
         canEdit(context, community);
 
-        log.info(LogManager.getHeader(context, "update_community",
+        log.info(LogHelper.getHeader(context, "update_community",
                                       "community_id=" + community.getID()));
 
         super.update(context, community);
@@ -365,7 +365,7 @@ public class CommunityServiceImpl extends DSpaceObjectServiceImpl<Community> imp
         // Check authorisation
         authorizeService.authorizeAction(context, community, Constants.ADD);
 
-        log.info(LogManager.getHeader(context, "add_collection",
+        log.info(LogHelper.getHeader(context, "add_collection",
                                       "community_id=" + community.getID() + ",collection_id=" + collection.getID()));
 
         if (!community.getCollections().contains(collection)) {
@@ -401,7 +401,7 @@ public class CommunityServiceImpl extends DSpaceObjectServiceImpl<Community> imp
         // Check authorisation
         authorizeService.authorizeAction(context, parentCommunity, Constants.ADD);
 
-        log.info(LogManager.getHeader(context, "add_subcommunity",
+        log.info(LogHelper.getHeader(context, "add_subcommunity",
                                       "parent_comm_id=" + parentCommunity.getID() + ",child_comm_id=" + childCommunity
                                           .getID()));
 
@@ -431,7 +431,7 @@ public class CommunityServiceImpl extends DSpaceObjectServiceImpl<Community> imp
             collection.removeCommunity(community);
         }
 
-        log.info(LogManager.getHeader(context, "remove_collection",
+        log.info(LogHelper.getHeader(context, "remove_collection",
                                       "community_id=" + community.getID() + ",collection_id=" + collection.getID()));
 
         // Remove any mappings
@@ -451,7 +451,7 @@ public class CommunityServiceImpl extends DSpaceObjectServiceImpl<Community> imp
 
         rawDelete(context, childCommunity);
 
-        log.info(LogManager.getHeader(context, "remove_subcommunity",
+        log.info(LogHelper.getHeader(context, "remove_subcommunity",
                                       "parent_comm_id=" + parentCommunity.getID() + ",child_comm_id=" + childCommunity
                                           .getID()));
 
@@ -519,7 +519,7 @@ public class CommunityServiceImpl extends DSpaceObjectServiceImpl<Community> imp
      */
     protected void rawDelete(Context context, Community community)
         throws SQLException, AuthorizeException, IOException {
-        log.info(LogManager.getHeader(context, "delete_community",
+        log.info(LogHelper.getHeader(context, "delete_community",
                                       "community_id=" + community.getID()));
 
         context.addEvent(new Event(Event.DELETE, Constants.COMMUNITY, community.getID(), community.getHandle(),

--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -47,7 +47,7 @@ import org.dspace.content.service.WorkspaceItemService;
 import org.dspace.content.virtual.VirtualMetadataPopulator;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
 import org.dspace.event.Event;
@@ -159,7 +159,7 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
         Item item = itemDAO.findByID(context, Item.class, id);
         if (item == null) {
             if (log.isDebugEnabled()) {
-                log.debug(LogManager.getHeader(context, "find_item",
+                log.debug(LogHelper.getHeader(context, "find_item",
                                                "not_found,item_id=" + id));
             }
             return null;
@@ -167,7 +167,7 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
 
         // not null, return item
         if (log.isDebugEnabled()) {
-            log.debug(LogManager.getHeader(context, "find_item", "item_id="
+            log.debug(LogHelper.getHeader(context, "find_item", "item_id="
                 + id));
         }
 
@@ -184,7 +184,7 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
         workspaceItem.setItem(item);
 
 
-        log.info(LogManager.getHeader(context, "create_item", "item_id="
+        log.info(LogHelper.getHeader(context, "create_item", "item_id="
             + item.getID()));
 
         return item;
@@ -202,7 +202,7 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
             collection.setTemplateItem(template);
             template.setTemplateItemOf(collection);
 
-            log.info(LogManager.getHeader(context, "create_template_item",
+            log.info(LogHelper.getHeader(context, "create_template_item",
                                           "collection_id=" + collection.getID() + ",template_item_id="
                                               + template.getID()));
 
@@ -340,7 +340,7 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
         // Check authorisation
         authorizeService.authorizeAction(context, item, Constants.ADD);
 
-        log.info(LogManager.getHeader(context, "add_bundle", "item_id="
+        log.info(LogHelper.getHeader(context, "add_bundle", "item_id="
             + item.getID() + ",bundle_id=" + bundle.getID()));
 
         // Check it's not already there
@@ -368,7 +368,7 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
         // Check authorisation
         authorizeService.authorizeAction(context, item, Constants.REMOVE);
 
-        log.info(LogManager.getHeader(context, "remove_bundle", "item_id="
+        log.info(LogHelper.getHeader(context, "remove_bundle", "item_id="
             + item.getID() + ",bundle_id=" + bundle.getID()));
 
         context.addEvent(new Event(Event.REMOVE, Constants.ITEM, item.getID(),
@@ -432,7 +432,7 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
         context.addEvent(new Event(Event.CREATE, Constants.ITEM, item.getID(),
                                    null, getIdentifiers(context, item)));
 
-        log.info(LogManager.getHeader(context, "create_item", "item_id=" + item.getID()));
+        log.info(LogHelper.getHeader(context, "create_item", "item_id=" + item.getID()));
 
         return item;
     }
@@ -490,7 +490,7 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
             authorizeService.authorizeAction(context, item, Constants.WRITE);
         }
 
-        log.info(LogManager.getHeader(context, "update_item", "item_id="
+        log.info(LogHelper.getHeader(context, "update_item", "item_id="
             + item.getID()));
 
         super.update(context, item);
@@ -595,7 +595,7 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
         }
 
         // Write log
-        log.info(LogManager.getHeader(context, "withdraw_item", "user="
+        log.info(LogHelper.getHeader(context, "withdraw_item", "user="
             + e.getEmail() + ",item_id=" + item.getID()));
     }
 
@@ -661,7 +661,7 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
         }
 
         // Write log
-        log.info(LogManager.getHeader(context, "reinstate_item", "user="
+        log.info(LogHelper.getHeader(context, "reinstate_item", "user="
             + e.getEmail() + ",item_id=" + item.getID()));
     }
 
@@ -682,7 +682,7 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
         context.addEvent(new Event(Event.DELETE, Constants.ITEM, item.getID(),
                                    item.getHandle(), getIdentifiers(context, item)));
 
-        log.info(LogManager.getHeader(context, "delete_item", "item_id="
+        log.info(LogHelper.getHeader(context, "delete_item", "item_id="
             + item.getID()));
 
         // Remove relationships
@@ -731,7 +731,7 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
 
         bundleService.delete(context, b);
 
-        log.info(LogManager.getHeader(context, "remove_bundle", "item_id="
+        log.info(LogHelper.getHeader(context, "remove_bundle", "item_id="
             + item.getID() + ",bundle_id=" + b.getID()));
         context
             .addEvent(new Event(Event.REMOVE, Constants.ITEM, item.getID(), Constants.BUNDLE, b.getID(), b.getName()));
@@ -802,7 +802,7 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
         adjustItemPolicies(context, item, collection);
         adjustBundleBitstreamPolicies(context, item, collection);
 
-        log.debug(LogManager.getHeader(context, "item_inheritCollectionDefaultPolicies",
+        log.debug(LogHelper.getHeader(context, "item_inheritCollectionDefaultPolicies",
                                        "item_id=" + item.getID()));
     }
 
@@ -890,7 +890,7 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
         // If we are moving from the owning collection, update that too
         if (isOwningCollection(item, from)) {
             // Update the owning collection
-            log.info(LogManager.getHeader(context, "move_item",
+            log.info(LogHelper.getHeader(context, "move_item",
                                           "item_id=" + item.getID() + ", from " +
                                               "collection_id=" + from.getID() + " to " +
                                               "collection_id=" + to.getID()));
@@ -898,7 +898,7 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
 
             // If applicable, update the item policies
             if (inheritDefaultPolicies) {
-                log.info(LogManager.getHeader(context, "move_item",
+                log.info(LogHelper.getHeader(context, "move_item",
                                               "Updating item with inherited policies"));
                 inheritCollectionDefaultPolicies(context, item, to);
             }

--- a/dspace-api/src/main/java/org/dspace/content/MetadataFieldServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/MetadataFieldServiceImpl.java
@@ -25,7 +25,7 @@ import org.dspace.content.service.MetadataValueService;
 import org.dspace.content.service.SiteService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.discovery.indexobject.IndexableMetadataField;
 import org.dspace.event.Event;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -83,7 +83,7 @@ public class MetadataFieldServiceImpl implements MetadataFieldService {
         metadataField = metadataFieldDAO.create(context, metadataField);
         metadataFieldDAO.save(context, metadataField);
 
-        log.info(LogManager.getHeader(context, "create_metadata_field",
+        log.info(LogHelper.getHeader(context, "create_metadata_field",
                                       "metadata_field_id=" + metadataField.getID()));
         // Update the index of type metadatafield
         this.triggerEventToUpdateIndex(context, metadataField.getID());
@@ -155,7 +155,7 @@ public class MetadataFieldServiceImpl implements MetadataFieldService {
 
         metadataFieldDAO.save(context, metadataField);
 
-        log.info(LogManager.getHeader(context, "update_metadatafieldregistry",
+        log.info(LogHelper.getHeader(context, "update_metadatafieldregistry",
                                       "metadata_field_id=" + metadataField.getID() + "element=" + metadataField
                                           .getElement()
                                           + "qualifier=" + metadataField.getQualifier()));
@@ -187,7 +187,7 @@ public class MetadataFieldServiceImpl implements MetadataFieldService {
                 .toString() + " cannot be deleted as it is currently used by one or more objects.");
         }
 
-        log.info(LogManager.getHeader(context, "delete_metadata_field",
+        log.info(LogHelper.getHeader(context, "delete_metadata_field",
                                       "metadata_field_id=" + metadataField.getID()));
         // Update the index of type metadatafield
         this.triggerEventToUpdateIndex(context, metadataField.getID());

--- a/dspace-api/src/main/java/org/dspace/content/MetadataSchemaServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/MetadataSchemaServiceImpl.java
@@ -17,7 +17,7 @@ import org.dspace.content.dao.MetadataSchemaDAO;
 import org.dspace.content.service.MetadataFieldService;
 import org.dspace.content.service.MetadataSchemaService;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -74,7 +74,7 @@ public class MetadataSchemaServiceImpl implements MetadataSchemaService {
         metadataSchema.setNamespace(namespace);
         metadataSchema.setName(name);
         metadataSchemaDAO.save(context, metadataSchema);
-        log.info(LogManager.getHeader(context, "create_metadata_schema",
+        log.info(LogHelper.getHeader(context, "create_metadata_schema",
                                       "metadata_schema_id="
                                           + metadataSchema.getID()));
         return metadataSchema;
@@ -106,7 +106,7 @@ public class MetadataSchemaServiceImpl implements MetadataSchemaService {
                                                      + " unique");
         }
         metadataSchemaDAO.save(context, metadataSchema);
-        log.info(LogManager.getHeader(context, "update_metadata_schema",
+        log.info(LogHelper.getHeader(context, "update_metadata_schema",
                                       "metadata_schema_id=" + metadataSchema.getID() + "namespace="
                                           + metadataSchema.getNamespace() + "name=" + metadataSchema.getName()));
     }
@@ -125,7 +125,7 @@ public class MetadataSchemaServiceImpl implements MetadataSchemaService {
 
         metadataSchemaDAO.delete(context, metadataSchema);
 
-        log.info(LogManager.getHeader(context, "delete_metadata_schema",
+        log.info(LogHelper.getHeader(context, "delete_metadata_schema",
                 "metadata_schema_id=" + metadataSchema.getID()));
     }
 

--- a/dspace-api/src/main/java/org/dspace/content/MetadataValueServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/MetadataValueServiceImpl.java
@@ -21,7 +21,7 @@ import org.dspace.content.service.DSpaceObjectService;
 import org.dspace.content.service.MetadataValueService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -80,7 +80,7 @@ public class MetadataValueServiceImpl implements MetadataValueService {
     @Override
     public void update(Context context, MetadataValue metadataValue) throws SQLException {
         metadataValueDAO.save(context, metadataValue);
-        log.info(LogManager.getHeader(context, "update_metadatavalue",
+        log.info(LogHelper.getHeader(context, "update_metadatavalue",
                                       "metadata_value_id=" + metadataValue.getID()));
 
     }
@@ -102,7 +102,7 @@ public class MetadataValueServiceImpl implements MetadataValueService {
 
     @Override
     public void delete(Context context, MetadataValue metadataValue) throws SQLException {
-        log.info(LogManager.getHeader(context, "delete_metadata_value",
+        log.info(LogHelper.getHeader(context, "delete_metadata_value",
                                       " metadata_value_id=" + metadataValue.getID()));
         metadataValueDAO.delete(context, metadataValue);
     }

--- a/dspace-api/src/main/java/org/dspace/content/RelationshipServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/RelationshipServiceImpl.java
@@ -339,7 +339,7 @@ public class RelationshipServiceImpl implements RelationshipService {
     @Override
     public void delete(Context context, Relationship relationship, boolean copyToLeftItem, boolean copyToRightItem)
         throws SQLException, AuthorizeException {
-        log.info(org.dspace.core.LogManager.getHeader(context, "delete_relationship",
+        log.info(org.dspace.core.LogHelper.getHeader(context, "delete_relationship",
                                                       "relationship_id=" + relationship.getID() + "&" +
                                                           "copyMetadataValuesToLeftItem=" + copyToLeftItem + "&" +
                                                           "copyMetadataValuesToRightItem=" + copyToRightItem));
@@ -356,7 +356,7 @@ public class RelationshipServiceImpl implements RelationshipService {
     @Override
     public void forceDelete(Context context, Relationship relationship, boolean copyToLeftItem, boolean copyToRightItem)
         throws SQLException, AuthorizeException {
-        log.info(org.dspace.core.LogManager.getHeader(context, "delete_relationship",
+        log.info(org.dspace.core.LogHelper.getHeader(context, "delete_relationship",
                                                       "relationship_id=" + relationship.getID() + "&" +
                                                           "copyMetadataValuesToLeftItem=" + copyToLeftItem + "&" +
                                                           "copyMetadataValuesToRightItem=" + copyToRightItem));

--- a/dspace-api/src/main/java/org/dspace/content/WorkspaceItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/WorkspaceItemServiceImpl.java
@@ -25,7 +25,7 @@ import org.dspace.content.service.ItemService;
 import org.dspace.content.service.WorkspaceItemService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.eperson.EPerson;
 import org.dspace.event.Event;
 import org.dspace.workflow.WorkflowItem;
@@ -66,12 +66,12 @@ public class WorkspaceItemServiceImpl implements WorkspaceItemService {
 
         if (workspaceItem == null) {
             if (log.isDebugEnabled()) {
-                log.debug(LogManager.getHeader(context, "find_workspace_item",
+                log.debug(LogHelper.getHeader(context, "find_workspace_item",
                                                "not_found,workspace_item_id=" + id));
             }
         } else {
             if (log.isDebugEnabled()) {
-                log.debug(LogManager.getHeader(context, "find_workspace_item",
+                log.debug(LogHelper.getHeader(context, "find_workspace_item",
                                                "workspace_item_id=" + id));
             }
         }
@@ -126,7 +126,7 @@ public class WorkspaceItemServiceImpl implements WorkspaceItemService {
         itemService.update(context, item);
         workspaceItem.setItem(item);
 
-        log.info(LogManager.getHeader(context, "create_workspace_item",
+        log.info(LogHelper.getHeader(context, "create_workspace_item",
                                       "workspace_item_id=" + workspaceItem.getID()
                                           + "item_id=" + item.getID() + "collection_id="
                                           + collection.getID()));
@@ -191,7 +191,7 @@ public class WorkspaceItemServiceImpl implements WorkspaceItemService {
     public void update(Context context, WorkspaceItem workspaceItem) throws SQLException, AuthorizeException {
         // Authorisation is checked by the item.update() method below
 
-        log.info(LogManager.getHeader(context, "update_workspace_item",
+        log.info(LogHelper.getHeader(context, "update_workspace_item",
                                       "workspace_item_id=" + workspaceItem.getID()));
 
         // Update the item
@@ -219,7 +219,7 @@ public class WorkspaceItemServiceImpl implements WorkspaceItemService {
                                              + "original submitter to delete a workspace item");
         }
 
-        log.info(LogManager.getHeader(context, "delete_workspace_item",
+        log.info(LogHelper.getHeader(context, "delete_workspace_item",
                                       "workspace_item_id=" + workspaceItem.getID() + "item_id=" + item.getID()
                                           + "collection_id=" + workspaceItem.getCollection().getID()));
 
@@ -256,7 +256,7 @@ public class WorkspaceItemServiceImpl implements WorkspaceItemService {
         Item item = workspaceItem.getItem();
         authorizeService.authorizeAction(context, item, Constants.WRITE);
 
-        log.info(LogManager.getHeader(context, "delete_workspace_item",
+        log.info(LogHelper.getHeader(context, "delete_workspace_item",
                                       "workspace_item_id=" + workspaceItem.getID() + "item_id=" + item.getID()
                                           + "collection_id=" + workspaceItem.getCollection().getID()));
 

--- a/dspace-api/src/main/java/org/dspace/content/packager/AbstractMETSDisseminator.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/AbstractMETSDisseminator.java
@@ -75,7 +75,7 @@ import org.dspace.content.service.BitstreamService;
 import org.dspace.content.service.SiteService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.core.Utils;
 import org.dspace.core.factory.CoreServiceFactory;
 import org.dspace.core.service.PluginService;
@@ -265,7 +265,7 @@ public abstract class AbstractMETSDisseminator
             } //end if/else
 
             // Assuming no errors, log this dissemination
-            log.info(LogManager.getHeader(context, "package_disseminate",
+            log.info(LogHelper.getHeader(context, "package_disseminate",
                                           "Disseminated package file=" + pkgFile.getName() +
                                               " for Object, type="
                                               + Constants.typeText[dso.getType()] + ", handle="

--- a/dspace-api/src/main/java/org/dspace/content/packager/AbstractMETSIngester.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/AbstractMETSIngester.java
@@ -43,7 +43,7 @@ import org.dspace.content.service.ItemService;
 import org.dspace.content.service.WorkspaceItemService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.handle.factory.HandleServiceFactory;
 import org.dspace.handle.service.HandleService;
 import org.dspace.services.ConfigurationService;
@@ -210,7 +210,7 @@ public abstract class AbstractMETSIngester extends AbstractPackageIngester {
         DSpaceObject dso = null;
 
         try {
-            log.info(LogManager.getHeader(context, "package_parse",
+            log.info(LogHelper.getHeader(context, "package_parse",
                                           "Parsing package for ingest, file=" + pkgFile.getName()));
 
             // Parse our ingest package, extracting out the METS manifest in the
@@ -257,7 +257,7 @@ public abstract class AbstractMETSIngester extends AbstractPackageIngester {
                 if (params.restoreModeEnabled()) {
                     action = "package_restore";
                 }
-                log.info(LogManager.getHeader(context, action,
+                log.info(LogHelper.getHeader(context, action,
                                               "Created new Object, type="
                                                   + Constants.typeText[dso.getType()] + ", handle="
                                                   + dso.getHandle() + ", dbID="
@@ -387,7 +387,7 @@ public abstract class AbstractMETSIngester extends AbstractPackageIngester {
                 //If user specified to skip item ingest if any "missing parent" error message occur
                 if (params.getBooleanProperty("skipIfParentMissing", false)) {
                     //log a warning instead of throwing an error
-                    log.warn(LogManager.getHeader(context, "package_ingest",
+                    log.warn(LogHelper.getHeader(context, "package_ingest",
                                                   "SKIPPING ingest of object '" + manifest.getObjID()
                                                       + "' as parent DSpace Object could not be found. "
                                                       + "If you are running a recursive ingest, it is likely this " +
@@ -1025,7 +1025,7 @@ public abstract class AbstractMETSIngester extends AbstractPackageIngester {
         DSpaceObject dso = null;
 
         try {
-            log.info(LogManager.getHeader(context, "package_parse",
+            log.info(LogHelper.getHeader(context, "package_parse",
                                           "Parsing package for replace, file=" + pkgFile.getName()));
 
             // Parse our ingest package, extracting out the METS manifest in the
@@ -1077,7 +1077,7 @@ public abstract class AbstractMETSIngester extends AbstractPackageIngester {
                 //if ingestion was successful
                 if (dso != null) {
                     // Log that we created an object
-                    log.info(LogManager.getHeader(context, "package_replace",
+                    log.info(LogHelper.getHeader(context, "package_replace",
                                                   "Created new Object, type="
                                                       + Constants.typeText[dso.getType()]
                                                       + ", handle=" + dso.getHandle() + ", dbID="
@@ -1093,7 +1093,7 @@ public abstract class AbstractMETSIngester extends AbstractPackageIngester {
                                     params, null);
 
                 // Log that we replaced an object
-                log.info(LogManager.getHeader(context, "package_replace",
+                log.info(LogHelper.getHeader(context, "package_replace",
                                               "Replaced Object, type="
                                                   + Constants.typeText[dso.getType()]
                                                   + ", handle=" + dso.getHandle() + ", dbID="

--- a/dspace-api/src/main/java/org/dspace/content/packager/AbstractPackageIngester.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/AbstractPackageIngester.java
@@ -27,7 +27,7 @@ import org.dspace.content.service.CollectionService;
 import org.dspace.content.service.ItemService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.handle.factory.HandleServiceFactory;
 import org.dspace.handle.service.HandleService;
 import org.dspace.workflow.WorkflowException;
@@ -147,7 +147,7 @@ public abstract class AbstractPackageIngester
 
                 //if we are skipping over (i.e. keeping) existing objects
                 if (params.keepExistingModeEnabled()) {
-                    log.warn(LogManager.getHeader(context, "skip_package_ingest",
+                    log.warn(LogHelper.getHeader(context, "skip_package_ingest",
                                                   "Object already exists, package-skipped=" + pkgFile.getName()));
                 } else {
                     // Pass this exception on -- which essentially causes a full rollback of all changes (this is
@@ -156,7 +156,7 @@ public abstract class AbstractPackageIngester
                 }
             }
         } else {
-            log.info(LogManager.getHeader(context, "skip_package_ingest",
+            log.info(LogHelper.getHeader(context, "skip_package_ingest",
                                           "Object was already ingested, package-skipped=" + pkgFile.getName()));
         }
 
@@ -274,7 +274,7 @@ public abstract class AbstractPackageIngester
             //      the object to be replaced from the package itself.
             replacedDso = replace(context, dso, pkgFile, params);
         } else {
-            log.info(LogManager.getHeader(context, "skip_package_replace",
+            log.info(LogHelper.getHeader(context, "skip_package_replace",
                                           "Object was already replaced, package-skipped=" + pkgFile.getName()));
         }
 

--- a/dspace-api/src/main/java/org/dspace/content/packager/PDFPackager.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/PDFPackager.java
@@ -45,7 +45,7 @@ import org.dspace.content.service.ItemService;
 import org.dspace.content.service.WorkspaceItemService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.core.SelfNamedPlugin;
 import org.dspace.core.Utils;
 import org.dspace.workflow.WorkflowException;
@@ -166,7 +166,7 @@ public class PDFPackager
 
             workspaceItemService.update(context, wi);
             success = true;
-            log.info(LogManager.getHeader(context, "ingest",
+            log.info(LogHelper.getHeader(context, "ingest",
                                           "Created new Item, db ID=" + String.valueOf(myitem.getID()) +
                                               ", WorkspaceItem ID=" + String.valueOf(wi.getID())));
 

--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -313,7 +313,7 @@ public class Context implements AutoCloseable {
         try {
             previousState = authStateChangeHistory.pop();
         } catch (EmptyStackException ex) {
-            log.warn(LogManager.getHeader(this, "restore_auth_sys_state",
+            log.warn(LogHelper.getHeader(this, "restore_auth_sys_state",
                                           "not previous state info available "
                                               + ex.getLocalizedMessage()));
             previousState = Boolean.FALSE;
@@ -328,7 +328,7 @@ public class Context implements AutoCloseable {
             // if previousCaller is not the current caller *only* log a warning
             if (!previousCaller.equals(caller)) {
                 log
-                    .warn(LogManager
+                    .warn(LogHelper
                               .getHeader(
                                   this,
                                   "restore_auth_sys_state",

--- a/dspace-api/src/main/java/org/dspace/core/LogHelper.java
+++ b/dspace-api/src/main/java/org/dspace/core/LogHelper.java
@@ -16,12 +16,12 @@ import org.dspace.eperson.EPerson;
  * @author Robert Tansley
  * @version $Revision$
  */
-public class LogManager {
+public class LogHelper {
 
     /**
      * Default constructor
      */
-    private LogManager() { }
+    private LogHelper() { }
 
     /**
      * Generate the log header

--- a/dspace-api/src/main/java/org/dspace/curate/XmlWorkflowCuratorServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/curate/XmlWorkflowCuratorServiceImpl.java
@@ -19,7 +19,7 @@ import org.dspace.content.Collection;
 import org.dspace.content.Item;
 import org.dspace.content.service.CollectionService;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.curate.service.XmlWorkflowCuratorService;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
@@ -107,7 +107,7 @@ public class XmlWorkflowCuratorServiceImpl
         if (wfi != null) {
             return curate(curator, c, wfi);
         } else {
-            LOG.warn(LogManager.getHeader(c, "No workflow item found for id: {}", null), wfId);
+            LOG.warn(LogHelper.getHeader(c, "No workflow item found for id: {}", null), wfId);
         }
         return false;
     }

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -59,7 +59,7 @@ import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.core.Email;
 import org.dspace.core.I18nUtil;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.discovery.configuration.DiscoveryConfiguration;
 import org.dspace.discovery.configuration.DiscoveryConfigurationParameters;
 import org.dspace.discovery.configuration.DiscoveryMoreLikeThisConfiguration;
@@ -153,7 +153,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
                     getIndexableObjectFactory(indexableObject);
             if (force || requiresIndexing(indexableObject.getUniqueIndexID(), indexableObject.getLastModified())) {
                 update(context, indexableObjectFactory, indexableObject);
-                log.info(LogManager.getHeader(context, "indexed_object", indexableObject.getUniqueIndexID()));
+                log.info(LogHelper.getHeader(context, "indexed_object", indexableObject.getUniqueIndexID()));
             }
         } catch (IOException | SQLException | SolrServerException | SearchServiceException e) {
             log.error(e.getMessage(), e);
@@ -890,7 +890,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
                         result.addIndexableObject(indexableObject);
                     } else {
                         // log has warn because we try to fix the issue
-                        log.warn(LogManager.getHeader(context,
+                        log.warn(LogHelper.getHeader(context,
                                 "Stale entry found in Discovery index,"
                               + " as we could not find the DSpace object it refers to. ",
                                 "Unique identifier: " + doc.getFirstValue(SearchUtils.RESOURCE_UNIQUE_ID)));
@@ -1116,7 +1116,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
         } catch (IOException | SQLException | SolrServerException e) {
             // Any acception that we get ignore it.
             // We do NOT want any crashed to shown by the user
-            log.error(LogManager.getHeader(context, "Error while quering solr", "Query: " + query), e);
+            log.error(LogHelper.getHeader(context, "Error while quering solr", "Query: " + query), e);
             return new ArrayList<>(0);
         }
     }
@@ -1224,8 +1224,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
                 }
             }
         } catch (IOException | SQLException | SolrServerException e) {
-            log.error(
-                LogManager.getHeader(context, "Error while retrieving related items", "Handle: "
+            log.error(LogHelper.getHeader(context, "Error while retrieving related items", "Handle: "
                     + item.getHandle()), e);
         }
         return results;

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceIndexCollectionSubmittersPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceIndexCollectionSubmittersPlugin.java
@@ -19,7 +19,7 @@ import org.dspace.content.Community;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.discovery.indexobject.IndexableCollection;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -67,7 +67,7 @@ public class SolrServiceIndexCollectionSubmittersPlugin implements SolrServiceIn
                         context.uncacheEntity(resourcePolicy);
                     }
                 } catch (SQLException e) {
-                    log.error(LogManager.getHeader(context, "Error while indexing resource policies",
+                    log.error(LogHelper.getHeader(context, "Error while indexing resource policies",
                              "Collection: (id " + col.getID() + " type " + col.getName() + ")" ));
                 }
             }

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServicePrivateItemPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServicePrivateItemPlugin.java
@@ -16,7 +16,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -50,7 +50,7 @@ public class SolrServicePrivateItemPlugin implements SolrServiceSearchPlugin {
 
             }
         } catch (SQLException ex) {
-            log.error(LogManager.getHeader(context, "Error looking up authorization rights of current user",
+            log.error(LogHelper.getHeader(context, "Error looking up authorization rights of current user",
                 ""), ex);
         }
     }

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceResourceRestrictionPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceResourceRestrictionPlugin.java
@@ -28,7 +28,7 @@ import org.dspace.content.service.CollectionService;
 import org.dspace.content.service.CommunityService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.discovery.indexobject.IndexableClaimedTask;
 import org.dspace.discovery.indexobject.IndexableDSpaceObject;
 import org.dspace.discovery.indexobject.IndexableInProgressSubmission;
@@ -129,7 +129,7 @@ public class SolrServiceResourceRestrictionPlugin implements SolrServiceIndexPlu
                     dso = ContentServiceFactory.getInstance().getDSpaceObjectService(dso).getParentObject(context, dso);
                 }
             } catch (SQLException e) {
-                log.error(LogManager.getHeader(context, "Error while indexing resource policies",
+                log.error(LogHelper.getHeader(context, "Error while indexing resource policies",
                                                "DSpace object: (id " + dso.getID() + " type " + dso.getType() + ")"
                 ));
             }
@@ -175,7 +175,7 @@ public class SolrServiceResourceRestrictionPlugin implements SolrServiceIndexPlu
                 solrQuery.addFilterQuery(resourceQuery.toString());
             }
         } catch (SQLException e) {
-            log.error(LogManager.getHeader(context, "Error while adding resource policy information to query", ""), e);
+            log.error(LogHelper.getHeader(context, "Error while adding resource policy information to query", ""), e);
         }
     }
 }

--- a/dspace-api/src/main/java/org/dspace/discovery/indexobject/ItemIndexFactoryImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/indexobject/ItemIndexFactoryImpl.java
@@ -41,7 +41,7 @@ import org.dspace.content.authority.service.MetadataAuthorityService;
 import org.dspace.content.service.ItemService;
 import org.dspace.content.service.WorkspaceItemService;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.discovery.FullTextContentStreams;
 import org.dspace.discovery.IndexableObject;
 import org.dspace.discovery.SearchUtils;
@@ -618,7 +618,7 @@ public class ItemIndexFactoryImpl extends DSpaceObjectIndexFactoryImpl<Indexable
             }
 
         } catch (Exception e) {
-            log.error(LogManager.getHeader(context, "item_metadata_discovery_error",
+            log.error(LogHelper.getHeader(context, "item_metadata_discovery_error",
                     "Item identifier: " + item.getID()), e);
         }
 
@@ -641,7 +641,7 @@ public class ItemIndexFactoryImpl extends DSpaceObjectIndexFactoryImpl<Indexable
             }
 
         } catch (Exception e) {
-            log.error(LogManager.getHeader(context, "item_publication_group_discovery_error",
+            log.error(LogHelper.getHeader(context, "item_publication_group_discovery_error",
                     "Item identifier: " + item.getID()), e);
         }
 

--- a/dspace-api/src/main/java/org/dspace/eperson/EPersonConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/EPersonConsumer.java
@@ -16,7 +16,7 @@ import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.core.Email;
 import org.dspace.core.I18nUtil;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.eperson.service.EPersonService;
 import org.dspace.event.Consumer;
@@ -96,10 +96,10 @@ public class EPersonConsumer implements Consumer {
 
                             adminEmail.send();
 
-                            log.info(LogManager.getHeader(context, "registerion_alert", "user="
+                            log.info(LogHelper.getHeader(context, "registerion_alert", "user="
                                 + eperson.getEmail()));
                         } catch (MessagingException me) {
-                            log.warn(LogManager.getHeader(context,
+                            log.warn(LogHelper.getHeader(context,
                                                           "error_emailing_administrator", ""), me);
                         }
                     }

--- a/dspace-api/src/main/java/org/dspace/eperson/EPersonServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/EPersonServiceImpl.java
@@ -36,7 +36,7 @@ import org.dspace.content.service.ItemService;
 import org.dspace.content.service.WorkspaceItemService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.core.Utils;
 import org.dspace.eperson.dao.EPersonDAO;
 import org.dspace.eperson.service.EPersonService;
@@ -220,7 +220,7 @@ public class EPersonServiceImpl extends DSpaceObjectServiceImpl<EPerson> impleme
         // Create a table row
         EPerson e = ePersonDAO.create(context, new EPerson());
 
-        log.info(LogManager.getHeader(context, "create_eperson", "eperson_id="
+        log.info(LogHelper.getHeader(context, "create_eperson", "eperson_id="
                 + e.getID()));
 
         context.addEvent(new Event(Event.CREATE, Constants.EPERSON, e.getID(),
@@ -385,7 +385,7 @@ public class EPersonServiceImpl extends DSpaceObjectServiceImpl<EPerson> impleme
         // Remove ourself
         ePersonDAO.delete(context, ePerson);
 
-        log.info(LogManager.getHeader(context, "delete_eperson",
+        log.info(LogHelper.getHeader(context, "delete_eperson",
                 "eperson_id=" + ePerson.getID()));
     }
 
@@ -486,7 +486,7 @@ public class EPersonServiceImpl extends DSpaceObjectServiceImpl<EPerson> impleme
 
         ePersonDAO.save(context, ePerson);
 
-        log.info(LogManager.getHeader(context, "update_eperson",
+        log.info(LogHelper.getHeader(context, "update_eperson",
                 "eperson_id=" + ePerson.getID()));
 
         if (ePerson.isModified()) {

--- a/dspace-api/src/main/java/org/dspace/eperson/GroupServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/GroupServiceImpl.java
@@ -34,7 +34,7 @@ import org.dspace.content.service.CollectionService;
 import org.dspace.content.service.CommunityService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.eperson.dao.Group2GroupCacheDAO;
 import org.dspace.eperson.dao.GroupDAO;
 import org.dspace.eperson.factory.EPersonServiceFactory;
@@ -110,7 +110,7 @@ public class GroupServiceImpl extends DSpaceObjectServiceImpl<Group> implements 
         // Create a table row
         Group g = groupDAO.create(context, new Group());
 
-        log.info(LogManager.getHeader(context, "create_group", "group_id="
+        log.info(LogHelper.getHeader(context, "create_group", "group_id="
             + g.getID()));
 
         context.addEvent(new Event(Event.CREATE, Constants.GROUP, g.getID(), null, getIdentifiers(context, g)));
@@ -502,7 +502,7 @@ public class GroupServiceImpl extends DSpaceObjectServiceImpl<Group> implements 
         groupDAO.delete(context, group);
         rethinkGroupCache(context, false);
 
-        log.info(LogManager.getHeader(context, "delete_group", "group_id="
+        log.info(LogHelper.getHeader(context, "delete_group", "group_id="
             + group.getID()));
     }
 
@@ -595,7 +595,7 @@ public class GroupServiceImpl extends DSpaceObjectServiceImpl<Group> implements 
             group.clearGroupsChanged();
         }
 
-        log.info(LogManager.getHeader(context, "update_group", "group_id="
+        log.info(LogHelper.getHeader(context, "update_group", "group_id="
             + group.getID()));
     }
 

--- a/dspace-api/src/main/java/org/dspace/eperson/SubscribeCLITool.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/SubscribeCLITool.java
@@ -37,7 +37,7 @@ import org.dspace.content.service.ItemService;
 import org.dspace.core.Context;
 import org.dspace.core.Email;
 import org.dspace.core.I18nUtil;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.eperson.service.SubscribeService;
 import org.dspace.handle.factory.HandleServiceFactory;
@@ -262,8 +262,8 @@ public class SubscribeCLITool {
         if (emailText.length() > 0) {
 
             if (test) {
-                log.info(LogManager.getHeader(context, "subscription:", "eperson=" + eperson.getEmail()));
-                log.info(LogManager.getHeader(context, "subscription:", "text=" + emailText.toString()));
+                log.info(LogHelper.getHeader(context, "subscription:", "eperson=" + eperson.getEmail()));
+                log.info(LogHelper.getHeader(context, "subscription:", "text=" + emailText.toString()));
 
             } else {
 
@@ -272,7 +272,7 @@ public class SubscribeCLITool {
                 email.addArgument(emailText.toString());
                 email.send();
 
-                log.info(LogManager.getHeader(context, "sent_subscription", "eperson_id=" + eperson.getID()));
+                log.info(LogHelper.getHeader(context, "sent_subscription", "eperson_id=" + eperson.getID()));
 
             }
 

--- a/dspace-api/src/main/java/org/dspace/eperson/SubscribeServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/SubscribeServiceImpl.java
@@ -17,7 +17,7 @@ import org.dspace.content.Collection;
 import org.dspace.content.service.CollectionService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.eperson.dao.SubscriptionDAO;
 import org.dspace.eperson.service.SubscribeService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -82,7 +82,7 @@ public class SubscribeServiceImpl implements SubscribeService {
             } else {
                 subscriptionDAO.deleteByCollectionAndEPerson(context, collection, eperson);
 
-                log.info(LogManager.getHeader(context, "unsubscribe",
+                log.info(LogHelper.getHeader(context, "unsubscribe",
                                               "eperson_id=" + eperson.getID() + ",collection_id="
                                                   + collection.getID()));
             }

--- a/dspace-api/src/main/java/org/dspace/external/service/impl/ExternalDataServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/external/service/impl/ExternalDataServiceImpl.java
@@ -21,7 +21,7 @@ import org.dspace.content.dto.MetadataValueDTO;
 import org.dspace.content.service.ItemService;
 import org.dspace.content.service.WorkspaceItemService;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.external.model.ExternalDataObject;
 import org.dspace.external.provider.ExternalDataProvider;
 import org.dspace.external.service.ExternalDataService;
@@ -105,7 +105,7 @@ public class ExternalDataServiceImpl implements ExternalDataService {
                                     metadataValueDTO.getConfidence());
         }
 
-        log.info(LogManager.getHeader(context, "create_item_from_externalDataObject", "Created item" +
+        log.info(LogHelper.getHeader(context, "create_item_from_externalDataObject", "Created item" +
             "with id: " + item.getID() + " from source: " + externalDataObject.getSource() + " with identifier: " +
             externalDataObject.getId()));
         return workspaceItem;

--- a/dspace-api/src/main/java/org/dspace/identifier/HandleIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/HandleIdentifierProvider.java
@@ -22,7 +22,7 @@ import org.dspace.content.MetadataValue;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.DSpaceObjectService;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.handle.service.HandleService;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
@@ -76,8 +76,7 @@ public class HandleIdentifierProvider extends IdentifierProvider {
 
             return id;
         } catch (IOException | SQLException | AuthorizeException e) {
-            log.error(
-                LogManager.getHeader(context, "Error while attempting to create handle", "Item id: " + dso.getID()), e);
+            log.error(LogHelper.getHeader(context, "Error while attempting to create handle", "Item id: " + dso.getID()), e);
             throw new RuntimeException("Error while attempting to create identifier for Item id: " + dso.getID(), e);
         }
     }
@@ -91,8 +90,7 @@ public class HandleIdentifierProvider extends IdentifierProvider {
                 populateHandleMetadata(context, item, identifier);
             }
         } catch (IOException | IllegalStateException | SQLException | AuthorizeException e) {
-            log.error(
-                LogManager.getHeader(context, "Error while attempting to create handle", "Item id: " + dso.getID()), e);
+            log.error(LogHelper.getHeader(context, "Error while attempting to create handle", "Item id: " + dso.getID()), e);
             throw new RuntimeException("Error while attempting to create identifier for Item id: " + dso.getID(), e);
         }
     }
@@ -103,8 +101,7 @@ public class HandleIdentifierProvider extends IdentifierProvider {
         try {
             handleService.createHandle(context, dso, identifier);
         } catch (IllegalStateException | SQLException e) {
-            log.error(
-                LogManager.getHeader(context, "Error while attempting to create handle", "Item id: " + dso.getID()), e);
+            log.error(LogHelper.getHeader(context, "Error while attempting to create handle", "Item id: " + dso.getID()), e);
             throw new RuntimeException("Error while attempting to create identifier for Item id: " + dso.getID());
         }
     }
@@ -126,8 +123,7 @@ public class HandleIdentifierProvider extends IdentifierProvider {
         try {
             return handleService.createHandle(context, dso);
         } catch (SQLException e) {
-            log.error(
-                LogManager.getHeader(context, "Error while attempting to create handle", "Item id: " + dso.getID()), e);
+            log.error(LogHelper.getHeader(context, "Error while attempting to create handle", "Item id: " + dso.getID()), e);
             throw new RuntimeException("Error while attempting to create identifier for Item id: " + dso.getID());
         }
     }
@@ -139,7 +135,7 @@ public class HandleIdentifierProvider extends IdentifierProvider {
             identifier = handleService.parseHandle(identifier);
             return handleService.resolveToObject(context, identifier);
         } catch (IllegalStateException | SQLException e) {
-            log.error(LogManager.getHeader(context, "Error while resolving handle to item", "handle: " + identifier),
+            log.error(LogHelper.getHeader(context, "Error while resolving handle to item", "handle: " + identifier),
                       e);
         }
 //        throw new IllegalStateException("Unsupported Handle Type "

--- a/dspace-api/src/main/java/org/dspace/identifier/HandleIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/HandleIdentifierProvider.java
@@ -76,7 +76,9 @@ public class HandleIdentifierProvider extends IdentifierProvider {
 
             return id;
         } catch (IOException | SQLException | AuthorizeException e) {
-            log.error(LogHelper.getHeader(context, "Error while attempting to create handle", "Item id: " + dso.getID()), e);
+            log.error(LogHelper.getHeader(context,
+                    "Error while attempting to create handle",
+                    "Item id: " + dso.getID()), e);
             throw new RuntimeException("Error while attempting to create identifier for Item id: " + dso.getID(), e);
         }
     }
@@ -90,7 +92,9 @@ public class HandleIdentifierProvider extends IdentifierProvider {
                 populateHandleMetadata(context, item, identifier);
             }
         } catch (IOException | IllegalStateException | SQLException | AuthorizeException e) {
-            log.error(LogHelper.getHeader(context, "Error while attempting to create handle", "Item id: " + dso.getID()), e);
+            log.error(LogHelper.getHeader(context,
+                    "Error while attempting to create handle",
+                    "Item id: " + dso.getID()), e);
             throw new RuntimeException("Error while attempting to create identifier for Item id: " + dso.getID(), e);
         }
     }
@@ -101,7 +105,9 @@ public class HandleIdentifierProvider extends IdentifierProvider {
         try {
             handleService.createHandle(context, dso, identifier);
         } catch (IllegalStateException | SQLException e) {
-            log.error(LogHelper.getHeader(context, "Error while attempting to create handle", "Item id: " + dso.getID()), e);
+            log.error(LogHelper.getHeader(context,
+                    "Error while attempting to create handle",
+                    "Item id: " + dso.getID()), e);
             throw new RuntimeException("Error while attempting to create identifier for Item id: " + dso.getID());
         }
     }
@@ -123,7 +129,9 @@ public class HandleIdentifierProvider extends IdentifierProvider {
         try {
             return handleService.createHandle(context, dso);
         } catch (SQLException e) {
-            log.error(LogHelper.getHeader(context, "Error while attempting to create handle", "Item id: " + dso.getID()), e);
+            log.error(LogHelper.getHeader(context,
+                    "Error while attempting to create handle",
+                    "Item id: " + dso.getID()), e);
             throw new RuntimeException("Error while attempting to create identifier for Item id: " + dso.getID());
         }
     }

--- a/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProvider.java
@@ -240,7 +240,9 @@ public class VersionedHandleIdentifierProvider extends IdentifierProvider {
         try {
             handleService.createHandle(context, dso, identifier);
         } catch (IllegalStateException | SQLException e) {
-            log.error(LogHelper.getHeader(context, "Error while attempting to create handle", "Item id: " + dso.getID()), e);
+            log.error(LogHelper.getHeader(context,
+                    "Error while attempting to create handle",
+                    "Item id: " + dso.getID()), e);
             throw new RuntimeException("Error while attempting to create identifier for Item id: " + dso.getID());
         }
     }
@@ -273,7 +275,9 @@ public class VersionedHandleIdentifierProvider extends IdentifierProvider {
             }
             return handleId;
         } catch (SQLException | AuthorizeException e) {
-            log.error(LogHelper.getHeader(context, "Error while attempting to create handle", "Item id: " + dso.getID()), e);
+            log.error(LogHelper.getHeader(context,
+                    "Error while attempting to create handle",
+                    "Item id: " + dso.getID()), e);
             throw new RuntimeException("Error while attempting to create identifier for Item id: " + dso.getID());
         }
     }

--- a/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProvider.java
@@ -27,7 +27,7 @@ import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.DSpaceObjectService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.handle.service.HandleService;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
@@ -89,7 +89,7 @@ public class VersionedHandleIdentifierProvider extends IdentifierProvider {
                 populateHandleMetadata(context, dso, id);
             }
         } catch (IOException | SQLException | AuthorizeException e) {
-            log.error(LogManager.getHeader(context, "Error while attempting to create handle",
+            log.error(LogHelper.getHeader(context, "Error while attempting to create handle",
                                            "Item id: " + (dso != null ? dso.getID() : "")), e);
             throw new RuntimeException(
                 "Error while attempting to create identifier for Item id: " + (dso != null ? dso.getID() : ""));
@@ -240,8 +240,7 @@ public class VersionedHandleIdentifierProvider extends IdentifierProvider {
         try {
             handleService.createHandle(context, dso, identifier);
         } catch (IllegalStateException | SQLException e) {
-            log.error(
-                LogManager.getHeader(context, "Error while attempting to create handle", "Item id: " + dso.getID()), e);
+            log.error(LogHelper.getHeader(context, "Error while attempting to create handle", "Item id: " + dso.getID()), e);
             throw new RuntimeException("Error while attempting to create identifier for Item id: " + dso.getID());
         }
     }
@@ -274,8 +273,7 @@ public class VersionedHandleIdentifierProvider extends IdentifierProvider {
             }
             return handleId;
         } catch (SQLException | AuthorizeException e) {
-            log.error(
-                LogManager.getHeader(context, "Error while attempting to create handle", "Item id: " + dso.getID()), e);
+            log.error(LogHelper.getHeader(context, "Error while attempting to create handle", "Item id: " + dso.getID()), e);
             throw new RuntimeException("Error while attempting to create identifier for Item id: " + dso.getID());
         }
     }
@@ -287,7 +285,7 @@ public class VersionedHandleIdentifierProvider extends IdentifierProvider {
             identifier = handleService.parseHandle(identifier);
             return handleService.resolveToObject(context, identifier);
         } catch (IllegalStateException | SQLException e) {
-            log.error(LogManager.getHeader(context, "Error while resolving handle to item", "handle: " + identifier),
+            log.error(LogHelper.getHeader(context, "Error while resolving handle to item", "handle: " + identifier),
                       e);
         }
         return null;

--- a/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProviderWithCanonicalHandles.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProviderWithCanonicalHandles.java
@@ -206,7 +206,9 @@ public class VersionedHandleIdentifierProviderWithCanonicalHandles extends Ident
                 }
             }
         } catch (IOException | SQLException | AuthorizeException e) {
-            log.error(LogHelper.getHeader(context, "Error while attempting to create handle", "Item id: " + dso.getID()), e);
+            log.error(LogHelper.getHeader(context,
+                    "Error while attempting to create handle",
+                    "Item id: " + dso.getID()), e);
             throw new RuntimeException("Error while attempting to create identifier for Item id: " + dso.getID(), e);
         }
     }
@@ -258,7 +260,9 @@ public class VersionedHandleIdentifierProviderWithCanonicalHandles extends Ident
         try {
             handleService.createHandle(context, dso, identifier);
         } catch (IllegalStateException | SQLException e) {
-            log.error(LogHelper.getHeader(context, "Error while attempting to create handle", "Item id: " + dso.getID()), e);
+            log.error(LogHelper.getHeader(context,
+                    "Error while attempting to create handle",
+                    "Item id: " + dso.getID()), e);
             throw new RuntimeException("Error while attempting to create identifier for Item id: " + dso.getID());
         }
     }
@@ -291,7 +295,9 @@ public class VersionedHandleIdentifierProviderWithCanonicalHandles extends Ident
             }
             return handleId;
         } catch (SQLException | AuthorizeException e) {
-            log.error(LogHelper.getHeader(context, "Error while attempting to create handle", "Item id: " + dso.getID()), e);
+            log.error(LogHelper.getHeader(context,
+                    "Error while attempting to create handle",
+                    "Item id: " + dso.getID()), e);
             throw new RuntimeException("Error while attempting to create identifier for Item id: " + dso.getID());
         }
     }
@@ -350,7 +356,9 @@ public class VersionedHandleIdentifierProviderWithCanonicalHandles extends Ident
                 }
             }
         } catch (RuntimeException | SQLException e) {
-            log.error(LogHelper.getHeader(context, "Error while attempting to register doi", "Item id: " + dso.getID()), e);
+            log.error(LogHelper.getHeader(context,
+                    "Error while attempting to register doi",
+                    "Item id: " + dso.getID()), e);
             throw new IdentifierException("Error while moving doi identifier", e);
         }
 

--- a/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProviderWithCanonicalHandles.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProviderWithCanonicalHandles.java
@@ -22,7 +22,7 @@ import org.dspace.content.MetadataValue;
 import org.dspace.content.service.ItemService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.handle.service.HandleService;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
@@ -206,8 +206,7 @@ public class VersionedHandleIdentifierProviderWithCanonicalHandles extends Ident
                 }
             }
         } catch (IOException | SQLException | AuthorizeException e) {
-            log.error(
-                LogManager.getHeader(context, "Error while attempting to create handle", "Item id: " + dso.getID()), e);
+            log.error(LogHelper.getHeader(context, "Error while attempting to create handle", "Item id: " + dso.getID()), e);
             throw new RuntimeException("Error while attempting to create identifier for Item id: " + dso.getID(), e);
         }
     }
@@ -259,8 +258,7 @@ public class VersionedHandleIdentifierProviderWithCanonicalHandles extends Ident
         try {
             handleService.createHandle(context, dso, identifier);
         } catch (IllegalStateException | SQLException e) {
-            log.error(
-                LogManager.getHeader(context, "Error while attempting to create handle", "Item id: " + dso.getID()), e);
+            log.error(LogHelper.getHeader(context, "Error while attempting to create handle", "Item id: " + dso.getID()), e);
             throw new RuntimeException("Error while attempting to create identifier for Item id: " + dso.getID());
         }
     }
@@ -293,8 +291,7 @@ public class VersionedHandleIdentifierProviderWithCanonicalHandles extends Ident
             }
             return handleId;
         } catch (SQLException | AuthorizeException e) {
-            log.error(
-                LogManager.getHeader(context, "Error while attempting to create handle", "Item id: " + dso.getID()), e);
+            log.error(LogHelper.getHeader(context, "Error while attempting to create handle", "Item id: " + dso.getID()), e);
             throw new RuntimeException("Error while attempting to create identifier for Item id: " + dso.getID());
         }
     }
@@ -305,7 +302,7 @@ public class VersionedHandleIdentifierProviderWithCanonicalHandles extends Ident
         try {
             return handleService.resolveToObject(context, identifier);
         } catch (IllegalStateException | SQLException e) {
-            log.error(LogManager.getHeader(context, "Error while resolving handle to item", "handle: " + identifier),
+            log.error(LogHelper.getHeader(context, "Error while resolving handle to item", "handle: " + identifier),
                       e);
         }
         return null;
@@ -353,8 +350,7 @@ public class VersionedHandleIdentifierProviderWithCanonicalHandles extends Ident
                 }
             }
         } catch (RuntimeException | SQLException e) {
-            log.error(
-                LogManager.getHeader(context, "Error while attempting to register doi", "Item id: " + dso.getID()), e);
+            log.error(LogHelper.getHeader(context, "Error while attempting to register doi", "Item id: " + dso.getID()), e);
             throw new IdentifierException("Error while moving doi identifier", e);
         }
 

--- a/dspace-api/src/main/java/org/dspace/scripts/ProcessServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/scripts/ProcessServiceImpl.java
@@ -41,7 +41,7 @@ import org.dspace.content.service.BitstreamService;
 import org.dspace.content.service.MetadataFieldService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.service.EPersonService;
 import org.dspace.scripts.service.ProcessService;
@@ -82,7 +82,7 @@ public class ProcessServiceImpl implements ProcessService {
         process.setParameters(DSpaceCommandLineParameter.concatenate(parameters));
         process.setCreationTime(new Date());
         Process createdProcess = processDAO.create(context, process);
-        log.info(LogManager.getHeader(context, "process_create",
+        log.info(LogHelper.getHeader(context, "process_create",
                                       "Process has been created for eperson with email " + ePerson.getEmail()
                                           + " with ID " + createdProcess.getID() + " and scriptName " +
                                           scriptName + " and parameters " + parameters));
@@ -124,7 +124,7 @@ public class ProcessServiceImpl implements ProcessService {
         process.setProcessStatus(ProcessStatus.RUNNING);
         process.setStartTime(new Date());
         update(context, process);
-        log.info(LogManager.getHeader(context, "process_start", "Process with ID " + process.getID()
+        log.info(LogHelper.getHeader(context, "process_start", "Process with ID " + process.getID()
             + " and name " + process.getName() + " has started"));
 
     }
@@ -134,7 +134,7 @@ public class ProcessServiceImpl implements ProcessService {
         process.setProcessStatus(ProcessStatus.FAILED);
         process.setFinishedTime(new Date());
         update(context, process);
-        log.info(LogManager.getHeader(context, "process_fail", "Process with ID " + process.getID()
+        log.info(LogHelper.getHeader(context, "process_fail", "Process with ID " + process.getID()
             + " and name " + process.getName() + " has failed"));
 
     }
@@ -144,7 +144,7 @@ public class ProcessServiceImpl implements ProcessService {
         process.setProcessStatus(ProcessStatus.COMPLETED);
         process.setFinishedTime(new Date());
         update(context, process);
-        log.info(LogManager.getHeader(context, "process_complete", "Process with ID " + process.getID()
+        log.info(LogHelper.getHeader(context, "process_complete", "Process with ID " + process.getID()
             + " and name " + process.getName() + " has been completed"));
 
     }
@@ -177,7 +177,7 @@ public class ProcessServiceImpl implements ProcessService {
             bitstreamService.delete(context, bitstream);
         }
         processDAO.delete(context, process);
-        log.info(LogManager.getHeader(context, "process_delete", "Process with ID " + process.getID()
+        log.info(LogHelper.getHeader(context, "process_delete", "Process with ID " + process.getID()
             + " and name " + process.getName() + " has been deleted"));
     }
 

--- a/dspace-api/src/main/java/org/dspace/statistics/AnonymizeStatistics.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/AnonymizeStatistics.java
@@ -16,7 +16,7 @@ import static java.util.Collections.singletonList;
 import static org.apache.commons.cli.Option.builder;
 import static org.apache.commons.lang.time.DateFormatUtils.format;
 import static org.apache.logging.log4j.LogManager.getLogger;
-import static org.dspace.core.LogManager.getHeader;
+import static org.dspace.core.LogHelper.getHeader;
 import static org.dspace.statistics.SolrLoggerServiceImpl.DATE_FORMAT_8601;
 
 import java.io.IOException;

--- a/dspace-api/src/main/java/org/dspace/statistics/export/IrusExportUsageEventListener.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/export/IrusExportUsageEventListener.java
@@ -13,7 +13,7 @@ import org.apache.logging.log4j.Logger;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.model.Event;
 import org.dspace.statistics.export.processor.BitstreamEventProcessor;
@@ -66,7 +66,7 @@ public class IrusExportUsageEventListener extends AbstractUsageEventListener {
                     } catch (Exception e1) {
                         type = -1;
                     }
-                    log.error(LogManager.getHeader(ue.getContext(), "Error while processing export of use event",
+                    log.error(LogHelper.getHeader(ue.getContext(), "Error while processing export of use event",
                                                    "Id: " + id + " type: " + type), e);
                 }
             }

--- a/dspace-api/src/main/java/org/dspace/usage/LoggerUsageEventListener.java
+++ b/dspace-api/src/main/java/org/dspace/usage/LoggerUsageEventListener.java
@@ -11,7 +11,7 @@ import org.apache.logging.log4j.Logger;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.core.Constants;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.services.model.Event;
 import org.dspace.usage.UsageEvent.Action;
 
@@ -33,7 +33,7 @@ public class LoggerUsageEventListener extends AbstractUsageEventListener {
         if (event instanceof UsageEvent && !(event instanceof UsageSearchEvent)) {
             UsageEvent ue = (UsageEvent) event;
 
-            log.info(LogManager.getHeader(
+            log.info(LogHelper.getHeader(
                 ue.getContext(),
                 formatAction(ue.getAction(), ue.getObject()),
                 formatMessage(ue.getObject()))

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowServiceImpl.java
@@ -45,7 +45,7 @@ import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.core.Email;
 import org.dspace.core.I18nUtil;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.curate.service.XmlWorkflowCuratorService;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
@@ -317,7 +317,7 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
         // current step cannot be completed and we must exit immediately.
         if (!xmlWorkflowCuratorService.doCuration(context, wfi)) {
             // don't proceed - either curation tasks queued, or item rejected
-            log.info(LogManager.getHeader(context, "start_workflow",
+            log.info(LogHelper.getHeader(context, "start_workflow",
                     "workflow_item_id=" + wfi.getID()
                             + ",item_id=" + wfi.getItem().getID()
                             + ",collection_id=" + wfi.getCollection().getID()
@@ -328,7 +328,7 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
 
         // Activate the step.
         firstActionConfig.getProcessingAction().activate(context, wfi);
-        log.info(LogManager.getHeader(context, "start_workflow",
+        log.info(LogHelper.getHeader(context, "start_workflow",
                 firstActionConfig.getProcessingAction()
                         + " workflow_item_id=" + wfi.getID()
                         + "item_id=" + wfi.getItem().getID()
@@ -366,7 +366,7 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
         // current step cannot be completed and we must exit immediately.
         if (!xmlWorkflowCuratorService.doCuration(c, wi)) {
             // don't proceed - either curation tasks queued, or item rejected
-            log.info(LogManager.getHeader(c, "advance_workflow",
+            log.info(LogHelper.getHeader(c, "advance_workflow",
                     "workflow_item_id=" + wi.getID()
                             + ",item_id=" + wi.getItem().getID()
                             + ",collection_id=" + wi.getCollection().getID()
@@ -391,7 +391,7 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
                 throw new AuthorizeException("You are not allowed to to perform this task.");
             }
         } catch (WorkflowConfigurationException e) {
-            log.error(LogManager.getHeader(c, "error while executing state",
+            log.error(LogHelper.getHeader(c, "error while executing state",
                     "workflow:  " + workflow.getID()
                             + " action: " + currentActionConfig.getId()
                             + " workflowItemId: " + workflowItemId), e);
@@ -509,7 +509,7 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
 
         }
 
-        log.error(LogManager.getHeader(c, "Invalid step outcome", "Workflow item id: " + wfi.getID()));
+        log.error(LogHelper.getHeader(c, "Invalid step outcome", "Workflow item id: " + wfi.getID()));
         throw new WorkflowException("Invalid step outcome");
     }
 
@@ -558,7 +558,7 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
             DSpaceServicesFactory.getInstance().getEventService().fireEvent(usageWorkflowEvent);
         } catch (SQLException e) {
             //Catch all errors we do not want our workflow to crash because the logging threw an exception
-            log.error(LogManager.getHeader(c, "Error while logging workflow event", "Workflow Item: " + wfi.getID()),
+            log.error(LogHelper.getHeader(c, "Error while logging workflow event", "Workflow Item: " + wfi.getID()),
                       e);
         }
     }
@@ -615,7 +615,7 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
         // Remove (if any) the workflowItemroles for this item
         workflowItemRoleService.deleteForWorkflowItem(context, wfi);
 
-        log.info(LogManager.getHeader(context, "archive_item", "workflow_item_id="
+        log.info(LogHelper.getHeader(context, "archive_item", "workflow_item_id="
             + wfi.getID() + "item_id=" + item.getID() + "collection_id="
             + collection.getID()));
 
@@ -630,7 +630,7 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
         itemService.update(context, item);
 
         // Log the event
-        log.info(LogManager.getHeader(context, "install_item", "workflow_item_id="
+        log.info(LogHelper.getHeader(context, "install_item", "workflow_item_id="
             + wfi.getID() + ", item_id=" + item.getID() + "handle=FIXME"));
 
         return item;
@@ -680,7 +680,7 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
                 email.send();
             }
         } catch (MessagingException e) {
-            log.warn(LogManager.getHeader(context, "notifyOfArchive",
+            log.warn(LogHelper.getHeader(context, "notifyOfArchive",
                     "cannot email user" + " item_id=" + item.getID()));
         }
     }
@@ -713,7 +713,7 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
                 email.send();
             }
         } catch (MessagingException e) {
-            log.warn(LogManager.getHeader(c, "notifyOfCuration",
+            log.warn(LogHelper.getHeader(c, "notifyOfCuration",
                     "cannot email users of workflow_item_id " + wi.getID()
                             + ":  " + e.getMessage()));
         }
@@ -981,7 +981,7 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
         xmlWorkflowItemService.deleteWrapper(context, wi);
         // Now delete the item
         itemService.delete(context, myitem);
-        log.info(LogManager.getHeader(context, "delete_workflow", "workflow_item_id="
+        log.info(LogHelper.getHeader(context, "delete_workflow", "workflow_item_id="
                 + workflowID + "item_id=" + itemID
                 + "collection_id=" + collID + "eperson_id="
                 + e.getID()));
@@ -1039,7 +1039,7 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
         revokeReviewerPolicies(context, myitem);
         // notify that it's been rejected
         notifyOfReject(context, wi, e, rejection_message);
-        log.info(LogManager.getHeader(context, "reject_workflow", "workflow_item_id="
+        log.info(LogHelper.getHeader(context, "reject_workflow", "workflow_item_id="
             + wi.getID() + "item_id=" + wi.getItem().getID()
             + "collection_id=" + wi.getCollection().getID() + "eperson_id="
             + e.getID()));
@@ -1063,7 +1063,7 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
         // convert into personal workspace
         WorkspaceItem wsi = returnToWorkspace(c, wi);
 
-        log.info(LogManager.getHeader(c, "abort_workflow", "workflow_item_id="
+        log.info(LogHelper.getHeader(c, "abort_workflow", "workflow_item_id="
             + wi.getID() + "item_id=" + wsi.getItem().getID()
             + "collection_id=" + wi.getCollection().getID() + "eperson_id="
             + e.getID()));
@@ -1114,7 +1114,7 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
         workspaceItemService.update(c, workspaceItem);
 
         //myitem.update();
-        log.info(LogManager.getHeader(c, "return_to_workspace",
+        log.info(LogHelper.getHeader(c, "return_to_workspace",
                                       "workflow_item_id=" + wfi.getID() + "workspace_item_id="
                                           + workspaceItem.getID()));
 
@@ -1192,7 +1192,7 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
             }
         } catch (IOException | MessagingException ex) {
             // log this email error
-            log.warn(LogManager.getHeader(c, "notify_of_reject",
+            log.warn(LogHelper.getHeader(c, "notify_of_reject",
                     "cannot email user" + " eperson_id" + e.getID()
                     + " eperson_email" + e.getEmail()
                     + " workflow_item_id" + wi.getID()));

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/migration/RestartWorkflow.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/migration/RestartWorkflow.java
@@ -19,7 +19,7 @@ import org.apache.logging.log4j.Logger;
 import org.dspace.content.Item;
 import org.dspace.content.WorkspaceItem;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.eperson.service.EPersonService;
@@ -137,7 +137,7 @@ public class RestartWorkflow {
                 WorkspaceItem wsi = workflowService
                     .sendWorkflowItemBackSubmission(context, workflowItem, myEPerson, provenance, "");
 
-                log.info(LogManager.getHeader(context, "restart_workflow", "workflow_item_id="
+                log.info(LogHelper.getHeader(context, "restart_workflow", "workflow_item_id="
                     + workflowItem.getID() + "item_id=" + workflowItem.getItem().getID()
                     + "collection_id=" + workflowItem.getCollection().getID()));
 

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/userassignment/AssignOriginalSubmitterAction.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/userassignment/AssignOriginalSubmitterAction.java
@@ -17,7 +17,7 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.eperson.EPerson;
 import org.dspace.workflow.WorkflowException;
 import org.dspace.xmlworkflow.RoleMembers;
@@ -87,7 +87,7 @@ public class AssignOriginalSubmitterAction extends UserSelectionAction {
                         xmlWorkflowService.getMyDSpaceLink()
                 );
             } catch (MessagingException e) {
-                log.info(LogManager.getHeader(c, "error emailing user(s) for claimed task",
+                log.info(LogHelper.getHeader(c, "error emailing user(s) for claimed task",
                                           "step: " + getParent().getStep().getId() + " workflowitem: " + wfi.getID()));
             }
         }

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/userassignment/AutoAssignAction.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/userassignment/AutoAssignAction.java
@@ -16,7 +16,7 @@ import javax.servlet.http.HttpServletRequest;
 import org.apache.logging.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.service.GroupService;
 import org.dspace.xmlworkflow.Role;
@@ -82,22 +82,22 @@ public class AutoAssignAction extends UserSelectionAction {
                         workflowItemRoleService.delete(c, workflowItemRole);
                     }
                 } else {
-                    log.warn(LogManager.getHeader(c, "Error while executing auto assign action",
+                    log.warn(LogHelper.getHeader(c, "Error while executing auto assign action",
                                                   "No valid next action. Workflow item:" + wfi.getID()));
                 }
             }
         } catch (SQLException e) {
-            log.error(LogManager.getHeader(c, "Error while executing auto assign action",
+            log.error(LogHelper.getHeader(c, "Error while executing auto assign action",
                                            "Workflow item: " + wfi.getID() + " step :" + getParent().getStep().getId()),
                       e);
             throw e;
         } catch (AuthorizeException e) {
-            log.error(LogManager.getHeader(c, "Error while executing auto assign action",
+            log.error(LogHelper.getHeader(c, "Error while executing auto assign action",
                                            "Workflow item: " + wfi.getID() + " step :" + getParent().getStep().getId()),
                       e);
             throw e;
         } catch (IOException e) {
-            log.error(LogManager.getHeader(c, "Error while executing auto assign action",
+            log.error(LogHelper.getHeader(c, "Error while executing auto assign action",
                                            "Workflow item: " + wfi.getID() + " step :" + getParent().getStep().getId()),
                       e);
             throw e;

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/userassignment/ClaimAction.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/userassignment/ClaimAction.java
@@ -16,7 +16,7 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.eperson.EPerson;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
@@ -54,7 +54,7 @@ public class ClaimAction extends UserSelectionAction {
                                      .createPoolTasks(context, wfItem, allroleMembers, owningStep, getParent());
             alertUsersOnActivation(context, wfItem, allroleMembers);
         } else {
-            log.info(LogManager.getHeader(context, "warning while activating claim action",
+            log.info(LogHelper.getHeader(context, "warning while activating claim action",
                                           "No group or person was found for the following roleid: " + getParent()
                                               .getStep().getRole().getId()));
         }
@@ -96,7 +96,7 @@ public class ClaimAction extends UserSelectionAction {
                     xmlWorkflowService.getMyDSpaceLink()
             );
         } catch (MessagingException e) {
-            log.info(LogManager.getHeader(c, "error emailing user(s) for claimed task",
+            log.info(LogHelper.getHeader(c, "error emailing user(s) for claimed task",
                     "step: " + getParent().getStep().getId() + " workflowitem: " + wfi.getID()));
         }
     }
@@ -113,7 +113,7 @@ public class ClaimAction extends UserSelectionAction {
             }
 
         } else {
-            log.info(LogManager.getHeader(c, "warning while activating claim action",
+            log.info(LogHelper.getHeader(c, "warning while activating claim action",
                                           "No group or person was found for the following roleid: " + getParent()
                                               .getStep().getId()));
         }

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/storedcomponents/XmlWorkflowItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/storedcomponents/XmlWorkflowItemServiceImpl.java
@@ -18,7 +18,7 @@ import org.dspace.content.Collection;
 import org.dspace.content.Item;
 import org.dspace.content.service.ItemService;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.eperson.EPerson;
 import org.dspace.xmlworkflow.service.WorkflowRequirementsService;
 import org.dspace.xmlworkflow.storedcomponents.dao.XmlWorkflowItemDAO;
@@ -77,12 +77,12 @@ public class XmlWorkflowItemServiceImpl implements XmlWorkflowItemService {
 
         if (workflowItem == null) {
             if (log.isDebugEnabled()) {
-                log.debug(LogManager.getHeader(context, "find_workflow_item",
+                log.debug(LogHelper.getHeader(context, "find_workflow_item",
                                                "not_found,workflowitem_id=" + id));
             }
         } else {
             if (log.isDebugEnabled()) {
-                log.debug(LogManager.getHeader(context, "find_workflow_item",
+                log.debug(LogHelper.getHeader(context, "find_workflow_item",
                                                "workflowitem_id=" + id));
             }
         }
@@ -176,7 +176,7 @@ public class XmlWorkflowItemServiceImpl implements XmlWorkflowItemService {
     @Override
     public void update(Context context, XmlWorkflowItem workflowItem) throws SQLException, AuthorizeException {
         // FIXME check auth
-        log.info(LogManager.getHeader(context, "update_workflow_item",
+        log.info(LogHelper.getHeader(context, "update_workflow_item",
                                       "workflowitem_id=" + workflowItem.getID()));
 
         // Update the item

--- a/dspace-rest/src/main/java/org/dspace/rest/CollectionsResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/CollectionsResource.java
@@ -45,7 +45,7 @@ import org.dspace.content.service.CollectionService;
 import org.dspace.content.service.ItemService;
 import org.dspace.content.service.WorkspaceItemService;
 import org.dspace.core.Constants;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.rest.common.Collection;
 import org.dspace.rest.common.Item;
 import org.dspace.rest.common.MetadataEntry;
@@ -376,7 +376,8 @@ public class CollectionsResource extends Resource {
                 workflowService.start(context, workspaceItem);
             } catch (Exception e) {
                 log.error(
-                    LogManager.getHeader(context, "Error while starting workflow", "Item id: " + dspaceItem.getID()),
+                    LogHelper.getHeader(context, "Error while starting workflow",
+                            "Item id: " + dspaceItem.getID()),
                     e);
                 throw new ContextException("Error while starting workflow for item(id=" + dspaceItem.getID() + ")", e);
             }

--- a/dspace-rest/src/main/java/org/dspace/rest/authentication/DSpaceAuthenticationProvider.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/authentication/DSpaceAuthenticationProvider.java
@@ -13,12 +13,13 @@ import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.authenticate.AuthenticationMethod;
 import org.dspace.authenticate.factory.AuthenticateServiceFactory;
 import org.dspace.authenticate.service.AuthenticationService;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
 import org.dspace.utils.DSpace;
@@ -40,7 +41,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
  */
 public class DSpaceAuthenticationProvider implements AuthenticationProvider {
 
-    private static Logger log = org.apache.logging.log4j.LogManager.getLogger(DSpaceAuthenticationProvider.class);
+    private static final Logger log = LogManager.getLogger();
 
     protected AuthenticationService authenticationService = AuthenticateServiceFactory.getInstance()
                                                                                       .getAuthenticationService();
@@ -62,7 +63,7 @@ public class DSpaceAuthenticationProvider implements AuthenticationProvider {
                 .authenticateImplicit(context, null, null, null, httpServletRequest);
 
             if (implicitStatus == AuthenticationMethod.SUCCESS) {
-                log.info(LogManager.getHeader(context, "login", "type=implicit"));
+                log.info(LogHelper.getHeader(context, "login", "type=implicit"));
                 addSpecialGroupsToGrantedAuthorityList(context, httpServletRequest, grantedAuthorities);
                 return createAuthenticationToken(password, context, grantedAuthorities);
 
@@ -72,15 +73,13 @@ public class DSpaceAuthenticationProvider implements AuthenticationProvider {
                 if (AuthenticationMethod.SUCCESS == authenticateResult) {
                     addSpecialGroupsToGrantedAuthorityList(context, httpServletRequest, grantedAuthorities);
 
-                    log.info(LogManager
-                                 .getHeader(context, "login", "type=explicit"));
+                    log.info(LogHelper.getHeader(context, "login", "type=explicit"));
 
                     return createAuthenticationToken(password, context, grantedAuthorities);
 
                 } else {
-                    log.info(LogManager.getHeader(context, "failed_login", "email="
-                        + name + ", result="
-                        + authenticateResult));
+                    log.info(LogHelper.getHeader(context, "failed_login",
+                            "email=" + name + ", result=" + authenticateResult));
                     throw new BadCredentialsException("Login failed");
                 }
             }
@@ -117,8 +116,8 @@ public class DSpaceAuthenticationProvider implements AuthenticationProvider {
             return new UsernamePasswordAuthenticationToken(ePerson.getEmail(), password, grantedAuthorities);
 
         } else {
-            log.info(
-                LogManager.getHeader(context, "failed_login", "No eperson with an non-blank e-mail address found"));
+            log.info(LogHelper.getHeader(context, "failed_login",
+                    "No eperson with an non-blank e-mail address found"));
             throw new BadCredentialsException("Login failed");
         }
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/OpenSearchController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/OpenSearchController.java
@@ -32,7 +32,7 @@ import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.CollectionService;
 import org.dspace.content.service.CommunityService;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.core.Utils;
 import org.dspace.discovery.DiscoverQuery;
 import org.dspace.discovery.DiscoverResult;
@@ -125,8 +125,7 @@ public class OpenSearchController {
                 qResults = SearchUtils.getSearchService().search(context,
                     container, queryArgs);
             } catch (SearchServiceException e) {
-                log.error(
-                    LogManager.getHeader(context, "opensearch", "query="
+                log.error(LogHelper.getHeader(context, "opensearch", "query="
                             + queryArgs.getQuery()
                             + ",error=" + e.getMessage()), e);
                 throw new RuntimeException(e.getMessage(), e);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ConverterService.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ConverterService.java
@@ -31,7 +31,6 @@ import org.dspace.app.rest.model.hateoas.HALResource;
 import org.dspace.app.rest.projection.DefaultProjection;
 import org.dspace.app.rest.projection.Projection;
 import org.dspace.app.rest.repository.DSpaceRestRepository;
-import org.dspace.app.rest.security.DSpacePermissionEvaluator;
 import org.dspace.app.rest.security.WebSecurityExpressionEvaluator;
 import org.dspace.app.rest.utils.Utils;
 import org.dspace.services.RequestService;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ConverterService.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ConverterService.java
@@ -80,9 +80,6 @@ public class ConverterService {
     private List<Projection> projections;
 
     @Autowired
-    private DSpacePermissionEvaluator dSpacePermissionEvaluator;
-
-    @Autowired
     private WebSecurityExpressionEvaluator webSecurityExpressionEvaluator;
 
     @Autowired

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/EPersonRestAuthenticationProvider.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/EPersonRestAuthenticationProvider.java
@@ -23,7 +23,7 @@ import org.dspace.authenticate.AuthenticationMethod;
 import org.dspace.authenticate.service.AuthenticationService;
 import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.eperson.EPerson;
 import org.dspace.services.RequestService;
 import org.slf4j.Logger;
@@ -90,19 +90,19 @@ public class EPersonRestAuthenticationProvider implements AuthenticationProvider
                 int implicitStatus = authenticationService.authenticateImplicit(newContext, null, null, null, request);
 
                 if (implicitStatus == AuthenticationMethod.SUCCESS) {
-                    log.info(LogManager.getHeader(newContext, "login", "type=implicit"));
+                    log.info(LogHelper.getHeader(newContext, "login", "type=implicit"));
                     output = createAuthentication(password, newContext);
                 } else {
                     int authenticateResult = authenticationService
                         .authenticate(newContext, name, password, null, request);
                     if (AuthenticationMethod.SUCCESS == authenticateResult) {
 
-                        log.info(LogManager
+                        log.info(LogHelper
                                      .getHeader(newContext, "login", "type=explicit"));
 
                         output = createAuthentication(password, newContext);
                     } else {
-                        log.info(LogManager.getHeader(newContext, "failed_login", "email="
+                        log.info(LogHelper.getHeader(newContext, "failed_login", "email="
                             + name + ", result="
                             + authenticateResult));
                         throw new BadCredentialsException("Login failed");
@@ -132,8 +132,7 @@ public class EPersonRestAuthenticationProvider implements AuthenticationProvider
             return new DSpaceAuthentication(ePerson, getGrantedAuthorities(context));
 
         } else {
-            log.info(
-                LogManager.getHeader(context, "failed_login", "No eperson with an non-blank e-mail address found"));
+            log.info(LogHelper.getHeader(context, "failed_login", "No eperson with an non-blank e-mail address found"));
             throw new BadCredentialsException("Login failed");
         }
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/DiscoverQueryBuilder.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/DiscoverQueryBuilder.java
@@ -24,7 +24,7 @@ import org.dspace.app.rest.exception.DSpaceBadRequestException;
 import org.dspace.app.rest.exception.InvalidSearchRequestException;
 import org.dspace.app.rest.parameter.SearchFilter;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.discovery.DiscoverFacetField;
 import org.dspace.discovery.DiscoverFilterQuery;
 import org.dspace.discovery.DiscoverHitHighlightingField;
@@ -230,7 +230,7 @@ public class DiscoverQueryBuilder implements InitializingBean {
                 queryArgs.addYearRangeFacet(facet, facetYearRange);
 
             } catch (Exception e) {
-                log.error(LogManager.getHeader(context, "Error in Discovery while setting up date facet range",
+                log.error(LogHelper.getHeader(context, "Error in Discovery while setting up date facet range",
                                                "date facet: " + facet), e);
             }
 

--- a/dspace-sword/src/main/java/org/dspace/sword/DSpaceSWORDServer.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/DSpaceSWORDServer.java
@@ -9,7 +9,7 @@ package org.dspace.sword;
 
 import org.apache.logging.log4j.Logger;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.purl.sword.base.AtomDocumentRequest;
 import org.purl.sword.base.AtomDocumentResponse;
 import org.purl.sword.base.Deposit;
@@ -56,12 +56,12 @@ public class DSpaceSWORDServer implements SWORDServer {
             Context context = sc.getContext();
 
             if (log.isDebugEnabled()) {
-                log.debug(LogManager
+                log.debug(LogHelper
                               .getHeader(context, "sword_do_service_document", ""));
             }
 
             // log the request
-            log.info(LogManager
+            log.info(LogHelper
                          .getHeader(context, "sword_service_document_request",
                                     "username=" + request.getUsername() +
                                         ",on_behalf_of=" +
@@ -105,12 +105,11 @@ public class DSpaceSWORDServer implements SWORDServer {
             Context context = sc.getContext();
 
             if (log.isDebugEnabled()) {
-                log.debug(
-                    LogManager.getHeader(context, "sword_do_deposit", ""));
+                log.debug(LogHelper.getHeader(context, "sword_do_deposit", ""));
             }
 
             // log the request
-            log.info(LogManager.getHeader(context, "sword_deposit_request",
+            log.info(LogHelper.getHeader(context, "sword_deposit_request",
                                           "username=" + deposit.getUsername() + ",on_behalf_of=" +
                                               deposit.getOnBehalfOf()));
 
@@ -155,12 +154,12 @@ public class DSpaceSWORDServer implements SWORDServer {
             Context context = sc.getContext();
 
             if (log.isDebugEnabled()) {
-                log.debug(LogManager
+                log.debug(LogHelper
                               .getHeader(context, "sword_do_atom_document", ""));
             }
 
             // log the request
-            log.info(LogManager
+            log.info(LogHelper
                          .getHeader(context, "sword_atom_document_request",
                                     "username=" + adr.getUsername()));
 

--- a/dspace-sword/src/main/java/org/dspace/sword/DepositManager.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/DepositManager.java
@@ -28,7 +28,7 @@ import org.dspace.content.Item;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.CollectionService;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.core.Utils;
 import org.purl.sword.base.Deposit;
 import org.purl.sword.base.DepositResponse;
@@ -125,7 +125,7 @@ public class DepositManager {
             if (swordContext.getOnBehalfOf() != null) {
                 oboEmail = swordContext.getOnBehalfOf().getEmail();
             }
-            log.info(LogManager.getHeader(context,
+            log.info(LogHelper.getHeader(context,
                                           "deposit_failed_authorisation",
                                           "user=" + swordContext.getAuthenticated().getEmail() +
                                               ",on_behalf_of=" + oboEmail));

--- a/dspace-sword/src/main/java/org/dspace/sword/SWORDAuthenticator.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/SWORDAuthenticator.java
@@ -29,7 +29,7 @@ import org.dspace.content.service.CommunityService;
 import org.dspace.content.service.ItemService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
 import org.dspace.eperson.factory.EPersonServiceFactory;
@@ -277,7 +277,7 @@ public class SWORDAuthenticator {
                                           "Mediated deposit to this service is not permitted");
         }
 
-        log.info(LogManager.getHeader(context, "sword_authenticate",
+        log.info(LogHelper.getHeader(context, "sword_authenticate",
                                       "username=" + un + ",on_behalf_of=" + obo));
 
         try {
@@ -341,14 +341,14 @@ public class SWORDAuthenticator {
             if (!authenticated) {
                 // decide what kind of error to throw
                 if (ep != null) {
-                    log.info(LogManager.getHeader(context,
+                    log.info(LogHelper.getHeader(context,
                                                   "sword_unable_to_set_user", "username=" + un));
                     throw new SWORDAuthenticationException(
                         "Unable to authenticate the supplied used");
                 } else {
                     // FIXME: this shouldn't ever happen now, but may as well leave it in just in case
                     // there's a bug elsewhere
-                    log.info(LogManager.getHeader(context,
+                    log.info(LogHelper.getHeader(context,
                                                   "sword_unable_to_set_on_behalf_of",
                                                   "username=" + un + ",on_behalf_of=" + obo));
                     throw new SWORDAuthenticationException(

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/CollectionDepositManagerDSpace.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/CollectionDepositManagerDSpace.java
@@ -15,7 +15,7 @@ import org.dspace.content.Collection;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.CollectionService;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.swordapp.server.AuthCredentials;
 import org.swordapp.server.CollectionDepositManager;
 import org.swordapp.server.Deposit;
@@ -57,8 +57,7 @@ public class CollectionDepositManagerDSpace extends DSpaceSwordAPI
             Context context = sc.getContext();
 
             if (log.isDebugEnabled()) {
-                log.debug(
-                    LogManager.getHeader(context, "sword_create_new", ""));
+                log.debug(LogHelper.getHeader(context, "sword_create_new", ""));
             }
 
             // get the deposit target
@@ -81,7 +80,7 @@ public class CollectionDepositManagerDSpace extends DSpaceSwordAPI
                 if (sc.getOnBehalfOf() != null) {
                     oboEmail = sc.getOnBehalfOf().getEmail();
                 }
-                log.info(LogManager
+                log.info(LogHelper
                              .getHeader(context, "deposit_failed_authorisation",
                                         "user=" +
                                             sc.getAuthenticated().getEmail() +

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/ContainerManagerDSpace.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/ContainerManagerDSpace.java
@@ -24,7 +24,7 @@ import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.WorkspaceItemService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.workflow.WorkflowItem;
 import org.dspace.workflow.WorkflowItemService;
 import org.dspace.workflow.factory.WorkflowServiceFactory;
@@ -141,7 +141,7 @@ public class ContainerManagerDSpace extends DSpaceSwordAPI
             Context context = sc.getContext();
 
             if (log.isDebugEnabled()) {
-                log.debug(LogManager.getHeader(context, "sword_replace", ""));
+                log.debug(LogHelper.getHeader(context, "sword_replace", ""));
             }
 
             // get the deposit target
@@ -164,7 +164,7 @@ public class ContainerManagerDSpace extends DSpaceSwordAPI
                 if (sc.getOnBehalfOf() != null) {
                     oboEmail = sc.getOnBehalfOf().getEmail();
                 }
-                log.info(LogManager.getHeader(
+                log.info(LogHelper.getHeader(
                     context, "replace_failed_authorisation",
                     "user=" + sc.getAuthenticated().getEmail() +
                         ",on_behalf_of=" + oboEmail));
@@ -246,7 +246,7 @@ public class ContainerManagerDSpace extends DSpaceSwordAPI
             Context context = sc.getContext();
 
             if (log.isDebugEnabled()) {
-                log.debug(LogManager.getHeader(
+                log.debug(LogHelper.getHeader(
                     context, "sword_create_new", ""));
             }
 
@@ -269,7 +269,7 @@ public class ContainerManagerDSpace extends DSpaceSwordAPI
                 if (sc.getOnBehalfOf() != null) {
                     oboEmail = sc.getOnBehalfOf().getEmail();
                 }
-                log.info(LogManager.getHeader(context,
+                log.info(LogHelper.getHeader(context,
                                               "deposit_failed_authorisation",
                                               "user=" + sc.getAuthenticated().getEmail() +
                                                   ",on_behalf_of=" + oboEmail));
@@ -356,7 +356,7 @@ public class ContainerManagerDSpace extends DSpaceSwordAPI
             Context context = sc.getContext();
 
             if (log.isDebugEnabled()) {
-                log.debug(LogManager.getHeader(context, "sword_replace", ""));
+                log.debug(LogHelper.getHeader(context, "sword_replace", ""));
             }
 
             // get the deposit target
@@ -379,7 +379,7 @@ public class ContainerManagerDSpace extends DSpaceSwordAPI
                 if (sc.getOnBehalfOf() != null) {
                     oboEmail = sc.getOnBehalfOf().getEmail();
                 }
-                log.info(LogManager.getHeader(
+                log.info(LogHelper.getHeader(
                     context, "replace_failed_authorisation",
                     "user=" + sc.getAuthenticated().getEmail() +
                         ",on_behalf_of=" + oboEmail));
@@ -463,7 +463,7 @@ public class ContainerManagerDSpace extends DSpaceSwordAPI
             Context context = sc.getContext();
 
             if (log.isDebugEnabled()) {
-                log.debug(LogManager.getHeader(context, "sword_delete", ""));
+                log.debug(LogHelper.getHeader(context, "sword_delete", ""));
             }
 
             // get the deposit target
@@ -486,7 +486,7 @@ public class ContainerManagerDSpace extends DSpaceSwordAPI
                 if (sc.getOnBehalfOf() != null) {
                     oboEmail = sc.getOnBehalfOf().getEmail();
                 }
-                log.info(LogManager.getHeader(context,
+                log.info(LogHelper.getHeader(context,
                                               "replace_failed_authorisation",
                                               "user=" + sc.getAuthenticated().getEmail() +
                                                   ",on_behalf_of=" + oboEmail));
@@ -542,7 +542,7 @@ public class ContainerManagerDSpace extends DSpaceSwordAPI
             Context context = sc.getContext();
 
             if (log.isDebugEnabled()) {
-                log.debug(LogManager.getHeader(
+                log.debug(LogHelper.getHeader(
                     context, "sword_modify_by_headers", ""));
             }
 
@@ -566,7 +566,7 @@ public class ContainerManagerDSpace extends DSpaceSwordAPI
                 if (sc.getOnBehalfOf() != null) {
                     oboEmail = sc.getOnBehalfOf().getEmail();
                 }
-                log.info(LogManager.getHeader(context,
+                log.info(LogHelper.getHeader(context,
                                               "modify_failed_authorisation",
                                               "user=" + sc.getAuthenticated().getEmail() +
                                                   ",on_behalf_of=" + oboEmail));

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/DSpaceSwordAPI.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/DSpaceSwordAPI.java
@@ -40,7 +40,7 @@ import org.dspace.content.service.BitstreamService;
 import org.dspace.content.service.BundleService;
 import org.dspace.content.service.ItemService;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.core.Utils;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
@@ -97,7 +97,7 @@ public class DSpaceSwordAPI {
         String obo = authCredentials.getOnBehalfOf() != null ?
             authCredentials.getOnBehalfOf() :
             "NONE";
-        log.info(LogManager.getHeader(sc.getContext(), "sword_auth_request",
+        log.info(LogHelper.getHeader(sc.getContext(), "sword_auth_request",
                                       "username=" + un + ",on_behalf_of=" + obo));
 
         return sc;

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/MediaResourceManagerDSpace.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/MediaResourceManagerDSpace.java
@@ -27,7 +27,7 @@ import org.dspace.content.Bundle;
 import org.dspace.content.Item;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.swordapp.server.AuthCredentials;
 import org.swordapp.server.Deposit;
 import org.swordapp.server.DepositReceipt;
@@ -267,7 +267,7 @@ public class MediaResourceManagerDSpace extends DSpaceSwordAPI
             Context context = sc.getContext();
 
             if (log.isDebugEnabled()) {
-                log.debug(LogManager.getHeader(context, "sword_replace", ""));
+                log.debug(LogHelper.getHeader(context, "sword_replace", ""));
             }
 
             DepositReceipt receipt;
@@ -348,7 +348,7 @@ public class MediaResourceManagerDSpace extends DSpaceSwordAPI
                     if (sc.getOnBehalfOf() != null) {
                         oboEmail = sc.getOnBehalfOf().getEmail();
                     }
-                    log.info(LogManager
+                    log.info(LogHelper
                                  .getHeader(context, "replace_failed_authorisation",
                                             "user=" +
                                                 sc.getAuthenticated().getEmail() +
@@ -435,7 +435,7 @@ public class MediaResourceManagerDSpace extends DSpaceSwordAPI
             Context context = sc.getContext();
 
             if (log.isDebugEnabled()) {
-                log.debug(LogManager.getHeader(context, "sword_delete", ""));
+                log.debug(LogHelper.getHeader(context, "sword_delete", ""));
             }
 
             SwordUrlManager urlManager = config.getUrlManager(context, config);
@@ -492,7 +492,7 @@ public class MediaResourceManagerDSpace extends DSpaceSwordAPI
                     if (sc.getOnBehalfOf() != null) {
                         oboEmail = sc.getOnBehalfOf().getEmail();
                     }
-                    log.info(LogManager
+                    log.info(LogHelper
                                  .getHeader(context, "replace_failed_authorisation",
                                             "user=" +
                                                 sc.getAuthenticated().getEmail() +
@@ -565,7 +565,7 @@ public class MediaResourceManagerDSpace extends DSpaceSwordAPI
             Context context = sc.getContext();
 
             if (log.isDebugEnabled()) {
-                log.debug(LogManager.getHeader(context, "sword_add", ""));
+                log.debug(LogHelper.getHeader(context, "sword_add", ""));
             }
 
             // get the deposit target
@@ -588,7 +588,7 @@ public class MediaResourceManagerDSpace extends DSpaceSwordAPI
                 if (sc.getOnBehalfOf() != null) {
                     oboEmail = sc.getOnBehalfOf().getEmail();
                 }
-                log.info(LogManager
+                log.info(LogHelper
                              .getHeader(context, "replace_failed_authorisation",
                                         "user=" +
                                             sc.getAuthenticated().getEmail() +
@@ -872,7 +872,7 @@ public class MediaResourceManagerDSpace extends DSpaceSwordAPI
             if (sc.getOnBehalfOf() != null) {
                 oboEmail = sc.getOnBehalfOf().getEmail();
             }
-            log.info(LogManager
+            log.info(LogHelper
                          .getHeader(context, "replace_failed_authorisation",
                                     "user=" +
                                         sc.getAuthenticated().getEmail() +

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/ServiceDocumentManagerDSpace.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/ServiceDocumentManagerDSpace.java
@@ -16,7 +16,7 @@ import org.dspace.content.DSpaceObject;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.CommunityService;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.swordapp.server.AuthCredentials;
@@ -59,7 +59,7 @@ public class ServiceDocumentManagerDSpace implements ServiceDocumentManager {
             WorkflowManagerFactory.getInstance().retrieveServiceDoc(context);
 
             if (log.isDebugEnabled()) {
-                log.debug(LogManager
+                log.debug(LogHelper
                               .getHeader(context, "sword_do_service_document", ""));
             }
 
@@ -70,7 +70,7 @@ public class ServiceDocumentManagerDSpace implements ServiceDocumentManager {
             String obo = authCredentials.getOnBehalfOf() != null ?
                 authCredentials.getOnBehalfOf() :
                 "NONE";
-            log.info(LogManager
+            log.info(LogHelper
                          .getHeader(context, "sword_service_document_request",
                                     "username=" + un + ",on_behalf_of=" + obo));
 

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/StatementManagerDSpace.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/StatementManagerDSpace.java
@@ -21,7 +21,7 @@ import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.content.Item;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.swordapp.server.AuthCredentials;
 import org.swordapp.server.Statement;
 import org.swordapp.server.StatementManager;
@@ -49,7 +49,7 @@ public class StatementManagerDSpace extends DSpaceSwordAPI
             Context context = sc.getContext();
 
             if (log.isDebugEnabled()) {
-                log.debug(LogManager
+                log.debug(LogHelper
                               .getHeader(context, "sword_get_statement", ""));
             }
 
@@ -60,7 +60,7 @@ public class StatementManagerDSpace extends DSpaceSwordAPI
             String obo = authCredentials.getOnBehalfOf() != null ?
                 authCredentials.getOnBehalfOf() :
                 "NONE";
-            log.info(LogManager.getHeader(context, "sword_get_statement",
+            log.info(LogHelper.getHeader(context, "sword_get_statement",
                                           "username=" + un + ",on_behalf_of=" + obo));
 
             // first thing is to figure out what we're being asked to work on

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/SwordAuthenticator.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/SwordAuthenticator.java
@@ -30,7 +30,7 @@ import org.dspace.content.service.CommunityService;
 import org.dspace.content.service.ItemService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
-import org.dspace.core.LogManager;
+import org.dspace.core.LogHelper;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
 import org.dspace.eperson.factory.EPersonServiceFactory;
@@ -168,7 +168,7 @@ public class SwordAuthenticator {
                                  "Mediated deposit to this service is not permitted");
         }
 
-        log.info(LogManager.getHeader(context, "sword_authenticate",
+        log.info(LogHelper.getHeader(context, "sword_authenticate",
                                       "username=" + un + ",on_behalf_of=" + obo));
 
         try {
@@ -233,14 +233,14 @@ public class SwordAuthenticator {
             if (!authenticated) {
                 // decide what kind of error to throw
                 if (ep != null) {
-                    log.info(LogManager.getHeader(context,
+                    log.info(LogHelper.getHeader(context,
                                                   "sword_unable_to_set_user", "username=" + un));
                     throw new SwordAuthException(
                         "Unable to authenticate with the supplied credentials");
                 } else {
                     // FIXME: this shouldn't ever happen now, but may as well leave it in just in case
                     // there's a bug elsewhere
-                    log.info(LogManager.getHeader(context,
+                    log.info(LogHelper.getHeader(context,
                                                   "sword_unable_to_set_on_behalf_of",
                                                   "username=" + un + ",on_behalf_of=" + obo));
                     throw new SwordAuthException(

--- a/dspace/modules/rest/pom.xml
+++ b/dspace/modules/rest/pom.xml
@@ -133,11 +133,13 @@
         <dependency>
             <groupId>org.dspace</groupId>
             <artifactId>dspace-rest</artifactId>
+            <version>${project.version}</version>
             <type>war</type>
         </dependency>
         <dependency>
             <groupId>org.dspace</groupId>
             <artifactId>dspace-rest</artifactId>
+            <version>${project.version}</version>
             <type>jar</type>
             <classifier>classes</classifier>
         </dependency>


### PR DESCRIPTION
## References
* Fixes DS-4548 / #7881

## Description
Rename LogManager to LogHelper.  The old name causes many annoying collisions with multiple logging packages, requiring the use of very long fully-qualified class names.

## Instructions for Reviewers
List of changes in this PR:
* Class renamed.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
