### PR TITLE
Fix OAI cli commands by replacing autowired with servicefactory call

### DIFF
--- a/dspace-oai/src/main/java/org/dspace/xoai/services/impl/solr/DSpaceSolrServerResolver.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/impl/solr/DSpaceSolrServerResolver.java
@@ -7,14 +7,13 @@
  */
 package org.dspace.xoai.services.impl.solr;
 
-import javax.inject.Named;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.dspace.service.impl.HttpConnectionPoolService;
+import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.xoai.services.api.config.ConfigurationService;
 import org.dspace.xoai.services.api.solr.SolrServerResolver;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,13 +25,15 @@ public class DSpaceSolrServerResolver implements SolrServerResolver {
     @Autowired
     private ConfigurationService configurationService;
 
-    @Autowired @Named("solrHttpConnectionPoolService")
-    private HttpConnectionPoolService httpConnectionPoolService;
-
     @Override
     public SolrClient getServer() throws SolrServerException {
         if (server == null) {
             String serverUrl = configurationService.getProperty("oai.solr.url");
+            HttpConnectionPoolService httpConnectionPoolService
+                = DSpaceServicesFactory.getInstance()
+                                       .getServiceManager()
+                                       .getServiceByName("solrHttpConnectionPoolService",
+                                                         HttpConnectionPoolService.class);
             try {
                 server = new HttpSolrClient.Builder(serverUrl)
                         .withHttpClient(httpConnectionPoolService.getClient())


### PR DESCRIPTION
## Description
PR #7987 accidentally broke OAI's commandline tools (e.g. `./dspace oai import`) because in the modifications to `DSpaceSolrServerResolver` in that PR, `@Autowired` was accidentally used.  

Unfortunately `dspace-oai` at this time is unable to autowire classes from `dspace-api`.  Instead, it must use a `ServiceFactory` class.  In that same PR, a different `dspace-oai` class `DSpaceSolrServer` had the correct approach and works fine.

This tiny PR just fixes `DSpaceSolrServerResolver` to use the same approach as `DSpaceSolrServer`.  This fixes the `./dspace oai import` (and similar) command.

**NOTE: Once GitHub CI approves this PR, this should be merged it immediately** as this error is currently blocking `dspace-angular` PRs from passing all e2e/integration tests. This is because dspace-angular e2e tests use a REST API spun up in Docker which happens to call `./dspace oai import` as part of its initialization process.  This results in the entire CI process failing, e.g. https://github.com/DSpace/dspace-angular/runs/4793658213?check_suite_focus=true#step:12:308