### PR TITLE
Ensure all automated CI / Docker builds use `--no-transfer-progress` maven flag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # Give Maven 1GB of memory to work with
-      # Suppress all Maven "downloading" messages in logs (see https://stackoverflow.com/a/35653426)
-      # This also slightly speeds builds, as there is less logging
-      MAVEN_OPTS: "-Xmx1024M -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+      MAVEN_OPTS: "-Xmx1024M"
     strategy:
       # Create a matrix of two separate configurations for Unit vs Integration Tests
       # This will ensure those tasks are run in parallel
@@ -67,7 +65,7 @@ jobs:
       - name: Run Maven ${{ matrix.type }}
         env:
           TEST_FLAGS: ${{ matrix.mvnflags }}
-        run: mvn install -B -V -P-assembly -Pcoverage-report $TEST_FLAGS
+        run: mvn --no-transfer-progress -V install -P-assembly -Pcoverage-report $TEST_FLAGS
 
       # If previous step failed, save results of tests to downloadable artifact for this job
       # (This artifact is downloadable at the bottom of any job's summary page)

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ USER dspace
 ADD --chown=dspace . /app/
 # Build DSpace (note: this build doesn't include the optional, deprecated "dspace-rest" webapp)
 # Copy the dspace-installer directory to /install.  Clean up the build to keep the docker image small
-RUN mvn package && \
+RUN mvn --no-transfer-progress package && \
   mv /app/dspace/target/${TARGET_DIR}/* /install && \
   mvn clean
 

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -19,7 +19,7 @@ USER dspace
 # Copy the DSpace source code (from local machine) into the workdir (excluding .dockerignore contents)
 ADD --chown=dspace . /app/
 # Build DSpace.  Copy the dspace-installer directory to /install.  Clean up the build to keep the docker image small
-RUN mvn package && \
+RUN mvn --no-transfer-progress package && \
   mv /app/dspace/target/${TARGET_DIR}/* /install && \
   mvn clean
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -22,7 +22,7 @@ USER dspace
 ADD --chown=dspace . /app/
 # Build DSpace (INCLUDING the optional, deprecated "dspace-rest" webapp)
 # Copy the dspace-installer directory to /install.  Clean up the build to keep the docker image small
-RUN mvn package -Pdspace-rest && \
+RUN mvn --no-transfer-progress package -Pdspace-rest && \
   mv /app/dspace/target/${TARGET_DIR}/* /install && \
   mvn clean
 


### PR DESCRIPTION
## Description
Discovered while tracking down #8368 

Our automated builds (both for GitHub CI and for Docker) are all very "noisy" in that they display all downloads during `mvn package` or `mvn install`.  While it's not a bug per say, there is a slight speed improvement to not logging all downloads.

This small PR ensures these automated builds all make use of the new `--no-transfer-progress` which tells Maven not to bother with logging all downloads, etc.

NOTE: Our CI process was using a much older way to do this same thing...but recent versions of Maven support this inherently via the `--no-transfer-progress` flag.