### PR TITLE
[Docker] Ensure any updated Solr configs are copied over to existing cores

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,15 +77,22 @@ services:
     # Keep Solr data directory between reboots
     - solr_data:/var/solr/data
     # Initialize all DSpace Solr cores using the mounted local configsets (see above), then start Solr
+    # * First, run precreate-core to create the core (if it doesn't yet exist). If exists already, this is a no-op
+    # * Second, copy updated configs from mounted configsets to this core. If it already existed, this updates core
+    #   to the latest configs. If it's a newly created core, this is a no-op.
     entrypoint:
     - /bin/bash
     - '-c'
     - |
       init-var-solr
       precreate-core authority /opt/solr/server/solr/configsets/authority
+      cp -r -u /opt/solr/server/solr/configsets/authority/* authority
       precreate-core oai /opt/solr/server/solr/configsets/oai
+      cp -r -u /opt/solr/server/solr/configsets/oai/* oai
       precreate-core search /opt/solr/server/solr/configsets/search
+      cp -r -u /opt/solr/server/solr/configsets/search/* search
       precreate-core statistics /opt/solr/server/solr/configsets/statistics
+      cp -r -u /opt/solr/server/solr/configsets/statistics/* statistics
       exec solr -f
 volumes:
   assetstore:


### PR DESCRIPTION
## Description
Minor update to our `docker-compose.yml` for Solr running in Docker.  This update ensures that updated Solr configs are copied over into pre-existing cores. Currently, when using Docker, the Solr configs are only copied to the core *during initial setup/installation*. This change ensures they are also updated in the core whenever a change to the configs is made.

This new behavior is required when testing new PRs which include Solr config changes (especially schema changes).  I encountered this during my testing of #7962

## Instructions for Reviewers
Requires using Docker to test the initial setup of Solr & test updates to Solr configs.  I've already done some testing & will do more myself, as I know I'm the main Docker user.  But, if others want to help, I'd recommend:
* Install this PR
* Reset any Docker containers/volumes.. Start over from scratch & verify everything installs properly
* Then install #7962 (which has a search core schema update). Build & deploy to Docker.  Verify the Solr schema update occurs (you can do that by accessing Solr directly, or by SSHing into the container (`docker exec -it dspacesolr /bin/bash`) & checking the schema file

Because I'm the primary user of Docker for development these days, I'm going to give this more testing on my end (to ensure stability) & then look to merge it sometime next week.