### PR TITLE
Updates the canvas dimension method to use multiple bundles.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/iiif/IIIFApiQueryServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/iiif/IIIFApiQueryServiceImpl.java
@@ -23,8 +23,7 @@ import org.dspace.iiif.util.IIIFSharedUtils;
 
 
 /**
- * Queries the configured IIIF server for image dimensions. Used for
- * formats that cannot be easily read using ImageIO (jpeg 2000).
+ * Queries the configured IIIF image server via the Image API.
  *
  * @author Michael Spalti mspalti@willamette.edu
  */

--- a/dspace-api/src/test/data/dspaceFolder/config/spring/api/iiif-processing.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/spring/api/iiif-processing.xml
@@ -4,6 +4,9 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd"
        default-lazy-init="true">
 
-    <bean class="org.dspace.iiif.MockIIIFApiQueryServiceImpl" id="org.dspace.iiif.IIIFApiQueryServiceImpl" autowire-candidate="true"/>
+    <bean id="iiifCanvasDimensionServiceFactory" class="org.dspace.iiif.canvasdimension.factory.IIIFCanvasDimensionServiceFactoryImpl"/>
+    <bean class="org.dspace.iiif.canvasdimension.IIIFCanvasDimensionServiceImpl" scope="prototype"/>
+    <bean class="org.dspace.iiif.MockIIIFApiQueryServiceImpl" id="org.dspace.iiif.IIIFApiQueryServiceImpl"
+          autowire-candidate="true"/>
 
 </beans>

--- a/dspace-api/src/test/java/org/dspace/iiif/MockIIIFApiQueryServiceImpl.java
+++ b/dspace-api/src/test/java/org/dspace/iiif/MockIIIFApiQueryServiceImpl.java
@@ -1,0 +1,16 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.iiif;
+
+import org.dspace.content.Bitstream;
+
+public class MockIIIFApiQueryServiceImpl extends IIIFApiQueryServiceImpl {
+    public int[] getImageDimensions(Bitstream bitstream) {
+        return new int[]{64, 64};
+    }
+}

--- a/dspace-api/src/test/java/org/dspace/iiif/MockIIIFApiQueryServiceImpl.java
+++ b/dspace-api/src/test/java/org/dspace/iiif/MockIIIFApiQueryServiceImpl.java
@@ -9,6 +9,10 @@ package org.dspace.iiif;
 
 import org.dspace.content.Bitstream;
 
+/**
+ * Mock for the IIIFApiQueryService.
+ * @author Michael Spalti (mspalti at willamette.edu)
+ */
 public class MockIIIFApiQueryServiceImpl extends IIIFApiQueryServiceImpl {
     public int[] getImageDimensions(Bitstream bitstream) {
         return new int[]{64, 64};

--- a/dspace-iiif/src/main/java/org/dspace/app/iiif/service/CanvasService.java
+++ b/dspace-iiif/src/main/java/org/dspace/app/iiif/service/CanvasService.java
@@ -9,7 +9,6 @@ package org.dspace.app.iiif.service;
 
 import static org.dspace.app.iiif.service.utils.IIIFUtils.METADATA_IMAGE_WIDTH;
 
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -85,20 +84,14 @@ public class CanvasService extends AbstractResourceService {
      * using the IIIF image service. Called once for each manifest.
      * @param bundles IIIF bundles for this item
      */
-    protected void guessCanvasDimensions(List<Bundle> bundles, Context context) {
+    protected void guessCanvasDimensions(Context context, List<Bundle> bundles) {
         // prevent redundant updates.
         boolean dimensionUpdated = false;
 
         for (Bundle bundle : bundles) {
             if (!dimensionUpdated) {
                 for (Bitstream bitstream : bundle.getBitstreams()) {
-                    boolean isImage = false;
-                    try {
-                        isImage = bitstream.getFormat(context).getMIMEType().contains("image/");
-                    } catch (SQLException e) {
-                        log.warn("Error reading the bitstream format: " + e.getMessage());
-                    }
-                    if (isImage) {
+                    if (utils.isIIIFBitstream(context, bitstream)) {
                         // check for width dimension
                         if (!utils.hasWidthMetadata(bitstream)) {
                             // get the dimensions of the image.

--- a/dspace-iiif/src/main/java/org/dspace/app/iiif/service/ManifestService.java
+++ b/dspace-iiif/src/main/java/org/dspace/app/iiif/service/ManifestService.java
@@ -156,7 +156,7 @@ public class ManifestService extends AbstractResourceService {
         List<Bundle> bundles = utils.getIIIFBundles(item);
         // Set the default canvas dimensions.
         if (guessCanvasDimension) {
-            canvasService.guessCanvasDimensions(bundles);
+            canvasService.guessCanvasDimensions(bundles, context);
         }
         for (Bundle bnd : bundles) {
             String bundleToCPrefix = null;

--- a/dspace-iiif/src/main/java/org/dspace/app/iiif/service/ManifestService.java
+++ b/dspace-iiif/src/main/java/org/dspace/app/iiif/service/ManifestService.java
@@ -156,7 +156,7 @@ public class ManifestService extends AbstractResourceService {
         List<Bundle> bundles = utils.getIIIFBundles(item);
         // Set the default canvas dimensions.
         if (guessCanvasDimension) {
-            canvasService.guessCanvasDimensions(bundles, context);
+            canvasService.guessCanvasDimensions(context, bundles);
         }
         for (Bundle bnd : bundles) {
             String bundleToCPrefix = null;

--- a/dspace-iiif/src/main/java/org/dspace/app/iiif/service/utils/IIIFUtils.java
+++ b/dspace-iiif/src/main/java/org/dspace/app/iiif/service/utils/IIIFUtils.java
@@ -137,7 +137,7 @@ public class IIIFUtils {
      * @param b the DSpace bitstream to check
      * @return true if the bitstream can be used as IIIF resource
      */
-    private boolean isIIIFBitstream(Context context, Bitstream b) {
+    public boolean isIIIFBitstream(Context context, Bitstream b) {
         return checkImageMimeType(getBitstreamMimeType(b, context)) && b.getMetadata().stream()
                 .filter(m -> m.getMetadataField().toString('.').contentEquals(METADATA_IIIF_ENABLED))
                 .noneMatch(m -> m.getValue().equalsIgnoreCase("false") || m.getValue().equalsIgnoreCase("no"));
@@ -228,7 +228,7 @@ public class IIIFUtils {
      * @param mimetype
      * @return true if an image
      */
-    public boolean checkImageMimeType(String mimetype) {
+    private boolean checkImageMimeType(String mimetype) {
         if (mimetype != null && mimetype.contains("image/")) {
             return true;
         }

--- a/dspace-server-webapp/src/test/data/dspaceFolder/config/spring/api/iiif-processing.xml
+++ b/dspace-server-webapp/src/test/data/dspaceFolder/config/spring/api/iiif-processing.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd"
+       default-lazy-init="true">
+
+    <bean class="org.dspace.iiif.MockIIIFApiQueryServiceImpl" id="org.dspace.iiif.IIIFApiQueryServiceImpl" primary="true"/>
+
+</beans>

--- a/dspace-server-webapp/src/test/java/org/dspace/iiif/MockIIIFApiQueryServiceImpl.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/iiif/MockIIIFApiQueryServiceImpl.java
@@ -1,0 +1,16 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.iiif;
+
+import org.dspace.content.Bitstream;
+
+public class MockIIIFApiQueryServiceImpl extends IIIFApiQueryServiceImpl {
+    public int[] getImageDimensions(Bitstream bitstream) {
+        return new int[]{64, 64};
+    }
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/iiif/MockIIIFApiQueryServiceImpl.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/iiif/MockIIIFApiQueryServiceImpl.java
@@ -9,6 +9,10 @@ package org.dspace.iiif;
 
 import org.dspace.content.Bitstream;
 
+/**
+ * Mock for the IIIFApiQueryService.
+ * @author Michael Spalti (mspalti at willamette.edu)
+ */
 public class MockIIIFApiQueryServiceImpl extends IIIFApiQueryServiceImpl {
     public int[] getImageDimensions(Bitstream bitstream) {
         return new int[]{64, 64};


### PR DESCRIPTION

## Description
The current method used to "guess" the default canvas dimensions assumes too much about bundle content. It just checks the first bitstream in the first bundle. We actually don't know which bundles contain IIIF image data. Nor can we assume that the first bitstream in a bundle is an image resource.

This PR updates the method that sets default canvas dimensions so it can handle all possibilities. 

## Instructions for Reviewers
You will need an IIIF-enabled DSpace instance and a running image server. There are lots of ways to test this, but I suggest creating a new iiif enabled Item. Add one or more images to a custom bundle (say 'iiif'). Do not add IIIF width or height to the bitstream metadata.

When you view the Item the manifest should deliver image canvases and the canvas dimensions should be those of the first image in your custom bundle.

You can further test by adding an image to the ORIGINAL bundle (again with no metadata). When you view the item you should see the additional image. The canvas dimensions should match those of the new image in the ORIGINAL bundle (because the ORIGINAL bundle is processed before the custom bundle you added previously). 

Unfortunately, since we don't currently include an image server in CI tests no integration tests are provided here.


## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
