### PR TITLE
Fix GoogleBitstreamComparator to return 0 when equal

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/GoogleBitstreamComparator.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/GoogleBitstreamComparator.java
@@ -86,8 +86,10 @@ public class GoogleBitstreamComparator implements Comparator<Bitstream> {
         if (priority1 > priority2) {
             return 1;
         } else if (priority1 == priority2) {
-            if (b1.getSizeBytes() <= b2.getSizeBytes()) {
+            if (b1.getSizeBytes() < b2.getSizeBytes()) {
                 return 1;
+            } else if (b1.getSizeBytes() == b2.getSizeBytes()) {
+                return 0;
             } else {
                 return -1;
             }

--- a/dspace-api/src/test/java/org/dspace/app/util/GoogleBitstreamComparatorTest.java
+++ b/dspace-api/src/test/java/org/dspace/app/util/GoogleBitstreamComparatorTest.java
@@ -164,6 +164,12 @@ public class GoogleBitstreamComparatorTest extends AbstractUnitTest {
                      toSort.get(1).getName());
         assertEquals("Bitstreams have same size and type, so order should remain unchanged", "bitstream3",
                      toSort.get(2).getName());
+
+        // Also, verify all bitstreams are considered equal (comparison returns 0)
+        GoogleBitstreamComparator comparator = new GoogleBitstreamComparator(context, settings);
+        assertEquals(0, comparator.compare(bitstream1, bitstream2));
+        assertEquals(0, comparator.compare(bitstream2, bitstream3));
+        assertEquals(0, comparator.compare(bitstream3, bitstream1));
     }
 
     /**


### PR DESCRIPTION
## References
Fixes #8211

## Description
Fix `compare()` by returning 0 when bitstreams are "equal" in size & priority.

This was already partially tested in the existing `GoogleBitstreamComparatorTest.testSameMimeTypeSameSize()` test method, but I added tests to ensure equality is always returned. This will ensure we don't trigger an `IllegalArgumentException: Comparison method violates its general contract!` in some scenarios.

## Instructions for Reviewers
* Review code changes & changes to test.  This likely only needs a code review, as the test proves it works.