### PR TITLE
Update Docker compose scripts to point at new Entities data

### DIFF
--- a/dspace/src/main/docker-compose/cli.assetstore.yml
+++ b/dspace/src/main/docker-compose/cli.assetstore.yml
@@ -24,6 +24,6 @@ services:
           tar xvfz /tmp/assetstore.tar.gz
         fi
 
-        /dspace/bin/dspace index-discovery
+        /dspace/bin/dspace index-discovery -b
         /dspace/bin/dspace oai import
         /dspace/bin/dspace oai clean-cache

--- a/dspace/src/main/docker-compose/db.entities.yml
+++ b/dspace/src/main/docker-compose/db.entities.yml
@@ -13,7 +13,7 @@ services:
     image: dspace/dspace-postgres-pgcrypto:loadsql
     environment:
       # This SQL is available from https://github.com/DSpace-Labs/AIP-Files/releases/tag/demo-entities-data
-      - LOADSQL=https://github.com/DSpace-Labs/AIP-Files/releases/download/demo-entities-data/dspace7-entities-2021-04-14.sql
+      - LOADSQL=https://github.com/DSpace-Labs/AIP-Files/releases/download/demo-entities-data/dspace7-entities-data.sql
   dspace:
     ### OVERRIDE default 'entrypoint' in 'docker-compose.yml ####
     # Ensure that the database is ready BEFORE starting tomcat


### PR DESCRIPTION
This PR includes minor updates to Docker Compose scripts to ensure it uses the latest Demo Entities Data, which I just updated today, see "Change History" section at the bottom of the demo test data at https://github.com/DSpace-Labs/AIP-Files/releases/tag/demo-entities-data

These same minor Docker Compose updates are included on the `dspace-angular` project PR https://github.com/DSpace/dspace-angular/pull/1513   

So, this PR just ensures the Docker Compose scripts in `dspace` are re-synced with those in `dspace-angular` once that PR is merged.

I'll wait to merge this until after https://github.com/DSpace/dspace-angular/pull/1513 is approved & merged.
