### PR TITLE
Corrects viewingHint omission and refactors services.

### DIFF
--- a/dspace-iiif/src/main/java/org/dspace/app/iiif/model/generator/RangeGenerator.java
+++ b/dspace-iiif/src/main/java/org/dspace/app/iiif/model/generator/RangeGenerator.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.validation.constraints.NotNull;
 
+import de.digitalcollections.iiif.model.enums.ViewingHint;
 import de.digitalcollections.iiif.model.sharedcanvas.Canvas;
 import de.digitalcollections.iiif.model.sharedcanvas.Range;
 import de.digitalcollections.iiif.model.sharedcanvas.Resource;
@@ -32,6 +33,7 @@ public class RangeGenerator implements IIIFResource {
 
     private String identifier;
     private String label;
+    private final List<ViewingHint> viewingHint = new ArrayList<>();
     private final List<Canvas> canvasList = new ArrayList<>();
     private final List<Range> rangesList = new ArrayList<>();
     private final RangeService rangeService;
@@ -69,6 +71,11 @@ public class RangeGenerator implements IIIFResource {
         return this;
     }
 
+    public RangeGenerator addViewingHint(String hint) {
+        viewingHint.add(new BehaviorGenerator().setType(hint).generateValue());
+        return this;
+    }
+
     /**
      * Adds canvas to range canvas list.
      * @param canvas list of canvas generators
@@ -98,6 +105,9 @@ public class RangeGenerator implements IIIFResource {
             range = new Range(identifier, label);
         } else {
             range = new Range(identifier);
+        }
+        if (viewingHint.size() > 0) {
+            range.setViewingHints(viewingHint);
         }
         for (Canvas canvas : canvasList) {
             range.addCanvas(canvas);

--- a/dspace-iiif/src/main/java/org/dspace/app/iiif/service/ManifestService.java
+++ b/dspace-iiif/src/main/java/org/dspace/app/iiif/service/ManifestService.java
@@ -9,7 +9,6 @@ package org.dspace.app.iiif.service;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -29,7 +28,6 @@ import org.dspace.content.Item;
 import org.dspace.content.MetadataValue;
 import org.dspace.content.service.ItemService;
 import org.dspace.core.Context;
-import org.dspace.core.I18nUtil;
 import org.dspace.services.ConfigurationService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -125,7 +123,7 @@ public class ManifestService extends AbstractResourceService {
         addMetadata(context, item);
         addViewingHint(item);
         addThumbnail(item, context);
-        addRanges(context, item, manifestId);
+        addCanvasAndRange(context, item, manifestId);
         manifestGenerator.addSequence(
                 sequenceService.getSequence(item));
         addRendering(item, context);
@@ -133,68 +131,49 @@ public class ManifestService extends AbstractResourceService {
     }
 
     /**
-     * Add the ranges to the manifest structure. Ranges are generated from the
+     * Adds canvases and ranges to the manifest. Ranges are generated from the
      * iiif.toc metadata
      * 
      * @param context the DSpace Context
      * @param item the DSpace Item to represent
      * @param manifestId the generated manifestId
      */
-    private void addRanges(Context context, Item item, String manifestId) {
+    private void addCanvasAndRange(Context context, Item item, String manifestId) {
+        // Process the bitstreams in each bundle.
         List<Bundle> bundles = utils.getIIIFBundles(item);
-        RangeGenerator root = new RangeGenerator(rangeService);
-        root.setLabel(I18nUtil.getMessage("iiif.toc.root-label"));
-        root.setIdentifier(manifestId + "/range/r0");
-
-        Map<String, RangeGenerator> tocRanges = new LinkedHashMap<String, RangeGenerator>();
         for (Bundle bnd : bundles) {
             String bundleToCPrefix = null;
             if (bundles.size() > 1) {
                 bundleToCPrefix = utils.getBundleIIIFToC(bnd);
             }
-            RangeGenerator lastRange = root;
-            for (Bitstream b : utils.getIIIFBitstreams(context, bnd)) {
-                CanvasGenerator canvasId = sequenceService.addCanvas(context, item, bnd, b);
-                List<String> tocs = utils.getIIIFToCs(b, bundleToCPrefix);
+            // Set the root range for this manifest.
+            rangeService.setInitialRange(manifestId);
+            for (Bitstream bitstream : utils.getIIIFBitstreams(context, bnd)) {
+
+                // Add the canvas to the manifest's sequence.
+                CanvasGenerator canvasGenerator = sequenceService.addCanvas(context, item, bnd, bitstream);
+
+                // Now process ranges.
+                List<String> tocs = utils.getIIIFToCs(bitstream, bundleToCPrefix);
                 if (tocs.size() > 0) {
-                    for (String toc : tocs) {
-                        RangeGenerator currRange = root;
-                        String[] parts = toc.split(IIIFUtils.TOC_SEPARATOR_REGEX);
-                        String key = "";
-                        for (int pIdx = 0; pIdx < parts.length; pIdx++) {
-                            if (pIdx > 0) {
-                                key += IIIFUtils.TOC_SEPARATOR;
-                            }
-                            key += parts[pIdx];
-                            if (tocRanges.get(key) != null) {
-                                currRange = tocRanges.get(key);
-                            } else {
-                                // create the sub range
-                                RangeGenerator range = new RangeGenerator(rangeService);
-                                range.setLabel(parts[pIdx]);
-                                // add the range reference to the currRange so to get an identifier
-                                currRange.addSubRange(range);
-
-                                // add the range to the manifest
-//                                manifestGenerator.addRange(range);
-
-                                // move the current range
-                                currRange = range;
-                                tocRanges.put(key, range);
-                            }
-                        }
-                        // add the bitstream canvas to the currRange
-                        currRange
-                                .addCanvas(canvasService.getRangeCanvasReference(canvasId.getIdentifier()));
-                        lastRange = currRange;
-                    }
+                    // If toc fields exist for the bitstream, start a new range.
+                    rangeService.setTocRange(tocs, canvasGenerator);
                 } else {
-                    lastRange.addCanvas(canvasService.getRangeCanvasReference(canvasId.getIdentifier()));
+                    // If ranges have been created, add canvas ids to the current range.
+                    if (rangeService.getTocRanges().size() > 0) {
+                        RangeGenerator currentRange = rangeService.getLastRange();
+                        currentRange.addCanvas(canvasService.getRangeCanvasReference(
+                            canvasGenerator.getIdentifier())
+                        );
+                    }
                 }
             }
         }
-        if (tocRanges.size() > 0) {
-            manifestGenerator.addRange(root);
+        // Finally, if ranges were found add them to manifest's structures element.
+        Map<String, RangeGenerator> tocRanges = rangeService.getTocRanges();
+        if (tocRanges != null && tocRanges.size() > 0) {
+            RangeGenerator rootRange = rangeService.getRootRange();
+            manifestGenerator.addRange(rootRange);
             for (RangeGenerator range : tocRanges.values()) {
                 manifestGenerator.addRange(range);
             }

--- a/dspace-iiif/src/main/java/org/dspace/app/iiif/service/ManifestService.java
+++ b/dspace-iiif/src/main/java/org/dspace/app/iiif/service/ManifestService.java
@@ -291,8 +291,8 @@ public class ManifestService extends AbstractResourceService {
     }
 
     /**
-     * This method looks for a PDF rendering in the Item's ORIGINAL bundle and adds
-     * it to the Sequence if found.
+     * This method looks for a PDF in the Item's ORIGINAL bundle and adds
+     * it as the Rendering resource if found.
      *
      * @param item DSpace Item
      * @param context DSpace context

--- a/dspace-iiif/src/main/java/org/dspace/app/iiif/service/RangeService.java
+++ b/dspace-iiif/src/main/java/org/dspace/app/iiif/service/RangeService.java
@@ -70,8 +70,12 @@ public class RangeService extends AbstractResourceService {
     }
 
 
+    /**
+     * Creates generator for the root table of contents range.
+     * @param manifestId manifest id
+     * @return root range generator
+     */
     private RangeGenerator getRootGenerator(String manifestId) {
-        // The root range that will be used for this manifest.
         RangeGenerator root = new RangeGenerator(this);
         // This hint is required.
         root.addViewingHint("top");
@@ -131,7 +135,7 @@ public class RangeService extends AbstractResourceService {
             // Finally, update the range that will be used in the next iteration.
             lastRange = currRange;
         }
-}
+    }
 
     /**
      * Ranges expect the sub-range object to have only an identifier.

--- a/dspace-iiif/src/main/java/org/dspace/app/iiif/service/RangeService.java
+++ b/dspace-iiif/src/main/java/org/dspace/app/iiif/service/RangeService.java
@@ -121,13 +121,13 @@ public class RangeService extends AbstractResourceService {
                     range.setLabel(parts[pIdx]);
                     // Add sub-range to the root Range
                     tempRange.addSubRange(range);
-                    // Make tempRange a reference to the new sub-range.
-                    tempRange = range;
                     // Add new sub-range to the map.
                     tocRanges.put(key, range);
+                    // Make tempRange a reference to the new sub-range.
+                    tempRange = range;
                 }
             }
-            // Add a simple canvas reference to the sub-range.
+            // Add a simple canvas reference to the Range.
             tempRange
                 .addCanvas(canvasService.getRangeCanvasReference(canvasGenerator.getIdentifier()));
 

--- a/dspace-iiif/src/main/java/org/dspace/app/iiif/service/RangeService.java
+++ b/dspace-iiif/src/main/java/org/dspace/app/iiif/service/RangeService.java
@@ -7,7 +7,14 @@
  */
 package org.dspace.app.iiif.service;
 
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.dspace.app.iiif.model.generator.CanvasGenerator;
 import org.dspace.app.iiif.model.generator.RangeGenerator;
+import org.dspace.app.iiif.service.utils.IIIFUtils;
+import org.dspace.core.I18nUtil;
 import org.dspace.services.ConfigurationService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -28,14 +35,108 @@ public class RangeService extends AbstractResourceService {
     @Autowired
     CanvasService canvasService;
 
+    private Map<String, RangeGenerator> tocRanges = new LinkedHashMap<String, RangeGenerator>();
+    private RangeGenerator lastRange;
+    private RangeGenerator root;
+
+
     public RangeService(ConfigurationService configurationService) {
         setConfiguration(configurationService);
     }
 
     /**
-     * Ranges expect the Sub range object to have only an identifier.
-     * 
-     * @param range the sub range to reference
+     * Returns the current range to which canvases should be added. The "last"
+     * range is updated every time a new toc entry is processed.
+     * @return
+     */
+    public RangeGenerator getLastRange() {
+        return this.lastRange;
+    }
+
+    /**
+     * Get the root range generator. This will contain table of contents entries.
+     * @return
+     */
+    public RangeGenerator getRootRange() {
+        return root;
+    }
+
+    /**
+     * Sets the root range generator to which sub-ranges will be added.
+     * @param manifestId id of the manifest to which ranges will be added.
+     */
+    public void setInitialRange(String manifestId) {
+        root = getRootGenerator(manifestId);
+    }
+
+
+    private RangeGenerator getRootGenerator(String manifestId) {
+        // The root range that will be used for this manifest.
+        RangeGenerator root = new RangeGenerator(this);
+        // This hint is required.
+        root.addViewingHint("top");
+        root.setLabel(I18nUtil.getMessage("iiif.toc.root-label"));
+        root.setIdentifier(manifestId + "/range/r0");
+        return root;
+    }
+
+    /**
+     * Gets the current ranges.
+     * @return map of toc ranges.
+     */
+    public Map<String, RangeGenerator> getTocRanges() {
+        return this.tocRanges;
+    }
+
+    /**
+     * When the bitstream has a toc metadata field, this creates a new range and adds the first canvas.
+     * If the toc metadata includes a separator, sub-ranges are created.
+     * @param tocs ranges from toc metadata
+     * @param canvasGenerator generator for the current canvas
+     * @return
+     */
+    public void setTocRange(List<String> tocs , CanvasGenerator canvasGenerator) {
+
+        for (String toc : tocs) {
+            // Set the current range. The first time called, this will be the root range.
+            RangeGenerator currRange = root;
+            String[] parts = toc.split(IIIFUtils.TOC_SEPARATOR_REGEX);
+            String key = "";
+            // Process range and sub-ranges.
+            for (int pIdx = 0; pIdx < parts.length; pIdx++) {
+                if (pIdx > 0) {
+                    key += IIIFUtils.TOC_SEPARATOR;
+                }
+                key += parts[pIdx];
+                if (tocRanges.get(key) != null) {
+                    // This handles the case of a bitstream that crosses two ranges.
+                    currRange = tocRanges.get(key);
+                } else {
+                    // Create the new range
+                    RangeGenerator range = new RangeGenerator(this);
+                    range.setLabel(parts[pIdx]);
+                    // Add it to the root range
+                    currRange.addSubRange(range);
+
+                    // Current range is now the new sub-range
+                    currRange = range;
+                    // Add sub-range to the list.
+                    tocRanges.put(key, range);
+                }
+            }
+            // Add a canvas to the current range.
+            currRange
+                .addCanvas(canvasService.getRangeCanvasReference(canvasGenerator.getIdentifier()));
+
+            // Finally, update the range that will be used in the next iteration.
+            lastRange = currRange;
+        }
+}
+
+    /**
+     * Ranges expect the sub-range object to have only an identifier.
+     *
+     * @param range the sub-range to reference
      * @return RangeGenerator able to create the reference
      */
     public RangeGenerator getRangeReference(RangeGenerator range) {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/iiif/IIIFControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/iiif/IIIFControllerIT.java
@@ -407,6 +407,7 @@ public class IIIFControllerIT extends AbstractControllerIntegrationTest {
                 .andExpect(jsonPath("$.structures[0].@id",
                         Matchers.endsWith("/iiif/" + publicItem1.getID() + "/manifest/range/r0")))
                 .andExpect(jsonPath("$.structures[0].label", is("Table of Contents")))
+                .andExpect(jsonPath("$.structures[0].viewingHint", is("top")))
                 .andExpect(jsonPath("$.structures[0].ranges[0]",
                         Matchers.endsWith("/iiif/" + publicItem1.getID() + "/manifest/range/r0-0")))
                 .andExpect(jsonPath("$.structures[0].ranges[1]",
@@ -484,6 +485,7 @@ public class IIIFControllerIT extends AbstractControllerIntegrationTest {
                 .andExpect(jsonPath("$.structures[0].@id",
                         Matchers.endsWith("/iiif/" + publicItem1.getID() + "/manifest/range/r0")))
                 .andExpect(jsonPath("$.structures[0].label", is("Table of Contents")))
+                .andExpect(jsonPath("$.structures[0].viewingHint", is("top")))
                 .andExpect(jsonPath("$.structures[0].ranges[0]",
                         Matchers.endsWith("/iiif/" + publicItem1.getID() + "/manifest/range/r0-0")))
                 .andExpect(jsonPath("$.structures[0].ranges[1]",
@@ -636,6 +638,7 @@ public class IIIFControllerIT extends AbstractControllerIntegrationTest {
                         Matchers.endsWith("/iiif/" + publicItem1.getID() + "/manifest/range/r0")))
                 // the toc contains two top sections 1 & 2 without direct children canvases
                 .andExpect(jsonPath("$.structures[0].label", is("Table of Contents")))
+                .andExpect(jsonPath("$.structures[0].viewingHint", is("top")))
                 .andExpect(jsonPath("$.structures[0].ranges", Matchers.hasSize(2)))
                 .andExpect(jsonPath("$.structures[0].ranges[0]",
                         Matchers.endsWith("/iiif/" + publicItem1.getID() + "/manifest/range/r0-0")))


### PR DESCRIPTION
## References
* Fixes #8048

## Description
This PR adds a new field to the generator for IIIF Ranges and uses it to set the viewing hint on the root (table of contents) range (IIIF Presentation API 2.1.1). It also refactors the manifest and range services to separate responsibilities.

## Instructions for Reviewers
The 7.1 release omitted the viewing hint from the Range resource. From the IIIF docs:

> top: A Range with this viewingHint is the top-most node in a hierarchy of ranges that represents a structure to be rendered by the client to assist in navigation.

 In Mirador, the viewingHint omission resulted in redundant layouts in which the TOC elements appeared twice, once in the collapsable table of contents node and again separately in a list. With the viewing set correctly, Mirador displays the list only.


List of changes in this PR:
* Modified RangeGenerator to include a viewHint.
* In RangeService, adding the viewing hint to the top-level Range
* Added check for viewingHint to ITs
* Refactored ManifestService and RangeService so that logic related to generating ranges lives in the RangeService.

**Include guidance for how to test or review your PR.** 
Testing the behavior requires an item with multiple bitstreams that include `iiif.toc` metadata. 
 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
