### PR TITLE
fix an error when harvesting arXiv OAI-PMH

### DIFF
--- a/dspace-api/src/main/java/org/dspace/core/Utils.java
+++ b/dspace-api/src/main/java/org/dspace/core/Utils.java
@@ -77,7 +77,7 @@ public final class Utils {
     private static final VMID vmid = new VMID();
 
     // for parseISO8601Date
-    private static final SimpleDateFormat parseFmt[]  = {
+    private static final SimpleDateFormat[] parseFmt = {
         // first try at parsing, has milliseconds (note General time zone)
         new SimpleDateFormat("yyyy'-'MM'-'dd'T'HH':'mm':'ss.SSSz"),
 
@@ -161,11 +161,11 @@ public final class Utils {
         StringBuilder result = new StringBuilder();
 
         // This is far from the most efficient way to do things...
-        for (int i = 0; i < data.length; i++) {
-            int low = (int) (data[i] & 0x0F);
-            int high = (int) (data[i] & 0xF0);
+        for (byte datum : data) {
+            int low = datum & 0x0F;
+            int high = datum & 0xF0;
 
-            result.append(Integer.toHexString(high).substring(0, 1));
+            result.append(Integer.toHexString(high).charAt(0));
             result.append(Integer.toHexString(low));
         }
 
@@ -201,13 +201,7 @@ public final class Utils {
         byte[] junk = new byte[16];
 
         random.nextBytes(junk);
-
-        String input = new StringBuilder()
-                .append(vmid)
-                .append(new java.util.Date())
-                .append(Arrays.toString(junk))
-                .append(counter++)
-                .toString();
+        String input = String.valueOf(vmid) + new Date() + Arrays.toString(junk) + counter++;
 
         return getMD5Bytes(input.getBytes(StandardCharsets.UTF_8));
     }
@@ -296,7 +290,7 @@ public final class Utils {
         }
 
         String units = m.group(2);
-        long multiplier = MS_IN_SECOND;
+        long multiplier;
 
         if ("s".equals(units)) {
             multiplier = MS_IN_SECOND;
@@ -343,9 +337,9 @@ public final class Utils {
 
         // try to parse without milliseconds
         ParseException lastError = null;
-        for (int i = 0; i < parseFmt.length; ++i) {
+        for (SimpleDateFormat simpleDateFormat : parseFmt) {
             try {
-                return parseFmt[i].parse(s);
+                return simpleDateFormat.parse(s);
             } catch (ParseException e) {
                 lastError = e;
             }
@@ -378,7 +372,7 @@ public final class Utils {
     }
 
     public static <E> java.util.Collection<E> emptyIfNull(java.util.Collection<E> collection) {
-        return collection == null ? Collections.<E>emptyList() : collection;
+        return collection == null ? Collections.emptyList() : collection;
     }
 
     /**
@@ -459,7 +453,7 @@ public final class Utils {
             if (hostname != null) {
                 return hostname.startsWith("www.") ? hostname.substring(4) : hostname;
             }
-            return hostname;
+            return null;
         } catch (URISyntaxException e) {
             return null;
         }

--- a/dspace-api/src/main/java/org/dspace/core/Utils.java
+++ b/dspace-api/src/main/java/org/dspace/core/Utils.java
@@ -87,7 +87,9 @@ public final class Utils {
         // finally, try without any timezone (defaults to current TZ)
         new SimpleDateFormat("yyyy'-'MM'-'dd'T'HH':'mm':'ss.SSS"),
 
-        new SimpleDateFormat("yyyy'-'MM'-'dd'T'HH':'mm':'ss")
+        new SimpleDateFormat("yyyy'-'MM'-'dd'T'HH':'mm':'ss"),
+
+        new SimpleDateFormat("yyyy'-'MM'-'dd")
     };
 
     // for formatISO8601Date
@@ -334,7 +336,7 @@ public final class Utils {
         char tzSign = s.charAt(s.length() - 6);
         if (s.endsWith("Z")) {
             s = s.substring(0, s.length() - 1) + "GMT+00:00";
-        } else if (tzSign == '-' || tzSign == '+') {
+        } else if ((tzSign == '-' || tzSign == '+') && s.length() > 10) {
             // check for trailing timezone
             s = s.substring(0, s.length() - 6) + "GMT" + s.substring(s.length() - 6);
         }


### PR DESCRIPTION
## Description
Fixes #8128 
Add a new entry to the `parseFmt` array for parsing dates in the format of `yyyy-MM-dd`.

## Instructions for Reviewers

This is a quick fix to the problem I encountered when I was harvesting the metadata from the arXIv OAI-PMH.

The first-time harvest is successful but all subsequent harvest fails and throws a null exception. The problem was that arXiv OAI-PMH gives the date in the format of "yyyy-MM-dd" e.g. `<datestamp>2021-11-02</datestamp>`. Subsequent harvest needs to compare the harvested item's date stamp to the one from the provider. Specifically, the following code causes the null exception (`OAIDatestamp` is null): 

https://github.com/DSpace/DSpace/blob/e297d9809592d63248cceb0155d51143ee535e46/dspace-api/src/main/java/org/dspace/harvest/OAIHarvester.java#L550

`parseISO8601Date` cannot parse a date such as `2021-11-02` as there is no matched date format. The actual error happens in the following for loop:

https://github.com/DSpace/DSpace/blob/e297d9809592d63248cceb0155d51143ee535e46/dspace-api/src/main/java/org/dspace/core/Utils.java#L344

Simply adding a new format `SimpleDateFormat("yyyy'-'MM'-'dd")` wouldn't solve the whole problem. One more step has to be done in the line:

https://github.com/DSpace/DSpace/blob/e297d9809592d63248cceb0155d51143ee535e46/dspace-api/src/main/java/org/dspace/core/Utils.java#L337

to ensure that dates such as `2021-11-02` will not be changed to `2021GMT-11-02`.

A separate commit performs some simple code refactoring.


## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
