### PR TITLE
Disable Docker image build action on forked repos & on non-maintenance branches

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,8 @@ on: [push, pull_request]
 
 jobs:
   docker:
+    # Ensure this job never runs on forked repos. It's only executed for 'dspace/dspace'
+    if: github.repository == 'dspace/dspace'
     runs-on: ubuntu-latest
     env:
       # Define tags to use for Docker images based on Git tags/branches (for docker/metadata-action)

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,8 +1,16 @@
 # DSpace Docker image build for hub.docker.com
 name: Docker images
 
-# Run this Build for all pushes / PRs to current branch
-on: [push, pull_request]
+# Run this Build for all pushes to 'main' or maintenance branches, or tagged releases.
+# Also run for PRs to ensure PR doesn't break Docker build process
+on:
+  push:
+    branches:
+      - main
+      - 'dspace-**'
+    tags:
+      - 'dspace-**'
+  pull_request:
 
 jobs:
   docker:
@@ -29,6 +37,7 @@ jobs:
       - name: Checkout codebase
         uses: actions/checkout@v2
 
+      # https://github.com/docker/setup-buildx-action
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v1
 


### PR DESCRIPTION
## Description
After running #8058 on `main` for the first time (after merging it), I've realized two things that were missing from our initial `docker.yml` action.

1. We need to disable this workflow action from running on forks.  Otherwise, it will always fail in forked repos (as the user who owns the fork cannot push Docker images to our DockerHub account).
2. We need to only run this workflow action for maintenance branches (e.g. `dspace-6_x`, etc), and not other branches we use occasionally (e.g. `rest-demo` which is the branch used by the api7.dspace.org demo backend).

This PR makes those minor changes/updates.
