### PR TITLE
Ensure that a mapped Item is exported only once.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/MetadataDSpaceCsvExportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/MetadataDSpaceCsvExportServiceImpl.java
@@ -9,12 +9,12 @@ package org.dspace.content;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
-import com.google.common.collect.Iterators;
 import org.dspace.app.bulkedit.DSpaceCSV;
 import org.dspace.app.util.service.DSpaceObjectUtils;
 import org.dspace.content.service.ItemService;
@@ -102,40 +102,36 @@ public class MetadataDSpaceCsvExportServiceImpl implements MetadataDSpaceCsvExpo
     }
 
     /**
-     * Build an array list of item ids that are in a community (include sub-communities and collections)
+     * Build a Java Collection of item IDs that are in a Community (including
+     * its sub-Communities and Collections)
      *
      * @param context   DSpace context
      * @param community The community to build from
-     * @return The list of item ids
+     * @return Iterator over the Collection of item ids
      * @throws SQLException if database error
      */
     private Iterator<Item> buildFromCommunity(Context context, Community community)
         throws SQLException {
+        Set<Item> result = new HashSet<>();
+
         // Add all the collections
         List<Collection> collections = community.getCollections();
-        Iterator<Item> result = Collections.<Item>emptyIterator();
         for (Collection collection : collections) {
             Iterator<Item> items = itemService.findByCollection(context, collection);
-            result = addItemsToResult(result, items);
-
+            while (items.hasNext()) {
+                result.add(items.next());
+            }
         }
-        // Add all the sub-communities
+
+    // Add all the sub-communities
         List<Community> communities = community.getSubcommunities();
         for (Community subCommunity : communities) {
             Iterator<Item> items = buildFromCommunity(context, subCommunity);
-            result = addItemsToResult(result, items);
+            while (items.hasNext()) {
+                result.add(items.next());
+            }
         }
 
-        return result;
-    }
-
-    private Iterator<Item> addItemsToResult(Iterator<Item> result, Iterator<Item> items) {
-        if (result == null) {
-            result = items;
-        } else {
-            result = Iterators.concat(result, items);
-        }
-
-        return result;
+        return result.iterator();
     }
 }

--- a/dspace-api/src/test/java/org/dspace/content/MetadataDSpaceCsvExportServiceImplIT.java
+++ b/dspace-api/src/test/java/org/dspace/content/MetadataDSpaceCsvExportServiceImplIT.java
@@ -1,0 +1,115 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.Iterator;
+import java.util.List;
+
+import org.dspace.AbstractIntegrationTestWithDatabase;
+import org.dspace.app.bulkedit.DSpaceCSV;
+import org.dspace.app.bulkedit.DSpaceCSVLine;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.ItemBuilder;
+import org.dspace.content.service.MetadataDSpaceCsvExportService;
+import org.dspace.scripts.handler.DSpaceRunnableHandler;
+import org.dspace.utils.DSpace;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ *
+ * @author Mark H. Wood <mwood@iupui.edu>
+ */
+public class MetadataDSpaceCsvExportServiceImplIT
+        extends AbstractIntegrationTestWithDatabase {
+    /**
+     * Test of handleExport method, of class MetadataDSpaceCsvExportServiceImpl.
+     * @throws java.lang.Exception passed through.
+     */
+    @Ignore
+    @Test
+    public void testHandleExport()
+            throws Exception {
+        System.out.println("handleExport");
+        boolean exportAllItems = false;
+        boolean exportAllMetadata = false;
+        String identifier = "";
+        DSpaceRunnableHandler handler = null;
+        MetadataDSpaceCsvExportServiceImpl instance = new MetadataDSpaceCsvExportServiceImpl();
+        DSpaceCSV expResult = null;
+        DSpaceCSV result = instance.handleExport(context, exportAllItems,
+                exportAllMetadata, identifier, handler);
+        assertEquals(expResult, result);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+
+    /**
+     * Test of export method, of class MetadataDSpaceCsvExportServiceImpl.
+     * @throws java.lang.Exception passed through.
+     */
+    @Ignore
+    @Test
+    public void testExport_3args_1()
+            throws Exception {
+        System.out.println("export");
+        Iterator<Item> toExport = null;
+        boolean exportAll = false;
+        MetadataDSpaceCsvExportServiceImpl instance = new MetadataDSpaceCsvExportServiceImpl();
+        DSpaceCSV expResult = null;
+        DSpaceCSV result = instance.export(context, toExport, exportAll);
+        assertEquals(expResult, result);
+        // TODO review the generated test code and remove the default call to fail.
+        fail("The test case is a prototype.");
+    }
+
+    /**
+     * Test of export with mapped Item.
+     * @throws java.lang.Exception passed through.
+     */
+    @Test
+    public void testMappedItem()
+            throws Exception {
+        System.out.println("export");
+
+        // Create some content with which to test.
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Community")
+                .build();
+        Collection collection1 = CollectionBuilder.createCollection(context, parentCommunity)
+                .withName("Collection1")
+                .build();
+        Collection collection2 = CollectionBuilder.createCollection(context, parentCommunity)
+                .withName("Collection2")
+                .build();
+        context.setCurrentUser(eperson);
+        Item item = ItemBuilder.createItem(context, collection1)
+                .withTitle("Item")
+                .withIssueDate("1957")
+                .build();
+        item.addCollection(collection2);
+        context.restoreAuthSystemState();
+
+        // Test!
+        MetadataDSpaceCsvExportService instance = new DSpace()
+                .getServiceManager()
+                .getServiceByName(MetadataDSpaceCsvExportServiceImpl.class.getCanonicalName(),
+                        MetadataDSpaceCsvExportService.class);
+        DSpaceCSV result = instance.export(context, parentCommunity, false);
+
+        // Examine the result.
+        List<DSpaceCSVLine> csvLines = result.getCSVLines();
+        assertEquals("One item mapped twice should produce one line",
+                1, csvLines.size());
+    }
+}


### PR DESCRIPTION
## References
* Fixes #7988
* Ported to 6_x as #7995

## Description
Ensure that a mapped item's metadata is exported only once.

## Instructions for Reviewers
List of changes in this PR:
* Instead of concatenating `Iterator`s, add each item to a Set to ensure uniqueness.
* Add a minimal integration test which proves this.

For manual testing:  create an Item which is mapped into multiple collections within a common community, export metadata from the community, check that no Item is duplicated.  See #7988 for specifics.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
