### PR TITLE
Add support for Java / JDK 17 (latest LTS release)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,11 +17,17 @@ jobs:
     strategy:
       # Create a matrix of two separate configurations for Unit vs Integration Tests
       # This will ensure those tasks are run in parallel
+      # Also ensure both are run for multiple versions of Java.
       matrix:
         include:
           # NOTE: Unit Tests include deprecated REST API v6 (as it has unit tests)
           #  - surefire.rerunFailingTestsCount => try again for flakey tests, and keep track of/report on number of retries
-          - type: "Unit Tests"
+          - type: "Unit Tests on Java 11"
+            java: 11
+            mvnflags: "-DskipUnitTests=false -Pdspace-rest -Dsurefire.rerunFailingTestsCount=2"
+            resultsdir: "**/target/surefire-reports/**"
+          - type: "Unit Tests on Java 17"
+            java: 17
             mvnflags: "-DskipUnitTests=false -Pdspace-rest -Dsurefire.rerunFailingTestsCount=2"
             resultsdir: "**/target/surefire-reports/**"
           # NOTE: ITs skip all code validation checks, as they are already done by Unit Test job.
@@ -30,7 +36,12 @@ jobs:
           #  - license.skip      => Skip all license header checks by license-maven-plugin
           #  - xml.skip          => Skip all XML/XSLT validation by xml-maven-plugin
           #  - failsafe.rerunFailingTestsCount => try again for flakey tests, and keep track of/report on number of retries
-          - type: "Integration Tests"
+          - type: "Integration Tests on Java 11"
+            java: 11
+            mvnflags: "-DskipIntegrationTests=false -Denforcer.skip=true -Dcheckstyle.skip=true -Dlicense.skip=true -Dxml.skip=true -Dfailsafe.rerunFailingTestsCount=2"
+            resultsdir: "**/target/failsafe-reports/**"
+          - type: "Integration Tests on Java 17"
+            java: 17
             mvnflags: "-DskipIntegrationTests=false -Denforcer.skip=true -Dcheckstyle.skip=true -Dlicense.skip=true -Dxml.skip=true -Dfailsafe.rerunFailingTestsCount=2"
             resultsdir: "**/target/failsafe-reports/**"
       # Do NOT exit immediately if one matrix job fails
@@ -43,10 +54,10 @@ jobs:
         uses: actions/checkout@v2
 
       # https://github.com/actions/setup-java
-      - name: Install JDK 11
+      - name: Install JDK ${{ matrix.java }}
         uses: actions/setup-java@v2
         with:
-          java-version: 11
+          java-version: ${{ matrix.java }}
           distribution: 'temurin'
 
       # https://github.com/actions/cache
@@ -73,7 +84,6 @@ jobs:
         with:
           name: ${{ matrix.type }} results
           path: ${{ matrix.resultsdir }}
-          retention-days: 7
 
       # https://github.com/codecov/codecov-action
       - name: Upload coverage to Codecov.io

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,17 +17,13 @@ jobs:
     strategy:
       # Create a matrix of two separate configurations for Unit vs Integration Tests
       # This will ensure those tasks are run in parallel
-      # Also ensure both are run for multiple versions of Java.
+      # Also specify version of Java to use (this can allow us to optionally run tests on multiple JDKs in future)
       matrix:
         include:
           # NOTE: Unit Tests include deprecated REST API v6 (as it has unit tests)
           #  - surefire.rerunFailingTestsCount => try again for flakey tests, and keep track of/report on number of retries
-          - type: "Unit Tests on Java 11"
+          - type: "Unit Tests"
             java: 11
-            mvnflags: "-DskipUnitTests=false -Pdspace-rest -Dsurefire.rerunFailingTestsCount=2"
-            resultsdir: "**/target/surefire-reports/**"
-          - type: "Unit Tests on Java 17"
-            java: 17
             mvnflags: "-DskipUnitTests=false -Pdspace-rest -Dsurefire.rerunFailingTestsCount=2"
             resultsdir: "**/target/surefire-reports/**"
           # NOTE: ITs skip all code validation checks, as they are already done by Unit Test job.
@@ -36,12 +32,8 @@ jobs:
           #  - license.skip      => Skip all license header checks by license-maven-plugin
           #  - xml.skip          => Skip all XML/XSLT validation by xml-maven-plugin
           #  - failsafe.rerunFailingTestsCount => try again for flakey tests, and keep track of/report on number of retries
-          - type: "Integration Tests on Java 11"
+          - type: "Integration Tests"
             java: 11
-            mvnflags: "-DskipIntegrationTests=false -Denforcer.skip=true -Dcheckstyle.skip=true -Dlicense.skip=true -Dxml.skip=true -Dfailsafe.rerunFailingTestsCount=2"
-            resultsdir: "**/target/failsafe-reports/**"
-          - type: "Integration Tests on Java 17"
-            java: 17
             mvnflags: "-DskipIntegrationTests=false -Denforcer.skip=true -Dcheckstyle.skip=true -Dlicense.skip=true -Dxml.skip=true -Dfailsafe.rerunFailingTestsCount=2"
             resultsdir: "**/target/failsafe-reports/**"
       # Do NOT exit immediately if one matrix job fails

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,7 @@ jobs:
       # Do NOT exit immediately if one matrix job fails
       # This ensures ITs continue running even if Unit Tests fail, or visa versa
       fail-fast: false
+    name: Run ${{ matrix.type }}
     # These are the actual CI steps to perform per job
     steps:
       # https://github.com/actions/checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 # This image will be published as dspace/dspace
 # See https://github.com/DSpace/DSpace/tree/main/dspace/src/main/docker for usage details
 #
-# This version is JDK11 compatible
-# - tomcat:9-jdk11
-# - ANT 1.10.12
-# - maven:3-jdk-11 (see dspace-dependencies)
 # - note: default tag for branch: dspace/dspace: dspace/dspace:dspace-7_x
+
+# This Dockerfile uses JDK11 by default, but has also been tested with JDK17.
+# To build with JDK17, use "--build-arg JDK_VERSION=17"
+ARG JDK_VERSION=11
 
 # Step 1 - Run Maven Build
 FROM dspace/dspace-dependencies:dspace-7_x as build
@@ -25,7 +25,7 @@ RUN mvn package && \
   mvn clean
 
 # Step 2 - Run Ant Deploy
-FROM tomcat:9-jdk11 as ant_build
+FROM openjdk:${JDK_VERSION}-slim as ant_build
 ARG TARGET_DIR=dspace-installer
 # COPY the /install directory from 'build' container to /dspace-src in this container
 COPY --from=build /install /dspace-src
@@ -34,6 +34,11 @@ WORKDIR /dspace-src
 ENV ANT_VERSION 1.10.12
 ENV ANT_HOME /tmp/ant-$ANT_VERSION
 ENV PATH $ANT_HOME/bin:$PATH
+# Need wget to install ant
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends wget \
+    && apt-get purge -y --auto-remove \
+    && rm -rf /var/lib/apt/lists/*
 # Download and install 'ant'
 RUN mkdir $ANT_HOME && \
     wget -qO- "https://archive.apache.org/dist/ant/binaries/apache-ant-$ANT_VERSION-bin.tar.gz" | tar -zx --strip-components=1 -C $ANT_HOME
@@ -42,7 +47,7 @@ RUN ant init_installation update_configs update_code update_webapps
 
 # Step 3 - Run tomcat
 # Create a new tomcat image that does not retain the the build directory contents
-FROM tomcat:9-jdk11
+FROM tomcat:9-jdk${JDK_VERSION}
 # NOTE: DSPACE_INSTALL must align with the "dspace.dir" default configuration.
 ENV DSPACE_INSTALL=/dspace
 # Copy the /dspace directory from 'ant_build' containger to /dspace in this container

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -1,11 +1,11 @@
 # This image will be published as dspace/dspace-cli
 # See https://github.com/DSpace/DSpace/tree/main/dspace/src/main/docker for usage details
 #
-# This version is JDK11 compatible
-# - openjdk:11
-# - ANT 1.10.12
-# - maven:3-jdk-11 (see dspace-dependencies)
 # - note: default tag for branch: dspace/dspace-cli: dspace/dspace-cli:dspace-7_x
+
+# This Dockerfile uses JDK11 by default, but has also been tested with JDK17.
+# To build with JDK17, use "--build-arg JDK_VERSION=17"
+ARG JDK_VERSION=11
 
 # Step 1 - Run Maven Build
 FROM dspace/dspace-dependencies:dspace-7_x as build
@@ -24,7 +24,7 @@ RUN mvn package && \
   mvn clean
 
 # Step 2 - Run Ant Deploy
-FROM openjdk:11 as ant_build
+FROM openjdk:${JDK_VERSION}-slim as ant_build
 ARG TARGET_DIR=dspace-installer
 # COPY the /install directory from 'build' container to /dspace-src in this container
 COPY --from=build /install /dspace-src
@@ -33,6 +33,11 @@ WORKDIR /dspace-src
 ENV ANT_VERSION 1.10.12
 ENV ANT_HOME /tmp/ant-$ANT_VERSION
 ENV PATH $ANT_HOME/bin:$PATH
+# Need wget to install ant
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends wget \
+    && apt-get purge -y --auto-remove \
+    && rm -rf /var/lib/apt/lists/*
 # Download and install 'ant'
 RUN mkdir $ANT_HOME && \
     wget -qO- "https://archive.apache.org/dist/ant/binaries/apache-ant-$ANT_VERSION-bin.tar.gz" | tar -zx --strip-components=1 -C $ANT_HOME
@@ -40,11 +45,10 @@ RUN mkdir $ANT_HOME && \
 RUN ant init_installation update_configs update_code
 
 # Step 3 - Run jdk
-# Create a new tomcat image that does not retain the the build directory contents
-FROM openjdk:11
+FROM openjdk:${JDK_VERSION}
 # NOTE: DSPACE_INSTALL must align with the "dspace.dir" default configuration.
 ENV DSPACE_INSTALL=/dspace
-# Copy the /dspace directory from 'ant_build' containger to /dspace in this container
+# Copy the /dspace directory from 'ant_build' container to /dspace in this container
 COPY --from=ant_build /dspace $DSPACE_INSTALL
 # Give java extra memory (1GB)
 ENV JAVA_OPTS=-Xmx1000m

--- a/Dockerfile.dependencies
+++ b/Dockerfile.dependencies
@@ -1,25 +1,34 @@
 # This image will be published as dspace/dspace-dependencies
 # The purpose of this image is to make the build for dspace/dspace run faster
 #
-# This version is JDK11 compatible
-# - maven:3-jdk-11
+
+# This Dockerfile uses JDK11 by default, but has also been tested with JDK17.
+# To build with JDK17, use "--build-arg JDK_VERSION=17"
+ARG JDK_VERSION=11
 
 # Step 1 - Run Maven Build
-FROM maven:3-jdk-11 as build
+FROM maven:3-openjdk-${JDK_VERSION}-slim as build
 ARG TARGET_DIR=dspace-installer
 WORKDIR /app
 # Create the 'dspace' user account & home directory
 RUN useradd dspace \
-    && mkdir /home/dspace \
+    && mkdir -p /home/dspace \
     && chown -Rv dspace: /home/dspace
 RUN chown -Rv dspace: /app
+# Need git to support buildnumber-maven-plugin, which lets us know what version of DSpace is being run.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git \
+    && apt-get purge -y --auto-remove \
+    && rm -rf /var/lib/apt/lists/*
+
+# Switch to dspace user & run below commands as that user
 USER dspace
 
 # Copy the DSpace source code (from local machine) into the workdir (excluding .dockerignore contents)
 ADD --chown=dspace . /app/
 
-# Trigger the installation of all maven dependencies
-RUN mvn package
+# Trigger the installation of all maven dependencies (hide download progress messages)
+RUN mvn --no-transfer-progress package
 
 # Clear the contents of the /app directory (including all maven builds), so no artifacts remain.
 # This ensures when dspace:dspace is built, it will use the Maven local cache (~/.m2) for dependencies

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,13 +1,13 @@
 # This image will be published as dspace/dspace
 # See https://github.com/DSpace/DSpace/tree/main/dspace/src/main/docker for usage details
 #
-# This version is JDK11 compatible
-# - tomcat:9-jdk11
-# - ANT 1.10.12
-# - maven:3-jdk-11 (see dspace-dependencies)
 # - note: default tag for branch: dspace/dspace: dspace/dspace:dspace-7_x-test
 #
 # This image is meant for TESTING/DEVELOPMENT ONLY as it deploys the old v6 REST API under HTTP (not HTTPS)
+
+# This Dockerfile uses JDK11 by default, but has also been tested with JDK17.
+# To build with JDK17, use "--build-arg JDK_VERSION=17"
+ARG JDK_VERSION=11
 
 # Step 1 - Run Maven Build
 FROM dspace/dspace-dependencies:dspace-7_x as build
@@ -27,7 +27,7 @@ RUN mvn package -Pdspace-rest && \
   mvn clean
 
 # Step 2 - Run Ant Deploy
-FROM tomcat:9-jdk11 as ant_build
+FROM openjdk:${JDK_VERSION}-slim as ant_build
 ARG TARGET_DIR=dspace-installer
 # COPY the /install directory from 'build' container to /dspace-src in this container
 COPY --from=build /install /dspace-src
@@ -36,6 +36,11 @@ WORKDIR /dspace-src
 ENV ANT_VERSION 1.10.12
 ENV ANT_HOME /tmp/ant-$ANT_VERSION
 ENV PATH $ANT_HOME/bin:$PATH
+# Need wget to install ant
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends wget \
+    && apt-get purge -y --auto-remove \
+    && rm -rf /var/lib/apt/lists/*
 # Download and install 'ant'
 RUN mkdir $ANT_HOME && \
     wget -qO- "https://archive.apache.org/dist/ant/binaries/apache-ant-$ANT_VERSION-bin.tar.gz" | tar -zx --strip-components=1 -C $ANT_HOME
@@ -44,7 +49,7 @@ RUN ant init_installation update_configs update_code update_webapps
 
 # Step 3 - Run tomcat
 # Create a new tomcat image that does not retain the the build directory contents
-FROM tomcat:9-jdk11
+FROM tomcat:9-jdk${JDK_VERSION}
 ENV DSPACE_INSTALL=/dspace
 ENV TOMCAT_INSTALL=/usr/local/tomcat
 # Copy the /dspace directory from 'ant_build' containger to /dspace in this container

--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -558,13 +558,6 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <!-- Different version provided by hibernate-ehcache -->
-                <exclusion>
-                    <groupId>net.bytebuddy</groupId>
-                    <artifactId>byte-buddy</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataWorkflow.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataWorkflow.java
@@ -13,6 +13,7 @@ import java.sql.SQLException;
 import java.text.ParseException;
 import java.time.LocalDate;
 import java.time.Period;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -158,8 +159,8 @@ public class StatisticsDataWorkflow extends StatisticsData {
     }
 
     private long getMonthsDifference(Date date1, Date date2) {
-        LocalDate earlier = LocalDate.from(date1.toInstant());
-        LocalDate later = LocalDate.from(date2.toInstant());
+        LocalDate earlier = LocalDate.ofInstant(date1.toInstant(), ZoneOffset.UTC);
+        LocalDate later = LocalDate.ofInstant(date2.toInstant(), ZoneOffset.UTC);
         return Period.between(earlier, later).toTotalMonths();
     }
 

--- a/dspace-sword/src/main/java/org/purl/sword/client/CmdClient.java
+++ b/dspace-sword/src/main/java/org/purl/sword/client/CmdClient.java
@@ -161,7 +161,7 @@ public class CmdClient implements ClientType {
                     for (Iterator i = acceptsPackaging.iterator(); i.hasNext(); ) {
                         SwordAcceptPackaging accept = (SwordAcceptPackaging) i.next();
                         acceptPackagingList.append(accept.getContent()).append(" (").append(accept.getQualityValue())
-                                           .append("), ").toString();
+                                           .append("), ");
                     }
 
                     System.out.println("Accepts Packaging: " + acceptPackagingList.toString());

--- a/dspace/src/main/docker-compose/README.md
+++ b/dspace/src/main/docker-compose/README.md
@@ -36,6 +36,12 @@ docker-compose -f docker-compose.yml -f docker-compose-cli.yml pull
 docker-compose -f docker-compose.yml -f docker-compose-cli.yml build
 ```
 
+OPTIONALLY, you can build DSpace images using a different JDK_VERSION like this:
+```
+docker-compose -f docker-compose.yml -f docker-compose-cli.yml build --build-arg JDK_VERSION=17
+```
+Default is Java 11, but other LTS releases (e.g. 17) are also supported.
+
 ## Run DSpace 7 REST from your current branch
 ```
 docker-compose -p d7 up -d

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <solr.client.version>8.8.1</solr.client.version>
 
         <axiom.version>1.2.22</axiom.version>
-        <errorprone.version>2.3.4</errorprone.version>
+        <errorprone.version>2.10.0</errorprone.version>
         <!-- NOTE: when updating jackson.version, also sync jackson-databind dependency below -->
         <jackson.version>2.12.3</jackson.version>
         <javax-annotation.version>1.3.2</javax-annotation.version>
@@ -140,10 +140,21 @@
                     <version>3.8.1</version>
                     <configuration>
                         <release>11</release>
-                        <!-- Turn on http://errorprone.info -->
+                        <!-- Turn on http://errorprone.info (requires fork=true & below compilerArgs)-->
+                        <fork>true</fork>
                         <compilerArgs>
                             <arg>-XDcompilePolicy=simple</arg>
                             <arg>-Xplugin:ErrorProne</arg>
+                            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+                            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+                            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+                            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+                            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+                            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+                            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+                            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+                            <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+                            <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
                         </compilerArgs>
                         <annotationProcessorPaths>
                             <path>
@@ -1642,7 +1653,7 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-inline</artifactId>
-                <version>3.8.0</version>
+                <version>3.12.4</version>
                 <scope>test</scope>
             </dependency>
             <!-- H2 is an in-memory database used for Unit/Integration tests -->
@@ -1756,6 +1767,13 @@
                 <groupId>javax.annotation</groupId>
                 <artifactId>javax.annotation-api</artifactId>
                 <version>${javax-annotation.version}</version>
+            </dependency>
+            <!-- mockito-inline and hibernate-ehcache pull in different versions of byte-buddy. Specify which we want. -->
+            <!-- TODO: We might be able to remove this after hibernate-ehcache is replaced by hibernate-jcache -->
+            <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy</artifactId>
+                <version>1.11.13</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Description
Recently on the [dspace-community list it was noted that DSpace 7 doesn't compile with JDK 17](https://groups.google.com/g/dspace-community/c/MZmu3FnZCuA/m/W9PsyXc_BAAJ) (latest [LTS release](https://www.oracle.com/java/technologies/java-se-support-roadmap.html)). 

This PR fixes those compilation issues by updating the following:
* Upgrades us to latest version of `errorprone` which is compatible with JDK 17
    * Also some minor code fixes to resolve new errorprone errors reported after this upgrade. See 52a8edc7d62fb5ef8a2186144573338c73d02277
* Upgrades us to more recent version of `mockito-inline` to ensure it is also compatible with JDK 17
* ~~Updates our CI build/test process to run our tests BOTH for JDK 11 and JDK 17  (_Optionally, we could remove this as needed, but I added it to prove that the tests work for both JDK 11 and 17._)~~ Reverted this, we still only run tests for JDK11 at this time, however kept the CI build process changes to allow us to support multiple JDKs easily, if we desired to in the future
* Updates Dockerfiles to support either JDK11 (default) or JDK17.  To run JDK17 with Docker images, you must pass this build arg: `docker-compose -f docker-compose.yml -f docker-compose-cli.yml build --build-arg JDK_VERSION=17`

~~**I have NOT fully tested all functionality with JDK 17 at this time.**  This PR simply ensures everything compiles and passes all tests.~~ UPDATE: I've been testing this locally and have not seen any issues so far.

However, since all tests pass (including integration tests), this implies that DSpace 7 _likely should work with JDK 17_ (but additional testing/verification should be done before we add JDK 17 to our list of supported Java versions.