### PR TITLE
Enable default value for `solr.authority.server`

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1413,9 +1413,12 @@ plugin.selfnamed.org.dspace.content.authority.ChoiceAuthority = \
 ## See manual or org.dspace.content.authority.Choices source for descriptions.
 authority.minconfidence = ambiguous
 
+# Solr Authority index location
+# Default is ${solr.server}/authority, unless solr.multicorePrefix is specified
+solr.authority.server=${solr.server}/${solr.multicorePrefix}authority
+
 # Configuration settings for ORCID based authority control.
-# Uncomment the lines below to enable configuration.
-#solr.authority.server=${solr.server}/${solr.multicorePrefix}authority
+# Uncomment the lines below to enable configuration
 #choices.plugin.dc.contributor.author = SolrAuthorAuthority
 #choices.presentation.dc.contributor.author = authorLookup
 #authority.controlled.dc.contributor.author = true

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1413,10 +1413,6 @@ plugin.selfnamed.org.dspace.content.authority.ChoiceAuthority = \
 ## See manual or org.dspace.content.authority.Choices source for descriptions.
 authority.minconfidence = ambiguous
 
-# Solr Authority index location
-# Default is ${solr.server}/authority, unless solr.multicorePrefix is specified
-solr.authority.server=${solr.server}/${solr.multicorePrefix}authority
-
 # Configuration settings for ORCID based authority control.
 # Uncomment the lines below to enable configuration
 #choices.plugin.dc.contributor.author = SolrAuthorAuthority

--- a/dspace/config/modules/solrauthority.cfg
+++ b/dspace/config/modules/solrauthority.cfg
@@ -4,6 +4,10 @@
 # These configs are only used by the SOLR authority index       #
 #---------------------------------------------------------------#
 
+# Solr Authority index location
+# Default is ${solr.server}/authority, unless solr.multicorePrefix is specified
+solr.authority.server=${solr.server}/${solr.multicorePrefix}authority
+
 # Update item metadata displayed values (not the authority keys)
 # with the lasted cached versions when running the UpdateAuthorities index script
 #solrauthority.auto-update-items=false


### PR DESCRIPTION
## References
* Fixes #8177

## Description
Simply enables `solr.authority.server` by default.  Corrects the comments around it to make it clear that this setting is no longer specific to ORCID authority control.

## Instructions for Reviewers
* Reproduce the error stacktrace noted in #8177 on `main`
* Install this PR, and verify that error no longer is logged.