### PR TITLE
Fix type bind validation to support fields configured more than once

### DIFF
--- a/dspace-api/src/test/data/dspaceFolder/config/item-submission.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/item-submission.xml
@@ -21,6 +21,7 @@
         <name-map collection-handle="123456789/language-test-1" submission-name="languagetestprocess"/>
         <name-map collection-handle="123456789/extraction-test" submission-name="extractiontestprocess"/>
         <name-map collection-handle="123456789/qualdrop-test" submission-name="qualdroptest"/>
+        <name-map collection-handle="123456789/typebind-test" submission-name="typebindtest"/>
         <name-map collection-handle="123456789/accessCondition-not-discoverable" submission-name="accessConditionNotDiscoverable"/>
     </submission-map>
 
@@ -78,6 +79,11 @@
         </step-definition>
 
         <step-definition id="qualdroptest">
+            <processing-class>org.dspace.app.rest.submit.step.DescribeStep</processing-class>
+            <type>submission-form</type>
+        </step-definition>
+
+        <step-definition id="typebindtest">
             <processing-class>org.dspace.app.rest.submit.step.DescribeStep</processing-class>
             <type>submission-form</type>
         </step-definition>
@@ -189,6 +195,10 @@
 
         <submission-process name="qualdroptest">
             <step id="qualdroptest" />
+        </submission-process>
+
+        <submission-process name="typebindtest">
+            <step id="typebindtest" />
         </submission-process>
 
         <submission-process name="accessConditionNotDiscoverable">

--- a/dspace-api/src/test/data/dspaceFolder/config/submission-forms.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/submission-forms.xml
@@ -154,7 +154,6 @@
          <!-- An input-type of qualdrop_value MUST be marked as repeatable -->
          <repeatable>true</repeatable>
          <label>Identifiers</label>
-         <type-bind>Article</type-bind>
          <input-type value-pairs-name="common_identifiers">qualdrop_value</input-type>
          <hint>If the item has any identification numbers or codes associated with
 it, please enter the types and the actual numbers or codes.</hint>

--- a/dspace-api/src/test/data/dspaceFolder/config/submission-forms.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/submission-forms.xml
@@ -154,6 +154,7 @@
          <!-- An input-type of qualdrop_value MUST be marked as repeatable -->
          <repeatable>true</repeatable>
          <label>Identifiers</label>
+         <type-bind>Article</type-bind>
          <input-type value-pairs-name="common_identifiers">qualdrop_value</input-type>
          <hint>If the item has any identification numbers or codes associated with
 it, please enter the types and the actual numbers or codes.</hint>
@@ -299,6 +300,75 @@ it, please enter the types and the actual numbers or codes.</hint>
          <hint>If the item has any identification numbers or codes associated with
            it, please enter the types and the actual numbers or codes.</hint>
          <required>please give an identifier</required>
+       </field>
+     </row>
+   </form>
+
+   <form name="typebindtest">
+     <row>
+       <field>
+         <dc-schema>dc</dc-schema>
+         <dc-element>title</dc-element>
+         <dc-qualifier></dc-qualifier>
+         <repeatable>false</repeatable>
+         <label>Title</label>
+         <input-type>onebox</input-type>
+         <hint>Enter the main title of the item.</hint>
+         <required>You must enter a main title for this item.</required>
+         <!--    <language value-pairs-name="common_iso_languages">true</language> -->
+       </field>
+     </row>
+     <row>
+       <field>
+         <dc-schema>dc</dc-schema>
+         <dc-element>date</dc-element>
+         <dc-qualifier>issued</dc-qualifier>
+         <repeatable>false</repeatable>
+         <label>Date of Issue</label>
+         <style>col-sm-4</style>
+         <input-type>date</input-type>
+         <hint>Please give the date of previous publication or public distribution.
+           You can leave out the day and/or month if they aren't
+           applicable.</hint>
+         <required>You must enter at least the year.</required>
+       </field>
+     </row>
+     <row>
+       <field>
+         <dc-schema>dc</dc-schema>
+         <dc-element>type</dc-element>
+         <dc-qualifier></dc-qualifier>
+         <repeatable>true</repeatable>
+         <label>Type</label>
+         <input-type value-pairs-name="common_types">dropdown</input-type>
+         <hint>Select the type(s) of content of the item. To select more than one value in the list, you may have to hold down the "CTRL" or "Shift" key.</hint>
+         <required></required>
+       </field>
+     </row>
+     <row>
+       <!-- ISBN bound to type Book and required -->
+       <field>
+         <dc-schema>dc</dc-schema>
+         <dc-element>identifier</dc-element>
+         <dc-qualifier>isbn</dc-qualifier>
+         <repeatable>true</repeatable>
+         <label>ISBN</label>
+         <type-bind>Book</type-bind>
+         <input-type>onebox</input-type>
+         <hint>Enter the ISBN of the book.</hint>
+         <required>An ISBN is required.</required>
+       </field>
+       <!-- ISBN bound to type Book chapter and NOT required and NOT repeatable -->
+       <field>
+         <dc-schema>dc</dc-schema>
+         <dc-element>identifier</dc-element>
+         <dc-qualifier>isbn</dc-qualifier>
+         <repeatable>true</repeatable>
+         <label>ISBN of Book</label>
+         <type-bind>Book chapter</type-bind>
+         <input-type>onebox</input-type>
+         <hint>Enter the ISBN of the book in which this chapter appears.</hint>
+         <required></required>
        </field>
      </row>
    </form>

--- a/dspace-api/src/test/java/org/dspace/app/util/SubmissionConfigTest.java
+++ b/dspace-api/src/test/java/org/dspace/app/util/SubmissionConfigTest.java
@@ -1,0 +1,88 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.dspace.AbstractUnitTest;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Tests for parsing and utilities on submission config forms / readers
+ *
+ * @author Kim Shepherd
+ */
+public class SubmissionConfigTest extends AbstractUnitTest {
+
+    DCInputsReader inputReader;
+
+    @BeforeClass
+    public static void setUpClass() {
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+    }
+
+    @Before
+    public void setUp() throws DCInputsReaderException {
+        inputReader = new DCInputsReader();
+    }
+
+    @After
+    public void tearDown() {
+        inputReader = null;
+    }
+
+    @Test
+    public void testReadAndProcessTypeBindSubmissionConfig()
+            throws SubmissionConfigReaderException, DCInputsReaderException {
+        // Set up test data. This should match the typebind test submission / form config
+        String typeBindHandle = "123456789/typebind-test";
+        String typeBindSubmissionName = "typebindtest";
+        String typeBindSubmissionStepName = "typebindtest";
+
+        // Expected field lists from typebindtest form
+        List<String> allConfiguredFields = new ArrayList<>();
+        allConfiguredFields.add("dc.title");
+        allConfiguredFields.add("dc.date.issued");
+        allConfiguredFields.add("dc.type");
+        allConfiguredFields.add("dc.identifier.isbn");
+        List<String> unboundFields = allConfiguredFields.subList(0, 3);
+
+        // Get submission configuration
+        SubmissionConfig submissionConfig =
+                new SubmissionConfigReader().getSubmissionConfigByCollection(typeBindHandle);
+        // Submission name should match name defined in item-submission.xml
+        assertEquals(typeBindSubmissionName, submissionConfig.getSubmissionName());
+        // Step 0 - our process only has one step. It should not be null and have the ID typebindtest
+        SubmissionStepConfig submissionStepConfig = submissionConfig.getStep(0);
+        assertNotNull(submissionStepConfig);
+        assertEquals(typeBindSubmissionStepName, submissionStepConfig.getId());
+        // Get inputs and allowed fields
+        DCInputSet inputConfig = inputReader.getInputsByFormName(submissionStepConfig.getId());
+        List<String> allowedFieldsForBook = inputConfig.populateAllowedFieldNames("Book");
+        List<String> allowedFieldsForBookChapter = inputConfig.populateAllowedFieldNames("Book chapter");
+        List<String> allowedFieldsForArticle = inputConfig.populateAllowedFieldNames("Article");
+        List<String> allowedFieldsForNoType = inputConfig.populateAllowedFieldNames(null);
+        // Book and book chapter should be allowed all 5 fields (each is bound to dc.identifier.isbn)
+        assertEquals(allConfiguredFields, allowedFieldsForBook);
+        assertEquals(allConfiguredFields, allowedFieldsForBookChapter);
+        // Article and type should match a subset of the fields without ISBN
+        assertEquals(unboundFields, allowedFieldsForArticle);
+        assertEquals(unboundFields, allowedFieldsForNoType);
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/validation/MetadataValidation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/validation/MetadataValidation.java
@@ -141,8 +141,8 @@ public class MetadataValidation extends AbstractValidation {
                         if (input.isAllowedFor(documentTypeValue)) {
                             // since this field is missing add to list of error
                             // fields
-                            addError(errors, ERROR_VALIDATION_REQUIRED,
-                                    "/" + WorkspaceItemRestRepository.OPERATION_PATH_SECTIONS + "/" + config.getId() + "/" +
+                            addError(errors, ERROR_VALIDATION_REQUIRED, "/"
+                                    + WorkspaceItemRestRepository.OPERATION_PATH_SECTIONS + "/" + config.getId() + "/" +
                                             input.getFieldName());
                         }
                     }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionDefinitionsControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionDefinitionsControllerIT.java
@@ -257,10 +257,10 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
                         Matchers.containsString("page=1"), Matchers.containsString("size=1"))))
                 .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
                         Matchers.containsString("/api/config/submissiondefinitions?"),
-                        Matchers.containsString("page=4"), Matchers.containsString("size=1"))))
+                        Matchers.containsString("page=5"), Matchers.containsString("size=1"))))
                 .andExpect(jsonPath("$.page.size", is(1)))
-                .andExpect(jsonPath("$.page.totalElements", is(5)))
-                .andExpect(jsonPath("$.page.totalPages", is(5)))
+                .andExpect(jsonPath("$.page.totalElements", is(6)))
+                .andExpect(jsonPath("$.page.totalPages", is(6)))
                 .andExpect(jsonPath("$.page.number", is(0)));
 
         getClient(tokenAdmin).perform(get("/api/config/submissiondefinitions")
@@ -283,10 +283,10 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
                         Matchers.containsString("page=1"), Matchers.containsString("size=1"))))
                 .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
                         Matchers.containsString("/api/config/submissiondefinitions?"),
-                        Matchers.containsString("page=4"), Matchers.containsString("size=1"))))
+                        Matchers.containsString("page="), Matchers.containsString("size=1"))))
                 .andExpect(jsonPath("$.page.size", is(1)))
-                .andExpect(jsonPath("$.page.totalElements", is(5)))
-                .andExpect(jsonPath("$.page.totalPages", is(5)))
+                .andExpect(jsonPath("$.page.totalElements", is(6)))
+                .andExpect(jsonPath("$.page.totalPages", is(6)))
                 .andExpect(jsonPath("$.page.number", is(1)));
 
         getClient(tokenAdmin).perform(get("/api/config/submissiondefinitions")
@@ -309,10 +309,10 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
                         Matchers.containsString("page=2"), Matchers.containsString("size=1"))))
                 .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
                         Matchers.containsString("/api/config/submissiondefinitions?"),
-                        Matchers.containsString("page=4"), Matchers.containsString("size=1"))))
+                        Matchers.containsString("page=5"), Matchers.containsString("size=1"))))
                 .andExpect(jsonPath("$.page.size", is(1)))
-                .andExpect(jsonPath("$.page.totalElements", is(5)))
-                .andExpect(jsonPath("$.page.totalPages", is(5)))
+                .andExpect(jsonPath("$.page.totalElements", is(6)))
+                .andExpect(jsonPath("$.page.totalPages", is(6)))
                 .andExpect(jsonPath("$.page.number", is(2)));
 
         getClient(tokenAdmin).perform(get("/api/config/submissiondefinitions")
@@ -335,10 +335,10 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
                 Matchers.containsString("page=3"), Matchers.containsString("size=1"))))
             .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
                 Matchers.containsString("/api/config/submissiondefinitions?"),
-                Matchers.containsString("page=4"), Matchers.containsString("size=1"))))
+                Matchers.containsString("page=5"), Matchers.containsString("size=1"))))
             .andExpect(jsonPath("$.page.size", is(1)))
-            .andExpect(jsonPath("$.page.totalElements", is(5)))
-            .andExpect(jsonPath("$.page.totalPages", is(5)))
+            .andExpect(jsonPath("$.page.totalElements", is(6)))
+            .andExpect(jsonPath("$.page.totalPages", is(6)))
             .andExpect(jsonPath("$.page.number", is(3)));
 
         getClient(tokenAdmin).perform(get("/api/config/submissiondefinitions")
@@ -353,16 +353,18 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
             .andExpect(jsonPath("$._links.prev.href", Matchers.allOf(
                 Matchers.containsString("/api/config/submissiondefinitions?"),
                 Matchers.containsString("page=3"), Matchers.containsString("size=1"))))
-            .andExpect(jsonPath("$._links.next").doesNotExist())
+                .andExpect(jsonPath("$._links.next.href", Matchers.allOf(
+                        Matchers.containsString("/api/config/submissiondefinitions?"),
+                        Matchers.containsString("page=5"), Matchers.containsString("size=1"))))
             .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
                 Matchers.containsString("/api/config/submissiondefinitions?"),
                 Matchers.containsString("page=4"), Matchers.containsString("size=1"))))
             .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
                 Matchers.containsString("/api/config/submissiondefinitions?"),
-                Matchers.containsString("page=4"), Matchers.containsString("size=1"))))
+                Matchers.containsString("page=5"), Matchers.containsString("size=1"))))
             .andExpect(jsonPath("$.page.size", is(1)))
-            .andExpect(jsonPath("$.page.totalElements", is(5)))
-            .andExpect(jsonPath("$.page.totalPages", is(5)))
+            .andExpect(jsonPath("$.page.totalElements", is(6)))
+            .andExpect(jsonPath("$.page.totalPages", is(6)))
             .andExpect(jsonPath("$.page.number", is(4)));
     }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionFormsControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionFormsControllerIT.java
@@ -67,13 +67,13 @@ public class SubmissionFormsControllerIT extends AbstractControllerIntegrationTe
                    .andExpect(content().contentType(contentType))
                    //The configuration file for the test env includes 6 forms
                    .andExpect(jsonPath("$.page.size", is(20)))
-                   .andExpect(jsonPath("$.page.totalElements", equalTo(7)))
+                   .andExpect(jsonPath("$.page.totalElements", equalTo(8)))
                    .andExpect(jsonPath("$.page.totalPages", equalTo(1)))
                    .andExpect(jsonPath("$.page.number", is(0)))
                    .andExpect(
                        jsonPath("$._links.self.href", Matchers.startsWith(REST_SERVER_URL + "config/submissionforms")))
-                   //The array of submissionforms should have a size of 6
-                   .andExpect(jsonPath("$._embedded.submissionforms", hasSize(equalTo(7))))
+                   //The array of submissionforms should have a size of 8
+                   .andExpect(jsonPath("$._embedded.submissionforms", hasSize(equalTo(8))))
         ;
     }
 
@@ -84,12 +84,12 @@ public class SubmissionFormsControllerIT extends AbstractControllerIntegrationTe
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(contentType))
                 .andExpect(jsonPath("$.page.size", is(20)))
-                .andExpect(jsonPath("$.page.totalElements", equalTo(7)))
+                .andExpect(jsonPath("$.page.totalElements", equalTo(8)))
                 .andExpect(jsonPath("$.page.totalPages", equalTo(1)))
                 .andExpect(jsonPath("$.page.number", is(0)))
                 .andExpect(jsonPath("$._links.self.href", Matchers.startsWith(REST_SERVER_URL
                            + "config/submissionforms")))
-                .andExpect(jsonPath("$._embedded.submissionforms", hasSize(equalTo(7))));
+                .andExpect(jsonPath("$._embedded.submissionforms", hasSize(equalTo(8))));
     }
 
     @Test
@@ -698,7 +698,7 @@ public class SubmissionFormsControllerIT extends AbstractControllerIntegrationTe
                          Matchers.containsString("/api/config/submissionforms?"),
                          Matchers.containsString("page=3"), Matchers.containsString("size=2"))))
                  .andExpect(jsonPath("$.page.size", is(2)))
-                 .andExpect(jsonPath("$.page.totalElements", equalTo(7)))
+                 .andExpect(jsonPath("$.page.totalElements", equalTo(8)))
                  .andExpect(jsonPath("$.page.totalPages", equalTo(4)))
                  .andExpect(jsonPath("$.page.number", is(0)));
 
@@ -725,7 +725,7 @@ public class SubmissionFormsControllerIT extends AbstractControllerIntegrationTe
                          Matchers.containsString("/api/config/submissionforms?"),
                          Matchers.containsString("page=3"), Matchers.containsString("size=2"))))
                  .andExpect(jsonPath("$.page.size", is(2)))
-                 .andExpect(jsonPath("$.page.totalElements", equalTo(7)))
+                 .andExpect(jsonPath("$.page.totalElements", equalTo(8)))
                  .andExpect(jsonPath("$.page.totalPages", equalTo(4)))
                  .andExpect(jsonPath("$.page.number", is(1)));
 
@@ -749,7 +749,7 @@ public class SubmissionFormsControllerIT extends AbstractControllerIntegrationTe
                         Matchers.containsString("/api/config/submissionforms?"),
                         Matchers.containsString("page=3"), Matchers.containsString("size=2"))))
                 .andExpect(jsonPath("$.page.size", is(2)))
-                .andExpect(jsonPath("$.page.totalElements", equalTo(7)))
+                .andExpect(jsonPath("$.page.totalElements", equalTo(8)))
                 .andExpect(jsonPath("$.page.totalPages", equalTo(4)))
                 .andExpect(jsonPath("$.page.number", is(2)));
 
@@ -772,7 +772,7 @@ public class SubmissionFormsControllerIT extends AbstractControllerIntegrationTe
                 Matchers.containsString("/api/config/submissionforms?"),
                 Matchers.containsString("page=3"), Matchers.containsString("size=2"))))
             .andExpect(jsonPath("$.page.size", is(2)))
-            .andExpect(jsonPath("$.page.totalElements", equalTo(7)))
+            .andExpect(jsonPath("$.page.totalElements", equalTo(8)))
             .andExpect(jsonPath("$.page.totalPages", equalTo(4)))
             .andExpect(jsonPath("$.page.number", is(3)));
     }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/WorkspaceItemMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/WorkspaceItemMatcher.java
@@ -107,6 +107,35 @@ public class WorkspaceItemMatcher {
     }
 
     /**
+     * Check that the workspace item has the expected type and a specific field value
+     * (used in type bind evaluation)
+     * @param witem the workspace item
+     * @param section form section name
+     * @param type  the dc.type value eg. Technical Report
+     * @param field  the field to check eg. dc.identifier.isbn
+     * @param value the value to check
+     * @return  Matcher result
+     */
+    public static Matcher matchItemWithTypeFieldAndValue(WorkspaceItem witem,
+                                                         String section, String type, String field, String value) {
+        String fieldJsonPath = "$.sections." + section + "['" + field + "'][0].value";
+        String dcTypeJsonPath = "$.sections." + section + "['dc.type'][0].value";
+        return allOf(
+                // Check workspaceitem properties
+                matchProperties(witem),
+                // Check type appears or is null
+                type != null ?
+                        hasJsonPath(dcTypeJsonPath, is(type)) :
+                        hasNoJsonPath(dcTypeJsonPath),
+                // Check ISBN as it appears (for type bind testing)
+                value != null ?
+                        hasJsonPath(fieldJsonPath, is(value)) :
+                        hasNoJsonPath(fieldJsonPath),
+                matchLinks(witem)
+        );
+    }
+
+    /**
      * Check that the id and type are exposed
      * 
      * @param witem


### PR DESCRIPTION
Fixes https://github.com/DSpace/dspace-angular/issues/1655
Follow-up to #8175

If a field like dc.title.subtitle is configured multiple times in one submission form with different rules for different type binding, when the validation encounters the input config that is *not* bound for the doc type, it will strip all metadata values even though the same field is allowed for this type elsewhere in the form. This commit should fix this by constructing a lookup map first so that the validation loop can check if **any input of this field name** is allowed for the current document type, not just the input being analysed in this loop iteration.

It does not have a way to rigorously enforcespecific rule conflicts like repeatable=true and repeatable=false for the same type, and so on, but a process to check for and report errors on configuration conflicts could be built into the earlier loop.

See a discussion of this issue at: https://github.com/DSpace/dspace-angular/issues/1655

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
