### PR TITLE
Fix configuration-dependent ITs

### DIFF
--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadatafieldRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadatafieldRestRepositoryIT.java
@@ -21,7 +21,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.Comparator;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.dspace.app.rest.matcher.MetadataFieldMatcher;
@@ -967,9 +970,13 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
 
     @Test
     public void findAllPaginationTest() throws Exception {
-
-        // Determine number of metadata fields from database
-        int numberOfMdFields = ContentServiceFactory.getInstance().getMetadataFieldService().findAll(context).size();
+        List<MetadataField> alphabeticMdFields =
+            ContentServiceFactory.getInstance()
+                                 .getMetadataFieldService()
+                                 .findAll(context).stream()
+                                 .sorted(Comparator.comparing(mdf -> mdf.toString('.')))
+                                 .collect(Collectors.toList());
+        int numberOfMdFields = alphabeticMdFields.size();
 
         // If we return 3 fields per page, determine number of pages we expect
         int pageSize = 3;
@@ -983,9 +990,9 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
                    .andExpect(content().contentType(contentType))
                    // Metadata fields are returned alphabetically. So, look for the first 3 alphabetically
                    .andExpect(jsonPath("$._embedded.metadatafields", Matchers.hasItems(
-                              MetadataFieldMatcher.matchMetadataFieldByKeys("creativework","datePublished", null),
-                              MetadataFieldMatcher.matchMetadataFieldByKeys("creativework", "editor", null),
-                              MetadataFieldMatcher.matchMetadataFieldByKeys("creativework", "keywords", null)
+                              MetadataFieldMatcher.matchMetadataField(alphabeticMdFields.get(0)),
+                              MetadataFieldMatcher.matchMetadataField(alphabeticMdFields.get(1)),
+                              MetadataFieldMatcher.matchMetadataField(alphabeticMdFields.get(2))
                               )))
                    .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
                            Matchers.containsString("/api/core/metadatafields?"),
@@ -1012,9 +1019,9 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
                    .andExpect(content().contentType(contentType))
                    // Metadata fields are returned alphabetically. So, look for the next 3 alphabetically
                    .andExpect(jsonPath("$._embedded.metadatafields", Matchers.hasItems(
-                              MetadataFieldMatcher.matchMetadataFieldByKeys("creativework","publisher", null),
-                              MetadataFieldMatcher.matchMetadataFieldByKeys("creativeworkseries", "issn", null),
-                              MetadataFieldMatcher.matchMetadataFieldByKeys("dc", "contributor", null)
+                              MetadataFieldMatcher.matchMetadataField(alphabeticMdFields.get(3)),
+                              MetadataFieldMatcher.matchMetadataField(alphabeticMdFields.get(4)),
+                              MetadataFieldMatcher.matchMetadataField(alphabeticMdFields.get(5))
                               )))
                    .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
                            Matchers.containsString("/api/core/metadatafields?"),

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ScriptRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ScriptRestRepositoryIT.java
@@ -22,6 +22,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
@@ -81,24 +82,14 @@ public class ScriptRestRepositoryIT extends AbstractControllerIntegrationTest {
         getClient(token).perform(get("/api/system/scripts"))
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$._embedded.scripts", containsInAnyOrder(
-                                ScriptMatcher.matchScript(scriptConfigurations.get(0).getName(),
-                                                          scriptConfigurations.get(0).getDescription()),
-                                ScriptMatcher.matchScript(scriptConfigurations.get(1).getName(),
-                                                          scriptConfigurations.get(1).getDescription()),
-                                ScriptMatcher.matchScript(scriptConfigurations.get(2).getName(),
-                                                          scriptConfigurations.get(2).getDescription()),
-                                ScriptMatcher.matchScript(scriptConfigurations.get(3).getName(),
-                                                          scriptConfigurations.get(3).getDescription()),
-                                ScriptMatcher.matchScript(scriptConfigurations.get(4).getName(),
-                                                      scriptConfigurations.get(4).getDescription()),
-                                ScriptMatcher.matchScript(scriptConfigurations.get(5).getName(),
-                                                      scriptConfigurations.get(5).getDescription()),
-                                ScriptMatcher.matchScript(scriptConfigurations.get(6).getName(),
-                                                          scriptConfigurations.get(6).getDescription()),
-                                ScriptMatcher.matchScript(scriptConfigurations.get(7).getName(),
-                                                          scriptConfigurations.get(7).getDescription())
+                            scriptConfigurations
+                                .stream()
+                                .map(scriptConfiguration -> ScriptMatcher.matchScript(
+                                    scriptConfiguration.getName(),
+                                    scriptConfiguration.getDescription()
+                                ))
+                                .collect(Collectors.toList())
                         )));
-
     }
 
 
@@ -113,66 +104,74 @@ public class ScriptRestRepositoryIT extends AbstractControllerIntegrationTest {
 
     @Test
     public void findAllScriptsPaginationTest() throws Exception {
+        List<ScriptConfiguration> alphabeticScripts =
+            scriptConfigurations.stream()
+                                .sorted(Comparator.comparing(s -> s.getClass().getName()))
+                                .collect(Collectors.toList());
+
+        int totalPages = scriptConfigurations.size();
+        int lastPage = totalPages - 1;
 
         String token = getAuthToken(admin.getEmail(), password);
 
+        // NOTE: the scripts are always returned in alphabetical order by fully qualified class name.
         getClient(token).perform(get("/api/system/scripts").param("size", "1"))
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$._embedded.scripts", Matchers.not(Matchers.hasItem(
-                                ScriptMatcher.matchScript(scriptConfigurations.get(2).getName(),
-                                                          scriptConfigurations.get(2).getDescription())
+                            ScriptMatcher.matchScript(alphabeticScripts.get(1).getName(),
+                                                      alphabeticScripts.get(1).getDescription())
                         ))))
                         .andExpect(jsonPath("$._embedded.scripts", hasItem(
-                                ScriptMatcher.matchScript(scriptConfigurations.get(5).getName(),
-                                                          scriptConfigurations.get(5).getDescription())
+                            ScriptMatcher.matchScript(alphabeticScripts.get(0).getName(),
+                                                      alphabeticScripts.get(0).getDescription())
                         )))
                         .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
-                                Matchers.containsString("/api/system/scripts?"),
-                                Matchers.containsString("page=0"), Matchers.containsString("size=1"))))
+                            Matchers.containsString("/api/system/scripts?"),
+                            Matchers.containsString("page=0"), Matchers.containsString("size=1"))))
                         .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
-                                Matchers.containsString("/api/system/scripts?"),
-                                Matchers.containsString("size=1"))))
+                            Matchers.containsString("/api/system/scripts?"),
+                            Matchers.containsString("size=1"))))
                         .andExpect(jsonPath("$._links.next.href", Matchers.allOf(
-                                Matchers.containsString("/api/system/scripts?"),
-                                Matchers.containsString("page=1"), Matchers.containsString("size=1"))))
+                            Matchers.containsString("/api/system/scripts?"),
+                            Matchers.containsString("page=1"), Matchers.containsString("size=1"))))
                         .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
-                                Matchers.containsString("/api/system/scripts?"),
-                                Matchers.containsString("page=7"), Matchers.containsString("size=1"))))
+                            Matchers.containsString("/api/system/scripts?"),
+                            Matchers.containsString("page=" + lastPage), Matchers.containsString("size=1"))))
                         .andExpect(jsonPath("$.page.size", is(1)))
                         .andExpect(jsonPath("$.page.number", is(0)))
-                        .andExpect(jsonPath("$.page.totalPages", is(8)))
-                        .andExpect(jsonPath("$.page.totalElements", is(8)));
+                        .andExpect(jsonPath("$.page.totalPages", is(totalPages)))
+                        .andExpect(jsonPath("$.page.totalElements", is(totalPages)));
 
 
         getClient(token).perform(get("/api/system/scripts").param("size", "1").param("page", "1"))
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$._embedded.scripts", hasItem(
-                                ScriptMatcher.matchScript(scriptConfigurations.get(2).getName(),
-                                                          scriptConfigurations.get(2).getDescription())
+                            ScriptMatcher.matchScript(alphabeticScripts.get(1).getName(),
+                                                      alphabeticScripts.get(1).getDescription())
                         )))
                         .andExpect(jsonPath("$._embedded.scripts", Matchers.not(hasItem(
-                                ScriptMatcher.matchScript(scriptConfigurations.get(5).getName(),
-                                                          scriptConfigurations.get(5).getDescription())
+                            ScriptMatcher.matchScript(alphabeticScripts.get(0).getName(),
+                                                      alphabeticScripts.get(0).getDescription())
                         ))))
                         .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
-                                Matchers.containsString("/api/system/scripts?"),
-                                Matchers.containsString("page=0"), Matchers.containsString("size=1"))))
+                            Matchers.containsString("/api/system/scripts?"),
+                            Matchers.containsString("page=0"), Matchers.containsString("size=1"))))
                         .andExpect(jsonPath("$._links.prev.href", Matchers.allOf(
-                                Matchers.containsString("/api/system/scripts?"),
-                                Matchers.containsString("page=0"), Matchers.containsString("size=1"))))
+                            Matchers.containsString("/api/system/scripts?"),
+                            Matchers.containsString("page=0"), Matchers.containsString("size=1"))))
                         .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
-                                Matchers.containsString("/api/system/scripts?"),
-                                Matchers.containsString("page=1"), Matchers.containsString("size=1"))))
+                            Matchers.containsString("/api/system/scripts?"),
+                            Matchers.containsString("page=1"), Matchers.containsString("size=1"))))
                         .andExpect(jsonPath("$._links.next.href", Matchers.allOf(
-                                Matchers.containsString("/api/system/scripts?"),
-                                Matchers.containsString("page=2"), Matchers.containsString("size=1"))))
+                            Matchers.containsString("/api/system/scripts?"),
+                            Matchers.containsString("page=2"), Matchers.containsString("size=1"))))
                         .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
-                                Matchers.containsString("/api/system/scripts?"),
-                                Matchers.containsString("page=7"), Matchers.containsString("size=1"))))
+                            Matchers.containsString("/api/system/scripts?"),
+                            Matchers.containsString("page=" + lastPage), Matchers.containsString("size=1"))))
                         .andExpect(jsonPath("$.page.size", is(1)))
                         .andExpect(jsonPath("$.page.number", is(1)))
-                        .andExpect(jsonPath("$.page.totalPages", is(8)))
-                        .andExpect(jsonPath("$.page.totalElements", is(8)));
+                        .andExpect(jsonPath("$.page.totalPages", is(totalPages)))
+                        .andExpect(jsonPath("$.page.totalElements", is(totalPages)));
     }
 
     @Test
@@ -182,8 +181,16 @@ public class ScriptRestRepositoryIT extends AbstractControllerIntegrationTest {
         getClient(token).perform(get("/api/system/scripts/mock-script"))
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$", ScriptMatcher
-                                .matchMockScript(
-                                        scriptConfigurations.get(scriptConfigurations.size() - 1).getOptions())));
+                            .matchMockScript(
+                                scriptConfigurations
+                                    .stream()
+                                    .filter(scriptConfiguration
+                                                -> scriptConfiguration.getName().equals("mock-script"))
+                                    .findAny()
+                                    .orElseThrow()
+                                    .getOptions()
+                            )
+                        ));
     }
 
     @Test


### PR DESCRIPTION
## Description

Remove hardcoded references to scripts & metadata fields from ITs

## Instructions for Reviewers

A couple of ITs are too dependent on configuration; we keep running into issues when running these in projects with customisations.

List of changes in this PR:

* `ScriptRestRepositoryIT`: refactor to use `@Autowired List<ScriptConfiguration>` instead of hardcoded values for script names, number of scripts & order
* `MetadatafieldRestRepositoryIT`: refactor to use `MetadataFieldService#findAll` instead of hardcoded values for metadata fields & order

##### Reviewing

1. The affected tests should still pass as they did before
2. The affected tests should _also_ pass when
   * Additional script configuration beans are added to `dspace-api/src/test/data/dspaceFolder/config/spring/api/scripts.xml`
   * Additional metadata fields (and/or schemas) are added to `dspace/config/registries/`

## Checklist

_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.

