### PR TITLE
Bitstream download filename lose non-latin characters

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/HttpHeadersInitializer.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/HttpHeadersInitializer.java
@@ -9,6 +9,7 @@ package org.dspace.app.rest.utils;
 
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
+import static javax.mail.internet.MimeUtility.encodeText;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -163,7 +164,8 @@ public class HttpHeadersInitializer {
         }
 
         httpHeaders.put(CONTENT_DISPOSITION, Collections.singletonList(String.format(CONTENT_DISPOSITION_FORMAT,
-                                                                                     disposition, fileName)));
+                                                                                     disposition,
+                                                                                     encodeText(fileName))));
         log.debug("Content-Disposition : {}", disposition);
 
         // Content phase


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #8023

## Description
When download a bitstream having filename with character other than latin, those characters will be missing in file save dialog. For example, file named "ภาษาไทย File.pdf", will be saved as " File.pdf" instead of as the 

This is because the text is not encoded when returned with the headers

## Instructions for Reviewers

List of changes in this PR:
* The same encoding that was initially applied to the older DSpace versions is also applied during the retrieval of the bitstreams (And subsequently, their names)
* This can be tested by uploading and downloading a bitstream with a 'special' name, and checking that the encoding applied result in the names being exactly the same 

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
