### PR TITLE
Allow changing an EPerson's password through the CLI

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -920,6 +920,12 @@
             <version>6.4.0</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-rules</artifactId>
+            <version>1.19.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/dspace-api/src/main/java/org/dspace/eperson/EPerson.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/EPerson.java
@@ -37,7 +37,6 @@ import org.hibernate.proxy.HibernateProxyHelper;
  * Class representing an e-person.
  *
  * @author David Stuve
- * @version $Revision$
  */
 @Entity
 @Cacheable
@@ -381,6 +380,13 @@ public class EPerson extends DSpaceObject implements DSpaceObjectLegacySupport {
         return digestAlgorithm;
     }
 
+    /**
+     * Store the digest algorithm used to hash the password.  You should also
+     * set the {@link setPassword password hash} and the
+     * {@link setDigestAlgorithm digest algorithm}.
+     *
+     * @param digestAlgorithm
+     */
     void setDigestAlgorithm(String digestAlgorithm) {
         this.digestAlgorithm = digestAlgorithm;
     }
@@ -389,6 +395,13 @@ public class EPerson extends DSpaceObject implements DSpaceObjectLegacySupport {
         return salt;
     }
 
+    /**
+     * Store the salt used when hashing the password.  You should also set the
+     * {@link setPassword password hash} and the {@link setDigestAlgorithm
+     * digest algorithm}.
+     *
+     * @param salt
+     */
     void setSalt(String salt) {
         this.salt = salt;
     }
@@ -397,6 +410,12 @@ public class EPerson extends DSpaceObject implements DSpaceObjectLegacySupport {
         return password;
     }
 
+    /**
+     * Store the <strong>hash of a</strong> password.  You should also set the
+     * {@link setSalt salt} and the {@link setDigestAlgorithm digest algorithm}.
+     *
+     * @param password
+     */
     void setPassword(String password) {
         this.password = password;
     }

--- a/dspace-api/src/main/java/org/dspace/eperson/EPersonCLITool.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/EPersonCLITool.java
@@ -63,6 +63,9 @@ public class EPersonCLITool {
     private static final Option OPT_NEW_PASSWORD
             = new Option("w", "newPassword", false, "prompt for new password");
 
+    static final String ERR_PASSWORD_EMPTY = "The new password may not be empty.";
+    static final String ERR_PASSWORD_NOMATCH = "Passwords do not match.  Password not set";
+
     private static final EPersonService ePersonService
             = EPersonServiceFactory.getInstance().getEPersonService();
 
@@ -382,7 +385,7 @@ public class EPersonCLITool {
                 char[] password2 = consoleService.readPassword(
                         "Enter new password again to verify:  ");
                 if (password1.length <= 0 || password2.length <= 0) {
-                    System.err.println("The new password may not be empty.");
+                    System.err.println(ERR_PASSWORD_EMPTY);
                 } else if (Arrays.equals(password1, password2)) {
                     PasswordHash newHashedPassword = new PasswordHash(String.valueOf(password1));
                     Arrays.fill(password1, '\0'); // Obliterate cleartext passwords
@@ -392,7 +395,7 @@ public class EPersonCLITool {
                     eperson.setDigestAlgorithm(newHashedPassword.getAlgorithm());
                     modified = true;
                 } else {
-                    System.err.println("Passwords do not match.  Password not set");
+                    System.err.println(ERR_PASSWORD_NOMATCH);
                 }
             }
             if (command.hasOption(OPT_GIVENNAME.getOpt())) {
@@ -442,6 +445,7 @@ public class EPersonCLITool {
     /**
      * Command to list known EPersons.
      */
+    @SuppressWarnings("unused")
     private static int cmdList(Context context, String[] argv) {
         // XXX ideas:
         // specific user/netid

--- a/dspace-api/src/main/java/org/dspace/eperson/EPersonCLITool.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/EPersonCLITool.java
@@ -29,6 +29,8 @@ import org.dspace.authorize.AuthorizeException;
 import org.dspace.core.Context;
 import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.eperson.service.EPersonService;
+import org.dspace.util.ConsoleService;
+import org.dspace.util.ConsoleServiceImpl;
 
 public class EPersonCLITool {
 
@@ -64,10 +66,13 @@ public class EPersonCLITool {
     private static final EPersonService ePersonService
             = EPersonServiceFactory.getInstance().getEPersonService();
 
+    private static ConsoleService consoleService
+            = new ConsoleServiceImpl();
+
     /**
      * Default constructor
      */
-    private EPersonCLITool() { }
+    EPersonCLITool() { }
 
     /**
      * Tool for manipulating user accounts.
@@ -372,14 +377,11 @@ public class EPersonCLITool {
                 modified = true;
             }
             if (command.hasOption(OPT_NEW_PASSWORD.getOpt())) {
-                // TODO prompt, collect password, verify
-                char[] password = System.console()
-                        .readPassword("Enter new password for user %s", userName);
-                char[] password2 = System.console()
-                        .readPassword("Enter new password again to verify");
-                if (Arrays.equals(password, password2)) {
-                    PasswordHash newHashedPassword = new PasswordHash(String.valueOf(password));
-                    Arrays.fill(password, '\0'); // Obliterate cleartext passwords
+                char[] password1 = consoleService.readPassword("Enter new password for user %s", userName);
+                char[] password2 = consoleService.readPassword("Enter new password again to verify");
+                if (Arrays.equals(password1, password2)) {
+                    PasswordHash newHashedPassword = new PasswordHash(String.valueOf(password1));
+                    Arrays.fill(password1, '\0'); // Obliterate cleartext passwords
                     Arrays.fill(password2, '\0');
                     eperson.setPassword(newHashedPassword.getHashString());
                     eperson.setSalt(newHashedPassword.getSaltString());
@@ -455,5 +457,14 @@ public class EPersonCLITool {
         }
 
         return 0;
+    }
+
+    /**
+     * Replace the ConsoleService for testing.
+     *
+     * @param service new ConsoleService to be used henceforth.
+     */
+    void setConsoleService(ConsoleService service) {
+        consoleService = service;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/eperson/EPersonCLITool.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/EPersonCLITool.java
@@ -377,9 +377,13 @@ public class EPersonCLITool {
                 modified = true;
             }
             if (command.hasOption(OPT_NEW_PASSWORD.getOpt())) {
-                char[] password1 = consoleService.readPassword("Enter new password for user %s", userName);
-                char[] password2 = consoleService.readPassword("Enter new password again to verify");
-                if (Arrays.equals(password1, password2)) {
+                char[] password1 = consoleService.readPassword(
+                        "Enter new password for user '%s':  ", userName);
+                char[] password2 = consoleService.readPassword(
+                        "Enter new password again to verify:  ");
+                if (password1.length <= 0 || password2.length <= 0) {
+                    System.err.println("The new password may not be empty.");
+                } else if (Arrays.equals(password1, password2)) {
                     PasswordHash newHashedPassword = new PasswordHash(String.valueOf(password1));
                     Arrays.fill(password1, '\0'); // Obliterate cleartext passwords
                     Arrays.fill(password2, '\0');

--- a/dspace-api/src/main/java/org/dspace/eperson/EPersonCLITool.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/EPersonCLITool.java
@@ -122,7 +122,6 @@ public class EPersonCLITool {
             new HelpFormatter().printHelp("user [options]", globalOptions);
             context.abort();
             status = 1;
-            throw new IllegalArgumentException();
         }
 
         if (context.isValid()) {

--- a/dspace-api/src/main/java/org/dspace/util/ConsoleService.java
+++ b/dspace-api/src/main/java/org/dspace/util/ConsoleService.java
@@ -1,0 +1,17 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.util;
+
+/**
+ * Make System.console mock-able for testing.
+ *
+ * @author Mark H. Wood <mwood@iupui.edu>
+ */
+public interface ConsoleService {
+    public char[] readPassword(String prompt, Object... args);
+}

--- a/dspace-api/src/main/java/org/dspace/util/ConsoleServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/util/ConsoleServiceImpl.java
@@ -1,0 +1,22 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+
+package org.dspace.util;
+
+/**
+ * Standard implementation of console IO using {@code System.console()}.
+ *
+ * @author Mark H. Wood <mwood@iupui.edu>
+ */
+public class ConsoleServiceImpl
+        implements ConsoleService {
+    @Override
+    public char[] readPassword(String prompt, Object... args) {
+        return System.console().readPassword(prompt, args);
+    }
+}

--- a/dspace-api/src/test/java/org/dspace/eperson/EPersonCLIToolIT.java
+++ b/dspace-api/src/test/java/org/dspace/eperson/EPersonCLIToolIT.java
@@ -1,0 +1,64 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.eperson;
+
+import static org.junit.Assert.assertNotEquals;
+
+import org.dspace.AbstractIntegrationTest;
+import org.dspace.util.FakeConsoleServiceImpl;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.ExpectedSystemExit;
+
+/**
+ *
+ * @author Mark H. Wood <mwood@iupui.edu>
+ */
+public class EPersonCLIToolIT
+        extends AbstractIntegrationTest {
+    private static final String NEW_PASSWORD = "secret";
+
+    // Handle System.exit() from unit under test.
+    @Rule
+    public final ExpectedSystemExit exit = ExpectedSystemExit.none();
+
+    /**
+     * Test --modify --newPassword
+     * @throws Exception passed through.
+     */
+    @Test
+    @SuppressWarnings("static-access")
+    public void testSetPassword()
+            throws Exception {
+        exit.expectSystemExitWithStatus(0);
+        System.out.println("main");
+
+        // Create a source of "console" input.
+        FakeConsoleServiceImpl consoleService = new FakeConsoleServiceImpl();
+        consoleService.setPassword("secret".toCharArray());
+
+        // Make certain that we know the eperson's email and old password hash.
+        String email = eperson.getEmail();
+        String oldPasswordHash = eperson.getPassword();
+
+        // Instantiate the unit under test.
+        EPersonCLITool instance = new EPersonCLITool();
+        instance.setConsoleService(consoleService);
+
+        // Test!
+        String[] argv = {
+            "--modify",
+            "--email", email,
+            "--newPassword", NEW_PASSWORD
+        };
+        instance.main(argv);
+
+        String newPasswordHash = eperson.getPassword();
+        assertNotEquals("Password hash did not change", oldPasswordHash, newPasswordHash);
+    }
+}

--- a/dspace-api/src/test/java/org/dspace/util/FakeConsoleServiceImpl.java
+++ b/dspace-api/src/test/java/org/dspace/util/FakeConsoleServiceImpl.java
@@ -11,19 +11,30 @@ package org.dspace.util;
  * A test version of ConsoleService which supplies any password input that we
  * want.
  *
+ * <p>This can return different passwords on even/odd calls, to test
+ * confirmation dialogs.  See {@link setPassword1} and {@link setPassword2}.
+ * Use {@link setPassword} to set both identically.
+ *
  * @author Mark H. Wood <mwood@iupui.edu>
  */
 public class FakeConsoleServiceImpl
         implements ConsoleService {
     private String prompt;
     private Object[] args;
-    private char[] password;
+    private char[] password1;
+    private char[] password2;
+    private int passwordCalls = 0;
 
     @Override
     public char[] readPassword(String prompt, Object... args) {
         this.prompt = prompt;
         this.args = args;
-        return this.password;
+        passwordCalls++;
+        if (passwordCalls % 2 != 0) {
+            return password1;
+        } else {
+            return password2;
+        }
     }
 
     public String getPasswordPrompt() {
@@ -34,7 +45,30 @@ public class FakeConsoleServiceImpl
         return this.args;
     }
 
+    /**
+     * Set both passwords identically.
+     * @param password the password to be returned each time.
+     */
     public void setPassword(char[] password) {
-        this.password = password;
+        setPassword1(password);
+        setPassword2(password);
+    }
+
+    /**
+     * Set the password returned on odd calls to {@link readPassword}.
+     * @param password the password to be returned.
+     */
+    public void setPassword1(char[] password) {
+        password1 = password;
+    }
+
+    /**
+     * Set the password returned on even calls to {@link readPassword},
+     * and reset the call counter.
+     * @param password the password to be returned.
+     */
+    public void setPassword2(char[] password) {
+        password2 = password;
+        passwordCalls = 0;
     }
 }

--- a/dspace-api/src/test/java/org/dspace/util/FakeConsoleServiceImpl.java
+++ b/dspace-api/src/test/java/org/dspace/util/FakeConsoleServiceImpl.java
@@ -1,0 +1,40 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.util;
+
+/**
+ * A test version of ConsoleService which supplies any password input that we
+ * want.
+ *
+ * @author Mark H. Wood <mwood@iupui.edu>
+ */
+public class FakeConsoleServiceImpl
+        implements ConsoleService {
+    private String prompt;
+    private Object[] args;
+    private char[] password;
+
+    @Override
+    public char[] readPassword(String prompt, Object... args) {
+        this.prompt = prompt;
+        this.args = args;
+        return this.password;
+    }
+
+    public String getPasswordPrompt() {
+        return prompt;
+    }
+
+    public Object[] getArgs() {
+        return this.args;
+    }
+
+    public void setPassword(char[] password) {
+        this.password = password;
+    }
+}


### PR DESCRIPTION
## References
* Fixes #3363

## Description
Add to 'bin/dspace user' and option to set a new password.

## Instructions for Reviewers
List of changes in this PR:
* A new option '--newPassword' is added to the '--modify' operation.  It should prompt for a password (which will not be echoed), prompt for the password again (to verify it), calculate a new password hash using a new salt and the default hashing algorithm, and set the EPerson's hash, salt and algorithm to these new values.  If the two passwords do not match, the password is not changed, but other modifications that were requested will be attempted.

After running `bin/dspace user --modify --newPassword {email or netid}` the old password should no longer be valid for the EPerson and the new password should be valid.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
