### PR TITLE
92174: Refactor OpenUrlServiceImplTest to avoid making http requests

### DIFF
--- a/dspace-api/src/main/java/org/dspace/statistics/export/service/OpenUrlServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/export/service/OpenUrlServiceImpl.java
@@ -69,14 +69,21 @@ public class OpenUrlServiceImpl implements OpenUrlService {
      */
     protected int getResponseCodeFromUrl(final String urlStr) throws IOException {
         HttpGet httpGet = new HttpGet(urlStr);
-        RequestConfig requestConfig = getRequestConfigBuilder().setConnectTimeout(10 * 1000).build();
-        HttpClient httpClient = HttpClientBuilder.create().setDefaultRequestConfig(requestConfig).build();
+        HttpClient httpClient = getHttpClient(getHttpClientRequestConfig());
         HttpResponse httpResponse = httpClient.execute(httpGet);
         return httpResponse.getStatusLine().getStatusCode();
     }
 
-    protected RequestConfig.Builder getRequestConfigBuilder() {
-        return RequestConfig.custom();
+    protected HttpClient getHttpClient(RequestConfig requestConfig) {
+        return HttpClientBuilder.create()
+            .setDefaultRequestConfig(requestConfig)
+            .build();
+    }
+
+    protected RequestConfig getHttpClientRequestConfig() {
+        return RequestConfig.custom()
+            .setConnectTimeout(10 * 1000)
+            .build();
     }
 
     /**


### PR DESCRIPTION
## References
* Fixes #8365

## Description
Changes in this PR:
- made injecting mocks and spying on `OpenUrlServiceImplTest` more explicit.
- tiny refactor of `OpenUrlServiceImpl`
- use mocked `HttpClient` for each test case and refactored all test cases to make use of it.
- bonuses:
  - increased test coverage of `#testReprocessFailedQueue` and `#testLogfailed`
  - cleaned up `#testTimeout`

## Instructions for Reviewers
Test `OpenUrlServiceImplTest` should NOT make HTTP requests after this PR is applied. You can put a breakpoint [here](https://github.com/DSpace/DSpace/blob/main/dspace-api/src/main/java/org/dspace/statistics/export/service/OpenUrlServiceImpl.java#L74) and assert that for each test case, variable `httpClient` is a mock.

## Checklist
- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
