### PR TITLE
 Fix condition for metadata validation if is Authority Controlled

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/validation/MetadataValidation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/validation/MetadataValidation.java
@@ -81,7 +81,7 @@ public class MetadataValidation extends AbstractValidation {
                         if (isAuthorityControlled) {
                             String authKey = md.getAuthority();
                             if (metadataAuthorityService.isAuthorityRequired(fieldKey) &&
-                                StringUtils.isNotBlank(authKey)) {
+                                StringUtils.isBlank(authKey)) {
                                 addError(ERROR_VALIDATION_AUTHORITY_REQUIRED,
                                     "/" + WorkspaceItemRestRepository.OPERATION_PATH_SECTIONS + "/" + config.getId() +
                                     "/" + input.getFieldName() + "/" + md.getPlace());


### PR DESCRIPTION
When an authority controlled input is filled in the submission form, an "ERROR_VALIDATION_AUTHORITY_REQUIRED" error occurs once it is saved.

In DSpace 6_x this conditions seems to be in 

https://github.com/DSpace/DSpace/blob/e196e748ade863a035c2861f0b5b87951479c918/dspace-api/src/main/java/org/dspace/submit/step/DescribeStep.java#L628-L629

Fixes #8041