### PR TITLE
Setting access condition to "administrator" won't restrict access to the file after archival

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -1072,7 +1072,7 @@ prevent the generation of resource policy entry values with null dspace_object a
     private boolean isNotAlreadyACustomRPOfThisTypeOnDSO(Context context, DSpaceObject dso) throws SQLException {
         List<ResourcePolicy> readRPs = resourcePolicyService.find(context, dso, Constants.READ);
         for (ResourcePolicy readRP : readRPs) {
-            if (readRP.getRpType().equals(ResourcePolicy.TYPE_CUSTOM)) {
+            if (readRP.getRpType() != null && readRP.getRpType().equals(ResourcePolicy.TYPE_CUSTOM)) {
                 return false;
             }
         }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkspaceItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkspaceItemRestRepositoryIT.java
@@ -43,12 +43,16 @@ import org.apache.commons.lang3.time.DateUtils;
 import org.dspace.app.rest.matcher.CollectionMatcher;
 import org.dspace.app.rest.matcher.ItemMatcher;
 import org.dspace.app.rest.matcher.MetadataMatcher;
+import org.dspace.app.rest.matcher.ResourcePolicyMatcher;
 import org.dspace.app.rest.matcher.WorkspaceItemMatcher;
 import org.dspace.app.rest.model.patch.AddOperation;
 import org.dspace.app.rest.model.patch.Operation;
 import org.dspace.app.rest.model.patch.RemoveOperation;
 import org.dspace.app.rest.model.patch.ReplaceOperation;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.authorize.ResourcePolicy;
+import org.dspace.authorize.factory.AuthorizeServiceFactory;
+import org.dspace.authorize.service.ResourcePolicyService;
 import org.dspace.builder.BitstreamBuilder;
 import org.dspace.builder.CollectionBuilder;
 import org.dspace.builder.CommunityBuilder;
@@ -67,9 +71,11 @@ import org.dspace.content.Item;
 import org.dspace.content.Relationship;
 import org.dspace.content.RelationshipType;
 import org.dspace.content.WorkspaceItem;
+import org.dspace.core.Constants;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
 import org.dspace.eperson.factory.EPersonServiceFactory;
+import org.dspace.eperson.service.GroupService;
 import org.dspace.services.ConfigurationService;
 import org.hamcrest.Matchers;
 import org.junit.Before;
@@ -88,6 +94,10 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
     @Autowired
     private ConfigurationService configurationService;
 
+    private GroupService groupService;
+
+    private ResourcePolicyService resourcePolicyService;
+
     private Group embargoedGroups;
     private Group embargoedGroup1;
     private Group embargoedGroup2;
@@ -98,6 +108,8 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
     public void setUp() throws Exception {
         super.setUp();
         context.turnOffAuthorisationSystem();
+        this.groupService = EPersonServiceFactory.getInstance().getGroupService();
+        this.resourcePolicyService = AuthorizeServiceFactory.getInstance().getResourcePolicyService();
 
         embargoedGroups = GroupBuilder.createGroup(context)
                 .withName("Embargoed Groups")
@@ -5297,6 +5309,234 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
                  .andExpect(jsonPath("$.sections.upload.files[0].accessConditions[0].name", is("openaccess")))
                  .andExpect(jsonPath("$.sections.upload.files[0].accessConditions[1].name", is("administrator")));
 
+    }
+
+    @Test
+    public void patchUploadAddAdminRPInstallAndVerifyOnlyAdminCanView() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Community community = CommunityBuilder.createCommunity(context).withName("Com").build();
+        Collection collection = CollectionBuilder.createCollection(context, community).withName("Col").build();
+        InputStream pdf = getClass().getResourceAsStream("simple-article.pdf");
+        WorkspaceItem wItem = WorkspaceItemBuilder.createWorkspaceItem(context, collection)
+                                                  .withSubmitter(eperson)
+                                                  .withTitle(
+                                                      "Test Item patchUploadAddAdminRPInstallAndVerifyOnlyAdminCanView")
+                                                  .withIssueDate("2019-03-06")
+                                                  .withFulltext("upload2.pdf", "/local/path/simple-article.pdf", pdf)
+                                                  .build();
+        context.restoreAuthSystemState();
+
+        // auth
+        String epersonToken = getAuthToken(eperson.getEmail(), password);
+        String adminToken = getAuthToken(admin.getEmail(), password);
+
+        // prepare patch body
+        Map<String, String> accessCondition = new HashMap<>();
+        accessCondition.put("name", "administrator");
+        List<Operation> ops = new ArrayList<>();
+        ops.add(new AddOperation("/sections/upload/files/0/accessConditions/-", accessCondition));
+        String patchBody = getPatchContent(ops);
+
+        // submit patch and verify response
+        getClient(epersonToken)
+            .perform(
+                patch("/api/submission/workspaceitems/" + wItem.getID())
+                    .content(patchBody)
+                    .contentType(MediaType.APPLICATION_JSON_PATCH_JSON)
+                    )
+            .andExpect(status().isOk());
+
+        Bitstream bitstream = wItem.getItem().getBundles().get(0).getBitstreams().get(0);
+        Group adminGroup = groupService.findByName(context, Group.ADMIN);
+
+        // verify that bitstream of workspace item has this admin RP
+        getClient(adminToken).perform(get("/api/authz/resourcepolicies/search/resource")
+            .param("uuid", bitstream.getID().toString()))
+                             .andExpect(status().isOk())
+                             .andExpect(jsonPath("$._embedded.resourcepolicies", Matchers.hasItems(
+                                 ResourcePolicyMatcher.matchResourcePolicyProperties(adminGroup, null, bitstream,
+                                     ResourcePolicy.TYPE_CUSTOM, Constants.READ, "administrator")
+                                                                                                  )));
+
+        // submit the workspaceitem to complete the deposit (as there is no workflow configured)
+        getClient(epersonToken)
+            .perform(post(BASE_REST_SERVER_URL + "/api/workflow/workflowitems")
+                .content("/api/submission/workspaceitems/" + wItem.getID())
+                .contentType(textUriContentType))
+            .andExpect(status().isCreated());
+
+        Group anonGroup = groupService.findByName(context, Group.ANONYMOUS);
+
+        // verify that bitstream of workspace item still has this admin RP and no Anon READ inherited policy
+        getClient(adminToken).perform(get("/api/authz/resourcepolicies/search/resource")
+            .param("uuid", bitstream.getID().toString()))
+                             .andExpect(status().isOk())
+                             .andExpect(jsonPath("$._embedded.resourcepolicies", Matchers.hasItems(
+                                 ResourcePolicyMatcher.matchResourcePolicyProperties(adminGroup, null, bitstream,
+                                     ResourcePolicy.TYPE_CUSTOM, Constants.READ, "administrator")
+                                                                                                  )))
+                             .andExpect(jsonPath("$._embedded.resourcepolicies", Matchers.not(Matchers.hasItems(
+                                 ResourcePolicyMatcher
+                                     .matchResourcePolicyProperties(anonGroup, null, bitstream, null, Constants.READ,
+                                         null)
+                                                                                                               ))));
+
+        // Bitstream should NOT be accessible to anon or eperson user, only to admin
+        getClient().perform(get("/api/core/bitstreams/" + bitstream.getID() + "/content"))
+                   .andExpect(status().isUnauthorized());
+        getClient(epersonToken).perform(get("/api/core/bitstreams/" + bitstream.getID() + "/content"))
+                               .andExpect(status().isForbidden());
+        getClient(adminToken).perform(get("/api/core/bitstreams/" + bitstream.getID() + "/content"))
+                             .andExpect(status().isOk());
+    }
+
+    @Test
+    public void patchUploadAddOpenAccessRPInstallAndVerifyAnonCanView() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Community community = CommunityBuilder.createCommunity(context).withName("Com").build();
+        Collection collection = CollectionBuilder.createCollection(context, community).withName("Col").build();
+        InputStream pdf = getClass().getResourceAsStream("simple-article.pdf");
+        WorkspaceItem wItem =
+            WorkspaceItemBuilder.createWorkspaceItem(context, collection).withSubmitter(eperson)
+                                .withTitle("Test Item patchUploadAddOpenAccessRPInstallAndVerifyOnlyAdminCanView")
+                                .withIssueDate("2019-03-06")
+                                .withFulltext("upload2.pdf", "/local/path/simple-article.pdf", pdf)
+                                .build();
+        context.restoreAuthSystemState();
+
+        // auth
+        String epersonToken = getAuthToken(eperson.getEmail(), password);
+        String adminToken = getAuthToken(admin.getEmail(), password);
+
+        // prepare patch body
+        Map<String, String> accessCondition = new HashMap<>();
+        accessCondition.put("name", "openaccess");
+        List<Operation> ops = new ArrayList<>();
+        ops.add(new AddOperation("/sections/upload/files/0/accessConditions/-", accessCondition));
+        String patchBody = getPatchContent(ops);
+
+        // submit patch and verify response
+        getClient(epersonToken)
+            .perform(
+                patch("/api/submission/workspaceitems/" + wItem.getID())
+                    .content(patchBody)
+                    .contentType(MediaType.APPLICATION_JSON_PATCH_JSON)
+                    )
+            .andExpect(status().isOk());
+
+        Bitstream bitstream = wItem.getItem().getBundles().get(0).getBitstreams().get(0);
+
+        // verify that bitstream of workspace item has this open access RP
+        getClient(adminToken).perform(get("/api/authz/resourcepolicies/search/resource")
+            .param("uuid", bitstream.getID().toString()))
+                             .andExpect(status().isOk())
+                             .andExpect(jsonPath("$._embedded.resourcepolicies", Matchers.hasItems(
+                                 ResourcePolicyMatcher.matchResourcePolicyProperties(anonymousGroup, null, bitstream,
+                                     ResourcePolicy.TYPE_CUSTOM, Constants.READ, "openaccess")
+                                                                                                  )));
+
+        // submit the workspaceitem to complete the deposit (as there is no workflow configured)
+        getClient(epersonToken)
+            .perform(post(BASE_REST_SERVER_URL + "/api/workflow/workflowitems")
+                .content("/api/submission/workspaceitems/" + wItem.getID())
+                .contentType(textUriContentType))
+            .andExpect(status().isCreated());
+
+        // verify that bitstream of workspace item still has this open access RP
+        getClient(adminToken).perform(get("/api/authz/resourcepolicies/search/resource")
+            .param("uuid", bitstream.getID().toString()))
+                             .andExpect(status().isOk())
+                             .andExpect(jsonPath("$._embedded.resourcepolicies", Matchers.hasItems(
+                                 ResourcePolicyMatcher.matchResourcePolicyProperties(anonymousGroup, null, bitstream,
+                                     ResourcePolicy.TYPE_CUSTOM, Constants.READ, "openaccess")
+                                                                                                  )));
+
+        // Bitstream should be accessible to anon
+        getClient().perform(get("/api/core/bitstreams/" + bitstream.getID() + "/content"))
+                   .andExpect(status().isOk());
+    }
+
+    @Test
+    public void patchUploadAddAdminThenOpenAccessRPInstallAndVerifyAnonCanView() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Community community = CommunityBuilder.createCommunity(context).withName("Com").build();
+        Collection collection = CollectionBuilder.createCollection(context, community).withName("Col").build();
+        InputStream pdf = getClass().getResourceAsStream("simple-article.pdf");
+        WorkspaceItem wItem =
+            WorkspaceItemBuilder.createWorkspaceItem(context, collection).withSubmitter(eperson)
+                                .withTitle("Test Item patchUploadAddOpenAccessRPInstallAndVerifyOnlyAdminCanView")
+                                .withIssueDate("2019-03-06")
+                                .withFulltext("upload2.pdf", "/local/path/simple-article.pdf", pdf)
+                                .build();
+        context.restoreAuthSystemState();
+
+        // auth
+        String epersonToken = getAuthToken(eperson.getEmail(), password);
+        String adminToken = getAuthToken(admin.getEmail(), password);
+
+        // prepare patch body
+        Map<String, String> accessCondition = new HashMap<>();
+        accessCondition.put("name", "administrator");
+        List<Operation> ops = new ArrayList<>();
+        ops.add(new AddOperation("/sections/upload/files/0/accessConditions/-", accessCondition));
+        String patchBody = getPatchContent(ops);
+
+        // submit patch and verify response
+        getClient(epersonToken)
+            .perform(
+                patch("/api/submission/workspaceitems/" + wItem.getID())
+                    .content(patchBody)
+                    .contentType(MediaType.APPLICATION_JSON_PATCH_JSON)
+                    )
+            .andExpect(status().isOk());
+
+        Bitstream bitstream = wItem.getItem().getBundles().get(0).getBitstreams().get(0);
+        Group adminGroup = groupService.findByName(context, Group.ADMIN);
+
+        // verify that bitstream of workspace item has this admin RP
+        getClient(adminToken).perform(get("/api/authz/resourcepolicies/search/resource")
+            .param("uuid", bitstream.getID().toString()))
+                             .andExpect(status().isOk())
+                             .andExpect(jsonPath("$._embedded.resourcepolicies", Matchers.hasItems(
+                                 ResourcePolicyMatcher.matchResourcePolicyProperties(adminGroup, null, bitstream,
+                                     ResourcePolicy.TYPE_CUSTOM, Constants.READ, "administrator")
+                                                                                                  )));
+
+        // prepare patch body
+        Map<String, String> accessCondition2 = new HashMap<>();
+        accessCondition2.put("name", "openaccess");
+        List<Operation> ops2 = new ArrayList<>();
+        ops2.add(new AddOperation("/sections/upload/files/0/accessConditions/-", accessCondition2));
+        String patchBody2 = getPatchContent(ops2);
+
+        // submit patch and verify response
+        getClient(epersonToken)
+            .perform(
+                patch("/api/submission/workspaceitems/" + wItem.getID())
+                    .content(patchBody2)
+                    .contentType(MediaType.APPLICATION_JSON_PATCH_JSON)
+                    )
+            .andExpect(status().isOk());
+
+        // verify that bitstream of workspace item has this open access RP
+        getClient(adminToken).perform(get("/api/authz/resourcepolicies/search/resource")
+            .param("uuid", bitstream.getID().toString()))
+                             .andExpect(status().isOk())
+                             .andExpect(jsonPath("$._embedded.resourcepolicies", Matchers.hasItems(
+                                 ResourcePolicyMatcher.matchResourcePolicyProperties(anonymousGroup, null, bitstream,
+                                     ResourcePolicy.TYPE_CUSTOM, Constants.READ, "openaccess")
+                                                                                                  )));
+
+        // submit the workspaceitem to complete the deposit (as there is no workflow configured)
+        getClient(epersonToken)
+            .perform(post(BASE_REST_SERVER_URL + "/api/workflow/workflowitems")
+                .content("/api/submission/workspaceitems/" + wItem.getID())
+                .contentType(textUriContentType))
+            .andExpect(status().isCreated());
+
+        // Bitstream should be accessible to anon
+        getClient().perform(get("/api/core/bitstreams/" + bitstream.getID() + "/content"))
+                   .andExpect(status().isOk());
     }
 
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/ResourcePolicyMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/ResourcePolicyMatcher.java
@@ -14,8 +14,13 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
+import javax.annotation.Nullable;
+
 import org.dspace.authorize.ResourcePolicy;
+import org.dspace.content.DSpaceObject;
 import org.dspace.core.Constants;
+import org.dspace.eperson.EPerson;
+import org.dspace.eperson.Group;
 import org.hamcrest.Matcher;
 
 /**
@@ -27,6 +32,27 @@ import org.hamcrest.Matcher;
 public class ResourcePolicyMatcher {
 
     private ResourcePolicyMatcher() {
+    }
+
+    public static Matcher<? super Object> matchResourcePolicyProperties(@Nullable Group group,
+        @Nullable EPerson eperson, DSpaceObject dso, @Nullable String rpType, int action, @Nullable String name) {
+        return allOf(
+            hasJsonPath("$.name", is(name)),
+            hasJsonPath("$.action", is(Constants.actionText[action])),
+            rpType != null ?
+                hasJsonPath("$.policyType", is(rpType)) :
+                hasNoJsonPath("$.policyType"),
+            hasJsonPath("$.type", is("resourcepolicy")),
+            hasJsonPath("$._embedded.resource.id", is(dso.getID().toString())),
+            eperson != null ?
+                hasJsonPath("$._embedded.eperson.id",
+                    is(eperson.getID().toString())) :
+                hasJsonPath("$._embedded.eperson", nullValue()),
+            group != null ?
+                hasJsonPath("$._embedded.group.id",
+                    is(group.getID().toString())) :
+                hasJsonPath("$._embedded.group", nullValue())
+                    );
     }
 
     public static Matcher<? super Object> matchResourcePolicy(ResourcePolicy resourcePolicy) {


### PR DESCRIPTION
## Description
Setting a file to "administrator" access condition during submission will still lead to the file being public after archival. 

## Instructions for Reviewers

* Start a new submission
* Upload a file
* Click on edit
* Change the “Access condition type” to “administrator”
* Save the file changes
* Finish the submission & archive the item

The file should now be private

List of changes in this PR:
* Change in the backend to ALSO check for custom permissions before applying the default collection permissions.
* Test to prove that it works. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
