### PR TITLE
Fix some complaints frm errorprone

### DIFF
--- a/dspace-api/src/test/java/org/dspace/AbstractIntegrationTest.java
+++ b/dspace-api/src/test/java/org/dspace/AbstractIntegrationTest.java
@@ -102,7 +102,7 @@ public class AbstractIntegrationTest extends AbstractUnitTest {
     }
 
     /**
-     * 
+     *
      * @return the full path to the in use local.cfg file
      */
     private String getLocalConfigurationFilePath() {
@@ -114,7 +114,7 @@ public class AbstractIntegrationTest extends AbstractUnitTest {
      * Append the input text to the current local.cfg file assuring
      * that the new text goes in a new line and sleep enough time to allow the
      * configuration reload
-     * 
+     *
      * @param textToAppend
      */
     protected void appendToLocalConfiguration(String textToAppend) {

--- a/dspace-api/src/test/java/org/dspace/builder/AbstractDSpaceObjectBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/AbstractDSpaceObjectBuilder.java
@@ -31,6 +31,7 @@ import org.joda.time.format.PeriodFormatter;
  *
  * @author Tom Desair (tom dot desair at atmire dot com)
  * @author Raf Ponsaerts (raf dot ponsaerts at atmire dot com)
+ * @param <T> Type of DSO being built.
  */
 public abstract class AbstractDSpaceObjectBuilder<T extends DSpaceObject>
     extends AbstractBuilder<T, DSpaceObjectService> {
@@ -52,6 +53,7 @@ public abstract class AbstractDSpaceObjectBuilder<T extends DSpaceObject>
 
 
     @Override
+    @SuppressWarnings("TypeParameterUnusedInFormals")
     protected <B> B handleException(final Exception e) {
         log.error(e.getMessage(), e);
         return null;


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #[issue-number]
* Related to [REST Contract](https://github.com/DSpace/Rest7Contract)

## Description
Short summary of changes (1-2 sentences).

## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* First, ...
* Second, ...

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
