### PR TITLE
Ensure SubmissionService doesn't swallow root exceptions

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/SubmissionService.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/SubmissionService.java
@@ -250,7 +250,7 @@ public class SubmissionService {
             id = Integer.parseInt(split[1]);
             wsi = workspaceItemService.find(context, id);
         } catch (NumberFormatException e) {
-            throw new UnprocessableEntityException("The provided workspaceitem URI is not valid");
+            throw new UnprocessableEntityException("The provided workspaceitem URI is not valid", e);
         }
         if (wsi == null) {
             throw new UnprocessableEntityException("Workspace item is not found");
@@ -265,7 +265,7 @@ public class SubmissionService {
             wi = workflowService.start(context, wsi);
         } catch (IOException e) {
             throw new RuntimeException("The workflow could not be started for workspaceItem with" +
-                                               "id:  " + id);
+                                               "id:  " + id, e);
         }
 
         return wi;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/SubmissionService.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/SubmissionService.java
@@ -265,7 +265,7 @@ public class SubmissionService {
             wi = workflowService.start(context, wsi);
         } catch (IOException e) {
             throw new RuntimeException("The workflow could not be started for workspaceItem with" +
-                                               "id:  " + id, e);
+                                               " id:  " + id, e);
         }
 
         return wi;


### PR DESCRIPTION
## Description
This PR is the result of this thread on dspace-tech: https://groups.google.com/g/dspace-tech/c/Z10Z4IIfqho/m/qjrMIylHBgAJ

Simply put, the `SubmissionService` is accidentally swallowing/discarding the root exception of some errors. This tiny PR fixes that.
