### PR TITLE
Fix OAI Harvesting by restoring Xalan (required by OCLC OAI Harvester 2 codebase)

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -550,9 +550,16 @@
             <groupId>com.ibm.icu</groupId>
             <artifactId>icu4j</artifactId>
         </dependency>
+        <!-- Codebase at https://github.com/OCLC-Research/oaiharvester2/ -->
         <dependency>
             <groupId>org.dspace</groupId>
             <artifactId>oclc-harvester2</artifactId>
+        </dependency>
+        <!-- Xalan is REQUIRED by 'oclc-harvester2' listed above (OAI harvesting fails without it).
+             Please do NOT use Xalan in DSpace codebase as it is not well maintained. -->
+        <dependency>
+            <groupId>xalan</groupId>
+            <artifactId>xalan</artifactId>
         </dependency>
         <dependency>
             <groupId>org.dspace</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1567,10 +1567,18 @@
                 <artifactId>ojdbc6</artifactId>
                 <version>11.2.0.4.0</version>
             </dependency>
+            <!-- Codebase at https://github.com/OCLC-Research/oaiharvester2/ -->
             <dependency>
                 <groupId>org.dspace</groupId>
                 <artifactId>oclc-harvester2</artifactId>
                 <version>0.1.12</version>
+            </dependency>
+            <!-- Xalan is REQUIRED by 'oclc-harvester2' listed above (OAI harvesting fails without it).
+                 Please do NOT use Xalan in DSpace codebase as it is not well maintained. -->
+            <dependency>
+                <groupId>xalan</groupId>
+                <artifactId>xalan</artifactId>
+                <version>2.7.2</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
## References
* Fixes #8347 

## Description
We removed Xalan in #8258 , which caused #8347 as an accidental side effect.  Unfortunately the OCLC OAI Harvester code (which is unmaintained) relies on Xalan: https://github.com/OCLC-Research/oaiharvester2/

This means we cannot fully remove Xalan until this Harvest code can be replaced or refactored.  I'll create a separate ticket for refactoring/replacing that OAI Harvester & schedule it for 7.4.

## Instructions for Reviewers
* Verify #8347 is no longer reproducible.  
* One easy test is to run this from commandline:
```
# Tests harvesting of the old DSpace 6.x demo site for the collection at 10673/1
./dspace harvest -g -a http://demo.dspace.org/oai/request -i com_10673_1
```
Without this PR, the above command will fail.  With this PR, it will succeed.