### PR TITLE
update collection metadata or removing the administrator group will not produce solr reindex

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
@@ -524,6 +524,8 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
 
         // register this as the admin group
         collection.setAdmins(admins);
+        context.addEvent(new Event(Event.MODIFY, Constants.COLLECTION, collection.getID(),
+                                              null, getIdentifiers(context, collection)));
         return admins;
     }
 
@@ -540,6 +542,8 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
 
         // Remove the link to the collection table.
         collection.setAdmins(null);
+        context.addEvent(new Event(Event.MODIFY, Constants.COLLECTION, collection.getID(),
+                                              null, getIdentifiers(context, collection)));
     }
 
     @Override
@@ -657,8 +661,11 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
             collection.clearModified();
         }
         if (collection.isMetadataModified()) {
-            collection.clearDetails();
+            context.addEvent(new Event(Event.MODIFY_METADATA, Constants.COLLECTION, collection.getID(),
+                                         collection.getDetails(),getIdentifiers(context, collection)));
+            collection.clearModified();
         }
+        collection.clearDetails();
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/content/CommunityServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CommunityServiceImpl.java
@@ -287,6 +287,8 @@ public class CommunityServiceImpl extends DSpaceObjectServiceImpl<Community> imp
 
         // register this as the admin group
         community.setAdmins(admins);
+        context.addEvent(new Event(Event.MODIFY, Constants.COMMUNITY, community.getID(),
+                                             null, getIdentifiers(context, community)));
         return admins;
     }
 
@@ -302,6 +304,8 @@ public class CommunityServiceImpl extends DSpaceObjectServiceImpl<Community> imp
 
         // Remove the link to the community table.
         community.setAdmins(null);
+        context.addEvent(new Event(Event.MODIFY, Constants.COMMUNITY, community.getID(),
+                                             null, getIdentifiers(context, community)));
     }
 
     @Override

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
@@ -16,6 +16,8 @@ import static org.dspace.app.rest.matcher.MetadataMatcher.matchMetadataStringEnd
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.springframework.data.rest.webmvc.RestMediaTypes.TEXT_URI_LIST_VALUE;
+import static org.springframework.http.MediaType.parseMediaType;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -39,6 +41,7 @@ import org.dspace.app.rest.matcher.HalMatcher;
 import org.dspace.app.rest.matcher.MetadataMatcher;
 import org.dspace.app.rest.matcher.PageMatcher;
 import org.dspace.app.rest.model.CommunityRest;
+import org.dspace.app.rest.model.GroupRest;
 import org.dspace.app.rest.model.MetadataRest;
 import org.dspace.app.rest.model.MetadataValueRest;
 import org.dspace.app.rest.projection.Projection;
@@ -2590,6 +2593,91 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
                    .andExpect(jsonPath("$.page.size", is(1)))
                    .andExpect(jsonPath("$.page.totalPages", is(2)))
                    .andExpect(jsonPath("$.page.totalElements", is(2)));
+    }
+
+    @Test
+    public void removeComAdminGroupToCheckReindexingTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Community rootCommunity = CommunityBuilder.createCommunity(context)
+                                                  .withName("Root Community")
+                                                  .build();
+
+        Community subCommunity = CommunityBuilder.createSubCommunity(context, rootCommunity)
+                                                 .withName("MyTestCom")
+                                                 .withAdminGroup(eperson)
+                                                 .build();
+        context.restoreAuthSystemState();
+
+        String epersonToken = getAuthToken(eperson.getEmail(), password);
+        getClient(epersonToken).perform(get("/api/core/communities/search/findAdminAuthorized")
+                               .param("query", "MyTestCom"))
+                               .andExpect(status().isOk())
+                               .andExpect(jsonPath("$._embedded.communities", Matchers.contains(CommunityMatcher
+                                          .matchProperties(subCommunity.getName(),
+                                                           subCommunity.getID(),
+                                                           subCommunity.getHandle())
+                                          )))
+                               .andExpect(jsonPath("$.page.totalElements", is(1)));
+
+        String token = getAuthToken(admin.getEmail(), password);
+        getClient(token).perform(delete("/api/core/communities/" + subCommunity.getID() + "/adminGroup"))
+                        .andExpect(status().isNoContent());
+
+        getClient(epersonToken).perform(get("/api/core/communities/search/findAdminAuthorized")
+                               .param("query", "MyTestCom"))
+                               .andExpect(status().isOk())
+                               .andExpect(jsonPath("$._embedded").doesNotExist())
+                               .andExpect(jsonPath("$.page.totalElements", is(0)));
+    }
+
+    @Test
+    public void addComAdminGroupToCheckReindexingTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        Community rootCommunity = CommunityBuilder.createCommunity(context)
+                                                  .withName("Root Community")
+                                                  .build();
+
+        Community subCommunity = CommunityBuilder.createSubCommunity(context, rootCommunity)
+                                                 .withName("MyTestCom")
+                                                 .build();
+
+        context.restoreAuthSystemState();
+
+        String epersonToken = getAuthToken(eperson.getEmail(), password);
+        getClient(epersonToken).perform(get("/api/core/communities/search/findAdminAuthorized")
+                               .param("query", "MyTestCom"))
+                               .andExpect(status().isOk())
+                               .andExpect(jsonPath("$._embedded").doesNotExist())
+                               .andExpect(jsonPath("$.page.totalElements", is(0)));
+
+        AtomicReference<UUID> idRef = new AtomicReference<>();
+        ObjectMapper mapper = new ObjectMapper();
+        GroupRest groupRest = new GroupRest();
+        String token = getAuthToken(admin.getEmail(), password);
+        getClient(token).perform(post("/api/core/communities/" + subCommunity.getID() + "/adminGroup")
+                        .content(mapper.writeValueAsBytes(groupRest))
+                        .contentType(contentType))
+                        .andExpect(status().isCreated())
+                        .andDo(result -> idRef.set(
+                               UUID.fromString(read(result.getResponse().getContentAsString(), "$.id")))
+                        );
+
+        String adminToken = getAuthToken(admin.getEmail(), password);
+        getClient(adminToken).perform(post("/api/eperson/groups/" + idRef.get() + "/epersons")
+                             .contentType(parseMediaType(TEXT_URI_LIST_VALUE))
+                             .content(REST_SERVER_URL + "eperson/groups/" + eperson.getID()
+                             ));
+
+        getClient(epersonToken).perform(get("/api/core/communities/search/findAdminAuthorized")
+                               .param("query", "MyTestCom"))
+                               .andExpect(status().isOk())
+                               .andExpect(jsonPath("$._embedded.communities", Matchers.contains(CommunityMatcher
+                                           .matchProperties(subCommunity.getName(),
+                                                            subCommunity.getID(),
+                                                            subCommunity.getHandle())
+                                           )))
+                               .andExpect(jsonPath("$.page.totalElements", is(1)));
     }
 
 }


### PR DESCRIPTION
## References
* Fixes #3326

## Description
The collection and community update were not raising a modify event. This would left the solr index out of date.
Test have been introduced to verify that the system behave correctly and consistently after an update.

## Instructions for Reviewers
Inspect the added tests. Try to update a collection or community metadata in the UI and check that the corresponding solr document has been updated

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [n/a] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [n/a] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ n/a] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
