### PR TITLE
Cleanup our LICENSE file so GitHub can detect our BSD license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-DSpace source code BSD License:
+BSD 3-Clause License
 
 Copyright (c) 2002-2021, LYRASIS.  All rights reserved.
 
@@ -13,13 +13,12 @@ notice, this list of conditions and the following disclaimer.
 notice, this list of conditions and the following disclaimer in the
 documentation and/or other materials provided with the distribution.
 
-- Neither the name DuraSpace nor the name of the DSpace Foundation
-nor the names of its contributors may be used to endorse or promote
-products derived from this software without specific prior written
-permission.
+- Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
 A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
 HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
@@ -30,10 +29,3 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 DAMAGE.
-
-
-DSpace uses third-party libraries which may be distributed under
-different licenses to the above. Information about these licenses
-is detailed in the LICENSES_THIRD_PARTY file at the root of the source
-tree.  You must agree to the terms of these licenses, in addition to
-the above DSpace source code license, in order to use this software.

--- a/NOTICE
+++ b/NOTICE
@@ -1,3 +1,13 @@
+Licenses of Third-Party Libraries
+=================================
+
+DSpace uses third-party libraries which may be distributed under
+different licenses than specified in our LICENSE file. Information
+about these licenses is detailed in the LICENSES_THIRD_PARTY file at
+the root of the source tree. You must agree to the terms of these
+licenses, in addition to the DSpace source code license, in order to
+use this software.
+
 Licensing Notices
 =================
 

--- a/README.md
+++ b/README.md
@@ -136,3 +136,6 @@ run automatically by [GitHub Actions](https://github.com/DSpace/DSpace/actions?q
 
 DSpace source code is freely available under a standard [BSD 3-Clause license](https://opensource.org/licenses/BSD-3-Clause).
 The full license is available in the [LICENSE](LICENSE) file or online at http://www.dspace.org/license/
+
+DSpace uses third-party libraries which may be distributed under different licenses. Those licenses are listed
+in the [LICENSES_THIRD_PARTY](LICENSES_THIRD_PARTY) file.


### PR DESCRIPTION
## Description
GitHub is able to detect the type of OSS license, provided that your `LICENSE` file doesn't contain a bunch of custom text.  See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository#detecting-a-license

This PR simply cleans up the formatting of our `LICENSE` file so that it matches a standard BSD 3-Clause License.  This includes:
* Minor formatting changes
* Replacing outdated text "Neither the name DuraSpace nor the name of the DSpace Foundation" with "Neither the name of the copyright holder" (which is the standard BSD language).
* Moving our note about "third party licenses" to our `NOTICE` and `README` files.

This PR changes no code. Instead, I'm simply creating a PR to **document** the reason for this change. Therefore, I'll merge it immediately.