### PR TITLE
Add deprecation notice for Oracle Support to 7.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Documentation for each release may be viewed online or downloaded via our [Docum
 The latest DSpace Installation instructions are available at:
 https://wiki.lyrasis.org/display/DSDOC7x/Installing+DSpace
 
-Please be aware that, as a Java web application, DSpace requires a database (PostgreSQL or Oracle)
+Please be aware that, as a Java web application, DSpace requires a database (PostgreSQL)
 and a servlet container (usually Tomcat) in order to function.
 More information about these and all other prerequisites can be found in the Installation instructions above.
 

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
@@ -406,6 +406,12 @@ public class DatabaseUtils {
         DatabaseMetaData meta = connection.getMetaData();
         String dbType = getDbType(connection);
         System.out.println("\nDatabase Type: " + dbType);
+        if (dbType.equals(DBMS_ORACLE)) {
+            System.out.println("====================================");
+            System.out.println("WARNING: Oracle support is deprecated!");
+            System.out.println("See https://github.com/DSpace/DSpace/issues/8214");
+            System.out.println("=====================================");
+        }
         System.out.println("Database URL: " + meta.getURL());
         System.out.println("Database Schema: " + getSchemaName(connection));
         System.out.println("Database Username: " + meta.getUserName());
@@ -538,6 +544,10 @@ public class DatabaseUtils {
             // Migration scripts are based on DBMS Keyword (see full path below)
             String dbType = getDbType(connection);
             connection.close();
+
+            if (dbType.equals(DBMS_ORACLE)) {
+                log.warn("ORACLE SUPPORT IS DEPRECATED! See https://github.com/DSpace/DSpace/issues/8214");
+            }
 
             // Determine location(s) where Flyway will load all DB migrations
             ArrayList<String> scriptLocations = new ArrayList<>();

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/README.md
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/README.md
@@ -1,5 +1,10 @@
 # Oracle Flyway Database Migrations (i.e. Upgrades)
 
+---
+WARNING: Oracle Support is deprecated.
+See https://github.com/DSpace/DSpace/issues/8214
+---
+
 The SQL scripts in this directory are Oracle-specific database migrations. They are
 used to automatically upgrade your DSpace database using [Flyway](http://flywaydb.org/).
 As such, these scripts are automatically called by Flyway when the DSpace

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -68,20 +68,22 @@ solr.multicorePrefix =
 
 ##### Database settings #####
 # DSpace only supports two database types: PostgreSQL or Oracle
+# PostgreSQL is highly recommended.
+# Oracle support is DEPRECATED. See https://github.com/DSpace/DSpace/issues/8214
 
 # URL for connecting to database
 #    * Postgres template: jdbc:postgresql://localhost:5432/dspace
-#    * Oracle template: jdbc:oracle:thin:@//localhost:1521/xe
+#    * Oracle template (DEPRECATED): jdbc:oracle:thin:@//localhost:1521/xe
 db.url = jdbc:postgresql://localhost:5432/dspace
 
 # JDBC Driver
 #    * For Postgres: org.postgresql.Driver
-#    * For Oracle:   oracle.jdbc.OracleDriver
+#    * For Oracle (DEPRECATED):   oracle.jdbc.OracleDriver
 db.driver = org.postgresql.Driver
 
 # Database Dialect (for Hibernate)
 #    * For Postgres: org.hibernate.dialect.PostgreSQL94Dialect
-#    * For Oracle:   org.hibernate.dialect.Oracle10gDialect
+#    * For Oracle (DEPRECATED):   org.hibernate.dialect.Oracle10gDialect
 db.dialect = org.hibernate.dialect.PostgreSQL94Dialect
 
 # Database username and password
@@ -90,7 +92,7 @@ db.password = dspace
 
 # Database Schema name
 #    * For Postgres, this is often "public" (default schema)
-#    * For Oracle, schema is equivalent to the username of your database account,
+#    * For Oracle (DEPRECATED), schema is equivalent to the username of your database account,
 #      so this may be set to ${db.username} in most scenarios.
 db.schema = public
 

--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -68,20 +68,22 @@ dspace.name = DSpace at My University
 # DATABASE CONFIGURATION #
 ##########################
 # DSpace only supports two database types: PostgreSQL or Oracle
+# PostgreSQL is highly recommended.
+# Oracle support is DEPRECATED. See https://github.com/DSpace/DSpace/issues/8214
 
 # URL for connecting to database
 #    * Postgres template: jdbc:postgresql://localhost:5432/dspace
-#    * Oracle template: jdbc:oracle:thin:@//localhost:1521/xe
+#    * Oracle template (DEPRECATED): jdbc:oracle:thin:@//localhost:1521/xe
 db.url = jdbc:postgresql://localhost:5432/dspace
 
 # JDBC Driver
 #    * For Postgres: org.postgresql.Driver
-#    * For Oracle:   oracle.jdbc.OracleDriver
+#    * For Oracle (DEPRECATED):   oracle.jdbc.OracleDriver
 db.driver = org.postgresql.Driver
 
 # Database Dialect (for Hibernate)
 #    * For Postgres: org.hibernate.dialect.PostgreSQL94Dialect
-#    * For Oracle:   org.hibernate.dialect.Oracle10gDialect
+#    * For Oracle (DEPRECATED):   org.hibernate.dialect.Oracle10gDialect
 db.dialect = org.hibernate.dialect.PostgreSQL94Dialect
 
 # Database username and password
@@ -90,7 +92,7 @@ db.password = dspace
 
 # Database Schema name
 #    * For Postgres, this is often "public" (default schema)
-#    * For Oracle, schema is equivalent to the username of your database account,
+#    * For Oracle (DEPRECATED), schema is equivalent to the username of your database account,
 #      so this may be set to ${db.username} in most scenarios.
 db.schema = public
 


### PR DESCRIPTION
## References
* Related to #8214 (keeping this ticket open though until Oracle support is entirely removed)

## Description
This small PR adds deprecation notices for Oracle to the following locations:
* READMEs (in the main README I chose to just remove Oracle from the list to discourage new users from using it)
* Configuration (dspace.cfg & local.cfg.EXAMPLE)
* `dspace.log` (on startup of DSpace), when Oracle is configured
* `dspace database info` output, when Oracle is configured

Alongside this PR, deprecation notices have also been added to documentation on the following pages;
* https://wiki.lyrasis.org/display/DSDOC7x/Installing+DSpace
* https://wiki.lyrasis.org/display/DSDOC7x/Upgrading+DSpace
* https://wiki.lyrasis.org/display/DSDOC7x/Configuration+Reference