### PR TITLE
Improved builder's cleanup to avoid consumers executions

### DIFF
--- a/dspace-api/src/test/java/org/dspace/builder/BitstreamBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/BitstreamBuilder.java
@@ -206,6 +206,7 @@ public class BitstreamBuilder extends AbstractDSpaceObjectBuilder<Bitstream> {
     @Override
     public void cleanup() throws Exception {
         try (Context c = new Context()) {
+            c.setDispatcher("noindex");
             c.turnOffAuthorisationSystem();
             // Ensure object and any related objects are reloaded before checking to see what needs cleanup
             bitstream = c.reloadEntity(bitstream);

--- a/dspace-api/src/test/java/org/dspace/builder/BitstreamFormatBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/BitstreamFormatBuilder.java
@@ -34,6 +34,7 @@ public class BitstreamFormatBuilder extends AbstractCRUDBuilder<BitstreamFormat>
     @Override
     public void cleanup() throws Exception {
         try (Context c = new Context()) {
+            c.setDispatcher("noindex");
             c.turnOffAuthorisationSystem();
             // Ensure object and any related objects are reloaded before checking to see what needs cleanup
             bitstreamFormat = c.reloadEntity(bitstreamFormat);

--- a/dspace-api/src/test/java/org/dspace/builder/BundleBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/BundleBuilder.java
@@ -55,6 +55,7 @@ public class BundleBuilder extends AbstractDSpaceObjectBuilder<Bundle>  {
     @Override
     public void cleanup() throws Exception {
         try (Context c = new Context()) {
+            c.setDispatcher("noindex");
             c.turnOffAuthorisationSystem();
             // Ensure object and any related objects are reloaded before checking to see what needs cleanup
             bundle = c.reloadEntity(bundle);

--- a/dspace-api/src/test/java/org/dspace/builder/ClaimedTaskBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/ClaimedTaskBuilder.java
@@ -124,6 +124,7 @@ public class ClaimedTaskBuilder extends AbstractBuilder<ClaimedTask, ClaimedTask
     @Override
     public void cleanup() throws Exception {
         try (Context c = new Context()) {
+            c.setDispatcher("noindex");
             c.turnOffAuthorisationSystem();
             // Ensure object and any related objects are reloaded before checking to see what needs cleanup
             workspaceItem = c.reloadEntity(workspaceItem);

--- a/dspace-api/src/test/java/org/dspace/builder/CollectionBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/CollectionBuilder.java
@@ -253,6 +253,7 @@ public class CollectionBuilder extends AbstractDSpaceObjectBuilder<Collection> {
     @Override
     public void cleanup() throws Exception {
        try (Context c = new Context()) {
+            c.setDispatcher("noindex");
             c.turnOffAuthorisationSystem();
             // Ensure object and any related objects are reloaded before checking to see what needs cleanup
             collection = c.reloadEntity(collection);

--- a/dspace-api/src/test/java/org/dspace/builder/CommunityBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/CommunityBuilder.java
@@ -116,6 +116,7 @@ public class CommunityBuilder extends AbstractDSpaceObjectBuilder<Community> {
     @Override
     public void cleanup() throws Exception {
        try (Context c = new Context()) {
+            c.setDispatcher("noindex");
             c.turnOffAuthorisationSystem();
             // Ensure object and any related objects are reloaded before checking to see what needs cleanup
             community = c.reloadEntity(community);

--- a/dspace-api/src/test/java/org/dspace/builder/EPersonBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/EPersonBuilder.java
@@ -32,6 +32,7 @@ public class EPersonBuilder extends AbstractDSpaceObjectBuilder<EPerson> {
     @Override
     public void cleanup() throws Exception {
         try (Context c = new Context()) {
+            c.setDispatcher("noindex");
             c.turnOffAuthorisationSystem();
             // Ensure object and any related objects are reloaded before checking to see what needs cleanup
             ePerson = c.reloadEntity(ePerson);

--- a/dspace-api/src/test/java/org/dspace/builder/EntityTypeBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/EntityTypeBuilder.java
@@ -36,6 +36,7 @@ public class EntityTypeBuilder extends AbstractBuilder<EntityType, EntityTypeSer
     @Override
     public void cleanup() throws Exception {
         try (Context c = new Context()) {
+            c.setDispatcher("noindex");
             c.turnOffAuthorisationSystem();
             // Ensure object and any related objects are reloaded before checking to see what needs cleanup
             entityType = c.reloadEntity(entityType);

--- a/dspace-api/src/test/java/org/dspace/builder/GroupBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/GroupBuilder.java
@@ -35,6 +35,7 @@ public class GroupBuilder extends AbstractDSpaceObjectBuilder<Group> {
     @Override
     public void cleanup() throws Exception {
         try (Context c = new Context()) {
+            c.setDispatcher("noindex");
             c.turnOffAuthorisationSystem();
             // Ensure object and any related objects are reloaded before checking to see what needs cleanup
             group = c.reloadEntity(group);

--- a/dspace-api/src/test/java/org/dspace/builder/ItemBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/ItemBuilder.java
@@ -209,6 +209,7 @@ public class ItemBuilder extends AbstractDSpaceObjectBuilder<Item> {
     @Override
     public void cleanup() throws Exception {
        try (Context c = new Context()) {
+            c.setDispatcher("noindex");
             c.turnOffAuthorisationSystem();
             // Ensure object and any related objects are reloaded before checking to see what needs cleanup
             item = c.reloadEntity(item);

--- a/dspace-api/src/test/java/org/dspace/builder/MetadataFieldBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/MetadataFieldBuilder.java
@@ -38,6 +38,7 @@ public class MetadataFieldBuilder extends AbstractBuilder<MetadataField, Metadat
     @Override
     public void cleanup() throws Exception {
         try (Context c = new Context()) {
+            c.setDispatcher("noindex");
             c.turnOffAuthorisationSystem();
             // Ensure object and any related objects are reloaded before checking to see what needs cleanup
             metadataField = c.reloadEntity(metadataField);

--- a/dspace-api/src/test/java/org/dspace/builder/MetadataSchemaBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/MetadataSchemaBuilder.java
@@ -37,6 +37,7 @@ public class MetadataSchemaBuilder extends AbstractBuilder<MetadataSchema, Metad
     @Override
     public void cleanup() throws Exception {
         try (Context c = new Context()) {
+            c.setDispatcher("noindex");
             c.turnOffAuthorisationSystem();
             // Ensure object and any related objects are reloaded before checking to see what needs cleanup
             metadataSchema = c.reloadEntity(metadataSchema);

--- a/dspace-api/src/test/java/org/dspace/builder/PoolTaskBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/PoolTaskBuilder.java
@@ -104,6 +104,7 @@ public class PoolTaskBuilder extends AbstractBuilder<PoolTask, PoolTaskService> 
     @Override
     public void cleanup() throws Exception {
         try (Context c = new Context()) {
+            c.setDispatcher("noindex");
             c.turnOffAuthorisationSystem();
             // Ensure object and any related objects are reloaded before checking to see what needs cleanup
             workspaceItem = c.reloadEntity(workspaceItem);

--- a/dspace-api/src/test/java/org/dspace/builder/ProcessBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/ProcessBuilder.java
@@ -60,6 +60,7 @@ public class ProcessBuilder extends AbstractBuilder<Process, ProcessService> {
     @Override
     public void cleanup() throws Exception {
         try (Context c = new Context()) {
+            c.setDispatcher("noindex");
             c.turnOffAuthorisationSystem();
             // Ensure object and any related objects are reloaded before checking to see what needs cleanup
             process = c.reloadEntity(process);

--- a/dspace-api/src/test/java/org/dspace/builder/RelationshipBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/RelationshipBuilder.java
@@ -39,6 +39,7 @@ public class RelationshipBuilder extends AbstractBuilder<Relationship, Relations
     @Override
     public void cleanup() throws Exception {
         try (Context c = new Context()) {
+            c.setDispatcher("noindex");
             c.turnOffAuthorisationSystem();
             // Ensure object and any related objects are reloaded before checking to see what needs cleanup
             relationship = c.reloadEntity(relationship);

--- a/dspace-api/src/test/java/org/dspace/builder/RelationshipTypeBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/RelationshipTypeBuilder.java
@@ -37,6 +37,7 @@ public class RelationshipTypeBuilder extends AbstractBuilder<RelationshipType, R
     @Override
     public void cleanup() throws Exception {
         try (Context c = new Context()) {
+            c.setDispatcher("noindex");
             c.turnOffAuthorisationSystem();
             // Ensure object and any related objects are reloaded before checking to see what needs cleanup
             relationshipType = c.reloadEntity(relationshipType);

--- a/dspace-api/src/test/java/org/dspace/builder/RequestItemBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/RequestItemBuilder.java
@@ -117,6 +117,7 @@ public class RequestItemBuilder
             throws Exception {
         LOG.debug("cleanup()");
         try ( Context ctx = new Context(); ) {
+            ctx.setDispatcher("noindex");
             ctx.turnOffAuthorisationSystem();
             requestItem = ctx.reloadEntity(requestItem);
             if (null != requestItem) {

--- a/dspace-api/src/test/java/org/dspace/builder/ResourcePolicyBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/ResourcePolicyBuilder.java
@@ -41,6 +41,7 @@ public class ResourcePolicyBuilder extends AbstractBuilder<ResourcePolicy, Resou
     @Override
     public void cleanup() throws Exception {
         try (Context c = new Context()) {
+            c.setDispatcher("noindex");
             c.turnOffAuthorisationSystem();
             // Ensure object and any related objects are reloaded before checking to see what needs cleanup
             resourcePolicy = c.reloadEntity(resourcePolicy);

--- a/dspace-api/src/test/java/org/dspace/builder/ResourcePolicyBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/ResourcePolicyBuilder.java
@@ -82,6 +82,7 @@ public class ResourcePolicyBuilder extends AbstractBuilder<ResourcePolicy, Resou
     public void delete(ResourcePolicy rp) throws Exception {
         try (Context c = new Context()) {
             c.turnOffAuthorisationSystem();
+            c.setDispatcher("noindex");
             ResourcePolicy attachedDso = c.reloadEntity(rp);
             if (attachedDso != null) {
                 getService().delete(c, attachedDso);

--- a/dspace-api/src/test/java/org/dspace/builder/VersionBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/VersionBuilder.java
@@ -85,6 +85,7 @@ public class VersionBuilder extends AbstractBuilder<Version, VersioningService> 
     public void delete(Version version) throws Exception {
         try (Context context = new Context()) {
             context.turnOffAuthorisationSystem();
+            context.setDispatcher("noindex");
             Version attachedTab = context.reloadEntity(version);
             if (attachedTab != null) {
                 getService().delete(context, attachedTab);

--- a/dspace-api/src/test/java/org/dspace/builder/WorkflowItemBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/WorkflowItemBuilder.java
@@ -116,6 +116,7 @@ public class WorkflowItemBuilder extends AbstractBuilder<XmlWorkflowItem, XmlWor
     @Override
     public void cleanup() throws Exception {
         try (Context c = new Context()) {
+            c.setDispatcher("noindex");
             c.turnOffAuthorisationSystem();
             // Ensure object and any related objects are reloaded before checking to see what needs cleanup
             workspaceItem = c.reloadEntity(workspaceItem);

--- a/dspace-api/src/test/java/org/dspace/builder/WorkspaceItemBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/WorkspaceItemBuilder.java
@@ -106,6 +106,7 @@ public class WorkspaceItemBuilder extends AbstractBuilder<WorkspaceItem, Workspa
     @Override
     public void cleanup() throws Exception {
         try (Context c = new Context()) {
+            c.setDispatcher("noindex");
             c.turnOffAuthorisationSystem();
             // Ensure object and any related objects are reloaded before checking to see what needs cleanup
             workspaceItem = c.reloadEntity(workspaceItem);


### PR DESCRIPTION
## References
With this PR I configure the contexts with which the deletes are made in the builder cleanups to use the "noindex" dispatcher: in this way the consumers are not activated after each deletion and therefore no operations are performed on solr. These operations are in fact useless because all the solr cores are cleaned manually after each test. According to the analyzes I have conducted, this change should allow for a decrease in test execution time by approximately 10%.

## Checklist

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
