### PR TITLE
Fix metadata value move patch operation bugs

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/DSpaceObjectServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/DSpaceObjectServiceImpl.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang.NotImplementedException;
@@ -742,12 +743,15 @@ public abstract class DSpaceObjectServiceImpl<T extends DSpaceObject> implements
     @Override
     public void moveMetadata(Context context, T dso, String schema, String element, String qualifier, int from, int to)
             throws SQLException, IllegalArgumentException {
-
         if (from == to) {
             throw new IllegalArgumentException("The \"from\" location MUST be different from \"to\" location");
         }
 
-        List<MetadataValue> list = getMetadata(dso, schema, element, qualifier);
+        List<MetadataValue> list =
+            getMetadata(dso, schema, element, qualifier).stream()
+                                                        .sorted(Comparator.comparing(MetadataValue::getPlace))
+                                                        .collect(Collectors.toList());
+
 
         if (from >= list.size() || to >= list.size() || to < 0 || from < 0) {
             throw new IllegalArgumentException(

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataMoveOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataMoveOperation.java
@@ -44,10 +44,10 @@ public class DSpaceObjectMetadataMoveOperation<R extends DSpaceObject> extends P
     public R perform(Context context, R resource, Operation operation) throws SQLException {
         DSpaceObjectService dsoService = ContentServiceFactory.getInstance().getDSpaceObjectService(resource);
         MetadataField metadataField = metadataPatchUtils.getMetadataField(context, operation);
-        String indexInPath = metadataPatchUtils.getIndexFromPath(operation.getPath());
-        String indexToMoveFrom = metadataPatchUtils.getIndexFromPath(((MoveOperation) operation).getFrom());
+        String indexTo = metadataPatchUtils.getIndexFromPath(operation.getPath());
+        String indexFrom = metadataPatchUtils.getIndexFromPath(((MoveOperation) operation).getFrom());
 
-        move(context, resource, dsoService, metadataField, indexInPath, indexToMoveFrom);
+        move(context, resource, dsoService, metadataField, indexFrom, indexTo);
         return resource;
     }
 


### PR DESCRIPTION
## Description

We fixed some issues that arose when rearranging metadata in DSOs using a drag-and-drop interface in Angular



## Instructions for Reviewers

#### Changes

* In certain situations, `ObjectUpdatesService.getMoveOperations` can interpret a single move operation as an equivalent sequence of operations; e.g. [4→1] becomes [1→2, 1→3, 2→4, 3→1]

* `DSpaceObjectServiceImpl.moveMetadata` couldn't handle multiple move operations in a single PATCH request because it assumed that the _order_ of metadata values in `getMetadata` is correct, which wasn't the case due to caching.

  We fixed this by explicitly re-sorting the cached metadata list by `getPlace`

* Added some ITs to cover PATCH operations to *DSO metadata* as `PatchMetadataIT` used to only cover `/submission` patch requests.

  `PatchMetadataIT.moveMetadataAuthorFourToOneMultiOpTest` is expected to fail at first in order to demonstrate that we fix it with the subsequent commit

  

## Checklist

_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.

