### PR TITLE
IT for file download so IS is closed & refactor file download with citation/cover page

### DIFF
--- a/dspace-api/src/main/java/org/dspace/curate/CitationPage.java
+++ b/dspace-api/src/main/java/org/dspace/curate/CitationPage.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.curate;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.sql.SQLException;
@@ -154,7 +155,8 @@ public class CitationPage extends AbstractCurationTask {
                     try {
                         //Create the cited document
                         InputStream citedInputStream =
-                            citationDocument.makeCitedDocument(Curator.curationContext(), bitstream).getLeft();
+                            new ByteArrayInputStream(
+                                citationDocument.makeCitedDocument(Curator.curationContext(), bitstream).getLeft());
                         //Add the cited document to the approiate bundle
                         this.addCitedPageToItem(citedInputStream, bundle, pBundle,
                                                 dBundle, displayMap, item, bitstream);

--- a/dspace-api/src/main/java/org/dspace/disseminate/CitationDocumentServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/disseminate/CitationDocumentServiceImpl.java
@@ -8,7 +8,6 @@
 package org.dspace.disseminate;
 
 import java.awt.Color;
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -297,7 +296,7 @@ public class CitationDocumentServiceImpl implements CitationDocumentService, Ini
     }
 
     @Override
-    public Pair<InputStream, Long> makeCitedDocument(Context context, Bitstream bitstream)
+    public Pair<byte[], Long> makeCitedDocument(Context context, Bitstream bitstream)
             throws IOException, SQLException, AuthorizeException {
         PDDocument document = new PDDocument();
         PDDocument sourceDocument = new PDDocument();
@@ -318,7 +317,7 @@ public class CitationDocumentServiceImpl implements CitationDocumentService, Ini
                 document.save(out);
 
                 byte[] data = out.toByteArray();
-                return Pair.of(new ByteArrayInputStream(data), Long.valueOf(data.length));
+                return Pair.of(data, Long.valueOf(data.length));
             }
 
         } finally {

--- a/dspace-api/src/main/java/org/dspace/disseminate/service/CitationDocumentService.java
+++ b/dspace-api/src/main/java/org/dspace/disseminate/service/CitationDocumentService.java
@@ -8,7 +8,6 @@
 package org.dspace.disseminate.service;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.sql.SQLException;
 
 import org.apache.commons.lang3.tuple.Pair;
@@ -84,7 +83,7 @@ public interface CitationDocumentService {
      * @throws SQLException       if database error
      * @throws AuthorizeException if authorization error
      */
-    public Pair<InputStream, Long> makeCitedDocument(Context context, Bitstream bitstream)
+    public Pair<byte[], Long> makeCitedDocument(Context context, Bitstream bitstream)
             throws IOException, SQLException, AuthorizeException;
 
     /**

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
@@ -132,7 +132,7 @@ public class BitstreamRestController {
 
         try {
             long filesize = bit.getSizeBytes();
-            var citationEnabledForBitstream = citationDocumentService.isCitationEnabledForBitstream(bit, context);
+            Boolean citationEnabledForBitstream = citationDocumentService.isCitationEnabledForBitstream(bit, context);
 
             HttpHeadersInitializer httpHeadersInitializer = new HttpHeadersInitializer()
                 .withBufferSize(BUFFER_SIZE)
@@ -152,10 +152,9 @@ public class BitstreamRestController {
                 httpHeadersInitializer.withDisposition(HttpHeadersInitializer.CONTENT_DISPOSITION_ATTACHMENT);
             }
 
-
             org.dspace.app.rest.utils.BitstreamResource bitstreamResource =
                 new org.dspace.app.rest.utils.BitstreamResource(
-                    bit, name, uuid, currentUser != null ? currentUser.getID() : null, citationEnabledForBitstream);
+                    name, uuid, currentUser != null ? currentUser.getID() : null, citationEnabledForBitstream);
 
             //We have all the data we need, close the connection to the database so that it doesn't stay open during
             //download/streaming

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
@@ -12,7 +12,6 @@ import static org.dspace.app.rest.utils.RegexUtils.REGEX_REQUESTMAPPING_IDENTIFI
 import static org.springframework.web.bind.annotation.RequestMethod.PUT;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.UUID;
@@ -22,7 +21,6 @@ import javax.ws.rs.core.Response;
 
 import org.apache.catalina.connector.ClientAbortException;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.converter.ConverterService;
 import org.dspace.app.rest.exception.DSpaceBadRequestException;
@@ -133,19 +131,12 @@ public class BitstreamRestController {
         }
 
         try {
-            long filesize;
-            if (citationDocumentService.isCitationEnabledForBitstream(bit, context)) {
-                final Pair<InputStream, Long> citedDocument = citationDocumentService.makeCitedDocument(context, bit);
-                filesize = citedDocument.getRight();
-                citedDocument.getLeft().close();
-            } else {
-                filesize = bit.getSizeBytes();
-            }
+            long filesize = bit.getSizeBytes();
+            var citationEnabledForBitstream = citationDocumentService.isCitationEnabledForBitstream(bit, context);
 
             HttpHeadersInitializer httpHeadersInitializer = new HttpHeadersInitializer()
                 .withBufferSize(BUFFER_SIZE)
                 .withFileName(name)
-                .withLength(filesize)
                 .withChecksum(bit.getChecksum())
                 .withMimetype(mimetype)
                 .with(request)
@@ -162,10 +153,9 @@ public class BitstreamRestController {
             }
 
 
-
             org.dspace.app.rest.utils.BitstreamResource bitstreamResource =
                 new org.dspace.app.rest.utils.BitstreamResource(
-                    bit, name, uuid, filesize, currentUser != null ? currentUser.getID() : null);
+                    bit, name, uuid, currentUser != null ? currentUser.getID() : null, citationEnabledForBitstream);
 
             //We have all the data we need, close the connection to the database so that it doesn't stay open during
             //download/streaming

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
@@ -24,6 +24,11 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.springframework.data.rest.webmvc.RestMediaTypes.TEXT_URI_LIST_VALUE;
 import static org.springframework.http.MediaType.parseMediaType;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -73,10 +78,13 @@ import org.dspace.statistics.ObjectCount;
 import org.dspace.statistics.SolrLoggerServiceImpl;
 import org.dspace.statistics.factory.StatisticsServiceFactory;
 import org.dspace.statistics.service.SolrLoggerService;
+import org.dspace.storage.bitstore.factory.StorageServiceFactory;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.ReflectionTestUtils;
 
 /**
  * Integration test to test the /api/core/bitstreams/[id]/* endpoints
@@ -968,4 +976,110 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
                 bitstreamService.getMetadataByMetadataString(bitstream, "dc.format")
         ));
     }
+
+
+    @Test
+    public void closeInputStreamsRegularDownload() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+        //1. A community-collection structure with one parent community and one collections.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .build();
+
+        Collection col1 =
+            CollectionBuilder.createCollection(context, parentCommunity).withName("Collection 1").build();
+
+        //2. A public item with a bitstream
+        String bitstreamContent = "0123456789";
+
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
+
+            Item publicItem1 = ItemBuilder.createItem(context, col1)
+                .withTitle("Public item 1")
+                .withIssueDate("2017-10-17")
+                .withAuthor("Smith, Donald").withAuthor("Doe, John")
+                .build();
+
+            bitstream = BitstreamBuilder
+                .createBitstream(context, publicItem1, is)
+                .withName("Test bitstream")
+                .withDescription("This is a bitstream to test range requests")
+                .withMimeType("text/plain")
+                .build();
+        }
+        context.restoreAuthSystemState();
+
+        var bitstreamStorageService = StorageServiceFactory.getInstance().getBitstreamStorageService();
+        var inputStream = bitstreamStorageService.retrieve(context, bitstream);
+        var inputStreamSpy = spy(inputStream);
+        var bitstreamStorageServiceSpy = spy(bitstreamStorageService);
+        ReflectionTestUtils.setField(bitstreamService, "bitstreamStorageService", bitstreamStorageServiceSpy);
+        doReturn(inputStreamSpy).when(bitstreamStorageServiceSpy).retrieve(any(), eq(bitstream));
+
+        //** WHEN **
+        //We download the bitstream
+        getClient().perform(get("/api/core/bitstreams/" + bitstream.getID() + "/content"))
+            //** THEN **
+            .andExpect(status().isOk());
+
+        Mockito.verify(bitstreamStorageServiceSpy, times(1)).retrieve(any(), eq(bitstream));
+        Mockito.verify(inputStreamSpy, times(1)).close();
+    }
+
+    @Test
+    public void closeInputStreamsDownloadWithCoverPage() throws Exception {
+        configurationService.setProperty("citation-page.enable_globally", true);
+        citationDocumentService.afterPropertiesSet();
+        context.turnOffAuthorisationSystem();
+
+
+        //** GIVEN **
+        //1. A community-collection structure with one parent community and one collections.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .build();
+
+        Collection col1 =
+            CollectionBuilder.createCollection(context, parentCommunity).withName("Collection 1").build();
+
+        //2. A public item with a bitstream
+        File originalPdf = new File(testProps.getProperty("test.bitstream"));
+
+        try (InputStream is = new FileInputStream(originalPdf)) {
+
+            Item publicItem1 = ItemBuilder.createItem(context, col1)
+                    .withTitle("Public item citation cover page test 1")
+                    .withIssueDate("2017-10-17")
+                    .withAuthor("Smith, Donald").withAuthor("Doe, John")
+                    .build();
+
+            bitstream = BitstreamBuilder
+                    .createBitstream(context, publicItem1, is)
+                    .withName("Test bitstream")
+                    .withDescription("This is a bitstream to test the citation cover page.")
+                    .withMimeType("application/pdf")
+                    .build();
+        }
+        context.restoreAuthSystemState();
+
+        var bitstreamStorageService = StorageServiceFactory.getInstance().getBitstreamStorageService();
+        var inputStreamSpy = spy(bitstreamStorageService.retrieve(context, bitstream));
+        var inputStreamSpy2 = spy(bitstreamStorageService.retrieve(context, bitstream));
+        var bitstreamStorageServiceSpy = spy(bitstreamStorageService);
+        ReflectionTestUtils.setField(bitstreamService, "bitstreamStorageService", bitstreamStorageServiceSpy);
+        doReturn(inputStreamSpy, inputStreamSpy2).when(bitstreamStorageServiceSpy).retrieve(any(), eq(bitstream));
+
+        //** WHEN **
+        //We download the bitstream
+        getClient().perform(get("/api/core/bitstreams/" + bitstream.getID() + "/content"))
+            //** THEN **
+            .andExpect(status().isOk());
+
+        Mockito.verify(bitstreamStorageServiceSpy, times(2)).retrieve(any(), eq(bitstream));
+        Mockito.verify(inputStreamSpy, times(1)).close();
+        Mockito.verify(inputStreamSpy2, times(1)).close();
+    }
+
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
@@ -1066,10 +1066,9 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
 
         var bitstreamStorageService = StorageServiceFactory.getInstance().getBitstreamStorageService();
         var inputStreamSpy = spy(bitstreamStorageService.retrieve(context, bitstream));
-        var inputStreamSpy2 = spy(bitstreamStorageService.retrieve(context, bitstream));
         var bitstreamStorageServiceSpy = spy(bitstreamStorageService);
         ReflectionTestUtils.setField(bitstreamService, "bitstreamStorageService", bitstreamStorageServiceSpy);
-        doReturn(inputStreamSpy, inputStreamSpy2).when(bitstreamStorageServiceSpy).retrieve(any(), eq(bitstream));
+        doReturn(inputStreamSpy).when(bitstreamStorageServiceSpy).retrieve(any(), eq(bitstream));
 
         //** WHEN **
         //We download the bitstream
@@ -1077,9 +1076,8 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
             //** THEN **
             .andExpect(status().isOk());
 
-        Mockito.verify(bitstreamStorageServiceSpy, times(2)).retrieve(any(), eq(bitstream));
+        Mockito.verify(bitstreamStorageServiceSpy, times(1)).retrieve(any(), eq(bitstream));
         Mockito.verify(inputStreamSpy, times(1)).close();
-        Mockito.verify(inputStreamSpy2, times(1)).close();
     }
 
 }


### PR DESCRIPTION
## References
* Fixes #8140
* IT related to https://github.com/DSpace/DSpace/issues/8078
* Related contract (`/api/core/bitstreams/<:uuid>/content`): https://github.com/DSpace/RestContract/blob/main/bitstreams.md

## Description
- Adds IT demonstrating that the [previous fix](https://github.com/DSpace/DSpace/issues/8078) for preventing S3 connection leak works and to ensure refactoring doesn't break this fix.
- File download (with cover/citation page) is refactored so the citation page is note created twice (previously once to determine length of file, and once in `BitstreamResource` to create the inputStream that will be closed.
- The inputStream (that isn't explicitly closed) isn't created until it is called in `BitstreamResource#getInputStream` 

## Instructions for Reviewers
Verify you can download a file with citation page (eg config `citation-page.enable_globally=true`) and that the `CitationDocumentService#makeCitedDocument` is now only called once. 
With an S3 assetstore the connections should not be used up anymore still. (see https://github.com/DSpace/DSpace/issues/8078)

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
