### PR TITLE
fix statistics rest permission evaluator to allow only administrators when access is restricted to this role

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/StatisticsRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/StatisticsRestController.java
@@ -20,7 +20,6 @@ import org.dspace.app.rest.model.hateoas.ViewEventResource;
 import org.dspace.app.rest.repository.SearchEventRestRepository;
 import org.dspace.app.rest.repository.StatisticsRestRepository;
 import org.dspace.app.rest.repository.ViewEventRestRepository;
-import org.dspace.app.rest.utils.Utils;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.rest.webmvc.ControllerUtils;
@@ -38,9 +37,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/" + RestAddressableModel.STATISTICS)
 public class StatisticsRestController implements InitializingBean {
-
-    @Autowired
-    private Utils utils;
 
     @Autowired
     private DiscoverableEndpointsService discoverableEndpointsService;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/CanViewUsageStatisticsFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/CanViewUsageStatisticsFeature.java
@@ -31,9 +31,9 @@ import org.springframework.stereotype.Component;
  * is the object's admin. Otherwise, authorization is granted if the current user can view the object.
  */
 @Component
-@AuthorizationFeatureDocumentation(name = ViewUsageStatisticsFeature.NAME,
+@AuthorizationFeatureDocumentation(name = CanViewUsageStatisticsFeature.NAME,
     description = "It can be used to verify if statistics can be viewed")
-public class ViewUsageStatisticsFeature implements AuthorizationFeature {
+public class CanViewUsageStatisticsFeature implements AuthorizationFeature {
 
     public final static String NAME = "canViewUsageStatistics";
 
@@ -47,6 +47,7 @@ public class ViewUsageStatisticsFeature implements AuthorizationFeature {
     private Utils utils;
 
     @Override
+    @SuppressWarnings("rawtypes")
     public boolean isAuthorized(Context context, BaseObjectRest object) throws SQLException {
         if (object instanceof SiteRest
             || object instanceof CommunityRest

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/StatisticsRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/StatisticsRestRepository.java
@@ -27,6 +27,7 @@ import org.dspace.core.Context;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Component;
 
@@ -53,7 +54,7 @@ public class StatisticsRestRepository extends DSpaceRestRepository<UsageReportRe
         try {
             DSpaceObject dso = dspaceObjectUtil.findDSpaceObject(context, uuidObject);
             if (dso == null) {
-                throw new IllegalArgumentException("No DSO found with uuid: " + uuidObject);
+                throw new ResourceNotFoundException("No DSO found with uuid: " + uuidObject);
             }
             usageReportRest = usageReportUtils.createUsageReport(context, dso, reportId);
 
@@ -73,7 +74,7 @@ public class StatisticsRestRepository extends DSpaceRestRepository<UsageReportRe
             Context context = obtainContext();
             DSpaceObject dso = dspaceObjectUtil.findDSpaceObject(context, uuid);
             if (dso == null) {
-                throw new IllegalArgumentException("No DSO found with uuid: " + uuid);
+                throw new ResourceNotFoundException("No DSO found with uuid: " + uuid);
             }
             usageReportsOfItem = usageReportUtils.getUsageReportsOfDSO(context, dso);
         } catch (SQLException | ParseException | SolrServerException | IOException e) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/UsageReportRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/UsageReportRestPermissionEvaluatorPlugin.java
@@ -72,7 +72,7 @@ public class UsageReportRestPermissionEvaluatorPlugin extends RestObjectPermissi
                 if (Objects.isNull(targetId)) {
                     return true;
                 }
-                if (configurationService.getBooleanProperty("usage-statistics.authorization.admin.usage", true)) {
+                if (configurationService.getBooleanProperty("usage-statistics.authorization.admin.usage", false)) {
                     return authorizeService.isAdmin(context);
                 } else  if (StringUtils.equalsIgnoreCase(UsageReportRest.NAME, targetType)) {
                     if (StringUtils.countMatches(targetId.toString(), "_") != 1) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/UsageReportRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/UsageReportRestPermissionEvaluatorPlugin.java
@@ -9,6 +9,7 @@ package org.dspace.app.rest.security;
 
 import java.io.Serializable;
 import java.sql.SQLException;
+import java.util.Objects;
 import java.util.UUID;
 
 import org.apache.commons.lang3.StringUtils;
@@ -18,12 +19,12 @@ import org.dspace.app.rest.utils.DSpaceObjectUtils;
 import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.content.DSpaceObject;
 import org.dspace.core.Context;
+import org.dspace.services.ConfigurationService;
 import org.dspace.services.RequestService;
 import org.dspace.services.model.Request;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
@@ -38,13 +39,16 @@ public class UsageReportRestPermissionEvaluatorPlugin extends RestObjectPermissi
     private static final Logger log = LoggerFactory.getLogger(UsageReportRestPermissionEvaluatorPlugin.class);
 
     @Autowired
+    private ConfigurationService configurationService;
+
+    @Autowired
     private RequestService requestService;
 
     @Autowired
     private DSpaceObjectUtils dspaceObjectUtil;
 
     @Autowired
-    AuthorizeService authorizeService;
+    private AuthorizeService authorizeService;
 
 
 
@@ -64,32 +68,38 @@ public class UsageReportRestPermissionEvaluatorPlugin extends RestObjectPermissi
             Request request = requestService.getCurrentRequest();
             Context context = ContextUtil.obtainContext(request.getHttpServletRequest());
             UUID uuidObject = null;
-            if (targetId != null) {
-                if (StringUtils.equalsIgnoreCase(UsageReportRest.NAME, targetType)) {
-                    if (StringUtils.countMatches(targetId.toString(), "_") != 1) {
-                        throw new IllegalArgumentException("Must end in objectUUID_reportId, example: " +
-                                                                   "1911e8a4-6939-490c-b58b-a5d70f8d91fb_TopCountries");
-                    }
-                    // Get uuid from uuidDSO_reportId pathParam
-                    uuidObject = UUID.fromString(StringUtils.substringBefore(targetId.toString(), "_"));
-                } else if (StringUtils.equalsIgnoreCase(UsageReportRest.NAME + "search", targetType)) {
-                    // Get uuid from url (selfLink of dso) queryParam
-                    uuidObject = UUID.fromString(StringUtils.substringAfterLast(targetId.toString(), "/"));
-                } else {
-                    return false;
+            try {
+                if (configurationService.getBooleanProperty("usage-statistics.authorization.admin.usage", true)) {
+                    return authorizeService.isAdmin(context);
                 }
-                try {
+                if (Objects.nonNull(targetId)) {
+                    if (StringUtils.equalsIgnoreCase(UsageReportRest.NAME, targetType)) {
+                        if (StringUtils.countMatches(targetId.toString(), "_") != 1) {
+                            throw new IllegalArgumentException("Must end in objectUUID_reportId, example: "
+                                    + "1911e8a4-6939-490c-b58b-a5d70f8d91fb_TopCountries");
+                        }
+                        // Get uuid from uuidDSO_reportId pathParam
+                        uuidObject = UUID.fromString(StringUtils.substringBefore(targetId.toString(), "_"));
+                    } else if (StringUtils.equalsIgnoreCase(UsageReportRest.NAME + "search", targetType)) {
+                        // Get uuid from url (selfLink of dso) queryParam
+                        uuidObject = UUID.fromString(StringUtils.substringAfterLast(targetId.toString(), "/"));
+                    } else {
+                        return false;
+                    }
+
                     DSpaceObject dso = dspaceObjectUtil.findDSpaceObject(context, uuidObject);
-                    if (dso == null) {
-                        throw new ResourceNotFoundException("No DSO found with this UUID: " + uuidObject);
+                    // If the dso is null then we give permission so we can throw another status code instead
+                    if (Objects.isNull(dso)) {
+                        return true;
                     }
+
                     return authorizeService.authorizeActionBoolean(context, dso, restPermission.getDspaceApiActionId());
-                } catch (SQLException e) {
-                    log.error(e.getMessage(), e);
                 }
+            } catch (SQLException e) {
+                log.error(e.getMessage(), e);
             }
-            return true;
         }
         return false;
     }
+
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/StatisticsRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/StatisticsRestRepositoryIT.java
@@ -57,6 +57,7 @@ import org.dspace.eperson.EPerson;
 import org.dspace.services.ConfigurationService;
 import org.dspace.statistics.factory.StatisticsServiceFactory;
 import org.hamcrest.Matchers;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -102,6 +103,7 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
 
         // Explicitly use solr commit in SolrLoggerServiceImpl#postView
         configurationService.setProperty("solr-statistics.autoCommit", false);
+        configurationService.setProperty("usage-statistics.authorization.admin.usage", true);
 
         context.turnOffAuthorisationSystem();
 
@@ -122,6 +124,12 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         adminToken = getAuthToken(admin.getEmail(), password);
 
         context.restoreAuthSystemState();
+    }
+
+    @After
+    public void tearDown()  {
+
+        configurationService.setProperty("usage-statistics.authorization.admin.usage", false);
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/StatisticsRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/StatisticsRestRepositoryIT.java
@@ -132,26 +132,27 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
 
     @Test
     public void usagereports_notProperUUIDAndReportId_Exception() throws Exception {
-        getClient().perform(get("/api/statistics/usagereports/notProperUUIDAndReportId"))
+        getClient(adminToken).perform(get("/api/statistics/usagereports/notProperUUIDAndReportId"))
                    .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
     }
 
     @Test
     public void usagereports_nonValidUUIDpart_Exception() throws Exception {
-        getClient().perform(get("/api/statistics/usagereports/notAnUUID" + "_" + TOTAL_VISITS_REPORT_ID))
+        getClient(adminToken).perform(get("/api/statistics/usagereports/notAnUUID" + "_" + TOTAL_VISITS_REPORT_ID))
                    .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
     }
 
     @Test
     public void usagereports_nonValidReportIDpart_Exception() throws Exception {
-        getClient().perform(get("/api/statistics/usagereports/" + itemNotVisitedWithBitstreams.getID() +
+        getClient(adminToken).perform(get("/api/statistics/usagereports/" + itemNotVisitedWithBitstreams.getID() +
                                 "_NotValidReport"))
                    .andExpect(status().is(HttpStatus.NOT_FOUND.value()));
     }
 
     @Test
     public void usagereports_NonExistentUUID_Exception() throws Exception {
-        getClient().perform(get("/api/statistics/usagereports/" + UUID.randomUUID() + "_" + TOTAL_VISITS_REPORT_ID))
+        getClient(adminToken).perform(
+                  get("/api/statistics/usagereports/" + UUID.randomUUID() + "_" + TOTAL_VISITS_REPORT_ID))
                    .andExpect(status().is(HttpStatus.NOT_FOUND.value()));
     }
 
@@ -207,7 +208,7 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         getClient(loggedInToken).perform(
             get("/api/statistics/usagereports/" + itemNotVisitedWithBitstreams.getID() + "_" + TOTAL_VISITS_REPORT_ID))
                                 // ** THEN **
-                                .andExpect(status().isOk());
+                                .andExpect(status().isForbidden());
         // We request a dso's TotalVisits usage stat report as another logged in eperson and has no read policy for
         // this user
         getClient(anotherLoggedInUserToken).perform(
@@ -237,7 +238,7 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         expectedPoint.setId(communityVisited.getID().toString());
 
         // And request that community's TotalVisits stat report
-        getClient().perform(
+        getClient(adminToken).perform(
             get("/api/statistics/usagereports/" + communityVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID))
                    // ** THEN **
                    .andExpect(status().isOk())
@@ -258,7 +259,7 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         expectedPoint.setId(communityNotVisited.getID().toString());
 
         // And request that community's TotalVisits stat report
-        getClient().perform(
+        getClient(adminToken).perform(
             get("/api/statistics/usagereports/" + communityNotVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID))
                    // ** THEN **
                    .andExpect(status().isOk())
@@ -295,7 +296,7 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         expectedPoint.setId(collectionVisited.getID().toString());
 
         // And request that collection's TotalVisits stat report
-        getClient().perform(
+        getClient(adminToken).perform(
             get("/api/statistics/usagereports/" + collectionVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID))
                    // ** THEN **
                    .andExpect(status().isOk())
@@ -316,7 +317,7 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         expectedPoint.setId(collectionNotVisited.getID().toString());
 
         // And request that collection's TotalVisits stat report
-        getClient().perform(
+        getClient(adminToken).perform(
             get("/api/statistics/usagereports/" + collectionNotVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID))
                    // ** THEN **
                    .andExpect(status().isOk())
@@ -348,7 +349,7 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         expectedPoint.setId(itemVisited.getID().toString());
 
         // And request that collection's TotalVisits stat report
-        getClient().perform(
+        getClient(adminToken).perform(
             get("/api/statistics/usagereports/" + itemVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID))
                    // ** THEN **
                    .andExpect(status().isOk())
@@ -369,7 +370,7 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         expectedPoint.setId(itemNotVisitedWithBitstreams.getID().toString());
 
         // And request that item's TotalVisits stat report
-        getClient().perform(
+        getClient(adminToken).perform(
             get("/api/statistics/usagereports/" + itemNotVisitedWithBitstreams.getID() + "_" + TOTAL_VISITS_REPORT_ID))
                    // ** THEN **
                    .andExpect(status().isOk())
@@ -401,7 +402,7 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         expectedPoint.setId(bitstreamVisited.getID().toString());
 
         // And request that bitstream's TotalVisits stat report
-        getClient().perform(
+        getClient(adminToken).perform(
             get("/api/statistics/usagereports/" + bitstreamVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID))
                    // ** THEN **
                    .andExpect(status().isOk())
@@ -410,6 +411,15 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
                            .matchUsageReport(bitstreamVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID,
                                TOTAL_VISITS_REPORT_ID, Arrays.asList(expectedPoint))))
                              );
+
+        // only admin access visits report
+        getClient(loggedInToken).perform(
+                  get("/api/statistics/usagereports/" + bitstreamVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID))
+                 .andExpect(status().isForbidden());
+
+        getClient().perform(
+                  get("/api/statistics/usagereports/" + bitstreamVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID))
+                 .andExpect(status().isUnauthorized());
     }
 
     @Test
@@ -421,8 +431,9 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         expectedPoint.setType("bitstream");
         expectedPoint.setId(bitstreamNotVisited.getID().toString());
 
+        String authToken = getAuthToken(admin.getEmail(), password);
         // And request that bitstream's TotalVisits stat report
-        getClient().perform(
+        getClient(authToken).perform(
             get("/api/statistics/usagereports/" + bitstreamNotVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID))
                    // ** THEN **
                    .andExpect(status().isOk())
@@ -431,6 +442,47 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
                            .matchUsageReport(bitstreamNotVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID,
                                TOTAL_VISITS_REPORT_ID, Arrays.asList(expectedPoint))))
                              );
+
+        String tokenEPerson = getAuthToken(eperson.getEmail(), password);
+        getClient(tokenEPerson).perform(
+                  get("/api/statistics/usagereports/" + bitstreamNotVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID))
+                 .andExpect(status().isForbidden());
+
+        getClient().perform(
+                    get("/api/statistics/usagereports/" + bitstreamNotVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID))
+                   .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void totalVisitsReport_Bitstream_NotVisited_WithUsageStatisticsParameterDisabled() throws Exception {
+        configurationService.setProperty("usage-statistics.authorization.admin.usage", false);
+        // ** WHEN **
+        // Bitstream is never visited
+        UsageReportPointDsoTotalVisitsRest expectedPoint = new UsageReportPointDsoTotalVisitsRest();
+        expectedPoint.addValue("views", 0);
+        expectedPoint.setType("bitstream");
+        expectedPoint.setId(bitstreamNotVisited.getID().toString());
+
+        String authToken = getAuthToken(admin.getEmail(), password);
+        // And request that bitstream's TotalVisits stat report
+        getClient(authToken).perform(
+            get("/api/statistics/usagereports/" + bitstreamNotVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID))
+                   // ** THEN **
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$", Matchers.is(
+                       UsageReportMatcher
+                           .matchUsageReport(bitstreamNotVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID,
+                               TOTAL_VISITS_REPORT_ID, Arrays.asList(expectedPoint))))
+                             );
+
+        String tokenEPerson = getAuthToken(eperson.getEmail(), password);
+        getClient(tokenEPerson).perform(
+                  get("/api/statistics/usagereports/" + bitstreamNotVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID))
+                 .andExpect(status().isNotFound());
+
+        getClient().perform(
+                    get("/api/statistics/usagereports/" + bitstreamNotVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID))
+                   .andExpect(status().isNotFound());
     }
 
     @Test
@@ -451,7 +503,7 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         List<UsageReportPointRest> expectedPoints = this.getListOfVisitsPerMonthsPoints(1);
 
         // And request that item's TotalVisitsPerMonth stat report
-        getClient().perform(
+        getClient(adminToken).perform(
             get("/api/statistics/usagereports/" + itemVisited.getID() + "_" + TOTAL_VISITS_PER_MONTH_REPORT_ID))
                    // ** THEN **
                    .andExpect(status().isOk())
@@ -459,6 +511,15 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
                        UsageReportMatcher
                            .matchUsageReport(itemVisited.getID() + "_" + TOTAL_VISITS_PER_MONTH_REPORT_ID,
                                TOTAL_VISITS_PER_MONTH_REPORT_ID, expectedPoints))));
+
+        // only admin has access
+        getClient(loggedInToken).perform(
+                 get("/api/statistics/usagereports/" + itemVisited.getID() + "_" + TOTAL_VISITS_PER_MONTH_REPORT_ID))
+                .andExpect(status().isForbidden());
+
+        getClient().perform(
+                 get("/api/statistics/usagereports/" + itemVisited.getID() + "_" + TOTAL_VISITS_PER_MONTH_REPORT_ID))
+                .andExpect(status().isUnauthorized());
     }
 
     @Test
@@ -468,7 +529,7 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         List<UsageReportPointRest> expectedPoints = this.getListOfVisitsPerMonthsPoints(0);
 
         // And request that item's TotalVisitsPerMonth stat report
-        getClient().perform(
+        getClient(adminToken).perform(
             get("/api/statistics/usagereports/" + itemNotVisitedWithBitstreams.getID() + "_" +
                 TOTAL_VISITS_PER_MONTH_REPORT_ID))
                    // ** THEN **
@@ -503,7 +564,7 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         List<UsageReportPointRest> expectedPoints = this.getListOfVisitsPerMonthsPoints(2);
 
         // And request that collection's TotalVisitsPerMonth stat report
-        getClient().perform(
+        getClient(adminToken).perform(
             get("/api/statistics/usagereports/" + collectionVisited.getID() + "_" + TOTAL_VISITS_PER_MONTH_REPORT_ID))
                    // ** THEN **
                    .andExpect(status().isOk())
@@ -534,7 +595,7 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         expectedPoint.setId(bitstreamVisited.getID().toString());
 
         // And request that bitstreams's TotalDownloads stat report
-        getClient().perform(
+        getClient(adminToken).perform(
             get("/api/statistics/usagereports/" + bitstreamVisited.getID() + "_" + TOTAL_DOWNLOADS_REPORT_ID))
                    // ** THEN **
                    .andExpect(status().isOk())
@@ -542,6 +603,15 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
                        UsageReportMatcher
                            .matchUsageReport(bitstreamVisited.getID() + "_" + TOTAL_DOWNLOADS_REPORT_ID,
                                TOTAL_DOWNLOADS_REPORT_ID, Arrays.asList(expectedPoint)))));
+
+        // only admin has access to downloads report
+        getClient(loggedInToken).perform(
+                  get("/api/statistics/usagereports/" + bitstreamVisited.getID() + "_" + TOTAL_DOWNLOADS_REPORT_ID))
+                 .andExpect(status().isForbidden());
+
+        getClient().perform(
+                  get("/api/statistics/usagereports/" + bitstreamVisited.getID() + "_" + TOTAL_DOWNLOADS_REPORT_ID))
+                 .andExpect(status().isUnauthorized());
     }
 
     @Test
@@ -565,7 +635,7 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         expectedPoint.setType("bitstream");
 
         // And request that item's TotalDownloads stat report
-        getClient().perform(
+        getClient(adminToken).perform(
             get("/api/statistics/usagereports/" + itemNotVisitedWithBitstreams.getID() + "_" +
                 TOTAL_DOWNLOADS_REPORT_ID))
                    // ** THEN **
@@ -581,7 +651,7 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         // ** WHEN **
         // You don't visit an item's bitstreams
         // And request that item's TotalDownloads stat report
-        getClient().perform(
+        getClient(adminToken).perform(
             get("/api/statistics/usagereports/" + itemNotVisitedWithBitstreams.getID() + "_" +
                 TOTAL_DOWNLOADS_REPORT_ID))
                    // ** THEN **
@@ -594,7 +664,7 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
 
     @Test
     public void TotalDownloadsReport_NotSupportedDSO_Collection() throws Exception {
-        getClient()
+        getClient(adminToken)
             .perform(get("/api/statistics/usagereports/" + collectionVisited.getID() + "_" + TOTAL_DOWNLOADS_REPORT_ID))
             .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
     }
@@ -623,7 +693,7 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         expectedPoint.setLabel("United States");
 
         // And request that collection's TopCountries report
-        getClient().perform(
+        getClient(adminToken).perform(
             get("/api/statistics/usagereports/" + collectionVisited.getID() + "_" + TOP_COUNTRIES_REPORT_ID))
                    // ** THEN **
                    .andExpect(status().isOk())
@@ -631,6 +701,15 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
                        UsageReportMatcher
                            .matchUsageReport(collectionVisited.getID() + "_" + TOP_COUNTRIES_REPORT_ID,
                                TOP_COUNTRIES_REPORT_ID, Arrays.asList(expectedPoint)))));
+
+        // only admin has access to countries report
+        getClient(loggedInToken).perform(
+                  get("/api/statistics/usagereports/" + collectionVisited.getID() + "_" + TOP_COUNTRIES_REPORT_ID))
+                 .andExpect(status().isForbidden());
+
+        getClient().perform(
+                  get("/api/statistics/usagereports/" + collectionVisited.getID() + "_" + TOP_COUNTRIES_REPORT_ID))
+                 .andExpect(status().isUnauthorized());
     }
 
     /**
@@ -662,7 +741,7 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         expectedPoint.setLabel("United States");
 
         // And request that collection's TopCountries report
-        getClient().perform(
+        getClient(adminToken).perform(
             get("/api/statistics/usagereports/" + communityVisited.getID() + "_" + TOP_COUNTRIES_REPORT_ID))
                    // ** THEN **
                    .andExpect(status().isOk())
@@ -680,7 +759,7 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         // ** WHEN **
         // Item is not visited
         // And request that item's TopCountries report
-        getClient().perform(
+        getClient(adminToken).perform(
             get("/api/statistics/usagereports/" + itemNotVisitedWithBitstreams.getID() + "_" + TOP_COUNTRIES_REPORT_ID))
                    // ** THEN **
                    .andExpect(status().isOk())
@@ -713,7 +792,7 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         expectedPoint.setId("New York");
 
         // And request that item's TopCities report
-        getClient().perform(
+        getClient(adminToken).perform(
             get("/api/statistics/usagereports/" + itemVisited.getID() + "_" + TOP_CITIES_REPORT_ID))
                    // ** THEN **
                    .andExpect(status().isOk())
@@ -721,6 +800,15 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
                        UsageReportMatcher
                            .matchUsageReport(itemVisited.getID() + "_" + TOP_CITIES_REPORT_ID,
                                TOP_CITIES_REPORT_ID, Arrays.asList(expectedPoint)))));
+
+        // only admin has access to cities report
+        getClient(loggedInToken).perform(
+                  get("/api/statistics/usagereports/" + itemVisited.getID() + "_" + TOP_CITIES_REPORT_ID))
+                 .andExpect(status().isForbidden());
+
+        getClient().perform(
+                  get("/api/statistics/usagereports/" + itemVisited.getID() + "_" + TOP_CITIES_REPORT_ID))
+                 .andExpect(status().isUnauthorized());
     }
 
     /**
@@ -756,7 +844,7 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         expectedPoint.setId("New York");
 
         // And request that community's TopCities report
-        getClient().perform(
+        getClient(adminToken).perform(
             get("/api/statistics/usagereports/" + communityVisited.getID() + "_" + TOP_CITIES_REPORT_ID))
                    // ** THEN **
                    .andExpect(status().isOk())
@@ -774,7 +862,7 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         // ** WHEN **
         // Collection is not visited
         // And request that collection's TopCountries report
-        getClient().perform(
+        getClient(adminToken).perform(
             get("/api/statistics/usagereports/" + collectionNotVisited.getID() + "_" + TOP_CITIES_REPORT_ID))
                    // ** THEN **
                    .andExpect(status().isOk())
@@ -786,7 +874,7 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
 
     @Test
     public void usagereportsSearch_notProperURI_Exception() throws Exception {
-        getClient().perform(get("/api/statistics/usagereports/search/object?uri=BadUri"))
+        getClient(adminToken).perform(get("/api/statistics/usagereports/search/object?uri=BadUri"))
                    .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
     }
 
@@ -798,7 +886,8 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
 
     @Test
     public void usagereportsSearch_NonExistentUUID_Exception() throws Exception {
-        getClient().perform(get("/api/statistics/usagereports/search/object?uri=http://localhost:8080/server/api/core" +
+        getClient(adminToken).perform(
+                  get("/api/statistics/usagereports/search/object?uri=http://localhost:8080/server/api/core" +
                                 "/items/" + UUID.randomUUID()))
                    .andExpect(status().is(HttpStatus.NOT_FOUND.value()));
     }
@@ -859,7 +948,7 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
             .perform(get("/api/statistics/usagereports/search/object?uri=http://localhost:8080/server/api/core" +
                          "/items/" + itemNotVisitedWithBitstreams.getID()))
             // ** THEN **
-            .andExpect(status().isOk());
+            .andExpect(status().isForbidden());
         // We request a dso's TotalVisits usage stat report as another logged in eperson and has no read policy for
         // this user
         getClient(anotherLoggedInUserToken)
@@ -959,7 +1048,7 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         expectedPointCountry.setLabel("United States");
 
         // And request the community usage reports
-        getClient()
+        getClient(adminToken)
             .perform(get("/api/statistics/usagereports/search/object?uri=http://localhost:8080/server/api/core" +
                          "/communities/" + communityVisited.getID()))
             // ** THEN **
@@ -983,13 +1072,13 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
     public void usageReportsSearch_Collection_NotVisited() throws Exception {
         // ** WHEN **
         // Collection is not visited
-
+try {
         UsageReportPointDsoTotalVisitsRest expectedPointTotalVisits = new UsageReportPointDsoTotalVisitsRest();
         expectedPointTotalVisits.addValue("views", 0);
         expectedPointTotalVisits.setType("collection");
         expectedPointTotalVisits.setId(collectionNotVisited.getID().toString());
         // And request the collection's usage reports
-        getClient()
+        getClient(adminToken)
             .perform(get("/api/statistics/usagereports/search/object?uri=http://localhost:8080/server/api/core" +
                          "/collections/" + collectionNotVisited.getID()))
             // ** THEN **
@@ -1008,6 +1097,9 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
                     TOP_CITIES_REPORT_ID, new ArrayList<>()),
                 UsageReportMatcher.matchUsageReport(collectionNotVisited.getID() + "_" + TOP_COUNTRIES_REPORT_ID,
                     TOP_COUNTRIES_REPORT_ID, new ArrayList<>()))));
+        } finally {
+            System.out.println("");
+        }
     }
 
     @Test
@@ -1040,7 +1132,7 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         expectedPointCountry.setLabel("United States");
 
         // And request the community usage reports
-        getClient()
+        getClient(adminToken)
             .perform(get("/api/statistics/usagereports/search/object?uri=http://localhost:8080/server/api/core" +
                          "/items/" + itemVisited.getID()))
             // ** THEN **
@@ -1133,7 +1225,7 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         totalDownloadsPoints.add(expectedPointTotalVisitsBit2);
 
         // And request the community usage reports
-        getClient()
+        getClient(adminToken)
             .perform(get("/api/statistics/usagereports/search/object?uri=http://localhost:8080/server/api/core" +
                          "/items/" + itemVisited.getID()))
             // ** THEN **
@@ -1185,7 +1277,7 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         expectedPointCountry.setLabel("United States");
 
         // And request the community usage reports
-        getClient()
+        getClient(adminToken)
             .perform(get("/api/statistics/usagereports/search/object?uri=http://localhost:8080/server/api/core" +
                          "/items/" + bitstreamVisited.getID()))
             // ** THEN **

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/StatisticsRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/StatisticsRestRepositoryIT.java
@@ -57,7 +57,6 @@ import org.dspace.eperson.EPerson;
 import org.dspace.services.ConfigurationService;
 import org.dspace.statistics.factory.StatisticsServiceFactory;
 import org.hamcrest.Matchers;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -126,12 +125,6 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         context.restoreAuthSystemState();
     }
 
-    @After
-    public void tearDown()  {
-
-        configurationService.setProperty("usage-statistics.authorization.admin.usage", false);
-    }
-
     @Test
     public void usagereports_withoutId_NotImplementedException() throws Exception {
         getClient().perform(get("/api/statistics/usagereports"))
@@ -153,6 +146,13 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
     @Test
     public void usagereports_nonValidReportIDpart_Exception() throws Exception {
         getClient(adminToken).perform(get("/api/statistics/usagereports/" + itemNotVisitedWithBitstreams.getID() +
+                                "_NotValidReport"))
+                   .andExpect(status().is(HttpStatus.NOT_FOUND.value()));
+    }
+
+    @Test
+    public void usagereports_nonValidReportIDpart_Exception_By_Anonymous_Test() throws Exception {
+        getClient().perform(get("/api/statistics/usagereports/" + itemNotVisitedWithBitstreams.getID() +
                                 "_NotValidReport"))
                    .andExpect(status().is(HttpStatus.NOT_FOUND.value()));
     }
@@ -679,7 +679,6 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         // make statistics visible to all
         configurationService.setProperty("usage-statistics.authorization.admin.usage", false);
 
-        // only admin has access to downloads report
         getClient(loggedInToken).perform(
                 get("/api/statistics/usagereports/" + bitstreamVisited.getID() + "_" + TOTAL_DOWNLOADS_REPORT_ID))
                 .andExpect(status().isOk())

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/StatisticsRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/StatisticsRestRepositoryIT.java
@@ -379,6 +379,36 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
                            .matchUsageReport(itemNotVisitedWithBitstreams.getID() + "_" + TOTAL_VISITS_REPORT_ID,
                                TOTAL_VISITS_REPORT_ID, Arrays.asList(expectedPoint))))
                              );
+
+        // only admin access visits report
+        getClient(loggedInToken).perform(
+             get("/api/statistics/usagereports/" + itemNotVisitedWithBitstreams.getID() + "_" + TOTAL_VISITS_REPORT_ID))
+            .andExpect(status().isForbidden());
+
+        getClient().perform(
+             get("/api/statistics/usagereports/" + itemNotVisitedWithBitstreams.getID() + "_" + TOTAL_VISITS_REPORT_ID))
+            .andExpect(status().isUnauthorized());
+
+        // make statistics visible to all
+        configurationService.setProperty("usage-statistics.authorization.admin.usage", false);
+
+        getClient(loggedInToken).perform(
+                get("/api/statistics/usagereports/"
+                        + itemNotVisitedWithBitstreams.getID() + "_" + TOTAL_VISITS_REPORT_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$",
+                        Matchers.is(UsageReportMatcher.matchUsageReport(
+                                itemNotVisitedWithBitstreams.getID() + "_" + TOTAL_VISITS_REPORT_ID,
+                                TOTAL_VISITS_REPORT_ID, Arrays.asList(expectedPoint)))));
+
+           getClient().perform(
+                get("/api/statistics/usagereports/"
+                        + itemNotVisitedWithBitstreams.getID() + "_" + TOTAL_VISITS_REPORT_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$",
+                        Matchers.is(UsageReportMatcher.matchUsageReport(
+                                itemNotVisitedWithBitstreams.getID() + "_" + TOTAL_VISITS_REPORT_ID,
+                                TOTAL_VISITS_REPORT_ID, Arrays.asList(expectedPoint)))));
     }
 
     @Test
@@ -420,6 +450,25 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         getClient().perform(
                   get("/api/statistics/usagereports/" + bitstreamVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID))
                  .andExpect(status().isUnauthorized());
+
+        // make statistics visible to all
+        configurationService.setProperty("usage-statistics.authorization.admin.usage", false);
+
+        getClient(loggedInToken).perform(
+                get("/api/statistics/usagereports/" + bitstreamVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$",
+                        Matchers.is(UsageReportMatcher.matchUsageReport(
+                                bitstreamVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID, TOTAL_VISITS_REPORT_ID,
+                                Arrays.asList(expectedPoint)))));
+
+        getClient().perform(
+                get("/api/statistics/usagereports/" + bitstreamVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$",
+                        Matchers.is(UsageReportMatcher.matchUsageReport(
+                                bitstreamVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID, TOTAL_VISITS_REPORT_ID,
+                                Arrays.asList(expectedPoint)))));
     }
 
     @Test
@@ -451,38 +500,25 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         getClient().perform(
                     get("/api/statistics/usagereports/" + bitstreamNotVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID))
                    .andExpect(status().isUnauthorized());
-    }
 
-    @Test
-    public void totalVisitsReport_Bitstream_NotVisited_WithUsageStatisticsParameterDisabled() throws Exception {
+        // make statistics visible to all
         configurationService.setProperty("usage-statistics.authorization.admin.usage", false);
-        // ** WHEN **
-        // Bitstream is never visited
-        UsageReportPointDsoTotalVisitsRest expectedPoint = new UsageReportPointDsoTotalVisitsRest();
-        expectedPoint.addValue("views", 0);
-        expectedPoint.setType("bitstream");
-        expectedPoint.setId(bitstreamNotVisited.getID().toString());
 
-        String authToken = getAuthToken(admin.getEmail(), password);
-        // And request that bitstream's TotalVisits stat report
-        getClient(authToken).perform(
-            get("/api/statistics/usagereports/" + bitstreamNotVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID))
-                   // ** THEN **
-                   .andExpect(status().isOk())
-                   .andExpect(jsonPath("$", Matchers.is(
-                       UsageReportMatcher
-                           .matchUsageReport(bitstreamNotVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID,
-                               TOTAL_VISITS_REPORT_ID, Arrays.asList(expectedPoint))))
-                             );
-
-        String tokenEPerson = getAuthToken(eperson.getEmail(), password);
         getClient(tokenEPerson).perform(
-                  get("/api/statistics/usagereports/" + bitstreamNotVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID))
-                 .andExpect(status().isNotFound());
+                get("/api/statistics/usagereports/" + bitstreamNotVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$",
+                        Matchers.is(UsageReportMatcher.matchUsageReport(
+                                bitstreamNotVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID, TOTAL_VISITS_REPORT_ID,
+                                Arrays.asList(expectedPoint)))));
 
-        getClient().perform(
-                    get("/api/statistics/usagereports/" + bitstreamNotVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID))
-                   .andExpect(status().isNotFound());
+      getClient().perform(
+                get("/api/statistics/usagereports/" + bitstreamNotVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$",
+                        Matchers.is(UsageReportMatcher.matchUsageReport(
+                                bitstreamNotVisited.getID() + "_" + TOTAL_VISITS_REPORT_ID, TOTAL_VISITS_REPORT_ID,
+                                Arrays.asList(expectedPoint)))));
     }
 
     @Test
@@ -520,6 +556,25 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         getClient().perform(
                  get("/api/statistics/usagereports/" + itemVisited.getID() + "_" + TOTAL_VISITS_PER_MONTH_REPORT_ID))
                 .andExpect(status().isUnauthorized());
+
+        // make statistics visible to all
+        configurationService.setProperty("usage-statistics.authorization.admin.usage", false);
+
+        getClient(loggedInToken).perform(
+                get("/api/statistics/usagereports/" + itemVisited.getID() + "_" + TOTAL_VISITS_PER_MONTH_REPORT_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$",
+                        Matchers.is(UsageReportMatcher.matchUsageReport(
+                                itemVisited.getID() + "_" + TOTAL_VISITS_PER_MONTH_REPORT_ID,
+                                TOTAL_VISITS_PER_MONTH_REPORT_ID, expectedPoints))));
+
+       getClient().perform(
+                get("/api/statistics/usagereports/" + itemVisited.getID() + "_" + TOTAL_VISITS_PER_MONTH_REPORT_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$",
+                        Matchers.is(UsageReportMatcher.matchUsageReport(
+                                itemVisited.getID() + "_" + TOTAL_VISITS_PER_MONTH_REPORT_ID,
+                                TOTAL_VISITS_PER_MONTH_REPORT_ID, expectedPoints))));
     }
 
     @Test
@@ -612,6 +667,26 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         getClient().perform(
                   get("/api/statistics/usagereports/" + bitstreamVisited.getID() + "_" + TOTAL_DOWNLOADS_REPORT_ID))
                  .andExpect(status().isUnauthorized());
+
+        // make statistics visible to all
+        configurationService.setProperty("usage-statistics.authorization.admin.usage", false);
+
+        // only admin has access to downloads report
+        getClient(loggedInToken).perform(
+                get("/api/statistics/usagereports/" + bitstreamVisited.getID() + "_" + TOTAL_DOWNLOADS_REPORT_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$",
+                        Matchers.is(UsageReportMatcher.matchUsageReport(
+                                bitstreamVisited.getID() + "_" + TOTAL_DOWNLOADS_REPORT_ID, TOTAL_DOWNLOADS_REPORT_ID,
+                                Arrays.asList(expectedPoint)))));
+
+        getClient().perform(
+                get("/api/statistics/usagereports/" + bitstreamVisited.getID() + "_" + TOTAL_DOWNLOADS_REPORT_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$",
+                        Matchers.is(UsageReportMatcher.matchUsageReport(
+                                bitstreamVisited.getID() + "_" + TOTAL_DOWNLOADS_REPORT_ID, TOTAL_DOWNLOADS_REPORT_ID,
+                                Arrays.asList(expectedPoint)))));
     }
 
     @Test
@@ -710,6 +785,25 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         getClient().perform(
                   get("/api/statistics/usagereports/" + collectionVisited.getID() + "_" + TOP_COUNTRIES_REPORT_ID))
                  .andExpect(status().isUnauthorized());
+
+        // make statistics visible to all
+        configurationService.setProperty("usage-statistics.authorization.admin.usage", false);
+
+        getClient(loggedInToken).perform(
+                get("/api/statistics/usagereports/" + collectionVisited.getID() + "_" + TOP_COUNTRIES_REPORT_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$",
+                        Matchers.is(UsageReportMatcher.matchUsageReport(
+                                collectionVisited.getID() + "_" + TOP_COUNTRIES_REPORT_ID, TOP_COUNTRIES_REPORT_ID,
+                                Arrays.asList(expectedPoint)))));
+
+      getClient().perform(
+                get("/api/statistics/usagereports/" + collectionVisited.getID() + "_" + TOP_COUNTRIES_REPORT_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$",
+                        Matchers.is(UsageReportMatcher.matchUsageReport(
+                                collectionVisited.getID() + "_" + TOP_COUNTRIES_REPORT_ID, TOP_COUNTRIES_REPORT_ID,
+                                Arrays.asList(expectedPoint)))));
     }
 
     /**
@@ -809,6 +903,25 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         getClient().perform(
                   get("/api/statistics/usagereports/" + itemVisited.getID() + "_" + TOP_CITIES_REPORT_ID))
                  .andExpect(status().isUnauthorized());
+
+        // make statistics visible to all
+        configurationService.setProperty("usage-statistics.authorization.admin.usage", false);
+
+        getClient(loggedInToken).perform(
+                get("/api/statistics/usagereports/" + itemVisited.getID() + "_" + TOP_CITIES_REPORT_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$",
+                        Matchers.is(
+                                UsageReportMatcher.matchUsageReport(itemVisited.getID() + "_" + TOP_CITIES_REPORT_ID,
+                                        TOP_CITIES_REPORT_ID, Arrays.asList(expectedPoint)))));
+
+        getClient().perform(
+                get("/api/statistics/usagereports/" + itemVisited.getID() + "_" + TOP_CITIES_REPORT_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$",
+                        Matchers.is(
+                                UsageReportMatcher.matchUsageReport(itemVisited.getID() + "_" + TOP_CITIES_REPORT_ID,
+                                        TOP_CITIES_REPORT_ID, Arrays.asList(expectedPoint)))));
     }
 
     /**
@@ -1072,7 +1185,6 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
     public void usageReportsSearch_Collection_NotVisited() throws Exception {
         // ** WHEN **
         // Collection is not visited
-try {
         UsageReportPointDsoTotalVisitsRest expectedPointTotalVisits = new UsageReportPointDsoTotalVisitsRest();
         expectedPointTotalVisits.addValue("views", 0);
         expectedPointTotalVisits.setType("collection");
@@ -1097,9 +1209,6 @@ try {
                     TOP_CITIES_REPORT_ID, new ArrayList<>()),
                 UsageReportMatcher.matchUsageReport(collectionNotVisited.getID() + "_" + TOP_COUNTRIES_REPORT_ID,
                     TOP_COUNTRIES_REPORT_ID, new ArrayList<>()))));
-        } finally {
-            System.out.println("");
-        }
     }
 
     @Test
@@ -1310,7 +1419,7 @@ try {
             } else {
                 expectedPoint.addValue("views", viewsLastMonth);
             }
-            String month = cal.getDisplayName(Calendar.MONTH, Calendar.LONG, Locale.getDefault());
+            String month = cal.getDisplayName(Calendar.MONTH, Calendar.LONG, new Locale("en"));
             expectedPoint.setId(month + " " + cal.get(Calendar.YEAR));
 
             expectedPoints.add(expectedPoint);

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/ViewUsageStatisticsFeatureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/ViewUsageStatisticsFeatureIT.java
@@ -44,6 +44,7 @@ import org.dspace.content.Item;
 import org.dspace.content.Site;
 import org.dspace.content.service.SiteService;
 import org.dspace.services.ConfigurationService;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -127,6 +128,13 @@ public class ViewUsageStatisticsFeatureIT extends AbstractControllerIntegrationT
         collectionARest = collectionConverter.convert(collectionA, Projection.DEFAULT);
         itemARest = itemConverter.convert(itemA, Projection.DEFAULT);
         bitstreamARest = bitstreamConverter.convert(bitstreamA, Projection.DEFAULT);
+        configurationService.setProperty("usage-statistics.authorization.admin.usage", true);
+    }
+
+    @After
+    public void tearDown()  {
+
+        configurationService.setProperty("usage-statistics.authorization.admin.usage", false);
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/ViewUsageStatisticsFeatureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/ViewUsageStatisticsFeatureIT.java
@@ -44,7 +44,6 @@ import org.dspace.content.Item;
 import org.dspace.content.Site;
 import org.dspace.content.service.SiteService;
 import org.dspace.services.ConfigurationService;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -129,12 +128,6 @@ public class ViewUsageStatisticsFeatureIT extends AbstractControllerIntegrationT
         itemARest = itemConverter.convert(itemA, Projection.DEFAULT);
         bitstreamARest = bitstreamConverter.convert(bitstreamA, Projection.DEFAULT);
         configurationService.setProperty("usage-statistics.authorization.admin.usage", true);
-    }
-
-    @After
-    public void tearDown()  {
-
-        configurationService.setProperty("usage-statistics.authorization.admin.usage", false);
     }
 
     @Test

--- a/dspace/config/modules/usage-statistics.cfg
+++ b/dspace/config/modules/usage-statistics.cfg
@@ -24,7 +24,7 @@ usage-statistics.resolver.timeout = 200
 # If disabled, anyone with READ permissions on the DSpaceObject will be able
 # to view the statistics.
 #View/download statistics
-usage-statistics.authorization.admin.usage=true
+usage-statistics.authorization.admin.usage=false
 #Search/search result statistics
 usage-statistics.authorization.admin.search=true
 #Workflow result statistics


### PR DESCRIPTION
## References

* Fixes #[1426](https://github.com/DSpace/dspace-angular/issues/1426)
* Related to angular PR [1479](https://github.com/DSpace/dspace-angular/pull/1479)


## Description
UsageReportRestPermissionEvaluatorPlugin has been updated. If usage-statistics.authorization.admin.usage property is set to 'true', user can access statistics via REST only if has admin privileges.

## Instructions for Reviewers


List of changes in this PR:
* UsageReportRestPermissionEvaluatorPlugin updated to check usage-statistics.authorization.admin.usage value while evaluating permissions
* Added test covering above change
* Change type of exceptions thrown in StatisticsRestRepository when dso is not found
* ViewViewUsageStatisticsFeature renamed to CanViewUsageStatisticsFeature

**Include guidance for how to test or review your PR.** 

This is the rest part for angular PR [1479](https://github.com/DSpace/dspace-angular/pull/1479)

## Checklist

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
