### PR TITLE
(Work in Progress) Tiny PR to investigate broken ITs in recent PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,6 @@ Documentation for each release may be viewed online or downloaded via our [Docum
 The latest DSpace Installation instructions are available at:
 https://wiki.lyrasis.org/display/DSDOC7x/Installing+DSpace
 
-Please be aware that, as a Java web application, DSpace requires a database (PostgreSQL or Oracle)
-and a servlet container (usually Tomcat) in order to function.
-More information about these and all other prerequisites can be found in the Installation instructions above.
-
 ## Running DSpace 7 in Docker
 
 NOTE: At this time, we do not have production-ready Docker images for DSpace.
@@ -56,7 +52,7 @@ We welcome contributions of any type. Here's a few basic guides that provide sug
 * [Code Contribution Guidelines](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines): How to give back code or contribute features, bug fixes, etc.
 * [DSpace Community Advisory Team (DCAT)](https://wiki.lyrasis.org/display/cmtygp/DSpace+Community+Advisory+Team): If you are not a developer, we also have an interest group specifically for repository managers. The DCAT group meets virtually, once a month, and sends open invitations to join their meetings via the [DCAT mailing list](https://groups.google.com/d/forum/DSpaceCommunityAdvisoryTeam).
 
-We also encourage GitHub Pull Requests (PRs) at any time. Please see our [Development with Git](https://wiki.lyrasis.org/display/DSPACE/Development+with+Git) guide for more info.
+We also encourage GitHub Pull Requests (PRs) at any time.
 
 In addition, a listing of all known contributors to DSpace software can be
 found online at: https://wiki.lyrasis.org/display/DSPACE/DSpaceContributors


### PR DESCRIPTION
## Description
Several recent PRs to DSpace/DSpace all seem to be failing with the same IT failures:
```
Error:  Failures: 
Error:    EntityTypeRestRepositoryIT.getAllEntityTypeEndpoint:55 JSON path "$.page.totalElements"
Expected: is <8>
     but: was <7>
Error:    EntityTypeRestRepositoryIT.getAllEntityTypeEndpointWithPaging:83 JSON path "$.page.totalElements"
Expected: is <8>
     but: was <7>
Error:  Errors: 
Error:    EntityTypeRestRepositoryIT.findAllPaginationTest:142 » NullPointer
```
(These IT failures seem related to changes made in #8026, which worked 2 weeks ago, but now seem to be causing problems)

This failure strangely is not appearing on `main` (at least not in the [most recent build](https://github.com/DSpace/DSpace/actions/workflows/build.yml?query=branch%3Amain)) & I've not been able to reproduce it locally either. So, I'm trying this tiny PR to see if it triggers the same IT failure.

**Currently, this PR contains just a tiny, cosmetic change to the README to remove outdated information.**  If I find a way to reliably reproduce the IT failures, I'll enhance this PR to try to fix them
