### PR TITLE
If a workflow user rejects an item that they submitted, the item becomes uneditable

### DIFF
--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowServiceImpl.java
@@ -1031,12 +1031,13 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
 
         itemService.update(context, myitem);
 
-        // convert into personal workspace
-        WorkspaceItem wsi = returnToWorkspace(context, wi);
-
         // remove policy for controller
         removeUserItemPolicies(context, myitem, e);
         revokeReviewerPolicies(context, myitem);
+
+        // convert into personal workspace
+        WorkspaceItem wsi = returnToWorkspace(context, wi);
+
         // notify that it's been rejected
         notifyOfReject(context, wi, e, rejection_message);
         log.info(LogHelper.getHeader(context, "reject_workflow", "workflow_item_id="

--- a/dspace-api/src/test/java/org/dspace/xmlworkflow/XmlWorkflowServiceIT.java
+++ b/dspace-api/src/test/java/org/dspace/xmlworkflow/XmlWorkflowServiceIT.java
@@ -1,0 +1,109 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.xmlworkflow;
+
+import static org.junit.Assert.assertTrue;
+
+import java.sql.SQLException;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+
+import org.dspace.AbstractIntegrationTestWithDatabase;
+import org.dspace.authorize.ResourcePolicy;
+import org.dspace.authorize.factory.AuthorizeServiceFactory;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.builder.ClaimedTaskBuilder;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.EPersonBuilder;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.Item;
+import org.dspace.core.Constants;
+import org.dspace.discovery.IndexingService;
+import org.dspace.eperson.EPerson;
+import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.xmlworkflow.factory.XmlWorkflowServiceFactory;
+import org.dspace.xmlworkflow.service.XmlWorkflowService;
+import org.dspace.xmlworkflow.state.Workflow;
+import org.dspace.xmlworkflow.storedcomponents.ClaimedTask;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * IT for {@link XmlWorkflowServiceImpl}
+ *
+ * @author Maria Verdonck (Atmire) on 14/12/21
+ */
+public class XmlWorkflowServiceIT extends AbstractIntegrationTestWithDatabase {
+
+    protected XmlWorkflowService xmlWorkflowService = XmlWorkflowServiceFactory.getInstance().getXmlWorkflowService();
+    protected IndexingService indexer = DSpaceServicesFactory.getInstance().getServiceManager()
+                                                             .getServiceByName(IndexingService.class.getName(),
+                                                                 IndexingService.class);
+    protected AuthorizeService authorizeService = AuthorizeServiceFactory.getInstance().getAuthorizeService();
+
+    /**
+     * Test to verify that if a user submits an item into the workflow, then it gets rejected that the submitter gets
+     * write access back on the item
+     *
+     * @throws Exception
+     */
+    @Test
+    public void workflowUserRejectsItemTheySubmitted_ItemShouldBeEditable() throws Exception {
+        context.turnOffAuthorisationSystem();
+        EPerson submitter = EPersonBuilder.createEPerson(context).withEmail("submitter@example.org").build();
+        context.setCurrentUser(submitter);
+        Community community = CommunityBuilder.createCommunity(context)
+                                              .withName("Parent Community")
+                                              .build();
+        Collection colWithWorkflow = CollectionBuilder.createCollection(context, community)
+                                                      .withName("Collection WITH workflow")
+                                                      .withWorkflowGroup(1, submitter)
+                                                      .build();
+        Workflow workflow = XmlWorkflowServiceFactory.getInstance().getWorkflowFactory().getWorkflow(colWithWorkflow);
+        ClaimedTask taskToReject = ClaimedTaskBuilder.createClaimedTask(context, colWithWorkflow, submitter)
+                                                     .withTitle("Test workflow item to reject").build();
+
+        // Submitter person is both original submitter as well as reviewer, should have edit access of claimed task
+        assertTrue(this.containsRPForUser(taskToReject.getWorkflowItem().getItem(), submitter, Constants.WRITE));
+
+        // reject
+        MockHttpServletRequest httpRejectRequest = new MockHttpServletRequest();
+        httpRejectRequest.setParameter("submit_reject", "submit_reject");
+        httpRejectRequest.setParameter("reason", "test");
+        executeWorkflowAction(httpRejectRequest, workflow, taskToReject);
+
+        // Submitter person is both original submitter as well as reviewer, should have edit access of reject, i.e.
+        // sent back/to submission task
+        assertTrue(this.containsRPForUser(taskToReject.getWorkflowItem().getItem(), submitter, Constants.WRITE));
+    }
+
+    private boolean containsRPForUser(Item item, EPerson user, int action) throws SQLException {
+        List<ResourcePolicy> rps = authorizeService.getPolicies(context, item);
+        for (ResourcePolicy rp : rps) {
+            if (rp.getEPerson().getID().equals(user.getID()) && rp.getAction() == action) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void executeWorkflowAction(HttpServletRequest httpServletRequest, Workflow workflow, ClaimedTask task)
+        throws Exception {
+        final EPerson previousUser = context.getCurrentUser();
+        task = context.reloadEntity(task);
+        context.setCurrentUser(task.getOwner());
+        xmlWorkflowService
+            .doState(context, task.getOwner(), httpServletRequest, task.getWorkflowItem().getID(), workflow,
+                workflow.getStep(task.getStepID()).getActionConfig(task.getActionID()));
+        context.commit();
+        indexer.commit();
+        context.setCurrentUser(previousUser);
+    }
+}

--- a/dspace-api/src/test/java/org/dspace/xmlworkflow/XmlWorkflowServiceIT.java
+++ b/dspace-api/src/test/java/org/dspace/xmlworkflow/XmlWorkflowServiceIT.java
@@ -69,6 +69,7 @@ public class XmlWorkflowServiceIT extends AbstractIntegrationTestWithDatabase {
         Workflow workflow = XmlWorkflowServiceFactory.getInstance().getWorkflowFactory().getWorkflow(colWithWorkflow);
         ClaimedTask taskToReject = ClaimedTaskBuilder.createClaimedTask(context, colWithWorkflow, submitter)
                                                      .withTitle("Test workflow item to reject").build();
+        context.restoreAuthSystemState();
 
         // Submitter person is both original submitter as well as reviewer, should have edit access of claimed task
         assertTrue(this.containsRPForUser(taskToReject.getWorkflowItem().getItem(), submitter, Constants.WRITE));


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #8042

## Description
If a certain users (who is also a reviewer) submits an item and they then reject their own item in the workflow, the item cannot be edited any longer in the workspace.

This is because all WRITE rights have been removed from that item.

## Instructions for Reviewers
Steps to reproduce the behavior:

* Create (a non admin) user whom is both submitter in a certain collection and a reviewer
* Submit an item in that collection
* Reject that item yourself
* Go back to your workspace & attempt to modify some metadata & save
* This won't work & you will get a message stating: "There was an issue when saving the item, please try again later."

List of changes in this PR:
* We moved the removal of the RIGHTS before we create the new workspace item (which in turn creates new RIGHTS for the submitter user.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
