### PR TITLE
Update deprecated Velocity configuration keys

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -927,7 +927,6 @@
         <dependency>
             <groupId>org.apache.velocity</groupId>
             <artifactId>velocity-engine-core</artifactId>
-            <type>jar</type>
         </dependency>
 
         <dependency>

--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -1001,7 +1001,7 @@
           <dependency>
             <groupId>org.apache.velocity</groupId>
             <artifactId>velocity-engine-core</artifactId>
-            <version>2.2</version>
+            <version>2.3</version>
           </dependency>
           <dependency>
               <groupId>org.xmlunit</groupId>

--- a/dspace-api/src/main/java/org/dspace/core/Email.java
+++ b/dspace-api/src/main/java/org/dspace/core/Email.java
@@ -152,14 +152,14 @@ public class Email {
     private static final String RESOURCE_REPOSITORY_NAME = "Email";
     private static final Properties VELOCITY_PROPERTIES = new Properties();
     static {
-        VELOCITY_PROPERTIES.put(Velocity.RESOURCE_LOADER, "string");
-        VELOCITY_PROPERTIES.put("string.resource.loader.description",
+        VELOCITY_PROPERTIES.put(Velocity.RESOURCE_LOADERS, "string");
+        VELOCITY_PROPERTIES.put("resource.loader.string.description",
                 "Velocity StringResource loader");
-        VELOCITY_PROPERTIES.put("string.resource.loader.class",
+        VELOCITY_PROPERTIES.put("resource.loader.string.class",
                 StringResourceLoader.class.getName());
-        VELOCITY_PROPERTIES.put("string.resource.loader.repository.name",
+        VELOCITY_PROPERTIES.put("resource.loader.string.repository.name",
                 RESOURCE_REPOSITORY_NAME);
-        VELOCITY_PROPERTIES.put("string.resource.loader.repository.static",
+        VELOCITY_PROPERTIES.put("resource.loader.string.repository.static",
                 "false");
     }
 


### PR DESCRIPTION
## References
* Fixes #8192

## Description
Replaced deprecated keys in Velocity engine properties.

## Instructions for Reviewers
Start DSpace and check the log for lack of deprecation warnings from Velocity.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
