### PR TITLE
Rename Hibernate caches as suggested by Hibernate.

### DIFF
--- a/dspace/config/hibernate-ehcache-config.xml
+++ b/dspace/config/hibernate-ehcache-config.xml
@@ -31,20 +31,22 @@
       </resources>
     </cache-template>
 
-   <!-- this cache tracks the timestamps of the most recent updates to particular
-        tables.  It is important that the cache timeout of the underlying cache
-        implementation be set to a higher value than the timeouts of any of the
-        query caches. In fact, it is recommended that the the underlying cache
-        not be configured for expiry at all. -->
-    <cache alias="org.hibernate.cache.spi.UpdateTimestampsCache">
+   <!-- This cache tracks the timestamps of the most recent updates to
+        particular tables.  It is important that the cache timeout of
+        the underlying cache implementation be set to a higher value
+        than the timeouts of any of the query caches.  In fact, it is
+        recommended that the the underlying cache not be configured
+        for expiry at all. -->
+    <cache alias='default-update-timestamps-region'>
       <expiry>
         <none/>
       </expiry>
       <heap unit='entries'>6000</heap>
     </cache>
 
-    <!-- this cache stores the actual objects pulled out of the DB by hibernate -->
-    <cache alias="org.hibernate.cache.internal.StandardQueryCache">
+    <!-- This cache stores the actual objects pulled out of the DB by
+         Hibernate. -->
+    <cache alias='default-query-results-region'>
       <expiry>
         <ttl>600</ttl>
       </expiry>


### PR DESCRIPTION
## References
* Fixes #8213

## Description
Hibernate now looks for two caches first under new names.  This patch renames those caches in the EHCache configuration.

Nothing is broken -- now.  But it might break in a future Hibernate release, and meanwhile this removes clutter from the log.

## Instructions for Reviewers
List of changes in this PR:
* Renames two general caches in `config/hibernate-ehcache-config.xml`.

To test:  start a DSpace webapp, and check `logs/dspace.log` for the absence of HHH90001007 warnings.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
