### PR TITLE
Fix DSpace/DSpace#8167 XSD for controlled vocabulary

### DIFF
--- a/dspace/config/controlled-vocabularies/controlledvocabulary.xsd
+++ b/dspace/config/controlled-vocabularies/controlledvocabulary.xsd
@@ -56,7 +56,7 @@ or refer to the Web site http://dspace-dev.dsi.uminho.pt.
 					</xs:complexType>
 				</xs:element>
 			</xs:all>
-			<xs:attribute name="id" type="xs:ID" use="optional"/>
+			<xs:attribute name="id" type="xs:ID" use="required"/>
 			<xs:attribute name="label" type="xs:string" use="required"/>
 			<xs:attribute name="selectable" type="xs:boolean" default="true"/>
 		</xs:complexType>


### PR DESCRIPTION
Require attribute `id` for `node`s in `controlledvocabulary.xsd` to align with requirements of Angular UI.

## References
* Fixes #8167

## Description
Previously `id` was optional for controlled vocabularies, but without an `id` present, the hierarchical tree view in the Angular UI does not work, as described in #8167.
This request just flips the flag for use of `id` for `node`s in `controlledvocabulary.xsd` from `optional` to `required`.

## Instructions for Reviewers
`controlledvocabulary.xsd` is not used anywhere in the project. It seems, it is here merely for documentation. So this change has no effect on the existing codebase. The two included sample vocabularies do not reference the schema.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.