### PR TITLE
Add GitHub action to build Docker images and push to DockerHub

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # Give Maven 1GB of memory to work with
-      # Suppress all Maven "downloading" messages in Travis logs (see https://stackoverflow.com/a/35653426)
+      # Suppress all Maven "downloading" messages in logs (see https://stackoverflow.com/a/35653426)
       # This also slightly speeds builds, as there is less logging
       MAVEN_OPTS: "-Xmx1024M -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
     strategy:
@@ -38,13 +38,14 @@ jobs:
     steps:
       # https://github.com/actions/checkout
       - name: Checkout codebase
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       # https://github.com/actions/setup-java
       - name: Install JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
           java-version: 11
+          distribution: 'temurin'
 
       # https://github.com/actions/cache
       - name: Cache Maven dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,4 +75,4 @@ jobs:
 
       # https://github.com/codecov/codecov-action
       - name: Upload coverage to Codecov.io
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,10 +8,6 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     env:
-      # Give Maven 1GB of memory to work with
-      # Suppress all Maven "downloading" messages in logs (see https://stackoverflow.com/a/35653426)
-      # This also slightly speeds builds, as there is less logging
-      MAVEN_OPTS: "-Xmx1024M -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
       # Define tags to use for Docker images based on Git tags/branches
       # For a new branch commit, tag Docker image with that branch name
       # Except for 'main' branch, where we use the literal 'dspace-7_x' tag (see below).
@@ -25,13 +21,6 @@ jobs:
       # https://github.com/actions/checkout
       - name: Checkout codebase
         uses: actions/checkout@v2
-
-      # https://github.com/actions/setup-java
-      - name: Install JDK 11
-        uses: actions/setup-java@v2
-        with:
-          java-version: 11
-          distribution: 'temurin'
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,14 +8,19 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     env:
-      # Define tags to use for Docker images based on Git tags/branches
-      # For a new branch commit, tag Docker image with that branch name
-      # Except for 'main' branch, where we use the literal 'dspace-7_x' tag (see below).
-      # For a new tag, tag Docker image with that same tag
+      # Define tags to use for Docker images based on Git tags/branches (for docker/metadata-action)
+      # For a new commit on default branch (main), use the literal tag 'dspace-7_x' on Docker image.
+      # For a new commit on other branches, use the branch name as the tag for Docker image.
+      # For a new tag, copy that tag name as the tag for Docker image.
       IMAGE_TAGS: |
-        type=ref,event=branch,enable=${{ github.ref != 'refs/heads/main' }}
-        type=raw,value=dspace-7_x,enable=${{ github.ref == 'refs/heads/main' }}
+        type=raw,value=dspace-7_x,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
+        type=ref,event=branch,enable=${{ !endsWith(github.ref, github.event.repository.default_branch) }}
         type=ref,event=tag
+      # Define default tag "flavor" for docker/metadata-action per
+      # https://github.com/docker/metadata-action#flavor-input
+      # We turn off 'latest' tag by default.
+      TAGS_FLAVOR: |
+        latest=false
 
     steps:
       # https://github.com/actions/checkout
@@ -45,6 +50,7 @@ jobs:
         with:
           images: dspace/dspace-dependencies
           tags: ${{ env.IMAGE_TAGS }}
+          flavor: ${{ env.TAGS_FLAVOR }}
 
       # https://github.com/docker/build-push-action
       - name: Build and push 'dspace-dependencies' image
@@ -70,6 +76,7 @@ jobs:
         with:
           images: dspace/dspace
           tags: ${{ env.IMAGE_TAGS }}
+          flavor: ${{ env.TAGS_FLAVOR }}
 
       - name: Build and push 'dspace' image
         id: docker_build
@@ -93,10 +100,11 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: dspace/dspace
-          # ONLY add 'dspace-7_x-test' version tag if this is the 'main' branch.
-          # (No other tags are added for this image, as it's only used for testing/development)
-          tags: |
-            type=raw,value=dspace-7_x-test,enable=${{ github.ref == 'refs/heads/main' }}
+          tags: ${{ env.IMAGE_TAGS }}
+          # As this is a test/development image, its tags are all suffixed with "-test". Otherwise, it uses the same
+          # tagging logic as the primary 'dspace/dspace' image above.
+          flavor: ${{ env.TAGS_FLAVOR }}
+            suffix=-test
 
       - name: Build and push 'dspace-test' image
         id: docker_build_test
@@ -121,6 +129,7 @@ jobs:
         with:
           images: dspace/dspace-cli
           tags: ${{ env.IMAGE_TAGS }}
+          flavor: ${{ env.TAGS_FLAVOR }}
 
       - name: Build and push 'dspace-cli' image
         id: docker_build_cli

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,147 @@
+# DSpace Docker image build for hub.docker.com
+name: Docker images
+
+# Run this Build for all pushes / PRs to current branch
+on: [push, pull_request]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    env:
+      # Give Maven 1GB of memory to work with
+      # Suppress all Maven "downloading" messages in logs (see https://stackoverflow.com/a/35653426)
+      # This also slightly speeds builds, as there is less logging
+      MAVEN_OPTS: "-Xmx1024M -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+      # Define tags to use for Docker images based on Git tags/branches
+      # For a new branch commit, tag Docker image with that branch name
+      # Except for 'main' branch, where we use the literal 'dspace-7_x' tag (see below).
+      # For a new tag, tag Docker image with that same tag
+      IMAGE_TAGS: |
+        type=ref,event=branch,enable=${{ github.ref != 'refs/heads/main' }}
+        type=raw,value=dspace-7_x,enable=${{ github.ref == 'refs/heads/main' }}
+        type=ref,event=tag
+
+    steps:
+      # https://github.com/actions/checkout
+      - name: Checkout codebase
+        uses: actions/checkout@v2
+
+      # https://github.com/actions/setup-java
+      - name: Install JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: 'temurin'
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      # https://github.com/docker/login-action
+      - name: Login to DockerHub
+        # Only login if not a PR, as PRs only trigger a Docker build and not a push
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+
+      ####################################################
+      # Build/Push the 'dspace/dspace-dependencies' image
+      ####################################################
+      # https://github.com/docker/metadata-action
+      # Get Metadata for docker_build_deps step below
+      - name: Sync metadata (tags, labels) from GitHub to Docker for 'dspace-dependencies' image
+        id: meta_build_deps
+        uses: docker/metadata-action@v3
+        with:
+          images: dspace/dspace-dependencies
+          tags: ${{ env.IMAGE_TAGS }}
+
+      # https://github.com/docker/build-push-action
+      - name: Build and push 'dspace-dependencies' image
+        id: docker_build_deps
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile.dependencies
+          # For pull requests, we run the Docker build (to ensure no PR changes break the build),
+          # but we ONLY do an image push to DockerHub if it's NOT a PR
+          push: ${{ github.event_name != 'pull_request' }}
+          # Use tags / labels provided by 'docker/metadata-action' above
+          tags: ${{ steps.meta_build_deps.outputs.tags }}
+          labels: ${{ steps.meta_build_deps.outputs.labels }}
+
+      #######################################
+      # Build/Push the 'dspace/dspace' image
+      #######################################
+      # Get Metadata for docker_build step below
+      - name: Sync metadata (tags, labels) from GitHub to Docker for 'dspace' image
+        id: meta_build
+        uses: docker/metadata-action@v3
+        with:
+          images: dspace/dspace
+          tags: ${{ env.IMAGE_TAGS }}
+
+      - name: Build and push 'dspace' image
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          # For pull requests, we run the Docker build (to ensure no PR changes break the build),
+          # but we ONLY do an image push to DockerHub if it's NOT a PR
+          push: ${{ github.event_name != 'pull_request' }}
+          # Use tags / labels provided by 'docker/metadata-action' above
+          tags: ${{ steps.meta_build.outputs.tags }}
+          labels: ${{ steps.meta_build.outputs.labels }}
+
+      #####################################################
+      # Build/Push the 'dspace/dspace' image ('-test' tag)
+      #####################################################
+      # Get Metadata for docker_build_test step below
+      - name: Sync metadata (tags, labels) from GitHub to Docker for 'dspace-test' image
+        id: meta_build_test
+        uses: docker/metadata-action@v3
+        with:
+          images: dspace/dspace
+          # ONLY add 'dspace-7_x-test' version tag if this is the 'main' branch.
+          # (No other tags are added for this image, as it's only used for testing/development)
+          tags: |
+            type=raw,value=dspace-7_x-test,enable=${{ github.ref == 'refs/heads/main' }}
+
+      - name: Build and push 'dspace-test' image
+        id: docker_build_test
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile.test
+          # For pull requests, we run the Docker build (to ensure no PR changes break the build),
+          # but we ONLY do an image push to DockerHub if it's NOT a PR
+          push: ${{ github.event_name != 'pull_request' }}
+          # Use tags / labels provided by 'docker/metadata-action' above
+          tags: ${{ steps.meta_build_test.outputs.tags }}
+          labels: ${{ steps.meta_build_test.outputs.labels }}
+
+      ###########################################
+      # Build/Push the 'dspace/dspace-cli' image
+      ###########################################
+      # Get Metadata for docker_build_test step below
+      - name: Sync metadata (tags, labels) from GitHub to Docker for 'dspace-cli' image
+        id: meta_build_cli
+        uses: docker/metadata-action@v3
+        with:
+          images: dspace/dspace-cli
+          tags: ${{ env.IMAGE_TAGS }}
+
+      - name: Build and push 'dspace-cli' image
+        id: docker_build_cli
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile.cli
+          # For pull requests, we run the Docker build (to ensure no PR changes break the build),
+          # but we ONLY do an image push to DockerHub if it's NOT a PR
+          push: ${{ github.event_name != 'pull_request' }}
+          # Use tags / labels provided by 'docker/metadata-action' above
+          tags: ${{ steps.meta_build_cli.outputs.tags }}
+          labels: ${{ steps.meta_build_cli.outputs.labels }}

--- a/dspace/src/main/docker/README.md
+++ b/dspace/src/main/docker/README.md
@@ -11,11 +11,11 @@ This Dockerfile is used to pre-cache Maven dependency downloads that will be use
 docker build -t dspace/dspace-dependencies:dspace-7_x -f Dockerfile.dependencies .
 ```
 
-**This image is built manually.**  It should be rebuilt each year or after each major release in order to refresh the cache of jars.
+This image is built *automatically* after each commit is made to the `main` branch.
 
 A corresponding image exists for DSpace 4-6.
 
-Admins to our DockerHub repo can publish with the following command.
+Admins to our DockerHub repo can manually publish with the following command.
 ```
 docker push dspace/dspace-dependencies:dspace-7_x
 ```
@@ -35,7 +35,7 @@ This image is built *automatically* after each commit is made to the `main` bran
 
 A corresponding image exists for DSpace 4-6.
 
-Admins to our DockerHub repo can publish with the following command.
+Admins to our DockerHub repo can manually publish with the following command.
 ```
 docker push dspace/dspace:dspace-7_x-test
 ```


### PR DESCRIPTION
## Description
This PR adds a new `docker.yml` GitHub action, which is configured to automatically build DSpace Docker images and push to DockerHub.

This includes the following setup:
* New `docker.yml` action runs for all pushes, releases and PRs.  However, PRs _only_ build the Docker images (to verify no new build errors occur). PRs do NOT push updated Docker images to DockerHub
* When a new commit occurs on `main`, images will all be built and tagged in DockerHub with `dspace-7_x`
    * When a new commit occurs on a different branch, images will be built and tagged with that branch name.
* When a new tag is created in GitHub, images will all be built and tagged in DockerHub with same tag as the DSpace release.
