### PR TITLE
Performance improvements

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/AdminRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/AdminRestPermissionEvaluatorPlugin.java
@@ -53,8 +53,7 @@ public class AdminRestPermissionEvaluatorPlugin extends RestObjectPermissionEval
         EPerson ePerson = null;
 
         try {
-            ePerson = ePersonService.findByEmail(context, (String) authentication.getPrincipal());
-
+            ePerson = context.getCurrentUser();
             if (ePerson != null) {
 
                 //Check if user is a repository admin

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/AuthorizeServicePermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/AuthorizeServicePermissionEvaluatorPlugin.java
@@ -76,7 +76,7 @@ public class AuthorizeServicePermissionEvaluatorPlugin extends RestObjectPermiss
                     return false;
                 }
 
-                ePerson = ePersonService.findByEmail(context, (String) authentication.getPrincipal());
+                ePerson = context.getCurrentUser();
 
                 if (dSpaceObjectService != null && dsoId != null) {
                     DSpaceObject dSpaceObject = dSpaceObjectService.find(context, dsoId);


### PR DESCRIPTION
## References
* Related #7971 


## Description
The checks in the authorization service have been reordered as follow
- check if the information is already in the local cache
- check if the user is a global admin
- check the direct policy on the target dspace object
- check if the user is an admin of the target object

the 4th check include the 2nd one but it makes sense to perform it externally as it is fast and would save lot of time for a repository administrators. The 3rd check is more likely to be the relevant one for public items and bitstreams that would represent to most common/frequent scenario in a repository.

Other than the changes in the authorization service we have fixed the way that the current user was retrieved in the evaluation plugin because, after the first changes these operation were spot as the most time consuming operation. 

**Update**
The CI build time is probably not 100% reliable, the last build of the main takes more than 45 minutes but previous builds were around 24 minutes (over the last two months we only have Build #998 and Build #974 that were a bit faster). On my repository it takes 22min 50' https://github.com/abollini/DSpace/actions/runs/1292372583

Moreover, our test are not really a good benchmark for "normal" usage as some operations and kind of users are much more frequent than other.

## Instructions for Reviewers
Inspect the changes no functional changes should be noted. Takes note of your local response time for the most common requests repeating them several times and check if the changes in the PR makes visible improments

## Checklist
- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [n/a ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [n/a] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [n/a] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
