### PR TITLE
Removes ShibAuthentication session dependency for special groups.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authenticate/ShibAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/ShibAuthentication.java
@@ -20,7 +20,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -235,6 +234,7 @@ public class ShibAuthentication implements AuthenticationMethod {
 
             // Step 4: Log the user in.
             context.setCurrentUser(eperson);
+            request.setAttribute("shib.authenticated", true);
             AuthenticateServiceFactory.getInstance().getAuthenticationService().initEPerson(context, request, eperson);
 
             log.info(eperson.getEmail() + " has been authenticated via shibboleth.");
@@ -387,11 +387,6 @@ public class ShibAuthentication implements AuthenticationMethod {
 
 
             log.info("Added current EPerson to special groups: " + groups);
-
-            List<UUID> groupIds = new ArrayList<>();
-            for (Group group : groups) {
-                groupIds.add(group.getID());
-            }
 
             return new ArrayList<>(groups);
 


### PR DESCRIPTION
## Description
Fixes #8161 

The Shibboleth auth plugin is currently broken for special groups.  This PR removes use of the session object in `getSpecialGroups()` in favor of information that's already provided by the JWT.  Before these changes an empty special groups list was always returned.
 
## Instructions for Reviewers

List of changes in this PR:
* Returns an empty list when eperson is not defined (without checking the session for shibboleth authentication status)
* Returns special groups when they exist in the current Context.

There are only a few code changes. I've tested them with a server that's being configured for production so I don't have great advice on how to test as a reviewer. But in the end, you should be able to login and view content that is restricted to a special group. Here's some DEBUG logging to show results on my system. Before these changes `getSpecialGroups` always returned an empty list and not the cached special groups shown here.

targeted-id=''
persistent-id=''
SHIB-NETID='abcd'
SHIB-MAIL='abcd@willamette.edu'
SHIB-GIVENNAME='ab'
SHIB-SURNAME='cd'
SHIB-SCOPED-AFFILIATION='member@willamette.edu;student@willamette.edu'
Shib-Application-ID='default'
REMOTE_USER='abcd'

2022-02-10 12:47:37,007 DEBUG unknown unknown org.dspace.authenticate.ShibAuthentication @ **Updated the eperson's minimal metadata**: 
 Email Header: 'SHIB-MAIL' = 'abcd@willamette.edu' 
 First Name Header: 'SHIB-GIVENNAME' = 'ab' 
 Last Name Header: 'SHIB-GIVENNAME' = 'cd'

2022-02-10 12:47:37,272 DEBUG unknown unknown org.dspace.authenticate.ShibAuthentication @ **Starting to determine special groups**
2022-02-10 12:47:37,273 DEBUG unknown unknown org.dspace.authenticate.ShibAuthentication @ Found Shibboleth role header: 'SHIB-SCOPED-AFFILIATION' = '[member@willamette.edu, student@willamette.edu]'
2022-02-10 12:47:37,273 DEBUG unknown unknown org.dspace.authenticate.ShibAuthentication @ Mapping role affiliation to DSpace group: 'WU Users'
2022-02-10 12:47:37,275 DEBUG unknown unknown org.dspace.authenticate.ShibAuthentication @ Mapping role affiliation to DSpace group: 'student'

2022-02-10 12:47:39,276 DEBUG unknown unknown org.dspace.authenticate.ShibAuthentication @ **Returning cached special groups.**


## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
