### PR TITLE
Fix two ITs for stability (PackagerIT.destroy() and RelationshipTypeRestControllerIT.findAllEntityTypes)

### DIFF
--- a/dspace-api/src/test/java/org/dspace/app/packager/PackagerIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/packager/PackagerIT.java
@@ -85,6 +85,7 @@ public class PackagerIT extends AbstractIntegrationTestWithDatabase {
     }
 
     @After
+    @Override
     public void destroy() throws Exception {
         tempFile.delete();
         super.destroy();

--- a/dspace-api/src/test/java/org/dspace/app/packager/PackagerIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/packager/PackagerIT.java
@@ -14,7 +14,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
-import java.sql.SQLException;
 import java.util.Iterator;
 import java.util.UUID;
 import java.util.zip.ZipEntry;
@@ -86,8 +85,9 @@ public class PackagerIT extends AbstractIntegrationTestWithDatabase {
     }
 
     @After
-    public void destroy() throws SQLException, IOException {
+    public void destroy() throws Exception {
         tempFile.delete();
+        super.destroy();
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/RelationshipTypeRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/RelationshipTypeRestControllerIT.java
@@ -49,7 +49,8 @@ public class RelationshipTypeRestControllerIT extends AbstractEntityIntegrationT
 
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$.page",
-                                       is(PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 7))))
+                                       is(PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 8))))
+                   // Expect it to return these specific Entity Types (in any order)
                    .andExpect(jsonPath("$._embedded.entitytypes", containsInAnyOrder(
                        EntityTypeMatcher.matchEntityTypeEntryForLabel("Publication"),
                        EntityTypeMatcher.matchEntityTypeEntryForLabel("Person"),
@@ -57,8 +58,10 @@ public class RelationshipTypeRestControllerIT extends AbstractEntityIntegrationT
                        EntityTypeMatcher.matchEntityTypeEntryForLabel("OrgUnit"),
                        EntityTypeMatcher.matchEntityTypeEntryForLabel("Journal"),
                        EntityTypeMatcher.matchEntityTypeEntryForLabel("JournalVolume"),
-                       EntityTypeMatcher.matchEntityTypeEntryForLabel("JournalIssue")
-
+                       EntityTypeMatcher.matchEntityTypeEntryForLabel("JournalIssue"),
+                       // None is the "empty" entity type used for allowing Collections / External Sources to work with
+                       // non-Entities (i.e. normal items)
+                       EntityTypeMatcher.matchEntityTypeEntryForLabel("none")
                    )))
         ;
     }


### PR DESCRIPTION
## References
* Fixes #8016
* Also fixes a separate broken test in `RelationshipTypeRestControllerIT` which was not accounting for the "none" entity type. This test has caused recent PR builds to fail, including the first build of this PR: https://github.com/DSpace/DSpace/runs/4110898410?check_suite_focus=true

## Description
Fixes #8016 by ensuring the `PackagerIT.destroy()` method calls `super.destroy()`, so that the `destroy()` method in `AbstractIntegrationTestWithDatabase` is also triggered

Fixes separate test in `RelationshipTypeRestControllerIT`

## Instructions for Reviewers
See #8016 for instructions on how to reproduce the IT issue, which only exists if `PackagerIT` happens to run *before* `DiscoveryIT`.