### PR TITLE
TOC exclusion bundle(s)

### DIFF
--- a/dspace-iiif/src/main/java/org/dspace/app/iiif/service/ManifestService.java
+++ b/dspace-iiif/src/main/java/org/dspace/app/iiif/service/ManifestService.java
@@ -158,7 +158,6 @@ public class ManifestService extends AbstractResourceService {
         if (guessCanvasDimension) {
             canvasService.guessCanvasDimensions(bundles);
         }
-        // canvasService.setDefaultCanvasDimensions();
         for (Bundle bnd : bundles) {
             String bundleToCPrefix = null;
             if (bundles.size() > 1) {

--- a/dspace-iiif/src/main/java/org/dspace/app/iiif/service/utils/IIIFUtils.java
+++ b/dspace-iiif/src/main/java/org/dspace/app/iiif/service/utils/IIIFUtils.java
@@ -49,8 +49,6 @@ public class IIIFUtils {
     // The DSpace bundle for other content related to item.
     protected static final String OTHER_CONTENT_BUNDLE = "OtherContent";
 
-    private static final String OMIT_FROM_TOC_BUNDLE = "iiif";
-
     // The canvas position will be appended to this string.
     private static final String CANVAS_PATH_BASE = "/canvas/c";
 

--- a/dspace-iiif/src/main/java/org/dspace/app/iiif/service/utils/IIIFUtils.java
+++ b/dspace-iiif/src/main/java/org/dspace/app/iiif/service/utils/IIIFUtils.java
@@ -48,6 +48,8 @@ public class IIIFUtils {
     // The DSpace bundle for other content related to item.
     protected static final String OTHER_CONTENT_BUNDLE = "OtherContent";
 
+    private static final String OMIT_FROM_TOC_BUNDLE = "iiif";
+
     // The canvas position will be appended to this string.
     private static final String CANVAS_PATH_BASE = "/canvas/c";
 
@@ -335,10 +337,17 @@ public class IIIFUtils {
     public String getBundleIIIFToC(Bundle bundle) {
         String label = bundle.getMetadata().stream()
                 .filter(m -> m.getMetadataField().toString('.').contentEquals(METADATA_IIIF_LABEL))
-                .findFirst().map(m -> m.getValue()).orElse(bundle.getName());
+                .findFirst().map(m -> m.getValue()).orElse(getBundleLabel(bundle));
         return bundle.getMetadata().stream()
                 .filter(m -> m.getMetadataField().toString('.').contentEquals(METADATA_IIIF_TOC))
                 .findFirst().map(m -> m.getValue() + TOC_SEPARATOR + label).orElse(label);
+    }
+
+    private String getBundleLabel(Bundle bundle) {
+        if (bundle.getName().contentEquals(OMIT_FROM_TOC_BUNDLE)) {
+            return null;
+        }
+        return bundle.getName();
     }
 
     /**

--- a/dspace-iiif/src/main/java/org/dspace/app/iiif/service/utils/IIIFUtils.java
+++ b/dspace-iiif/src/main/java/org/dspace/app/iiif/service/utils/IIIFUtils.java
@@ -14,6 +14,7 @@ import static org.dspace.iiif.util.IIIFSharedUtils.METADATA_IIIF_WIDTH_QUALIFIER
 
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -337,14 +338,21 @@ public class IIIFUtils {
     public String getBundleIIIFToC(Bundle bundle) {
         String label = bundle.getMetadata().stream()
                 .filter(m -> m.getMetadataField().toString('.').contentEquals(METADATA_IIIF_LABEL))
-                .findFirst().map(m -> m.getValue()).orElse(getBundleLabel(bundle));
+                .findFirst().map(m -> m.getValue()).orElse(getToCBundleLabel(bundle));
         return bundle.getMetadata().stream()
                 .filter(m -> m.getMetadataField().toString('.').contentEquals(METADATA_IIIF_TOC))
                 .findFirst().map(m -> m.getValue() + TOC_SEPARATOR + label).orElse(label);
     }
 
-    private String getBundleLabel(Bundle bundle) {
-        if (bundle.getName().contentEquals(OMIT_FROM_TOC_BUNDLE)) {
+    /**
+     * Excludes bundles found in the iiif.exclude.toc.bundle list
+     *
+     * @param bundle    the dspace bundle
+     * @return  bundle name or null if bundle is excluded
+     */
+    private String getToCBundleLabel(Bundle bundle) {
+        String[] iiifAlternate = configurationService.getArrayProperty("iiif.exclude.toc.bundle");
+        if (Arrays.stream(iiifAlternate).anyMatch(x -> x.contentEquals(bundle.getName()))) {
             return null;
         }
         return bundle.getName();

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/iiif/IIIFControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/iiif/IIIFControllerIT.java
@@ -750,7 +750,7 @@ public class IIIFControllerIT extends AbstractControllerIntegrationTest {
         }
         context.restoreAuthSystemState();
 
-        // Expected a rendering element and no structures (because all images are inside the IIIF exclusive bundle)
+        // Expected a rendering element and no structures (because all images are inside the toc excluded bundle)
         getClient().perform(get("/iiif/" + publicItem1.getID() + "/manifest"))
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$.@context", is("http://iiif.io/api/presentation/2/context.json")))

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/iiif/IIIFControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/iiif/IIIFControllerIT.java
@@ -33,16 +33,20 @@ import org.dspace.content.Item;
 import org.dspace.content.service.ItemService;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
+import org.dspace.services.ConfigurationService;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class IIIFControllerIT extends AbstractControllerIntegrationTest {
 
-    public static final String IIIFBundle = "IIIF";
+    public static final String IIIFBundle = "RANGETEST";
 
     @Autowired
     ItemService itemService;
+
+    @Autowired
+    private ConfigurationService configurationService;
 
     @Test
     public void disabledTest() throws Exception {
@@ -491,11 +495,11 @@ public class IIIFControllerIT extends AbstractControllerIntegrationTest {
                    .andExpect(jsonPath("$.structures[0].ranges[1]",
                                        Matchers.endsWith("/iiif/" + publicItem1.getID() + "/manifest/range/r0-1")))
 
-                   // Should contain a structure with label=IIIF, corresponding to IIIF bundle
+                   // Should contain a structure with label=RANGETEST, corresponding to IIIF bundle
                    // It should have exactly 2 canvases (corresponding to 2 bitstreams)
-                   .andExpect(jsonPath("$.structures[?(@.label=='IIIF')].canvases[0]").exists())
-                   .andExpect(jsonPath("$.structures[?(@.label=='IIIF')].canvases[1]").exists())
-                   .andExpect(jsonPath("$.structures[?(@.label=='IIIF')].canvases[2]").doesNotExist())
+                   .andExpect(jsonPath("$.structures[?(@.label=='RANGETEST')].canvases[0]").exists())
+                   .andExpect(jsonPath("$.structures[?(@.label=='RANGETEST')].canvases[1]").exists())
+                   .andExpect(jsonPath("$.structures[?(@.label=='RANGETEST')].canvases[2]").doesNotExist())
 
                    // Should contain a structure with label=ORIGINAL, corresponding to ORIGINAL bundle
                    // It should have exactly 1 canvas (corresponding to 1 bitstream)
@@ -694,6 +698,79 @@ public class IIIFControllerIT extends AbstractControllerIntegrationTest {
                         Matchers.containsString("/iiif/" + publicItem1.getID() + "/canvas/c7")))
                 .andExpect(jsonPath("$.service").exists());
     }
+
+    @Test
+    public void findOneWithAlternateIIIFBundleAndNoStructures() throws Exception {
+
+        String altBundle = "IIIFAlternate";
+
+        context.turnOffAuthorisationSystem();
+
+        configurationService.setProperty("iiif.exclude.toc.bundle", altBundle);
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+        Collection col1 = CollectionBuilder.createCollection(context, parentCommunity).withName("Collection 1")
+                                           .build();
+        Item publicItem1 = ItemBuilder.createItem(context, col1)
+                                      .withTitle("Public item 1")
+                                      .withIssueDate("2017-10-17")
+                                      .withAuthor("Smith, Donald").withAuthor("Doe, John")
+                                      .withIIIFCanvasHeight(3000)
+                                      .withIIIFCanvasWidth(2000)
+                                      .withIIIFCanvasNaming("Global")
+                                      .enableIIIF()
+                                      .enableIIIFSearch()
+                                      .build();
+
+        String bitstreamContent = "ThisIsSomeText";
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
+            // add PDF to ORIGINAL
+            BitstreamBuilder
+                .createBitstream(context, publicItem1, is)
+                .withName("Bitstream1.pdf")
+                .withMimeType("application/pdf")
+                .build();
+        }
+        // Add images to the alternate IIIF bundle
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
+            BitstreamBuilder
+                .createBitstream(context, publicItem1, is, altBundle)
+                .withName("Bitstream2.png")
+                .withMimeType("image/png")
+                .build();
+        }
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
+            BitstreamBuilder
+                .createBitstream(context, publicItem1, is, altBundle)
+                .withName("Bitstream3.tiff")
+                .withMimeType("image/tiff")
+                .build();
+        }
+        context.restoreAuthSystemState();
+
+        // Expected a rendering element and no structures (because all images are inside the IIIF exclusive bundle)
+        getClient().perform(get("/iiif/" + publicItem1.getID() + "/manifest"))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.@context", is("http://iiif.io/api/presentation/2/context.json")))
+                   // should contain 3 canvases, corresponding to each bitstream
+                   .andExpect(jsonPath("$.sequences[0].canvases[*].label",
+                       Matchers.contains("Global 1", "Global 2")))
+
+                   // structures should not be present
+                   .andExpect(jsonPath("$.structures").doesNotExist())
+
+                   // Should sequence with exactly 2 canvases (corresponding to 2 bitstreams)
+                   .andExpect(jsonPath("$.sequences[0].canvases[0]").exists())
+                   .andExpect(jsonPath("$.sequences[0].canvases[1]").exists())
+                   .andExpect(jsonPath("$.sequences[1].canvases[2]").doesNotExist())
+
+                   // Should include the pdf file in rendering
+                   .andExpect(jsonPath("$.rendering[?(@.format=='application/pdf')]").exists());
+
+    }
+
 
     @Test
     public void findOneIIIFNotSearcheableIT() throws Exception {

--- a/dspace/config/modules/iiif.cfg
+++ b/dspace/config/modules/iiif.cfg
@@ -83,13 +83,10 @@ iiif.document.viewing.hint = individuals
 # iiif.canvas.default-width = 2200
 # iiif.canvas.default-height = 1600
 
-# the names of Bundles that include IIIF canvas resources WITHOUT ALSO generating
-# a nested Range (table of contents). The default behavior is to create IIIF Ranges
-# when an Item has multiple IIIF-eligible Bundles. A Range entry is created for
-# each Bundle that contains canvas resources.
-# This setting allows you to add IIIF canvas resources to a Bundle other than ORIGINAL
-# without also creating a nested Range. Be sure to add ALL IIIF canvas resources
-# to this Bundle or Bundles (e.g. if you also add image files to the ORIGINAL
-# Bundle a range for that Bundle will still be created.)
-# Multiple comma-separated Bundle names are allowed.
-# iiif.exclude.toc.bundle = IIIF
+# the names of Bundles that can include IIIF canvas resources WITHOUT ALSO generating
+# a nested Range (table of contents).
+# The default is to create IIIF Ranges when an Item has multiple IIIF-eligible Bundles.
+# A Range entry is created for each Bundle that contains canvas resources.
+# This setting allows you to add IIIF canvas resources to the designated Bundles
+# without also creating a nested Range. Multiple comma-separated Bundle names are allowed.
+# iiif.exclude.toc.bundle = ORIGINAL, IIIF

--- a/dspace/config/modules/iiif.cfg
+++ b/dspace/config/modules/iiif.cfg
@@ -83,3 +83,13 @@ iiif.document.viewing.hint = individuals
 # iiif.canvas.default-width = 2200
 # iiif.canvas.default-height = 1600
 
+# the names of Bundles that include IIIF canvas resources WITHOUT ALSO generating
+# a nested Range (table of contents). The default behavior is to create IIIF Ranges
+# when an Item has multiple IIIF-eligible Bundles. A Range entry is created for
+# each Bundle that contains canvas resources.
+# This setting allows you to add IIIF canvas resources to a Bundle other than ORIGINAL
+# without also creating a nested Range. Be sure to add ALL IIIF canvas resources
+# to this Bundle or Bundles (e.g. if you also add image files to the ORIGINAL
+# Bundle a range for that Bundle will still be created.)
+# Multiple comma-separated Bundle names are allowed.
+# iiif.exclude.toc.bundle = IIIF


### PR DESCRIPTION
## Description
By default, table of contents ranges (ToC's) are created when multiple IIIF bundles exist for the item. This allows us to use bundles to create nested ranges. 

There are scenarios in which it's better to not display IIIF image resources for download in the Item's bitstream list. For example, imagine an item with a single PDF file and hundreds of jp2 images, one for each page in the document. Listing the jp2 images in the DSpace UI is unnecessary noise and  exposes these images to crawlers (which may not be desired). The simplest solution, without invoking complex access restrictions, is to put image files into a separate bundle (not the ORIGINAL) and then expose images only via the IIIF viewer. The Mirador viewer provides a configurable plugin for downloading images as jpegs.

However, we need to do this without creating an unwanted ToC entry.

This PR makes that possible. It adds a `iiif.exclude.toc.bundle` setting to `iiif.cfg`. When all canvas resources are placed into excluded IIIF bundles no ToC entry is created.

`# iiif.exclude.toc.bundle = ORIGINAL, IIIF`

Off hand, I can think of ways this might be accomplished by changing the default behavior, instead of introducing a new configuration option, but I worry about side effects. @abollini , bundle-based ranges were contributed by 4Science so you are probably are probably the best person to comment on this one.

## Instructions for Reviewers

1. Create an item and add all image resources to a new custom bundle. 
2. View the item. 
3. You should see that a ToC entry was created, using the name of the bundle as the label. 
4. Set `iiif.exclude.toc.bundle` to include the name of your bundle. 
5. Restart DSpace and when you view the item the ToC entry should be gone.

List of changes in this PR:
* New config option in iiif.cfg
* Modified IIIF bundle util functions to use the config setting



## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
