### PR TITLE
 DSpaceApiExceptionControllerAdvice should always log the exception message and location

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
@@ -54,7 +54,7 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
     private static final Logger log = LogManager.getLogger(DSpaceApiExceptionControllerAdvice.class);
 
     /**
-     * Set of HTTP error codes to log as ERROR with full stacktrace.
+     * Set of HTTP error codes to log as ERROR with full stack trace.
      */
     private static final Set<Integer> LOG_AS_ERROR = Set.of(422);
 
@@ -126,8 +126,14 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
 
     /**
      * Add user-friendly error messages to the response body for selected errors.
-     * Since the error messages will be exposed to the API user, the exception classes are expected to implement
-     * {@link TranslatableException} such that the error messages can be translated.
+     * Since the error messages will be exposed to the API user, the
+     * exception classes are expected to implement {@link TranslatableException}
+     * such that the error messages can be translated.
+     *
+     * @param request the client's request
+     * @param response our response
+     * @param ex exception thrown in handling request
+     * @throws java.io.IOException passed through.
      */
     @ExceptionHandler({
         RESTEmptyWorkflowGroupException.class,
@@ -192,8 +198,9 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
 
     /**
      * Send the error to the response.
-     * 5xx errors will be logged as ERROR with a full stack trace, 4xx errors will be logged as WARN without a
-     * stacktrace. Specific 4xx errors where an ERROR log with full stacktrace is more appropriate are configured in
+     * 5xx errors will be logged as ERROR with a full stack trace.  4xx errors
+     * will be logged as WARN without a stack trace. Specific 4xx errors where
+     * an ERROR log with full stack trace is more appropriate are configured in
      * {@link #LOG_AS_ERROR}
      * @param request current request
      * @param response current response
@@ -202,8 +209,10 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
      * @param statusCode status code to send in response
      * @throws IOException
      */
-    private void sendErrorResponse(final HttpServletRequest request, final HttpServletResponse response,
-                                   final Exception ex, final String message, final int statusCode) throws IOException {
+    private void sendErrorResponse(final HttpServletRequest request,
+            final HttpServletResponse response,
+            final Exception ex, final String message, final int statusCode)
+            throws IOException {
         //Make sure Spring picks up this exception
         request.setAttribute(EXCEPTION_ATTRIBUTE, ex);
 
@@ -213,7 +222,10 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
             log.error("{} (status:{})", message, statusCode, ex);
         } else if (HttpStatus.valueOf(statusCode).is4xxClientError()) {
             // Log the error as a single-line WARN
-            log.warn("{} (status:{})", message, statusCode);
+            StackTraceElement[] trace = ex.getStackTrace();
+            String location = trace.length <= 0 ? "unknown" : trace[0].toString();
+            log.warn("{} (status:{} exception: {} at: {})", message, statusCode,
+                    ex.getMessage(), location);
         }
 
         //Exception properties will be set by org.springframework.boot.web.support.ErrorPageFilter

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
@@ -222,10 +222,18 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
             log.error("{} (status:{})", message, statusCode, ex);
         } else if (HttpStatus.valueOf(statusCode).is4xxClientError()) {
             // Log the error as a single-line WARN
-            StackTraceElement[] trace = ex.getStackTrace();
-            String location = trace.length <= 0 ? "unknown" : trace[0].toString();
+            String location;
+            String exceptionMessage;
+            if (null == ex) {
+                exceptionMessage = "none";
+                location = "unknown";
+            } else {
+                exceptionMessage = ex.getMessage();
+                StackTraceElement[] trace = ex.getStackTrace();
+                location = trace.length <= 0 ? "unknown" : trace[0].toString();
+            }
             log.warn("{} (status:{} exception: {} at: {})", message, statusCode,
-                    ex.getMessage(), location);
+                    exceptionMessage, location);
         }
 
         //Exception properties will be set by org.springframework.boot.web.support.ErrorPageFilter

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
@@ -13,6 +13,8 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.util.Objects;
 import java.util.Set;
+import javax.inject.Inject;
+import javax.inject.Named;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -51,12 +53,22 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
  */
 @ControllerAdvice
 public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionHandler {
-    private static final Logger log = LogManager.getLogger(DSpaceApiExceptionControllerAdvice.class);
+    private static final Logger log = LogManager.getLogger();
 
     /**
      * Set of HTTP error codes to log as ERROR with full stack trace.
      */
-    private static final Set<Integer> LOG_AS_ERROR = Set.of(422);
+    private final Set<Integer> LOG_AS_ERROR;
+
+    /**
+     * @param statuses HTTP status codes to be logged as ERROR, with stack trace.
+     */
+    @Inject
+    public DSpaceApiExceptionControllerAdvice(
+            @Named("org.dspace.app.rest.StackTracedHttpStatuses")
+                    Set<Integer> statuses) {
+        LOG_AS_ERROR = statuses;
+    }
 
     @ExceptionHandler({AuthorizeException.class, RESTAuthorizationException.class, AccessDeniedException.class})
     protected void handleAuthorizeException(HttpServletRequest request, HttpServletResponse response, Exception ex)

--- a/dspace-server-webapp/src/main/resources/spring/spring-dspace-core-services.xml
+++ b/dspace-server-webapp/src/main/resources/spring/spring-dspace-core-services.xml
@@ -9,9 +9,12 @@
 
 -->
 <beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:util="http://www.springframework.org/schema/util"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-           http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
+           http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+           http://www.springframework.org/schema/util
+           http://www.springframework.org/schema/util/spring-util.xsd">
 
     <bean id="patchConfigurationService" class="org.dspace.app.rest.submit.PatchConfigurationService">
         <property name="map">
@@ -125,4 +128,11 @@
     </bean>
 
     <bean id="org.dspace.app.rest.utils.BitstreamMetadataValuePathUtils" class="org.dspace.app.rest.utils.BitstreamMetadataValuePathUtils"/>
+
+    <util:set id='org.dspace.app.rest.StackTracedHttpStatuses'>
+      <description>
+        HTTP status codes to be logged at ERROR level with stack trace.
+      </description>
+      <value>422</value>
+    </util:set>
 </beans>

--- a/dspace-server-webapp/src/main/resources/spring/spring-dspace-core-services.xml
+++ b/dspace-server-webapp/src/main/resources/spring/spring-dspace-core-services.xml
@@ -9,12 +9,9 @@
 
 -->
 <beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:util="http://www.springframework.org/schema/util"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-           http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-           http://www.springframework.org/schema/util
-           http://www.springframework.org/schema/util/spring-util.xsd">
+           http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
 
     <bean id="patchConfigurationService" class="org.dspace.app.rest.submit.PatchConfigurationService">
         <property name="map">
@@ -128,11 +125,4 @@
     </bean>
 
     <bean id="org.dspace.app.rest.utils.BitstreamMetadataValuePathUtils" class="org.dspace.app.rest.utils.BitstreamMetadataValuePathUtils"/>
-
-    <util:set id='org.dspace.app.rest.StackTracedHttpStatuses'>
-      <description>
-        HTTP status codes to be logged at ERROR level with stack trace.
-      </description>
-      <value>422</value>
-    </util:set>
 </beans>

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -216,12 +216,14 @@ mail.message.headers = charset
 
 ##### Logging configuration #####
 # Main logging settings can be found in config/log4j2.xml
-# below some configuration properties for the server webapp that can be modified at runtime
+# Below are some configuration properties for the server webapp that can be
+# modified at runtime.
 logging.server.include-after-request = false
-logging.server.include-payload = false
-logging.server.include-headers = false
-logging.server.include-query-string = false
 logging.server.include-client-info = false
+logging.server.include-headers = false
+logging.server.include-payload = false
+logging.server.include-query-string = false
+logging.server.include-stacktrace-for-httpcode = 422
 logging.server.max-payload-length = 10000
 
 ##### DOI registration agency credentials ######

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -223,6 +223,8 @@ logging.server.include-client-info = false
 logging.server.include-headers = false
 logging.server.include-payload = false
 logging.server.include-query-string = false
+# include-stacktrace-for-httpcode accepts multiple values, comma-separated or by
+# repeating the assignment
 logging.server.include-stacktrace-for-httpcode = 422
 logging.server.max-payload-length = 10000
 


### PR DESCRIPTION
## References
* Fixes #8148

## Description
When not logging a stack trace, DSpaceApiExceptionControllerAdvice will log the exception's message and location.

## Instructions for Reviewers

List of changes in this PR:
* SendErrorResponse adds exception's message and location to the log entry.

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
