### PR TITLE
File downloads don't close inputstreams when cached fix

### DIFF
--- a/dspace-api/src/main/java/org/dspace/curate/CitationPage.java
+++ b/dspace-api/src/main/java/org/dspace/curate/CitationPage.java
@@ -154,7 +154,7 @@ public class CitationPage extends AbstractCurationTask {
                     try {
                         //Create the cited document
                         InputStream citedInputStream =
-                            citationDocument.getCitedDocument(Curator.curationContext(), bitstream);
+                            citationDocument.makeCitedDocument(Curator.curationContext(), bitstream).getLeft();
                         //Add the cited document to the approiate bundle
                         this.addCitedPageToItem(citedInputStream, bundle, pBundle,
                                                 dBundle, displayMap, item, bitstream);

--- a/dspace-api/src/main/java/org/dspace/curate/CitationPage.java
+++ b/dspace-api/src/main/java/org/dspace/curate/CitationPage.java
@@ -15,7 +15,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Bitstream;
@@ -154,10 +153,10 @@ public class CitationPage extends AbstractCurationTask {
                                                + bitstream.getName() + " is citable.");
                     try {
                         //Create the cited document
-                        Pair<InputStream, Long> citedDocument =
-                            citationDocument.makeCitedDocument(Curator.curationContext(), bitstream);
+                        InputStream citedInputStream =
+                            citationDocument.getCitedDocument(Curator.curationContext(), bitstream);
                         //Add the cited document to the approiate bundle
-                        this.addCitedPageToItem(citedDocument.getLeft(), bundle, pBundle,
+                        this.addCitedPageToItem(citedInputStream, bundle, pBundle,
                                                 dBundle, displayMap, item, bitstream);
                     } catch (Exception e) {
                         //Could be many things, but nothing that should be

--- a/dspace-api/src/main/java/org/dspace/disseminate/CitationDocumentServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/disseminate/CitationDocumentServiceImpl.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.pdfbox.pdmodel.PDDocument;
@@ -296,33 +297,30 @@ public class CitationDocumentServiceImpl implements CitationDocumentService, Ini
     }
 
     @Override
-    public InputStream getCitedDocument(Context context, Bitstream bitstream)
-        throws SQLException, AuthorizeException, IOException {
-        byte [] citedDocumentContent = getCitedDocumentContent(context, bitstream);
-        return new ByteArrayInputStream(citedDocumentContent);
-    }
-
-    @Override
-    public Long getCitedDocumentLength(Context context, Bitstream bitstream)
-        throws SQLException, AuthorizeException, IOException {
-        byte[] citedDocumentContent = getCitedDocumentContent(context, bitstream);
-        return Long.valueOf(citedDocumentContent.length);
-    }
-
-    private byte[] getCitedDocumentContent(Context context, Bitstream bitstream)
-        throws SQLException, AuthorizeException, IOException {
+    public Pair<InputStream, Long> makeCitedDocument(Context context, Bitstream bitstream)
+            throws IOException, SQLException, AuthorizeException {
         PDDocument document = new PDDocument();
         PDDocument sourceDocument = new PDDocument();
         try {
             Item item = (Item) bitstreamService.getParentObject(context, bitstream);
-            sourceDocument = sourceDocument.load(bitstreamService.retrieve(context, bitstream));
+            final InputStream inputStream = bitstreamService.retrieve(context, bitstream);
+            try {
+                sourceDocument = sourceDocument.load(inputStream);
+            } finally {
+                inputStream.close();
+            }
             PDPage coverPage = new PDPage(citationPageFormat);
             generateCoverPage(context, document, coverPage, item);
             addCoverPageToDocument(document, sourceDocument, coverPage);
+
+            //We already have the full PDF in memory, so keep it there
             try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
                 document.save(out);
-                return out.toByteArray();
+
+                byte[] data = out.toByteArray();
+                return Pair.of(new ByteArrayInputStream(data), Long.valueOf(data.length));
             }
+
         } finally {
             sourceDocument.close();
             document.close();

--- a/dspace-api/src/main/java/org/dspace/disseminate/service/CitationDocumentService.java
+++ b/dspace-api/src/main/java/org/dspace/disseminate/service/CitationDocumentService.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.sql.SQLException;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
 import org.apache.pdfbox.pdmodel.font.PDFont;
@@ -83,12 +84,8 @@ public interface CitationDocumentService {
      * @throws SQLException       if database error
      * @throws AuthorizeException if authorization error
      */
-    public InputStream getCitedDocument(Context context, Bitstream bitstream)
-        throws SQLException, AuthorizeException, IOException;
-
-    public Long getCitedDocumentLength(Context context, Bitstream bitstream)
-        throws SQLException, AuthorizeException, IOException;
-
+    public Pair<InputStream, Long> makeCitedDocument(Context context, Bitstream bitstream)
+            throws IOException, SQLException, AuthorizeException;
 
     /**
      * @param page          page

--- a/dspace-api/src/main/java/org/dspace/disseminate/service/CitationDocumentService.java
+++ b/dspace-api/src/main/java/org/dspace/disseminate/service/CitationDocumentService.java
@@ -11,7 +11,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.sql.SQLException;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
 import org.apache.pdfbox.pdmodel.font.PDFont;
@@ -84,8 +83,12 @@ public interface CitationDocumentService {
      * @throws SQLException       if database error
      * @throws AuthorizeException if authorization error
      */
-    public Pair<InputStream, Long> makeCitedDocument(Context context, Bitstream bitstream)
-            throws IOException, SQLException, AuthorizeException;
+    public InputStream getCitedDocument(Context context, Bitstream bitstream)
+        throws SQLException, AuthorizeException, IOException;
+
+    public Long getCitedDocumentLength(Context context, Bitstream bitstream)
+        throws SQLException, AuthorizeException, IOException;
+
 
     /**
      * @param page          page

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
@@ -12,7 +12,6 @@ import static org.dspace.app.rest.utils.RegexUtils.REGEX_REQUESTMAPPING_IDENTIFI
 import static org.springframework.web.bind.annotation.RequestMethod.PUT;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.UUID;
@@ -22,7 +21,6 @@ import javax.ws.rs.core.Response;
 
 import org.apache.catalina.connector.ClientAbortException;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.converter.ConverterService;
 import org.dspace.app.rest.exception.DSpaceBadRequestException;
@@ -38,6 +36,7 @@ import org.dspace.content.service.BitstreamFormatService;
 import org.dspace.content.service.BitstreamService;
 import org.dspace.core.Context;
 import org.dspace.disseminate.service.CitationDocumentService;
+import org.dspace.eperson.EPerson;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.EventService;
 import org.dspace.usage.UsageEvent;
@@ -109,6 +108,11 @@ public class BitstreamRestController {
 
         Bitstream bit = bitstreamService.find(context, uuid);
         if (bit == null) {
+            throw new ResourceNotFoundException();
+        }
+        EPerson currentUser = context.getCurrentUser();
+
+        if (bit == null) {
             response.sendError(HttpServletResponse.SC_NOT_FOUND);
             return null;
         }
@@ -117,8 +121,6 @@ public class BitstreamRestController {
         BitstreamFormat format = bit.getFormat(context);
         String mimetype = format.getMIMEType();
         String name = getBitstreamName(bit, format);
-
-        Pair<InputStream, Long> bitstreamTuple = getBitstreamInputStreamAndSize(context, bit);
 
         if (StringUtils.isBlank(request.getHeader("Range"))) {
             //We only log a download request when serving a request without Range header. This is because
@@ -131,18 +133,15 @@ public class BitstreamRestController {
                     bit));
         }
 
-        // Pipe the bits
-        InputStream is = bitstreamTuple.getLeft();
         try {
-            HttpHeadersInitializer httpHeadersInitializer = HttpHeadersInitializer
-                    .fromInputStream(is)
-                    .withBufferSize(BUFFER_SIZE)
-                    .withFileName(name)
-                    .withLength(bitstreamTuple.getRight())
-                    .withChecksum(bit.getChecksum())
-                    .withMimetype(mimetype)
-                    .with(request)
-                    .with(response);
+            HttpHeadersInitializer httpHeadersInitializer = new HttpHeadersInitializer()
+                .withBufferSize(BUFFER_SIZE)
+                .withFileName(name)
+                .withLength(bit.getSizeBytes())
+                .withChecksum(bit.getChecksum())
+                .withMimetype(mimetype)
+                .with(request)
+                .with(response);
 
             if (lastModified != null) {
                 httpHeadersInitializer.withLastModified(lastModified);
@@ -150,13 +149,21 @@ public class BitstreamRestController {
 
             //Determine if we need to send the file as a download or if the browser can open it inline
             long dispositionThreshold = configurationService.getLongProperty("webui.content_disposition_threshold");
-            if (dispositionThreshold >= 0 && bitstreamTuple.getRight() > dispositionThreshold) {
+            if (dispositionThreshold >= 0 && bit.getSizeBytes() > dispositionThreshold) {
                 httpHeadersInitializer.withDisposition(HttpHeadersInitializer.CONTENT_DISPOSITION_ATTACHMENT);
+            }
+
+            long filesize;
+            if (citationDocumentService.isCitationEnabledForBitstream(bit, context)) {
+                filesize = citationDocumentService.getCitedDocumentLength(context, bit);
+            } else {
+                filesize = bit.getSizeBytes();
             }
 
 
             org.dspace.app.rest.utils.BitstreamResource bitstreamResource =
-                new org.dspace.app.rest.utils.BitstreamResource(is, name, uuid, bit.getSizeBytes());
+                new org.dspace.app.rest.utils.BitstreamResource(
+                    bit, name, uuid, filesize, currentUser != null ? currentUser.getID() : null);
 
             //We have all the data we need, close the connection to the database so that it doesn't stay open during
             //download/streaming
@@ -171,32 +178,10 @@ public class BitstreamRestController {
         } catch (ClientAbortException ex) {
             log.debug("Client aborted the request before the download was completed. " +
                           "Client is probably switching to a Range request.", ex);
+        } catch (Exception e) {
+            throw e;
         }
         return null;
-    }
-
-    private Pair<InputStream, Long> getBitstreamInputStreamAndSize(Context context, Bitstream bit)
-        throws SQLException, IOException, AuthorizeException {
-
-        if (citationDocumentService.isCitationEnabledForBitstream(bit, context)) {
-            return generateBitstreamWithCitation(context, bit);
-        } else {
-            return Pair.of(bitstreamService.retrieve(context, bit),bit.getSizeBytes());
-        }
-    }
-
-    private Pair<InputStream, Long> generateBitstreamWithCitation(Context context, Bitstream bitstream)
-        throws SQLException, IOException, AuthorizeException {
-        //Create the cited document
-        Pair<InputStream, Long> citationDocument = citationDocumentService.makeCitedDocument(context, bitstream);
-        if (citationDocument.getLeft() == null) {
-            log.error("CitedDocument was null");
-        } else {
-            if (log.isDebugEnabled()) {
-                log.debug("CitedDocument was ok, has size " + citationDocument.getRight());
-            }
-        }
-        return citationDocument;
     }
 
     private String getBitstreamName(Bitstream bit, BitstreamFormat format) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
@@ -12,6 +12,7 @@ import static org.dspace.app.rest.utils.RegexUtils.REGEX_REQUESTMAPPING_IDENTIFI
 import static org.springframework.web.bind.annotation.RequestMethod.PUT;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.UUID;
@@ -21,6 +22,7 @@ import javax.ws.rs.core.Response;
 
 import org.apache.catalina.connector.ClientAbortException;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.converter.ConverterService;
 import org.dspace.app.rest.exception.DSpaceBadRequestException;
@@ -133,7 +135,9 @@ public class BitstreamRestController {
         try {
             long filesize;
             if (citationDocumentService.isCitationEnabledForBitstream(bit, context)) {
-                filesize = citationDocumentService.getCitedDocumentLength(context, bit);
+                final Pair<InputStream, Long> citedDocument = citationDocumentService.makeCitedDocument(context, bit);
+                filesize = citedDocument.getRight();
+                citedDocument.getLeft().close();
             } else {
                 filesize = bit.getSizeBytes();
             }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
@@ -134,10 +134,17 @@ public class BitstreamRestController {
         }
 
         try {
+            long filesize;
+            if (citationDocumentService.isCitationEnabledForBitstream(bit, context)) {
+                filesize = citationDocumentService.getCitedDocumentLength(context, bit);
+            } else {
+                filesize = bit.getSizeBytes();
+            }
+
             HttpHeadersInitializer httpHeadersInitializer = new HttpHeadersInitializer()
                 .withBufferSize(BUFFER_SIZE)
                 .withFileName(name)
-                .withLength(bit.getSizeBytes())
+                .withLength(filesize)
                 .withChecksum(bit.getChecksum())
                 .withMimetype(mimetype)
                 .with(request)
@@ -149,16 +156,10 @@ public class BitstreamRestController {
 
             //Determine if we need to send the file as a download or if the browser can open it inline
             long dispositionThreshold = configurationService.getLongProperty("webui.content_disposition_threshold");
-            if (dispositionThreshold >= 0 && bit.getSizeBytes() > dispositionThreshold) {
+            if (dispositionThreshold >= 0 && filesize > dispositionThreshold) {
                 httpHeadersInitializer.withDisposition(HttpHeadersInitializer.CONTENT_DISPOSITION_ATTACHMENT);
             }
 
-            long filesize;
-            if (citationDocumentService.isCitationEnabledForBitstream(bit, context)) {
-                filesize = citationDocumentService.getCitedDocumentLength(context, bit);
-            } else {
-                filesize = bit.getSizeBytes();
-            }
 
 
             org.dspace.app.rest.utils.BitstreamResource bitstreamResource =

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
@@ -107,9 +107,6 @@ public class BitstreamRestController {
         Context context = ContextUtil.obtainContext(request);
 
         Bitstream bit = bitstreamService.find(context, uuid);
-        if (bit == null) {
-            throw new ResourceNotFoundException();
-        }
         EPerson currentUser = context.getCurrentUser();
 
         if (bit == null) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/SitemapRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/SitemapRestController.java
@@ -117,8 +117,7 @@ public class SitemapRestController {
                                              HttpServletRequest request) throws SQLException, IOException {
         // Pipe the bits
         try (InputStream is = new FileInputStream(foundSitemapFile)) {
-            HttpHeadersInitializer sender = HttpHeadersInitializer
-                .fromInputStream(is)
+            HttpHeadersInitializer sender = new HttpHeadersInitializer()
                 .withBufferSize(BUFFER_SIZE)
                 .withFileName(foundSitemapFile.getName())
                 .withLength(foundSitemapFile.length())

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/BitstreamResource.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/BitstreamResource.java
@@ -66,7 +66,7 @@ public class BitstreamResource extends AbstractResource {
             InputStream out;
 
             if (citationDocumentService.isCitationEnabledForBitstream(bitstream, context)) {
-                out = citationDocumentService.getCitedDocument(context, bitstream);
+                out = citationDocumentService.makeCitedDocument(context, bitstream).getLeft();
             } else {
                 out = bitstreamService.retrieve(context, bitstream);
             }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/BitstreamResource.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/BitstreamResource.java
@@ -9,8 +9,19 @@ package org.dspace.app.rest.utils;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.sql.SQLException;
 import java.util.UUID;
 
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.content.Bitstream;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.BitstreamService;
+import org.dspace.core.Context;
+import org.dspace.disseminate.service.CitationDocumentService;
+import org.dspace.eperson.EPerson;
+import org.dspace.eperson.factory.EPersonServiceFactory;
+import org.dspace.eperson.service.EPersonService;
+import org.dspace.utils.DSpace;
 import org.springframework.core.io.AbstractResource;
 
 /**
@@ -21,16 +32,24 @@ import org.springframework.core.io.AbstractResource;
  */
 public class BitstreamResource extends AbstractResource {
 
-    private InputStream inputStream;
+    private Bitstream bitstream;
     private String name;
     private UUID uuid;
     private long sizeBytes;
+    private UUID currentUserUUID;
 
-    public BitstreamResource(InputStream inputStream, String name, UUID uuid, long sizeBytes) {
-        this.inputStream = inputStream;
+    private BitstreamService bitstreamService = ContentServiceFactory.getInstance().getBitstreamService();
+    private EPersonService ePersonService = EPersonServiceFactory.getInstance().getEPersonService();
+    private CitationDocumentService citationDocumentService =
+        new DSpace().getServiceManager()
+            .getServicesByType(CitationDocumentService.class).get(0);
+
+    public BitstreamResource(Bitstream bitstream, String name, UUID uuid, long sizeBytes, UUID currentUserUUID) {
+        this.bitstream = bitstream;
         this.name = name;
         this.uuid = uuid;
         this.sizeBytes = sizeBytes;
+        this.currentUserUUID = currentUserUUID;
     }
 
     @Override
@@ -40,7 +59,28 @@ public class BitstreamResource extends AbstractResource {
 
     @Override
     public InputStream getInputStream() throws IOException {
-        return inputStream;
+        Context context = new Context();
+        try {
+            EPerson currentUser = ePersonService.find(context, currentUserUUID);
+            context.setCurrentUser(currentUser);
+            InputStream out;
+
+            if (citationDocumentService.isCitationEnabledForBitstream(bitstream, context)) {
+                out = citationDocumentService.getCitedDocument(context, bitstream);
+            } else {
+                out = bitstreamService.retrieve(context, bitstream);
+            }
+
+            return out;
+        } catch (SQLException | AuthorizeException e) {
+            throw new IOException(e);
+        } finally {
+            try {
+                context.complete();
+            } catch (SQLException e) {
+                throw new IOException(e);
+            }
+        }
     }
 
     @Override

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/HttpHeadersInitializer.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/HttpHeadersInitializer.java
@@ -10,9 +10,7 @@ package org.dspace.app.rest.utils;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 
-import java.io.BufferedInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Collections;
 import javax.servlet.http.HttpServletRequest;
@@ -64,7 +62,6 @@ public class HttpHeadersInitializer {
     //no-cache so request is always performed for logging
     private static final String CACHE_CONTROL_SETTING = "private,no-cache";
 
-    private BufferedInputStream inputStream;
     private HttpServletRequest request;
     private HttpServletResponse response;
     private String contentType;
@@ -74,14 +71,8 @@ public class HttpHeadersInitializer {
     private String fileName;
     private String checksum;
 
-    public HttpHeadersInitializer(final InputStream inputStream) {
+    public HttpHeadersInitializer() {
         //Convert to BufferedInputStream so we can re-read the stream
-        this.inputStream = new BufferedInputStream(inputStream);
-    }
-
-
-    public static HttpHeadersInitializer fromInputStream(InputStream inputStream) {
-        return new HttpHeadersInitializer(inputStream);
     }
 
     public HttpHeadersInitializer with(HttpServletRequest httpRequest) {
@@ -195,12 +186,6 @@ public class HttpHeadersInitializer {
      */
     public boolean isValid() throws IOException {
         if (response == null || request == null) {
-            return false;
-        }
-
-        if (inputStream == null) {
-            log.error("Input stream has no content");
-            response.sendError(HttpServletResponse.SC_NOT_FOUND);
             return false;
         }
 


### PR DESCRIPTION
## References
* Fixes #8078

## Description
We changed it so that the BitstreamResource doesn't open up an inputstream that would potentially not be closed IF the response was cached by spring.

## Instructions for Reviewers
The easiest way to test would be with an S3 assetstore, push a few files there & download them in quick succession. After a while the S3 connections will be used up & the file download won't work anymore.


## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
