### PR TITLE
Minor update to latest Spring / Spring Boot / Spring Security.  

### DIFF
--- a/dspace-iiif/pom.xml
+++ b/dspace-iiif/pom.xml
@@ -57,6 +57,13 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-rest</artifactId>
             <version>${spring-boot.version}</version>
+            <exclusions>
+                <!-- Later version brought in by spring-boot-starter-web above -->
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.datatype</groupId>
+                    <artifactId>jackson-datatype-jdk8</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -73,7 +80,6 @@
         <dependency>
             <groupId>javax.cache</groupId>
             <artifactId>cache-api</artifactId>
-            <version>1.1.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.ehcache/ehcache -->
         <dependency>

--- a/dspace-rest/pom.xml
+++ b/dspace-rest/pom.xml
@@ -19,7 +19,6 @@
     <properties>
         <!-- This is the path to the root [dspace-src] directory. -->
         <root.basedir>${basedir}/..</root.basedir>
-        <spring-security.version>5.3.10.RELEASE</spring-security.version>
     </properties>
     <build>
         <plugins>

--- a/dspace-server-webapp/pom.xml
+++ b/dspace-server-webapp/pom.xml
@@ -264,6 +264,13 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-rest</artifactId>
             <version>${spring-boot.version}</version>
+            <exclusions>
+                <!-- Later version brought in by spring-boot-starter-web above -->
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.datatype</groupId>
+                    <artifactId>jackson-datatype-jdk8</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -457,7 +464,6 @@
         <dependency>
             <groupId>javax.cache</groupId>
             <artifactId>cache-api</artifactId>
-            <version>1.1.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.ehcache/ehcache -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,9 @@
     <properties>
         <!--=== GENERAL / DSPACE-API DEPENDENCIES ===-->
         <java.version>11</java.version>
-        <spring.version>5.3.18</spring.version>
-        <spring-boot.version>2.6.6</spring-boot.version>
-        <spring-security.version>5.6.2</spring-security.version> <!-- sync with version used by spring-boot-->
+        <spring.version>5.3.20</spring.version>
+        <spring-boot.version>2.6.8</spring-boot.version>
+        <spring-security.version>5.6.5</spring-security.version> <!-- sync with version used by spring-boot-->
         <hibernate.version>5.6.5.Final</hibernate.version>
         <hibernate-validator.version>6.0.23.Final</hibernate-validator.version>
         <postgresql.driver.version>42.3.3</postgresql.driver.version>


### PR DESCRIPTION
Fixes CVE-2022-22970 and a few other minor recent Spring vulnerabilities

## Description
Minor update to bring us to the latest version of Spring Core , Spring Boot & Spring Security.

A few other very minor dependency fixes including fixes for dependency convergence & removal of some duplicate version tags (for dependencies whose versions are already controlled in Parent POM)

## Instructions for Reviewers
* Perform some sanity checks of backend.  These are minor updates so I don't anticipate any issues
* Also test deprecated REST API  (I'll do this myself but other eyes are welcome)