### PR TITLE
[CST-5756] Embedding of RelationshipType in Relationship resource

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/RelationshipRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/RelationshipRest.java
@@ -18,9 +18,17 @@ import org.dspace.app.rest.RestResourceController;
  * This class acts as a data holder for the RelationshipResource
  * Refer to {@link org.dspace.content.Relationship} for explanation about the properties
  */
+@LinksRest(links = {
+    @LinkRest(
+        name = RelationshipRest.RELATIONSHIP_TYPE,
+        method = "getRelationshipType"
+    )
+})
 public class RelationshipRest extends BaseObjectRest<Integer> {
     public static final String NAME = "relationship";
     public static final String CATEGORY = "core";
+
+    public static final String RELATIONSHIP_TYPE = "relationshipType";
 
     @JsonIgnore
     private UUID leftId;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RelationshipTypeRelationshipLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RelationshipTypeRelationshipLinkRepository.java
@@ -1,0 +1,56 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.repository;
+
+import java.sql.SQLException;
+import javax.annotation.Nullable;
+import javax.servlet.http.HttpServletRequest;
+
+import org.dspace.app.rest.model.RelationshipRest;
+import org.dspace.app.rest.model.RelationshipTypeRest;
+import org.dspace.app.rest.projection.Projection;
+import org.dspace.content.Relationship;
+import org.dspace.content.RelationshipType;
+import org.dspace.content.service.RelationshipService;
+import org.dspace.core.Context;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.rest.webmvc.ResourceNotFoundException;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Component;
+
+/**
+ * Link repository for "relationships" subresource of an individual Relationship.
+ */
+@Component(RelationshipRest.CATEGORY + "." + RelationshipRest.NAME + "." + RelationshipRest.RELATIONSHIP_TYPE)
+public class RelationshipTypeRelationshipLinkRepository extends AbstractDSpaceRestRepository
+        implements LinkRestRepository {
+
+    @Autowired
+    RelationshipService relationshipService;
+
+    @PreAuthorize("permitAll()")
+    public RelationshipTypeRest getRelationshipType(@Nullable HttpServletRequest request,
+                                                            Integer relationshipId,
+                                                            @Nullable Pageable optionalPageable,
+                                                            Projection projection) {
+        try {
+            Context context = obtainContext();
+            Relationship relationship = relationshipService.find(context, relationshipId);
+            if (relationship == null) {
+                throw new ResourceNotFoundException("No such relationship: " + relationshipId);
+            }
+            int total = relationshipService.countByRelationshipType(context, relationship.getRelationshipType());
+            Pageable pageable = utils.getPageable(optionalPageable);
+            RelationshipType relationshipType = relationship.getRelationshipType();
+            return converter.toRest(relationshipType, projection);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RelationshipTypeRelationshipLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RelationshipTypeRelationshipLinkRepository.java
@@ -25,7 +25,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Component;
 
 /**
- * Link repository for "relationships" subresource of an individual Relationship.
+ * Link repository for "relationshipType" subresource of an individual Relationship.
  */
 @Component(RelationshipRest.CATEGORY + "." + RelationshipRest.NAME + "." + RelationshipRest.RELATIONSHIP_TYPE)
 public class RelationshipTypeRelationshipLinkRepository extends AbstractDSpaceRestRepository

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/RelationshipRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/RelationshipRestRepositoryIT.java
@@ -3164,4 +3164,28 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
                    .andExpect(jsonPath("$.page.totalElements", is(2)));
     }
 
+    @Test
+    public void findTheCreatedRelationshipTypeTest() throws Exception {
+
+        context.turnOffAuthorisationSystem();
+
+        Relationship relationship = RelationshipBuilder
+            .createRelationshipBuilder(context, author1, orgUnit1, isOrgUnitOfPersonRelationshipType).build();
+
+        context.restoreAuthSystemState();
+
+        Integer relationshipId = relationship.getID();
+        getClient().perform(get("/api/core/relationships/" + relationshipId))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.id", is(relationship.getID())))
+                   .andExpect(jsonPath("$._embedded.relationships").doesNotExist())
+                   .andExpect(jsonPath("$._links.relationshipType.href",
+                       containsString("/api/core/relationships/" + relationshipId + "/relationshipType"))
+                   );
+
+        String adminToken = getAuthToken(admin.getEmail(), password);
+        getClient(adminToken).perform(get("/api/core/relationships/" + relationshipId + "/relationshipType"))
+                             .andExpect(status().isOk());
+    }
+
 }


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #7984 
* Related to [REST Contract PR #195](https://github.com/DSpace/RestContract/pull/195)

## Description
The aim of this PR is rendering relationshipType information in Relationship resource in the canonical <relationship-uri>/relationshipType pattern


## Instructions for Reviewers

Navigate Relationship resource (`/server/api/core/relationships`), and check "relationshipType" link is expressed as `/server/api/core/relationships/<id>/relationshipType`, and if followed a response containing relationshipType information is returned. The same response should be present when `/server/api/core/relationships?embed=relationshipType` and `/server/api/core/relationships?projection=full` calls

List of changes in this PR:
* RelationshipRest class updated with `@LinkRest` annotation
* A LinkRepository class has been provided to find RelationshipType information given a Relationship
* A test has been added checking that relationshipType link is returned in expected form in the Relationship endpoint response.


## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
