### PR TITLE
Docker Fixes: Ensure multiple architecture build is disabled for PRs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,6 +31,11 @@ jobs:
       # We turn off 'latest' tag by default.
       TAGS_FLAVOR: |
         latest=false
+      # Architectures / Platforms for which we will build Docker images
+      # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
+      # If this is NOT a PR (e.g. a tag or merge commit), also build for ARM64. NOTE: The ARM64 build takes MUCH
+      # longer (around 45mins or so) which is why we only run it when pushing a new Docker image.
+      PLATFORMS: linux/amd64${{ github.event_name != 'pull_request' && ', linux/arm64' || '' }}
 
     steps:
       # https://github.com/actions/checkout
@@ -42,7 +47,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       # https://github.com/docker/setup-qemu-action
-      - name: Set up QEMU
+      - name: Set up QEMU emulation to build for multiple architectures
         uses: docker/setup-qemu-action@v2
 
       # https://github.com/docker/login-action
@@ -74,7 +79,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile.dependencies
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.PLATFORMS }}
           # For pull requests, we run the Docker build (to ensure no PR changes break the build),
           # but we ONLY do an image push to DockerHub if it's NOT a PR
           push: ${{ github.event_name != 'pull_request' }}
@@ -100,7 +105,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.PLATFORMS }}
           # For pull requests, we run the Docker build (to ensure no PR changes break the build),
           # but we ONLY do an image push to DockerHub if it's NOT a PR
           push: ${{ github.event_name != 'pull_request' }}
@@ -129,7 +134,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile.test
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.PLATFORMS }}
           # For pull requests, we run the Docker build (to ensure no PR changes break the build),
           # but we ONLY do an image push to DockerHub if it's NOT a PR
           push: ${{ github.event_name != 'pull_request' }}
@@ -155,7 +160,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile.cli
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.PLATFORMS }}
           # For pull requests, we run the Docker build (to ensure no PR changes break the build),
           # but we ONLY do an image push to DockerHub if it's NOT a PR
           push: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
## References
* Followup to #8305

## Description
After #8305 was merged, I realized that PRs were regularly taking **over one hour** to complete the Docker build process.  Prior to this PR, that build process would usually be less than 10 mins.  Looking at the logs, the AM64 build still only takes around 8-10 minutes, but the ARM64 build takes 45+ minutes.

After digging around, I found it's likely this slowness comes from the QEMU emulation... and it might be specific to ARM64.  See for example https://github.com/docker/setup-qemu-action/issues/22

So, this PR ensures that future PRs will only trigger an AMD64 build.  The ARM64 build will only occur when a PR is merged into `main` or when a new tag is created.

There's unfortunately no way to fully test this without merging this PR.

TODO: If this works, it needs to be ported to `dspace-angular` as well.  DONE! See https://github.com/DSpace/dspace-angular/pull/1667