### PR TITLE
Fix claimed user on `AssignOriginalSubmitterAction`

### DIFF
--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/userassignment/AssignOriginalSubmitterAction.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/userassignment/AssignOriginalSubmitterAction.java
@@ -136,7 +136,7 @@ public class AssignOriginalSubmitterAction extends UserSelectionAction {
     protected void createTaskForEPerson(Context c, XmlWorkflowItem wfi, Step step, WorkflowActionConfig actionConfig,
                                         EPerson user) throws SQLException, AuthorizeException, IOException {
         if (claimedTaskService.find(c, wfi, step.getId(), actionConfig.getId()) != null) {
-            workflowRequirementsService.addClaimedUser(c, wfi, step, c.getCurrentUser());
+            workflowRequirementsService.addClaimedUser(c, wfi, step, user);
             XmlWorkflowServiceFactory.getInstance().getXmlWorkflowService()
                                      .createOwnedTask(c, wfi, step, actionConfig, user);
         }


### PR DESCRIPTION
## Description
`AssignOriginalSubmitterAction` creates a task for the original submitter, but sets the current EPerson as the claimed user. If those are not the same, the original submitter can't do anything with the task.

Originally noticed on DSpace 6.3

## Reproducing

Run a local DSpace instance with `webui.user.assumelogin=true` and the `finaleditstep` changed to

```xml
<bean name="finaleditstep" class="org.dspace.xmlworkflow.state.Step">
    <property name="userSelectionMethod" ref="originalSubmitterAssignAction"/>
    <property name="actions">
        <list>
            <ref bean="finaleditaction"/>
        </list>
    </property>
</bean>
```

[in `config/spring/api/workflow.xml`](https://github.com/DSpace/DSpace/blob/31f706042f098e2b78cfcc9a637f5852f8d307a1/dspace/config/spring/api/workflow.xml#L84)

→ at the last step the WFI should be automatically assigned to the original submitter instead of appearing in the final editor pool

1. Set up a collection with the admin EPerson in all workflow roles and a non-admin EPerson in the submitter group
2. Submit an Item to this Collection as the submitter EPerson
3. Log in as the admin and approve the Item through two workflow steps
4. Log in as the submitter and check the workflow status
   * The WFI will appear to be claimed by the submitter
   * The submitter can edit the WFI
   * **The submitter cannot approve the WFI** and it 
     * REST request fails w/ HTTP 500
     * Notification: `Error occurred during operation...`

## Reviewing

Confirm that the issue can no longer be reproduced and the `AssignOriginalSubmitterAction` now behaves as expected



## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.