### PR TITLE
Attempt to fix random ConcurrentModificationExceptions in ITs

### DIFF
--- a/dspace-api/src/test/java/org/dspace/builder/util/AbstractBuilderCleanupUtil.java
+++ b/dspace-api/src/test/java/org/dspace/builder/util/AbstractBuilderCleanupUtil.java
@@ -65,12 +65,12 @@ public class AbstractBuilderCleanupUtil {
         map.put(BitstreamBuilder.class.getName(), new LinkedList<>());
         map.put(BitstreamFormatBuilder.class.getName(), new LinkedList<>());
         map.put(ClaimedTaskBuilder.class.getName(), new LinkedList<>());
-        map.put(EPersonBuilder.class.getName(), new LinkedList<>());
-        map.put(GroupBuilder.class.getName(), new LinkedList<>());
         map.put(BundleBuilder.class.getName(), new LinkedList<>());
         map.put(ItemBuilder.class.getName(), new LinkedList<>());
         map.put(CollectionBuilder.class.getName(), new LinkedList<>());
         map.put(CommunityBuilder.class.getName(), new LinkedList<>());
+        map.put(GroupBuilder.class.getName(), new LinkedList<>());
+        map.put(EPersonBuilder.class.getName(), new LinkedList<>());
         map.put(MetadataFieldBuilder.class.getName(), new LinkedList<>());
         map.put(MetadataSchemaBuilder.class.getName(), new LinkedList<>());
         map.put(SiteBuilder.class.getName(), new LinkedList<>());

--- a/dspace-api/src/test/java/org/dspace/builder/util/AbstractBuilderCleanupUtil.java
+++ b/dspace-api/src/test/java/org/dspace/builder/util/AbstractBuilderCleanupUtil.java
@@ -65,12 +65,12 @@ public class AbstractBuilderCleanupUtil {
         map.put(BitstreamBuilder.class.getName(), new LinkedList<>());
         map.put(BitstreamFormatBuilder.class.getName(), new LinkedList<>());
         map.put(ClaimedTaskBuilder.class.getName(), new LinkedList<>());
-        map.put(CollectionBuilder.class.getName(), new LinkedList<>());
-        map.put(CommunityBuilder.class.getName(), new LinkedList<>());
         map.put(EPersonBuilder.class.getName(), new LinkedList<>());
         map.put(GroupBuilder.class.getName(), new LinkedList<>());
         map.put(BundleBuilder.class.getName(), new LinkedList<>());
         map.put(ItemBuilder.class.getName(), new LinkedList<>());
+        map.put(CollectionBuilder.class.getName(), new LinkedList<>());
+        map.put(CommunityBuilder.class.getName(), new LinkedList<>());
         map.put(MetadataFieldBuilder.class.getName(), new LinkedList<>());
         map.put(MetadataSchemaBuilder.class.getName(), new LinkedList<>());
         map.put(SiteBuilder.class.getName(), new LinkedList<>());


### PR DESCRIPTION
## Description
Randomly, we are getting `ConcurrentModificationException` errors in IT builds.  

They seem to all begin with the `CollectionBuilder.cleanup()` process like...
```
Tests run: 39, Failures: 0, Errors: 39, Skipped: 0, Time elapsed: 1.918 s <<< FAILURE! - in org.dspace.app.rest.authorization.GenericAuthorizationFeatureIT
testCanMakeDiscoverableAdmin(org.dspace.app.rest.authorization.GenericAuthorizationFeatureIT)  Time elapsed: 1.741 s  <<< ERROR!
java.lang.RuntimeException: java.util.ConcurrentModificationException
	at org.dspace.AbstractIntegrationTestWithDatabase.destroy(AbstractIntegrationTestWithDatabase.java:205)
...
Caused by: java.util.ConcurrentModificationException
	at java.base/java.util.HashMap.forEach(HashMap.java:1339)
	at org.hibernate.resource.jdbc.internal.ResourceRegistryStandardImpl.releaseResources(ResourceRegistryStandardImpl.java:323)
	at org.hibernate.resource.jdbc.internal.AbstractLogicalConnectionImplementor.afterTransaction(AbstractLogicalConnectionImplementor.java:55)
	at org.hibernate.resource.jdbc.internal.LogicalConnectionManagedImpl.afterTransaction(LogicalConnectionManagedImpl.java:154)
	at org.hibernate.resource.jdbc.internal.LogicalConnectionManagedImpl.afterCompletion(LogicalConnectionManagedImpl.java:267)
	at org.hibernate.resource.jdbc.internal.AbstractLogicalConnectionImplementor.commit(AbstractLogicalConnectionImplementor.java:90)
	at org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorImpl$TransactionDriverControlImpl.commit(JdbcResourceLocalTransactionCoordinatorImpl.java:282)
	at org.hibernate.engine.transaction.internal.TransactionImpl.commit(TransactionImpl.java:101)
	at org.dspace.core.HibernateDBConnection.commit(HibernateDBConnection.java:161)
	at org.dspace.core.Context.commit(Context.java:432)
	at org.dspace.core.Context.complete(Context.java:389)
	at org.dspace.builder.AbstractDSpaceObjectBuilder.delete(AbstractDSpaceObjectBuilder.java:286)
	at org.dspace.builder.CollectionBuilder.cleanup(CollectionBuilder.java:260)
	at org.dspace.builder.util.AbstractBuilderCleanupUtil.cleanupBuilders(AbstractBuilderCleanupUtil.java:99)
	at org.dspace.builder.AbstractBuilder.cleanupObjects(AbstractBuilder.java:181)
	at org.dspace.AbstractIntegrationTestWithDatabase.destroy(AbstractIntegrationTestWithDatabase.java:175)
```

My suspicion is that the `CollectionBuilder` is attempting to cleanup too much because it runs too early in the cleanup process. One possible issue might be that it runs *before* `ItemBuilder`, which means it will cleanup most Items in place of the `ItemBuilder` (as deleting a Collection deletes all Items within it).

So, in this PR, I've moved the `CollectionBuilder` and `CommunityBuilder` later in the cleanup process.  I also moved `EPersonBuilder` after `GroupBuilder`, as some groups are not allowed to be empty (e.g. workflow step groups) and therefore must be deleted prior to an EPersons in those groups.

I cannot guarantee this will fix the ConcurrentModificationException, but the new cleanup order makes more logical sense.

## Instructions for Reviewers

* Ensure the new order makes sense.
* Optionally, rebuild several times in GitHub CI to see whether a ConcurrentModificationException can still be triggered.

(NOTE: I'm rebuilding this a number of times to verify no `ConcurrentModificationExceptions` occur.  So far, it's built successfully **five times in a row**.)