### PR TITLE
Scripts & processes error handling

### DIFF
--- a/dspace-api/src/main/java/org/dspace/scripts/handler/DSpaceRunnableHandler.java
+++ b/dspace-api/src/main/java/org/dspace/scripts/handler/DSpaceRunnableHandler.java
@@ -78,6 +78,13 @@ public interface DSpaceRunnableHandler {
     public void logError(String message);
 
     /**
+     * This method will perform the error logging of the message given along with a stack trace
+     * @param message   The message to be logged as an error
+     * @param throwable The original exception
+     */
+    public void logError(String message, Throwable throwable);
+
+    /**
      * This method will print the help for the options and name
      * @param options   The options for the script
      * @param name      The name of the script

--- a/dspace-api/src/main/java/org/dspace/scripts/handler/impl/CommandLineDSpaceRunnableHandler.java
+++ b/dspace-api/src/main/java/org/dspace/scripts/handler/impl/CommandLineDSpaceRunnableHandler.java
@@ -85,6 +85,12 @@ public class CommandLineDSpaceRunnableHandler implements DSpaceRunnableHandler {
     }
 
     @Override
+    public void logError(String message, Throwable throwable) {
+        System.err.println(message);
+        log.error(message, throwable);
+    }
+
+    @Override
     public void printHelp(Options options, String name) {
         if (options != null) {
             HelpFormatter formatter = new HelpFormatter();

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ScriptRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ScriptRestRepository.java
@@ -152,10 +152,14 @@ public class ScriptRestRepository extends DSpaceRestRepository<ScriptRest, Strin
             restDSpaceRunnableHandler.schedule(dSpaceRunnable);
         } catch (ParseException e) {
             dSpaceRunnable.printHelp();
-            restDSpaceRunnableHandler
-                .handleException(
-                    "Failed to parse the arguments given to the script with name: " + scriptToExecute.getName()
-                        + " and args: " + args, e);
+            try {
+                restDSpaceRunnableHandler.handleException(
+                    "Failed to parse the arguments given to the script with name: "
+                        + scriptToExecute.getName() + " and args: " + args, e
+                );
+            } catch (Exception re) {
+                // ignore re-thrown exception
+            }
         }
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/scripts/handler/impl/RestDSpaceRunnableHandler.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/scripts/handler/impl/RestDSpaceRunnableHandler.java
@@ -134,18 +134,12 @@ public class RestDSpaceRunnableHandler implements DSpaceRunnableHandler {
 
     @Override
     public void handleException(String message, Exception e) {
-        if (message != null) {
-            logError(message);
-        }
-        if (e != null) {
-            logError(ExceptionUtils.getStackTrace(e));
-        }
+        logError(message, e);
 
         Context context = new Context();
         try {
             Process process = processService.find(context, processId);
             processService.fail(context, process);
-
 
             addLogBitstreamToProcess(context);
             context.complete();
@@ -161,6 +155,9 @@ public class RestDSpaceRunnableHandler implements DSpaceRunnableHandler {
                 context.abort();
             }
         }
+
+        // Make sure execution actually ends after we handle the exception
+        throw new RuntimeException(e);
     }
 
     @Override
@@ -180,7 +177,6 @@ public class RestDSpaceRunnableHandler implements DSpaceRunnableHandler {
         log.info(logMessage);
 
         appendLogToProcess(message, ProcessLogLevel.INFO);
-
     }
 
     @Override
@@ -189,7 +185,6 @@ public class RestDSpaceRunnableHandler implements DSpaceRunnableHandler {
         log.warn(logMessage);
 
         appendLogToProcess(message, ProcessLogLevel.WARNING);
-
     }
 
     @Override
@@ -198,7 +193,17 @@ public class RestDSpaceRunnableHandler implements DSpaceRunnableHandler {
         log.error(logMessage);
 
         appendLogToProcess(message, ProcessLogLevel.ERROR);
+    }
 
+    @Override
+    public void logError(String message, Throwable throwable) {
+        String logMessage = getLogMessage(message);
+        log.error(logMessage, throwable);
+
+        appendLogToProcess(message, ProcessLogLevel.ERROR);
+        if (throwable != null) {
+            appendLogToProcess(ExceptionUtils.getStackTrace(throwable), ProcessLogLevel.ERROR);
+        }
     }
 
     @Override


### PR DESCRIPTION
## References

* Fixes #3291

## Description

Make sure scripts running in REST stop running on exceptions

## Instructions for Reviewers

List of changes in this PR:

* `RestDSpaceRunnableHandler#handleException` now re-throws exceptions after logging to the process & setting it to "FAILED"
* Quick fix  `ScriptRestRepository#runDSpaceScript`: ignore re-thrown exception on parsing errors

**Testing:** 

1. On a local DSpace, add the following line to the `internalRun()` of any script to make it fail by default

   ```java
   handler.handleException("something's going wrong", new Exception("test"));
   ```

2. Run the modified script via http://localhost:4000/processes/new
   * The script should fail immediately; status should show "FAILED"
   * The process output should include the message & stack trace

## Checklist

_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.

