### PR TITLE
Disable the copy request for specific DSpace objects

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/RequestCopyFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/RequestCopyFeature.java
@@ -92,12 +92,14 @@ public class RequestCopyFeature implements AuthorizationFeature {
             if (object instanceof DSpaceObjectRest) {
                 DSpaceObjectRest dspaceObjectRest = (DSpaceObjectRest) object;
                 String uuid = dspaceObjectRest.getUuid();
+                // Look if the object itself is restricted.
                 if (Arrays.stream(restrictions).anyMatch(uuid::equals)) {
                     return false;
                 }
                 // Security in case we encounter an infinite loop.
                 DSpaceObject previousParent = null;
                 DSpaceObject parent = (DSpaceObject) utils.getDSpaceAPIObjectFromRest(context, object);
+                // Look if any parent in the hierarchy is restricted.
                 do {
                     previousParent = parent;
                     parent = getParentObject(context, parent);

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1520,6 +1520,11 @@ log.report.dir = ${dspace.dir}/log
 request.item.type = all
 # Should all Request Copy emails go to the helpdesk instead of the item submitter?
 request.item.helpdesk.override = false
+# List (comma-separated) of DSpace object UUID (communities, collections, items, others)
+# for which the request-copy feature must be disabled.
+# request.item.restricted = item-uuid-1, \
+#                           item-uuid-2, \
+#                           item-uuid-3
 
 #------------------------------------------------------------------#
 #------------------SUBMISSION CONFIGURATION------------------------#


### PR DESCRIPTION
## References
* Fixes #8290

## Description
Added the possibility to disable the copy request feature based on a new configuration `request.item.restricted`. This configuration is enumerating the GUID of DSpace objects for which the feature should be disabled.

## Instructions for Reviewers
Add the new configuration in the file `local.cfg` with at least one valid GUID of DSpace object where you don't want the copy feature to be enabled.

```
# List (comma-separated) of DSpace object UUID (communities, collections, items, others)
# for which the request-copy feature must be disabled.
# request.item.restricted = item-uuid-1, \
#                           item-uuid-2, \
#                           item-uuid-3
```

List of changes in this PR:
* Added a configuration example in the file `dspace.cfg`.
* Implemented the restriction functionality in the class `RequestCopyFeature` by looking at the GUID for the object itself, but also for the GUID of every parent in the hierarchy.
* Added some tests in the class `RequestCopyFeatureIT` to cover some use cases.

**If the copy request feature is disabled using this new configuration, for anonymous users, clicking on a copy request link will show the login page. If the user is logged in, it will show a 403 forbidden access.**

## Checklist
- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
