### PR TITLE
o.d.core.AbstractHibernateDAO#uniqueResult has useless pagination arguments

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/requestitem/dao/impl/RequestItemDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/requestitem/dao/impl/RequestItemDAOImpl.java
@@ -37,7 +37,7 @@ public class RequestItemDAOImpl extends AbstractHibernateDAO<RequestItem> implem
         Root<RequestItem> requestItemRoot = criteriaQuery.from(RequestItem.class);
         criteriaQuery.select(requestItemRoot);
         criteriaQuery.where(criteriaBuilder.equal(requestItemRoot.get(RequestItem_.token), token));
-        return uniqueResult(context, criteriaQuery, false, RequestItem.class, -1, -1);
+        return uniqueResult(context, criteriaQuery, false, RequestItem.class);
     }
 
 

--- a/dspace-api/src/main/java/org/dspace/checker/dao/impl/ChecksumResultDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/checker/dao/impl/ChecksumResultDAOImpl.java
@@ -21,7 +21,7 @@ import org.dspace.core.Context;
 
 /**
  * Hibernate implementation of the Database Access Object interface class for the ChecksumResult object.
- * This class is responsible for all database calls for the ChecksumResult object and is autowired by spring
+ * This class is responsible for all database calls for the ChecksumResult object and is autowired by Spring.
  * This class should never be accessed directly.
  *
  * @author kevinvandevelde at atmire.com
@@ -39,6 +39,6 @@ public class ChecksumResultDAOImpl extends AbstractHibernateDAO<ChecksumResult> 
         Root<ChecksumResult> checksumResultRoot = criteriaQuery.from(ChecksumResult.class);
         criteriaQuery.select(checksumResultRoot);
         criteriaQuery.where(criteriaBuilder.equal(checksumResultRoot.get(ChecksumResult_.resultCode), code));
-        return uniqueResult(context, criteriaQuery, false, ChecksumResult.class, -1, -1);
+        return uniqueResult(context, criteriaQuery, false, ChecksumResult.class);
     }
 }

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/BitstreamFormatDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/BitstreamFormatDAOImpl.java
@@ -23,7 +23,7 @@ import org.dspace.core.Context;
 
 /**
  * Hibernate implementation of the Database Access Object interface class for the BitstreamFormat object.
- * This class is responsible for all database calls for the BitstreamFormat object and is autowired by spring
+ * This class is responsible for all database calls for the BitstreamFormat object and is autowired by Spring.
  * This class should never be accessed directly.
  *
  * @author kevinvandevelde at atmire.com
@@ -86,7 +86,7 @@ public class BitstreamFormatDAOImpl extends AbstractHibernateDAO<BitstreamFormat
         Root<BitstreamFormat> bitstreamFormatRoot = criteriaQuery.from(BitstreamFormat.class);
         criteriaQuery.select(bitstreamFormatRoot);
         criteriaQuery.where(criteriaBuilder.equal(bitstreamFormatRoot.get(BitstreamFormat_.shortDescription), desc));
-        return uniqueResult(context, criteriaQuery, false, BitstreamFormat.class, -1, -1);
+        return uniqueResult(context, criteriaQuery, false, BitstreamFormat.class);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/CollectionDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/CollectionDAOImpl.java
@@ -34,7 +34,7 @@ import org.dspace.eperson.Group;
 
 /**
  * Hibernate implementation of the Database Access Object interface class for the Collection object.
- * This class is responsible for all database calls for the Collection object and is autowired by spring
+ * This class is responsible for all database calls for the Collection object and is autowired by Spring.
  * This class should never be accessed directly.
  *
  * @author kevinvandevelde at atmire.com
@@ -95,7 +95,7 @@ public class CollectionDAOImpl extends AbstractHibernateDSODAO<Collection> imple
         Root<Collection> collectionRoot = criteriaQuery.from(Collection.class);
         criteriaQuery.select(collectionRoot);
         criteriaQuery.where(criteriaBuilder.equal(collectionRoot.get(Collection_.template), item));
-        return uniqueResult(context, criteriaQuery, false, Collection.class, -1, -1);
+        return uniqueResult(context, criteriaQuery, false, Collection.class);
     }
 
     @Override
@@ -119,7 +119,7 @@ public class CollectionDAOImpl extends AbstractHibernateDSODAO<Collection> imple
         CriteriaQuery criteriaQuery = getCriteriaQuery(criteriaBuilder, Collection.class);
         Root<Collection> collectionRoot = criteriaQuery.from(Collection.class);
         Join<Collection, ResourcePolicy> join = collectionRoot.join("resourcePolicies");
-        List<Predicate> orPredicates = new LinkedList<Predicate>();
+        List<Predicate> orPredicates = new LinkedList<>();
         for (Integer action : actions) {
             orPredicates.add(criteriaBuilder.equal(join.get(ResourcePolicy_.actionId), action));
         }

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/EntityTypeDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/EntityTypeDAOImpl.java
@@ -18,6 +18,15 @@ import org.dspace.content.dao.EntityTypeDAO;
 import org.dspace.core.AbstractHibernateDAO;
 import org.dspace.core.Context;
 
+/**
+ * Hibernate implementation of the Database Access Object interface class for
+ * the EntityType object.
+ * This class is responsible for all database calls for the EntityType object
+ * and is autowired by Spring.
+ * This class should never be accessed directly.
+ *
+ * @author kevinvandevelde at atmire.com
+ */
 public class EntityTypeDAOImpl extends AbstractHibernateDAO<EntityType> implements EntityTypeDAO {
 
     @Override
@@ -28,6 +37,6 @@ public class EntityTypeDAOImpl extends AbstractHibernateDAO<EntityType> implemen
         criteriaQuery.select(entityTypeRoot);
         criteriaQuery.where(criteriaBuilder.equal(criteriaBuilder.upper(entityTypeRoot.get(EntityType_.label)),
                                                   entityType.toUpperCase()));
-        return uniqueResult(context, criteriaQuery, true, EntityType.class, -1, -1);
+        return uniqueResult(context, criteriaQuery, true, EntityType.class);
     }
 }

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/RelationshipTypeDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/RelationshipTypeDAOImpl.java
@@ -20,6 +20,15 @@ import org.dspace.content.dao.RelationshipTypeDAO;
 import org.dspace.core.AbstractHibernateDAO;
 import org.dspace.core.Context;
 
+/**
+ * Hibernate implementation of the Database Access Object interface class for
+ * the RelationshipType object.
+ * This class is responsible for all database calls for the RelationshipType
+ * object and is autowired by Spring.
+ * This class should never be accessed directly.
+ *
+ * @author kevinvandevelde at atmire.com
+ */
 public class RelationshipTypeDAOImpl extends AbstractHibernateDAO<RelationshipType> implements RelationshipTypeDAO {
 
     @Override
@@ -36,7 +45,7 @@ public class RelationshipTypeDAOImpl extends AbstractHibernateDAO<RelationshipTy
                 criteriaBuilder.equal(relationshipTypeRoot.get(RelationshipType_.rightType), rightType),
                 criteriaBuilder.equal(relationshipTypeRoot.get(RelationshipType_.leftwardType), leftwardType),
                 criteriaBuilder.equal(relationshipTypeRoot.get(RelationshipType_.rightwardType), rightwardType)));
-        return uniqueResult(context, criteriaQuery, false, RelationshipType.class, -1, -1);
+        return uniqueResult(context, criteriaQuery, false, RelationshipType.class);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/SiteDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/SiteDAOImpl.java
@@ -19,7 +19,7 @@ import org.dspace.core.Context;
 
 /**
  * Hibernate implementation of the Database Access Object interface class for the Site object.
- * This class is responsible for all database calls for the Site object and is autowired by spring
+ * This class is responsible for all database calls for the Site object and is autowired by Spring.
  * This class should never be accessed directly.
  *
  * @author kevinvandevelde at atmire.com
@@ -35,6 +35,6 @@ public class SiteDAOImpl extends AbstractHibernateDAO<Site> implements SiteDAO {
         CriteriaQuery criteriaQuery = getCriteriaQuery(criteriaBuilder, Site.class);
         Root<Site> siteRoot = criteriaQuery.from(Site.class);
         criteriaQuery.select(siteRoot);
-        return uniqueResult(context, criteriaQuery, true, Site.class, -1, -1);
+        return uniqueResult(context, criteriaQuery, true, Site.class);
     }
 }

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/WorkspaceItemDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/WorkspaceItemDAOImpl.java
@@ -31,7 +31,7 @@ import org.dspace.eperson.Group;
 
 /**
  * Hibernate implementation of the Database Access Object interface class for the WorkspaceItem object.
- * This class is responsible for all database calls for the WorkspaceItem object and is autowired by spring
+ * This class is responsible for all database calls for the WorkspaceItem object and is autowired by Spring.
  * This class should never be accessed directly.
  *
  * @author kevinvandevelde at atmire.com
@@ -81,7 +81,7 @@ public class WorkspaceItemDAOImpl extends AbstractHibernateDAO<WorkspaceItem> im
         Root<WorkspaceItem> workspaceItemRoot = criteriaQuery.from(WorkspaceItem.class);
         criteriaQuery.select(workspaceItemRoot);
         criteriaQuery.where(criteriaBuilder.equal(workspaceItemRoot.get(WorkspaceItem_.item), i));
-        return uniqueResult(context, criteriaQuery, false, WorkspaceItem.class, -1, -1);
+        return uniqueResult(context, criteriaQuery, false, WorkspaceItem.class);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/core/AbstractHibernateDAO.java
+++ b/dspace-api/src/main/java/org/dspace/core/AbstractHibernateDAO.java
@@ -212,16 +212,14 @@ public abstract class AbstractHibernateDAO<T> implements GenericDAO<T> {
      * @param criteriaQuery JPA criteria
      * @param cacheable whether or not this query should be cacheable.
      * @param clazz type of object that should match the query.
-     * @param maxResults return at most this many results.
-     * @param offset skip this many leading results.
      * @return the single model object specified by the criteria,
      *          or {@code null} if none match.
      * @throws java.sql.SQLException passed through.
      * @throws IllegalArgumentException if multiple objects match.
      */
-    public T uniqueResult(Context context, CriteriaQuery criteriaQuery, boolean cacheable, Class<T> clazz,
-                          int maxResults, int offset) throws SQLException {
-        List<T> list = list(context, criteriaQuery, cacheable, clazz, maxResults, offset);
+    public T uniqueResult(Context context, CriteriaQuery criteriaQuery,
+            boolean cacheable, Class<T> clazz) throws SQLException {
+        List<T> list = list(context, criteriaQuery, cacheable, clazz, -1, -1);
         if (CollectionUtils.isNotEmpty(list)) {
             if (list.size() == 1) {
                 return list.get(0);

--- a/dspace-api/src/main/java/org/dspace/core/AbstractHibernateDSODAO.java
+++ b/dspace-api/src/main/java/org/dspace/core/AbstractHibernateDSODAO.java
@@ -48,7 +48,7 @@ public abstract class AbstractHibernateDSODAO<T extends DSpaceObject> extends Ab
         CriteriaQuery criteriaQuery = getCriteriaQuery(criteriaBuilder, clazz);
         Root<T> root = criteriaQuery.from(clazz);
         criteriaQuery.where(criteriaBuilder.equal(root.get("legacyId"), legacyId));
-        return uniqueResult(context, criteriaQuery, false, clazz, -1, -1);
+        return uniqueResult(context, criteriaQuery, false, clazz);
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/eperson/dao/impl/EPersonDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/dao/impl/EPersonDAOImpl.java
@@ -33,7 +33,7 @@ import org.dspace.eperson.dao.EPersonDAO;
 
 /**
  * Hibernate implementation of the Database Access Object interface class for the EPerson object.
- * This class is responsible for all database calls for the EPerson object and is autowired by spring
+ * This class is responsible for all database calls for the EPerson object and is autowired by Spring.
  * This class should never be accessed directly.
  *
  * @author kevinvandevelde at atmire.com
@@ -50,7 +50,7 @@ public class EPersonDAOImpl extends AbstractHibernateDSODAO<EPerson> implements 
         Root<EPerson> ePersonRoot = criteriaQuery.from(EPerson.class);
         criteriaQuery.select(ePersonRoot);
         criteriaQuery.where(criteriaBuilder.equal(ePersonRoot.get(EPerson_.email), email.toLowerCase()));
-        return uniqueResult(context, criteriaQuery, true, EPerson.class, -1, -1);
+        return uniqueResult(context, criteriaQuery, true, EPerson.class);
     }
 
 
@@ -61,7 +61,7 @@ public class EPersonDAOImpl extends AbstractHibernateDSODAO<EPerson> implements 
         Root<EPerson> ePersonRoot = criteriaQuery.from(EPerson.class);
         criteriaQuery.select(ePersonRoot);
         criteriaQuery.where((criteriaBuilder.equal(ePersonRoot.get(EPerson_.netid), netid)));
-        return uniqueResult(context, criteriaQuery, true, EPerson.class, -1, -1);
+        return uniqueResult(context, criteriaQuery, true, EPerson.class);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/eperson/dao/impl/Group2GroupCacheDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/dao/impl/Group2GroupCacheDAOImpl.java
@@ -25,7 +25,7 @@ import org.dspace.eperson.dao.Group2GroupCacheDAO;
 
 /**
  * Hibernate implementation of the Database Access Object interface class for the Group2GroupCache object.
- * This class is responsible for all database calls for the Group2GroupCache object and is autowired by spring
+ * This class is responsible for all database calls for the Group2GroupCache object and is autowired by Spring.
  * This class should never be accessed directly.
  *
  * @author kevinvandevelde at atmire.com
@@ -83,7 +83,7 @@ public class Group2GroupCacheDAOImpl extends AbstractHibernateDAO<Group2GroupCac
                                 criteriaBuilder.equal(group2GroupCacheRoot.get(Group2GroupCache_.child), child)
             )
         );
-        return uniqueResult(context, criteriaQuery, true, Group2GroupCache.class, -1, -1);
+        return uniqueResult(context, criteriaQuery, true, Group2GroupCache.class);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/eperson/dao/impl/RegistrationDataDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/dao/impl/RegistrationDataDAOImpl.java
@@ -21,7 +21,7 @@ import org.dspace.eperson.dao.RegistrationDataDAO;
 
 /**
  * Hibernate implementation of the Database Access Object interface class for the RegistrationData object.
- * This class is responsible for all database calls for the RegistrationData object and is autowired by spring
+ * This class is responsible for all database calls for the RegistrationData object and is autowired by Spring.
  * This class should never be accessed directly.
  *
  * @author kevinvandevelde at atmire.com
@@ -39,7 +39,7 @@ public class RegistrationDataDAOImpl extends AbstractHibernateDAO<RegistrationDa
         Root<RegistrationData> registrationDataRoot = criteriaQuery.from(RegistrationData.class);
         criteriaQuery.select(registrationDataRoot);
         criteriaQuery.where(criteriaBuilder.equal(registrationDataRoot.get(RegistrationData_.email), email));
-        return uniqueResult(context, criteriaQuery, false, RegistrationData.class, -1, -1);
+        return uniqueResult(context, criteriaQuery, false, RegistrationData.class);
     }
 
     @Override
@@ -49,7 +49,7 @@ public class RegistrationDataDAOImpl extends AbstractHibernateDAO<RegistrationDa
         Root<RegistrationData> registrationDataRoot = criteriaQuery.from(RegistrationData.class);
         criteriaQuery.select(registrationDataRoot);
         criteriaQuery.where(criteriaBuilder.equal(registrationDataRoot.get(RegistrationData_.token), token));
-        return uniqueResult(context, criteriaQuery, false, RegistrationData.class, -1, -1);
+        return uniqueResult(context, criteriaQuery, false, RegistrationData.class);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/identifier/dao/impl/DOIDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/dao/impl/DOIDAOImpl.java
@@ -24,7 +24,7 @@ import org.dspace.identifier.dao.DOIDAO;
 
 /**
  * Hibernate implementation of the Database Access Object interface class for the DOI object.
- * This class is responsible for all database calls for the DOI object and is autowired by spring
+ * This class is responsible for all database calls for the DOI object and is autowired by Spring.
  * This class should never be accessed directly.
  *
  * @author kevinvandevelde at atmire.com
@@ -41,7 +41,7 @@ public class DOIDAOImpl extends AbstractHibernateDAO<DOI> implements DOIDAO {
         Root<DOI> doiRoot = criteriaQuery.from(DOI.class);
         criteriaQuery.select(doiRoot);
         criteriaQuery.where(criteriaBuilder.equal(doiRoot.get(DOI_.doi), doi));
-        return uniqueResult(context, criteriaQuery, false, DOI.class, -1, -1);
+        return uniqueResult(context, criteriaQuery, false, DOI.class);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/storedcomponents/dao/impl/ClaimedTaskDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/storedcomponents/dao/impl/ClaimedTaskDAOImpl.java
@@ -23,7 +23,7 @@ import org.dspace.xmlworkflow.storedcomponents.dao.ClaimedTaskDAO;
 
 /**
  * Hibernate implementation of the Database Access Object interface class for the ClaimedTask object.
- * This class is responsible for all database calls for the ClaimedTask object and is autowired by spring
+ * This class is responsible for all database calls for the ClaimedTask object and is autowired by Spring.
  * This class should never be accessed directly.
  *
  * @author kevinvandevelde at atmire.com
@@ -56,7 +56,7 @@ public class ClaimedTaskDAOImpl extends AbstractHibernateDAO<ClaimedTask> implem
                                 criteriaBuilder.equal(claimedTaskRoot.get(ClaimedTask_.owner), ePerson)
             )
         );
-        return uniqueResult(context, criteriaQuery, false, ClaimedTask.class, -1, -1);
+        return uniqueResult(context, criteriaQuery, false, ClaimedTask.class);
 
 
     }
@@ -101,7 +101,7 @@ public class ClaimedTaskDAOImpl extends AbstractHibernateDAO<ClaimedTask> implem
                                 criteriaBuilder.equal(claimedTaskRoot.get(ClaimedTask_.actionId), actionID)
             )
         );
-        return uniqueResult(context, criteriaQuery, false, ClaimedTask.class, -1, -1);
+        return uniqueResult(context, criteriaQuery, false, ClaimedTask.class);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/storedcomponents/dao/impl/CollectionRoleDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/storedcomponents/dao/impl/CollectionRoleDAOImpl.java
@@ -24,7 +24,7 @@ import org.dspace.xmlworkflow.storedcomponents.dao.CollectionRoleDAO;
 
 /**
  * Hibernate implementation of the Database Access Object interface class for the CollectionRole object.
- * This class is responsible for all database calls for the CollectionRole object and is autowired by spring
+ * This class is responsible for all database calls for the CollectionRole object and is autowired by Spring.
  * This class should never be accessed directly.
  *
  * @author kevinvandevelde at atmire.com
@@ -66,7 +66,7 @@ public class CollectionRoleDAOImpl extends AbstractHibernateDAO<CollectionRole> 
                                 criteriaBuilder.equal(collectionRoleRoot.get(CollectionRole_.roleId), role)
             )
         );
-        return uniqueResult(context, criteriaQuery, false, CollectionRole.class, -1, -1);
+        return uniqueResult(context, criteriaQuery, false, CollectionRole.class);
 
     }
 

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/storedcomponents/dao/impl/InProgressUserDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/storedcomponents/dao/impl/InProgressUserDAOImpl.java
@@ -23,7 +23,7 @@ import org.dspace.xmlworkflow.storedcomponents.dao.InProgressUserDAO;
 
 /**
  * Hibernate implementation of the Database Access Object interface class for the InProgressUser object.
- * This class is responsible for all database calls for the InProgressUser object and is autowired by spring
+ * This class is responsible for all database calls for the InProgressUser object and is autowired by Spring.
  * This class should never be accessed directly.
  *
  * @author kevinvandevelde at atmire.com
@@ -46,7 +46,7 @@ public class InProgressUserDAOImpl extends AbstractHibernateDAO<InProgressUser> 
             criteriaBuilder.equal(inProgressUserRoot.get(InProgressUser_.ePerson), ePerson)
                             )
         );
-        return uniqueResult(context, criteriaQuery, false, InProgressUser.class, -1, -1);
+        return uniqueResult(context, criteriaQuery, false, InProgressUser.class);
 
     }
 

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/storedcomponents/dao/impl/PoolTaskDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/storedcomponents/dao/impl/PoolTaskDAOImpl.java
@@ -24,7 +24,7 @@ import org.dspace.xmlworkflow.storedcomponents.dao.PoolTaskDAO;
 
 /**
  * Hibernate implementation of the Database Access Object interface class for the PoolTask object.
- * This class is responsible for all database calls for the PoolTask object and is autowired by spring
+ * This class is responsible for all database calls for the PoolTask object and is autowired by Spring.
  * This class should never be accessed directly.
  *
  * @author kevinvandevelde at atmire.com
@@ -77,7 +77,7 @@ public class PoolTaskDAOImpl extends AbstractHibernateDAO<PoolTask> implements P
                                        criteriaBuilder.equal(poolTaskRoot.get(PoolTask_.ePerson), ePerson)
                    )
         );
-        return uniqueResult(context, criteriaQuery, false, PoolTask.class, -1, -1);
+        return uniqueResult(context, criteriaQuery, false, PoolTask.class);
     }
 
     @Override
@@ -92,6 +92,6 @@ public class PoolTaskDAOImpl extends AbstractHibernateDAO<PoolTask> implements P
                                        criteriaBuilder.equal(poolTaskRoot.get(PoolTask_.group), group)
                    )
         );
-        return uniqueResult(context, criteriaQuery, false, PoolTask.class, -1, -1);
+        return uniqueResult(context, criteriaQuery, false, PoolTask.class);
     }
 }

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/storedcomponents/dao/impl/XmlWorkflowItemDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/storedcomponents/dao/impl/XmlWorkflowItemDAOImpl.java
@@ -26,7 +26,7 @@ import org.dspace.xmlworkflow.storedcomponents.dao.XmlWorkflowItemDAO;
 
 /**
  * Hibernate implementation of the Database Access Object interface class for the XmlWorkflowItem object.
- * This class is responsible for all database calls for the XmlWorkflowItem object and is autowired by spring
+ * This class is responsible for all database calls for the XmlWorkflowItem object and is autowired by Spring.
  * This class should never be accessed directly.
  *
  * @author kevinvandevelde at atmire.com
@@ -132,6 +132,6 @@ public class XmlWorkflowItemDAOImpl extends AbstractHibernateDAO<XmlWorkflowItem
         Root<XmlWorkflowItem> xmlWorkflowItemRoot = criteriaQuery.from(XmlWorkflowItem.class);
         criteriaQuery.select(xmlWorkflowItemRoot);
         criteriaQuery.where(criteriaBuilder.equal(xmlWorkflowItemRoot.get(XmlWorkflowItem_.item), item));
-        return uniqueResult(context, criteriaQuery, false, XmlWorkflowItem.class, -1, -1);
+        return uniqueResult(context, criteriaQuery, false, XmlWorkflowItem.class);
     }
 }


### PR DESCRIPTION
## References
* Fixes #3369

## Description
Remove useless pagination arguments.

## Instructions for Reviewers
List of changes in this PR:
* Removed useless arguments, passing down fixed (-1, -1) instead.
* Fixed all usages by removing useless arguments.

There should be no changes in behavior, and all tests should still pass.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
