### PR TITLE
[DS-3088] Add existing item to a collection / linking items to multiple collections via REST (DSpace 6)

### DIFF
--- a/dspace-rest/README.md
+++ b/dspace-rest/README.md
@@ -97,6 +97,9 @@ Find collection by name
 Update collection
 - PUT http://localhost:8080/rest/collections/:ID
 
+Add item in collection
+- PUT http://localhost:8080/rest/collections/:ID/items
+
 Delete collection
 - DELETE http://localhost:8080/rest/collections/:ID
 

--- a/dspace-rest/src/main/java/org/dspace/rest/RestIndex.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/RestIndex.java
@@ -79,7 +79,8 @@ public class RestIndex {
                           "<li>GET /collections/{collectionId}/items - Return all items of the specified collection.</li>" +
                           "<li>POST /collections/{collectionId}/items - Create an item in the specified collection. You must post an item.</li>" +
                           "<li>POST /collections/find-collection - Find a collection by name.</li>" +
-                          "<li>PUT /collections/{collectionId} </li> - Update the specified collection. You must post a collection." +
+                          "<li>PUT /collections/{collectionId} - Update the specified collection. You must post a collection.</li>" +
+                          "<li>PUT /collections/{collectionId}/items - Adds an existing item to the specified collection. You must post an item." +
                           "<li>DELETE /collections/{collectionId} - Delete the specified collection from DSpace.</li>" +
                           "<li>DELETE /collections/{collectionId}/items/{itemId} - Delete the specified item (itemId) in the specified collection (collectionId). </li>" +
                       "</ul>" +


### PR DESCRIPTION
## References
* Fixes #6444
* Related to #1329

## Description

This is a DSpace 6 -port of DSpace 5 -specific REST API extension by @danmalthesen that allow adding existing items to a collection using a new endpoint _PUT /collections/{collectionId}/items_. This enables linking items to multiple collections using a REST-based solution.

Feedback regarding error messages mentioned in #1329 comments are accommodated in this patch.

I understand that this extension may conflict with newer DSpace 7 REST API but considering that this has been successfully used in JYU's repository since 2019 I wish to make this available to other DSpace 6 users as well.

Usage example: 
`curl -k -X PUT -b cookie.txt -H "Content-Type: application/json" -d "{\"uuid\":\"item-uuid\"}" "https://dspace.installation/rest/collections/collection-uuid-to-be-linked/items"
`