### PR TITLE
Fixed bitstream content download error when using special groups

### DIFF
--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -658,6 +658,15 @@ public class Context implements AutoCloseable {
     }
 
     /**
+     * Get a set of all of the special groups uuids that current user is a member of.
+     *
+     * @return list of special groups uuids
+     */
+    public Set<UUID> getSpecialGroupUuids() {
+        return CollectionUtils.isEmpty(specialGroups) ? Set.of() : specialGroups;
+    }
+
+    /**
      * Temporary change the user bound to the context, empty the special groups that
      * are retained to allow subsequent restore
      *

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
@@ -153,8 +153,9 @@ public class BitstreamRestController {
             }
 
             org.dspace.app.rest.utils.BitstreamResource bitstreamResource =
-                new org.dspace.app.rest.utils.BitstreamResource(
-                    name, uuid, currentUser != null ? currentUser.getID() : null, citationEnabledForBitstream);
+                new org.dspace.app.rest.utils.BitstreamResource(name, uuid,
+                    currentUser != null ? currentUser.getID() : null,
+                    context.getSpecialGroupUuids(), citationEnabledForBitstream);
 
             //We have all the data we need, close the connection to the database so that it doesn't stay open during
             //download/streaming

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
@@ -720,9 +720,13 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
 
         context.restoreAuthSystemState();
 
+        String authToken = getAuthToken(eperson.getEmail(), password);
+        getClient(authToken).perform(get("/api/core/bitstreams/" + bitstream.getID() + "/content"))
+            .andExpect(status().isForbidden());
+
         configurationService.setProperty("authentication-password.login.specialgroup", "Restricted Group");
 
-        String authToken = getAuthToken(eperson.getEmail(), password);
+        authToken = getAuthToken(eperson.getEmail(), password);
         getClient(authToken).perform(get("/api/core/bitstreams/" + bitstream.getID() + "/content"))
             .andExpect(status().isOk());
 


### PR DESCRIPTION
## References
* Fixes #8301

## Description
The methods of org.dspace.app.rest.utils.BitstreamResource classs used to take the content of a bitstream initialize a new context without setting any special groups present in the original context. This can cause read permission problems on the bitstream. With this change I introduced a test to verify this behavior and I solved the problem by setting them.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
