### PR TITLE
Make IdentifierService code less "noisy" in the logs

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/DSpaceObjectServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/DSpaceObjectServiceImpl.java
@@ -95,20 +95,6 @@ public abstract class DSpaceObjectServiceImpl<T extends DSpaceObject> implements
             }
         }
 
-        if (log.isDebugEnabled()) {
-            StringBuilder dbgMsg = new StringBuilder();
-            for (String id : identifiers) {
-                if (dbgMsg.capacity() == 0) {
-                    dbgMsg.append("This DSO's Identifiers are: ");
-                } else {
-                    dbgMsg.append(", ");
-                }
-                dbgMsg.append(id);
-            }
-            dbgMsg.append(".");
-            log.debug(dbgMsg.toString());
-        }
-
         return identifiers;
     }
 

--- a/dspace-api/src/main/java/org/dspace/identifier/IdentifierServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/IdentifierServiceImpl.java
@@ -150,7 +150,6 @@ public class IdentifierServiceImpl implements IdentifierService {
                                  + "Identifier for " + contentServiceFactory.getDSpaceObjectService(dso)
                                                                             .getTypeText(dso) + ", "
                                  + dso.getID().toString() + ".");
-                    log.debug(ex.getMessage(), ex);
                 } catch (IdentifierException e) {
                     log.error(e.getMessage(), e);
                 }
@@ -181,7 +180,6 @@ public class IdentifierServiceImpl implements IdentifierService {
                              + "Identifier for " + contentServiceFactory.getDSpaceObjectService(dso)
                                                                         .getTypeText(dso) + ", "
                              + dso.getID().toString() + ".");
-                log.debug(ex.getMessage(), ex);
             } catch (IdentifierException ex) {
                 log.error(ex.getMessage(), ex);
             }
@@ -228,7 +226,6 @@ public class IdentifierServiceImpl implements IdentifierService {
                     log.info(service.getClass().getName() + " cannot resolve "
                                  + "Identifier " + identifier + ": identifier not "
                                  + "found.");
-                    log.debug(ex.getMessage(), ex);
                 } catch (IdentifierException ex) {
                     log.error(ex.getMessage(), ex);
                 }

--- a/dspace-api/src/main/java/org/dspace/identifier/IdentifierServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/IdentifierServiceImpl.java
@@ -151,7 +151,7 @@ public class IdentifierServiceImpl implements IdentifierService {
                                                                             .getTypeText(dso) + ", "
                                  + dso.getID().toString() + ".");
                 } catch (IdentifierException e) {
-                    log.error(e.getMessage(), e);
+                    log.error(e);
                 }
             }
         }
@@ -161,6 +161,8 @@ public class IdentifierServiceImpl implements IdentifierService {
     @Override
     public List<String> lookup(Context context, DSpaceObject dso) {
         List<String> identifiers = new ArrayList<>();
+        // Attempt to lookup DSO's identifiers using every available provider
+        // TODO: We may want to eventually limit providers based on DSO type, as not every provider supports every DSO
         for (IdentifierProvider service : providers) {
             try {
                 String result = service.lookup(context, dso);
@@ -176,12 +178,14 @@ public class IdentifierServiceImpl implements IdentifierService {
                     identifiers.add(result);
                 }
             } catch (IdentifierNotFoundException ex) {
-                log.info(service.getClass().getName() + " doesn't find an "
+                // This IdentifierNotFoundException is NOT logged by default, as some providers do not apply to
+                // every DSO (e.g. DOIs usually don't apply to EPerson objects). So it is expected some may fail lookup.
+                log.debug(service.getClass().getName() + " doesn't find an "
                              + "Identifier for " + contentServiceFactory.getDSpaceObjectService(dso)
                                                                         .getTypeText(dso) + ", "
                              + dso.getID().toString() + ".");
             } catch (IdentifierException ex) {
-                log.error(ex.getMessage(), ex);
+                log.error(ex);
             }
         }
 


### PR DESCRIPTION
## Description
In debugging test issues (like #8097), I've noticed that our IdentifierServices are very noisy in the logs (especially when debug mode is enabled), and often log repetitive information.

This PR makes things a lot less noisy by doing the following:
* Removes logging of identifiers from `DSpaceObjectServiceImpl`, as this is already done by the `identifierService.lookup()` method called earlier in that same method. There's no reason to log these identifiers twice.
* Removes `log.debug` of `IdentifierNotFoundException`s from `IdentifierServiceImpl.java`.  When those exceptions occur they are always logging the same information we already log via a `log.info` statement. The debug log provides no extra new information here.
* Updates `identifierService.lookup(Context context, DSpaceObject dso)` to no longer log `IdentifierNotFoundException`s as INFO, and instead make them DEBUG. This is because this method loops through every identifier provider (regardless of the DSO type) and this means `IdentifierNotFoundException` is often **expected behavior**.  For example, an EPerson object would almost never have a DOI, so there's no need to log that information as an INFO statement.
