### PR TITLE
Overwrite getName usage in applicable services & missing log statements

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/indexobject/IndexFactoryImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/indexobject/IndexFactoryImpl.java
@@ -113,9 +113,11 @@ public abstract class IndexFactoryImpl<T extends IndexableObject, S> implements 
                         log.info("Full text is larger than the configured limit (discovery.solr.fulltext.charLimit)."
                                      + " Only the first {} characters were indexed.", charLimit);
                     } else {
+                        log.error("Tika parsing error. Could not index full text.", saxe);
                         throw new IOException("Tika parsing error. Could not index full text.", saxe);
                     }
                 } catch (TikaException ex) {
+                    log.error("Tika parsing error. Could not index full text.", ex);
                     throw new IOException("Tika parsing error. Could not index full text.", ex);
                 }
 

--- a/dspace-api/src/main/java/org/dspace/eperson/EPersonServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/EPersonServiceImpl.java
@@ -569,4 +569,9 @@ public class EPersonServiceImpl extends DSpaceObjectServiceImpl<EPerson> impleme
     public int countTotal(Context context) throws SQLException {
         return ePersonDAO.countRows(context);
     }
+
+    @Override
+    public String getName(EPerson dso) {
+        return dso.getName();
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/eperson/GroupServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/GroupServiceImpl.java
@@ -829,4 +829,9 @@ public class GroupServiceImpl extends DSpaceObjectServiceImpl<Group> implements 
                                            final MetadataField metadataField) throws SQLException {
         return groupDAO.findByMetadataField(context, searchValue, metadataField);
     }
+
+    @Override
+    public String getName(Group dso) {
+        return dso.getName();
+    }
 }


### PR DESCRIPTION
## Description
Not all objects extending DSpaceObject and thus not all services extending DSpaceObjectService have their name in the`dc.title` metadata field. Logic for where the name comes from can be decided for all DSO's in DSpaceObject#getName() (i.e. for Group DSO the value in name column), so DSpaceObjectService#getName(dso) should pass this request along to the DSO itself. 

I also added two log statements for scenario's where something goes wrong parsing using Apache Tika.
This already happens for exceptions above so these two cases should be logged as well.

## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* Overwrite get `getName` method from the `DSpaceObjectServiceImpl` in both the `GroupServiceImpl` and `EPersonServiceImpl`
* Added log statements for two cases where an exception could occur while indexing a file using Apache's Tika in `IndexFactoryImpl`, this should be logged since it is already happening for similar scenarios above.


## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
