### PR TITLE
W2p 81832 solr search core fix index authority mdv without vocabulary or pairs type

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceMetadataBrowseIndexingPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceMetadataBrowseIndexingPlugin.java
@@ -174,8 +174,13 @@ public class SolrServiceMetadataBrowseIndexingPlugin implements SolrServiceIndex
                                                                            Boolean.FALSE),
                                                                    true);
                                         if (!ignorePrefered) {
-                                            preferedLabel = choiceAuthorityService
-                                                .getLabel(values.get(x), collection, values.get(x).getLanguage());
+                                            try {
+                                                preferedLabel = choiceAuthorityService
+                                                    .getLabel(values.get(x), collection, values.get(x).getLanguage());
+                                            } catch (Exception e) {
+                                                log.warn("Failed to get preferred label for "
+                                                             + values.get(x).getMetadataField().toString('.'), e);
+                                            }
                                         }
                                         List<String> variants = null;
 
@@ -193,9 +198,13 @@ public class SolrServiceMetadataBrowseIndexingPlugin implements SolrServiceIndex
                                                                            Boolean.FALSE),
                                                                    true);
                                         if (!ignoreVariants) {
-                                            variants = choiceAuthorityService
-                                                .getVariants(
-                                                    values.get(x), collection);
+                                            try {
+                                                variants = choiceAuthorityService
+                                                    .getVariants(values.get(x), collection);
+                                            } catch (Exception e) {
+                                                log.warn("Failed to get variants for "
+                                                             + values.get(x).getMetadataField().toString(), e);
+                                            }
                                         }
 
                                         if (StringUtils

--- a/dspace-api/src/main/java/org/dspace/discovery/indexobject/ItemIndexFactoryImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/indexobject/ItemIndexFactoryImpl.java
@@ -359,10 +359,13 @@ public class ItemIndexFactoryImpl extends DSpaceObjectIndexFactoryImpl<Indexable
                                                                 "discovery.index.authority.ignore-prefered",
                                                                 Boolean.FALSE),
                                                 true);
-                        if (!ignorePrefered) {
 
-                            preferedLabel = choiceAuthorityService
-                                    .getLabel(meta, collection, meta.getLanguage());
+                        if (!ignorePrefered) {
+                            try {
+                                preferedLabel = choiceAuthorityService.getLabel(meta, collection, meta.getLanguage());
+                            } catch (Exception e) {
+                                log.warn("Failed to get preferred label for " + field, e);
+                            }
                         }
 
                         boolean ignoreVariants =
@@ -377,8 +380,12 @@ public class ItemIndexFactoryImpl extends DSpaceObjectIndexFactoryImpl<Indexable
                                                                 Boolean.FALSE),
                                                 true);
                         if (!ignoreVariants) {
-                            variants = choiceAuthorityService
+                            try {
+                                variants = choiceAuthorityService
                                     .getVariants(meta, collection);
+                            } catch (Exception e) {
+                                log.warn("Failed to get variants for " + field, e);
+                            }
                         }
 
                     }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -196,15 +196,8 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
 
     @Test
     public void discoverFacetsAuthorWithAuthorityWithSizeParameter() throws Exception {
-        configurationService.setProperty("choices.plugin.dc.contributor.author",
-                                         "SolrAuthorAuthority");
-        configurationService.setProperty("authority.controlled.dc.contributor.author",
-                                         "true");
-        configurationService.setProperty("discovery.browse.authority.ignore-prefered.author", true);
-        configurationService.setProperty("discovery.index.authority.ignore-prefered.dc.contributor.author", true);
-        configurationService.setProperty("discovery.browse.authority.ignore-variants.author", true);
-        configurationService.setProperty("discovery.index.authority.ignore-variants.dc.contributor.author", true);
-
+        configurationService.setProperty("choices.plugin.dc.contributor.author", "SolrAuthorAuthority");
+        configurationService.setProperty("authority.controlled.dc.contributor.author", "true");
 
         metadataAuthorityService.clearCache();
 


### PR DESCRIPTION
## References

* Fixes #3193

## Description

Make sure discovery indexing doesn't crash for authority-controlled MDVs _without_ an associated value-pair in submission

## Instructions for Reviewers

List of changes in this PR:

* Update `DiscoveryRestControllerIT`: don't ignore uthor label/variant explicitly. This used to be required for this test to pass, so we expect this commit to fail by itself.
* Try/catch `getLabel`/`getVariants` calls → log a warning & continue if they fail. The updated IT should now succeed.

**Reviewing**

1. Enable config for the Solr Authority indexing for a metadata field

   ```
   choices.plugin.dc.contributor.author = SolrAuthorAuthority
   authority.controlled.dc.contributor.author = true
   ```

2. Create an Item with an `AuthorityValue` in a `dc.contributor.author` metadata value

3. The Item should get indexed into the `search` Solr core

## Checklist

_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.

