### PR TITLE
IIIF manifest and canvas cache eviction is asynchronous and could led to unexpected responses

### DIFF
--- a/dspace-api/src/main/java/org/dspace/iiif/consumer/CanvasCacheEvictService.java
+++ b/dspace-api/src/main/java/org/dspace/iiif/consumer/CanvasCacheEvictService.java
@@ -23,7 +23,7 @@ public class CanvasCacheEvictService {
     CacheManager cacheManager;
 
     public void evictSingleCacheValue(String cacheKey) {
-        Objects.requireNonNull(cacheManager.getCache(CACHE_NAME)).evict(cacheKey);
+        Objects.requireNonNull(cacheManager.getCache(CACHE_NAME)).evictIfPresent(cacheKey);
     }
 
 }

--- a/dspace-api/src/main/java/org/dspace/iiif/consumer/ManifestsCacheEvictService.java
+++ b/dspace-api/src/main/java/org/dspace/iiif/consumer/ManifestsCacheEvictService.java
@@ -30,7 +30,7 @@ public class ManifestsCacheEvictService {
     }
 
     public void evictAllCacheValues() {
-        Objects.requireNonNull(cacheManager.getCache(CACHE_NAME)).clear();
+        Objects.requireNonNull(cacheManager.getCache(CACHE_NAME)).invalidate();
     }
 
 }

--- a/dspace-api/src/main/java/org/dspace/iiif/consumer/ManifestsCacheEvictService.java
+++ b/dspace-api/src/main/java/org/dspace/iiif/consumer/ManifestsCacheEvictService.java
@@ -26,7 +26,7 @@ public class ManifestsCacheEvictService {
     CacheManager cacheManager;
 
     public void evictSingleCacheValue(String cacheKey) {
-        Objects.requireNonNull(cacheManager.getCache(CACHE_NAME)).evict(cacheKey);
+        Objects.requireNonNull(cacheManager.getCache(CACHE_NAME)).evictIfPresent(cacheKey);
     }
 
     public void evictAllCacheValues() {


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #8243

## Description
Short summary of changes (1-2 sentences).
Used cache eviction or invalidation methods which guarantee synchronous execution.


List of changes in this PR:
* dspace-api/src/main/java/org/dspace/iiif/consumer/CanvasCacheEvictService.java evictSingleValue method uses evictIfPresent method for eviction
* dspace-api/src/main/java/org/dspace/iiif/consumer/ManifestsCacheEvictService.java evictSingleValue method uses evictIfPresent method for eviction
* dspace-api/src/main/java/org/dspace/iiif/consumer/ManifestsCacheEvictService.java evictAllCacheValues method uses invalidate method for eviction

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

The only evidence of impact of reported problem emerged during parallel builds on same machine. It is possible to run in parallel two or more builds and check that IIIFControllerIT.findOneWithCacheEvictionAfterBitstreamUpdate and IIIFControllerIT.findOneWithCacheEvictionAfterItemUpdate are not failing anymore.


## Checklist


- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
