### PR TITLE
Dockerfile.test and docker-compose: expose port 8000, set JDWP java opts

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -58,9 +58,9 @@ COPY --from=ant_build /dspace $DSPACE_INSTALL
 # NOTE: secretRequired="false" should only be used when AJP is NOT accessible from an external network. But, secretRequired="true" isn't supported by mod_proxy_ajp until Apache 2.5
 RUN sed -i '/Service name="Catalina".*/a \\n    <Connector protocol="AJP/1.3" port="8009" address="0.0.0.0" redirectPort="8443" URIEncoding="UTF-8" secretRequired="false" />' $TOMCAT_INSTALL/conf/server.xml
 # Expose Tomcat port and AJP port
-EXPOSE 8080 8009
+EXPOSE 8080 8009 8000
 # Give java extra memory (2GB)
-ENV JAVA_OPTS=-Xmx2000m
+ENV JAVA_OPTS=-Xmx2000m\ -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=*:8000
 
 # Link the DSpace 'server' webapp into Tomcat's webapps directory.
 # This ensures that when we start Tomcat, it runs from /server path (e.g. http://localhost:8080/server/)

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -60,7 +60,9 @@ RUN sed -i '/Service name="Catalina".*/a \\n    <Connector protocol="AJP/1.3" po
 # Expose Tomcat port and AJP port
 EXPOSE 8080 8009 8000
 # Give java extra memory (2GB)
-ENV JAVA_OPTS=-Xmx2000m\ -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=*:8000
+ENV JAVA_OPTS=-Xmx2000m
+# Set up debugging
+ENV CATALINA_OPTS=-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=*:8000
 
 # Link the DSpace 'server' webapp into Tomcat's webapps directory.
 # This ensures that when we start Tomcat, it runs from /server path (e.g. http://localhost:8080/server/)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,8 @@ services:
       target: 8080
     - published: 8009
       target: 8009
+    - published: 8000
+      target: 8000
     stdin_open: true
     tty: true
     volumes:


### PR DESCRIPTION
This allows a remote JVM debugger to be connected to port 8000 on the
dspace docker container (test environment).

This may need a documentation note to warn against running the supplied docker-compose / Dockerfile.test config in production or on any unsecured network -- already a good warning but made more important now that the JVM can be exposed to a debugger for reading memory.

## To review

Rebuild and start the test docker services with `docker-compose -p ${projectName} ...` (`build`, `up -d`) where project name is eg. d7 or whatever you prefer to use for v7 docker testing environment.

Attach a debugger to a remote JVM using **localhost:8000** as the address. Here's a screenshot from my IDE as an example:
![Screenshot from 2022-05-25 10-45-15](https://user-images.githubusercontent.com/194773/170144057-256d3658-67d4-456a-a789-25034e4a0b44.png)


- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR doesn't modify any actual DSpace code or maven projects, just docker configuration