### PR TITLE
Advanced item level versioning

### DIFF
--- a/dspace-api/src/main/java/org/dspace/handle/dao/HandleDAO.java
+++ b/dspace-api/src/main/java/org/dspace/handle/dao/HandleDAO.java
@@ -32,6 +32,8 @@ public interface HandleDAO extends GenericDAO<Handle> {
 
     public List<Handle> findByPrefix(Context context, String prefix) throws SQLException;
 
+    public List<Handle> findByVersion(Context context, String prefix) throws SQLException;
+
     public long countHandlesByPrefix(Context context, String prefix) throws SQLException;
 
     int updateHandlesWithNewPrefix(Context context, String newPrefix, String oldPrefix) throws SQLException;

--- a/dspace-api/src/main/java/org/dspace/handle/dao/impl/HandleDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/handle/dao/impl/HandleDAOImpl.java
@@ -84,6 +84,23 @@ public class HandleDAOImpl extends AbstractHibernateDAO<Handle> implements Handl
     }
 
     @Override
+    public List<Handle> findByVersion(Context context, String prefix) throws SQLException {
+        Query query = createQuery(context,
+            "select h " +
+            "from Handle h, DSpaceObject dso, Version v " +
+            "where h.dso = dso.id " +
+            "and v.item = dso.id " +
+            "and h.handle like :handle " +
+            "order by v.versionDate desc "
+            );
+
+        query.setParameter("handle", prefix + "%");
+
+        query.setCacheable(true);
+        return list(query);
+    }
+
+    @Override
     public long countHandlesByPrefix(Context context, String prefix) throws SQLException {
         Criteria criteria = createCriteria(context, Handle.class);
         criteria.add(Restrictions.like("handle", prefix + "%"));

--- a/dspace-api/src/main/java/org/dspace/handle/service/HandleService.java
+++ b/dspace-api/src/main/java/org/dspace/handle/service/HandleService.java
@@ -139,6 +139,8 @@ public interface HandleService {
      * Return the object which handle maps to, or null. This is the object
      * itself, not a URL which points to it.
      *
+     * This version does indeed fall back to versioned resolution upon miss of a verbatim match, see fallbackResolvingToMostRecentVersion=true in overridden method.
+     *
      * @param context
      *            DSpace context
      * @param handle
@@ -153,6 +155,26 @@ public interface HandleService {
     public DSpaceObject resolveToObject(Context context, String handle)
             throws IllegalStateException, SQLException;
 
+    /**
+     * Return the object which handle maps to, or null. This is the object
+     * itself, not a URL which points to it.
+     *
+     * @param context
+     *            DSpace context
+     * @param handle
+     *            The handle to resolve
+     * @param fallbackResolvingToMostRecentVersion
+     *            When set to true, resolving a non-versioned handle prefix/suffix will fall back to the most recent version, if the specified handle does not exist in its verbatim form.
+     *            Supply true value only in handle resolving context. Supply false value e.g. for exsistence checks upon handle creation.
+     * @return The object which handle maps to, or null if handle is not mapped
+     *         to any object.
+     * @exception IllegalStateException
+     *                If handle was found but is not bound to an object
+     * @exception SQLException
+     *                If a database error occurs
+     */
+    public DSpaceObject resolveToObject(Context context, String handle, boolean fallbackResolvingToMostRecentVersion)
+            throws IllegalStateException, SQLException;
 
     /**
      * Return the handle for an Object, or null if the Object has no handle.

--- a/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProvider.java
@@ -413,8 +413,9 @@ public class VersionedHandleIdentifierProvider extends IdentifierProvider {
             identifier = identifier.concat(String.valueOf(DOT)).concat(String.valueOf(versionNumber));
         }
 
+        // in case of creating new version we do not need try to find handles without version numbers
         // Ensure this handle does not exist already.
-        if (handleService.resolveToObject(context, identifier) == null)
+        if (handleService.resolveToObject(context, identifier, false) == null)
         {
              handleService.createHandle(context, dso, identifier);
         }
@@ -422,6 +423,7 @@ public class VersionedHandleIdentifierProvider extends IdentifierProvider {
         {
             throw new IllegalStateException("A versioned handle is used for another version already!");
         }
+
         return identifier;
     }
     


### PR DESCRIPTION
## References
* Fixes https://jira.lyrasis.org/browse/DS-4586
* Fixes #7919 

## Description
DS 6.3, XMLUI

As per the linked ticket
> We were thinking of improving item versioning. Our aim was to:
>
> 1. provide a persistent Handle for each item version
> 2. provide a persistent Handle that references always the most recent version

> While the current DSpace Handle versioning scheme allows (1), it does not provide (2). Basically our idea is the scheme of how  arXiv.org provides persistent item references.

## Instructions for Reviewers
With these modifications we may add a configuration property to the basic config: `initialVersionSuffix`.
> If this option is missing or if it has an empty value then the item versioning acts like before. However, if it has a string of ".1" then the Handle of the very first version of the item will get a version suffix.

Most of the modifications have been applied on the `HandleServiceImpl.java` in order to add a new parameter for the function `findHandleInternal`. With the new boolean argument we can make difference between the calls:
 1. Are we trying to resolve a handle - use true.
 2. Are we checking the existence of a handle during id creation - use false.

We also has changed the `createId` function to use the `initialVersionSuffix` and to determine wheter the new handle id will be used for an item or any other resource?

A new function `findByVersion` within `HandleDAO` class aims the modified functionality in the `findHandleInternal`. It returns a handle list within the Version table based on the given handle.

Applying our modifications result the followings when using the item versioning feature (assuming the `initialVersionSuffix` is set to _.1_):
 1. Every new item gets a versioned handle like 123456789/1.1
 2. Every new version added will get new version numbers increased by one.
 3. Linking to a handle with a specific version number renderers the exact item. However linking to an item without any version suffix (like 123456789/1) returns the most recent version of the item.

In case of missing option `initialVersionSuffix` or leaving it empty means the original item versionig will be used.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
