### PR TITLE
Uncaching bitstreams to improve performance of iiif-canvas-dimensions

### DIFF
--- a/dspace-api/src/main/java/org/dspace/iiif/canvasdimension/CanvasDimensionCLI.java
+++ b/dspace-api/src/main/java/org/dspace/iiif/canvasdimension/CanvasDimensionCLI.java
@@ -17,6 +17,7 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.MissingArgumentException;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
+import org.apache.commons.lang3.StringUtils;
 import org.dspace.app.util.factory.UtilServiceFactory;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
@@ -64,7 +65,8 @@ public class CanvasDimensionCLI {
         String identifier = null;
         String eperson = null;
 
-        Context context = new Context();
+        Context context = new Context(Context.Mode.BATCH_EDIT);
+
         IIIFCanvasDimensionService canvasProcessor = IIIFCanvasDimensionServiceFactory.getInstance()
                                                                                       .getIiifCanvasDimensionService();
 

--- a/dspace-api/src/main/java/org/dspace/iiif/canvasdimension/CanvasDimensionCLI.java
+++ b/dspace-api/src/main/java/org/dspace/iiif/canvasdimension/CanvasDimensionCLI.java
@@ -8,6 +8,7 @@
 package org.dspace.iiif.canvasdimension;
 
 import java.util.Arrays;
+import java.util.Date;
 import java.util.UUID;
 
 import org.apache.commons.cli.CommandLine;
@@ -48,6 +49,7 @@ public class CanvasDimensionCLI {
 
     public static void main(String[] argv) throws Exception {
 
+        Date startTime = new Date();
 
         boolean iiifEnabled = configurationService.getBooleanProperty("iiif.enabled");
         if (!iiifEnabled) {
@@ -223,6 +225,13 @@ public class CanvasDimensionCLI {
 
         // Always print summary to standard out.
         System.out.println(processed + " IIIF items were processed.");
+
+        Date endTime = new Date();
+        System.out.println("Started: " + startTime.getTime());
+        System.out.println("Ended: " + endTime.getTime());
+        System.out.println(
+            "Elapsed time: " + ((endTime.getTime() - startTime.getTime()) / 1000) + " secs (" + (endTime
+                .getTime() - startTime.getTime()) + " msecs)");
 
     }
 

--- a/dspace-api/src/main/java/org/dspace/iiif/canvasdimension/CanvasDimensionCLI.java
+++ b/dspace-api/src/main/java/org/dspace/iiif/canvasdimension/CanvasDimensionCLI.java
@@ -223,9 +223,6 @@ public class CanvasDimensionCLI {
             context.commit();
         }
 
-        // Always print summary to standard out.
-        System.out.println(processed + " IIIF items were processed.");
-
         Date endTime = new Date();
         System.out.println("Started: " + startTime.getTime());
         System.out.println("Ended: " + endTime.getTime());
@@ -233,6 +230,8 @@ public class CanvasDimensionCLI {
             "Elapsed time: " + ((endTime.getTime() - startTime.getTime()) / 1000) + " secs (" + (endTime
                 .getTime() - startTime.getTime()) + " msecs)");
 
+        // Always print summary to standard out.
+        System.out.println(processed + " IIIF items were processed.");
     }
 
 }

--- a/dspace-api/src/main/java/org/dspace/iiif/canvasdimension/CanvasDimensionCLI.java
+++ b/dspace-api/src/main/java/org/dspace/iiif/canvasdimension/CanvasDimensionCLI.java
@@ -17,7 +17,6 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.MissingArgumentException;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
-import org.apache.commons.lang3.StringUtils;
 import org.dspace.app.util.factory.UtilServiceFactory;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;

--- a/dspace-api/src/main/java/org/dspace/iiif/canvasdimension/IIIFCanvasDimensionServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/iiif/canvasdimension/IIIFCanvasDimensionServiceImpl.java
@@ -117,11 +117,11 @@ public class IIIFCanvasDimensionServiceImpl implements IIIFCanvasDimensionServic
             boolean isIIIFItem = IIIFSharedUtils.isIIIFItem(item);
             if (isIIIFItem) {
                 if (processItemBundles(context, item)) {
+                    context.uncacheEntity(item);
                     ++processed;
                 }
             }
         }
-        context.uncacheEntity(item);
     }
 
     /**
@@ -138,6 +138,7 @@ public class IIIFCanvasDimensionServiceImpl implements IIIFCanvasDimensionServic
             List<Bitstream> bitstreams = bundle.getBitstreams();
             for (Bitstream bit : bitstreams) {
                 done |= processBitstream(context, bit);
+                context.uncacheEntity(bit);
             }
         }
         if (done) {
@@ -199,7 +200,6 @@ public class IIIFCanvasDimensionServiceImpl implements IIIFCanvasDimensionServic
                 }
             }
         }
-        context.uncacheEntity(bitstream);
         return processed;
     }
 

--- a/dspace-api/src/main/java/org/dspace/iiif/canvasdimension/IIIFCanvasDimensionServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/iiif/canvasdimension/IIIFCanvasDimensionServiceImpl.java
@@ -121,6 +121,7 @@ public class IIIFCanvasDimensionServiceImpl implements IIIFCanvasDimensionServic
                 }
             }
         }
+        context.uncacheEntity(item);
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/iiif/canvasdimension/IIIFCanvasDimensionServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/iiif/canvasdimension/IIIFCanvasDimensionServiceImpl.java
@@ -198,6 +198,7 @@ public class IIIFCanvasDimensionServiceImpl implements IIIFCanvasDimensionServic
                 }
             }
         }
+        context.uncacheEntity(bitstream);
         return processed;
     }
 

--- a/dspace-api/src/main/java/org/dspace/iiif/canvasdimension/IIIFCanvasDimensionServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/iiif/canvasdimension/IIIFCanvasDimensionServiceImpl.java
@@ -122,7 +122,6 @@ public class IIIFCanvasDimensionServiceImpl implements IIIFCanvasDimensionServic
                 context.uncacheEntity(item);
             }
         }
-        context.uncacheEntity(item);
     }
 
     /**
@@ -201,7 +200,6 @@ public class IIIFCanvasDimensionServiceImpl implements IIIFCanvasDimensionServic
                 }
             }
         }
-        context.uncacheEntity(bitstream);
         return processed;
     }
 

--- a/dspace-api/src/main/java/org/dspace/iiif/canvasdimension/IIIFCanvasDimensionServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/iiif/canvasdimension/IIIFCanvasDimensionServiceImpl.java
@@ -117,9 +117,9 @@ public class IIIFCanvasDimensionServiceImpl implements IIIFCanvasDimensionServic
             boolean isIIIFItem = IIIFSharedUtils.isIIIFItem(item);
             if (isIIIFItem) {
                 if (processItemBundles(context, item)) {
-                    context.uncacheEntity(item);
                     ++processed;
                 }
+                context.uncacheEntity(item);
             }
         }
     }

--- a/dspace-api/src/test/java/org/dspace/iiif/canvasdimension/CanvasDimensionsIT.java
+++ b/dspace-api/src/test/java/org/dspace/iiif/canvasdimension/CanvasDimensionsIT.java
@@ -7,13 +7,13 @@
  */
 package org.dspace.iiif.canvasdimension;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
+import java.util.regex.Pattern;
 
 import org.apache.commons.lang.StringUtils;
 import org.dspace.AbstractIntegrationTestWithDatabase;
@@ -232,9 +232,7 @@ public class CanvasDimensionsIT extends AbstractIntegrationTestWithDatabase  {
             .withName("Bitstream2.jpg")
             .withMimeType("image/jpeg")
             .build();
-
         context.restoreAuthSystemState();
-
         String id = parentCommunity.getID().toString();
         execCanvasScript(id);
 
@@ -409,7 +407,8 @@ public class CanvasDimensionsIT extends AbstractIntegrationTestWithDatabase  {
 
         execCanvasScriptWithMaxRecs(id);
         // check System.out for number of items processed.
-        assertEquals("2 IIIF items were processed.", StringUtils.chomp(outContent.toString()));
+        Pattern regex = Pattern.compile(".*2 IIIF items were processed", Pattern.DOTALL);
+        assertTrue(regex.matcher(StringUtils.chomp(outContent.toString())).find());
     }
 
     @Test


### PR DESCRIPTION
## Description
The canvas dimension task becomes quite slow when processing a large number of images. Removing each bitstream from the hibernate cache after it has been processed fixes the problem.

## Instructions for Reviewers
This is a simple one-liner PR. If you have an IIIF collection handy you could run the script against it, using the force option if necessary. 


**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
