### PR TITLE
DS-3296 Return 400 for invalid UUID when retrieving item via REST (6.x)

### DIFF
--- a/dspace-rest/src/main/java/org/dspace/rest/ItemsResource.java
+++ b/dspace-rest/src/main/java/org/dspace/rest/ItemsResource.java
@@ -992,7 +992,16 @@ public class ItemsResource extends Resource
         org.dspace.content.Item item = null;
         try
         {
-            item = itemService.findByIdOrLegacyId(context, id);
+            try
+            {
+                item = itemService.findByIdOrLegacyId(context, id);
+            }
+            catch (IllegalArgumentException e)
+            {
+                context.abort();
+                log.warn("Erroneous uuid (id=" + id + ")!");
+                throw new WebApplicationException(Response.Status.BAD_REQUEST);
+            }
 
             if (item == null)
             {


### PR DESCRIPTION
## References
* Fixes #6651

## Description
Added check for UUID parsing to endpoint GET /items/{itemID}. HTTP status 400 Bad Request is returned if the UUID is invalid.

## Instructions for Reviewers

In the issue http status 404 is mentioned. However, with the present 6.x code valid UUID:s are already handled and 404 is returned if the item is not found. However, if the UUID is syntactically invalid, the method fails with IllegalArgumentException, resulting to 500 server error.

```
java.lang.IllegalArgumentException: Invalid UUID string: fsfdgdg
	java.util.UUID.fromString(UUID.java:194)
	org.dspace.content.ItemServiceImpl.findByIdOrLegacyId(ItemServiceImpl.java:1242)
	org.dspace.content.ItemServiceImpl.findByIdOrLegacyId(ItemServiceImpl.java:61)
	org.dspace.rest.ItemsResource.findItem(ItemsResource.java:1004)
	org.dspace.rest.ItemsResource.getItem(ItemsResource.java:103)
```

This patch handles the IllegalArgumentException and ends the request with 400 Bad Request, which should be the proper response (=malformed UUID is a client error) instead of 404.

Test cases:

 - with nonexistent but valid UUID, e.g. https://demo.dspace.org/rest/items/00000000-0000-0000-0000-000000000000 should return 404
 - using invalid UUID, e.g. https://demo.dspace.org/rest/items/something_invalid should return 400
 - and using existing UUID should return basic information about the item.