### PR TITLE
Minor dispatcher fix for bitstreams that have no parent

### DIFF
--- a/dspace-api/src/main/java/org/dspace/iiif/IIIFCacheEventConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/iiif/IIIFCacheEventConsumer.java
@@ -74,7 +74,8 @@ public class IIIFCacheEventConsumer implements Consumer {
                 clearAll = true;
             }
 
-            if ((et == Event.ADD || et == Event.MODIFY_METADATA  ) && subject != null) {
+            if ((et == Event.ADD || et == Event.MODIFY_METADATA  ) && subject != null
+                && ((Bitstream) subject).getBundles().size() > 0) {
                 // set subject to be the parent Item.
                 Bundle bundle = ((Bitstream) subject).getBundles().get(0);
                 subject = bundle.getItems().get(0);


### PR DESCRIPTION
## References
* Fixes a dispatcher issue discovered during review of #8076


## Description
Prevents an index out of bounds error caused by bitstreams that have no parent. 


## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
