### PR TITLE
Tag GoogleRecorderEventListener as deprecated

### DIFF
--- a/dspace-api/src/main/java/org/dspace/google/GoogleRecorderEventListener.java
+++ b/dspace-api/src/main/java/org/dspace/google/GoogleRecorderEventListener.java
@@ -40,7 +40,9 @@ import org.springframework.beans.factory.annotation.Autowired;
  * Time: 10:05
  *
  * Notify Google Analytics of... well anything we want really.
+ * @deprecated
  */
+@Deprecated
 public class GoogleRecorderEventListener extends AbstractUsageEventListener {
 
     private String analyticsKey;

--- a/dspace-api/src/main/java/org/dspace/google/GoogleRecorderEventListener.java
+++ b/dspace-api/src/main/java/org/dspace/google/GoogleRecorderEventListener.java
@@ -40,7 +40,7 @@ import org.springframework.beans.factory.annotation.Autowired;
  * Time: 10:05
  *
  * Notify Google Analytics of... well anything we want really.
- * @deprecated
+ * @deprecated Use org.dspace.google.GoogleAsyncEventListener instead
  */
 @Deprecated
 public class GoogleRecorderEventListener extends AbstractUsageEventListener {


### PR DESCRIPTION
Something we forgot to do after #2248 