### PR TITLE
Fix BrowseBy list are statically configured

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/BrowseIndexConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/BrowseIndexConverter.java
@@ -31,6 +31,7 @@ public class BrowseIndexConverter implements DSpaceConverter<BrowseIndex, Browse
         BrowseIndexRest bir = new BrowseIndexRest();
         bir.setProjection(projection);
         bir.setId(obj.getName());
+        bir.setDataType(obj.getDataType());
         bir.setOrder(obj.getDefaultOrder());
         bir.setMetadataBrowse(obj.isMetadataIndex());
         List<String> metadataList = new ArrayList<String>();

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/BrowseIndexRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/BrowseIndexRest.java
@@ -43,6 +43,8 @@ public class BrowseIndexRest extends BaseObjectRest<String> {
     @JsonProperty(value = "metadata")
     List<String> metadataList;
 
+    String dataType;
+
     List<SortOption> sortOptions;
 
     String order;
@@ -72,6 +74,14 @@ public class BrowseIndexRest extends BaseObjectRest<String> {
 
     public void setMetadataList(List<String> metadataList) {
         this.metadataList = metadataList;
+    }
+
+    public String getDataType() {
+        return dataType;
+    }
+
+    public void setDataType(String dataType) {
+        this.dataType = dataType;
     }
 
     public String getOrder() {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/BrowseIndexMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/BrowseIndexMatcher.java
@@ -32,6 +32,7 @@ public class BrowseIndexMatcher {
         return allOf(
             hasJsonPath("$.metadata", contains("dc.subject.*")),
             hasJsonPath("$.metadataBrowse", Matchers.is(true)),
+            hasJsonPath("$.dataType", equalToIgnoringCase("text")),
             hasJsonPath("$.order", equalToIgnoringCase(order)),
             hasJsonPath("$.sortOptions[*].name", containsInAnyOrder("title", "dateissued", "dateaccessioned")),
             hasJsonPath("$._links.self.href", is(REST_SERVER_URL + "discover/browses/subject")),
@@ -44,6 +45,7 @@ public class BrowseIndexMatcher {
         return allOf(
             hasJsonPath("$.metadata", contains("dc.title")),
             hasJsonPath("$.metadataBrowse", Matchers.is(false)),
+            hasJsonPath("$.dataType", equalToIgnoringCase("title")),
             hasJsonPath("$.order", equalToIgnoringCase(order)),
             hasJsonPath("$.sortOptions[*].name", containsInAnyOrder("title", "dateissued", "dateaccessioned")),
             hasJsonPath("$._links.self.href", is(REST_SERVER_URL + "discover/browses/title")),
@@ -55,6 +57,7 @@ public class BrowseIndexMatcher {
         return allOf(
             hasJsonPath("$.metadata", contains("dc.contributor.*", "dc.creator")),
             hasJsonPath("$.metadataBrowse", Matchers.is(true)),
+            hasJsonPath("$.dataType", equalToIgnoringCase("text")),
             hasJsonPath("$.order", equalToIgnoringCase(order)),
             hasJsonPath("$.sortOptions[*].name", containsInAnyOrder("title", "dateissued", "dateaccessioned")),
             hasJsonPath("$._links.self.href", is(REST_SERVER_URL + "discover/browses/author")),
@@ -67,6 +70,7 @@ public class BrowseIndexMatcher {
         return allOf(
             hasJsonPath("$.metadata", contains("dc.date.issued")),
             hasJsonPath("$.metadataBrowse", Matchers.is(false)),
+            hasJsonPath("$.dataType", equalToIgnoringCase("date")),
             hasJsonPath("$.order", equalToIgnoringCase(order)),
             hasJsonPath("$.sortOptions[*].name", containsInAnyOrder("title", "dateissued", "dateaccessioned")),
             hasJsonPath("$._links.self.href", is(REST_SERVER_URL + "discover/browses/dateissued")),


### PR DESCRIPTION
## References
* Fixes the REST part of https://github.com/DSpace/dspace-angular/issues/852
* Related to [REST Contract](https://github.com/DSpace/RestContract/pull/177)

## Description
This PR will add the browse data type (text, title, date) to the browse endpoint (/api/discover/browses/)

## Instructions for Reviewers
The data type was already stored in the BrowseIndex class.
I've also added it as a property to the BrowseIndexRest class, and altered the BrowseIndexConverter to store it.
I've altered the BrowseIndexMatcher to verify the data type in the tests.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
