### PR TITLE
Upgrade aws-java-sdk-s3 version to avoid exception on start "Socket n…

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -855,7 +855,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
-            <version>1.10.50</version>
+            <version>1.12.116</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Current docker imagem `dspace/dspace:dspace-7.1` when enable s3Store into bitstore.xml throw exception  when start application beacause of the current version of `aws-java-sdk-s3` is incompatible with java 11. So I upgrade version to resolve the problem.

