### PR TITLE
Fix OAI page unstyled when '/' is missing at the end of the URL

### DIFF
--- a/dspace-oai/src/main/java/org/dspace/xoai/controller/DSpaceOAIDataProvider.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/controller/DSpaceOAIDataProvider.java
@@ -72,7 +72,12 @@ public class DSpaceOAIDataProvider {
 
     private DSpaceResumptionTokenFormatter resumptionTokenFormat = new DSpaceResumptionTokenFormatter();
 
-    @RequestMapping({"", "/"})
+    @RequestMapping("")
+    public void index(HttpServletResponse response, HttpServletRequest request) throws IOException {
+        response.sendRedirect(request.getRequestURI() + "/");
+    }
+
+    @RequestMapping({"/"})
     public String indexAction(HttpServletResponse response, Model model) throws ServletException {
         try {
             XOAIManager manager = xoaiManagerResolver.getManager();

--- a/dspace-server-webapp/src/test/java/org/dspace/app/oai/OAIpmhIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/oai/OAIpmhIT.java
@@ -63,9 +63,9 @@ public class OAIpmhIT extends AbstractControllerIntegrationTest {
     private ConfigurationService configurationService;
 
     // All OAI-PMH paths that we test against
-    private final String ROOT_PATH = "/oai";
+    private final String ROOT_PATH = "/oai/";
     private final String DEFAULT_CONTEXT_PATH = "request";
-    private final String DEFAULT_CONTEXT = ROOT_PATH + "/" + DEFAULT_CONTEXT_PATH;
+    private final String DEFAULT_CONTEXT = ROOT_PATH + DEFAULT_CONTEXT_PATH;
 
     // Mock to ensure XOAI caching is disabled for all tests (see @Before method)
     @MockBean


### PR DESCRIPTION
## References
* Fixes #3059

## Description
Added a fix for the unstyled OAI page 

## Instructions for Reviewers

List of changes in this PR:
* Added a redirect when OAI is reached without the trailing '/'
In order to test the fix reach the OAI endpoint with the missing trailing '/' 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
