### PR TITLE
[DURACOM-71] Mark 'dc-qualifier' as optional

### DIFF
--- a/dspace-api/src/test/data/dspaceFolder/config/submission-forms.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/submission-forms.xml
@@ -27,7 +27,6 @@
 	       <field>
 	         <dc-schema>dc</dc-schema>
 	         <dc-element>title</dc-element>
-	         <dc-qualifier></dc-qualifier>
 	         <repeatable>false</repeatable>
 	         <label>Title</label>
 	         <input-type>onebox</input-type>
@@ -73,7 +72,6 @@
        <field>
          <dc-schema>dc</dc-schema>
          <dc-element>title</dc-element>
-         <dc-qualifier></dc-qualifier>
          <repeatable>false</repeatable>
          <label>Title</label>
          <input-type>onebox</input-type>
@@ -112,7 +110,6 @@
        <field>
          <dc-schema>dc</dc-schema>
          <dc-element>publisher</dc-element>
-         <dc-qualifier></dc-qualifier>
          <repeatable>false</repeatable>
          <label>Publisher</label>
          <style>col-sm-8</style>
@@ -150,7 +147,6 @@
        <field>
          <dc-schema>dc</dc-schema>
          <dc-element>identifier</dc-element>
-         <dc-qualifier></dc-qualifier>
          <!-- An input-type of qualdrop_value MUST be marked as repeatable -->
          <repeatable>true</repeatable>
          <label>Identifiers</label>
@@ -164,7 +160,6 @@ it, please enter the types and the actual numbers or codes.</hint>
        <field>
          <dc-schema>dc</dc-schema>
          <dc-element>type</dc-element>
-         <dc-qualifier></dc-qualifier>
          <repeatable>true</repeatable>
          <label>Type</label>
          <input-type value-pairs-name="common_types">dropdown</input-type>
@@ -191,7 +186,6 @@ it, please enter the types and the actual numbers or codes.</hint>
        <field>
          <dc-schema>dc</dc-schema>
          <dc-element>subject</dc-element>
-         <dc-qualifier></dc-qualifier>
          <!-- An input-type of twobox MUST be marked as repeatable -->
          <repeatable>true</repeatable>
          <label>Subject Keywords</label>
@@ -229,7 +223,6 @@ it, please enter the types and the actual numbers or codes.</hint>
        <field>
          <dc-schema>dc</dc-schema>
          <dc-element>description</dc-element>
-         <dc-qualifier></dc-qualifier>
          <repeatable>false</repeatable>
          <label>Description</label>
          <input-type>textarea</input-type>
@@ -292,7 +285,6 @@ it, please enter the types and the actual numbers or codes.</hint>
        <field>
          <dc-schema>dc</dc-schema>
          <dc-element>identifier</dc-element>
-         <dc-qualifier></dc-qualifier>
          <repeatable>true</repeatable>
          <label>Identifiers</label>
          <input-type value-pairs-name="common_identifiers">qualdrop_value</input-type>
@@ -308,7 +300,6 @@ it, please enter the types and the actual numbers or codes.</hint>
        <field>
          <dc-schema>dc</dc-schema>
          <dc-element>title</dc-element>
-         <dc-qualifier></dc-qualifier>
          <repeatable>false</repeatable>
          <label>Title</label>
          <input-type>onebox</input-type>
@@ -336,7 +327,6 @@ it, please enter the types and the actual numbers or codes.</hint>
        <field>
          <dc-schema>dc</dc-schema>
          <dc-element>type</dc-element>
-         <dc-qualifier></dc-qualifier>
          <repeatable>true</repeatable>
          <label>Type</label>
          <input-type value-pairs-name="common_types">dropdown</input-type>

--- a/dspace/config/submission-forms.dtd
+++ b/dspace/config/submission-forms.dtd
@@ -11,7 +11,7 @@
  <!ELEMENT field (dc-schema, dc-element, dc-qualifier?, language?, repeatable?, label, style?, type-bind?, input-type, hint, required?, regex?, vocabulary?, visibility?, readonly?) >
  <!ELEMENT dc-schema (#PCDATA) >
  <!ELEMENT dc-element (#PCDATA) >
- <!ELEMENT dc-qualifier (#PCDATA)? >
+ <!ELEMENT dc-qualifier (#PCDATA?) >
  <!ELEMENT language (#PCDATA)>
  <!ELEMENT type-bind (#PCDATA) >
 

--- a/dspace/config/submission-forms.dtd
+++ b/dspace/config/submission-forms.dtd
@@ -11,7 +11,7 @@
  <!ELEMENT field (dc-schema, dc-element, dc-qualifier?, language?, repeatable?, label, style?, type-bind?, input-type, hint, required?, regex?, vocabulary?, visibility?, readonly?) >
  <!ELEMENT dc-schema (#PCDATA) >
  <!ELEMENT dc-element (#PCDATA) >
- <!ELEMENT dc-qualifier (#PCDATA) >
+ <!ELEMENT dc-qualifier (#PCDATA)? >
  <!ELEMENT language (#PCDATA)>
  <!ELEMENT type-bind (#PCDATA) >
 


### PR DESCRIPTION
## References
* Fixes #8386

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
