### PR TITLE
Use lenient stubbing in MockSolrLoggerServiceImpl

### DIFF
--- a/dspace-api/src/test/java/org/dspace/statistics/MockSolrLoggerServiceImpl.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/MockSolrLoggerServiceImpl.java
@@ -9,7 +9,6 @@ package org.dspace.statistics;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.net.InetAddress;
 import java.util.ArrayList;
@@ -29,6 +28,7 @@ import com.maxmind.geoip2.record.Postal;
 import com.maxmind.geoip2.record.RepresentedCountry;
 import com.maxmind.geoip2.record.Traits;
 import org.dspace.solr.MockSolrServer;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.stereotype.Service;
@@ -55,7 +55,7 @@ public class MockSolrLoggerServiceImpl
         // Mock GeoIP's DatabaseReader
         DatabaseReader reader = mock(DatabaseReader.class);
         // Ensure that any tests requesting a city() get a mock/fake CityResponse
-        when(reader.city(any(InetAddress.class))).thenReturn(mockCityResponse());
+        Mockito.lenient().when(reader.city(any(InetAddress.class))).thenReturn(mockCityResponse());
         // Save this mock DatabaseReader to be used by SolrLoggerService
         locationService = reader;
     }


### PR DESCRIPTION
## Description
[This stub](https://github.com/DSpace/DSpace/blob/5064352ddf59759b6a3bf8a23fa38e57d980ae8a/dspace-api/src/test/java/org/dspace/statistics/MockSolrLoggerServiceImpl.java#L58) is useful, but there is no guarantee that all test classes trigger it. In that case, the "violating" test class will fail with an `Unnecessary Stubbing` error from Mockito.

This PR sets the respective stub to "lenient", because tests should not fail if they happen to not use this general stub.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
