### PR TITLE
Revert changes to OAI-PMH TransformerFactory initialization. It MUST use Saxon

### DIFF
--- a/dspace-oai/src/main/java/org/dspace/xoai/services/impl/resources/DSpaceResourceResolver.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/impl/resources/DSpaceResourceResolver.java
@@ -22,8 +22,9 @@ import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 
 public class DSpaceResourceResolver implements ResourceResolver {
+    // Requires usage of Saxon as OAI-PMH uses some XSLT 2 functions
     private static final TransformerFactory transformerFactory = TransformerFactory
-            .newInstance();
+            .newInstance("net.sf.saxon.TransformerFactoryImpl", null);
 
     private final String basePath;
 

--- a/dspace-oai/src/test/java/org/dspace/xoai/tests/stylesheets/AbstractXSLTest.java
+++ b/dspace-oai/src/test/java/org/dspace/xoai/tests/stylesheets/AbstractXSLTest.java
@@ -19,8 +19,9 @@ import javax.xml.transform.stream.StreamSource;
 import org.apache.commons.io.IOUtils;
 
 public abstract class AbstractXSLTest {
+    // Requires usage of Saxon as OAI-PMH uses some XSLT 2 functions
     private static final TransformerFactory factory = TransformerFactory
-            .newInstance();
+            .newInstance("net.sf.saxon.TransformerFactoryImpl", null);
 
     protected TransformBuilder apply(String xslLocation) throws Exception {
         return new TransformBuilder(xslLocation);


### PR DESCRIPTION
## References
* Reverts a minor change added in #8258 

## Description
After #8258 was merged, I stumbled on a small bug in the OAI-PMH interface caused by that PR.  It seems our OAI-PMH interface **must** use Saxon, as several of its crosswalks rely on XSLT 2 functions.

In #8258, I changed the behavior to allow it to select any XSLT transformer.  But, today after booting up the backend, I noticed these errors:
```
SystemId Unknown; Line #21; Column #150; Could not find function: format-date
SystemId Unknown; Line #21; Column #150; Could not find function: current-date
SystemId Unknown; Line #21; Column #150; Could not find function: format-time
SystemId Unknown; Line #21; Column #150; Could not find function: current-time
SystemId Unknown; Line #21; Column #150; function token not found.
(Location of error unknown)java.lang.NullPointerException
SystemId Unknown; Line #649; Column #60; Could not find function: ends-with
SystemId Unknown; Line #649; Column #60; function token not found.
(Location of error unknown)java.lang.NullPointerException
```

I also noticed that the `metadataPrefix=mets` wasn't working because it uses XSLT 2 functions, e.g. http://localhost:8080/server/oai/request?verb=ListRecords&metadataPrefix=mets

## Instructions for Reviewers
* Check code. Reverts two changes to OAI-PMH from #8258, and adds comments to explain why they are needed.
* Optionally test OAI-PMH (I already did this as well)

## Related work

This relates back to #2627 and #2708 where OAI-PMH was updated to support XSLT 2
