### PR TITLE
Refactor QDCCrosswalkTest to avoid config errors

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/QDCCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/QDCCrosswalk.java
@@ -129,7 +129,7 @@ public class QDCCrosswalk extends SelfNamedPlugin
 
     protected ItemService itemService = ContentServiceFactory.getInstance().getItemService();
 
-    protected static final ConfigurationService configurationService
+    protected final ConfigurationService configurationService
             = DSpaceServicesFactory.getInstance().getConfigurationService();
 
     private final CrosswalkMetadataValidator metadataValidator = new CrosswalkMetadataValidator();
@@ -141,9 +141,17 @@ public class QDCCrosswalk extends SelfNamedPlugin
     private static String aliases[] = null;
 
     static {
+        initStatic();
+    }
+
+    /**
+     * Call this method again in tests to repeat initialization if necessary.
+     */
+    public static void initStatic() {
         List<String> aliasList = new ArrayList<>();
         String propname = CONFIG_PREFIX + ".properties.";
-        List<String> configKeys = configurationService.getPropertyKeys(propname);
+        List<String> configKeys =
+            DSpaceServicesFactory.getInstance().getConfigurationService().getPropertyKeys(propname);
         for (String key : configKeys) {
             aliasList.add(key.substring(propname.length()));
         }

--- a/dspace-api/src/test/java/org/dspace/content/crosswalk/QDCCrosswalkTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/crosswalk/QDCCrosswalkTest.java
@@ -76,6 +76,8 @@ public class QDCCrosswalkTest
 
     @Before
     public void setUp() {
+        // make sure that the config properties set in @BeforeClass are picked up
+        QDCCrosswalk.initStatic();
     }
 
     @After


### PR DESCRIPTION
## Description
On several occasions, adding a new test to DSpace has resulted in `QDCCrosswalkTest` failing. This PR modifies `QDCCrosswalkTest` such that it is less affected by unrelated test classes.

## Instructions for Reviewers
To reproduce the issue this PR solves, it is sufficient to add `new QDCCrosswalk();` as the first line of `QDCCrosswalkTest#setUpClass`. Observe that the following errors occur:
- assertion error in `QDCCrosswalkTest#testGetPluginNames` : names array contains `QDC` and `qdc` , expected `qdctest` (set in `@BeforeClass`)
- NPE in `QDCCrosswalkTest#testGetSchemaLocation` : instance is `null` (no `qdctest` plugin available)
- NPE in `QDCCrosswalkTest#testGetNamespaces` : idem
- NPE in `QDCCrosswalkTest#testPreferList` : idem

Adding the mentionned line implies the [static block in QDCCrosswalk](https://github.com/DSpace/DSpace/blob/5064352ddf59759b6a3bf8a23fa38e57d980ae8a/dspace-api/src/main/java/org/dspace/content/crosswalk/QDCCrosswalk.java#L143) executes. This permanently locks in the `aliases` array with values from `dspace.cfg`. This also means that the test-setup code in [@BeforeClass of QDCCrosswalkTest](https://github.com/DSpace/DSpace/blob/5064352ddf59759b6a3bf8a23fa38e57d980ae8a/dspace-api/src/test/java/org/dspace/content/crosswalk/QDCCrosswalkTest.java#L53-L71) has no effect.

In practice, I suspect `QDCCrosswalk` gets loaded in test cases under specific circumstances (e.g. a test for a different crosswalk) BEFORE `QDCCrosswalkTest` executes. That gives rise to exactly the same errors as above.

Notice that with the changes in this PR, `QDCCrosswalkTest` succeeds even when `new QDCCrosswalk();` is added.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
