### PR TITLE
Fix PATCH of resource policy end date when start date is null

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/resourcePolicy/ResourcePolicyUtils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/resourcePolicy/ResourcePolicyUtils.java
@@ -134,7 +134,7 @@ public class ResourcePolicyUtils {
         String dateS = (String) operation.getValue();
         try {
             Date date = simpleDateFormat.parse(dateS);
-            if (resource.getEndDate() != null && resource.getStartDate().after(date)) {
+            if (resource.getStartDate() != null && resource.getStartDate().after(date)) {
                 throw new DSpaceBadRequestException("Attempting to set an invalid endDate smaller than the startDate.");
             }
         } catch (ParseException e) {


### PR DESCRIPTION
## References
* Fixes #8239

## Description
Fixes a tiny, obvious typo which causes the issue described in #8239.  Code should check if **StartDate** is not null before validating with StartDate.
