### PR TITLE
Add migration to fix metadatavalue.place

### DIFF
--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V7.1_2021.10.18__Fix_MDV_place_after_migrating_from_DSpace_5.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V7.1_2021.10.18__Fix_MDV_place_after_migrating_from_DSpace_5.sql
@@ -1,0 +1,28 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+----------------------------------------------------
+-- Make sure the metadatavalue.place column starts at 0 instead of 1
+----------------------------------------------------
+CREATE LOCAL TEMPORARY TABLE mdv_minplace (
+  dspace_object_id UUID NOT NULL,
+  metadata_field_id INT NOT NULL,
+  minplace INT NOT NULL,
+);
+
+INSERT INTO mdv_minplace
+SELECT dspace_object_id, metadata_field_id, MIN(place) AS minplace
+FROM metadatavalue
+GROUP BY dspace_object_id, metadata_field_id;
+
+UPDATE metadatavalue AS mdv
+SET place = mdv.place - (
+  SELECT minplace FROM mdv_minplace AS mp
+  WHERE mp.dspace_object_id = mdv.dspace_object_id
+    AND mp.metadata_field_id = mdv.metadata_field_id
+);

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/V7.1_2021.10.18__Fix_MDV_place_after_migrating_from_DSpace_5.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/V7.1_2021.10.18__Fix_MDV_place_after_migrating_from_DSpace_5.sql
@@ -9,13 +9,16 @@
 ----------------------------------------------------
 -- Make sure the metadatavalue.place column starts at 0 instead of 1
 ----------------------------------------------------
-UPDATE metadatavalue AS mdv
-SET place = mdv.place - minplace
-FROM (
-       SELECT dspace_object_id, metadata_field_id, MIN(place) AS minplace
-       FROM metadatavalue
-       GROUP BY dspace_object_id, metadata_field_id
-     ) AS mp
-WHERE mdv.dspace_object_id = mp.dspace_object_id
+MERGE INTO metadatavalue mdv
+USING (
+  SELECT dspace_object_id, metadata_field_id, MIN(place) AS minplace
+  FROM metadatavalue
+  GROUP BY dspace_object_id, metadata_field_id
+) mp
+ON (
+  mdv.dspace_object_id = mp.dspace_object_id
   AND mdv.metadata_field_id = mp.metadata_field_id
-  AND minplace > 0;
+  AND mp.minplace > 0
+)
+WHEN MATCHED THEN UPDATE
+SET mdv.place = mdv.place - mp.minplace;

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.1_2021.10.18__Fix_MDV_place_after_migrating_from_DSpace_5.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.1_2021.10.18__Fix_MDV_place_after_migrating_from_DSpace_5.sql
@@ -1,0 +1,21 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+----------------------------------------------------
+-- Make sure the metadatavalue.place column starts at 0 instead of 1
+----------------------------------------------------
+UPDATE metadatavalue AS mdv
+SET place = mdv.place - minplace
+FROM (
+       SELECT dspace_object_id, metadata_field_id, MIN(place) AS minplace
+       FROM metadatavalue
+       GROUP BY dspace_object_id, metadata_field_id
+     ) AS mp
+WHERE mdv.dspace_object_id = mp.dspace_object_id
+  AND mdv.metadata_field_id = mp.metadata_field_id
+  AND minplace > 0;


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #7997

## Description
Add a SQL migration to fix `metadata.place` after migrating from DSpace 5.x

## Reviewing
1. Follow the steps "to reproduce" from the issue linked above 
    * `metadatavalue.place` should start from 1 (this is the bug)
2. Update the test instance ~ this PR & run migrations
    * `metadatavalue.place` should start now start from 0

## TODO
* [x] Port to Oracle & H2

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
