### PR TITLE
Remove Xalan & Xerces as direct dependencies of dspace-api

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -531,14 +531,6 @@
             <artifactId>fontbox</artifactId>
         </dependency>
         <dependency>
-            <groupId>xalan</groupId>
-            <artifactId>xalan</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>xerces</groupId>
-            <artifactId>xercesImpl</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.ibm.icu</groupId>
             <artifactId>icu4j</artifactId>
         </dependency>

--- a/dspace-api/src/main/java/org/dspace/administer/MetadataImporter.java
+++ b/dspace-api/src/main/java/org/dspace/administer/MetadataImporter.java
@@ -11,13 +11,16 @@ import java.io.IOException;
 import java.sql.SQLException;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.xpath.XPathAPI;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.MetadataField;
 import org.dspace.content.MetadataSchema;
@@ -90,7 +93,7 @@ public class MetadataImporter {
     public static void main(String[] args)
         throws ParseException, SQLException, IOException, TransformerException,
         ParserConfigurationException, AuthorizeException, SAXException,
-        NonUniqueMetadataException, RegistryImportException {
+        NonUniqueMetadataException, RegistryImportException, XPathExpressionException {
 
         // create an options object and populate it
         CommandLineParser parser = new DefaultParser();
@@ -124,8 +127,8 @@ public class MetadataImporter {
      * @throws RegistryImportException      if import fails
      */
     public static void loadRegistry(String file, boolean forceUpdate)
-        throws SQLException, IOException, TransformerException, ParserConfigurationException,
-        AuthorizeException, SAXException, NonUniqueMetadataException, RegistryImportException {
+        throws SQLException, IOException, TransformerException, ParserConfigurationException, AuthorizeException,
+        SAXException, NonUniqueMetadataException, RegistryImportException, XPathExpressionException {
         Context context = null;
 
         try {
@@ -137,7 +140,9 @@ public class MetadataImporter {
             Document document = RegistryImporter.loadXML(file);
 
             // Get the nodes corresponding to types
-            NodeList schemaNodes = XPathAPI.selectNodeList(document, "/dspace-dc-types/dc-schema");
+            XPath xPath = XPathFactory.newInstance().newXPath();
+            NodeList schemaNodes = (NodeList) xPath.compile("/dspace-dc-types/dc-schema")
+                                                   .evaluate(document, XPathConstants.NODESET);
 
             // Add each one as a new format to the registry
             for (int i = 0; i < schemaNodes.getLength(); i++) {
@@ -146,7 +151,8 @@ public class MetadataImporter {
             }
 
             // Get the nodes corresponding to types
-            NodeList typeNodes = XPathAPI.selectNodeList(document, "/dspace-dc-types/dc-type");
+            NodeList typeNodes = (NodeList) xPath.compile("/dspace-dc-types/dc-type")
+                                                 .evaluate(document, XPathConstants.NODESET);
 
             // Add each one as a new format to the registry
             for (int i = 0; i < typeNodes.getLength(); i++) {
@@ -178,8 +184,8 @@ public class MetadataImporter {
      * @throws RegistryImportException    if import fails
      */
     private static void loadSchema(Context context, Node node, boolean updateExisting)
-        throws SQLException, IOException, TransformerException,
-        AuthorizeException, NonUniqueMetadataException, RegistryImportException {
+        throws SQLException, AuthorizeException, NonUniqueMetadataException, RegistryImportException,
+        XPathExpressionException {
         // Get the values
         String name = RegistryImporter.getElementData(node, "name");
         String namespace = RegistryImporter.getElementData(node, "namespace");
@@ -236,8 +242,8 @@ public class MetadataImporter {
      * @throws RegistryImportException    if import fails
      */
     private static void loadType(Context context, Node node)
-        throws SQLException, IOException, TransformerException,
-        AuthorizeException, NonUniqueMetadataException, RegistryImportException {
+        throws SQLException, IOException, AuthorizeException, NonUniqueMetadataException, RegistryImportException,
+        XPathExpressionException {
         // Get the values
         String schema = RegistryImporter.getElementData(node, "schema");
         String element = RegistryImporter.getElementData(node, "element");

--- a/dspace-api/src/main/java/org/dspace/administer/RegistryImporter.java
+++ b/dspace-api/src/main/java/org/dspace/administer/RegistryImporter.java
@@ -13,8 +13,11 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
 
-import org.apache.xpath.XPathAPI;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -72,9 +75,10 @@ public class RegistryImporter {
      * @throws TransformerException if error
      */
     public static String getElementData(Node parentElement, String childName)
-        throws TransformerException {
+        throws XPathExpressionException {
         // Grab the child node
-        Node childNode = XPathAPI.selectSingleNode(parentElement, childName);
+        XPath xPath = XPathFactory.newInstance().newXPath();
+        Node childNode = (Node) xPath.compile(childName).evaluate(parentElement, XPathConstants.NODE);
 
         if (childNode == null) {
             // No child node, so no values
@@ -115,9 +119,10 @@ public class RegistryImporter {
      * @throws TransformerException if error
      */
     public static String[] getRepeatedElementData(Node parentElement,
-                                                  String childName) throws TransformerException {
+                                                  String childName) throws XPathExpressionException {
         // Grab the child node
-        NodeList childNodes = XPathAPI.selectNodeList(parentElement, childName);
+        XPath xPath = XPathFactory.newInstance().newXPath();
+        NodeList childNodes = (NodeList) xPath.compile(childName).evaluate(parentElement, XPathConstants.NODESET);
 
         String[] data = new String[childNodes.getLength()];
 

--- a/dspace-api/src/main/java/org/dspace/administer/RegistryLoader.java
+++ b/dspace-api/src/main/java/org/dspace/administer/RegistryLoader.java
@@ -16,9 +16,12 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.xpath.XPathAPI;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.BitstreamFormat;
 import org.dspace.content.factory.ContentServiceFactory;
@@ -122,12 +125,13 @@ public class RegistryLoader {
      */
     public static void loadBitstreamFormats(Context context, String filename)
         throws SQLException, IOException, ParserConfigurationException,
-        SAXException, TransformerException, AuthorizeException {
+        SAXException, TransformerException, AuthorizeException, XPathExpressionException {
         Document document = loadXML(filename);
 
         // Get the nodes corresponding to formats
-        NodeList typeNodes = XPathAPI.selectNodeList(document,
-                                                     "dspace-bitstream-types/bitstream-type");
+        XPath xPath = XPathFactory.newInstance().newXPath();
+        NodeList typeNodes = (NodeList) xPath.compile("dspace-bitstream-types/bitstream-type")
+                                             .evaluate(document, XPathConstants.NODESET);
 
         // Add each one as a new format to the registry
         for (int i = 0; i < typeNodes.getLength(); i++) {
@@ -151,8 +155,7 @@ public class RegistryLoader {
      * @throws AuthorizeException   if authorization error
      */
     private static void loadFormat(Context context, Node node)
-        throws SQLException, IOException, TransformerException,
-        AuthorizeException {
+        throws SQLException, AuthorizeException, XPathExpressionException {
         // Get the values
         String mimeType = getElementData(node, "mimetype");
         String shortDesc = getElementData(node, "short_description");
@@ -231,9 +234,10 @@ public class RegistryLoader {
      * @throws TransformerException if transformer error
      */
     private static String getElementData(Node parentElement, String childName)
-        throws TransformerException {
+        throws XPathExpressionException {
         // Grab the child node
-        Node childNode = XPathAPI.selectSingleNode(parentElement, childName);
+        XPath xPath = XPathFactory.newInstance().newXPath();
+        Node childNode = (Node) xPath.compile(childName).evaluate(parentElement, XPathConstants.NODE);
 
         if (childNode == null) {
             // No child node, so no values
@@ -274,9 +278,10 @@ public class RegistryLoader {
      * @throws TransformerException if transformer error
      */
     private static String[] getRepeatedElementData(Node parentElement,
-                                                   String childName) throws TransformerException {
+                                                   String childName) throws XPathExpressionException {
         // Grab the child node
-        NodeList childNodes = XPathAPI.selectNodeList(parentElement, childName);
+        XPath xPath = XPathFactory.newInstance().newXPath();
+        NodeList childNodes = (NodeList) xPath.compile(childName).evaluate(parentElement, XPathConstants.NODESET);
 
         String[] data = new String[childNodes.getLength()];
 

--- a/dspace-api/src/main/java/org/dspace/administer/StructBuilder.java
+++ b/dspace-api/src/main/java/org/dspace/administer/StructBuilder.java
@@ -30,6 +30,10 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -38,7 +42,6 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.xpath.XPathAPI;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
@@ -137,8 +140,8 @@ public class StructBuilder {
      * @throws TransformerException if the input document is invalid.
      */
     public static void main(String[] argv)
-            throws ParserConfigurationException, SQLException,
-            FileNotFoundException, IOException, TransformerException {
+        throws ParserConfigurationException, SQLException,
+        IOException, TransformerException, XPathExpressionException {
         // Define command line options.
         Options options = new Options();
 
@@ -240,7 +243,7 @@ public class StructBuilder {
      * @throws SQLException
      */
     static void importStructure(Context context, InputStream input, OutputStream output)
-            throws IOException, ParserConfigurationException, SQLException, TransformerException {
+        throws IOException, ParserConfigurationException, SQLException, TransformerException, XPathExpressionException {
 
         // load the XML
         Document document = null;
@@ -258,13 +261,15 @@ public class StructBuilder {
         // is properly structured.
         try {
             validate(document);
-        } catch (TransformerException ex) {
+        } catch (XPathExpressionException ex) {
             System.err.format("The input document is invalid:  %s%n", ex.getMessage());
             System.exit(1);
         }
 
         // Check for 'identifier' attributes -- possibly output by this class.
-        NodeList identifierNodes = XPathAPI.selectNodeList(document, "//*[@identifier]");
+        XPath xPath = XPathFactory.newInstance().newXPath();
+        NodeList identifierNodes = (NodeList) xPath.compile("//*[@identifier]")
+                                                   .evaluate(document, XPathConstants.NODESET);
         if (identifierNodes.getLength() > 0) {
             System.err.println("The input document has 'identifier' attributes, which will be ignored.");
         }
@@ -287,7 +292,8 @@ public class StructBuilder {
         Element[] elements = new Element[]{};
         try {
             // get the top level community list
-            NodeList first = XPathAPI.selectNodeList(document, "/import_structure/community");
+            NodeList first = (NodeList) xPath.compile("/import_structure/community")
+                                             .evaluate(document, XPathConstants.NODESET);
 
             // run the import starting with the top level communities
             elements = handleCommunities(context, first, null);
@@ -456,14 +462,16 @@ public class StructBuilder {
      * @throws TransformerException if transformer error
      */
     private static void validate(org.w3c.dom.Document document)
-        throws TransformerException {
+        throws XPathExpressionException {
         StringBuilder err = new StringBuilder();
         boolean trip = false;
 
         err.append("The following errors were encountered parsing the source XML.\n");
         err.append("No changes have been made to the DSpace instance.\n\n");
 
-        NodeList first = XPathAPI.selectNodeList(document, "/import_structure/community");
+        XPath xPath = XPathFactory.newInstance().newXPath();
+        NodeList first = (NodeList) xPath.compile("/import_structure/community")
+                                         .evaluate(document, XPathConstants.NODESET);
         if (first.getLength() == 0) {
             err.append("-There are no top level communities in the source document.");
             System.out.println(err.toString());
@@ -493,14 +501,15 @@ public class StructBuilder {
      * no errors.
      */
     private static String validateCommunities(NodeList communities, int level)
-        throws TransformerException {
+        throws XPathExpressionException {
         StringBuilder err = new StringBuilder();
         boolean trip = false;
         String errs = null;
+        XPath xPath = XPathFactory.newInstance().newXPath();
 
         for (int i = 0; i < communities.getLength(); i++) {
             Node n = communities.item(i);
-            NodeList name = XPathAPI.selectNodeList(n, "name");
+            NodeList name = (NodeList) xPath.compile("name").evaluate(n, XPathConstants.NODESET);
             if (name.getLength() != 1) {
                 String pos = Integer.toString(i + 1);
                 err.append("-The level ").append(level)
@@ -510,7 +519,7 @@ public class StructBuilder {
             }
 
             // validate sub communities
-            NodeList subCommunities = XPathAPI.selectNodeList(n, "community");
+            NodeList subCommunities = (NodeList) xPath.compile("community").evaluate(n, XPathConstants.NODESET);
             String comErrs = validateCommunities(subCommunities, level + 1);
             if (comErrs != null) {
                 err.append(comErrs);
@@ -518,7 +527,7 @@ public class StructBuilder {
             }
 
             // validate collections
-            NodeList collections = XPathAPI.selectNodeList(n, "collection");
+            NodeList collections = (NodeList) xPath.compile("collection").evaluate(n, XPathConstants.NODESET);
             String colErrs = validateCollections(collections, level + 1);
             if (colErrs != null) {
                 err.append(colErrs);
@@ -542,14 +551,15 @@ public class StructBuilder {
      * @return the errors to be generated by the calling method, or null if none
      */
     private static String validateCollections(NodeList collections, int level)
-        throws TransformerException {
+        throws XPathExpressionException {
         StringBuilder err = new StringBuilder();
         boolean trip = false;
         String errs = null;
+        XPath xPath = XPathFactory.newInstance().newXPath();
 
         for (int i = 0; i < collections.getLength(); i++) {
             Node n = collections.item(i);
-            NodeList name = XPathAPI.selectNodeList(n, "name");
+            NodeList name = (NodeList) xPath.compile("name").evaluate(n, XPathConstants.NODESET);
             if (name.getLength() != 1) {
                 String pos = Integer.toString(i + 1);
                 err.append("-The level ").append(level)
@@ -613,8 +623,9 @@ public class StructBuilder {
      * created communities (e.g. the handles they have been assigned)
      */
     private static Element[] handleCommunities(Context context, NodeList communities, Community parent)
-        throws TransformerException, SQLException, AuthorizeException {
+        throws TransformerException, SQLException, AuthorizeException, XPathExpressionException {
         Element[] elements = new Element[communities.getLength()];
+        XPath xPath = XPathFactory.newInstance().newXPath();
 
         for (int i = 0; i < communities.getLength(); i++) {
             Community community;
@@ -634,7 +645,7 @@ public class StructBuilder {
             // now update the metadata
             Node tn = communities.item(i);
             for (Map.Entry<String, MetadataFieldName> entry : communityMap.entrySet()) {
-                NodeList nl = XPathAPI.selectNodeList(tn, entry.getKey());
+                NodeList nl = (NodeList) xPath.compile(entry.getKey()).evaluate(tn, XPathConstants.NODESET);
                 if (nl.getLength() == 1) {
                     communityService.setMetadataSingleValue(context, community,
                             entry.getValue(), null, getStringValue(nl.item(0)));
@@ -700,11 +711,11 @@ public class StructBuilder {
             }
 
             // handle sub communities
-            NodeList subCommunities = XPathAPI.selectNodeList(tn, "community");
+            NodeList subCommunities = (NodeList) xPath.compile("community").evaluate(tn, XPathConstants.NODESET);
             Element[] subCommunityElements = handleCommunities(context, subCommunities, community);
 
             // handle collections
-            NodeList collections = XPathAPI.selectNodeList(tn, "collection");
+            NodeList collections = (NodeList) xPath.compile("collection").evaluate(tn, XPathConstants.NODESET);
             Element[] collectionElements = handleCollections(context, collections, community);
 
             int j;
@@ -731,8 +742,9 @@ public class StructBuilder {
      * created collections (e.g. the handle)
      */
     private static Element[] handleCollections(Context context, NodeList collections, Community parent)
-        throws TransformerException, SQLException, AuthorizeException {
+        throws SQLException, AuthorizeException, XPathExpressionException {
         Element[] elements = new Element[collections.getLength()];
+        XPath xPath = XPathFactory.newInstance().newXPath();
 
         for (int i = 0; i < collections.getLength(); i++) {
             Element element = new Element("collection");
@@ -745,7 +757,7 @@ public class StructBuilder {
             // import the rest of the metadata
             Node tn = collections.item(i);
             for (Map.Entry<String, MetadataFieldName> entry : collectionMap.entrySet()) {
-                NodeList nl = XPathAPI.selectNodeList(tn, entry.getKey());
+                NodeList nl = (NodeList) xPath.compile(entry.getKey()).evaluate(tn, XPathConstants.NODESET);
                 if (nl.getLength() == 1) {
                     collectionService.setMetadataSingleValue(context, collection,
                             entry.getValue(), null, getStringValue(nl.item(0)));

--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
@@ -51,6 +51,10 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
 
 import org.apache.commons.collections4.ComparatorUtils;
 import org.apache.commons.io.FileDeleteStrategy;
@@ -59,7 +63,6 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.logging.log4j.Logger;
-import org.apache.xpath.XPathAPI;
 import org.dspace.app.itemimport.service.ItemImportService;
 import org.dspace.app.util.LocalSchemaFilenameFilter;
 import org.dspace.app.util.RelationshipUtils;
@@ -863,7 +866,7 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
     // Load all metadata schemas into the item.
     protected void loadMetadata(Context c, Item myitem, String path)
         throws SQLException, IOException, ParserConfigurationException,
-        SAXException, TransformerException, AuthorizeException {
+        SAXException, TransformerException, AuthorizeException, XPathExpressionException {
         // Load the dublin core metadata
         loadDublinCore(c, myitem, path + "dublin_core.xml");
 
@@ -877,14 +880,15 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
 
     protected void loadDublinCore(Context c, Item myitem, String filename)
         throws SQLException, IOException, ParserConfigurationException,
-        SAXException, TransformerException, AuthorizeException {
+        SAXException, TransformerException, AuthorizeException, XPathExpressionException {
         Document document = loadXML(filename);
 
         // Get the schema, for backward compatibility we will default to the
         // dublin core schema if the schema name is not available in the import
         // file
         String schema;
-        NodeList metadata = XPathAPI.selectNodeList(document, "/dublin_core");
+        XPath xPath = XPathFactory.newInstance().newXPath();
+        NodeList metadata = (NodeList) xPath.compile("/dublin_core").evaluate(document, XPathConstants.NODESET);
         Node schemaAttr = metadata.item(0).getAttributes().getNamedItem(
             "schema");
         if (schemaAttr == null) {
@@ -894,8 +898,7 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
         }
 
         // Get the nodes corresponding to formats
-        NodeList dcNodes = XPathAPI.selectNodeList(document,
-                                                   "/dublin_core/dcvalue");
+        NodeList dcNodes = (NodeList) xPath.compile("/dublin_core/dcvalue").evaluate(document, XPathConstants.NODESET);
 
         if (!isQuiet) {
             System.out.println("\tLoading dublin core from " + filename);

--- a/dspace-api/src/main/java/org/dspace/authority/util/XMLUtils.java
+++ b/dspace-api/src/main/java/org/dspace/authority/util/XMLUtils.java
@@ -14,11 +14,12 @@ import java.util.Iterator;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.TransformerException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.xpath.XPathAPI;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -62,36 +63,26 @@ public class XMLUtils {
 
     /**
      * @param xml           The starting context (a Node or a Document, for example).
-     * @param NodeListXPath xpath
+     * @param nodeListXPath xpath
      * @return A Node matches the NodeListXPath
      * null if nothing matches the NodeListXPath
      * @throws XPathExpressionException if xpath error
      */
-    public static Node getNode(Node xml, String NodeListXPath) throws XPathExpressionException {
-        Node result = null;
-        try {
-            result = XPathAPI.selectSingleNode(xml, NodeListXPath);
-        } catch (TransformerException e) {
-            log.error("Error", e);
-        }
-        return result;
+    public static Node getNode(Node xml, String nodeListXPath) throws XPathExpressionException {
+        XPath xPath = XPathFactory.newInstance().newXPath();
+        return (Node) xPath.compile(nodeListXPath).evaluate(xml, XPathConstants.NODE);
     }
 
     /**
      * @param xml           The starting context (a Node or a Document, for example).
-     * @param NodeListXPath xpath
+     * @param nodeListXPath xpath
      * @return A NodeList containing the nodes that match the NodeListXPath
      * null if nothing matches the NodeListXPath
      * @throws XPathExpressionException if xpath error
      */
-    public static NodeList getNodeList(Node xml, String NodeListXPath) throws XPathExpressionException {
-        NodeList nodeList = null;
-        try {
-            nodeList = XPathAPI.selectNodeList(xml, NodeListXPath);
-        } catch (TransformerException e) {
-            log.error("Error", e);
-        }
-        return nodeList;
+    public static NodeList getNodeList(Node xml, String nodeListXPath) throws XPathExpressionException {
+        XPath xPath = XPathFactory.newInstance().newXPath();
+        return (NodeList) xPath.compile(nodeListXPath).evaluate(xml, XPathConstants.NODESET);
     }
 
     public static Iterator<Node> getNodeListIterator(Node xml, String NodeListXPath) throws XPathExpressionException {

--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/XSLTCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/XSLTCrosswalk.java
@@ -134,7 +134,7 @@ public abstract class XSLTCrosswalk extends SelfNamedPlugin {
      * We need to force this, because some dependency elsewhere interferes.
      */
     private static final String TRANSFORMER_FACTORY_CLASS
-        = "com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl";
+        = "org.apache.xalan.processor.TransformerFactoryImpl";
 
     private Transformer transformer = null;
     private File transformFile = null;

--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/XSLTCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/XSLTCrosswalk.java
@@ -130,12 +130,6 @@ public abstract class XSLTCrosswalk extends SelfNamedPlugin {
         return aliasList.toArray(new String[aliasList.size()]);
     }
 
-    /**
-     * We need to force this, because some dependency elsewhere interferes.
-     */
-    private static final String TRANSFORMER_FACTORY_CLASS
-        = "org.apache.xalan.processor.TransformerFactoryImpl";
-
     private Transformer transformer = null;
     private File transformFile = null;
     private long transformLastModified = 0;
@@ -181,8 +175,7 @@ public abstract class XSLTCrosswalk extends SelfNamedPlugin {
                 Source transformSource
                     = new StreamSource(new FileInputStream(transformFile));
                 TransformerFactory transformerFactory
-                    = TransformerFactory.newInstance(
-                    TRANSFORMER_FACTORY_CLASS, null);
+                    = TransformerFactory.newInstance();
                 transformer = transformerFactory.newTransformer(transformSource);
                 transformLastModified = transformFile.lastModified();
             } catch (TransformerConfigurationException | FileNotFoundException e) {

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/RegistryUpdater.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/RegistryUpdater.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.sql.SQLException;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
+import javax.xml.xpath.XPathExpressionException;
 
 import org.dspace.administer.MetadataImporter;
 import org.dspace.administer.RegistryImportException;
@@ -89,7 +90,7 @@ public class RegistryUpdater implements Callback {
         } catch (IOException | SQLException | ParserConfigurationException
                 | TransformerException | RegistryImportException
                 | AuthorizeException | NonUniqueMetadataException
-                | SAXException e) {
+                | SAXException | XPathExpressionException e) {
             log.error("Error attempting to update Bitstream Format and/or Metadata Registries", e);
             throw new RuntimeException("Error attempting to update Bitstream Format and/or Metadata Registries", e);
         } finally {

--- a/dspace-api/src/main/java/org/dspace/submit/migration/SubmissionFormsMigration.java
+++ b/dspace-api/src/main/java/org/dspace/submit/migration/SubmissionFormsMigration.java
@@ -64,12 +64,6 @@ public class SubmissionFormsMigration extends DSpaceRunnable<SubmissionFormsMigr
         "<!ELEMENT input-forms (form-map, form-definitions, form-value-pairs) >";
     private List<File> tempFiles = new ArrayList<>();
 
-    /**
-     * We need to force this, because some dependency elsewhere interferes.
-     */
-    private static final String TRANSFORMER_FACTORY_CLASS
-        = "org.apache.xalan.processor.TransformerFactoryImpl";
-
     @Override
     public void internalRun() throws TransformerException {
         if (help) {
@@ -101,8 +95,7 @@ public class SubmissionFormsMigration extends DSpaceRunnable<SubmissionFormsMigr
         Result result = new StreamResult(new File(outputPath));
 
         // Create an instance of TransformerFactory
-        TransformerFactory transformerFactory = TransformerFactory.newInstance(
-            TRANSFORMER_FACTORY_CLASS, null);
+        TransformerFactory transformerFactory = TransformerFactory.newInstance();
 
         Transformer trans;
         try {

--- a/dspace-oai/pom.xml
+++ b/dspace-oai/pom.xml
@@ -83,10 +83,6 @@
                     <artifactId>mockito-all</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>xml-apis</groupId>
-                    <artifactId>xml-apis</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>org.apache.commons</groupId>
                     <artifactId>commons-lang3</artifactId>
                 </exclusion>

--- a/dspace-oai/src/main/java/org/dspace/xoai/services/impl/resources/DSpaceResourceResolver.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/impl/resources/DSpaceResourceResolver.java
@@ -23,7 +23,7 @@ import org.dspace.services.factory.DSpaceServicesFactory;
 
 public class DSpaceResourceResolver implements ResourceResolver {
     private static final TransformerFactory transformerFactory = TransformerFactory
-            .newInstance("net.sf.saxon.TransformerFactoryImpl", null);
+            .newInstance();
 
     private final String basePath;
 

--- a/dspace-oai/src/test/java/org/dspace/xoai/tests/stylesheets/AbstractXSLTest.java
+++ b/dspace-oai/src/test/java/org/dspace/xoai/tests/stylesheets/AbstractXSLTest.java
@@ -20,7 +20,7 @@ import org.apache.commons.io.IOUtils;
 
 public abstract class AbstractXSLTest {
     private static final TransformerFactory factory = TransformerFactory
-            .newInstance("net.sf.saxon.TransformerFactoryImpl", null);
+            .newInstance();
 
     protected TransformBuilder apply(String xslLocation) throws Exception {
         return new TransformBuilder(xslLocation);

--- a/dspace-sword/pom.xml
+++ b/dspace-sword/pom.xml
@@ -61,10 +61,6 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>xml-apis</groupId>
-                    <artifactId>xml-apis</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
 
@@ -127,7 +123,7 @@
         <dependency>
             <groupId>xom</groupId>
             <artifactId>xom</artifactId>
-            <version>1.2.5</version>
+            <version>1.3.7</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1542,16 +1542,13 @@
                 <artifactId>fontbox</artifactId>
                 <version>${pdfbox-version}</version>
             </dependency>
-            <dependency>
-                <groupId>xalan</groupId>
-                <artifactId>xalan</artifactId>
-                <version>2.7.0</version>
-            </dependency>
+            <!-- Tika and Jena disagree on version of Xerces to use. Select latest -->
             <dependency>
                 <groupId>xerces</groupId>
                 <artifactId>xercesImpl</artifactId>
                 <version>2.12.2</version>
             </dependency>
+            <!-- SWORDv1 and SWORDv2 modules both pull in various versions of xml-apis. Select latest version -->
             <dependency>
                 <groupId>xml-apis</groupId>
                 <artifactId>xml-apis</artifactId>


### PR DESCRIPTION
## Description

This small PR is loosely related to #8222, in that I discovered during building that PR that we were still including Xalan & Xerces as direct dependencies of `dspace-api`.  Both Xalan & Xerces libraries are outdated/unmaintained and it's now recommended to use `javax.xml.*` classes that are built into Java.

This PR removes both as direct dependencies, migrating any old `org.apache.xpath.*` code to use `javax.xml.xpath.*`.  (I chose to migrate these to `javax.xml.xpath.*` instead of JDOM2 simply because it's a smaller/easier migration.  Moving to JDOM2 would require a larger code refactor, and it seemed unnecessary to solve this issue.)

(NOTE: While Xerces is removed as a direct dependency, it still is brought in by both Tika & Jena, which is why it is still included in our `<dependencyManagement>` in the Parent POM.)


## Instructions for Reviewers

* Review code changes & verify existing tests succeed (they do)
* Optionally test OAI-PMH as some classes there changed (I've tested already)
* Optionally test SWORD v1 as some classes there changed (I've done basic tests already)
* Optionally test several CLI tools which are updated, including `registry-loader` (tested), `structure-builder` (NOT yet tested), `import` (NOT yet tested), `submission-forms-migrate` (tested)
