### PR TITLE
Final Prepartions/Updates for 6.4 bug-fix-only release

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-DSpace source code BSD License:
+BSD 3-Clause License
 
-Copyright (c) 2002-2020, LYRASIS.  All rights reserved.
+Copyright (c) 2002-2022, LYRASIS.  All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -13,13 +13,12 @@ notice, this list of conditions and the following disclaimer.
 notice, this list of conditions and the following disclaimer in the
 documentation and/or other materials provided with the distribution.
 
-- Neither the name DuraSpace nor the name of the DSpace Foundation
-nor the names of its contributors may be used to endorse or promote
-products derived from this software without specific prior written
-permission.
+- Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
 A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
 HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
@@ -30,10 +29,3 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 DAMAGE.
-
-
-DSpace uses third-party libraries which may be distributed under
-different licenses to the above. Information about these licenses
-is detailed in the LICENSES_THIRD_PARTY file at the root of the source
-tree.  You must agree to the terms of these licenses, in addition to
-the above DSpace source code license, in order to use this software.

--- a/LICENSES_THIRD_PARTY
+++ b/LICENSES_THIRD_PARTY
@@ -15,13 +15,14 @@ PLEASE NOTE: Some dependencies may be listed under multiple licenses if they
 are dual-licensed. This is especially true of anything listed as 
 "GNU General Public Library" below, as DSpace actually does NOT allow for any 
 dependencies that are solely released under GPL terms. For more info see:
-https://wiki.duraspace.org/display/DSPACE/Code+Contribution+Guidelines
+https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines
 ---------------------------------------------------
 
     Apache Software License, Version 2.0:
 
         * Ant-Contrib Tasks (ant-contrib:ant-contrib:1.0b3 - http://ant-contrib.sourceforge.net)
         * Code Generation Library (cglib:cglib:2.2.2 - http://cglib.sourceforge.net/)
+        * reload4j (ch.qos.reload4j:reload4j:1.2.20 - https://reload4j.qos.ch)
         * AWS SDK for Java - Core (com.amazonaws:aws-java-sdk-core:1.10.50 - https://aws.amazon.com/sdkforjava)
         * AWS Java SDK for AWS KMS (com.amazonaws:aws-java-sdk-kms:1.10.50 - https://aws.amazon.com/sdkforjava)
         * AWS Java SDK for Amazon S3 (com.amazonaws:aws-java-sdk-s3:1.10.50 - https://aws.amazon.com/sdkforjava)
@@ -53,6 +54,7 @@ https://wiki.duraspace.org/display/DSPACE/Code+Contribution+Guidelines
         * MaxMind DB Reader (com.maxmind.db:maxmind-db:1.2.2 - http://dev.maxmind.com/)
         * MaxMind GeoIP2 API (com.maxmind.geoip2:geoip2:2.11.0 - http://dev.maxmind.com/geoip/geoip2/web-services)
         * Spatial4J (com.spatial4j:spatial4j:0.4.1 - https://github.com/spatial4j/spatial4j)
+        * fastinfoset (com.sun.xml.fastinfoset:FastInfoset:1.2.15 - http://fi.java.net)
         * Apache Commons BeanUtils (commons-beanutils:commons-beanutils:1.9.2 - http://commons.apache.org/proper/commons-beanutils/)
         * Apache Commons CLI (commons-cli:commons-cli:1.3.1 - http://commons.apache.org/proper/commons-cli/)
         * Apache Commons Codec (commons-codec:commons-codec:1.10 - http://commons.apache.org/proper/commons-codec/)
@@ -112,9 +114,9 @@ https://wiki.duraspace.org/display/DSPACE/Code+Contribution+Guidelines
         * Apache Commons Collections (org.apache.commons:commons-collections4:4.1 - http://commons.apache.org/proper/commons-collections/)
         * Apache Commons Compress (org.apache.commons:commons-compress:1.7 - http://commons.apache.org/proper/commons-compress/)
         * Apache Commons CSV (org.apache.commons:commons-csv:1.0 - http://commons.apache.org/proper/commons-csv/)
-        * Apache Commons DBCP (org.apache.commons:commons-dbcp2:2.1.1 - http://commons.apache.org/dbcp/)
+        * Apache Commons DBCP (org.apache.commons:commons-dbcp2:2.8.0 - https://commons.apache.org/dbcp/)
         * Apache Commons Lang (org.apache.commons:commons-lang3:3.3.2 - http://commons.apache.org/proper/commons-lang/)
-        * Apache Commons Pool (org.apache.commons:commons-pool2:2.4.2 - http://commons.apache.org/proper/commons-pool/)
+        * Apache Commons Pool (org.apache.commons:commons-pool2:2.10.0 - https://commons.apache.org/proper/commons-pool/)
         * Excalibur Pool API (org.apache.excalibur.components:excalibur-pool-api:2.2.1 - http://www.apache.org/excalibur/excalibur-components-modules/excalibur-pool-modules/excalibur-pool-api/)
         * Excalibur Sourceresolve (org.apache.excalibur.components:excalibur-sourceresolve:2.2.3 - http://www.apache.org/excalibur/excalibur-sourceresolve/)
         * Excalibur Store (org.apache.excalibur.components:excalibur-store:2.2.1 - http://www.apache.org/excalibur/excalibur-components-modules/excalibur-store/)
@@ -170,9 +172,9 @@ https://wiki.duraspace.org/display/DSPACE/Code+Contribution+Guidelines
         * Lucene Spatial (org.apache.lucene:lucene-spatial:4.10.4 - http://lucene.apache.org/lucene-parent/lucene-spatial)
         * Lucene Suggest (org.apache.lucene:lucene-suggest:4.10.2 - http://lucene.apache.org/lucene-parent/lucene-suggest)
         * Lucene Suggest (org.apache.lucene:lucene-suggest:4.10.4 - http://lucene.apache.org/lucene-parent/lucene-suggest)
-        * Apache FontBox (org.apache.pdfbox:fontbox:2.0.2 - http://pdfbox.apache.org/)
+        * Apache FontBox (org.apache.pdfbox:fontbox:2.0.24 - http://pdfbox.apache.org/)
         * Apache JempBox (org.apache.pdfbox:jempbox:1.8.4 - http://www.apache.org/pdfbox-parent/jempbox/)
-        * Apache PDFBox (org.apache.pdfbox:pdfbox:2.0.2 - http://www.apache.org/pdfbox-parent/pdfbox/)
+        * Apache PDFBox (org.apache.pdfbox:pdfbox:2.0.24 - https://www.apache.org/pdfbox-parent/pdfbox/)
         * Apache POI (org.apache.poi:poi:3.17 - http://poi.apache.org/)
         * Apache POI (org.apache.poi:poi-ooxml:3.17 - http://poi.apache.org/)
         * Apache POI (org.apache.poi:poi-ooxml-schemas:3.10.1 - http://poi.apache.org/)
@@ -214,8 +216,8 @@ https://wiki.duraspace.org/display/DSPACE/Code+Contribution+Guidelines
         * Objenesis (org.objenesis:objenesis:2.1 - http://objenesis.org)
         * parboiled-core (org.parboiled:parboiled-core:1.1.6 - http://parboiled.org)
         * parboiled-java (org.parboiled:parboiled-java:1.1.6 - http://parboiled.org)
-        * org.restlet (org.restlet.jee:org.restlet:2.1.1 - no url defined)
-        * org.restlet.ext.servlet (org.restlet.jee:org.restlet.ext.servlet:2.1.1 - no url defined)
+        * Restlet Core - API and Engine (org.restlet.jee:org.restlet:2.1.1 - http://www.restlet.org/org.restlet)
+        * Restlet Extension - Servlet (org.restlet.jee:org.restlet.ext.servlet:2.1.1 - http://www.restlet.org/org.restlet.ext.servlet)
         * rome-modules (org.rometools:rome-modules:1.0 - http://www.rometools.org)
         * Spring AOP (org.springframework:spring-aop:3.2.16.RELEASE - https://github.com/SpringSource/spring-framework)
         * Spring AOP (org.springframework:spring-aop:3.2.5.RELEASE - https://github.com/SpringSource/spring-framework)
@@ -280,25 +282,26 @@ https://wiki.duraspace.org/display/DSPACE/Code+Contribution+Guidelines
         * Morfologik Stemming Dictionary for Polish (org.carrot2:morfologik-polish:1.7.1 - http://morfologik.blogspot.com/morfologik-polish/)
         * Morfologik Stemming APIs (org.carrot2:morfologik-stemming:1.7.1 - http://morfologik.blogspot.com/morfologik-stemming/)
         * Stax2 API (org.codehaus.woodstox:stax2-api:3.1.1 - http://woodstox.codehaus.org/StAX2)
-        * DSpace Kernel :: API and Implementation (org.dspace:dspace-api:6.3-SNAPSHOT - https://github.com/dspace/DSpace/dspace-api)
-        * DSpace I18N :: Language Packs (org.dspace:dspace-api-lang:6.0.5 - https://github.com/dspace/dspace-api-lang)
-        * DSpace JSP-UI (org.dspace:dspace-jspui:6.3-SNAPSHOT - https://github.com/dspace/DSpace/dspace-jspui)
-        * DSpace OAI-PMH (org.dspace:dspace-oai:6.3-SNAPSHOT - https://github.com/dspace/DSpace/dspace-oai)
-        * DSpace RDF (org.dspace:dspace-rdf:6.3-SNAPSHOT - https://github.com/dspace/DSpace/dspace-rdf)
-        * DSpace REST :: API and Implementation (org.dspace:dspace-rest:6.3-SNAPSHOT - http://demo.dspace.org)
-        * DSpace Services Framework :: API and Implementation (org.dspace:dspace-services:6.3-SNAPSHOT - https://github.com/dspace/DSpace/dspace-services)
-        * Apache Solr Webapp (org.dspace:dspace-solr:6.3-SNAPSHOT - https://github.com/dspace/DSpace/dspace-solr)
-        * DSpace SWORD (org.dspace:dspace-sword:6.3-SNAPSHOT - https://github.com/dspace/DSpace/dspace-sword)
-        * DSpace SWORD v2 (org.dspace:dspace-swordv2:6.3-SNAPSHOT - https://github.com/dspace/DSpace/dspace-swordv2)
-        * DSpace XML-UI (Manakin) (org.dspace:dspace-xmlui:6.3-SNAPSHOT - https://github.com/dspace/DSpace/dspace-xmlui)
-        * DSpace XML-UI (Manakin) I18N :: Language Packs (org.dspace:dspace-xmlui-lang:6.0.6 - https://github.com/dspace/dspace-xmlui-lang)
+        * dom4j (org.dom4j:dom4j:2.1.0 - http://dom4j.github.io/)
+        * DSpace Kernel :: API and Implementation (org.dspace:dspace-api:6.4-SNAPSHOT - https://github.com/dspace/DSpace/dspace-api)
+        * DSpace I18N :: Language Packs (org.dspace:dspace-api-lang:6.0.6 - https://github.com/dspace/dspace-api-lang)
+        * DSpace JSP-UI (org.dspace:dspace-jspui:6.4-SNAPSHOT - https://github.com/dspace/DSpace/dspace-jspui)
+        * DSpace OAI-PMH (org.dspace:dspace-oai:6.4-SNAPSHOT - https://github.com/dspace/DSpace/dspace-oai)
+        * DSpace RDF (org.dspace:dspace-rdf:6.4-SNAPSHOT - https://github.com/dspace/DSpace/dspace-rdf)
+        * DSpace REST :: API and Implementation (org.dspace:dspace-rest:6.4-SNAPSHOT - http://demo.dspace.org)
+        * DSpace Services Framework :: API and Implementation (org.dspace:dspace-services:6.4-SNAPSHOT - https://github.com/dspace/DSpace/dspace-services)
+        * Apache Solr Webapp (org.dspace:dspace-solr:6.4-SNAPSHOT - https://github.com/dspace/DSpace/dspace-solr)
+        * DSpace SWORD (org.dspace:dspace-sword:6.4-SNAPSHOT - https://github.com/dspace/DSpace/dspace-sword)
+        * DSpace SWORD v2 (org.dspace:dspace-swordv2:6.4-SNAPSHOT - https://github.com/dspace/DSpace/dspace-swordv2)
+        * DSpace XML-UI (Manakin) (org.dspace:dspace-xmlui:6.4-SNAPSHOT - https://github.com/dspace/DSpace/dspace-xmlui)
+        * DSpace XML-UI (Manakin) I18N :: Language Packs (org.dspace:dspace-xmlui-lang:6.0.7 - https://github.com/dspace/dspace-xmlui-lang)
         * handle (org.dspace:handle:6.2 - no url defined)
         * jargon (org.dspace:jargon:1.4.25 - no url defined)
         * mets (org.dspace:mets:1.5.2 - no url defined)
         * oclc-harvester2 (org.dspace:oclc-harvester2:0.1.12 - no url defined)
-        * XOAI : OAI-PMH Java Toolkit (org.dspace:xoai:3.2.10 - http://nexus.sonatype.org/oss-repository-hosting.html/xoai)
+        * XOAI : OAI-PMH Java Toolkit (org.dspace:xoai:3.3.0 - https://github.com/dspace/xoai)
         * Repackaged Cocoon Servlet Service Implementation (org.dspace.dependencies.cocoon:dspace-cocoon-servlet-service-impl:1.0.3 - http://projects.dspace.org/dspace-pom/dspace-cocoon-servlet-service-impl)
-        * DSpace Kernel :: Additions and Local Customizations (org.dspace.modules:additions:6.3-SNAPSHOT - https://github.com/dspace/DSpace/modules/additions)
+        * DSpace Kernel :: Additions and Local Customizations (org.dspace.modules:additions:6.4-SNAPSHOT - https://github.com/dspace/DSpace/modules/additions)
         * Hamcrest All (org.hamcrest:hamcrest-all:1.3 - https://github.com/hamcrest/JavaHamcrest/hamcrest-all)
         * Hamcrest Core (org.hamcrest:hamcrest-core:1.3 - https://github.com/hamcrest/JavaHamcrest/hamcrest-core)
         * JBibTeX (org.jbibtex:jbibtex:1.0.10 - http://www.jbibtex.org)
@@ -307,6 +310,7 @@ https://wiki.duraspace.org/display/DSPACE/Code+Contribution+Guidelines
         * ASM Commons (org.ow2.asm:asm-commons:4.1 - http://asm.objectweb.org/asm-commons/)
         * ASM Tree (org.ow2.asm:asm-tree:4.1 - http://asm.objectweb.org/asm-tree/)
         * ASM Util (org.ow2.asm:asm-util:4.1 - http://asm.objectweb.org/asm-util/)
+        * PostgreSQL JDBC Driver - JDBC 4.2 (org.postgresql:postgresql:42.2.1 - https://github.com/pgjdbc/pgjdbc)
         * XMLUnit for Java (xmlunit:xmlunit:1.1 - http://xmlunit.sourceforge.net/)
         * XMLUnit for Java (xmlunit:xmlunit:1.3 - http://xmlunit.sourceforge.net/)
 
@@ -316,9 +320,10 @@ https://wiki.duraspace.org/display/DSPACE/Code+Contribution+Guidelines
 
     Common Development and Distribution License (CDDL):
 
-        * JAXB Reference Implementation (com.sun.xml.bind:jaxb-impl:2.2.5 - http://jaxb.java.net/)
+        * istack common utility code runtime (com.sun.istack:istack-commons-runtime:3.0.7 - http://java.net/istack-commons/istack-commons-runtime/)
         * JHighlight (com.uwyn:jhighlight:1.0 - https://jhighlight.dev.java.net/)
         * JavaBeans(TM) Activation Framework (javax.activation:activation:1.1.1 - http://java.sun.com/javase/technologies/desktop/javabeans/jaf/index.jsp)
+        * JavaBeans Activation Framework API jar (javax.activation:javax.activation-api:1.2.0 - http://java.net/all/javax.activation-api/)
         * javax.annotation API (javax.annotation:javax.annotation-api:1.2 - http://jcp.org/en/jsr/detail?id=250)
         * JavaMail API (compat) (javax.mail:mail:1.4.7 - http://kenai.com/projects/javamail/mail)
         * Java Servlet API (javax.servlet:javax.servlet-api:3.1.0 - http://servlet-spec.java.net)
@@ -326,6 +331,7 @@ https://wiki.duraspace.org/display/DSPACE/Code+Contribution+Guidelines
         * jstl (javax.servlet:jstl:1.2 - no url defined)
         * servlet-api (javax.servlet:servlet-api:2.5 - no url defined)
         * javax.ws.rs-api (javax.ws.rs:javax.ws.rs-api:2.0.1 - http://jax-rs-spec.java.net)
+        * jaxb-api (javax.xml.bind:jaxb-api:2.3.1 - https://github.com/javaee/jaxb-spec/jaxb-api)
         * Class Model for Hk2 (org.glassfish.hk2:class-model:2.4.0-b31 - https://hk2.java.net/class-model)
         * HK2 config types (org.glassfish.hk2:config-types:2.4.0-b31 - https://hk2.java.net/hk2-configuration/hk2-configuration-persistence/hk2-xml-dom/config-types)
         * HK2 module of HK2 itself (org.glassfish.hk2:hk2:2.4.0-b31 - https://hk2.java.net/hk2)
@@ -341,6 +347,8 @@ https://wiki.duraspace.org/display/DSPACE/Code+Contribution+Guidelines
         * ASM library repackaged as OSGi bundle (org.glassfish.hk2.external:asm-all-repackaged:2.4.0-b31 - https://hk2.java.net/external/asm-all-repackaged)
         * javax.validation:1.1.0.Final as OSGi bundle (org.glassfish.hk2.external:bean-validator:2.4.0-b31 - https://hk2.java.net/external/bean-validator)
         * javax.inject:1 as OSGi bundle (org.glassfish.hk2.external:javax.inject:2.4.0-b31 - https://hk2.java.net/external/javax.inject)
+        * JAXB Runtime (org.glassfish.jaxb:jaxb-runtime:2.3.1 - http://jaxb.java.net/jaxb-runtime-parent/jaxb-runtime)
+        * TXW2 Runtime (org.glassfish.jaxb:txw2:2.3.1 - http://jaxb.java.net/jaxb-txw-parent/txw2)
         * jersey-repackaged-guava (org.glassfish.jersey.bundles.repackaged:jersey-guava:2.22.1 - https://jersey.java.net/project/project/jersey-guava/)
         * jersey-container-servlet (org.glassfish.jersey.containers:jersey-container-servlet:2.22.1 - https://jersey.java.net/project/jersey-container-servlet/)
         * jersey-container-servlet-core (org.glassfish.jersey.containers:jersey-container-servlet-core:2.22.1 - https://jersey.java.net/project/jersey-container-servlet-core/)
@@ -353,6 +361,9 @@ https://wiki.duraspace.org/display/DSPACE/Code+Contribution+Guidelines
         * jersey-media-json-jackson (org.glassfish.jersey.media:jersey-media-json-jackson:2.22.1 - https://jersey.java.net/project/jersey-media-json-jackson/)
         * Java Transaction API (org.jboss.spec.javax.transaction:jboss-transaction-api_1.1_spec:1.0.1.Final - http://www.jboss.org/jboss-transaction-api_1.1_spec)
         * Type arithmetic library for Java5 (org.jvnet:tiger-types:1.4 - http://java.net/tiger-types/)
+        * Extended StAX API (org.jvnet.staxex:stax-ex:1.8 - http://stax-ex.java.net/)
+        * Restlet Core - API and Engine (org.restlet.jee:org.restlet:2.1.1 - http://www.restlet.org/org.restlet)
+        * Restlet Extension - Servlet (org.restlet.jee:org.restlet.ext.servlet:2.1.1 - http://www.restlet.org/org.restlet.ext.servlet)
 
     Eclipse Public License:
 
@@ -362,6 +373,8 @@ https://wiki.duraspace.org/display/DSPACE/Code+Contribution+Guidelines
         * Jetty Server (org.mortbay.jetty:jetty:6.1.26 - http://www.eclipse.org/jetty/jetty-parent/project/modules/jetty)
         * Jetty Servlet Tester (org.mortbay.jetty:jetty-servlet-tester:6.1.26 - http://www.eclipse.org/jetty/jetty-parent/project/jetty-servlet-tester)
         * Jetty Utilities (org.mortbay.jetty:jetty-util:6.1.26 - http://www.eclipse.org/jetty/jetty-parent/project/jetty-util)
+        * Restlet Core - API and Engine (org.restlet.jee:org.restlet:2.1.1 - http://www.restlet.org/org.restlet)
+        * Restlet Extension - Servlet (org.restlet.jee:org.restlet.ext.servlet:2.1.1 - http://www.restlet.org/org.restlet.ext.servlet)
 
     GNU General Public License, Version 2 with the Classpath Exception:
 
@@ -379,6 +392,8 @@ https://wiki.duraspace.org/display/DSPACE/Code+Contribution+Guidelines
         * Javassist (org.javassist:javassist:3.18.1-GA - http://www.javassist.org/)
         * JBoss Logging 3 (org.jboss.logging:jboss-logging:3.1.0.GA - http://www.jboss.org)
         * org.jdesktop - Swing Worker (org.jdesktop:swing-worker:1.1 - no url defined)
+        * Restlet Core - API and Engine (org.restlet.jee:org.restlet:2.1.1 - http://www.restlet.org/org.restlet)
+        * Restlet Extension - Servlet (org.restlet.jee:org.restlet.ext.servlet:2.1.1 - http://www.restlet.org/org.restlet.ext.servlet)
         * xom (xom:xom:1.1 - http://www.xom.nu)
         * XOM (xom:xom:1.2.5 - http://xom.nu)
 
@@ -401,18 +416,15 @@ https://wiki.duraspace.org/display/DSPACE/Code+Contribution+Guidelines
         * JCL 1.1.1 implemented over SLF4J (org.slf4j:jcl-over-slf4j:1.7.14 - http://www.slf4j.org)
         * JUL to SLF4J bridge (org.slf4j:jul-to-slf4j:1.7.14 - http://www.slf4j.org)
         * SLF4J API Module (org.slf4j:slf4j-api:1.7.14 - http://www.slf4j.org)
-        * SLF4J LOG4J-12 Binding (org.slf4j:slf4j-log4j12:1.7.14 - http://www.slf4j.org)
+        * SLF4J Reload4j Binding (org.slf4j:slf4j-reload4j:1.7.36 - http://reload4j.qos.ch)
 
     Mozilla Public License:
 
         * juniversalchardet (com.googlecode.juniversalchardet:juniversalchardet:1.0.3 - http://juniversalchardet.googlecode.com/)
         * h2 (com.h2database:h2:1.4.187 - no url defined)
+        * Saxon-HE (net.sf.saxon:Saxon-HE:9.8.0-14 - http://www.saxonica.com/)
         * Javassist (org.javassist:javassist:3.18.1-GA - http://www.javassist.org/)
         * Rhino (rhino:js:1.6R7 - http://www.mozilla.org/rhino/)
-
-    The PostgreSQL License:
-
-        * PostgreSQL JDBC Driver - JDBC 4.2 (org.postgresql:postgresql:42.2.1 - https://github.com/pgjdbc/pgjdbc)
 
     Public Domain:
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,3 +1,13 @@
+Licenses of Third-Party Libraries
+=================================
+
+DSpace uses third-party libraries which may be distributed under
+different licenses than specified in our LICENSE file. Information
+about these licenses is detailed in the LICENSES_THIRD_PARTY file at
+the root of the source tree. You must agree to the terms of these
+licenses, in addition to the DSpace source code license, in order to
+use this software.
+
 Licensing Notices
 =================
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 
 # DSpace
 
-[![Build Status](https://travis-ci.org/DSpace/DSpace.png?branch=master)](https://travis-ci.org/DSpace/DSpace)
+[![Build Status](https://github.com/DSpace/DSpace/workflows/Build/badge.svg?branch=dspace-6_x)](https://github.com/DSpace/DSpace/actions?query=workflow%3ABuild)
 
-[DSpace Documentation](https://wiki.duraspace.org/display/DSDOC/) |
+[DSpace Documentation](https://wiki.lyrasis.org/display/DSDOC/) |
 [DSpace Releases](https://github.com/DSpace/DSpace/releases) |
-[DSpace Wiki](https://wiki.duraspace.org/display/DSPACE/Home) |
-[Support](https://wiki.duraspace.org/display/DSPACE/Support)
+[DSpace Wiki](https://wiki.lyrasis.org/display/DSPACE/Home) |
+[Support](https://wiki.lyrasis.org/display/DSPACE/Support)
 
 DSpace open source software is a turnkey repository application used by more than
 1000+ organizations and institutions worldwide to provide durable access to digital resources.
@@ -20,10 +20,10 @@ Past releases are all available via GitHub at https://github.com/DSpace/DSpace/r
 
 ## Documentation / Installation
 
-Documentation for each release may be viewed online or downloaded via our [Documentation Wiki](https://wiki.duraspace.org/display/DSDOC/).
+Documentation for each release may be viewed online or downloaded via our [Documentation Wiki](https://wiki.lyrasis.org/display/DSDOC/).
 
 The latest DSpace Installation instructions are available at:
-https://wiki.duraspace.org/display/DSDOC6x/Installing+DSpace
+https://wiki.lyrasis.org/display/DSDOC6x/Installing+DSpace
 
 Please be aware that, as a Java web application, DSpace requires a database (PostgreSQL or Oracle)
 and a servlet container (usually Tomcat) in order to function.
@@ -38,14 +38,14 @@ DSpace is a community built and supported project. We do not have a centralized 
 but have a dedicated group of volunteers who help us improve the software, documentation, resources, etc.
 
 We welcome contributions of any type. Here's a few basic guides that provide suggestions for contributing to DSpace:
-* [How to Contribute to DSpace](https://wiki.duraspace.org/display/DSPACE/How+to+Contribute+to+DSpace): How to contribute in general (via code, documentation, bug reports, expertise, etc)
-* [Code Contribution Guidelines](https://wiki.duraspace.org/display/DSPACE/Code+Contribution+Guidelines): How to give back code or contribute features, bug fixes, etc.
-* [DSpace Community Advisory Team (DCAT)](https://wiki.duraspace.org/display/cmtygp/DSpace+Community+Advisory+Team): If you are not a developer, we also have an interest group specifically for repository managers. The DCAT group meets virtually, once a month, and sends open invitations to join their meetings via the [DCAT mailing list](https://groups.google.com/d/forum/DSpaceCommunityAdvisoryTeam).
+* [How to Contribute to DSpace](https://wiki.lyrasis.org/display/DSPACE/How+to+Contribute+to+DSpace): How to contribute in general (via code, documentation, bug reports, expertise, etc)
+* [Code Contribution Guidelines](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines): How to give back code or contribute features, bug fixes, etc.
+* [DSpace Community Advisory Team (DCAT)](https://wiki.lyrasis.org/display/cmtygp/DSpace+Community+Advisory+Team): If you are not a developer, we also have an interest group specifically for repository managers. The DCAT group meets virtually, once a month, and sends open invitations to join their meetings via the [DCAT mailing list](https://groups.google.com/d/forum/DSpaceCommunityAdvisoryTeam).
 
-We also encourage GitHub Pull Requests (PRs) at any time. Please see our [Development with Git](https://wiki.duraspace.org/display/DSPACE/Development+with+Git) guide for more info.
+We also encourage GitHub Pull Requests (PRs) at any time. Please see our [Development with Git](https://wiki.lyrasis.org/display/DSPACE/Development+with+Git) guide for more info.
 
 In addition, a listing of all known contributors to DSpace software can be
-found online at: https://wiki.duraspace.org/display/DSPACE/DSpaceContributors
+found online at: https://wiki.lyrasis.org/display/DSPACE/DSpaceContributors
 
 ## Getting Help
 
@@ -53,10 +53,10 @@ DSpace provides public mailing lists where you can post questions or raise topic
 We welcome everyone to participate in these lists:
 
 * [dspace-community@googlegroups.com](https://groups.google.com/d/forum/dspace-community) : General discussion about DSpace platform, announcements, sharing of best practices
-* [dspace-tech@googlegroups.com](https://groups.google.com/d/forum/dspace-tech) : Technical support mailing list. See also our guide for [How to troubleshoot an error](https://wiki.duraspace.org/display/DSPACE/Troubleshoot+an+error).
+* [dspace-tech@googlegroups.com](https://groups.google.com/d/forum/dspace-tech) : Technical support mailing list. See also our guide for [How to troubleshoot an error](https://wiki.lyrasis.org/display/DSPACE/Troubleshoot+an+error).
 * [dspace-devel@googlegroups.com](https://groups.google.com/d/forum/dspace-devel) : Developers / Development mailing list
 
-Additional support options are listed at https://wiki.duraspace.org/display/DSPACE/Support
+Additional support options are listed at https://wiki.lyrasis.org/display/DSPACE/Support
 
 DSpace also has an active service provider network. If you'd rather hire a service provider to
 install, upgrade, customize or host DSpace, then we recommend getting in touch with one of our

--- a/dspace-api/src/main/resources/Messages.properties
+++ b/dspace-api/src/main/resources/Messages.properties
@@ -599,7 +599,7 @@ jsp.home.search1                                                = Search
 jsp.home.search2                                                = Enter some text in the box below to search DSpace.
 jsp.home.title                                                  = Home
 jsp.layout.footer-default.feedback                              = Feedback
-jsp.layout.footer-default.text                                  = <a target="_blank" rel="noopener" href="http://www.dspace.org/">DSpace Software</a> Copyright&nbsp;&copy;&nbsp;2002-2013&nbsp; <a target="_blank" rel="noopener" href="http://www.duraspace.org/">Duraspace</a>
+jsp.layout.footer-default.text                                  = <a target="_blank" rel="noopener" href="http://www.dspace.org/">DSpace Software</a> Copyright&nbsp;&copy;&nbsp;2002-2022&nbsp; <a target="_blank" rel="noopener" href="http://lyrasis.org/">LYRASIS</a>
 jsp.layout.footer-default.theme-by								= Theme by
 jsp.layout.header-default.about                                 = About DSpace Software
 jsp.layout.header-default.alt                                   = DSpace

--- a/dspace-xmlui-mirage2/src/main/webapp/xsl/core/page-structure.xsl
+++ b/dspace-xmlui-mirage2/src/main/webapp/xsl/core/page-structure.xsl
@@ -705,7 +705,7 @@
                     <hr/>
                     <div class="col-xs-7 col-sm-8">
                         <div>
-                            <a href="http://www.dspace.org/" target="_blank" rel="noopener">DSpace software</a> copyright&#160;&#169;&#160;2002-2016&#160; <a href="http://www.duraspace.org/" target="_blank" rel="noopener">DuraSpace</a>
+                            <a href="http://www.dspace.org/" target="_blank" rel="noopener">DSpace software</a> copyright&#160;&#169;&#160;2002-2022&#160; <a href="http://lyrasis.org/" target="_blank" rel="noopener">LYRASIS</a>
                         </div>
                         <div class="hidden-print">
                             <a>

--- a/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/core/page-structure.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/core/page-structure.xsl
@@ -589,7 +589,7 @@
         <div id="ds-footer-wrapper">
             <div id="ds-footer">
                 <div id="ds-footer-left">
-                    <a href="http://www.dspace.org/" target="_blank" rel="noopener">DSpace software</a> copyright&#160;&#169;&#160;2002-2016&#160; <a href="http://www.duraspace.org/" target="_blank" rel="noopener">DuraSpace</a>
+                    <a href="http://www.dspace.org/" target="_blank" rel="noopener">DSpace software</a> copyright&#160;&#169;&#160;2002-2022&#160; <a href="http://lyrasis.org/" target="_blank" rel="noopener">LYRASIS</a>
                 </div>
                 <div id="ds-footer-right">
                     <span class="theme-by">Theme by&#160;</span>

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -213,7 +213,7 @@ identifier.doi.namespaceseparator = dspace/
 #   [dspace]/config/spring/api/discovery.xml
 #
 # See also the Discovery Documentation:
-#   https://wiki.duraspace.org/display/DSDOC6x/Discovery
+#   https://wiki.lyrasis.org/display/DSDOC6x/Discovery
 #
 # Underlying Apache Solr configurations may also be tweaked at:
 #   [dspace]/solr/search/conf/

--- a/dspace/etc/oracle/README.md
+++ b/dspace/etc/oracle/README.md
@@ -6,7 +6,7 @@ Therefore, all `database_schema*.sql` files have been removed. Starting
 with DSpace 4.x -> 5.0 upgrade, you will no longer need to manually run any
 SQL scripts to upgrade your database.
 
-Please see the [5.0 Upgrade Instructions](https://wiki.duraspace.org/display/DSDOC5x/Upgrading+DSpace)
+Please see the [5.0 Upgrade Instructions](https://wiki.lyrasis.org/display/DSDOC5x/Upgrading+DSpace)
 for more information on upgrading to DSpace 5.
 
 
@@ -25,7 +25,7 @@ manually. For more information, please see the `README.md` in the scripts direct
 The `update-sequences.sql` script in this directory may still be used to update
 your internal database counts if you feel they have gotten out of "sync". This
 may sometimes occur after large restores of content (e.g. when using the DSpace
-[AIP Backup and Restore](https://wiki.duraspace.org/display/DSDOC5x/AIP+Backup+and+Restore) 
+[AIP Backup and Restore](https://wiki.lyrasis.org/display/DSDOC5x/AIP+Backup+and+Restore)
 feature).
 
 This `update-sequences.sql` script can be run manually. It will not harm your 

--- a/dspace/etc/postgres/README.md
+++ b/dspace/etc/postgres/README.md
@@ -6,7 +6,7 @@ Therefore, all `database_schema*.sql` files have been removed. Starting
 with DSpace 4.x -> 5.0 upgrade, you will no longer need to manually run any
 SQL scripts to upgrade your database.
 
-Please see the [5.0 Upgrade Instructions](https://wiki.duraspace.org/display/DSDOC5x/Upgrading+DSpace)
+Please see the [5.0 Upgrade Instructions](https://wiki.lyrasis.org/display/DSDOC5x/Upgrading+DSpace)
 for more information on upgrading to DSpace 5.
 
 
@@ -25,7 +25,7 @@ manually. For more information, please see the `README.md` in the scripts direct
 The `update-sequences.sql` script in this directory may still be used to update
 your internal database counts if you feel they have gotten out of "sync". This
 may sometimes occur after large restores of content (e.g. when using the DSpace
-[AIP Backup and Restore](https://wiki.duraspace.org/display/DSDOC5x/AIP+Backup+and+Restore) 
+[AIP Backup and Restore](https://wiki.lyrasis.org/display/DSDOC5x/AIP+Backup+and+Restore)
 feature).
 
 This `update-sequences.sql` script can be run manually. It will not harm your 

--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,8 @@
     <url>https://github.com/dspace/DSpace</url>
 
     <organization>
-        <name>DuraSpace</name>
-        <url>http://www.dspace.org</url>
+        <name>LYRASIS</name>
+        <url>http://dspace.org</url>
     </organization>
 
     <prerequisites>
@@ -24,7 +24,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>${project.build.sourceEncoding}</project.reporting.outputEncoding>
         
-        <!--  See https://jira.duraspace.org/browse/DS-3903 for a discussion of the version of jackson that is needed -->
+        <!--  See https://github.com/DSpace/DSpace/issues/7250 for a discussion of the version of jackson that is needed -->
         <jackson.version>2.8.11</jackson.version>
         <jersey.version>2.22.1</jersey.version>
         <java.version>1.7</java.version>
@@ -458,9 +458,9 @@
                                         <licenseMerge>Apache Software License, Version 2.0|http://ant-contrib.sourceforge.net/tasks/LICENSE.txt</licenseMerge>
                                         <!-- XML Commons claims these licenses, but it's really Apache License: https://xerces.apache.org/xml-commons/licenses.html -->
                                         <licenseMerge>Apache Software License, Version 2.0|The SAX License|The W3C License</licenseMerge>
-                                        <licenseMerge>BSD License|The BSD License|BSD licence|BSD license|BSD|BSD-style license|New BSD License|New BSD license|Revised BSD License|BSD 2-Clause license</licenseMerge>
-                                        <!-- DuraSpace uses a BSD License for DSpace -->
-                                        <licenseMerge>BSD License|DuraSpace BSD License|DuraSpace Sourcecode License</licenseMerge>
+                                        <licenseMerge>BSD License|The BSD License|BSD licence|BSD license|BSD|BSD-style license|New BSD License|New BSD license|Revised BSD License|BSD 2-Clause license|BSD-2-Clause|BSD 3-clause New License</licenseMerge>
+                                        <!-- DSpace uses a BSD License -->
+                                        <licenseMerge>BSD License|DSpace BSD License|DuraSpace BSD License|DuraSpace Sourcecode License</licenseMerge>
                                         <!-- Coverity uses modified BSD: https://github.com/coverity/coverity-security-library -->
                                         <licenseMerge>BSD License|BSD style modified by Coverity</licenseMerge>
                                         <!-- Jaxen claims this license, but it's really BSD: http://jaxen.codehaus.org/license.html -->
@@ -474,6 +474,10 @@
                                         <licenseMerge>Common Development and Distribution License (CDDL)|GPLv2+CE</licenseMerge>
                                         <!-- JAXB claims this license, but it is dual licensed with CDDL being one: https://jaxb.java.net/ -->
                                         <licenseMerge>Common Development and Distribution License (CDDL)|GPL2 w/ CPE</licenseMerge>
+                                        <!-- JavaBeans Activation Framework claims this license, but it is dual licensed with CDDL -->
+                                        <licenseMerge>Common Development and Distribution License (CDDL)|CDDL/GPLv2+CE</licenseMerge>
+                                        <!-- Extended StAX API claims this license, but it is dual licensed with CDDL -->
+                                        <licenseMerge>Common Development and Distribution License (CDDL)|Dual license consisting of the CDDL v1.1 and GPL v2</licenseMerge>
                                         <licenseMerge>Eclipse Public License|Eclipse Public License - Version 1.0|Eclipse Public License - v 1.0|EPL 1.0 license</licenseMerge>
                                         <!-- JUnit claims this license but is actually Eclipse Public License: http://junit.org/license.html -->
                                         <licenseMerge>Eclipse Public License|Common Public License Version 1.0</licenseMerge>
@@ -481,7 +485,7 @@
                                         <licenseMerge>MIT License|The MIT License|MIT LICENSE</licenseMerge>
                                         <!-- BouncyCastle uses a modified MIT License: http://www.bouncycastle.org/license.html -->
                                         <licenseMerge>MIT License|Bouncy Castle Licence</licenseMerge>
-                                        <licenseMerge>Mozilla Public License|Mozilla Public License version 1.1|Mozilla Public License 1.1 (MPL 1.1)|MPL 1.1</licenseMerge>
+                                        <licenseMerge>Mozilla Public License|Mozilla Public License version 1.1|Mozilla Public License 1.1 (MPL 1.1)|MPL 1.1|Mozilla Public License Version 2.0</licenseMerge>
                                         <!-- H2 Database claims this license, but for our purposes it's MPL: http://www.h2database.com -->
                                         <licenseMerge>Mozilla Public License|MPL 2.0, and EPL 1.0</licenseMerge>
                                         <!-- "concurrent.concurrent" claims this license, but is actually Public Domain: http://mvnrepository.com/artifact/concurrent/concurrent/ -->
@@ -774,7 +778,7 @@
          The 'release' profile is used by the 'maven-release-plugin' (see above)
          to actually perform a DSpace software release to Maven central.
          This profile contains settings which are ONLY enabled when performing
-         a DSpace release. See alse https://wiki.duraspace.org/display/DSPACE/Release+Procedure
+         a DSpace release. See also https://wiki.lyrasis.org/display/DSPACE/Release+Procedure
         -->
         <profile>
             <id>release</id>
@@ -1476,8 +1480,8 @@
 
     <licenses>
         <license>
-            <name>DuraSpace BSD License</name>
-            <url>https://raw.github.com/DSpace/DSpace/master/LICENSE</url>
+            <name>DSpace BSD License</name>
+            <url>https://raw.github.com/DSpace/DSpace/main/LICENSE</url>
             <distribution>repo</distribution>
             <comments>
                A BSD 3-Clause license for the DSpace codebase.
@@ -1486,8 +1490,8 @@
     </licenses>
 
     <issueManagement>
-        <system>JIRA</system>
-        <url>https://jira.duraspace.org/browse/DS</url>
+        <system>GitHub</system>
+        <url>https://github.com/DSpace/DSpace/issues</url>
     </issueManagement>
 
     <mailingLists>
@@ -1548,7 +1552,7 @@
         <developer>
            <name>DSpace Committers</name>
            <email>dspace-devel@googlegroups.com</email>
-           <url>https://wiki.duraspace.org/display/DSPACE/DSpace+Committers</url>
+           <url>https://wiki.lyrasis.org/display/DSPACE/DSpace+Committers</url>
            <roles>
              <role>committer</role>
            </roles>
@@ -1559,7 +1563,7 @@
         <contributor>
            <name>DSpace Contributors</name>
            <email>dspace-tech@googlegroups.com</email>
-           <url>https://wiki.duraspace.org/display/DSPACE/DSpaceContributors</url>
+           <url>https://wiki.lyrasis.org/display/DSPACE/DSpaceContributors</url>
            <roles>
              <role>developer</role>
            </roles>

--- a/src/main/license/third-party-file-groupByLicense.ftl
+++ b/src/main/license/third-party-file-groupByLicense.ftl
@@ -61,7 +61,7 @@ PLEASE NOTE: Some dependencies may be listed under multiple licenses if they
 are dual-licensed. This is especially true of anything listed as 
 "GNU General Public Library" below, as DSpace actually does NOT allow for any 
 dependencies that are solely released under GPL terms. For more info see:
-https://wiki.duraspace.org/display/DSPACE/Code+Contribution+Guidelines
+https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines
 ---------------------------------------------------
     <#list licenseMap as e>
         <#assign license = e.getKey()/>


### PR DESCRIPTION
## Description
Minor changes to prepare for 6.4 release.  Includes:
* Updating `LICENSES_THIRD_PARTY` for 6.4
* Resyncing `LICENSE` and `NOTICE` files with `main`. (minor updates)
* Replacing many old duraspace.org links with new lyrasis.org links.

## Instructions for Reviewers
No code has been changed in this PR.  Just minor link updates, documentation updates and POM updates.

Once this builds successfully in CI, I'll merge it immediately.