### PR TITLE
Upgrade to latest PostgreSQL driver 42.2.x and Flyway 6.x

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -743,7 +743,7 @@
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
-            <version>6.5.5</version>
+            <version>6.5.7</version>
         </dependency>
 
         <!-- Google Analytics -->

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <spring-security.version>5.2.2.RELEASE</spring-security.version> <!-- sync with version used by spring-boot-->
         <hibernate.version>5.4.10.Final</hibernate.version>
         <hibernate-validator.version>6.0.18.Final</hibernate-validator.version>
-        <postgresql.driver.version>42.2.9</postgresql.driver.version>
+        <postgresql.driver.version>42.2.23</postgresql.driver.version>
         <solr.client.version>8.8.1</solr.client.version>
 
         <axiom.version>1.2.22</axiom.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <spring-security.version>5.2.2.RELEASE</spring-security.version> <!-- sync with version used by spring-boot-->
         <hibernate.version>5.4.10.Final</hibernate.version>
         <hibernate-validator.version>6.0.18.Final</hibernate-validator.version>
-        <postgresql.driver.version>42.2.23</postgresql.driver.version>
+        <postgresql.driver.version>42.2.24</postgresql.driver.version>
         <solr.client.version>8.8.1</solr.client.version>
 
         <axiom.version>1.2.22</axiom.version>


### PR DESCRIPTION
## Description
This PR is a minor version upgrade for both our PostgreSQL driver and our FlywayDB version.  The reason for this upgrade is to bypass this known [XXE vulnerability in PostgreSQL drivers v42.2.12 and below](https://nvd.nist.gov/vuln/detail/CVE-2020-13692).

While this vulnerability was fixed in v42.2.13, I decided to upgrade to the latest PostgreSQL driver v42.2.23.
The Flyway upgrade was because Flyway also used an old version of this driver, but that was fixed in v6.5.7 of Flyway, see https://flywaydb.org/documentation/learnmore/releaseNotes#6.5.7

## Instructions for Reviewers
* Verify tests pass.
* Optionally, deploy this branch locally to verify no issues in this minor dependency upgrade. (I've tested this locally and haven't found any issues so far on Postgres v12)