### PR TITLE
Use platform file separator in SimpleMapConverterTest instead of '/'

### DIFF
--- a/dspace-api/src/test/java/org/dspace/util/SimpleMapConverterTest.java
+++ b/dspace-api/src/test/java/org/dspace/util/SimpleMapConverterTest.java
@@ -112,8 +112,12 @@ public class SimpleMapConverterTest {
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
             () -> simpleMapConverter.init());
 
+        // Get path separator used for this platform (eg. / for Linux, \ for Windows)
+        String separator = File.separator;
+
         assertThat(exception.getMessage(),
-            is("An error occurs parsing " + dspaceDir.getAbsolutePath() + "/config/crosswalks/test.properties"));
+            is("An error occurs parsing " + dspaceDir.getAbsolutePath() + separator + "config" + separator
+                    + "crosswalks" + separator + "test.properties"));
 
         Throwable cause = exception.getCause();
         assertThat(cause, notNullValue());


### PR DESCRIPTION
This small change uses the platform's file separator (/ in Linux or Mac, \ in Windows) to construct the path used in `SimpleMapConverterTest.testPropertiesParsingWithAnUnexistingFile` so that the test passes in Windows.

The test is currently broken in Windows. This bug was reported by @wwelling in Slack. I have not opened an issue as it was a small bug we can fix quickly.

There are other ways of achieving this:
1. `System.getProperty('file.separator')` which allows override of the separator through java options
2. NIO instead of core File IO

I think the File IO approach will work fine, but happy to change to a different method if we need to.

To test, run the related unit test `SimpleMapConverterTest.testPropertiesParsingWithAnUnexistingFile` in both Linux and Windows.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
