### PR TITLE
Mirage2 discover

### DIFF
--- a/dspace-xmlui-mirage2/src/main/webapp/scripts/search-controls.js
+++ b/dspace-xmlui-mirage2/src/main/webapp/scripts/search-controls.js
@@ -278,7 +278,8 @@
     }
 
     function restoreOriginalFilters() {
-        DSpace.discovery.filters = DSpace.discovery.orig_filters.slice(0);
+        DSpace.discovery.filters = [];
+        $('#filters-overview-wrapper').remove();
     }
 
 })(jQuery);

--- a/dspace-xmlui-mirage2/src/main/webapp/scripts/search-controls.js
+++ b/dspace-xmlui-mirage2/src/main/webapp/scripts/search-controls.js
@@ -26,10 +26,6 @@
         });
     }
 
-
-
-
-
     function getAdvancedFiltersTemplate() {
         if (!advanced_filters_template) {
             advanced_filters_template = DSpace.getTemplate('discovery_advanced_filters');
@@ -157,11 +153,11 @@
     }
 
     function assignSimpleFilterEventHandlers() {
-        $('#filters-overview-wrapper .label').click(function (e) {
+        $('#filters-overview-wrapper .label').on('click', function (e) {
             var index = $(this).data('index');
             removeFilterAtIndex(index);
             renderAdvancedFilterSection();
-            $('#aspect_discovery_SimpleSearch_div_search-filters').submit();
+            $('#aspect_discovery_SimpleSearch_div_search-filters').trigger('submit');
             return false;
         });
     }
@@ -172,18 +168,18 @@
 
     function assignAdvancedFilterEventHandlers() {
         var $filters = $('.search-filter');
-        $filters.find('select, input').change(function() {
+        $filters.find('select, input').on('change', function() {
             updateFilterValues($(this).closest('.search-filter'));
             renderAdvancedFilterSection();
         });
-        $filters.find('.filter-control.filter-add').click(function (e) {
+        $filters.find('.filter-control.filter-add').on('click', function (e) {
             var index = getIndexFromFilterRow($(this).closest('.search-filter'));
             addNewFilter(index + 1, null, null, '');
             renderAdvancedFilterSection();
             return false;
         });
         var $removeButtons = $filters.find('.filter-control.filter-remove');
-        $removeButtons.click(function (e) {
+        $removeButtons.on('click', function (e) {
             var index = getIndexFromFilterRow($(this).closest('.search-filter'));
             removeFilterAtIndex(index);
             renderAdvancedFilterSection();
@@ -199,7 +195,7 @@
     }
 
     function assignGlobalEventHandlers() {
-        $('.show-advanced-filters').click(function () {
+        $('.show-advanced-filters').on('click', function () {
             var wrapper = $('#aspect_discovery_SimpleSearch_div_discovery-filters-wrapper');
             wrapper.parent().find('.discovery-filters-wrapper-head').hide().removeClass('hidden').fadeIn(200);
             wrapper.hide().removeClass('hidden').slideDown(200);
@@ -208,7 +204,7 @@
             return false;
         });
 
-        $('.hide-advanced-filters').click(function () {
+        $('.hide-advanced-filters').on('click', function () {
             var wrapper = $('#aspect_discovery_SimpleSearch_div_discovery-filters-wrapper');
             wrapper.parent().find('.discovery-filters-wrapper-head').fadeOut(200, function() {
                 $(this).addClass('hidden').removeAttr('style');
@@ -221,20 +217,20 @@
             return false;
         });
 
-        $('#aspect_discovery_SimpleSearch_field_submit_reset_filter').click(function() {
+        $('#aspect_discovery_SimpleSearch_field_submit_reset_filter').on('click', function() {
             restoreOriginalFilters();
             calculateFilterIndices();
             renderAdvancedFilterSection();
             return false;
         });
 
-        $('.discovery-add-filter-button').click(function() {
+        $('.discovery-add-filter-button').on('click', function() {
             addNewFilter(null, null, null, '');
             renderAdvancedFilterSection();
             return false;
         });
 
-        $('.controls-gear-wrapper').find('li.gear-option,li.gear-option a').click(function(event){
+        $('.controls-gear-wrapper').find('li.gear-option,li.gear-option a').on('click', function(event){
             var value, param, mainForm, params, listItem, $this;
             event.stopPropagation();
             $this = $(this);
@@ -271,7 +267,7 @@
             //Clear the page param
             mainForm.find('input[name="page"]').val('1');
 
-            mainForm.submit();
+            mainForm.trigger('submit');
             $this.closest('.open').removeClass('open');
             return false;
         });


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #8329

## Description
Fix restoreOriginalFilters function.

## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* Update jQuery methods.
* Change restoreOriginalFilters JS function in order to fix problem.

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

*Describe the bug*
DSpace version: 6.x
Theme: Mirage2
When advanced filters are set and user wants to restore filters form, reset button doesn't execute an action.

*To Reproduce*
Steps to reproduce the behavior:

1. Go to /discover.
2. Set an advance filter like title (at least one filter).
3. Click on "Apply" button.
4. After results has been shown, click "Reset" button. You will notice that this button has no effect.

*Expected behavior*
After results are shown, clicking "Reset" button should restore advanced filters form to its original empty state.

Related work
https://github.com/DSpace/DSpace/issues/8329

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
