### PR TITLE
Fixed InitializeEntitiesIT destroy method to not delete none entity type

### DIFF
--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/InitializeEntitiesIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/InitializeEntitiesIT.java
@@ -25,6 +25,7 @@ import org.dspace.content.RelationshipType;
 import org.dspace.content.service.EntityTypeService;
 import org.dspace.content.service.RelationshipService;
 import org.dspace.content.service.RelationshipTypeService;
+import org.dspace.core.Constants;
 import org.dspace.services.ConfigurationService;
 import org.junit.After;
 import org.junit.Before;
@@ -83,7 +84,9 @@ public class InitializeEntitiesIT extends AbstractControllerIntegrationTest {
         }
 
         for (EntityType entityType: entityTypeList) {
-            entityTypeService.delete(context, entityType);
+            if (!Constants.ENTITY_TYPE_NONE.equals(entityType.getLabel())) {
+                entityTypeService.delete(context, entityType);
+            }
         }
         context.restoreAuthSystemState();
 


### PR DESCRIPTION
This small PR should fix the occasional failure of some EntityTypeRestRepositoryIT tests. I added a check on the destroy method of InitializeEntitiesIT to not delete the type none, which is then required for EntityTypeRestRepositoryIT tests.

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
