### PR TITLE
When sending a user registration email fails, allow the log statement to include full error details

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RegistrationRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RegistrationRestRepository.java
@@ -96,7 +96,7 @@ public class RegistrationRestRepository extends DSpaceRestRepository<Registratio
                 }
                 accountService.sendForgotPasswordInfo(context, registrationRest.getEmail());
             } catch (SQLException | IOException | MessagingException | AuthorizeException e) {
-                log.error("Something went wrong with sending forgot password info for email: "
+                log.error("Something went wrong with sending forgot password info email: "
                               + registrationRest.getEmail(), e);
             }
         } else {
@@ -107,8 +107,8 @@ public class RegistrationRestRepository extends DSpaceRestRepository<Registratio
                 }
                 accountService.sendRegistrationInfo(context, registrationRest.getEmail());
             } catch (SQLException | IOException | MessagingException | AuthorizeException e) {
-                log.error("Something with wrong with sending registration info for email: "
-                              + registrationRest.getEmail());
+                log.error("Something went wrong with sending registration info email: "
+                              + registrationRest.getEmail(), e);
             }
         }
         return null;


### PR DESCRIPTION
## Description

When a user registration email fails to send properly it could be due to a variety of problems. For example, the SMTP server could be set up incorrectly, the credentials to that SMTP server may be incorrect, or the DSpace configuration could be wrong in several ways. Currently, the exception that is thrown in this scenario is swallowed and a generic notice is added to the log. This PR updates the log message that is printed on error to include the thrown exception so that it can be visible in the logs.

## Instructions for Reviewers

List of changes in this PR:
* First, adds the thrown exception to the error log call, so that the full stack trace will be captured in the log. This matches the existing behavior in a similar catch statement within the same method.
* Second, fixes log message typos

Testing this PR:
* Set an incorrect value in your dspace.cfg (or local.cfg) for `mail.server.password`
* Restart your server app (tomcat)
* Attempt to register as a new user via the UI
* Review the dspace.log to see the error message printed

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
