### PR TITLE
[CST-4882] The search loads indefinitely if the written query is invalid

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/DiscoveryRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/DiscoveryRestController.java
@@ -53,7 +53,7 @@ public class DiscoveryRestController implements InitializingBean {
 
     private static final Logger log = LogManager.getLogger();
 
-    private static final String SOLR_PARSE_ERROR_MESSAGE = "Cannot parse";
+    private static final String SOLR_PARSE_ERROR_CLASS = "org.apache.solr.search.SyntaxError";
 
     @Autowired
     protected Utils utils;
@@ -161,7 +161,7 @@ public class DiscoveryRestController implements InitializingBean {
             halLinkService.addLinks(searchResultsResource, page);
             return searchResultsResource;
         } catch (IllegalArgumentException e) {
-            boolean isParsingException = e.getMessage().contains(SOLR_PARSE_ERROR_MESSAGE);
+            boolean isParsingException = e.getMessage().contains(SOLR_PARSE_ERROR_CLASS);
             if (isParsingException) {
                 throw new UnprocessableEntityException(e.getMessage());
             } else {
@@ -219,7 +219,12 @@ public class DiscoveryRestController implements InitializingBean {
             halLinkService.addLinks(facetResultsResource, page);
             return facetResultsResource;
         } catch (Exception e) {
-            boolean isParsingException = e.getMessage().contains(SOLR_PARSE_ERROR_MESSAGE);
+            boolean isParsingException = e.getMessage().contains(SOLR_PARSE_ERROR_CLASS);
+            /*
+             * We unfortunately have to do a string comparison to locate the source of the error, as Solr only sends
+             * back a generic exception, and the org.apache.solr.search.SyntaxError is only available as plain text
+             * in the error message.
+             */
             if (isParsingException) {
                 throw new UnprocessableEntityException(e.getMessage());
             } else {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/DiscoveryRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/DiscoveryRestController.java
@@ -17,6 +17,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.converter.ConverterService;
+import org.dspace.app.rest.exception.UnprocessableEntityException;
 import org.dspace.app.rest.link.HalLinkService;
 import org.dspace.app.rest.model.FacetConfigurationRest;
 import org.dspace.app.rest.model.FacetResultsRest;
@@ -51,6 +52,8 @@ import org.springframework.web.bind.annotation.RestController;
 public class DiscoveryRestController implements InitializingBean {
 
     private static final Logger log = LogManager.getLogger();
+
+    private static final String SOLR_PARSE_ERROR_MESSAGE = "Cannot parse";
 
     @Autowired
     protected Utils utils;
@@ -149,13 +152,22 @@ public class DiscoveryRestController implements InitializingBean {
         }
 
         //Get the Search results in JSON format
-        SearchResultsRest searchResultsRest = discoveryRestRepository
-            .getSearchObjects(query, dsoTypes, dsoScope, configuration, searchFilters, page, utils.obtainProjection());
+        try {
+            SearchResultsRest searchResultsRest = discoveryRestRepository.getSearchObjects(query, dsoTypes, dsoScope,
+                configuration, searchFilters, page, utils.obtainProjection());
 
-        //Convert the Search JSON results to paginated HAL resources
-        SearchResultsResource searchResultsResource = new SearchResultsResource(searchResultsRest, utils, page);
-        halLinkService.addLinks(searchResultsResource, page);
-        return searchResultsResource;
+            //Convert the Search JSON results to paginated HAL resources
+            SearchResultsResource searchResultsResource = new SearchResultsResource(searchResultsRest, utils, page);
+            halLinkService.addLinks(searchResultsResource, page);
+            return searchResultsResource;
+        } catch (IllegalArgumentException e) {
+            boolean isParsingException = e.getMessage().contains(SOLR_PARSE_ERROR_MESSAGE);
+            if (isParsingException) {
+                throw new UnprocessableEntityException(e.getMessage());
+            } else {
+                throw e;
+            }
+        }
     }
 
     @RequestMapping(method = RequestMethod.GET, value = "/facets")
@@ -186,6 +198,7 @@ public class DiscoveryRestController implements InitializingBean {
                                                       configuration,
                                               List<SearchFilter> searchFilters,
                                               Pageable page) throws Exception {
+        System.out.println("FACETS/xxxxx");
 
         dsoTypes = emptyIfNull(dsoTypes);
 
@@ -198,13 +211,23 @@ public class DiscoveryRestController implements InitializingBean {
                           + ", page: " + Objects.toString(page));
         }
 
-        FacetResultsRest facetResultsRest = discoveryRestRepository
-            .getFacetObjects(facetName, prefix, query, dsoTypes, dsoScope, configuration, searchFilters, page);
+        try {
+            FacetResultsRest facetResultsRest = discoveryRestRepository
+                .getFacetObjects(facetName, prefix, query, dsoTypes, dsoScope, configuration, searchFilters, page);
 
-        FacetResultsResource facetResultsResource = converter.toResource(facetResultsRest);
+            FacetResultsResource facetResultsResource = converter.toResource(facetResultsRest);
 
-        halLinkService.addLinks(facetResultsResource, page);
-        return facetResultsResource;
+            halLinkService.addLinks(facetResultsResource, page);
+            return facetResultsResource;
+        } catch (Exception e) {
+            System.out.println("ERROR = " + e.getMessage());
+            boolean isParsingException = e.getMessage().contains(SOLR_PARSE_ERROR_MESSAGE);
+            if (isParsingException) {
+                throw new UnprocessableEntityException(e.getMessage());
+            } else {
+                throw e;
+            }
+        }
     }
 
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/DiscoveryRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/DiscoveryRestController.java
@@ -198,7 +198,6 @@ public class DiscoveryRestController implements InitializingBean {
                                                       configuration,
                                               List<SearchFilter> searchFilters,
                                               Pageable page) throws Exception {
-        System.out.println("FACETS/xxxxx");
 
         dsoTypes = emptyIfNull(dsoTypes);
 
@@ -220,7 +219,6 @@ public class DiscoveryRestController implements InitializingBean {
             halLinkService.addLinks(facetResultsResource, page);
             return facetResultsResource;
         } catch (Exception e) {
-            System.out.println("ERROR = " + e.getMessage());
             boolean isParsingException = e.getMessage().contains(SOLR_PARSE_ERROR_MESSAGE);
             if (isParsingException) {
                 throw new UnprocessableEntityException(e.getMessage());

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/DiscoveryRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/DiscoveryRestRepository.java
@@ -131,7 +131,8 @@ public class DiscoveryRestRepository extends AbstractDSpaceRestRepository {
     }
 
     public FacetResultsRest getFacetObjects(String facetName, String prefix, String query, List<String> dsoTypes,
-            String dsoScope, final String configuration, List<SearchFilter> searchFilters, Pageable page) {
+            String dsoScope, final String configuration, List<SearchFilter> searchFilters, Pageable page)
+                    throws SearchServiceException {
 
         Context context = obtainContext();
 
@@ -139,17 +140,9 @@ public class DiscoveryRestRepository extends AbstractDSpaceRestRepository {
         DiscoveryConfiguration discoveryConfiguration = searchConfigurationService
             .getDiscoveryConfigurationByNameOrDso(configuration, scopeObject);
 
-        DiscoverResult searchResult = null;
-        DiscoverQuery discoverQuery = null;
-        try {
-            discoverQuery = queryBuilder.buildFacetQuery(context, scopeObject, discoveryConfiguration, prefix, query,
-                    searchFilters, dsoTypes, page, facetName);
-            searchResult = searchService.search(context, scopeObject, discoverQuery);
-
-        } catch (SearchServiceException e) {
-            log.error("Error while searching with Discovery", e);
-            //TODO TOM handle search exception
-        }
+        DiscoverQuery discoverQuery = queryBuilder.buildFacetQuery(context, scopeObject, discoveryConfiguration, prefix,
+                query, searchFilters, dsoTypes, page, facetName);
+        DiscoverResult searchResult = searchService.search(context, scopeObject, discoverQuery);
 
         FacetResultsRest facetResultsRest = discoverFacetResultsConverter.convert(context, facetName, prefix, query,
                 dsoTypes, dsoScope, searchFilters, searchResult, discoveryConfiguration, page,

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -1442,6 +1442,66 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                 //There always needs to be a self link available
                 .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
         ;
+
+        getClient().perform(get("/api/discover/search/objects")
+                .param("query", "test"))
+                .andExpect(status().isOk());
+
+        getClient().perform(get("/api/discover/search/objects")
+                .param("query", "test:"))
+                .andExpect(status().isUnprocessableEntity());
+
+    }
+
+
+    @Test
+    public void discoverSearchObjectsTestWithInvalidSolrQuery() throws Exception {
+//        //We turn off the authorization system in order to create the structure defined below
+//        context.turnOffAuthorisationSystem();
+//
+//        //** GIVEN **
+//        //1. A community-collection structure with one parent community with sub-community and two collections.
+//        parentCommunity = CommunityBuilder.createCommunity(context)
+//                .withName("Parent Community")
+//                .build();
+//        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+//                .withName("Sub Community")
+//                .build();
+//        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+//        Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
+//
+//        //2. Three public items that are readable by Anonymous with different subjects
+//        Item publicItem1 = ItemBuilder.createItem(context, col1)
+//                .withTitle("Test")
+//                .withIssueDate("2010-10-17")
+//                .withAuthor("Smith, Donald").withAuthor("Testing, Works")
+//                .withSubject("ExtraEntry")
+//                .build();
+//
+//        Item publicItem2 = ItemBuilder.createItem(context, col2)
+//                .withTitle("Test 2")
+//                .withIssueDate("1990-02-13")
+//                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
+//                .withSubject("TestingForMore").withSubject("ExtraEntry")
+//                .build();
+//
+//        Item publicItem3 = ItemBuilder.createItem(context, col2)
+//                .withTitle("Public item 2")
+//                .withIssueDate("2010-02-13")
+//                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
+//                .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
+//                .build();
+//
+//        context.restoreAuthSystemState();
+
+        getClient().perform(get("/api/discover/search/objects")
+                .param("query", "test"))
+                .andExpect(status().isOk());
+
+        getClient().perform(get("/api/discover/search/objects")
+                .param("query", "test:"))
+                .andExpect(status().isUnprocessableEntity());
+
     }
 
 
@@ -3910,7 +3970,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         getClient().perform(get("/api/discover/search/objects")
                                 .param("query", "OR"))
 
-                   .andExpect(status().isBadRequest())
+                   .andExpect(status().isUnprocessableEntity())
         ;
 
     }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -1456,43 +1456,6 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
 
     @Test
     public void discoverSearchObjectsTestWithInvalidSolrQuery() throws Exception {
-//        //We turn off the authorization system in order to create the structure defined below
-//        context.turnOffAuthorisationSystem();
-//
-//        //** GIVEN **
-//        //1. A community-collection structure with one parent community with sub-community and two collections.
-//        parentCommunity = CommunityBuilder.createCommunity(context)
-//                .withName("Parent Community")
-//                .build();
-//        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
-//                .withName("Sub Community")
-//                .build();
-//        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
-//        Collection col2 = CollectionBuilder.createCollection(context, child1).withName("Collection 2").build();
-//
-//        //2. Three public items that are readable by Anonymous with different subjects
-//        Item publicItem1 = ItemBuilder.createItem(context, col1)
-//                .withTitle("Test")
-//                .withIssueDate("2010-10-17")
-//                .withAuthor("Smith, Donald").withAuthor("Testing, Works")
-//                .withSubject("ExtraEntry")
-//                .build();
-//
-//        Item publicItem2 = ItemBuilder.createItem(context, col2)
-//                .withTitle("Test 2")
-//                .withIssueDate("1990-02-13")
-//                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("Testing, Works")
-//                .withSubject("TestingForMore").withSubject("ExtraEntry")
-//                .build();
-//
-//        Item publicItem3 = ItemBuilder.createItem(context, col2)
-//                .withTitle("Public item 2")
-//                .withIssueDate("2010-02-13")
-//                .withAuthor("Smith, Maria").withAuthor("Doe, Jane").withAuthor("test,test")
-//                .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
-//                .build();
-//
-//        context.restoreAuthSystemState();
 
         getClient().perform(get("/api/discover/search/objects")
                 .param("query", "test"))


### PR DESCRIPTION
## References
* Fixes DSpace/dspace-angular#1365
* Related to DSpace/dspace-angular#1419

## Description
Return 422 instead of 500 when Solr query is not valid.

## Instructions for Reviewers
If Solr query throws an exception containing "Cannot parse" in its message error then the GET request throws an `UnprocessableEntityException` (error 422)

This can by tested by searching `test:`.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
