### PR TITLE
Google meta citation date jmarton

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/GoogleMetadata.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/GoogleMetadata.java
@@ -68,6 +68,8 @@ public class GoogleMetadata
 
     protected final String DATE = "citation_date";
 
+    protected final String PUBLICATION_DATE = "citation_publication_date";
+
     protected final String VOLUME = "citation_volume";
 
     protected final String ISSUE = "citation_issue";
@@ -667,6 +669,9 @@ public class GoogleMetadata
         // DATE
         addSingleField(DATE);
 
+        // PUBLICATION_DATE
+        addSingleField(PUBLICATION_DATE);
+
         // ISSN
         addSingleField(ISSN);
 
@@ -831,7 +836,15 @@ public class GoogleMetadata
      */
     public List<String> getDate()
     {
-        return metadataMappings.get(DATE);
+        if (metadataMappings.containsKey(DATE)) {
+            return metadataMappings.get(DATE);
+        }
+        else if (metadataMappings.containsKey(PUBLICATION_DATE)) {
+            return metadataMappings.get(PUBLICATION_DATE);
+        }
+        else {
+            return null;
+        }
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/app/util/GoogleMetadata.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/GoogleMetadata.java
@@ -66,6 +66,7 @@ public class GoogleMetadata
 
     protected final String AUTHORS = "citation_author";
 
+    // superseded by citation_publication_date, but will be used as its fallback. See DS-4518
     protected final String DATE = "citation_date";
 
     protected final String PUBLICATION_DATE = "citation_publication_date";
@@ -97,6 +98,8 @@ public class GoogleMetadata
     protected final String KEYWORDS = "citation_keywords";
 
     protected final String CONFERENCE = "citation_conference";
+
+    protected final String CONFERENCE_TITLE = "citation_conference_title";
 
     protected final String DISSERTATION_ID = "identifiers.dissertation";
 
@@ -182,6 +185,15 @@ public class GoogleMetadata
             }
         }
 
+        if (!googleScholarSettings.containsKey("citation_publication_date"))
+        {
+            log.warn("Google Metadata configuration not found for key "
+                     + GOOGLE_PREFIX + "citation_publication_date. "
+                     + "DSpace will fall back to use settings for key (if present) "
+                     + GOOGLE_PREFIX + "citation_date. "
+                     + "Consider upgrading your DSpace configuration.");
+        }
+
         if (log.isDebugEnabled())
         {
             logConfiguration();
@@ -235,7 +247,15 @@ public class GoogleMetadata
 
         if (null == config || config.equals(""))
         {
-            return false;
+            // if PUBLICATION_DATE is not configured, we will fall back to DATE instead
+            if (PUBLICATION_DATE.equals(fieldName)) {
+                config = googleScholarSettings.get(DATE);
+            }
+
+            if (null == config || config.equals(""))
+            {
+                return false;
+            }
         }
 
         if (log.isDebugEnabled())
@@ -666,9 +686,6 @@ public class GoogleMetadata
         // AUTHORS (multi)
         addMultipleValues(AUTHORS);
 
-        // DATE
-        addSingleField(DATE);
-
         // PUBLICATION_DATE
         addSingleField(PUBLICATION_DATE);
 
@@ -716,6 +733,9 @@ public class GoogleMetadata
 
         // CONFERENCE
         addSingleField(CONFERENCE);
+
+        // CONFERENCE_TITLE
+        addSingleField(CONFERENCE_TITLE);
 
         // Dissertations
         if (itemIsDissertation())
@@ -832,19 +852,11 @@ public class GoogleMetadata
     }
 
     /**
-     * @return the citation_date
+     * @return the citation_publication_date
      */
     public List<String> getDate()
     {
-        if (metadataMappings.containsKey(DATE)) {
-            return metadataMappings.get(DATE);
-        }
-        else if (metadataMappings.containsKey(PUBLICATION_DATE)) {
-            return metadataMappings.get(PUBLICATION_DATE);
-        }
-        else {
-            return null;
-        }
+        return metadataMappings.get(PUBLICATION_DATE);
     }
 
     /**
@@ -957,6 +969,14 @@ public class GoogleMetadata
     public List<String> getConference()
     {
         return metadataMappings.get(CONFERENCE);
+    }
+
+    /**
+     * @return the citation_conference_title
+     */
+    public List<String> getConferenceTitle()
+    {
+        return metadataMappings.get(CONFERENCE_TITLE);
     }
 
     /**

--- a/dspace/config/crosswalks/google-metadata.properties
+++ b/dspace/config/crosswalks/google-metadata.properties
@@ -39,7 +39,13 @@ google.identifiers.technical_report = dc.type:Technical Report
 google.citation_title = dc.title
 google.citation_publisher = dc.publisher
 google.citation_author = dc.author | dc.contributor.author | dc.creator
-google.citation_date = dc.date.issued
+# citation_date tag is deprecated, use citation_publication_date instead. See: DS-4518
+# If google.citation_publication_date is available in the configuration, the settings
+#   given there will be used.
+# If google.citation_publication_date is not available in the configuration, to provide
+#   configuration-compatibility with older versions, DSpace will fall back to the settings
+#   given for citation_date, but still publishes the datum under the new citation_publication_date key.
+google.citation_publication_date = dc.date.issued
 google.citation_language = dc.language.iso
 google.citation_pmid =
 google.citation_abstract_html_url = $handle


### PR DESCRIPTION
## References
* Fixes https://jira.lyrasis.org/browse/DS-4518

## Description
DS 6.3, XMLUI

Possibility to set citation_publication_date instead of citation_date which is deprecarted (see 2.C at https://scholar.google.com/intl/en/scholar/inclusion.html#indexing)
Also citation_conference_title can be set in the config file.

## Instructions for Reviewers
Provides configuration compatibility by falling back to use settings in citation_date if citation_publication_date is not cofigured.
However, the resulting date will still be published under the new citation_publication_date key.

To check please see the meta **citation_** tags in the source of the HTML page.

## Checklist

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
