### PR TITLE
Add custom exception for deleting Group with pending tasks

### DIFF
--- a/dspace-api/src/main/resources/Messages.properties
+++ b/dspace-api/src/main/resources/Messages.properties
@@ -119,3 +119,4 @@ org.dspace.app.rest.exception.RESTEmptyWorkflowGroupException.message = Refused 
     workflow group {1}. Delete the tasks and group first if you want to remove this user.
 org.dspace.app.rest.exception.EPersonNameNotProvidedException.message = The eperson.firstname and eperson.lastname values need to be filled in
 org.dspace.app.rest.exception.GroupNameNotProvidedException.message = Cannot create group, no group name is provided
+org.dspace.app.rest.exception.GroupHasPendingWorkflowTasksException.message = Cannot delete group, the associated workflow role still has pending tasks

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
@@ -133,6 +133,7 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
         RESTEmptyWorkflowGroupException.class,
         EPersonNameNotProvidedException.class,
         GroupNameNotProvidedException.class,
+        GroupHasPendingWorkflowTasksException.class,
     })
     protected void handleCustomUnprocessableEntityException(HttpServletRequest request, HttpServletResponse response,
                                                             TranslatableException ex) throws IOException {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/GroupHasPendingWorkflowTasksException.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/GroupHasPendingWorkflowTasksException.java
@@ -20,7 +20,7 @@ import org.dspace.core.I18nUtil;
 public class GroupHasPendingWorkflowTasksException
         extends UnprocessableEntityException implements TranslatableException {
     public static final String MESSAGE_KEY =
-        "org.dspace.app.rest.exception.GroupHasPendingTasksException.message";
+        "org.dspace.app.rest.exception.GroupHasPendingWorkflowTasksException.message";
 
     public GroupHasPendingWorkflowTasksException() {
         super(I18nUtil.getMessage(MESSAGE_KEY));

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/GroupHasPendingWorkflowTasksException.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/GroupHasPendingWorkflowTasksException.java
@@ -1,0 +1,36 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+
+package org.dspace.app.rest.exception;
+
+import org.dspace.core.I18nUtil;
+
+/**
+ * <p>Extend {@link UnprocessableEntityException} to provide a specific error message
+ * in the REST response. The error message is added to the response in
+ * {@link DSpaceApiExceptionControllerAdvice#handleCustomUnprocessableEntityException},
+ * hence it should not contain sensitive or security-compromising info.</p>
+ *
+ */
+public class GroupHasPendingWorkflowTasksException
+        extends UnprocessableEntityException implements TranslatableException {
+    public static final String MESSAGE_KEY =
+        "org.dspace.app.rest.exception.GroupHasPendingTasksException.message";
+
+    public GroupHasPendingWorkflowTasksException() {
+        super(I18nUtil.getMessage(MESSAGE_KEY));
+    }
+
+    public GroupHasPendingWorkflowTasksException(Throwable cause) {
+        super(I18nUtil.getMessage(MESSAGE_KEY), cause);
+    }
+
+    public String getMessageKey() {
+        return MESSAGE_KEY;
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CollectionRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CollectionRestRepository.java
@@ -24,6 +24,7 @@ import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.Parameter;
 import org.dspace.app.rest.SearchRestMethod;
 import org.dspace.app.rest.exception.DSpaceBadRequestException;
+import org.dspace.app.rest.exception.GroupHasPendingWorkflowTasksException;
 import org.dspace.app.rest.exception.RepositoryMethodNotImplementedException;
 import org.dspace.app.rest.exception.UnprocessableEntityException;
 import org.dspace.app.rest.model.BitstreamRest;
@@ -695,8 +696,8 @@ public class CollectionRestRepository extends DSpaceObjectRestRepository<Collect
         throws SQLException, WorkflowConfigurationException, AuthorizeException, WorkflowException, IOException {
         Group group = workflowService.getWorkflowRoleGroup(context, collection, workflowRole, null);
         if (!poolTaskService.findByGroup(context, group).isEmpty()) {
-            throw new UnprocessableEntityException("The Group that was attempted to be deleted " +
-                                                       "still has Pooltasks open");
+            // todo: also handle claimed tasks that would become associated with this group once returned to the pool
+            throw new GroupHasPendingWorkflowTasksException();
         }
         if (group == null) {
             throw new ResourceNotFoundException("The requested Group was not found");

--- a/dspace-server-webapp/src/main/resources/application.properties
+++ b/dspace-server-webapp/src/main/resources/application.properties
@@ -77,6 +77,9 @@ spring.http.encoding.force=true
 # However, you may wish to set this to "always" in your 'local.cfg' for development or debugging purposes.
 server.error.include-stacktrace = never
 
+# When to include the error message in error responses (introduced in Spring 2.3.x)
+server.error.include-message = always
+
 # Spring Boot proxy configuration (can be overridden in local.cfg).
 # By default, Spring Boot does not automatically use X-Forwarded-* Headers when generating links (and similar) in the
 # DSpace REST API. Three options are currently supported by Spring Boot:

--- a/dspace-server-webapp/src/test/resources/Messages_pl.properties
+++ b/dspace-server-webapp/src/test/resources/Messages_pl.properties
@@ -11,3 +11,4 @@ org.dspace.app.rest.exception.RESTEmptyWorkflowGroupException.message = [PL] Ref
     workflow group {1}. Delete the tasks and group first if you want to remove this user.
 org.dspace.app.rest.exception.EPersonNameNotProvidedException.message = [PL] The eperson.firstname and eperson.lastname values need to be filled in
 org.dspace.app.rest.exception.GroupNameNotProvidedException.message = [PL] Cannot create group, no group name is provided
+org.dspace.app.rest.exception.GroupHasPendingWorkflowTasksException.message = [PL] Cannot delete group, the associated workflow role still has pending tasks


### PR DESCRIPTION
## References

_Add references/links to any related issues or PRs. These may include:_
* Related to #8272
* Frontend PR: https://github.com/DSpace/dspace-angular/pull/1640

## Description
Introduced a new `GroupHasPendingWorkflowTasksException` for `CollectionRestRepository.deleteWorkflowGroupForRole` to throw when a Group should not be deleted if this would break the workflow.

## Instructions for Reviewers
Follow the instructions in the frontend PR.

* In `dspace.log`, you should see that `GroupHasPendingWorkflowTasksException` was thrown
* The error notification should contain the text defined in `Messages.properties`

## Checklist

_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.