### PR TITLE
Fix for resource policy end date add patch not working

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/resourcePolicy/ResourcePolicyEndDateAddOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/resourcePolicy/ResourcePolicyEndDateAddOperation.java
@@ -43,7 +43,6 @@ public class ResourcePolicyEndDateAddOperation<R> extends PatchOperation<R> {
         checkOperationValue(operation.getValue());
         if (this.supports(resource, operation)) {
             ResourcePolicy resourcePolicy = (ResourcePolicy) resource;
-            resourcePolicyUtils.checkResourcePolicyForExistingEndDateValue(resourcePolicy, operation);
             resourcePolicyUtils.checkResourcePolicyForConsistentEndDateValue(resourcePolicy, operation);
             this.add(resourcePolicy, operation);
             return resource;


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/DSpace/issues/8179
* Related rest contract: https://github.com/DSpace/RestContract/blob/main/resourcepolicies.md

## Description
The code responsible for the ADD operation on the resource policy's end date incorrectly did a check that the previous state of the resource policy didn't have endDate=null [here](https://github.com/DSpace/DSpace/blame/main/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/resourcePolicy/ResourcePolicyEndDateAddOperation.java#L46). This check should only be done on the REPLACE operation, for an ADD the value doesn't need to be not null.

## Instructions for Reviewers
List of changes in this PR:
* Incorrect check removed
* IT testing this case

Failing request example `PATCH /server/api/authz/resourcepolicies/<:id>` `[{op: "add", path: "/endDate", value: "2023-02-09T01:00:00Z"}]`

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
