### PR TITLE
Fix Creative Commons step not loading

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/SubmissionService.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/SubmissionService.java
@@ -306,7 +306,9 @@ public class SubmissionService {
         result.setRights(creativeCommonsService.getLicenseName(item));
 
         Bitstream licenseRdfBitstream = creativeCommonsService.getLicenseRdfBitstream(item);
-        result.setFile(converter.toRest(licenseRdfBitstream, Projection.DEFAULT));
+        if (licenseRdfBitstream != null) {
+            result.setFile(converter.toRest(licenseRdfBitstream, Projection.DEFAULT));
+        }
 
         return result;
     }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CCLicenseAddPatchOperationIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CCLicenseAddPatchOperationIT.java
@@ -10,7 +10,7 @@ package org.dspace.app.rest;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -118,7 +118,11 @@ public class CCLicenseAddPatchOperationIT extends AbstractControllerIntegrationT
                                               .content(patchBody)
                                               .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                              .andExpect(status().isOk())
-                             .andExpect(jsonPath("$.sections", not(hasJsonPath("cclicense"))));
+                             .andExpect(jsonPath("$.sections.cclicense", allOf(
+                                     hasJsonPath("$.uri", nullValue()),
+                                     hasJsonPath("$.rights",nullValue()),
+                                     hasJsonPath("$.file", nullValue())
+                             )));
 
 
     }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CCLicenseRemovePatchOperationIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CCLicenseRemovePatchOperationIT.java
@@ -10,7 +10,7 @@ package org.dspace.app.rest;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -95,7 +95,11 @@ public class CCLicenseRemovePatchOperationIT extends AbstractControllerIntegrati
                                               .content(removePatch)
                                               .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                              .andExpect(status().isOk())
-                             .andExpect(jsonPath("$.sections", not(hasJsonPath("cclicense"))));
+                             .andExpect(jsonPath("$.sections.cclicense", allOf(
+                                     hasJsonPath("$.uri", nullValue()),
+                                     hasJsonPath("$.rights",nullValue()),
+                                     hasJsonPath("$.file", nullValue())
+                             )));
     }
 
 


### PR DESCRIPTION
## References

* Fixes #7991

## Description
Fix a Null pointer exception thats prevents to load the Creative Commons submission step.

## Instructions for Reviewers

List of changes in this PR:
* Check for not converting to Rest a null CC RDF bitstream to avoid a Null Pointer Exception
* Two test functions has been modified to check that when a workspace item doesn't have a Creative Commons granted the CC section is generated but with all properties set to null. I have understood in the Rest contract that it is the expected behavior: https://github.com/DSpace/RestContract/blob/main/workspaceitem-data-cclicense.md

**Include guidance for how to test or review your PR.** 

* Activate the cclicense step in item-submission.xml
* Start a new submission and check that the Creative commons step is loaded and the dspace.log doesn't show a Null pointer exception

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
