### PR TITLE
Add docker-compose script for IIIF server

### DIFF
--- a/dspace/src/main/docker-compose/README.md
+++ b/dspace/src/main/docker-compose/README.md
@@ -49,6 +49,17 @@ docker-compose -p d7 up -d
 docker-compose -p d7 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-angular.yml up -d
 ```
 
+## Run DSpace 7 REST with a IIIF Image Server from your branch
+*Only useful for testing IIIF support in a development environment*
+
+This command starts our `dspace-iiif` container alongside the REST API.
+That container provides a [Cantaloupe image server](https://cantaloupe-project.github.io/),
+which can be used when IIIF support is enabled in DSpace (`iiif.enabled=true`).
+
+```
+docker-compose -p d7 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-iiif.yml up -d
+```
+
 ## Run DSpace 7 REST and Shibboleth SP (in Apache) from your branch
 
 *Only useful for testing Shibboleth in a development environment*

--- a/dspace/src/main/docker-compose/docker-compose-iiif.yml
+++ b/dspace/src/main/docker-compose/docker-compose-iiif.yml
@@ -1,0 +1,38 @@
+#
+# The contents of this file are subject to the license and copyright
+# detailed in the LICENSE and NOTICE files at the root of the source
+# tree and available online at
+#
+# http://www.dspace.org/license/
+#
+
+#
+# Test environment for DSpace + Cantaloupe for IIIF support. See README for instructions.
+# This should NEVER be used in production scenarios.
+#
+version: '3.7'
+networks:
+  dspacenet:
+services:
+  dspace-iiif:
+    container_name: dspace-iiif
+    depends_on:
+      - dspace
+    # Using UCLA Library image as it seems to be most maintained at this time. There is no official image.
+    image: uclalibrary/cantaloupe:5.0.4-0
+    networks:
+      dspacenet:
+    ports:
+      - '8182:8182'
+    # For a guide of environment variables that can be used, see
+    # https://github.com/UCLALibrary/docker-cantaloupe/tree/main/src/main/docker/configs
+    environment:
+      # Enable the /admin UI for Cantaloupe
+      CANTALOUPE_ENDPOINT_ADMIN_ENABLED: 'true'
+      CANTALOUPE_ENDPOINT_ADMIN_USERNAME: 'admin'
+      CANTALOUPE_ENDPOINT_ADMIN_SECRET: 'admin'
+      # Configure Cantaloupe to use HTTP to load images, point it at the REST API /bitstreams/[uuid]/content endpoint
+      CANTALOUPE_SOURCE_STATIC: 'HttpSource'
+      # Notice this URL accesses the 'dspace' container, port 8080, which is the container running the REST API.
+      CANTALOUPE_HTTPSOURCE_BASICLOOKUPSTRATEGY_URL_PREFIX: 'http://dspace:8080/server/api/core/bitstreams/'
+      CANTALOUPE_HTTPSOURCE_BASICLOOKUPSTRATEGY_URL_SUFFIX: '/content'

--- a/dspace/src/main/docker-compose/docker-compose-iiif.yml
+++ b/dspace/src/main/docker-compose/docker-compose-iiif.yml
@@ -19,6 +19,7 @@ services:
     depends_on:
       - dspace
     # Using UCLA Library image as it seems to be most maintained at this time. There is no official image.
+    # https://hub.docker.com/r/uclalibrary/cantaloupe
     image: uclalibrary/cantaloupe:5.0.4-0
     networks:
       dspacenet:


### PR DESCRIPTION
## References
* Requires #3210
* Can be used to test https://github.com/DSpace/dspace-angular/pull/1079

## Description
Simple docker-compose script to spin up a Cantaloupe IIIF server for easier testing with Docker.

To run this with the REST API backend, just start up the DSpace backend using:
```
docker-compose -p d7 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-iiif.yml up -d
```

Flagging as a WIP as I need to add more docs about this to the docker-compose README.md.