### PR TITLE
Integration Test Cleanup

### DIFF
--- a/dspace-api/src/test/java/org/dspace/app/csv/CSVMetadataImportReferenceIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/csv/CSVMetadataImportReferenceIT.java
@@ -12,6 +12,7 @@ import static junit.framework.TestCase.assertEquals;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -135,6 +136,9 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
             "+,Publication,dc.identifier.other:0," + col1.getHandle() + ",1"};
         Item[] items = runImport(csv);
         assertRelationship(items[1], items[0], 1, "left", 0);
+
+        // remove created items
+        cleanupImportItems(items);
     }
 
     /**
@@ -154,6 +158,20 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
     }
 
     /**
+     * Delete the Items in the given array. This method is used for cleanup after using "runImport"
+     * @param items items array
+     * @throws SQLException
+     * @throws IOException
+     */
+    private void cleanupImportItems(Item[] items) throws SQLException, IOException {
+        context.turnOffAuthorisationSystem();
+        for (Item item: items) {
+            ItemBuilder.deleteItem(item.getID());
+        }
+        context.restoreAuthSystemState();
+    }
+
+    /**
      * Test existence of newly created item with proper relationships defined in the item's metadata via
      * a rowName reference
      */
@@ -165,6 +183,8 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
             "+,Test Item 2,Publication,rowName:idVal," + col1.getHandle() + ",anything,1"};
         Item[] items = runImport(csv);
         assertRelationship(items[1], items[0], 1, "left", 0);
+        // remove created items
+        cleanupImportItems(items);
     }
 
     /**
@@ -180,6 +200,8 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
         Item[] items = runImport(csv);
         assertRelationship(items[2], items[0], 1, "left", 0);
         assertRelationship(items[2], items[1], 1, "left", 1);
+        // remove created items
+        cleanupImportItems(items);
     }
 
     /**
@@ -195,6 +217,8 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
         Item[] items = runImport(csv);
         assertRelationship(items[2], items[0], 1, "left", 0);
         assertRelationship(items[2], items[1], 1, "left", 1);
+        // remove created items
+        cleanupImportItems(items);
     }
 
     /**
@@ -217,6 +241,8 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
             "+,Publication," + person.getID().toString() + "," + col1.getHandle() + ",anything,0"};
         Item[] items = runImport(csv);
         assertRelationship(items[0], person, 1, "left", 0);
+        // remove created items
+        cleanupImportItems(items);
     }
 
     /**
@@ -248,6 +274,8 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
         Item[] items = runImport(csv);
         assertRelationship(items[0], person, 1, "left", 0);
         assertRelationship(items[0], person2, 1, "left", 1);
+        // remove created items
+        cleanupImportItems(items);
     }
 
     /**
@@ -273,6 +301,8 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
         Item[] items = runImport(csv);
         assertRelationship(items[1], person, 1, "left", 0);
         assertRelationship(items[1], items[0], 1, "left", 1);
+        // remove created items
+        cleanupImportItems(items);
     }
 
     /**
@@ -310,6 +340,8 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
         assertRelationship(items[1], person, 1, "left", 0);
         assertRelationship(items[1], person2, 1, "left", 1);
         assertRelationship(items[1], items[0], 1, "left", 2);
+        // remove created items
+        cleanupImportItems(items);
     }
 
     /**
@@ -324,6 +356,8 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
             "+,Pub1,Publication,dc.title:Person:," + col1.getHandle() + ",anything,1"};
         Item[] items = runImport(csv);
         assertRelationship(items[1], items[0], 1, "left", 0);
+        // remove created items
+        cleanupImportItems(items);
     }
 
     /**
@@ -540,6 +574,8 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
         Item[] items = runImport(csv);
         assertRelationship(items[1], items[0], 1, "left", 0);
         assertRelationship(items[2], items[0], 1, "left", 0);
+        // remove created items
+        cleanupImportItems(items);
     }
 
     @Test
@@ -643,6 +679,5 @@ public class CSVMetadataImportReferenceIT extends AbstractIntegrationTestWithDat
         }
         return uuidList.get(0);
     }
-
 
 }

--- a/dspace-api/src/test/java/org/dspace/builder/RelationshipTypeBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/RelationshipTypeBuilder.java
@@ -8,13 +8,11 @@
 package org.dspace.builder;
 
 import java.sql.SQLException;
-import java.util.List;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.EntityType;
-import org.dspace.content.Relationship;
 import org.dspace.content.RelationshipType;
 import org.dspace.content.service.RelationshipTypeService;
 import org.dspace.core.Context;
@@ -42,11 +40,6 @@ public class RelationshipTypeBuilder extends AbstractBuilder<RelationshipType, R
             c.turnOffAuthorisationSystem();
             // Ensure object and any related objects are reloaded before checking to see what needs cleanup
             relationshipType = c.reloadEntity(relationshipType);
-            List<Relationship> byRelationshipType = relationshipService
-                .findByRelationshipType(c, relationshipType);
-            for (Relationship relationship : byRelationshipType) {
-                relationshipService.delete(c, relationship);
-            }
             if (relationshipType != null) {
                 delete(c, relationshipType);
             }

--- a/dspace-api/src/test/java/org/dspace/builder/util/AbstractBuilderCleanupUtil.java
+++ b/dspace-api/src/test/java/org/dspace/builder/util/AbstractBuilderCleanupUtil.java
@@ -57,8 +57,6 @@ public class AbstractBuilderCleanupUtil {
     private void initMap() {
         map.put(ResourcePolicyBuilder.class.getName(), new ArrayList<>());
         map.put(RelationshipBuilder.class.getName(), new ArrayList<>());
-        map.put(RelationshipTypeBuilder.class.getName(), new ArrayList<>());
-        map.put(EntityTypeBuilder.class.getName(), new ArrayList<>());
         map.put(PoolTaskBuilder.class.getName(), new ArrayList<>());
         map.put(WorkflowItemBuilder.class.getName(), new ArrayList<>());
         map.put(WorkspaceItemBuilder.class.getName(), new ArrayList<>());
@@ -71,6 +69,8 @@ public class AbstractBuilderCleanupUtil {
         map.put(CommunityBuilder.class.getName(), new ArrayList<>());
         map.put(GroupBuilder.class.getName(), new ArrayList<>());
         map.put(EPersonBuilder.class.getName(), new ArrayList<>());
+        map.put(RelationshipTypeBuilder.class.getName(), new ArrayList<>());
+        map.put(EntityTypeBuilder.class.getName(), new ArrayList<>());
         map.put(MetadataFieldBuilder.class.getName(), new ArrayList<>());
         map.put(MetadataSchemaBuilder.class.getName(), new ArrayList<>());
         map.put(SiteBuilder.class.getName(), new ArrayList<>());

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/AuthorizationFeatureServiceIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/AuthorizationFeatureServiceIT.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.commons.lang3.ArrayUtils;
-import org.dspace.AbstractIntegrationTestWithDatabase;
 import org.dspace.app.rest.authorization.AlwaysFalseFeature;
 import org.dspace.app.rest.authorization.AlwaysThrowExceptionFeature;
 import org.dspace.app.rest.authorization.AlwaysTrueFeature;
@@ -27,35 +26,20 @@ import org.dspace.app.rest.converter.SiteConverter;
 import org.dspace.app.rest.model.CollectionRest;
 import org.dspace.app.rest.model.SiteRest;
 import org.dspace.app.rest.projection.DefaultProjection;
-import org.dspace.app.rest.utils.DSpaceConfigurationInitializer;
-import org.dspace.app.rest.utils.DSpaceKernelInitializer;
+import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
 import org.dspace.content.Site;
 import org.dspace.content.service.SiteService;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.test.context.web.WebAppConfiguration;
+
 
 /**
  * Test for the Authorization Feature Service
- * 
+ *
  * @author Andrea Bollini (andrea.bollini at 4science.it)
  *
  */
-//Run tests with JUnit 4 and Spring TestContext Framework
-@RunWith(SpringRunner.class)
-//Specify main class to use to load Spring ApplicationContext
-//NOTE: By default, Spring caches and reuses ApplicationContext for each integration test (to speed up tests)
-//See: https://docs.spring.io/spring/docs/current/spring-framework-reference/testing.html#integration-testing
-@SpringBootTest(classes = Application.class)
-//Load DSpace initializers in Spring ApplicationContext (to initialize DSpace Kernel & Configuration)
-@ContextConfiguration(initializers = { DSpaceKernelInitializer.class, DSpaceConfigurationInitializer.class })
-//Tell Spring to make ApplicationContext an instance of WebApplicationContext (for web-based tests)
-@WebAppConfiguration
-public class AuthorizationFeatureServiceIT extends AbstractIntegrationTestWithDatabase {
+public class AuthorizationFeatureServiceIT extends AbstractControllerIntegrationTest {
     @Autowired
     private SiteService siteService;
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/InitializeEntitiesIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/InitializeEntitiesIT.java
@@ -15,7 +15,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.io.File;
-import java.util.Iterator;
 import java.util.List;
 
 import org.dspace.app.rest.matcher.RelationshipTypeMatcher;
@@ -67,6 +66,7 @@ public class InitializeEntitiesIT extends AbstractControllerIntegrationTest {
     }
 
     @After
+    @Override
     public void destroy() throws Exception {
         //Clean up the database for the next test
         context.turnOffAuthorisationSystem();
@@ -74,26 +74,18 @@ public class InitializeEntitiesIT extends AbstractControllerIntegrationTest {
         List<EntityType> entityTypeList = entityTypeService.findAll(context);
         List<Relationship> relationships = relationshipService.findAll(context);
 
-        Iterator<Relationship> relationshipIterator = relationships.iterator();
-        while (relationshipIterator.hasNext()) {
-            Relationship relationship = relationshipIterator.next();
-            relationshipIterator.remove();
+        for (Relationship relationship : relationships) {
             relationshipService.delete(context, relationship);
         }
 
-        Iterator<RelationshipType> relationshipTypeIterator = relationshipTypeList.iterator();
-        while (relationshipTypeIterator.hasNext()) {
-            RelationshipType relationshipType = relationshipTypeIterator.next();
-            relationshipTypeIterator.remove();
+        for (RelationshipType relationshipType : relationshipTypeList) {
             relationshipTypeService.delete(context, relationshipType);
         }
 
-        Iterator<EntityType> entityTypeIterator = entityTypeList.iterator();
-        while (entityTypeIterator.hasNext()) {
-            EntityType entityType = entityTypeIterator.next();
-            entityTypeIterator.remove();
+        for (EntityType entityType: entityTypeList) {
             entityTypeService.delete(context, entityType);
         }
+        context.restoreAuthSystemState();
 
         super.destroy();
     }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProcessRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProcessRestRepositoryIT.java
@@ -36,7 +36,6 @@ import org.dspace.scripts.Process;
 import org.dspace.scripts.ProcessLogLevel;
 import org.dspace.scripts.service.ProcessService;
 import org.hamcrest.Matchers;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -806,11 +805,5 @@ public class ProcessRestRepositoryIT extends AbstractControllerIntegrationTest {
                                             is("script_output")));
 
 
-    }
-
-    @After
-    @Override
-    public void destroy() throws Exception {
-        super.destroy();
     }
 }


### PR DESCRIPTION
## Description
This PR does some Integration Test cleanup based on recent issues discovered in the codebase.

Cleanup tasks include:
1. Updating `CSVMetadataImportReferenceIT` to ensure it cleans up Items that it creates.  This was stumbled on while I was reviewing build issues in #3329 
2. Fix `AuthorizationFeatureServiceIT` to correctly extend `AbstractControllerIntegrationTest` (instead of doing it's own setup via SpringRunner, etc)
3. Fix `RelationshipTypeBuilder` to ONLY delete RelationshipType objects (and not also deleting Relationship objects).  Reorder builder cleanup to support that. 
4. Other minor cleanup

## Instructions for Reviewers
* Review code changes & ensure ITs still succeed.
