### PR TITLE
endpoint to find with a single call many authorizations for multiple objects and features

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/AuthorizationRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/AuthorizationRestRepository.java
@@ -176,8 +176,8 @@ public class AuthorizationRestRepository extends DSpaceRestRepository<Authorizat
 
     @PreAuthorize("#epersonUuid==null || hasPermission(#epersonUuid, 'EPERSON', 'READ')")
     @SearchRestMethod(name = "objects")
-    public Page<AuthorizationRest> findByObjects(@Parameter(value = "uuid") List<String> uuidList,
-            @Parameter(value = "type") String type,
+    public Page<AuthorizationRest> findByObjects(@Parameter(value = "uuid", required = true) List<String> uuidList,
+            @Parameter(value = "type", required = true) String type,
             @Parameter(value = "eperson") UUID epersonUuid, @Parameter(value = "feature") List<String> featureNames,
             Pageable pageable) throws AuthorizeException, SQLException {
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/AuthorizationRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/AuthorizationRestRepository.java
@@ -167,7 +167,7 @@ public class AuthorizationRestRepository extends DSpaceRestRepository<Authorizat
 
         List<Authorization> authorizations = findAuthorizationsForUri(context, user, uri, featureName);
 
-        if (currUser != user) {
+        if (ObjectUtils.notEqual(currUser, user)) {
             // restore the real current user
             context.restoreContextUser();
         }
@@ -196,7 +196,7 @@ public class AuthorizationRestRepository extends DSpaceRestRepository<Authorizat
         List<Authorization> authorizations =
                 findAuthorizationsByUUIDList(context, type, uuidList, user, featureNames);
 
-        if (currUser != user) {
+        if (ObjectUtils.notEqual(currUser, user)) {
             // restore the real current user
             context.restoreContextUser();
         }
@@ -223,7 +223,7 @@ public class AuthorizationRestRepository extends DSpaceRestRepository<Authorizat
                 try {
                     authorizations.addAll(authorizationsForObject(context, user, featureName, object));
                 } catch (Exception ex) {
-                    log.error(ex.getMessage(), ex);
+                    log.error("An error occurred during authorizations check");
                     throw new RuntimeException(ex);
                 }
             }));

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/AuthorizationRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/AuthorizationRestRepository.java
@@ -15,6 +15,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.ObjectUtils;
 import org.dspace.app.rest.Parameter;
@@ -154,12 +155,8 @@ public class AuthorizationRestRepository extends DSpaceRestRepository<Authorizat
 
         Context context = obtainContext();
 
-        BaseObjectRest obj = utils.getBaseObjectRestFromUri(context, uri);
-        if (obj == null) {
-            return null;
-        }
-
         EPerson currUser = context.getCurrentUser();
+
         // get the user specified in the requested parameters, can be null for anonymous
         EPerson user = getUserFromRequestParameter(context, epersonUuid);
         if (ObjectUtils.notEqual(currUser, user)) {
@@ -168,11 +165,97 @@ public class AuthorizationRestRepository extends DSpaceRestRepository<Authorizat
             context.switchContextUser(user);
         }
 
+        List<Authorization> authorizations = findAuthorizationsForUri(context, user, uri, featureName);
+
+        if (currUser != user) {
+            // restore the real current user
+            context.restoreContextUser();
+        }
+        return converter.toRestPage(authorizations, pageable, utils.obtainProjection());
+    }
+
+    @PreAuthorize("#epersonUuid==null || hasPermission(#epersonUuid, 'EPERSON', 'READ')")
+    @SearchRestMethod(name = "objects")
+    public Page<AuthorizationRest> findByObjects(@Parameter(value = "uuid") List<String> uuidList,
+            @Parameter(value = "type") String type,
+            @Parameter(value = "eperson") UUID epersonUuid, @Parameter(value = "feature") List<String> featureNames,
+            Pageable pageable) throws AuthorizeException, SQLException {
+
+        Context context = obtainContext();
+
+        EPerson currUser = context.getCurrentUser();
+
+        // get the user specified in the requested parameters, can be null for anonymous
+        EPerson user = getUserFromRequestParameter(context, epersonUuid);
+        if (ObjectUtils.notEqual(currUser, user)) {
+            // Temporarily change the Context's current user in order to retrieve
+            // authorizations based on that user
+            context.switchContextUser(user);
+        }
+
+        List<Authorization> authorizations =
+                findAuthorizationsByUUIDList(context, type, uuidList, user, featureNames);
+
+        if (currUser != user) {
+            // restore the real current user
+            context.restoreContextUser();
+        }
+        return converter.toRestPage(authorizations, null, utils.obtainProjection());
+    }
+
+    private List<Authorization> findAuthorizationsByUUIDList(
+        Context context,
+        String type, List<String> uuidList, EPerson user,
+        List<String> featureNames) {
+
+        if (featureNames.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        List<Authorization> authorizations = new ArrayList<>();
+
+        List<BaseObjectRest> objects = uuidList.stream()
+            .map(uuid -> utils.getBaseObjectRestFromTypeAndUUID(context, type, uuid))
+            .collect(Collectors.toList());
+
+        objects.forEach(object ->
+            featureNames.forEach(featureName -> {
+                try {
+                    authorizations.addAll(authorizationsForObject(context, user, featureName, object));
+                } catch (Exception ex) {
+                    log.error(ex.getMessage(), ex);
+                    throw new RuntimeException(ex);
+                }
+            }));
+        return authorizations;
+    }
+
+    private List<Authorization> findAuthorizationsForUri(
+        Context context,
+        EPerson user,
+        String uri,
+        String featureName) throws SQLException {
+
+        BaseObjectRest restObject = utils.getBaseObjectRestFromUri(context, uri);
+        return authorizationsForObject(context, user, featureName, restObject);
+    }
+
+    private List<Authorization> authorizationsForObject(
+        Context context,
+        EPerson user, String featureName,
+        BaseObjectRest obj)
+        throws SQLException {
+
+        if (obj == null) {
+            return new ArrayList<>();
+        }
+
         List<Authorization> authorizations;
         if (isNotBlank(featureName)) {
             authorizations = findByObjectAndFeature(context, user, obj, featureName);
         } else {
-            List<AuthorizationFeature> features = authorizationFeatureService.findByResourceType(obj.getUniqueType());
+            List<AuthorizationFeature> features =
+                    authorizationFeatureService.findByResourceType(obj.getUniqueType());
             authorizations = new ArrayList<>();
             for (AuthorizationFeature f : features) {
                 if (authorizationFeatureService.isAuthorized(context, f, obj)) {
@@ -181,11 +264,7 @@ public class AuthorizationRestRepository extends DSpaceRestRepository<Authorizat
             }
         }
 
-        if (currUser != user) {
-            // restore the real current user
-            context.restoreContextUser();
-        }
-        return converter.toRestPage(authorizations, pageable, utils.obtainProjection());
+        return authorizations;
     }
 
     private List<Authorization> findByObjectAndFeature(

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/Utils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/Utils.java
@@ -964,22 +964,54 @@ public class Utils {
             throw new IllegalArgumentException("the supplied uri lacks required path elements: " + uri);
         }
 
+        return findBaseObjectRest(context, uriParts[0], uriParts[1], uriParts[2]);
+    }
+
+    /**
+     * Gets the rest object of of specified type (i.e. "core.item", "core.collection", "workflow.workflowitem",...)
+     * having given uuid.
+     *
+     * @param context the DSpace context
+     * @param type Object type
+     * @param uuid Object uuid
+     * @return the {@link BaseObjectRest} identified by the provided uuid
+     */
+
+    public BaseObjectRest getBaseObjectRestFromTypeAndUUID(Context context, String type, String uuid) {
+
+        if (StringUtils.isBlank(type)) {
+            throw new IllegalArgumentException("Type is missing");
+        }
+
+        String[] split = type.split("\\.");
+        if (split.length != 2) {
+            throw new IllegalArgumentException("Provided type is not valid: " + type);
+        }
+        return findBaseObjectRest(context, split[0], split[1], uuid);
+    }
+
+    private BaseObjectRest findBaseObjectRest(Context context, String apiCategory, String model, String uuid) {
+
         DSpaceRestRepository repository;
         try {
-            repository = getResourceRepository(uriParts[0], uriParts[1]);
+            repository = getResourceRepository(apiCategory, model);
             if (!(repository instanceof ReloadableEntityObjectRepository)) {
-                throw new IllegalArgumentException("the supplied uri is not for the right type of repository: " + uri);
+                throw new IllegalArgumentException("the supplied category and model are not" +
+                    " for the right type of repository: " +
+                    String.format("%s.%s", apiCategory, model));
             }
         } catch (RepositoryNotFoundException e) {
-            throw new IllegalArgumentException("the repository for the URI '" + uri + "' was not found", e);
+            throw new IllegalArgumentException("the repository for the category '" + apiCategory + "' and model '"
+                + model + "' was not found", e);
         }
 
         Serializable pk;
         try {
             // cast the string id in the uriParts to the real pk class
-            pk = castToPKClass((ReloadableEntityObjectRepository) repository, uriParts[2]);
+            pk = castToPKClass((ReloadableEntityObjectRepository) repository, uuid);
         } catch (Exception e) {
-            throw new IllegalArgumentException("the supplied uri could not be cast to a Primary Key class: " + uri, e);
+            throw new IllegalArgumentException(
+                "the supplied uuid could not be cast to a Primary Key class: " + uuid, e);
         }
         try {
             // disable the security as we only need to retrieve the object to further process the authorization

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/Utils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/Utils.java
@@ -976,7 +976,6 @@ public class Utils {
      * @param uuid Object uuid
      * @return the {@link BaseObjectRest} identified by the provided uuid
      */
-
     public BaseObjectRest getBaseObjectRestFromTypeAndUUID(Context context, String type, String uuid) {
 
         if (StringUtils.isBlank(type)) {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/AuthorizationRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/AuthorizationRestRepositoryIT.java
@@ -1551,16 +1551,17 @@ public class AuthorizationRestRepositoryIT extends AbstractControllerIntegration
 
         // verify that it works for administrators - with eperson parameter
 
-        Supplier<MockHttpServletRequestBuilder> baseFeatureRequest = () -> get("/api/authz/authorizations/search/objects")
-            .param("type", "core.community")
-            .param("uuid", comId)
-            .param("uuid", secondComId)
-            .param("projection", "level")
-            .param("embedLevelDepth", "1")
-            .param("feature", alwaysTrue.getName())
-            .param("feature", alwaysFalse.getName())
-            .param("feature", trueForLoggedUsers.getName())
-            .param("feature", trueForAdmins.getName());
+        Supplier<MockHttpServletRequestBuilder> baseFeatureRequest = () ->
+            get("/api/authz/authorizations/search/objects")
+                .param("type", "core.community")
+                .param("uuid", comId)
+                .param("uuid", secondComId)
+                .param("projection", "level")
+                .param("embedLevelDepth", "1")
+                .param("feature", alwaysTrue.getName())
+                .param("feature", alwaysFalse.getName())
+                .param("feature", trueForLoggedUsers.getName())
+                .param("feature", trueForAdmins.getName());
 
         getClient(adminToken).perform(baseFeatureRequest.get()
             .param("eperson", admin.getID().toString()))

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/AuthorizationRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/AuthorizationRestRepositoryIT.java
@@ -1826,7 +1826,6 @@ public class AuthorizationRestRepositoryIT extends AbstractControllerIntegration
 
         // verify that it works for administators inspecting other users - by assuming login
         getClient(adminToken).perform(baseFeatureRequest.get()
-//            .param("feature", trueForLoggedUsers.getName())
             .header("X-On-Behalf-Of", eperson.getID()))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.page.totalElements", is(4)))

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/AuthorizationRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/AuthorizationRestRepositoryIT.java
@@ -10,6 +10,7 @@ package org.dspace.app.rest;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
@@ -34,6 +35,7 @@ import org.dspace.app.rest.authorization.TrueForTestUsersFeature;
 import org.dspace.app.rest.authorization.TrueForUsersInGroupTestFeature;
 import org.dspace.app.rest.converter.CommunityConverter;
 import org.dspace.app.rest.converter.EPersonConverter;
+import org.dspace.app.rest.converter.ItemConverter;
 import org.dspace.app.rest.converter.SiteConverter;
 import org.dspace.app.rest.matcher.AuthorizationMatcher;
 import org.dspace.app.rest.model.BaseObjectRest;
@@ -44,10 +46,14 @@ import org.dspace.app.rest.model.SiteRest;
 import org.dspace.app.rest.projection.DefaultProjection;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
 import org.dspace.app.rest.utils.Utils;
+import org.dspace.builder.CollectionBuilder;
 import org.dspace.builder.CommunityBuilder;
 import org.dspace.builder.EPersonBuilder;
 import org.dspace.builder.GroupBuilder;
+import org.dspace.builder.ItemBuilder;
+import org.dspace.content.Collection;
 import org.dspace.content.Community;
+import org.dspace.content.Item;
 import org.dspace.content.Site;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.SiteService;
@@ -83,6 +89,8 @@ public class AuthorizationRestRepositoryIT extends AbstractControllerIntegration
     private CommunityConverter communityConverter;
     @Autowired
     private ConfigurationService configurationService;
+    @Autowired
+    private ItemConverter itemConverter;
 
     @Autowired
     private Utils utils;
@@ -1514,6 +1522,873 @@ public class AuthorizationRestRepositoryIT extends AbstractControllerIntegration
         getClient().perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("feature", alwaysException.getName()))
+            .andExpect(status().isInternalServerError());
+    }
+
+    @Test
+    /**
+     * Verify that the search by multiple objects and features works properly in allowed scenarios:
+     * - for an administrator
+     * - for an administrator that want to inspect permission of the anonymous users or another user
+     * - for a logged-in "normal" user
+     * - for anonymous
+     *
+     * @throws Exception
+     */
+    public void findByMultipleObjectsAndFeaturesTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Community com = CommunityBuilder.createCommunity(context).withName("A test community").build();
+        String comId = com.getID().toString();
+        CommunityRest comRest = communityConverter.convert(com, DefaultProjection.DEFAULT);
+        Community secondCom = CommunityBuilder.createCommunity(context).withName("Another test community").build();
+        String secondComId = secondCom.getID().toString();
+        CommunityRest secondComRest = communityConverter.convert(secondCom, DefaultProjection.DEFAULT);
+        context.restoreAuthSystemState();
+
+        String adminToken = getAuthToken(admin.getEmail(), password);
+
+        // verify that it works for administrators - with eperson parameter
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/objects")
+            .param("type", "core.community")
+            .param("uuid", comId)
+            .param("uuid", secondComId)
+            .param("projection", "level")
+            .param("embedLevelDepth", "1")
+            .param("feature", alwaysTrue.getName())
+            .param("feature", alwaysFalse.getName())
+            .param("feature", trueForAdmins.getName())
+            .param("eperson", admin.getID().toString()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", is(4)))
+            .andExpect(jsonPath("$._embedded.authorizations", containsInAnyOrder(
+                allOf(
+                    hasJsonPath("$.id", is(admin.getID().toString() + "_" + alwaysTrue.getName() + "_"
+                        + comRest.getUniqueType() + "_" + comRest.getId())),
+                    hasJsonPath("$.type", is("authorization")),
+                    hasJsonPath("$._embedded.feature.id", is(alwaysTrue.getName())),
+                    hasJsonPath("$._embedded.eperson.id", is(admin.getID().toString()))
+                ),
+                allOf(
+                    hasJsonPath("$.id", is(admin.getID().toString() + "_" + trueForAdmins.getName() + "_"
+                        + comRest.getUniqueType() + "_" + comRest.getId())),
+                    hasJsonPath("$.type", is("authorization")),
+                    hasJsonPath("$._embedded.feature.id", is(trueForAdmins.getName())),
+                    hasJsonPath("$._embedded.eperson.id", is(admin.getID().toString()))
+                ),
+                allOf(
+                    hasJsonPath("$.id", is(admin.getID().toString() + "_" + alwaysTrue.getName() + "_"
+                        + secondComRest.getUniqueType() + "_" + secondComRest.getId())),
+                    hasJsonPath("$.type", is("authorization")),
+                    hasJsonPath("$._embedded.feature.id", is(alwaysTrue.getName())),
+                    hasJsonPath("$._embedded.eperson.id", is(admin.getID().toString()))
+                ),
+                allOf(
+                    hasJsonPath("$.id", is(admin.getID().toString() + "_" + trueForAdmins.getName() + "_"
+                        + secondComRest.getUniqueType() + "_" + secondComRest.getId())),
+                    hasJsonPath("$.type", is("authorization")),
+                    hasJsonPath("$._embedded.feature.id", is(trueForAdmins.getName())),
+                    hasJsonPath("$._embedded.eperson.id", is(admin.getID().toString()))
+                )
+            )));
+
+        // verify that it works for administrators - without eperson parameter
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/objects")
+            .param("type", "core.community")
+            .param("uuid", comId)
+            .param("uuid", secondComId)
+            .param("projection", "level")
+            .param("embedLevelDepth", "1")
+            .param("feature", alwaysFalse.getName())
+            .param("feature", trueForAdmins.getName())
+            .param("feature", alwaysTrue.getName()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", is(4)))
+            .andExpect(jsonPath("$._embedded.authorizations", containsInAnyOrder(
+                allOf(
+                    hasJsonPath("$.id", is(
+                        admin.getID().toString() + "_"
+                            + alwaysTrue.getName() + "_"
+                            + comRest.getUniqueType() + "_" + comRest.getId()
+                    )),
+                    hasJsonPath("$.type", is("authorization")),
+                    hasJsonPath("$._embedded.feature.id", is(alwaysTrue.getName())),
+                    hasJsonPath("$._embedded.eperson.id", is(admin.getID().toString()))
+                ),
+                allOf(
+                    hasJsonPath("$.id", is(
+                        admin.getID().toString() + "_"
+                            + trueForAdmins.getName() + "_"
+                            + comRest.getUniqueType() + "_" + comRest.getId()
+                    )),
+                    hasJsonPath("$.type", is("authorization")),
+                    hasJsonPath("$._embedded.feature.id", is(trueForAdmins.getName())),
+                    hasJsonPath("$._embedded.eperson.id", is(admin.getID().toString()))
+                ),
+                allOf(
+                    hasJsonPath("$.id", is(
+                        admin.getID().toString() + "_"
+                            + alwaysTrue.getName() + "_"
+                            + secondComRest.getUniqueType() + "_" + secondComRest.getId()
+                    )),
+                    hasJsonPath("$.type", is("authorization")),
+                    hasJsonPath("$._embedded.feature.id", is(alwaysTrue.getName())),
+                    hasJsonPath("$._embedded.eperson.id", is(admin.getID().toString()))
+                ),
+                allOf(
+                    hasJsonPath("$.id", is(
+                        admin.getID().toString() + "_"
+                            + trueForAdmins.getName() + "_"
+                            + secondComRest.getUniqueType() + "_" + secondComRest.getId()
+                    )),
+                    hasJsonPath("$.type", is("authorization")),
+                    hasJsonPath("$._embedded.feature.id", is(trueForAdmins.getName())),
+                    hasJsonPath("$._embedded.eperson.id", is(admin.getID().toString()))
+                )
+            )));
+
+        String epersonToken = getAuthToken(eperson.getEmail(), password);
+
+        // verify that it works for normal loggedin users - with eperson parameter
+        getClient(epersonToken).perform(get("/api/authz/authorizations/search/objects")
+            .param("type", "core.community")
+            .param("uuid", comId)
+            .param("uuid", secondComId)
+            .param("projection", "level")
+            .param("embedLevelDepth", "1")
+            .param("feature", alwaysTrue.getName())
+            .param("feature", alwaysFalse.getName())
+            .param("feature", trueForAdmins.getName())
+            .param("eperson", eperson.getID().toString()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", is(2)))
+            .andExpect(jsonPath("$._embedded.authorizations", containsInAnyOrder(
+                allOf(
+                    hasJsonPath("$.id", is(
+                        eperson.getID().toString() + "_"
+                            + alwaysTrue.getName() + "_"
+                            + comRest.getUniqueType() + "_" + comRest.getId()
+                    )),
+                    hasJsonPath("$.type", is("authorization")),
+                    hasJsonPath("$._embedded.feature.id", is(alwaysTrue.getName())),
+                    hasJsonPath("$._embedded.eperson.id", is(eperson.getID().toString()))
+                ),
+                allOf(
+                    hasJsonPath("$.id", is(
+                        eperson.getID().toString() + "_"
+                            + alwaysTrue.getName() + "_"
+                            + secondComRest.getUniqueType() + "_" + secondComRest.getId()
+                    )),
+                    hasJsonPath("$.type", is("authorization")),
+                    hasJsonPath("$._embedded.feature.id", is(alwaysTrue.getName())),
+                    hasJsonPath("$._embedded.eperson.id", is(eperson.getID().toString()))
+                )
+            )));
+
+        // verify that it works for normal loggedin users - without eperson parameter
+        getClient(epersonToken).perform(get("/api/authz/authorizations/search/objects")
+            .param("type", "core.community")
+            .param("uuid", comId)
+            .param("uuid", secondComId)
+            .param("projection", "level")
+            .param("embedLevelDepth", "1")
+            .param("feature", alwaysFalse.getName())
+            .param("feature", trueForLoggedUsers.getName())
+            .param("feature", alwaysTrue.getName()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", is(4)))
+            .andExpect(jsonPath("$._embedded.authorizations", containsInAnyOrder(
+                allOf(
+                    hasJsonPath("$.id", is(
+                        eperson.getID().toString() + "_"
+                            + alwaysTrue.getName() + "_"
+                            + comRest.getUniqueType() + "_" + comRest.getId()
+                    )),
+                    hasJsonPath("$.type", is("authorization")),
+                    hasJsonPath("$._embedded.feature.id", is(alwaysTrue.getName())),
+                    hasJsonPath("$._embedded.eperson.id", is(eperson.getID().toString()))
+                ),
+                allOf(
+                    hasJsonPath("$.id", is(
+                        eperson.getID().toString() + "_"
+                            + trueForLoggedUsers.getName() + "_"
+                            + comRest.getUniqueType() + "_" + comRest.getId()
+                    )),
+                    hasJsonPath("$.type", is("authorization")),
+                    hasJsonPath("$._embedded.feature.id", is(trueForLoggedUsers.getName())),
+                    hasJsonPath("$._embedded.eperson.id", is(eperson.getID().toString()))
+                ),
+                allOf(
+                    hasJsonPath("$.id", is(
+                        eperson.getID().toString() + "_"
+                            + alwaysTrue.getName() + "_"
+                            + secondComRest.getUniqueType() + "_" + secondComRest.getId()
+                    )),
+                    hasJsonPath("$.type", is("authorization")),
+                    hasJsonPath("$._embedded.feature.id", is(alwaysTrue.getName())),
+                    hasJsonPath("$._embedded.eperson.id", is(eperson.getID().toString()))
+                ),
+                allOf(
+                    hasJsonPath("$.id", is(
+                        eperson.getID().toString() + "_"
+                            + trueForLoggedUsers.getName() + "_"
+                            + secondComRest.getUniqueType() + "_" + secondComRest.getId()
+                    )),
+                    hasJsonPath("$.type", is("authorization")),
+                    hasJsonPath("$._embedded.feature.id", is(trueForLoggedUsers.getName())),
+                    hasJsonPath("$._embedded.eperson.id", is(eperson.getID().toString()))
+                )
+            )));
+
+        // verify that it works for administators inspecting other users - by using the eperson parameter
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/objects")
+            .param("type", "core.community")
+            .param("uuid", comId)
+            .param("uuid", secondComId)
+            .param("projection", "level")
+            .param("embedLevelDepth", "1")
+            .param("feature", alwaysTrue.getName())
+            .param("feature", alwaysFalse.getName())
+            .param("feature", trueForAdmins.getName())
+            .param("feature", trueForLoggedUsers.getName())
+            .param("eperson", eperson.getID().toString()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", is(4)))
+            .andExpect(jsonPath("$._embedded.authorizations", containsInAnyOrder(
+                allOf(
+                    hasJsonPath("$.id", is(
+                        eperson.getID().toString() + "_"
+                            + alwaysTrue.getName() + "_"
+                            + comRest.getUniqueType() + "_" + comRest.getId()
+                    )),
+                    hasJsonPath("$.type", is("authorization")),
+                    hasJsonPath("$._embedded.feature.id", is(alwaysTrue.getName())),
+                    hasJsonPath("$._embedded.eperson.id", is(eperson.getID().toString()))
+                ),
+                allOf(
+                    hasJsonPath("$.id", is(
+                        eperson.getID().toString() + "_"
+                            + trueForLoggedUsers.getName() + "_"
+                            + comRest.getUniqueType() + "_" + comRest.getId()
+                    )),
+                    hasJsonPath("$.type", is("authorization")),
+                    hasJsonPath("$._embedded.feature.id", is(trueForLoggedUsers.getName())),
+                    hasJsonPath("$._embedded.eperson.id", is(eperson.getID().toString()))
+                ),
+                allOf(
+                    hasJsonPath("$.id", is(
+                        eperson.getID().toString() + "_"
+                            + alwaysTrue.getName() + "_"
+                            + secondComRest.getUniqueType() + "_" + secondComRest.getId()
+                    )),
+                    hasJsonPath("$.type", is("authorization")),
+                    hasJsonPath("$._embedded.feature.id", is(alwaysTrue.getName())),
+                    hasJsonPath("$._embedded.eperson.id", is(eperson.getID().toString()))
+                ),
+                allOf(
+                    hasJsonPath("$.id", is(
+                        eperson.getID().toString() + "_"
+                            + trueForLoggedUsers.getName() + "_"
+                            + secondComRest.getUniqueType() + "_" + secondComRest.getId()
+                    )),
+                    hasJsonPath("$.type", is("authorization")),
+                    hasJsonPath("$._embedded.feature.id", is(trueForLoggedUsers.getName())),
+                    hasJsonPath("$._embedded.eperson.id", is(eperson.getID().toString()))
+                )
+            )));
+
+        // verify that it works for administators inspecting other users - by assuming login
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/objects")
+            .param("type", "core.community")
+            .param("uuid", comId)
+            .param("uuid", secondComId)
+            .param("projection", "level")
+            .param("embedLevelDepth", "1")
+            .param("feature", alwaysTrue.getName())
+            .param("feature", alwaysFalse.getName())
+            .param("feature", trueForAdmins.getName())
+            .header("X-On-Behalf-Of", eperson.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", is(2)))
+            .andExpect(jsonPath("$._embedded.authorizations", contains(
+                allOf(
+                    hasJsonPath("$.id", is(
+                        eperson.getID().toString() + "_"
+                            + alwaysTrue.getName() + "_"
+                            + comRest.getUniqueType() + "_" + comRest.getId()
+                    )),
+                    hasJsonPath("$.type", is("authorization")),
+                    hasJsonPath("$._embedded.feature.id", is(alwaysTrue.getName())),
+                    hasJsonPath("$._embedded.eperson.id", is(eperson.getID().toString()))
+                ),
+                allOf(
+                    hasJsonPath("$.id", is(
+                        eperson.getID().toString() + "_"
+                            + alwaysTrue.getName() + "_"
+                            + secondComRest.getUniqueType() + "_" + secondComRest.getId()
+                    )),
+                    hasJsonPath("$.type", is("authorization")),
+                    hasJsonPath("$._embedded.feature.id", is(alwaysTrue.getName())),
+                    hasJsonPath("$._embedded.eperson.id", is(eperson.getID().toString()))
+                )
+            )));
+
+        // verify that it works for anonymous users
+        getClient().perform(get("/api/authz/authorizations/search/objects")
+            .param("type", "core.community")
+            .param("uuid", comId)
+            .param("uuid", secondComId)
+            .param("projection", "level")
+            .param("embedLevelDepth", "1")
+            .param("feature", alwaysFalse.getName())
+            .param("feature", trueForAdmins.getName())
+            .param("feature", alwaysTrue.getName()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", is(2)))
+            .andExpect(jsonPath("$._embedded.authorizations", containsInAnyOrder(
+                allOf(
+                    hasJsonPath("$.id", is(
+                        alwaysTrue.getName() + "_"
+                            + comRest.getUniqueType() + "_" + comRest.getId()
+                    )),
+                    hasJsonPath("$.type", is("authorization")),
+                    hasJsonPath("$._embedded.feature.id", is(alwaysTrue.getName())),
+                    hasJsonPath("$._embedded.eperson", nullValue())
+                ),
+                allOf(
+                    hasJsonPath("$.id", is(
+                        alwaysTrue.getName() + "_"
+                            + secondComRest.getUniqueType() + "_" + secondComRest.getId()
+                    )),
+                    hasJsonPath("$.type", is("authorization")),
+                    hasJsonPath("$._embedded.feature.id", is(alwaysTrue.getName())),
+                    hasJsonPath("$._embedded.eperson", nullValue())
+                )
+            )));
+    }
+
+    @Test
+    /**
+     * Verify that the search by many objects and features works return 204 No Content when no feature is granted.
+     *
+     * @throws Exception
+     */
+    public void findByMultipleObjectsAndFeatureNotGrantedTest() throws Exception {
+
+        context.turnOffAuthorisationSystem();
+
+        Community community = CommunityBuilder.createCommunity(context).build();
+        Collection collection = CollectionBuilder.createCollection(context,community).build();
+        Item item = ItemBuilder.createItem(context, collection).build();
+        String itemId = item.getID().toString();
+        ItemRest itemRest = itemConverter.convert(item, DefaultProjection.DEFAULT);
+        Item secondItem = ItemBuilder.createItem(context, collection).build();
+        String secondItemId = secondItem.getID().toString();
+        ItemRest secondItemRest = itemConverter.convert(secondItem, DefaultProjection.DEFAULT);
+
+        context.restoreAuthSystemState();
+
+        String adminToken = getAuthToken(admin.getEmail(), password);
+
+        // verify that it works for administrators - with eperson parameter
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/objects")
+            .param("type", "core.item")
+            .param("uuid", itemId)
+            .param("uuid", secondItemId)
+            .param("feature", alwaysFalse.getName())
+            .param("feature", alwaysFalse.getName())
+            .param("eperson", admin.getID().toString()))
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
+
+        // verify that it works for administrators - without eperson parameter
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/objects")
+            .param("type", "core.item")
+            .param("uuid", itemId)
+            .param("uuid", secondItemId)
+            .param("feature", alwaysFalse.getName())
+            .param("feature", alwaysFalse.getName()))
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
+
+        String epersonToken = getAuthToken(eperson.getEmail(), password);
+
+        // verify that it works for normal loggedin users - with eperson parameter
+        getClient(epersonToken).perform(get("/api/authz/authorizations/search/objects")
+            .param("type", "core.item")
+            .param("uuid", itemId)
+            .param("uuid", secondItemId)
+            .param("feature", alwaysFalse.getName())
+            .param("feature", alwaysFalse.getName())
+            .param("eperson", eperson.getID().toString()))
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
+
+        // verify that it works for normal loggedin users - without eperson parameter
+        getClient(epersonToken).perform(get("/api/authz/authorizations/search/objects")
+            .param("type", "core.item")
+            .param("uuid", itemId)
+            .param("uuid", secondItemId)
+            .param("feature", alwaysFalse.getName())
+            .param("feature", trueForAdmins.getName()))
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
+
+        // verify that it works for administators inspecting other users - by using the eperson parameter
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/objects")
+            .param("type", "core.item")
+            .param("uuid", itemId)
+            .param("uuid", secondItemId)
+            .param("feature", alwaysFalse.getName())
+            .param("feature", trueForAdmins.getName())
+            .param("eperson", eperson.getID().toString()))
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
+
+        // verify that it works for administators inspecting other users - by assuming login
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/objects")
+            .param("type", "core.item")
+            .param("uuid", itemId)
+            .param("uuid", secondItemId)
+            .param("feature", alwaysFalse.getName())
+            .param("feature", trueForAdmins.getName())
+            .header("X-On-Behalf-Of", eperson.getID()))
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
+
+        // verify that it works for anonymous users
+        getClient().perform(get("/api/authz/authorizations/search/objects")
+            .param("type", "core.item")
+            .param("uuid", itemId)
+            .param("uuid", secondItemId)
+            .param("feature", alwaysFalse.getName())
+            .param("feature", trueForLoggedUsers.getName()))
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
+    }
+
+    @Test
+    /**
+     * Verify that the find by multiple objects and features
+     * return the 204 No Content code when the requested object doesn't exist but the uri
+     * is potentially valid (i.e. deleted object) or the feature doesn't exist
+     *
+     * @throws Exception
+     */
+    public void findByNotExistingMultipleObjectsAndFeatureTest() throws Exception {
+        UUID wrongSiteId = UUID.randomUUID();
+        String siteId = wrongSiteId.toString();
+        String wrongSiteUri = "http://localhost/api/core/sites/" + wrongSiteId;
+        Site site = siteService.findSite(context);
+        SiteRest siteRest = siteConverter.convert(site, DefaultProjection.DEFAULT);
+        String siteUri = utils.linkToSingleResource(siteRest, "self").getHref();
+
+        // disarm the alwaysThrowExceptionFeature
+        configurationService.setProperty("org.dspace.app.rest.authorization.AlwaysThrowExceptionFeature.turnoff", true);
+
+        String adminToken = getAuthToken(admin.getEmail(), password);
+
+        // verify that it works for administrators, no result - with eperson parameter
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/objects")
+            .param("type", "core.site")
+            .param("uuid", siteId)
+            .param("uuid", siteId)
+            .param("feature", alwaysTrue.getName())
+            .param("eperson", admin.getID().toString()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
+
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/objects")
+            .param("type", "core.site")
+            .param("uuid", siteId)
+            .param("uuid", siteId)
+            .param("feature", "not-existing-feature")
+            .param("eperson", admin.getID().toString()))
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
+
+        // verify that it works for administrators, no result - without eperson parameter
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/objects")
+            .param("type", "core.site")
+            .param("uuid", siteId)
+            .param("uuid", siteId)
+            .param("feature", alwaysTrue.getName()))
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
+
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/objects")
+            .param("type", "core.site")
+            .param("uuid", siteId)
+            .param("uuid", siteId)
+            .param("feature", "not-existing-one")
+            .param("feature", "not-existing-feature"))
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
+
+        String epersonToken = getAuthToken(eperson.getEmail(), password);
+
+        // verify that it works for normal loggedin users - with eperson parameter
+        getClient(epersonToken).perform(get("/api/authz/authorizations/search/objects")
+            .param("type", "core.site")
+            .param("uuid", siteId)
+            .param("uuid", siteId)
+            .param("feature", "not-existing-one")
+            .param("feature", alwaysTrue.getName())
+            .param("eperson", eperson.getID().toString()))
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
+
+        getClient(epersonToken).perform(get("/api/authz/authorizations/search/objects")
+            .param("type", "core.site")
+            .param("uuid", siteId)
+            .param("uuid", siteId)
+            .param("feature", "not-existing-one")
+            .param("feature", "not-existing-feature")
+            .param("eperson", eperson.getID().toString()))
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
+
+        // verify that it works for normal loggedin users - without eperson parameter
+        getClient(epersonToken).perform(get("/api/authz/authorizations/search/objects")
+            .param("type", "core.site")
+            .param("uuid", siteId)
+            .param("uuid", siteId)
+            .param("feature", "not-existing-one")
+            .param("feature", alwaysTrue.getName()))
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
+
+        getClient(epersonToken).perform(get("/api/authz/authorizations/search/objects")
+            .param("type", "core.site")
+            .param("uuid", siteId)
+            .param("uuid", siteId)
+            .param("feature", "not-existing-one")
+            .param("feature", "not-existing-feature"))
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
+
+        // verify that it works for administators inspecting other users - by using the eperson parameter
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/objects")
+            .param("type", "core.site")
+            .param("uuid", siteId)
+            .param("uuid", siteId)
+            .param("feature", "not-existing-one")
+            .param("feature", alwaysTrue.getName())
+            .param("eperson", eperson.getID().toString()))
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
+
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/objects")
+            .param("type", "core.site")
+            .param("uuid", siteId)
+            .param("uuid", siteId)
+            .param("feature", "not-existing-one")
+            .param("feature", "not-existing-feature")
+            .param("eperson", eperson.getID().toString()))
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
+
+        // verify that it works for administators inspecting other users - by assuming login
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/objects")
+            .param("type", "core.site")
+            .param("uuid", siteId)
+            .param("uuid", siteId)
+            .param("feature", "not-existing-one")
+            .param("feature", alwaysTrue.getName())
+            .header("X-On-Behalf-Of", eperson.getID()))
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
+
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/objects")
+            .param("type", "core.site")
+            .param("uuid", siteId)
+            .param("uuid", siteId)
+            .param("feature", "not-existing-one")
+            .param("feature", "not-existing-feature")
+            .header("X-On-Behalf-Of", eperson.getID()))
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
+
+        // verify that it works for anonymous users
+        getClient().perform(get("/api/authz/authorizations/search/objects")
+            .param("type", "core.site")
+            .param("uuid", siteId)
+            .param("uuid", siteId)
+            .param("feature", "not-existing-one")
+            .param("feature", alwaysTrue.getName()))
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
+
+        getClient().perform(get("/api/authz/authorizations/search/objects")
+            .param("type", "core.site")
+            .param("uuid", siteId)
+            .param("uuid", siteId)
+            .param("feature", "not-existing-one")
+            .param("feature", "not-existing-feature"))
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
+    }
+
+    @Test
+    /**
+     * Verify that the find by multiple objects and features
+     * return the 400 Bad Request response for invalid or missing UUID or type
+     *
+     * @throws Exception
+     */
+    public void findByMultipleObjectsAndFeatureBadRequestTest() throws Exception {
+        String[] invalidUris = new String[] {
+            "foo",
+            "",
+            "boo-invalid",
+            "this-is-not-an-uuid"
+        };
+        // disarm the alwaysThrowExceptionFeature
+        configurationService.setProperty("org.dspace.app.rest.authorization.AlwaysThrowExceptionFeature.turnoff", true);
+
+        String adminToken = getAuthToken(admin.getEmail(), password);
+        String epersonToken = getAuthToken(eperson.getEmail(), password);
+//        for (String invalidUri : invalidUris) {
+//            log.debug("findByObjectAndFeatureBadRequestTest - Testing the URI: " + invalidUri);
+
+            // verify that it works for administrators with an invalid or missing uuid - with eperson parameter
+            getClient(adminToken).perform(get("/api/authz/authorizations/search/objects")
+                .param("type", "core.item")
+                .param("uuid", "foo")
+                .param("uuid", "")
+                .param("uuid", "invalid")
+                .param("uuid", "this-is-not-an-uuid")
+                .param("feature", alwaysTrue.getName())
+                .param("eperson", admin.getID().toString()))
+                .andExpect(status().isBadRequest());
+
+            // verify that it works for administrators with an invalid or missing uuid - without eperson parameter
+            getClient(adminToken).perform(get("/api/authz/authorizations/search/objects")
+                .param("type", "core.item")
+                .param("uuid", "foo")
+                .param("uuid", "")
+                .param("uuid", "invalid")
+                .param("uuid", "this-is-not-an-uuid")
+                .param("feature", alwaysTrue.getName()))
+                .andExpect(status().isBadRequest());
+
+            // verify that it works for normal loggedin users with an invalid or missing uuid - with eperson parameter
+            getClient(epersonToken).perform(get("/api/authz/authorizations/search/objects")
+                .param("type", "core.item")
+                .param("uuid", "foo")
+                .param("uuid", "")
+                .param("uuid", "invalid")
+                .param("uuid", "this-is-not-an-uuid")
+                .param("feature", alwaysTrue.getName())
+                .param("eperson", eperson.getID().toString()))
+                .andExpect(status().isBadRequest());
+
+            // verify that it works for normal loggedin users with an invalid or missing
+            // uuid - without eperson parameter
+            getClient(epersonToken).perform(get("/api/authz/authorizations/search/objects")
+                .param("type", "core.item")
+                .param("uuid", "foo")
+                .param("uuid", "")
+                .param("uuid", "invalid")
+                .param("uuid", "this-is-not-an-uuid")
+                .param("feature", alwaysTrue.getName()))
+                .andExpect(status().isBadRequest());
+
+            // verify that it works for administators inspecting other users with an invalid or missing uri - by
+            // using the eperson parameter
+            getClient(adminToken).perform(get("/api/authz/authorizations/search/objects")
+                .param("type", "core.item")
+                .param("uuid", "foo")
+                .param("uuid", "")
+                .param("uuid", "invalid")
+                .param("uuid", "this-is-not-an-uuid")
+                .param("feature", alwaysTrue.getName())
+                .param("eperson", eperson.getID().toString()))
+                .andExpect(status().isBadRequest());
+
+            // verify that it works for administators inspecting other users with an invalid or missing uri - by
+            // assuming login
+            getClient(adminToken).perform(get("/api/authz/authorizations/search/objects")
+                .param("type", "core.item")
+                .param("uuid", "foo")
+                .param("uuid", "")
+                .param("uuid", "invalid")
+                .param("uuid", "this-is-not-an-uuid")
+                .param("feature", alwaysTrue.getName())
+                .header("X-On-Behalf-Of", eperson.getID()))
+                .andExpect(status().isBadRequest());
+
+            // verify that it works for anonymous users with an invalid or missing uri
+            getClient().perform(get("/api/authz/authorizations/search/objects")
+                .param("type", "core.item")
+                .param("uuid", "foo")
+                .param("uuid", "")
+                .param("uuid", "invalid")
+                .param("uuid", "this-is-not-an-uuid")
+                .param("feature", alwaysTrue.getName()))
+                .andExpect(status().isBadRequest());
+
+            // verify that returns bad request for invalid type
+        getClient().perform(get("/api/authz/authorizations/search/objects")
+            .param("type", "INVALID")
+            .param("uuid", UUID.randomUUID().toString())
+            .param("uuid", UUID.randomUUID().toString())
+            .param("feature", alwaysTrue.getName()))
+            .andExpect(status().isBadRequest());
+
+        // verify that returns bad request for missing type
+        getClient().perform(get("/api/authz/authorizations/search/objects")
+            .param("uuid", UUID.randomUUID().toString())
+            .param("uuid", UUID.randomUUID().toString())
+            .param("feature", alwaysTrue.getName()))
+            .andExpect(status().isBadRequest());
+//        }
+    }
+
+    @Test
+    /**
+     * Verify that the find by multiple objects and features return
+     * the 401 Unauthorized response when an eperson is involved
+     *
+     * @throws Exception
+     */
+    public void findByMultipleObjectsAndFeatureUnauthorizedTest() throws Exception {
+        Site site = siteService.findSite(context);
+        String siteId = site.getID().toString();
+
+        // disarm the alwaysThrowExceptionFeature
+        configurationService.setProperty("org.dspace.app.rest.authorization.AlwaysThrowExceptionFeature.turnoff", true);
+
+        // verify that it works for an anonymous user inspecting an admin user - by using the eperson parameter
+        getClient().perform(get("/api/authz/authorizations/search/objects")
+            .param("type", "core.site")
+            .param("uuid", siteId)
+            .param("uuid", siteId)
+            .param("feature", alwaysTrue.getName())
+            .param("eperson", admin.getID().toString()))
+            .andExpect(status().isUnauthorized());
+
+        // verify that it works for an anonymous user inspecting an admin user - by assuming login
+        getClient().perform(get("/api/authz/authorizations/search/objects")
+            .param("type", "core.site")
+            .param("uuid", siteId)
+            .param("uuid", siteId)
+            .param("feature", alwaysTrue.getName())
+            .header("X-On-Behalf-Of", admin.getID()))
+            .andExpect(status().isUnauthorized());
+
+        // verify that it works for an anonymous user inspecting a normal user - by using the eperson parameter
+        getClient().perform(get("/api/authz/authorizations/search/objects")
+            .param("type", "core.site")
+            .param("uuid", siteId)
+            .param("uuid", siteId)
+            .param("feature", alwaysTrue.getName())
+            .param("eperson", eperson.getID().toString()))
+            .andExpect(status().isUnauthorized());
+
+        // verify that it works for an anonymous user inspecting a normal user - by assuming login
+        getClient().perform(get("/api/authz/authorizations/search/objects")
+            .param("type", "core.site")
+            .param("uuid", siteId)
+            .param("uuid", siteId)
+            .param("feature", alwaysTrue.getName())
+            .header("X-On-Behalf-Of", eperson.getID()))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    /**
+     * Verify that the find by multiple objects and features
+     * returns the 403 Forbidden response when a non-admin eperson try to search
+     * the authorization of another eperson
+     *
+     * @throws Exception
+     */
+    public void findByMultipleObjectsAndFeatureForbiddenTest() throws Exception {
+        Site site = siteService.findSite(context);
+        String siteId = site.getID().toString();
+
+        context.turnOffAuthorisationSystem();
+        EPerson anotherEperson = EPersonBuilder.createEPerson(context).withEmail("another@example.com")
+            .withPassword(password).build();
+        context.restoreAuthSystemState();
+        // disarm the alwaysThrowExceptionFeature
+        configurationService.setProperty("org.dspace.app.rest.authorization.AlwaysThrowExceptionFeature.turnoff", true);
+        String anotherToken = getAuthToken(anotherEperson.getEmail(), password);
+
+        // verify that he cannot search the admin authorizations - by using the eperson parameter
+        getClient(anotherToken).perform(get("/api/authz/authorizations/search/objects")
+            .param("type", "core.site")
+            .param("uuid", siteId)
+            .param("uuid", siteId)
+            .param("feature", alwaysFalse.getName())
+            .param("feature", alwaysTrue.getName())
+            .param("eperson", admin.getID().toString()))
+            .andExpect(status().isForbidden());
+
+        // verify that he cannot search the admin authorizations - by assuming login
+        getClient(anotherToken).perform(get("/api/authz/authorizations/search/objects")
+            .param("type", "core.site")
+            .param("uuid", siteId)
+            .param("uuid", siteId)
+            .param("feature", alwaysFalse.getName())
+            .param("feature", alwaysTrue.getName())
+            .header("X-On-Behalf-Of", admin.getID()))
+            .andExpect(status().isForbidden());
+
+        // verify that he cannot search the authorizations of another "normal" eperson - by using the eperson parameter
+        getClient(anotherToken).perform(get("/api/authz/authorizations/search/objects")
+            .param("type", "core.site")
+            .param("uuid", siteId)
+            .param("uuid", siteId)
+            .param("feature", alwaysFalse.getName())
+            .param("feature", alwaysTrue.getName())
+            .param("eperson", eperson.getID().toString()))
+            .andExpect(status().isForbidden());
+
+        // verify that he cannot search the authorizations of another "normal" eperson - by assuming login
+        getClient(anotherToken).perform(get("/api/authz/authorizations/search/objects")
+            .param("type", "core.site")
+            .param("uuid", siteId)
+            .param("uuid", siteId)
+            .param("feature", alwaysFalse.getName())
+            .param("feature", alwaysTrue.getName())
+            .header("X-On-Behalf-Of", eperson.getID()))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    /**
+     * Verify that an exception in the multiple authorization features check will be reported back
+     * @throws Exception
+     */
+    public void findByMultipleObjectsAndFeatureInternalServerErrorTest() throws Exception {
+        Site site = siteService.findSite(context);
+        String siteId = site.getID().toString();
+
+        String adminToken = getAuthToken(admin.getEmail(), password);
+
+        // verify that it works for administrators - with eperson parameter
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/objects")
+            .param("type", "core.site")
+            .param("uuid", siteId)
+            .param("uuid", siteId)
+            .param("feature", alwaysException.getName())
+            .param("eperson", admin.getID().toString()))
+            .andExpect(status().isInternalServerError());
+
+        // verify that it works for administrators - without eperson parameter
+        getClient(adminToken).perform(get("/api/authz/authorizations/search/objects")
+            .param("type", "core.site")
+            .param("uuid", siteId)
+            .param("uuid", siteId)
+            .param("feature", alwaysException.getName()))
+            .andExpect(status().isInternalServerError());
+
+        String epersonToken = getAuthToken(eperson.getEmail(), password);
+
+        // verify that it works for normal loggedin users - with eperson parameter
+        getClient(epersonToken).perform(get("/api/authz/authorizations/search/objects")
+            .param("type", "core.site")
+            .param("uuid", siteId)
+            .param("uuid", siteId)
+            .param("feature", alwaysException.getName())
+            .param("eperson", eperson.getID().toString()))
+            .andExpect(status().isInternalServerError());
+
+        // verify that it works for normal loggedin users - without eperson parameter
+        getClient(epersonToken).perform(get("/api/authz/authorizations/search/objects")
+            .param("type", "core.site")
+            .param("uuid", siteId)
+            .param("uuid", siteId)
+            .param("feature", alwaysException.getName()))
+            .andExpect(status().isInternalServerError());
+
+        // verify that it works for anonymous users
+        getClient().perform(get("/api/authz/authorizations/search/objects")
+            .param("type", "core.site")
+            .param("uuid", siteId)
+            .param("uuid", siteId)
+            .param("feature", alwaysException.getName()))
             .andExpect(status().isInternalServerError());
     }
 


### PR DESCRIPTION
## References
* Needed for [angular issue #1044](https://github.com/DSpace/dspace-angular/issues/1044)
* Related to [REST Contract PR](https://github.com/DSpace/RestContract/pull/168)

## Description
We have added an endpoint accepting resource type, and a list of resource uuids and features to which the caller want authorization(s) verified

## Instructions for Reviewers
* Entry point is new method findByObjects in AuthorizationRestRepository class, this class has been refactored a bit. 
* New method collaborates with Utils getBaseObjectRestFromTypeAndUUID method, used to obtain a Rest Object. Starting from list of uuids, Rest Objects are retrieved, and for each objects feature(s) are verified.

List of changes in this PR:
* Refactoring in Utils part retrieving BaseRestObjects in order to have a method retrieving it with apiCategory, model and uuid, informations. This method is used by the existing that retrieves BaseRestObject with uri, and from a new one accepting type ("core.item", "core.collection",...) and uuid and returning its Rest representation.
* A new "findByObject" method has been added to AuthorizationRestRepository
* new private methods in AuthorizationRestRepository to retrieve objects starting from their uuids and evaluating the authorization features for each object
* AuthorizationRestRepository refactoring, added private methods to retrieve authorizations for an object represented by an uri
* Added IT covering same scenarios covered for "/api/authz/authorizations/object" endpoint

**Include guidance for how to test or review your PR.** 
To test it, call the new endpoint "/api/authz/authorizations/objects" with a type parameter ("core.item"), one or many item uuids and one or many feature to be verified. Results should be the same than what obtained by performing single calls for each item uri and for each feature using the single "/api/authz/authorizations/object" endpoint.

## Checklist

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
