### PR TITLE
Changing the name of a group should not recalculate group2groupcache table

### DIFF
--- a/dspace-api/src/main/java/org/dspace/eperson/Group.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/Group.java
@@ -201,7 +201,6 @@ public class Group extends DSpaceObject implements DSpaceObjectLegacySupport {
     void setName(String name) throws SQLException {
         if (!StringUtils.equals(this.name, name) && !isPermanent()) {
             this.name = name;
-            groupsChanged = true;
         }
     }
 

--- a/dspace-api/src/main/java/org/dspace/eperson/Group.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/Group.java
@@ -201,6 +201,7 @@ public class Group extends DSpaceObject implements DSpaceObjectLegacySupport {
     void setName(String name) throws SQLException {
         if (!StringUtils.equals(this.name, name) && !isPermanent()) {
             this.name = name;
+            setMetadataModified();
         }
     }
 


### PR DESCRIPTION
## References
* Fixes #8155

## Description
Remove the line that set to true the property `groupsChanged` when the name of the group is changed. 

## Instructions for Reviewers
It is a small change.
I have tested it in a DSpace 6x instance with many groups relations (1000 entries in group2group table).
1) Go to group administration
2) Create a new group and change the name
The response should be quicker than adding a new subgroup.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.