### PR TITLE
Expose 'versioning.item.history.include.submitter' via configuration endpoint

### DIFF
--- a/dspace/config/modules/rest.cfg
+++ b/dspace/config/modules/rest.cfg
@@ -29,8 +29,10 @@ rest.projection.specificLevel.maxEmbed = 5
 # rest endpoint. If a rest request is made for a property which exists, but isn't listed here, the server will
 # respond that the property wasn't found. This property can be defined multiple times to allow access to multiple
 # configuration properties.
+# (Requires reboot of servlet container, e.g. Tomcat, to reload)
 rest.properties.exposed = plugin.named.org.dspace.curate.CurationTask
 rest.properties.exposed = google.analytics.key
+rest.properties.exposed = versioning.item.history.include.submitter
 
 #---------------------------------------------------------------#
 # These configs are used by the deprecated REST (v4-6) module   #

--- a/dspace/config/modules/versioning.cfg
+++ b/dspace/config/modules/versioning.cfg
@@ -12,9 +12,9 @@
 # If disabled anyone with READ permissions on the item will be able to view the versioning history
 versioning.item.history.view.admin=false
 
-# The property item.history.include.submitter controls whether the name of
-# the submitter of a version should be included in the version history of
-# an item.
+# Controls whether the name of the submitter of a version should be included in the version history of an item.
+# When true, the submitter name will be shown only if you have administrative privileges on the Item.
+# When false, the submitter name is never shown.
 versioning.item.history.include.submitter=false
 
 # If you want to allow submitters to create new versions of there items, set


### PR DESCRIPTION
## References
* Required by https://github.com/DSpace/dspace-angular/pull/1476

## Description
Ensures the `versioning.item.history.include.submitter` is available via our REST API configuration endpoint by default, which allows https://github.com/DSpace/dspace-angular/pull/1476 to work.