### PR TITLE
Add bundleName parameter to items REST endpoint (POST bitstreams) (6.x)

### DIFF
--- a/dspace-rest/src/main/java/org/dspace/rest/ItemsResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/ItemsResource.java
@@ -453,7 +453,7 @@ public class ItemsResource extends Resource
 
             // add bitstream to specified bundle
             if (bundleName == null) {
-                bundleName = "ORIGINAL";
+                bundleName = org.dspace.core.Constants.CONTENT_BUNDLE_NAME;
             }
             for (Bundle existingBundle : bundles)
             {

--- a/dspace-rest/src/main/java/org/dspace/rest/ItemsResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/ItemsResource.java
@@ -427,7 +427,7 @@ public class ItemsResource extends Resource
     @POST
     @Path("/{item_id}/bitstreams")
     public Bitstream addItemBitstream(@PathParam("item_id") String itemId, InputStream inputStream,
-            @QueryParam("name") String name, @QueryParam("description") String description,
+            @QueryParam("name") String name, @QueryParam("description") String description, @QueryParam("bundleName") String bundleName,
             @QueryParam("groupId") String groupId, @QueryParam("year") Integer year, @QueryParam("month") Integer month,
             @QueryParam("day") Integer day, @QueryParam("userIP") String user_ip, @QueryParam("userAgent") String user_agent,
             @QueryParam("xforwardedfor") String xforwardedfor, @Context HttpHeaders headers, @Context HttpServletRequest request)
@@ -449,16 +449,25 @@ public class ItemsResource extends Resource
             log.trace("Creating bitstream in item.");
             org.dspace.content.Bundle bundle = null;
             org.dspace.content.Bitstream dspaceBitstream = null;
-            List<Bundle> bundles = itemService.getBundles(dspaceItem, org.dspace.core.Constants.CONTENT_BUNDLE_NAME);
+            List<Bundle> bundles = dspaceItem.getBundles();
 
-			if(bundles != null && bundles.size() != 0)
-			{
-				bundle = bundles.get(0); // There should be only one bundle ORIGINAL.
-			}
+            // add bitstream to specified bundle
+            if (bundleName == null) {
+                bundleName = "ORIGINAL";
+            }
+            for (Bundle existingBundle : bundles)
+            {
+                if (existingBundle.getName().equals(bundleName))
+                {
+                    bundle = existingBundle;
+                    break;
+                }
+            }
+
             if (bundle == null)
             {
-                log.trace("Creating bundle in item.");
-                dspaceBitstream = itemService.createSingleBitstream(context, inputStream, dspaceItem);
+                log.trace("Creating bundle "+bundleName+" in item.");
+                dspaceBitstream = itemService.createSingleBitstream(context, inputStream, dspaceItem, bundleName);
             }
             else
             {


### PR DESCRIPTION
## References
* Fixes #8342
* Extends behaviour from #777

## Description

This patch adds optional bundleName parameter to DSpace 6.x REST API endpoint
`POST /items/{item id}/bitstreams (Add a bitstream to the specified item)
`
allowing to set a custom bundle while adding a bitstream to item. If the bundle does not exist, it is created. ORIGINAL is used by default.

For now, this is the last of the 6.x REST API customizations used at the JYU (others are #8337 and #8339) and provided in the hope that it is of use to other DSpace 6 users relying on legacy REST API.


## Instructions for Reviewers

Usage example:

`curl -v -k -X POST --cookie "JSESSIONID=..." -T testdoc.pdf "https://dspace.installation/rest/items/item-uuid/bitstreams?name=testdoc.pdf&description=descriptionHere&bundleName=DATASET"
`
