### PR TITLE
Fixed context's mode handling to improve performances

### DIFF
--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -111,7 +111,7 @@ public class Context implements AutoCloseable {
     /**
      * Context mode
      */
-    private Mode mode = Mode.READ_WRITE;
+    private Mode mode;
 
     /**
      * Cache that is only used the context is in READ_ONLY mode
@@ -129,7 +129,6 @@ public class Context implements AutoCloseable {
     }
 
     protected Context(EventService eventService, DBConnection dbConnection) {
-        this.mode = Mode.READ_WRITE;
         this.eventService = eventService;
         this.dbConnection = dbConnection;
         init();
@@ -141,7 +140,6 @@ public class Context implements AutoCloseable {
      * No user is authenticated.
      */
     public Context() {
-        this.mode = Mode.READ_WRITE;
         init();
     }
 
@@ -184,7 +182,11 @@ public class Context implements AutoCloseable {
 
         authStateChangeHistory = new ConcurrentLinkedDeque<>();
         authStateClassCallHistory = new ConcurrentLinkedDeque<>();
-        setMode(this.mode);
+
+        if (this.mode != null) {
+            setMode(this.mode);
+        }
+
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -775,7 +775,7 @@ public class Context implements AutoCloseable {
      * @return The current mode
      */
     public Mode getCurrentMode() {
-        return mode;
+        return mode != null ? mode : Mode.READ_WRITE;
     }
 
     /**

--- a/dspace-api/src/main/resources/spring/spring-dspace-core-services.xml
+++ b/dspace-api/src/main/resources/spring/spring-dspace-core-services.xml
@@ -37,7 +37,7 @@
         <property name="configurationService" ref="org.dspace.services.ConfigurationService"/>
     </bean>
 
-    <bean name="org.dspace.core.DBConnection" class="org.dspace.core.HibernateDBConnection" lazy-init="true"/>
+    <bean name="org.dspace.core.DBConnection" class="org.dspace.core.HibernateDBConnection" lazy-init="true" scope="prototype"/>
 
     <!-- Register all our Flyway callback classes (which run before/after database migrations) -->
     <bean class="org.dspace.storage.rdbms.RegistryUpdater"/>

--- a/dspace-api/src/test/java/org/dspace/AbstractIntegrationTestWithDatabase.java
+++ b/dspace-api/src/test/java/org/dspace/AbstractIntegrationTestWithDatabase.java
@@ -105,7 +105,7 @@ public class AbstractIntegrationTestWithDatabase extends AbstractDSpaceIntegrati
     public void setUp() throws Exception {
         try {
             //Start a new context
-            context = new Context(Context.Mode.BATCH_EDIT);
+            context = new Context(Context.Mode.READ_WRITE);
             context.turnOffAuthorisationSystem();
 
             //Find our global test EPerson account. If it doesn't exist, create it.


### PR DESCRIPTION
Alternative to / Related to #8007 

## Description
The configuration of the modes in the context has the following problem: the bean of the HibernateDBConnection class allows to configure the readOnly or batch modes linked to the transaction/session but, being a singleton, the set of a new mode of a context (also through the initialization of a new context) can modify the previously set modes. 
This is the case of the IndexClient class which during setup sets the context with mode READ_ONLY but then, by initializing a new Context with the call to SolrServiceImpl.cleanIndex (boolean), the mode is set again as READ_WRITE. This leads to a serious drop in performance due to constant flush checks by hibernate.

With the changes of this PR it is avoided that the initialization of a new context within the same session can affect the modes set by previously initialized contexts if the mode is not explicitly set. Furthermore, the bean of the HibernateDBConnection class has been made a prototype to prevent the modalities set by a context from affecting all subsequent uses of the HibernateDBConnection class.

Here is an example of comparison between indexing performance of 13000 items with initial cleanup before and after the change:
- without the context's mode improvement 
![image](https://user-images.githubusercontent.com/16231083/143907622-84095548-d014-4cd7-815f-a8d421a39336.png)
- with the context's mode improvement
![image](https://user-images.githubusercontent.com/16231083/143908587-60fdf9a3-1919-46e1-8c4b-ca2b5079eeaf.png)

The two images show the methods that required a longer execution time: it can be seen that without the improvements, flush operations require almost half of the total execution time (for a total of about 265 seconds), while in the second case the contribution linked to the flush disappears with a much shorter total indexing time (about 112 seconds).

As the number of items increases, the time linked to the flushes should have a much greater impact compared to the total execution time. 

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
