### PR TITLE
Increase test timeout for MetadataFieldPerformanceTest.testManyMetadataAdds()

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/MetadataValueServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/MetadataValueServiceImpl.java
@@ -55,6 +55,8 @@ public class MetadataValueServiceImpl implements MetadataValueService {
 //An update here isn't needed, this is persited upon the merge of the owning object
 //        metadataValueDAO.save(context, metadataValue);
         metadataValue = metadataValueDAO.create(context, metadataValue);
+        log.info(LogHelper.getHeader(context, "add_metadatavalue",
+                                     "metadata_value_id=" + metadataValue.getID()));
 
         return metadataValue;
     }

--- a/dspace-api/src/test/java/org/dspace/content/MetadataFieldPerformanceTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/MetadataFieldPerformanceTest.java
@@ -74,7 +74,7 @@ public class MetadataFieldPerformanceTest extends AbstractUnitTest {
 
         long duration = (endTime - startTime);
 
-        double maxDurationPerCall = .3;
+        double maxDurationPerCall = .4;
         double maxDuration = maxDurationPerCall * amount;
         //Duration is 1.542 without performance improvements
         //Duration is 0.0538 with performance improvements


### PR DESCRIPTION
## Description
As others have noticed, the `MetadataFieldPerformanceTest.testManyMetadataAdds()` test has been prone to random failures recently. It seems we are bumping up against the 0.3ms average time limit we've set for adds.

This is a tiny PR that only makes two changes:
* Increases that limit from 0.3ms to 0.4ms, as we are barely bumping up against that time limit.
* Ensures that metadata *adds* are also logged (in `MetadataValueServiceImpl`). We already log updates and deletes, but strangely adds are not logged.  This is not necessary for this PR (so if others disagree, I could remove it).  However, I felt this change could help us better debug why this time limit has increased by knowing _when_ adds occur...as currently they are not visible in logs.

NOTE: For what it's worth, it's good to see that the separate `MetadataFieldPerformanceTest.testManyQueries()` method is still passing its performance checks, as that's the more important performance test (as it verifies all the `findByElement()` metadata methods are super quick).  This `MetadataFieldPerformanceTest.testManyMetadataAdds()` is primarily testing when new metadata is created (which is less frequent & has a smaller performance impact).