### PR TITLE
Speed up IPMatcherTest (by testing fewer IPs) & enable rerun flakey tests in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,16 +20,18 @@ jobs:
       matrix:
         include:
           # NOTE: Unit Tests include deprecated REST API v6 (as it has unit tests)
+          #  - surefire.rerunFailingTestsCount => try again for flakey tests, and keep track of/report on number of retries
           - type: "Unit Tests"
-            mvnflags: "-DskipUnitTests=false -Pdspace-rest"
+            mvnflags: "-DskipUnitTests=false -Pdspace-rest -Dsurefire.rerunFailingTestsCount=2"
             resultsdir: "**/target/surefire-reports/**"
           # NOTE: ITs skip all code validation checks, as they are already done by Unit Test job.
           #  - enforcer.skip     => Skip maven-enforcer-plugin rules
           #  - checkstyle.skip   => Skip all checkstyle checks by maven-checkstyle-plugin
           #  - license.skip      => Skip all license header checks by license-maven-plugin
           #  - xml.skip          => Skip all XML/XSLT validation by xml-maven-plugin
+          #  - failsafe.rerunFailingTestsCount => try again for flakey tests, and keep track of/report on number of retries
           - type: "Integration Tests"
-            mvnflags: "-DskipIntegrationTests=false -Denforcer.skip=true -Dcheckstyle.skip=true -Dlicense.skip=true -Dxml.skip=true"
+            mvnflags: "-DskipIntegrationTests=false -Denforcer.skip=true -Dcheckstyle.skip=true -Dlicense.skip=true -Dxml.skip=true -Dfailsafe.rerunFailingTestsCount=2"
             resultsdir: "**/target/failsafe-reports/**"
       # Do NOT exit immediately if one matrix job fails
       # This ensures ITs continue running even if Unit Tests fail, or visa versa

--- a/dspace-api/src/test/java/org/dspace/authenticate/IPMatcherTest.java
+++ b/dspace-api/src/test/java/org/dspace/authenticate/IPMatcherTest.java
@@ -29,7 +29,7 @@ public class IPMatcherTest {
     private static final String IP6_FULL_ADDRESS2 = "2001:18e8:3:171:218:8bff:fe2a:56a3";
     private static final String IP6_MASKED_ADDRESS = "2001:18e8:3::/48";
 
-    private final static int increment = 6;
+    private final static int increment = 17;
 
     private static IPMatcher ip6FullMatcher;
     private static IPMatcher ip6MaskedMatcher;


### PR DESCRIPTION
## Description
This PR has two small fixes to our testing environment..

1. `IPMatcherTest` takes ~5mins to finish (on a good day), as it tests against a very larger number of IP addresses (approx 3.1 million, if my math is correct).  This simply changes the increment from 6 to 17, which decreases the number of checked IP addresses to about 50K (again if my math is correct).  This decreases the execution time to around 6 seconds
2. Set `rerunFailingTestsCount=2` for both Unit & Integration Tests.  This ensures that flakey tests will be run at least two more times before a failure is reported by our build process.