### PR TITLE
Improved orcid queue consumer description

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -753,7 +753,7 @@ event.dispatcher.default.class = org.dspace.event.BasicDispatcher
 # Adding doi here makes DSpace send metadata updates to your doi registration agency.
 # Add rdf here, if you are using dspace-rdf to export your repository content as RDF.
 # Add iiif here, if you are using dspace-iiif.
-# Add orcidqueue here, if you are using ORCID authentication and wish to enable the synchronization queue functionality
+# Add orcidqueue here, if the integration with ORCID is configured and wish to enable the synchronization queue functionality
 event.dispatcher.default.consumers = versioning, discovery, eperson
 
 # The noindex dispatcher will not create search or browse indexes (useful for batch item imports)


### PR DESCRIPTION
Minor improvement on ORCID Queue consumer description in the dspace.cfg file.
The Queue to synchronize items on ORCID can be used even if the ORCID authentication is disabled (an user can also connect an already existing profile with ORCID).

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
