### PR TITLE
[DS-1977] "Private" Items are incorrectly listed in Google Sitemaps v2

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/sitemap/GenerateSitemaps.java
+++ b/dspace-api/src/main/java/org/dspace/app/sitemap/GenerateSitemaps.java
@@ -220,18 +220,20 @@ public class GenerateSitemaps
             String url = handleURLStem + i.getHandle();
             Date lastMod = i.getLastModified();
 
-            if (makeHTMLMap)
-            {
-                html.addURL(url, lastMod);
-            }
-            if (makeSitemapOrg)
-            {
-                sitemapsOrg.addURL(url, lastMod);
-            }
+            if( i.isDiscoverable() ){
+                if (makeHTMLMap)
+                {
+                    html.addURL(url, lastMod);
+                }
+                if (makeSitemapOrg)
+                {
+                    sitemapsOrg.addURL(url, lastMod);
+                }
 
-            c.uncacheEntity(i);
+                c.uncacheEntity(i);
 
-            itemCount++;
+                itemCount++;
+            }
         }
 
         if (makeHTMLMap)

--- a/dspace-api/src/main/java/org/dspace/app/sitemap/GenerateSitemaps.java
+++ b/dspace-api/src/main/java/org/dspace/app/sitemap/GenerateSitemaps.java
@@ -229,11 +229,9 @@ public class GenerateSitemaps
                 {
                     sitemapsOrg.addURL(url, lastMod);
                 }
-
-                c.uncacheEntity(i);
-
                 itemCount++;
             }
+			c.uncacheEntity(i);
         }
 
         if (makeHTMLMap)


### PR DESCRIPTION
## References
* Fixes #5343 
* Replaces #7930 

## Description
This is a replacement patch for Private items fix by @alejandratenorio that includes uncaching all iterated entities regardless of their discoverability. Tested in local installation, to improve effectiveness with search engines should be applied with DS-1980 noindex meta tag (already merged to 6.x).