### PR TITLE
Qualdrop values not play well with mandatory flag

### DIFF
--- a/dspace-api/src/test/data/dspaceFolder/config/item-submission.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/item-submission.xml
@@ -20,6 +20,7 @@
         <name-map collection-handle="default" submission-name="traditional"/>
         <name-map collection-handle="123456789/language-test-1" submission-name="languagetestprocess"/>
         <name-map collection-handle="123456789/extraction-test" submission-name="extractiontestprocess"/>
+        <name-map collection-handle="123456789/qualdrop-test" submission-name="qualdroptest"/>
     </submission-map>
 
 
@@ -73,6 +74,11 @@
             <processing-class>org.dspace.app.rest.submit.step.LicenseStep</processing-class>
             <type>license</type>
             <scope visibilityOutside="read-only">submission</scope>
+        </step-definition>
+
+        <step-definition id="qualdrop">
+            <processing-class>org.dspace.app.rest.submit.step.DescribeStep</processing-class>
+            <type></type>
         </step-definition>
 
         <!-- Step Upload Item with Embargo Features to enable this step, please
@@ -165,6 +171,10 @@
             <step id="extractionstep"/>
             <step id="license"/>
             <step id="cclicense"/>
+        </submission-process>
+
+        <submission-process name="qualdroptest">
+            <step id="qualdrop" />
         </submission-process>
 
     </submission-definitions>

--- a/dspace-api/src/test/data/dspaceFolder/config/item-submission.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/item-submission.xml
@@ -76,9 +76,9 @@
             <scope visibilityOutside="read-only">submission</scope>
         </step-definition>
 
-        <step-definition id="qualdrop">
+        <step-definition id="qualdroptest">
             <processing-class>org.dspace.app.rest.submit.step.DescribeStep</processing-class>
-            <type></type>
+            <type>submission-form</type>
         </step-definition>
 
         <!-- Step Upload Item with Embargo Features to enable this step, please
@@ -174,7 +174,7 @@
         </submission-process>
 
         <submission-process name="qualdroptest">
-            <step id="qualdrop" />
+            <step id="qualdroptest" />
         </submission-process>
 
     </submission-definitions>

--- a/dspace-api/src/test/data/dspaceFolder/config/submission-forms.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/submission-forms.xml
@@ -286,7 +286,7 @@ it, please enter the types and the actual numbers or codes.</hint>
      </row>
    </form>
 
-   <form name="qualdrop">
+   <form name="qualdroptest">
      <row>
        <field>
          <dc-schema>dc</dc-schema>

--- a/dspace-api/src/test/data/dspaceFolder/config/submission-forms.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/submission-forms.xml
@@ -286,6 +286,22 @@ it, please enter the types and the actual numbers or codes.</hint>
      </row>
    </form>
 
+   <form name="qualdrop">
+     <row>
+       <field>
+         <dc-schema>dc</dc-schema>
+         <dc-element>identifier</dc-element>
+         <dc-qualifier></dc-qualifier>
+         <repeatable>true</repeatable>
+         <label>Identifiers</label>
+         <input-type value-pairs-name="common_identifiers">qualdrop_value</input-type>
+         <hint>If the item has any identification numbers or codes associated with
+           it, please enter the types and the actual numbers or codes.</hint>
+         <required>please give an identifier</required>
+       </field>
+     </row>
+   </form>
+
    <form name="languagetest">
       <row>
         <field>

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionDefinitionsControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionDefinitionsControllerIT.java
@@ -258,10 +258,10 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
                         Matchers.containsString("page=1"), Matchers.containsString("size=1"))))
                 .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
                         Matchers.containsString("/api/config/submissiondefinitions?"),
-                        Matchers.containsString("page=2"), Matchers.containsString("size=1"))))
+                        Matchers.containsString("page=3"), Matchers.containsString("size=1"))))
                 .andExpect(jsonPath("$.page.size", is(1)))
-                .andExpect(jsonPath("$.page.totalElements", is(3)))
-                .andExpect(jsonPath("$.page.totalPages", is(3)))
+                .andExpect(jsonPath("$.page.totalElements", is(4)))
+                .andExpect(jsonPath("$.page.totalPages", is(4)))
                 .andExpect(jsonPath("$.page.number", is(0)));
 
         getClient(tokenAdmin).perform(get("/api/config/submissiondefinitions")
@@ -284,10 +284,10 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
                         Matchers.containsString("page=1"), Matchers.containsString("size=1"))))
                 .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
                         Matchers.containsString("/api/config/submissiondefinitions?"),
-                        Matchers.containsString("page=2"), Matchers.containsString("size=1"))))
+                        Matchers.containsString("page=3"), Matchers.containsString("size=1"))))
                 .andExpect(jsonPath("$.page.size", is(1)))
-                .andExpect(jsonPath("$.page.totalElements", is(3)))
-                .andExpect(jsonPath("$.page.totalPages", is(3)))
+                .andExpect(jsonPath("$.page.totalElements", is(4)))
+                .andExpect(jsonPath("$.page.totalPages", is(4)))
                 .andExpect(jsonPath("$.page.number", is(1)));
 
         getClient(tokenAdmin).perform(get("/api/config/submissiondefinitions")
@@ -295,24 +295,50 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
                 .param("page", "2"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(contentType))
-                .andExpect(jsonPath("$._embedded.submissiondefinitions[0].id", is("extractiontestprocess")))
+                .andExpect(jsonPath("$._embedded.submissiondefinitions[0].id", is("qualdroptest")))
                 .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
                         Matchers.containsString("/api/config/submissiondefinitions?"),
                         Matchers.containsString("page=0"), Matchers.containsString("size=1"))))
                 .andExpect(jsonPath("$._links.prev.href", Matchers.allOf(
                         Matchers.containsString("/api/config/submissiondefinitions?"),
                         Matchers.containsString("page=1"), Matchers.containsString("size=1"))))
-                .andExpect(jsonPath("$._links.next").doesNotExist())
+                .andExpect(jsonPath("$._links.next.href", Matchers.allOf(
+                        Matchers.containsString("/api/config/submissiondefinitions?"),
+                        Matchers.containsString("page=3"), Matchers.containsString("size=1"))))
                 .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
                         Matchers.containsString("/api/config/submissiondefinitions?"),
                         Matchers.containsString("page=2"), Matchers.containsString("size=1"))))
                 .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
                         Matchers.containsString("/api/config/submissiondefinitions?"),
-                        Matchers.containsString("page=2"), Matchers.containsString("size=1"))))
+                        Matchers.containsString("page=3"), Matchers.containsString("size=1"))))
                 .andExpect(jsonPath("$.page.size", is(1)))
-                .andExpect(jsonPath("$.page.totalElements", is(3)))
-                .andExpect(jsonPath("$.page.totalPages", is(3)))
+                .andExpect(jsonPath("$.page.totalElements", is(4)))
+                .andExpect(jsonPath("$.page.totalPages", is(4)))
                 .andExpect(jsonPath("$.page.number", is(2)));
+
+        getClient(tokenAdmin).perform(get("/api/config/submissiondefinitions")
+            .param("size", "1")
+            .param("page", "3"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._embedded.submissiondefinitions[0].id", is("extractiontestprocess")))
+            .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=0"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.prev.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=2"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.next").doesNotExist())
+            .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=3"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=3"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$.page.size", is(1)))
+            .andExpect(jsonPath("$.page.totalElements", is(4)))
+            .andExpect(jsonPath("$.page.totalPages", is(4)))
+            .andExpect(jsonPath("$.page.number", is(3)));
     }
 
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionFormsControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionFormsControllerIT.java
@@ -66,13 +66,13 @@ public class SubmissionFormsControllerIT extends AbstractControllerIntegrationTe
                    .andExpect(content().contentType(contentType))
                    //The configuration file for the test env includes 6 forms
                    .andExpect(jsonPath("$.page.size", is(20)))
-                   .andExpect(jsonPath("$.page.totalElements", equalTo(6)))
+                   .andExpect(jsonPath("$.page.totalElements", equalTo(7)))
                    .andExpect(jsonPath("$.page.totalPages", equalTo(1)))
                    .andExpect(jsonPath("$.page.number", is(0)))
                    .andExpect(
                        jsonPath("$._links.self.href", Matchers.startsWith(REST_SERVER_URL + "config/submissionforms")))
                    //The array of submissionforms should have a size of 6
-                   .andExpect(jsonPath("$._embedded.submissionforms", hasSize(equalTo(6))))
+                   .andExpect(jsonPath("$._embedded.submissionforms", hasSize(equalTo(7))))
         ;
     }
 
@@ -83,12 +83,12 @@ public class SubmissionFormsControllerIT extends AbstractControllerIntegrationTe
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(contentType))
                 .andExpect(jsonPath("$.page.size", is(20)))
-                .andExpect(jsonPath("$.page.totalElements", equalTo(6)))
+                .andExpect(jsonPath("$.page.totalElements", equalTo(7)))
                 .andExpect(jsonPath("$.page.totalPages", equalTo(1)))
                 .andExpect(jsonPath("$.page.number", is(0)))
                 .andExpect(jsonPath("$._links.self.href", Matchers.startsWith(REST_SERVER_URL
                            + "config/submissionforms")))
-                .andExpect(jsonPath("$._embedded.submissionforms", hasSize(equalTo(6))));
+                .andExpect(jsonPath("$._embedded.submissionforms", hasSize(equalTo(7))));
     }
 
     @Test
@@ -663,10 +663,10 @@ public class SubmissionFormsControllerIT extends AbstractControllerIntegrationTe
                          Matchers.containsString("page=1"), Matchers.containsString("size=2"))))
                  .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
                          Matchers.containsString("/api/config/submissionforms?"),
-                         Matchers.containsString("page=2"), Matchers.containsString("size=2"))))
+                         Matchers.containsString("page=3"), Matchers.containsString("size=2"))))
                  .andExpect(jsonPath("$.page.size", is(2)))
-                 .andExpect(jsonPath("$.page.totalElements", equalTo(6)))
-                 .andExpect(jsonPath("$.page.totalPages", equalTo(3)))
+                 .andExpect(jsonPath("$.page.totalElements", equalTo(7)))
+                 .andExpect(jsonPath("$.page.totalPages", equalTo(4)))
                  .andExpect(jsonPath("$.page.number", is(0)));
 
         getClient(tokenAdmin).perform(get("/api/config/submissionforms")
@@ -675,7 +675,7 @@ public class SubmissionFormsControllerIT extends AbstractControllerIntegrationTe
                  .andExpect(status().isOk())
                  .andExpect(content().contentType(contentType))
                  .andExpect(jsonPath("$._embedded.submissionforms[0].id", is("languagetest")))
-                 .andExpect(jsonPath("$._embedded.submissionforms[1].id", is("traditionalpagetwo")))
+                 .andExpect(jsonPath("$._embedded.submissionforms[1].id", is("qualdroptest")))
                  .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
                          Matchers.containsString("/api/config/submissionforms?"),
                          Matchers.containsString("page=0"), Matchers.containsString("size=2"))))
@@ -690,10 +690,10 @@ public class SubmissionFormsControllerIT extends AbstractControllerIntegrationTe
                          Matchers.containsString("page=2"), Matchers.containsString("size=2"))))
                  .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
                          Matchers.containsString("/api/config/submissionforms?"),
-                         Matchers.containsString("page=2"), Matchers.containsString("size=2"))))
+                         Matchers.containsString("page=3"), Matchers.containsString("size=2"))))
                  .andExpect(jsonPath("$.page.size", is(2)))
-                 .andExpect(jsonPath("$.page.totalElements", equalTo(6)))
-                 .andExpect(jsonPath("$.page.totalPages", equalTo(3)))
+                 .andExpect(jsonPath("$.page.totalElements", equalTo(7)))
+                 .andExpect(jsonPath("$.page.totalPages", equalTo(4)))
                  .andExpect(jsonPath("$.page.number", is(1)));
 
         getClient(tokenAdmin).perform(get("/api/config/submissionforms")
@@ -701,8 +701,8 @@ public class SubmissionFormsControllerIT extends AbstractControllerIntegrationTe
                 .param("page", "2"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(contentType))
-                .andExpect(jsonPath("$._embedded.submissionforms[0].id", is("sampleauthority")))
-                .andExpect(jsonPath("$._embedded.submissionforms[1].id", is("traditionalpageone")))
+                .andExpect(jsonPath("$._embedded.submissionforms[0].id", is("traditionalpagetwo")))
+                .andExpect(jsonPath("$._embedded.submissionforms[1].id", is("sampleauthority")))
                 .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
                         Matchers.containsString("/api/config/submissionforms?"),
                         Matchers.containsString("page=0"), Matchers.containsString("size=2"))))
@@ -714,10 +714,33 @@ public class SubmissionFormsControllerIT extends AbstractControllerIntegrationTe
                         Matchers.containsString("page=2"), Matchers.containsString("size=2"))))
                 .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
                         Matchers.containsString("/api/config/submissionforms?"),
-                        Matchers.containsString("page=2"), Matchers.containsString("size=2"))))
+                        Matchers.containsString("page=3"), Matchers.containsString("size=2"))))
                 .andExpect(jsonPath("$.page.size", is(2)))
-                .andExpect(jsonPath("$.page.totalElements", equalTo(6)))
-                .andExpect(jsonPath("$.page.totalPages", equalTo(3)))
+                .andExpect(jsonPath("$.page.totalElements", equalTo(7)))
+                .andExpect(jsonPath("$.page.totalPages", equalTo(4)))
                 .andExpect(jsonPath("$.page.number", is(2)));
+
+        getClient(tokenAdmin).perform(get("/api/config/submissionforms")
+            .param("size", "2")
+            .param("page", "3"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._embedded.submissionforms[0].id", is("traditionalpageone")))
+            .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissionforms?"),
+                Matchers.containsString("page=0"), Matchers.containsString("size=2"))))
+            .andExpect(jsonPath("$._links.prev.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissionforms?"),
+                Matchers.containsString("page=2"), Matchers.containsString("size=2"))))
+            .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissionforms?"),
+                Matchers.containsString("page=3"), Matchers.containsString("size=2"))))
+            .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissionforms?"),
+                Matchers.containsString("page=3"), Matchers.containsString("size=2"))))
+            .andExpect(jsonPath("$.page.size", is(2)))
+            .andExpect(jsonPath("$.page.totalElements", equalTo(7)))
+            .andExpect(jsonPath("$.page.totalPages", equalTo(4)))
+            .andExpect(jsonPath("$.page.number", is(3)));
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkspaceItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkspaceItemRestRepositoryIT.java
@@ -5940,7 +5940,7 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
 
         MetadataFieldName issnFieldName = new MetadataFieldName("dc", "identifier", "issn");
         MetadataFieldName isbnFieldName = new MetadataFieldName("dc", "identifier", "isbn");
-        MetadataFieldName urlfieldName = new MetadataFieldName("dc", "identifier", "url");
+        MetadataFieldName citationFieldName = new MetadataFieldName("dc", "identifier", "citation");
 
         WorkspaceItem workspaceItem1 = WorkspaceItemBuilder.createWorkspaceItem(context, collection)
             .withTitle("test workspace item 1")
@@ -5956,7 +5956,7 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
         WorkspaceItem workspaceItem3 = WorkspaceItemBuilder.createWorkspaceItem(context, collection)
             .withTitle("test workspace item 3")
             .build();
-        itemService.setMetadataSingleValue(context, workspaceItem3.getItem(), urlfieldName, null, "url");
+        itemService.setMetadataSingleValue(context, workspaceItem3.getItem(),citationFieldName, null, "citation");
 
         context.restoreAuthSystemState();
 
@@ -5973,7 +5973,7 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
             .andExpect(status().isOk())
             .andExpect(jsonPath(errorPath).doesNotExist());
 
-        getClient(authToken).perform(get(workspaceItemsUri + workspaceItem3.getItem()))
+        getClient(authToken).perform(get(workspaceItemsUri + workspaceItem3.getID()))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.errors[?(@.message=='error.validation.required')]",
                 Matchers.contains(

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -150,7 +150,7 @@
                     <hint>If the item has any identification numbers or codes associated with
                         it, please enter the types and the actual numbers or codes.
                     </hint>
-                    <required>test for requred</required>
+                    <required></required>
                 </field>
             </row>
             <row>

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -150,7 +150,7 @@
                     <hint>If the item has any identification numbers or codes associated with
                         it, please enter the types and the actual numbers or codes.
                     </hint>
-                    <required></required>
+                    <required>test for requred</required>
                 </field>
             </row>
             <row>


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #7927

## Description
We changed the validation so that qualdrop values when mandatory check that a single value is present with one of the provided qualifiers.

## Instructions for Reviewers
Make the qualdrop required in the submission & attempt to submit, if you have no values filled in it should throw an error when validating. If you do have a single (or more) values filled in it should work. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
