### PR TITLE
Changed default cors policy for IIIF endpoints.

### DIFF
--- a/dspace/config/modules/iiif.cfg
+++ b/dspace/config/modules/iiif.cfg
@@ -26,12 +26,10 @@ iiif.document.viewing.hint = individuals
 # an individual or organization associated with the resource it is attached to.
 # iiif.logo.image = https://image/url/i.png
 
-# Only these origins (client URLs) can successfully communicate with the IIIF API. This
-# allows XHR requests from remote IIIF clients. Defaults to ${dspace.ui.url} if unspecified
-# (as the embedded IIIF client must have access to the API). Multiple allowed origin URLs may
-# be comma separated. Wildcard value (*) is NOT SUPPORTED. # (Requires reboot of servlet
-# container, e.g. Tomcat, to reload)
-iiif.cors.allowed-origins = ${dspace.ui.url}
+# By default the IIIF endpoint is available to all clients. This allows for sharing
+# and interoperability that are the primary goals of IIIF. You are free to restrict
+# IIIF access to ${dspace.ui.url} and specific domains if you choose to do so.
+iiif.cors.allowed-origins = *
 
 # Whether or not to allow credentials (e.g. cookies) sent by the client/browser in CORS
 # requests (in "Access-Control-Allow-Credentials" header).


### PR DESCRIPTION
## Description
In `rest.cfg` our comment for CORS configuration specifically says the *Wildcard value (*) is NOT SUPPORTED.* In `iiif.cfg` we make the same comment for the `iiif.cors.allowed-origins` property and provide `${dspace.ui.url}` as the default value.   This is not appropriate for the IIIF endpoint because it severely limits interoperability that is the PRIMARY goal of IIIF.

I'm not sure how **or if** the wildcard prohibition is actually enforced for rest endpoints, but it is currently allowed for iiif endpoints. This PR updates the comment and default `iiif.cors.allowed-origins` value to use the wildcard "*"

(Note, I am prompted to make this request now because I just returned from the 2022 IIIF conference and the experience elevated my sense of urgency. If this change doesn't make it into 7.3 we can update our IIIF documentation in the meantime.)


## Instructions for Reviewers
The change can be tested by loading the manifest url into a remote IIIF client like the universal viewer demo at https://universalviewer.io/. If the `allowed-origins` is `${dspace.ui.url}` the item will not be displayed. If the allowed-origins is '*' (the new default proposed here) then the item will appear in the viewer. To use the test recipe you obviously need to use an internet accessible dspace host.

List of changes in this PR:
* Updated iiif.cfg

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
