### PR TITLE
Remove unnecessary second Context in RDFConsumer in DSpace 6

### DIFF
--- a/dspace-api/src/main/java/org/dspace/rdf/RDFConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/rdf/RDFConsumer.java
@@ -317,50 +317,54 @@ public class RDFConsumer implements Consumer
     @Override
     public void end(Context ctx) throws Exception {
         log.debug("Started processing of queued events.");
-        // create a new context, to be sure to work as anonymous user
-        // we don't want to store private data in a triplestore with public
-        // SPARQL endpoint.
-        ctx = new Context(Context.Mode.READ_ONLY);
-        if (toDelete == null) 
-        {
-            log.debug("Deletion queue does not exists, creating empty queue.");
-            this.toDelete = new LinkedList<>();
-        }
-        if (toConvert != null)
-        {
-            log.debug("Starting conversion of DSpaceObjects.");
-            while (true)
-            {
-                DSOIdentifier id;
-                try { id = toConvert.removeFirst(); }
-                catch (NoSuchElementException ex) { break; }
-
-                if (toDelete.contains(id))
-                {
-                    log.debug("Skipping " + Constants.typeText[id.type] + " " 
-                            + id.id.toString() + " as it is marked for "
-                            + "deletion as well.");
-                    continue;
-                }
-                log.debug("Converting " + Constants.typeText[id.type] + " " 
-                            + id.id.toString() + ".");
-                convert(ctx, id);
+        // store the context mode, set context read only for performance reasons, and restore the old mode
+        Context.Mode oldMode = ctx.getCurrentMode();
+        try {
+            ctx.setMode(Context.Mode.READ_ONLY);
+            if (toDelete == null) {
+                log.debug("Deletion queue does not exists, creating empty queue.");
+                this.toDelete = new LinkedList<>();
             }
-            log.debug("Conversion ended.");
+            if (toConvert != null) {
+                log.debug("Starting conversion of DSpaceObjects.");
+                while (true) {
+                    DSOIdentifier id;
+                    try {
+                        id = toConvert.removeFirst();
+                    } catch (NoSuchElementException ex) {
+                        break;
+                    }
+
+                    if (toDelete.contains(id)) {
+                        log.debug("Skipping " + Constants.typeText[id.type] + " "
+                                      + id.id.toString() + " as it is marked for "
+                                      + "deletion as well.");
+                        continue;
+                    }
+                    log.debug("Converting " + Constants.typeText[id.type] + " "
+                                  + id.id.toString() + ".");
+                    convert(ctx, id);
+                }
+                log.debug("Conversion ended.");
+            }
+            log.debug("Starting to delete data from the triple store...");
+            while (true) {
+                DSOIdentifier id;
+                try {
+                    id = toDelete.removeFirst();
+                } catch (NoSuchElementException ex) {
+                    break;
+                }
+
+                log.debug("Going to delete data from " +
+                              Constants.typeText[id.type] + " "
+                              + id.id.toString() + ".");
+                delete(ctx, id);
+            }
+        } finally {
+            // restore context mode
+            ctx.setMode(oldMode);
         }
-        log.debug("Starting to delete data from the triple store...");
-        while (true)
-        {
-            DSOIdentifier id;
-            try { id = toDelete.removeFirst(); }
-            catch (NoSuchElementException ex) { break; }
-            
-            log.debug("Going to delete data from " +
-                    Constants.typeText[id.type] + " " 
-                    + id.id.toString() + ".");
-            delete(ctx, id);
-        }
-        ctx.abort();
         log.debug("Deletion finished.");
     }
 


### PR DESCRIPTION
## References
fixes #8152 for DSpace 6

There also exists a PR against master: https://github.com/DSpace/DSpace/pull/8153

## Description
In DSpace 6 calling context.abort() when two instances of org.dspace.core.Context exists, seem to affect both instances. It is not necessary for RDFConsumer to create a new Context on its own. This PR changes this behavior.

## Instructions for Reviewers
This is a very small bug, but hard to find. I hope, a review by seeing the minimal changes should be good enough.

In DSpace 6 add rdf to event.dispatcher.default.consumers and try to submit a new item. Without this patch you'll get an internal error messages and a log of entries in the log (compare to the issue linked above). With this patch: everything runs smooth again.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
