### PR TITLE
IRUS patch performance improvements by adding a timeout

### DIFF
--- a/dspace-api/src/main/java/org/dspace/statistics/export/service/OpenUrlServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/export/service/OpenUrlServiceImpl.java
@@ -9,12 +9,9 @@ package org.dspace.statistics.export.service;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
-import java.net.URL;
-import java.net.URLConnection;
 import java.sql.SQLException;
 import java.util.Date;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.HttpResponse;
@@ -24,7 +21,6 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.tools.ant.taskdefs.condition.Http;
 import org.dspace.core.Context;
 import org.dspace.statistics.export.OpenURLTracker;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -64,7 +60,9 @@ public class OpenUrlServiceImpl implements OpenUrlService {
     }
 
     /**
-     * Returns the response code from accessing the url
+     * Returns the response code from accessing the url. Returns a http status 408 when the external service doesn't
+     * reply in 10 seconds
+     *
      * @param urlStr
      * @return response code from the url
      * @throws IOException
@@ -77,7 +75,7 @@ public class OpenUrlServiceImpl implements OpenUrlService {
         return httpResponse.getStatusLine().getStatusCode();
     }
 
-    RequestConfig.Builder getRequestConfigBuilder(){
+    protected RequestConfig.Builder getRequestConfigBuilder(){
         return RequestConfig.custom();
     }
 

--- a/dspace-api/src/main/java/org/dspace/statistics/export/service/OpenUrlServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/export/service/OpenUrlServiceImpl.java
@@ -71,15 +71,14 @@ public class OpenUrlServiceImpl implements OpenUrlService {
      */
     protected int getResponseCodeFromUrl(final String urlStr) throws IOException {
         HttpGet httpGet = new HttpGet(urlStr);
-        HttpClient httpClient = getHttpClient();
+        RequestConfig requestConfig = getRequestConfigBuilder().setConnectTimeout(10*1000).build();
+        HttpClient httpClient =  HttpClientBuilder.create().setDefaultRequestConfig(requestConfig).build();
         HttpResponse httpResponse = httpClient.execute(httpGet);
         return httpResponse.getStatusLine().getStatusCode();
     }
 
-    HttpClient getHttpClient(){
-        //setting a timeout of 10 seconds so the connection pool doesn't exhaust when waiting a long time for a reply.
-        RequestConfig requestConfig = RequestConfig.custom().setConnectTimeout(10*1000).build();
-        return HttpClientBuilder.create().setDefaultRequestConfig(requestConfig).build();
+    RequestConfig.Builder getRequestConfigBuilder(){
+        return RequestConfig.custom();
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/statistics/export/service/OpenUrlServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/export/service/OpenUrlServiceImpl.java
@@ -69,13 +69,13 @@ public class OpenUrlServiceImpl implements OpenUrlService {
      */
     protected int getResponseCodeFromUrl(final String urlStr) throws IOException {
         HttpGet httpGet = new HttpGet(urlStr);
-        RequestConfig requestConfig = getRequestConfigBuilder().setConnectTimeout(10*1000).build();
-        HttpClient httpClient =  HttpClientBuilder.create().setDefaultRequestConfig(requestConfig).build();
+        RequestConfig requestConfig = getRequestConfigBuilder().setConnectTimeout(10 * 1000).build();
+        HttpClient httpClient = HttpClientBuilder.create().setDefaultRequestConfig(requestConfig).build();
         HttpResponse httpResponse = httpClient.execute(httpGet);
         return httpResponse.getStatusLine().getStatusCode();
     }
 
-    protected RequestConfig.Builder getRequestConfigBuilder(){
+    protected RequestConfig.Builder getRequestConfigBuilder() {
         return RequestConfig.custom();
     }
 

--- a/dspace-api/src/test/java/org/dspace/statistics/export/service/OpenUrlServiceImplTest.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/export/service/OpenUrlServiceImplTest.java
@@ -143,7 +143,11 @@ public class OpenUrlServiceImplTest {
 
     }
 
-    @Test()
+    /**
+     * Tests whether the timeout gets set to 10 seconds when processing a url
+     * @throws SQLException
+     */
+    @Test
     public void testTimeout() throws SQLException {
         Context context = mock(Context.class);
         String URL = "http://bla.com";

--- a/dspace-api/src/test/java/org/dspace/statistics/export/service/OpenUrlServiceImplTest.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/export/service/OpenUrlServiceImplTest.java
@@ -11,7 +11,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
@@ -26,26 +25,15 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.amazonaws.http.client.HttpClientFactory;
-import org.apache.http.HttpVersion;
-import org.apache.http.ProtocolVersion;
-import org.apache.http.client.HttpClient;
 import org.apache.http.client.config.RequestConfig;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.message.BasicHttpResponse;
-import org.apache.solr.client.solrj.impl.HttpClientBuilderFactory;
 import org.dspace.core.Context;
 import org.dspace.statistics.export.OpenURLTracker;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.Spy;
-import org.mockito.internal.stubbing.answers.AnswersWithDelay;
-import org.mockito.internal.stubbing.answers.Returns;
 import org.mockito.junit.MockitoJUnitRunner;
 
 /**
@@ -154,11 +142,11 @@ public class OpenUrlServiceImplTest {
 
         RequestConfig.Builder requestConfig = mock(RequestConfig.Builder.class);
         doReturn(requestConfig).when(openUrlService).getRequestConfigBuilder();
-        doReturn(requestConfig).when(requestConfig).setConnectTimeout(10*1000);
+        doReturn(requestConfig).when(requestConfig).setConnectTimeout(10 * 1000);
         doReturn(RequestConfig.custom().build()).when(requestConfig).build();
 
         openUrlService.processUrl(context, URL);
 
-        Mockito.verify(requestConfig).setConnectTimeout(10*1000);
+        Mockito.verify(requestConfig).setConnectTimeout(10 * 1000);
     }
 }


### PR DESCRIPTION
## References
* Fixes the same issue that was previously adressed in IRUS patch when it wasn't included in the default DSpace codebase: https://github.com/atmire/IRUS/releases/tag/stable-6x-06-09-2021 

## Description
* Whenever an item is visited or a file is downloaded a request is sent out to IRUS
    * If the related service is unavailable, the timeout can be very long (leading to very slowly loading item pages).
* A timeout has been included to avoid these long loading times as well as open requests hogging up the connections

## Instructions for Reviewers
For testing locally alter the [IRUS tracker configuration depending on which one you are using locally](https://github.com/DSpace/DSpace/blob/e1478f6fddb6c919548602ce1200b169e5bf637d/dspace/config/modules/irus-statistics.cfg#L19) into a url using the ip : “10.255.255.1”
That should cause a timeout which should only delay the item pages by 10 seconds, but it WILL timeout in the code afterwards (Where the code prior to these changes will wait for other sections of the call to timeout

List of changes in this PR:
* The existing default connection to the IRUS tracker has been changed into one where a timeout can be provided
* This timeout is currently set to 10 seconds 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
