### PR TITLE
Fix findSubmitAuthorized endpoint to support queries by starts with

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
@@ -1010,7 +1010,7 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
         if (StringUtils.isNotBlank(q)) {
             StringBuilder buildQuery = new StringBuilder();
             String escapedQuery = ClientUtils.escapeQueryChars(q);
-            buildQuery.append(escapedQuery).append(" OR ").append(escapedQuery).append("*");
+            buildQuery.append("(").append(escapedQuery).append(" OR ").append(escapedQuery).append("*").append(")");
             discoverQuery.setQuery(buildQuery.toString());
         }
         DiscoverResult resp = searchService.search(context, discoverQuery);


### PR DESCRIPTION
* Fixes #8066 

The query sent to solr to search for a collection that match exactly OR starts with the filter query string in retrieveCollectionsWithSubmit method of CollectionServiceImpl class is not constructed properly. The problem was in [this line](https://github.com/DSpace/DSpace/blob/main/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java#L1013) where "q" query has to be enclosed between "( )"

I added the brackets and the query worked as expected
