### PR TITLE
Log4j v2 : switch to %X{var} syntax instead of $${ctx:var}

### DIFF
--- a/dspace/config/log4j2.xml
+++ b/dspace/config/log4j2.xml
@@ -28,8 +28,10 @@
                   fileName='${log.dir}/dspace.log'
 
         >
+            <!-- NOTE: The %equals patterns are providing a default value of "unknown" if "correlationID" or
+                 "requestID" are not currently set in the ThreadContext. -->
             <Layout type='PatternLayout'
-                    pattern='%d %-5p $$$${ctx:correlationID:-unknown} $$$${ctx:requestID:-unknown} %c @ %m%n'/>
+                    pattern='%d %-5p %equals{%X{correlationID}}{}{unknown} %equals{%X{requestID}}{}{unknown} %c @ %m%n'/>
             <policies>
                 <policy type='TimeBasedTriggeringPolicy'>yyyy-MM-dd</policy>
                 <!-- Sample deletion policy:  keep last 30 archived files


### PR DESCRIPTION
## Description
During one of our recent log4j v2 security updates (I'm honestly not sure which one) on `main`, the Context map lookup syntax `$${ctx:variable}` stopped working.  In the DSpace logs on `main`, I see log lines that look like this...
```
2022-01-05 19:52:15,060 INFO  $${ctx:correlationID:-unknown} $${ctx:requestID:-unknown} org.dspace.app.rest.utils.DSpaceAPIRequestLoggingFilter @
 Before request [GET /server/api/authn/status] originated from /
```
(Notice that it is no longer translating the `$${ctx:correlationID}` or `$${ctx:requestID}` variables.)

To me, it appears that a recent change in log4j has broken the `$${ctx:*}` syntax we were using.


## Changes in this PR

This PR swaps us over to the `%X{variable}` syntax for Context Map lookups: https://logging.apache.org/log4j/2.x/manual/lookups.html

This syntax is similar to the old syntax, but the big difference is that you can no longer define a default value (if the Context Map variable is not found). Therefore, I've added an `%equals{pattern}{test}{substitution}`  clause to ensure the default value of "unknown" is written to logs when the variable cannot be found.  This was based on a suggestion in this StackOverflow answer: https://stackoverflow.com/a/51332271 

## Instructions for Reviewers
1. Spin up backend using `main` branch & verify that your `dspace.log` file has the literal strings `$${ctx:correlationID:-unknown} $${ctx:requestID:-unknown}` in each line of the logs
2. Then rebuild using this PR (or just replace your log4j2.xml with this one) and verify that the `dspace.log` lines are back to normal with UUIDs for the `correlationID` and `requestID` (or `unknown` where they are not specified).