### PR TITLE
DSpace 6.x - replace log4j with reload4j, slf4j-log4j12 with slf4j-reload4j

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -334,6 +334,16 @@
             <groupId>org.apache.jena</groupId>
             <artifactId>apache-jena-libs</artifactId>
             <type>pom</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>
@@ -396,8 +406,8 @@
             <artifactId>jdom</artifactId>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
         </dependency>
         <dependency>
             <groupId>oro</groupId>
@@ -518,6 +528,14 @@
                     <groupId>org.mockito</groupId>
                     <artifactId>mockito-core</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -534,6 +552,10 @@
                 <exclusion>
                     <groupId>org.mockito</groupId>
                     <artifactId>mockito-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -557,6 +579,14 @@
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/dspace-oai/pom.xml
+++ b/dspace-oai/pom.xml
@@ -107,6 +107,14 @@
                      <groupId>org.apache.commons</groupId>
                      <artifactId>commons-lang3</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -159,6 +167,14 @@
                      <groupId>org.apache.commons</groupId>
                      <artifactId>commons-lang3</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -190,12 +206,12 @@
 
         <!-- Logging -->
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
             <scope>runtime</scope>
         </dependency>
 

--- a/dspace-rdf/pom.xml
+++ b/dspace-rdf/pom.xml
@@ -67,8 +67,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>

--- a/dspace-rest/pom.xml
+++ b/dspace-rest/pom.xml
@@ -241,8 +241,8 @@
             <version>1.2.1</version>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
         </dependency>
         <dependency>
             <groupId>org.dspace</groupId>

--- a/dspace-services/pom.xml
+++ b/dspace-services/pom.xml
@@ -139,11 +139,11 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
         </dependency>
         <dependency>
             <!-- needed to ensure that all JCL is 1.1.1 -->

--- a/dspace-solr/pom.xml
+++ b/dspace-solr/pom.xml
@@ -74,7 +74,7 @@
                             <warSourceExcludes>WEB-INF/classes/**</warSourceExcludes>
                             <packagingExcludes>
                                 WEB-INF/classes/**,
-                                WEB-INF/lib/slf4j-jdk14-*.jar,
+                                WEB-INF/lib/slf4j-reload4j-*.jar,
                                 WEB-INF/lib/log4j-over-slf4j-*.jar
                             </packagingExcludes>
                         </configuration>
@@ -234,13 +234,8 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
             <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <artifactId>log4j</artifactId>
-            <groupId>log4j</groupId>
-            <type>jar</type>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/dspace-sword/pom.xml
+++ b/dspace-sword/pom.xml
@@ -120,8 +120,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
             <exclusions>
                 <exclusion>
                     <artifactId>jmxtools</artifactId>

--- a/dspace-swordv2/pom.xml
+++ b/dspace-swordv2/pom.xml
@@ -94,6 +94,14 @@
                     <groupId>org.apache.abdera</groupId>
                     <artifactId>abdera-client</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -107,8 +115,8 @@
             <artifactId>dspace-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
             <exclusions>
                 <exclusion>
                     <artifactId>jmxtools</artifactId>

--- a/dspace-xmlui/pom.xml
+++ b/dspace-xmlui/pom.xml
@@ -121,6 +121,10 @@
                     <groupId>org.apache.excalibur.components</groupId>
                     <artifactId>excalibur-sourceresolve</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -173,6 +177,12 @@
         <dependency>
             <groupId>org.swordapp</groupId>
             <artifactId>sword-common</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Explicitly Specify Latest Version of Spring -->

--- a/dspace/modules/oai/pom.xml
+++ b/dspace/modules/oai/pom.xml
@@ -132,7 +132,7 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <jena.version>2.13.0</jena.version>
         <slf4j.version>1.7.14</slf4j.version>
         <reload4j.version>1.2.18.3</reload4j.version>
-        <slf4j-reload4j.version>1.7.15</slf4j-reload4j.version>
+        <slf4j-reload4j.version>1.7.36</slf4j-reload4j.version>
         <!--
             Hibernate version pinned to 4.2, 4.3 does not work with the spring version we are currently using
             Upgrading the spring version will make the XMLUI crash
@@ -1360,7 +1360,7 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-reload4j</artifactId>
-                <version>1.7.35</version>
+                <version>${slf4j-reload4j.version}</version>
             </dependency>
             <!-- JMockit, JUnit and Hamcrest are used for Unit/Integration tests -->
             <dependency> <!-- Keep jmockit before junit -->

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <solr.version>4.10.4</solr.version>
         <jena.version>2.13.0</jena.version>
         <slf4j.version>1.7.14</slf4j.version>
-        <reload4j.version>1.2.18.3</reload4j.version>
+        <reload4j.version>1.2.20</reload4j.version>
         <slf4j-reload4j.version>1.7.36</slf4j-reload4j.version>
         <!--
             Hibernate version pinned to 4.2, 4.3 does not work with the spring version we are currently using

--- a/pom.xml
+++ b/pom.xml
@@ -431,7 +431,7 @@
                 <plugins>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>license-maven-plugin</artifactId>
+                        <artifactId>#license-maven-plugin</artifactId>
                         <version>1.8</version>
                         <!-- This plugin only needs to be run on the Parent POM
                              as it aggregates results from all child POMs. -->
@@ -1080,6 +1080,16 @@
                 <artifactId>apache-jena-libs</artifactId>
                 <type>pom</type>
                 <version>${jena.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-log4j12</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.dspace</groupId>
@@ -1187,9 +1197,14 @@
                 <version>1.1.3</version>
             </dependency>
             <dependency>
-                <groupId>log4j</groupId>
-                <artifactId>log4j</artifactId>
-                <version>1.2.17</version>
+                <groupId>ch.qos.reload4j</groupId>
+                <artifactId>reload4j</artifactId>
+                <version>1.2.18.3</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-reload4j</artifactId>
+                <version>1.7.35</version>
             </dependency>
             <dependency>
                 <groupId>oro</groupId>
@@ -1339,10 +1354,11 @@
                 <artifactId>slf4j-jdk14</artifactId>
                 <version>${slf4j.version}</version>
             </dependency>
+            <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-reload4j -->
             <dependency>
                 <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-log4j12</artifactId>
-                <version>${slf4j.version}</version>
+                <artifactId>slf4j-reload4j</artifactId>
+                <version>1.7.35</version>
             </dependency>
             <!-- JMockit, JUnit and Hamcrest are used for Unit/Integration tests -->
             <dependency> <!-- Keep jmockit before junit -->

--- a/pom.xml
+++ b/pom.xml
@@ -431,7 +431,7 @@
                 <plugins>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>#license-maven-plugin</artifactId>
+                        <artifactId>license-maven-plugin</artifactId>
                         <version>1.8</version>
                         <!-- This plugin only needs to be run on the Parent POM
                              as it aggregates results from all child POMs. -->

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,8 @@
         <solr.version>4.10.4</solr.version>
         <jena.version>2.13.0</jena.version>
         <slf4j.version>1.7.14</slf4j.version>
+        <reload4j.version>1.2.18.3</reload4j.version>
+        <slf4j-reload4j.version>1.7.15</slf4j-reload4j.version>
         <!--
             Hibernate version pinned to 4.2, 4.3 does not work with the spring version we are currently using
             Upgrading the spring version will make the XMLUI crash
@@ -1199,12 +1201,12 @@
             <dependency>
                 <groupId>ch.qos.reload4j</groupId>
                 <artifactId>reload4j</artifactId>
-                <version>1.2.18.3</version>
+                <version>${reload4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-reload4j</artifactId>
-                <version>1.7.35</version>
+                <version>${slf4j-reload4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>oro</groupId>


### PR DESCRIPTION
## References
* Fixes #8143 

## Description
See #8143 and https://reload4j.qos.ch for more information about reload4j

* Replaced log4j dependencies with reload4j 1.2.18 in `pom.xml` files for all relevant maven projects
* Replaced slf4j-log4j12 dependencies with slf4j-reload4j in `pom.xml` files for all relevant maven projects
* Wrote exclusions for some dependencies to ensure there are no transitive inclusions of the old log4j or slf4j-log4j12 artifacts anywhere in DSpace and to force usage of the new artifacts

No code or import changes are needed as these artifacts are exact replacements, written by the original log4j 1.x author, with a handful of security fixes included as per the [website](https://reload4j.qos.ch)

## Instructions for Reviewers

1. Build, preferably with `-U` and `clean` options so we can ensure a fresh build using reload4j
2. Basic application testing, ensuring every DSpace module / webapp / API can log normally, in exactly the same way as log4j 1.2.17
3. Test log4j configuration changes, ensure they are honoured after a restart
4. Review of POM changes - happy to hear suggestions if there are tidier ways to achieve all the transitive exclusions, etc.
