### PR TITLE
Prefix Solr core names to facilitate multiple DSpace instances on a single Solr instance

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -42,8 +42,13 @@ default.language = en_US
 
 # Solr server/webapp.
 # DSpace uses Solr for all search/browse capability (and for usage statistics).
-# Since DSpace 7, SOLR must be installed as a stand-alone service
+# Since DSpace 7, SOLR must be installed as a stand-alone service.
 solr.server = http://localhost:8983/solr
+
+# Solr core name prefix.
+# If you connect multiple instances of DSpace to a single Solr instance, you
+# can organize them with a common core name prefix.
+solr.multicorePrefix =
 
 # Solr connection pool.
 # If you change these values, the changes are not effective until DSpace is
@@ -1349,11 +1354,11 @@ sherpa.romeo.apikey =
 # org.dspace.content.authority.SampleAuthority = Sample, \
 # org.dspace.content.authority.SHERPARoMEOPublisher = SRPublisher, \
 # org.dspace.content.authority.SHERPARoMEOJournalTitle = SRJournalTitle, \
-#  org.dspace.content.authority.SolrAuthority = SolrAuthorAuthority
+# org.dspace.content.authority.SolrAuthority = SolrAuthorAuthority
 
 #Uncomment to enable ORCID authority control
 #plugin.named.org.dspace.content.authority.ChoiceAuthority = \
-#    org.dspace.content.authority.SolrAuthority = SolrAuthorAuthority
+# org.dspace.content.authority.SolrAuthority = SolrAuthorAuthority
 
 # URL of ORCID API
 # Defaults to using the Public API V3 (pub.orcid.org)
@@ -1403,8 +1408,9 @@ plugin.selfnamed.org.dspace.content.authority.ChoiceAuthority = \
 ## See manual or org.dspace.content.authority.Choices source for descriptions.
 authority.minconfidence = ambiguous
 
-# Configuration settings for ORCID based authority control, uncomment the lines below to enable configuration
-#solr.authority.server=${solr.server}/authority
+# Configuration settings for ORCID based authority control.
+# Uncomment the lines below to enable configuration.
+#solr.authority.server=${solr.server}/${solr.multicorePrefix}authority
 #choices.plugin.dc.contributor.author = SolrAuthorAuthority
 #choices.presentation.dc.contributor.author = authorLookup
 #authority.controlled.dc.contributor.author = true

--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -59,6 +59,11 @@ dspace.name = DSpace at My University
 # Since DSpace 7, SOLR must be installed as a stand-alone service
 #solr.server = http://localhost:8983/solr
 
+# Solr core name prefix.
+# If you connect multiple instances of DSpace to a single Solr instance, you
+# can organize them with a common core name prefix.
+#solr.multicorePrefix =
+
 ##########################
 # DATABASE CONFIGURATION #
 ##########################

--- a/dspace/config/modules/discovery.cfg
+++ b/dspace/config/modules/discovery.cfg
@@ -5,7 +5,7 @@
 # faceted-search system.                                        #
 #---------------------------------------------------------------#
 ##### Search Indexing #####
-discovery.search.server = ${solr.server}/search
+discovery.search.server = ${solr.server}/${solr.multicorePrefix}search
 
 #Enable the url validation of the search.server setting above.
 #Defaults to true: validation is enabled

--- a/dspace/config/modules/iiif.cfg
+++ b/dspace/config/modules/iiif.cfg
@@ -10,7 +10,7 @@ iiif.image.server = http://localhost:8182/iiif/2/
 # Base URL of the search service used to support the (experimental) IIIF Search
 # capability. The actual path will depend on how search is being supported.
 # This example uses the solr plugin https://dbmdz.github.io/solr-ocrhighlighting/
-# iiif.search.url = ${solr.server}/word_highlighting
+# iiif.search.url = ${solr.server}/${solr.multicorePrefix}word_highlighting
 
 # The search plugin used to support (experimental) IIIF Search.
 # This is the class used with https://dbmdz.github.io/solr-ocrhighlighting/

--- a/dspace/config/modules/oai.cfg
+++ b/dspace/config/modules/oai.cfg
@@ -24,7 +24,7 @@ oai.storage=solr
 oai.url = ${dspace.server.url}/${oai.path}
 
 # Base solr index
-oai.solr.url=${solr.server}/oai
+oai.solr.url=${solr.server}/${solr.multicorePrefix}oai
 
 # OAI persistent identifier prefix
 # This field is used for two purposes:

--- a/dspace/config/modules/solr-statistics.cfg
+++ b/dspace/config/modules/solr-statistics.cfg
@@ -10,7 +10,7 @@
 # set this to be the port you run the dspace "solr" webapp
 # on, by default, we are assuming a test configuration with
 # tomcat still running on port 8080
-solr-statistics.server = ${solr.server}/statistics
+solr-statistics.server = ${solr.server}/${solr.multicorePrefix}statistics
 
 # A comma-separated list that contains the bundles for which the bitstreams will be displayed
 solr-statistics.query.filter.bundles=ORIGINAL


### PR DESCRIPTION
## References
* Fixes #8129

## Description
Adds an optional common prefix to the names of the Solr cores.  By changing a single property, you can make all of the cores for a DSpace instance distinct from other instances which share a common Solr instance.

## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* Created the `solr.multicorePrefix` property in `config/dspace.cfg`
* Inserted references to this property in the URIs for various Solr cores (search, oai, etc.)

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
