### PR TITLE
CVE-2022-22965 fixes for 7.0, 7.1 or 7.2 backend (Bump Spring from 5.2.5 to 5.2.20)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <!--=== GENERAL / DSPACE-API DEPENDENCIES ===-->
         <java.version>11</java.version>
-        <spring.version>5.2.5.RELEASE</spring.version>
+        <spring.version>5.2.20.RELEASE</spring.version>
         <spring-boot.version>2.2.6.RELEASE</spring-boot.version>
         <spring-security.version>5.2.2.RELEASE</spring-security.version> <!-- sync with version used by spring-boot-->
         <hibernate.version>5.4.10.Final</hibernate.version>
@@ -1215,6 +1215,12 @@
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-expression</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-context-support</artifactId>
                 <version>${spring.version}</version>
             </dependency>
 


### PR DESCRIPTION
## Overview
**DSpace 7 is impacted by the Spring4Shell vulnerability (CVE-2022-22965)** provided that you are running the DSpace 7 backend on Apache Tomcat (which most likely are)​. See also https://spring.io/blog/2022/03/31/spring-framework-rce-early-announcement

The fix for this vulnerability is in this PR, which upgrades Spring from 5.2.5 to 5.2.20 to avoid CVE-2022-22965.

You have several options below in patching your DSpace 7 site (each of which is documented below). CHOOSE ONE.
* Upgrade 7.2 backend to 7.2.1
* Patch / Quick fix for 7.0 or 7.1 or 7.2
* Workarounds / Alternative Fixes

## Upgrade 7.2 backend to 7.2.1

This fix is available in the backend version 7.2.1: https://github.com/DSpace/DSpace/releases/tag/dspace-7.2.1   If you are already on DSpace 7.2, the quickest fix may be to simply upgrade your backend to 7.2.1.  
1. Download the 7.2.1 release of the backend.
2. Rebuild & redeploy the backend
    * `mvn -U clean package`
    * `cd [dspace-source]/dspace/target/dspace-installer`
    * `ant update`
    * (If necessary in your setup, copy the updated `server` webapp over into Tomcat)
3. Finally, restart your Tomcat (or other servlet container).

_NOTE:_ If you are not already running DSpace 7.2, you will need to upgrade to DSpace 7.2 *first* before you can use the 7.2.1 release of the backend.  So, if you are running 7.1 or 7.0, one of the fixes below may be easiest.

## Patch / Quick Fix for 7.0, 7.1 or 7.2

This PR is a valid quick-fix of CVE-2022-22965 for either a 7.0, 7.1 or 7.2 backend.
1. Apply the same changes to your root `pom.xml` (i.e. the one in the top-level source folder), or cherry-pick the commit.  These same changes will work for either 7.0, 7.1 or 7.2.
2. After applying these changes, you will need to rebuild and redeploy your DSpace 7 backend (to ensure it is now using a secure version of Spring). For example:
    * `mvn -U clean package`
    * `cd [dspace-source]/dspace/target/dspace-installer`
    * `ant update`
    * (If necessary in your setup, copy the updated `server` webapp over into Tomcat)
3. Finally, restart your Tomcat (or other servlet container).

(_NOTE:_ This PR should never need to be applied to `main` as it will be rendered obsolete by #8215, which will fix this issue for the upcoming 7.3 release.)

## Workarounds / Alternative Fixes
* If you cannot update DSpace, you can instead **upgrade Apache Tomcat to version 9.0.62 (or a later 9.x release)** as documented at https://spring.io/blog/2022/03/31/spring-framework-rce-early-announcement#suggested-workarounds
    * This version of Apache Tomcat guards against the vulnerability. So, if you upgrade Tomcat, your existing DSpace 7 site should be protected.

## Doesn't affect 6.x or earlier

This PR will _not_ be backported to 6.x or earlier releases, as CVE-2022-22965 does not appear to affect those releases.  DSpace 6.x and earlier releases could _not_ be run on Java 9 or later, and this vulnerability has been documented to only affect applications running on Java 9 or later.
