### PR TITLE
Workspace/Workflow only discovery configuration isn't working

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/indexobject/InprogressSubmissionIndexFactoryImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/indexobject/InprogressSubmissionIndexFactoryImpl.java
@@ -14,13 +14,16 @@ import java.util.List;
 import org.apache.solr.common.SolrInputDocument;
 import org.dspace.content.InProgressSubmission;
 import org.dspace.content.Item;
+import org.dspace.content.WorkspaceItem;
 import org.dspace.core.Context;
 import org.dspace.discovery.SearchUtils;
+import org.dspace.discovery.configuration.DiscoveryConfiguration;
 import org.dspace.discovery.indexobject.factory.CollectionIndexFactory;
 import org.dspace.discovery.indexobject.factory.InprogressSubmissionIndexFactory;
 import org.dspace.discovery.indexobject.factory.ItemIndexFactory;
 import org.dspace.eperson.EPerson;
 import org.dspace.util.SolrUtils;
+import org.dspace.workflow.WorkflowItem;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -68,7 +71,15 @@ public abstract class InprogressSubmissionIndexFactoryImpl
         locations.add("l" + inProgressSubmission.getCollection().getID());
 
         // Add item metadata
-        indexableItemService.addDiscoveryFields(doc, context, item, SearchUtils.getAllDiscoveryConfigurations(item));
+        List<DiscoveryConfiguration> discoveryConfigurations;
+        if (inProgressSubmission instanceof WorkflowItem) {
+            discoveryConfigurations = SearchUtils.getAllDiscoveryConfigurations((WorkflowItem) inProgressSubmission);
+        } else if (inProgressSubmission instanceof WorkspaceItem) {
+            discoveryConfigurations = SearchUtils.getAllDiscoveryConfigurations((WorkspaceItem) inProgressSubmission);
+        } else {
+            discoveryConfigurations = SearchUtils.getAllDiscoveryConfigurations(item);
+        }
+        indexableItemService.addDiscoveryFields(doc, context, item, discoveryConfigurations);
         indexableCollectionService.storeCommunityCollectionLocations(doc, locations);
     }
 }


### PR DESCRIPTION
## References
* Fixes #8119

## Description
If you create facet configuration in the "workspaceConfiguration" / "workflowConfiguration" discovery configurations alone that are specific for the MyDSpace page but aren't in the "default", the facets won't show any values for these specific facets.

## Instructions for Reviewers

In order to verify this PR:
* Alter the "workspaceConfiguration" or the "workflowConfiguration" to include a few facets that aren't in any other configurations
* Add a few items in your workspace that have these values
* Check the MyDSpace for the facets

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
