### PR TITLE
dspace-api: check for null AND empty qualifier in findByElement()

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/MetadataFieldDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/MetadataFieldDAOImpl.java
@@ -78,7 +78,7 @@ public class MetadataFieldDAOImpl extends AbstractHibernateDAO<MetadataField> im
     {
         Query query;
 
-        if(qualifier != null) {
+        if(qualifier != null && !qualifier.isEmpty()) {
             query = createQuery(context, "SELECT mf " +
                     "FROM MetadataField mf " +
                     "JOIN FETCH mf.metadataSchema ms " +
@@ -95,7 +95,7 @@ public class MetadataFieldDAOImpl extends AbstractHibernateDAO<MetadataField> im
         query.setParameter("name", metadataSchema);
         query.setParameter("element", element);
 
-        if(qualifier != null) {
+        if(qualifier != null && !qualifier.isEmpty()) {
             query.setParameter("qualifier", qualifier);
         }
 


### PR DESCRIPTION
The legacy [DSpace 6 REST API passes an _empty string_ ("") to findByElement() for elements with no qualifier](https://github.com/DSpace/DSpace/blob/dspace-6_x/dspace-rest/src/main/java/org/dspace/rest/MetadataRegistryResource.java#L218) when requesting the following path:

    /registries/schema/{schema}/metadata-fields/{element}

... yet MetadataFieldDAOImpl's findByElement() only checks for a _null_ qualifier, which is of course not the same thing as an empty string! We could technically change the REST API so it passes null, but it's probably more correct to just check for not null and not empty in dspace-api.

Note: there is at least one other case in MetadataFieldDAOImpl where we only check if the qualifier is null. We should probably check if it is an empty string there as well.

## References

* Fixes #7946

## Instructions for Reviewers

Test the following request before and after the patch:

- http://localhost:8080/rest/registries/schema/dc/metadata-fields/title

## Checklist
- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.