### PR TITLE
[Prep for 5.11] Fix DSpace 5.x branch to make it releasable again.  Add Docker Compose for easier testing.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,12 @@
 # Auto detect text files and perform LF normalization
 * text=auto
 
+# Ensure Unix files always keep Unix line endings
+*.sh text eol=lf
+
+# Ensure Windows files always keep Windows line endings
+*.bat text eol=crlf
+
 # Standard to msysgit
 *.doc  diff=astextplain
 *.DOC  diff=astextplain

--- a/Dockerfile.cli.jdk8
+++ b/Dockerfile.cli.jdk8
@@ -2,11 +2,11 @@
 # See https://dspace-labs.github.io/DSpace-Docker-Images/ for usage details
 # 
 # This version is JDK8 compatible
-# - tomcat:7-jre8
+# - openjdk:8-jdk
 # - ANT 1.10.7
 # - maven:3-jdk-8
 # - note: 
-# - default tag for branch: dspace/dspace: dspace/dspace:dspace-5_x-jdk8
+# - default tag for branch: dspace/dspace-cli: dspace/dspace-cli:dspace-5_x
 
 # Step 1 - Run Maven Build
 FROM dspace/dspace-dependencies:dspace-5_x-jdk8 as build
@@ -24,12 +24,12 @@ ADD --chown=dspace . /app/
 COPY --chown=dspace dspace/src/main/docker/build.properties /app/build.properties
 
 # Build DSpace.  Copy the dspace-install directory to /install.  Clean up the build to keep the docker image small
-RUN mvn package -Dmirage2.on=true && \
+RUN mvn package -P'!dspace-solr,!dspace-jspui,!dspace-xmlui,!dspace-rest,!dspace-xmlui-mirage2,!dspace-rdf,!dspace-sword,!dspace-swordv2' && \
   mv /app/dspace/target/${TARGET_DIR}/* /install && \
   mvn clean
 
 # Step 2 - Run Ant Deploy
-FROM tomcat:7-jre8 as ant_build
+FROM openjdk:8-jdk as ant_build
 ARG TARGET_DIR=dspace-installer
 COPY --from=build /install /dspace-src
 WORKDIR /dspace-src
@@ -42,31 +42,19 @@ ENV PATH $ANT_HOME/bin:$PATH
 RUN mkdir $ANT_HOME && \
     wget -qO- "https://archive.apache.org/dist/ant/binaries/apache-ant-$ANT_VERSION-bin.tar.gz" | tar -zx --strip-components=1 -C $ANT_HOME
 
-RUN ant init_installation update_configs update_code update_webapps update_solr_indexes
+RUN ant init_installation update_configs update_code
 
-# Step 3 - Run tomcat
-# Create a new tomcat image that does not retain the the build directory contents
-FROM tomcat:7-jre8
+# Step 3 - Run jdk
+# Create a new jdk image that does not retain the the build directory contents
+FROM openjdk:8-jdk
 ENV DSPACE_INSTALL=/dspace
 COPY --from=ant_build /dspace $DSPACE_INSTALL
-EXPOSE 8080 8009
 
-ENV JAVA_OPTS=-Xmx2000m
+ENV JAVA_OPTS=-Xmx1000m
 
-RUN ln -s $DSPACE_INSTALL/webapps/solr    /usr/local/tomcat/webapps/solr    && \
-    ln -s $DSPACE_INSTALL/webapps/xmlui   /usr/local/tomcat/webapps/xmlui   && \
-    ln -s $DSPACE_INSTALL/webapps/jspui   /usr/local/tomcat/webapps/jspui   && \
-    ln -s $DSPACE_INSTALL/webapps/rest    /usr/local/tomcat/webapps/rest    && \
-    ln -s $DSPACE_INSTALL/webapps/oai     /usr/local/tomcat/webapps/oai     && \
-    ln -s $DSPACE_INSTALL/webapps/rdf     /usr/local/tomcat/webapps/rdf     && \
-    ln -s $DSPACE_INSTALL/webapps/sword   /usr/local/tomcat/webapps/sword   && \
-    ln -s $DSPACE_INSTALL/webapps/swordv2 /usr/local/tomcat/webapps/swordv2
-
+# This script is used to parse environment variables to configs in dspace.cfg
+# It is not executed in this Docker file, so it's up to docker-compose to call it.
 COPY dspace/src/main/docker/parse_env_to_configs.sh $DSPACE_INSTALL/bin/parse_env_to_configs.sh
 
 # Ensure all scripts are executable
 RUN chmod +x $DSPACE_INSTALL/bin/*
-
-# On startup run this command to parse environment variables to configs in dspace.cfg
-# Then start Tomcat
-CMD ["sh", "-c", "$DSPACE_INSTALL/bin/parse_env_to_configs.sh && catalina.sh run"]

--- a/Dockerfile.jdk8-test
+++ b/Dockerfile.jdk8-test
@@ -67,3 +67,12 @@ COPY dspace/src/main/docker/test/rest_web.xml $DSPACE_INSTALL/webapps/rest/WEB-I
 
 RUN sed -i -e "s|\${dspace.dir}|$DSPACE_INSTALL|" $DSPACE_INSTALL/webapps/solr/WEB-INF/web.xml && \
     sed -i -e "s|\${dspace.dir}|$DSPACE_INSTALL|" $DSPACE_INSTALL/webapps/rest/WEB-INF/web.xml
+
+COPY dspace/src/main/docker/parse_env_to_configs.sh $DSPACE_INSTALL/bin/parse_env_to_configs.sh
+
+# Ensure all scripts are executable
+RUN chmod +x $DSPACE_INSTALL/bin/*
+
+# On startup run this command to parse environment variables to configs in dspace.cfg
+# Then start Tomcat
+CMD ["sh", "-c", "$DSPACE_INSTALL/bin/parse_env_to_configs.sh && catalina.sh run"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-DSpace source code BSD License:
+BSD 3-Clause License
 
-Copyright (c) 2002-2020, LYRASIS.  All rights reserved.
+Copyright (c) 2002-2022, LYRASIS.  All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -13,13 +13,12 @@ notice, this list of conditions and the following disclaimer.
 notice, this list of conditions and the following disclaimer in the
 documentation and/or other materials provided with the distribution.
 
-- Neither the name DuraSpace nor the name of the DSpace Foundation
-nor the names of its contributors may be used to endorse or promote
-products derived from this software without specific prior written
-permission.
+- Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
 A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
 HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
@@ -30,10 +29,3 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 DAMAGE.
-
-
-DSpace uses third-party libraries which may be distributed under
-different licenses to the above. Information about these licenses
-is detailed in the LICENSES_THIRD_PARTY file at the root of the source
-tree.  You must agree to the terms of these licenses, in addition to
-the above DSpace source code license, in order to use this software.

--- a/NOTICE
+++ b/NOTICE
@@ -1,3 +1,13 @@
+Licenses of Third-Party Libraries
+=================================
+
+DSpace uses third-party libraries which may be distributed under
+different licenses than specified in our LICENSE file. Information
+about these licenses is detailed in the LICENSES_THIRD_PARTY file at
+the root of the source tree. You must agree to the terms of these
+licenses, in addition to the DSpace source code license, in order to
+use this software.
+
 Licensing Notices
 =================
 

--- a/README
+++ b/README
@@ -1,18 +1,16 @@
 DSpace version information can be viewed online at
- - https://wiki.duraspace.org/display/DSDOC/
+ - https://wiki.lyrasis.org/display/DSDOC/
 
 Documentation for the most recent stable release(s) may be downloaded
 or viewed online at
  - http://www.dspace.org/latest-release/
- - https://wiki.duraspace.org/display/DSDOC/
- - http://sourceforge.net/projects/dspace/files/DSpace%20Stable/
-     (select a version and read DSpace-Manual.pdf)
+ - https://wiki.lyrasis.org/display/DSDOC/
 
 Installation instructions are to be found in that documentation.
 
 In addition, a listing of all known contributors to DSpace software can be
 found online at:
-https://wiki.duraspace.org/display/DSPACE/DSpaceContributors
+https://wiki.lyrasis.org/display/DSPACE/DSpaceContributors
 
 Installation instructions for other versions may be different, so you
 are encouraged to obtain the appropriate version of the Documentation
@@ -26,20 +24,20 @@ or just:
 
  - git clone git://github.com/DSpace/DSpace.git
 
-Please refer any further problems to the dspace-tech@lists.sourceforge.net
+Please refer any further problems to the dspace-tech@googlegroups.com
 mailing list.
 
- - http://sourceforge.net/mail/?group_id=19984
+ - https://groups.google.com/d/forum/dspace-tech
 
 
-Detailed Issue Tracking for DSpace is done on our JIRA Issue Tracker
+Detailed Issue Tracking for DSpace is done in GitHub issues
 
- - https://jira.duraspace.org/browse/DS
+ - https://github.com/DSpace/DSpace/issues
 
 
 To contribute to DSpace, please see:
 
- - https://wiki.duraspace.org/display/DSPACE/How+to+Contribute+to+DSpace
+ - https://wiki.lyrasis.org/display/DSPACE/How+to+Contribute+to+DSpace
 
 
 For more details about DSpace, including a list of service providers,
@@ -47,8 +45,5 @@ places to seek help, news articles and lists of other users, please see:
 
  - http://www.dspace.org/
 
-
-DSpace source code licensing information available online at:
- - http://www.dspace.org/license/
-
-Copyright (c) 2002-2015, DuraSpace.  All rights reserved.
+DSpace source code is freely available under a standard [BSD 3-Clause license](https://opensource.org/licenses/BSD-3-Clause).
+The full license is available at http://www.dspace.org/license/

--- a/docker-compose-cli.yml
+++ b/docker-compose-cli.yml
@@ -1,0 +1,42 @@
+#
+# The contents of this file are subject to the license and copyright
+# detailed in the LICENSE and NOTICE files at the root of the source
+# tree and available online at
+#
+# http://www.dspace.org/license/
+#
+
+version: "3.7"
+
+services:
+  dspace-cli:
+    image: "dspace/dspace-cli:${DSPACE_VER:-dspace-5_x}"
+    container_name: dspace-cli
+    build:
+      context: .
+      dockerfile: Dockerfile.cli.jdk8
+    environment:
+      # Env vars with double underbars in names will be replaced with periods and written to dspace.cfg
+      # The defaul values for dspace.cfg will be provided here
+      # __D__ -> -
+      # __P__ -> .
+      - dspace__P__dir=/dspace
+      - db__P__url=jdbc:postgresql://dspacedb:5432/dspace
+      - dspace__P__hostname=localhost
+      - dspace__P__baseUrl=http://localhost:8080
+      - dspace__P__name=DSpace Started with Docker Compose
+      - solr__P__server=http://localhost:8080/solr
+    volumes:
+      - assetstore:/dspace/assetstore
+    entrypoint: /dspace/bin/parse_env_to_configs.sh && /dspace/bin/dspace
+    command: help
+    networks:
+      - dspacenet
+    tty: true
+    stdin_open: true
+
+volumes:
+  assetstore:
+
+networks:
+  dspacenet:

--- a/docker-compose-cli.yml
+++ b/docker-compose-cli.yml
@@ -25,10 +25,11 @@ services:
       - dspace__P__hostname=localhost
       - dspace__P__baseUrl=http://localhost:8080
       - dspace__P__name=DSpace Started with Docker Compose
-      - solr__P__server=http://localhost:8080/solr
+      - solr__P__server=http://dspace:8080/solr
     volumes:
       - assetstore:/dspace/assetstore
-    entrypoint: /dspace/bin/parse_env_to_configs.sh && /dspace/bin/dspace
+    entrypoint: /dspace/bin/parse_env_to_configs.sh
+    # Any commands passed here will be forwarded to /dspace/bin/dspace by parse_env_to_configs.sh (see its code)
     command: help
     networks:
       - dspacenet

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,8 +44,6 @@ services:
       - solr_oai:/dspace/solr/oai/data
       - solr_search:/dspace/solr/search/data
       - solr_statistics:/dspace/solr/statistics/data
-    #entrypoint: /dspace/bin/parse_configs.sh
-    #command: catalina.sh run
   dspacedb:
     container_name: dspacedb
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,66 @@
+#
+# The contents of this file are subject to the license and copyright
+# detailed in the LICENSE and NOTICE files at the root of the source
+# tree and available online at
+#
+# http://www.dspace.org/license/
+#
+
+version: '3.7'
+networks:
+  dspacenet:
+services:
+  dspace:
+    container_name: dspace
+    depends_on:
+      - dspacedb
+    image: "${DOCKER_OWNER:-dspace}/dspace:${DSPACE_VER:-dspace-5_x-jdk8-test}"
+    environment:
+      # Env vars with double underbars in names will be replaced with periods and written to dspace.cfg
+      # The defaul values for dspace.cfg will be provided here
+      # __D__ -> -
+      # __P__ -> .
+      - dspace__P__dir=/dspace
+      - db__P__url=jdbc:postgresql://dspacedb:5432/dspace
+      - dspace__P__hostname=localhost
+      - dspace__P__baseUrl=http://localhost:8080
+      - dspace__P__name=DSpace Started with Docker Compose
+      - solr__P__server=http://localhost:8080/solr
+    build:
+      context: .
+      dockerfile: Dockerfile.jdk8-test
+    networks:
+      dspacenet:
+    ports:
+      - published: 8080
+        target: 8080
+    stdin_open: true
+    tty: true
+    volumes:
+      - ./dspace/src/main/docker-compose/xmlui.xconf:/dspace/config/xmlui.xconf
+      - ./dspace/src/main/docker-compose/parse_configs.sh:/dspace/bin/parse_configs.sh
+      - assetstore:/dspace/assetstore
+      - solr_authority:/dspace/solr/authority/data
+      - solr_oai:/dspace/solr/oai/data
+      - solr_search:/dspace/solr/search/data
+      - solr_statistics:/dspace/solr/statistics/data
+    #entrypoint: /dspace/bin/parse_configs.sh
+    #command: catalina.sh run
+  dspacedb:
+    container_name: dspacedb
+    environment:
+      PGDATA: /pgdata
+    image: dspace/dspace-postgres-pgcrypto
+    networks:
+      dspacenet:
+    stdin_open: true
+    tty: true
+    volumes:
+      - pgdata:/pgdata
+volumes:
+  assetstore:
+  pgdata:
+  solr_authority:
+  solr_oai:
+  solr_search:
+  solr_statistics:

--- a/dspace-api/src/main/resources/Messages.properties
+++ b/dspace-api/src/main/resources/Messages.properties
@@ -599,7 +599,7 @@ jsp.home.search1                                                = Search
 jsp.home.search2                                                = Enter some text in the box below to search DSpace.
 jsp.home.title                                                  = Home
 jsp.layout.footer-default.feedback                              = Feedback
-jsp.layout.footer-default.text                                  = <a target="_blank" href="http://www.dspace.org/">DSpace Software</a> Copyright&nbsp;&copy;&nbsp;2002-2013&nbsp; <a target="_blank" href="http://www.duraspace.org/">Duraspace</a>
+jsp.layout.footer-default.text                                  = <a target="_blank" href="http://www.dspace.org/">DSpace Software</a> Copyright&nbsp;&copy;&nbsp;2002-2022&nbsp; <a target="_blank" href="http://lyrasis.org/">LYRASIS</a>
 jsp.layout.footer-default.theme-by								= Theme by
 jsp.layout.header-default.about                                 = About DSpace Software
 jsp.layout.header-default.alt                                   = DSpace

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/README.md
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/README.md
@@ -76,14 +76,14 @@ to upper case.
 
 Oracle complains with ORA-01408 if you attempt to create an index on a column which
 has already had the UNIQUE contraint added (such an index is implicit in maintaining the uniqueness
-of the column). See [DS-1370](https://jira.duraspace.org/browse/DS-1370) for details.
+of the column). See [DS-1370](https://github.com/DSpace/DSpace/issues/4739) for details.
 
 ## Using the update-sequences.sql script
 
 The `update-sequences.sql` script in this directory may still be used to update
 your internal database counts if you feel they have gotten out of "sync". This
 may sometimes occur after large restores of content (e.g. when using the DSpace
-[AIP Backup and Restore](https://wiki.duraspace.org/display/DSDOC5x/AIP+Backup+and+Restore) 
+[AIP Backup and Restore](https://wiki.lyrasis.org/display/DSDOC5x/AIP+Backup+and+Restore) 
 feature).
 
 This `update-sequences.sql` script can be executed by running 

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/README.md
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/README.md
@@ -22,7 +22,7 @@ Please see the Flyway Documentation for more information: http://flywaydb.org/
 The `update-sequences.sql` script in this directory may still be used to update
 your internal database counts if you feel they have gotten out of "sync". This
 may sometimes occur after large restores of content (e.g. when using the DSpace
-[AIP Backup and Restore](https://wiki.duraspace.org/display/DSDOC5x/AIP+Backup+and+Restore) 
+[AIP Backup and Restore](https://wiki.lyrasis.org/display/DSDOC5x/AIP+Backup+and+Restore) 
 feature).
 
 This `update-sequences.sql` script can be executed by running 

--- a/dspace-xmlui-mirage2/src/main/webapp/xsl/core/page-structure.xsl
+++ b/dspace-xmlui-mirage2/src/main/webapp/xsl/core/page-structure.xsl
@@ -695,7 +695,7 @@
                     <hr/>
                     <div class="col-xs-7 col-sm-8">
                         <div>
-                            <a href="http://www.dspace.org/" target="_blank">DSpace software</a> copyright&#160;&#169;&#160;2002-2015&#160; <a href="http://www.duraspace.org/" target="_blank">DuraSpace</a>
+                            <a href="http://www.dspace.org/" target="_blank">DSpace software</a> copyright&#160;&#169;&#160;2002-2022&#160; <a href="http://lyrasis.org/" target="_blank">LYRASIS</a>
                         </div>
                         <div class="hidden-print">
                             <a>

--- a/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/core/page-structure.xsl
+++ b/dspace-xmlui/src/main/webapp/themes/Mirage/lib/xsl/core/page-structure.xsl
@@ -584,7 +584,7 @@
         <div id="ds-footer-wrapper">
             <div id="ds-footer">
                 <div id="ds-footer-left">
-                    <a href="http://www.dspace.org/" target="_blank">DSpace software</a> copyright&#160;&#169;&#160;2002-2015&#160; <a href="http://www.duraspace.org/" target="_blank">DuraSpace</a>
+                    <a href="http://www.dspace.org/" target="_blank">DSpace software</a> copyright&#160;&#169;&#160;2002-2022&#160; <a href="http://lyrasis.org/" target="_blank">LYRASIS</a>
                 </div>
                 <div id="ds-footer-right">
                     <span class="theme-by">Theme by&#160;</span>

--- a/dspace/bin/.gitattributes
+++ b/dspace/bin/.gitattributes
@@ -1,0 +1,9 @@
+# Ensure Unix files in this folder always keep Unix line endings
+dspace text eol=lf
+dspace-info.pl text eol=lf
+log-reporter text eol=lf
+make-handle-config text eol=lf
+start-handle-server text eol=lf
+
+# Ensure Windows files in this folder always keep Windows line endings
+*.bat text eol=crlf

--- a/dspace/etc/oracle/README.md
+++ b/dspace/etc/oracle/README.md
@@ -6,7 +6,7 @@ Therefore, all `database_schema*.sql` files have been removed. Starting
 with DSpace 4.x -> 5.0 upgrade, you will no longer need to manually run any
 SQL scripts to upgrade your database.
 
-Please see the [5.0 Upgrade Instructions](https://wiki.duraspace.org/display/DSDOC5x/Upgrading+to+5.x)
+Please see the [5.0 Upgrade Instructions](https://wiki.lyrasis.org/display/DSDOC5x/Upgrading+to+5.x)
 for more information on upgrading to DSpace 5.
 
 
@@ -25,7 +25,7 @@ manually. For more information, please see the `README.md` in the scripts direct
 The `update-sequences.sql` script in this directory may still be used to update
 your internal database counts if you feel they have gotten out of "sync". This
 may sometimes occur after large restores of content (e.g. when using the DSpace
-[AIP Backup and Restore](https://wiki.duraspace.org/display/DSDOC5x/AIP+Backup+and+Restore) 
+[AIP Backup and Restore](https://wiki.lyrasis.org/display/DSDOC5x/AIP+Backup+and+Restore) 
 feature).
 
 This `update-sequences.sql` script can be run manually. It will not harm your 

--- a/dspace/etc/postgres/README.md
+++ b/dspace/etc/postgres/README.md
@@ -6,7 +6,7 @@ Therefore, all `database_schema*.sql` files have been removed. Starting
 with DSpace 4.x -> 5.0 upgrade, you will no longer need to manually run any
 SQL scripts to upgrade your database.
 
-Please see the [5.0 Upgrade Instructions](https://wiki.duraspace.org/display/DSDOC5x/Upgrading+to+5.x)
+Please see the [5.0 Upgrade Instructions](https://wiki.lyrasis.org/display/DSDOC5x/Upgrading+to+5.x)
 for more information on upgrading to DSpace 5.
 
 
@@ -25,7 +25,7 @@ manually. For more information, please see the `README.md` in the scripts direct
 The `update-sequences.sql` script in this directory may still be used to update
 your internal database counts if you feel they have gotten out of "sync". This
 may sometimes occur after large restores of content (e.g. when using the DSpace
-[AIP Backup and Restore](https://wiki.duraspace.org/display/DSDOC5x/AIP+Backup+and+Restore) 
+[AIP Backup and Restore](https://wiki.lyrasis.org/display/DSDOC5x/AIP+Backup+and+Restore) 
 feature).
 
 This `update-sequences.sql` script can be run manually. It will not harm your 

--- a/dspace/modules/xmlui-mirage2/pom.xml
+++ b/dspace/modules/xmlui-mirage2/pom.xml
@@ -37,6 +37,15 @@
             <!-- Filter using the properties file defined by dspace-parent POM -->
             <filter>${filters.file}</filter>
         </filters>
+        <extensions>
+            <extension>
+                <!-- Allows us to download Ruby gems -->
+                <!-- See https://github.com/jruby/mavengem -->
+                <groupId>org.torquebox.mojo</groupId>
+                <artifactId>mavengem-wagon</artifactId>
+                <version>1.0.3</version>
+            </extension>
+        </extensions>
         <!-- Centrally manage the versions of all plugins used below -->
         <pluginManagement>
             <plugins>
@@ -295,9 +304,10 @@
                 </property>
             </activation>
             <repositories>
+                <!-- https://github.com/jruby/mavengem -->
                 <repository>
-                    <id>rubygems-release</id>
-                    <url>http://rubygems-proxy.torquebox.org/releases</url>
+                    <id>mavengems</id>
+                    <url>mavengem:https://rubygems.org</url>
                 </repository>
             </repositories>
             <dependencies>

--- a/dspace/src/main/docker-compose/README.md
+++ b/dspace/src/main/docker-compose/README.md
@@ -1,0 +1,44 @@
+# Docker Compose Resources
+
+## Root directory
+- docker-compose.yml
+    - Docker compose file to orchestrate DSpace 5 components
+- docker-compose-cli
+    - Docker compose file to run DSpace CLI tasks within a running DSpace instance in Docker
+
+## dspace/src/main/docker-compose
+
+- cli.ingest.yml
+    - Docker compose file that will run an AIP ingest into DSpace 5.
+- local.cfg
+    - Sets the environment used across containers run with docker-compose
+- xmlui.xconf
+    - Brings up the XMLUI Mirage2 theme by default.
+
+## To refresh / pull DSpace images from Dockerhub
+```
+docker-compose -f docker-compose.yml -f docker-compose-cli.yml pull
+```
+
+## To build DSpace images using code in your branch
+```
+docker-compose -f docker-compose.yml -f docker-compose-cli.yml build
+```
+
+## To run DSpace from your branch
+
+```
+docker-compose -p d5 up -d
+```
+
+## Ingesting test content
+
+Create an admin account.  By default, the dspace-cli container runs the dspace command.
+```
+docker-compose -p d5 -f docker-compose-cli.yml run dspace-cli create-administrator -e test@test.edu -f admin -l user -p admin -c en
+```
+
+Download a Zip file of AIP content and ingest test data
+```
+docker-compose -p d5 -f docker-compose-cli.yml -f dspace/src/main/docker-compose/cli.ingest.yml run dspace-cli
+```

--- a/dspace/src/main/docker-compose/README.md
+++ b/dspace/src/main/docker-compose/README.md
@@ -10,8 +10,6 @@
 
 - cli.ingest.yml
     - Docker compose file that will run an AIP ingest into DSpace 5.
-- local.cfg
-    - Sets the environment used across containers run with docker-compose
 - xmlui.xconf
     - Brings up the XMLUI Mirage2 theme by default.
 

--- a/dspace/src/main/docker-compose/cli.ingest.yml
+++ b/dspace/src/main/docker-compose/cli.ingest.yml
@@ -25,10 +25,11 @@ services:
         curl $${AIPZIP} -L -s --output aip.zip
         unzip aip.zip
         cd $${AIPDIR}
-        
+
+        /dspace/bin/parse_env_to_configs.sh
+
         /dspace/bin/dspace packager -r -a -t AIP -e $${ADMIN_EMAIL} -f -u SITE*.zip
-        #/dspace/bin/dspace database update-sequences
-        touch /dspace/solr/search/conf/reindex.flag
-        
+
+        /dspace/bin/dspace index-discovery -b
         /dspace/bin/dspace oai import
         /dspace/bin/dspace oai clean-cache

--- a/dspace/src/main/docker-compose/cli.ingest.yml
+++ b/dspace/src/main/docker-compose/cli.ingest.yml
@@ -1,0 +1,34 @@
+#
+# The contents of this file are subject to the license and copyright
+# detailed in the LICENSE and NOTICE files at the root of the source
+# tree and available online at
+#
+# http://www.dspace.org/license/
+#
+
+version: "3.7"
+
+services:
+  dspace-cli:
+    environment:
+      - AIPZIP=https://github.com/DSpace-Labs/AIP-Files/raw/master/dogAndReport.zip
+      - ADMIN_EMAIL=test@test.edu
+      - AIPDIR=/tmp/aip-dir
+    entrypoint:
+      - /bin/bash
+      - '-c'
+      - |
+        rm -rf $${AIPDIR}
+        mkdir $${AIPDIR} /dspace/upload
+        cd $${AIPDIR}
+        pwd
+        curl $${AIPZIP} -L -s --output aip.zip
+        unzip aip.zip
+        cd $${AIPDIR}
+        
+        /dspace/bin/dspace packager -r -a -t AIP -e $${ADMIN_EMAIL} -f -u SITE*.zip
+        #/dspace/bin/dspace database update-sequences
+        touch /dspace/solr/search/conf/reindex.flag
+        
+        /dspace/bin/dspace oai import
+        /dspace/bin/dspace oai clean-cache

--- a/dspace/src/main/docker-compose/xmlui.xconf
+++ b/dspace/src/main/docker-compose/xmlui.xconf
@@ -1,0 +1,176 @@
+<?xml version="1.0"?>
+<!DOCTYPE xmlui SYSTEM "xmlui.dtd">
+
+<!--
+    - xmlui.xconf
+    -
+    - Copyright (c) 2002-2009, The DSpace Foundation.  All rights reserved.
+    -
+    - Redistribution and use in source and binary forms, with or without
+    - modification, are permitted provided that the following conditions are
+    - met:
+    -
+    - - Redistributions of source code must retain the above copyright
+    - notice, this list of conditions and the following disclaimer.
+    -
+    - - Redistributions in binary form must reproduce the above copyright
+    - notice, this list of conditions and the following disclaimer in the
+    - documentation and/or other materials provided with the distribution.
+    -
+    - Neither the name of the DSpace Foundation nor the names of its
+    - contributors may be used to endorse or promote products derived from
+    - this software without specific prior written permission.
+    -
+    - THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    - ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    - LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    - A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    - HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    - INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    - BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+    - OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+    - ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+    - TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+    - USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+    - DAMAGE.
+-->
+
+
+<!--
+    - The XMLUI (Manakin Release) configuration file
+    -
+    - Authors: Scott Phillips
+    - Version: $Revision$
+    - Date:    $Date$
+-->
+
+<xmlui>
+    <!--
+        This section configures the Aspect "chain". An Aspect provides a set
+        of coupled features for the system. All Aspects are chained together
+        such that together they form the complete DSpace website. This is where
+        the chain is defined, the order in which each aspect is declared
+        determines it's order in the chain. Aspects at the top are invoked
+        first.
+
+        The <aspect> element has two attributes, name & path. The name is used
+        to identify the Aspect, while the path determines the directory. The
+        path attribute should be listed exactly as it is found in the
+        /xmlui/cocoon/aspects/ directory followed by a slash.
+    -->
+    <aspects>
+        <!-- =====================
+             Item Level Versioning
+             ===================== -->
+        <!--
+             To enable Item Level Versioning features, uncomment this aspect.
+             This is currently disabled by default because of one known issue:
+             DS-1382. Please, review them to see whether they apply
+             to you before enabling versioning.
+        -->
+        <!--<aspect name="Versioning Aspect" path="resource://aspects/Versioning/" />-->
+
+        <!-- =====================
+             Base Features/Aspects
+             ===================== -->
+        <!-- Base DSpace XMLUI Aspects for Display, Browse, Search, Admin, Login and Submission -->
+        <aspect name="Displaying Artifacts" path="resource://aspects/ViewArtifacts/" />
+        <aspect name="Browsing Artifacts" path="resource://aspects/BrowseArtifacts/" />
+        <aspect name="Discovery" path="resource://aspects/Discovery/" />
+        <aspect name="Administration" path="resource://aspects/Administrative/" />
+        <aspect name="E-Person" path="resource://aspects/EPerson/" />
+        <aspect name="Submission and Workflow" path="resource://aspects/Submission/" />
+
+        <!-- ========================
+             Usage Statistics Engines
+             ======================== -->
+        <!-- By default, DSpace uses a Statistics engine based on SOLR -->
+        <aspect name="Statistics" path="resource://aspects/Statistics/" />
+
+        <!--
+             If you prefer to use "Elastic Search" Statistics, you can uncomment the below
+             aspect and COMMENT OUT the default "Statistics" aspect above.
+             You must also enable the ElasticSearchLoggerEventListener.
+        -->
+        <!-- <aspect name="Statistics - Elastic Search" path="resource://aspects/StatisticsElasticSearch/" /> -->
+
+        <!-- Additionally you may choose to expose your Google Analytics statistics in DSpace -->
+        <!-- <aspect name="StatisticsGoogleAnalytics" path="resource://aspects/StatisticsGoogleAnalytics/" /> -->
+
+        <!-- =========================
+             Approval Workflow Systems
+             ========================= -->
+        <!-- By default, DSpace uses a legacy 3-step approval workflow for new submissions -->
+        <aspect name="Original Workflow" path="resource://aspects/Workflow/" />
+
+        <!-- If you prefer, a Configurable XML-based Workflow is available. To enable it, you can
+             uncomment the below aspect and comment out the "Original Workflow" aspect above.
+             PLEASE NOTE: in order to use the configurable workflow you must also run the
+             database migration scripts as detailed in the DSpace Documentation -->
+        <!-- <aspect name="XMLWorkflow" path="resource://aspects/XMLWorkflow/" /> -->
+
+        <!-- ==============
+             SWORDv1 Client
+             ============== -->
+        <!-- DSpace also comes with an option SWORD Client aspect, which allows
+             you to submit content FROM your DSpace TO another SWORD-enabled repository.
+             To enable this feature, uncomment the aspect below. -->
+        <!-- <aspect name="SwordClient" path="resource://aspects/SwordClient/" /> -->
+
+        <!--
+            This demo aspect tests the various possible DRI features.
+            It may be useful to developers in developing new aspects or themes.
+            It's accessible for admins in the XMLTest menu or via the /XMLTest/ URL.
+        -->
+        <!-- <aspect name="XML Tests" path="resource://aspects/XMLTest/"/> -->
+    </aspects>
+
+    <!--
+        This section configures which Theme should apply to a particular URL.
+        Themes stylize an abstract DRI document (generated by the Aspect
+        chain from above) and produce XHTML (or possibly another format) for
+        display to the user. Each theme rule is processed in the order that it
+        is listed below, the first rule that matches is the theme that is applied.
+
+        The <theme> element has several attributes including: name, id, regex,
+        handle, and path. The name attribute is used to identify the theme, while
+        the path determines the directory. The path attribute should be listed
+        exactly as it is found in the /xmlui/cocoon/themes/ directory. Both the
+        regex and handle attributes determine if the theme rule matches the URL.
+        If either the pattern or handle attribute is left off then the only the
+        other component is used to determine matching.
+
+        Keep in mind that the order of <theme> elements matters in the case of
+        overlapping matching rules. For example, a theme rule with a very broad
+        matching rule (like regex=".*") will override a more specific theme
+        declaration (like handle="1234/23") if placed before it.
+
+        Finally, theme application also "cascades" down to pages derived from the
+        one that the theme directly applies to. Thus, a theme applied to a
+        specific community will also apply to that community's collections and
+        their respective items.
+    -->
+    <themes>
+        <!-- Example configuration -->
+
+        <!-- <theme name="Test Theme 1" handle="123456789/1" path="theme1/"/>    -->
+        <!-- <theme name="Test Theme 2" regex="community-list" path="theme2/"/> -->
+
+        <!-- Mirage theme, @mire contributed theme, default since DSpace 3.0 -->
+        <theme name="Atmire Mirage Theme" regex=".*" path="Mirage2/" />
+
+        <!-- Reference theme, the default Manakin XMLUI layout up to DSpace 1.8 -->
+        <!-- <theme name="Default Reference Theme" regex=".*" path="Reference/" /> -->
+
+        <!-- Classic theme, inspired by the JSP UI -->
+        <!-- <theme name="Classic" regex=".*" path="Classic/" /> -->
+
+        <!-- The Kubrick theme -->
+        <!-- <theme name="Kubrick" regex=".*" path="Kubrick/" /> -->
+
+        <!--
+             For information on configuring the mobile theme, see:
+             dspace-xmlui/src/main/webapp/themes/mobile/readme.txt
+        -->
+    </themes>
+</xmlui>

--- a/dspace/src/main/docker/parse_env_to_configs.sh
+++ b/dspace/src/main/docker/parse_env_to_configs.sh
@@ -7,3 +7,10 @@ do
   grep -v "^${v}=" /dspace/config/dspace.cfg > /dspace/config/dspace.cfg
 done
 env | egrep "__.*=" | egrep -v "=.*__" | sed -e "s/__P__/./g" | sed -e "s/__D__/-/g" >> /dspace/config/dspace.cfg
+
+# Optionally call /dspace/bin/dspace with any other params
+# This is used by dspace-cli image to run commands after parsing env to config
+if [ $# -ne 0 ]
+  then
+    /dspace/bin/dspace "$@"
+fi

--- a/dspace/src/main/docker/parse_env_to_configs.sh
+++ b/dspace/src/main/docker/parse_env_to_configs.sh
@@ -1,11 +1,29 @@
 #!/bin/sh
+#
+# The contents of this file are subject to the license and copyright
+# detailed in the LICENSE and NOTICE files at the root of the source
+# tree and available online at
+#
+# http://www.dspace.org/license/
+#
+
+#
+# This script is used by DSpace 5 to convert/save runtime environment variables used by v6 or 7 into dspace.cfg
+# This is necessary because DSpace 5 doesn't support runtime configs like v6 or 7.  All configs are added to dspace.cfg
+# during the Maven build process -- local.cfg didn't come about until 6.x
+#
+# This script passes any params to "[dspace]/bin/dspace", as this is necessary to support "dspace-cli" containers
+# as those containers need this script to dynamically update configs and then run a command from commandline.
 
 # Substitute values in dspace.cfg for DSpace 5 from environment variables
+# Converts environment variables like "dspace__P__dir" to "dspace.dir" and appends to end of dspace.cfg
 VARS=`env | egrep "__.*="|cut -f1 -d=` | sed -e "s/__P__/\./g" | sed -e "s/__D__/-/g"
 for v in $VARS
 do
+  # First write all non-matching lines back to the dspace.cfg
   grep -v "^${v}=" /dspace/config/dspace.cfg > /dspace/config/dspace.cfg
 done
+# Then write all converted environment variables at the end of dspace.cfg
 env | egrep "__.*=" | egrep -v "=.*__" | sed -e "s/__P__/./g" | sed -e "s/__D__/-/g" >> /dspace/config/dspace.cfg
 
 # Optionally call /dspace/bin/dspace with any other params

--- a/dspace/src/main/docker/parse_env_to_configs.sh
+++ b/dspace/src/main/docker/parse_env_to_configs.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# Substitute values in dspace.cfg for DSpace 5 from environment variables
+VARS=`env | egrep "__.*="|cut -f1 -d=` | sed -e "s/__P__/\./g" | sed -e "s/__D__/-/g"
+for v in $VARS
+do
+  grep -v "^${v}=" /dspace/config/dspace.cfg > /dspace/config/dspace.cfg
+done
+env | egrep "__.*=" | egrep -v "=.*__" | sed -e "s/__P__/./g" | sed -e "s/__D__/-/g" >> /dspace/config/dspace.cfg

--- a/pom.xml
+++ b/pom.xml
@@ -16,14 +16,6 @@
       <url>http://dspace.org</url>
    </organization>
 
-    <!-- brings the sonatype snapshot repository and signing requirement on board -->
-    <parent>
-        <groupId>org.sonatype.oss</groupId>
-        <artifactId>oss-parent</artifactId>
-        <version>9</version>
-        <relativePath />
-    </parent>
-
     <prerequisites>
         <maven>3.0</maven>
     </prerequisites>
@@ -85,7 +77,7 @@
              <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.17</version>
+                <version>2.22.2</version>
                 <configuration>
                     <!-- Allow for the ability to pass JVM memory flags for Unit Tests. Since
                          maven-surefire-plugin forks a new JVM, it ignores MAVEN_OPTS.-->
@@ -96,6 +88,8 @@
                     </excludes>
                     <!-- Detailed logs in reportsDirectory/testName-output.txt instead of stdout -->
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                    <!-- Ensure full stacktrace is logged (when errors occur) -->
+                    <trimStackTrace>false</trimStackTrace>
                     <!--
                     Enable to debug Maven Surefire tests in remote proces
                     <debugForkedProcess>true</debugForkedProcess>
@@ -105,7 +99,7 @@
              <plugin>
                   <groupId>org.codehaus.mojo</groupId>
                   <artifactId>findbugs-maven-plugin</artifactId>
-                  <version>3.0.0</version>
+                  <version>3.0.3</version>
                   <configuration>
                       <effort>Max</effort>
                       <threshold>Low</threshold>
@@ -143,6 +137,34 @@
                 <artifactId>license-maven-plugin</artifactId>
                 <version>2.6</version>
              </plugin>
+              <!-- Used to generate a new release via Sonatype (see release profile). -->
+              <plugin>
+                  <groupId>org.sonatype.plugins</groupId>
+                  <artifactId>nexus-staging-maven-plugin</artifactId>
+                  <version>1.6.7</version>
+              </plugin>
+              <!-- Used to generate JavaDocs for new releases (see release profile). -->
+              <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-javadoc-plugin</artifactId>
+                  <version>2.10.3</version>
+                  <configuration>
+                      <!-- Never fail a build based on Javadoc errors -->
+                      <failOnError>false</failOnError>
+                  </configuration>
+              </plugin>
+              <!-- Used to generate source JARs for new releases (see release profile). -->
+              <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-source-plugin</artifactId>
+                  <version>2.4</version>
+              </plugin>
+              <!-- Used to sign new releases via GPG (see release profile). -->
+              <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-gpg-plugin</artifactId>
+                  <version>1.6</version>
+              </plugin>
           </plugins>
       </pluginManagement>
 
@@ -182,7 +204,7 @@
 
          <plugin>
             <artifactId>maven-release-plugin</artifactId>
-            <version>2.5</version>
+            <version>2.5.3</version>
             <configuration>
                 <!-- During release:perform, enable the "release" profile (see below) -->
                 <releaseProfiles>release</releaseProfiles>
@@ -711,6 +733,66 @@
              <module>dspace-xmlui-mirage2</module>
              <module>dspace-xmlui</module>
          </modules>
+          <build>
+              <plugins>
+                  <!-- Configure Nexus plugin for new releases via Sonatype.
+                       See: http://central.sonatype.org/pages/apache-maven.html -->
+                  <plugin>
+                      <groupId>org.sonatype.plugins</groupId>
+                      <artifactId>nexus-staging-maven-plugin</artifactId>
+                      <version>1.6.7</version>
+                      <extensions>true</extensions>
+                      <configuration>
+                          <!-- In your settings.xml, your username/password
+                               MUST be specified for server 'ossrh' -->
+                          <serverId>ossrh</serverId>
+                          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                          <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                      </configuration>
+                  </plugin>
+                  <!-- For new releases, generate Source JAR files -->
+                  <plugin>
+                      <groupId>org.apache.maven.plugins</groupId>
+                      <artifactId>maven-source-plugin</artifactId>
+                      <executions>
+                          <execution>
+                              <id>attach-sources</id>
+                              <goals>
+                                  <goal>jar-no-fork</goal>
+                              </goals>
+                          </execution>
+                      </executions>
+                  </plugin>
+                  <!-- For new releases, generate JavaDocs -->
+                  <plugin>
+                      <groupId>org.apache.maven.plugins</groupId>
+                      <artifactId>maven-javadoc-plugin</artifactId>
+                      <executions>
+                          <execution>
+                              <id>attach-javadocs</id>
+                              <goals>
+                                  <goal>aggregate-jar</goal>
+                              </goals>
+                          </execution>
+                      </executions>
+                  </plugin>
+                  <!-- Sign any new releases via GPG.
+                       NOTE: you may optionall specify the "gpg.passphrase" in your settings.xml -->
+                  <plugin>
+                      <groupId>org.apache.maven.plugins</groupId>
+                      <artifactId>maven-gpg-plugin</artifactId>
+                      <executions>
+                          <execution>
+                              <id>sign-artifacts</id>
+                              <phase>verify</phase>
+                              <goals>
+                                  <goal>sign</goal>
+                              </goals>
+                          </execution>
+                      </executions>
+                  </plugin>
+              </plugins>
+          </build>
       </profile>
 
    </profiles>
@@ -1612,13 +1694,18 @@
    </scm>
 
     <!--
-        Distribution Management is currently used by the Continuum
-        server to update snapshots it generates. This will also be used
-        on release to deploy release versions to the repository by the
-        release manager.
+         Configure our release repositories to use Sonatype.
+         See: http://central.sonatype.org/pages/apache-maven.html
     -->
     <distributionManagement>
-        <!-- further distribution management is found upstream in the sonatype parent -->
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
     </distributionManagement>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,8 @@
    <url>https://github.com/dspace/DSpace</url>
 
    <organization>
-      <name>DuraSpace</name>
-      <url>http://www.dspace.org</url>
+      <name>LYRASIS</name>
+      <url>http://dspace.org</url>
    </organization>
 
     <!-- brings the sonatype snapshot repository and signing requirement on board -->
@@ -413,7 +413,7 @@
                                         <!-- XML Commons claims these licenses, but it's really Apache License: https://xerces.apache.org/xml-commons/licenses.html -->
                                         <licenseMerge>Apache Software License, Version 2.0|The SAX License|The W3C License</licenseMerge>
                                         <licenseMerge>BSD License|The BSD License|BSD licence|BSD license|BSD|BSD-style license|BSD-Style License|New BSD License|New BSD license|Revised BSD License|BSD 2-Clause license</licenseMerge>
-                                        <!-- DuraSpace uses a BSD License for DSpace -->
+                                        <!-- DSpace uses a BSD License -->
                                         <licenseMerge>BSD License|DuraSpace BSD License|DuraSpace Sourcecode License</licenseMerge>
                                         <!-- Coverity uses modified BSD: https://github.com/coverity/coverity-security-library -->
                                         <licenseMerge>BSD License|BSD style modified by Coverity</licenseMerge>
@@ -1322,8 +1322,8 @@
 
    <licenses>
       <license>
-         <name>DuraSpace BSD License</name>
-         <url>https://raw.github.com/DSpace/DSpace/master/LICENSE</url>
+         <name>DSpace BSD License</name>
+         <url>https://raw.github.com/DSpace/DSpace/main/LICENSE</url>
          <distribution>repo</distribution>
          <comments>
             A BSD 3-Clause license for the DSpace codebase.
@@ -1332,61 +1332,60 @@
     </licenses>
 
    <issueManagement>
-      <system>JIRA</system>
-      <url>https://jira.duraspace.org/browse/DS</url>
+      <system>GitHub</system>
+      <url>https://github.com/DSpace/DSpace/issues</url>
    </issueManagement>
 
    <mailingLists>
       <mailingList>
          <name>DSpace Technical Users List</name>
          <subscribe>
-            http://lists.sourceforge.net/lists/listinfo/dspace-tech
+            https://groups.google.com/d/forum/dspace-tech
          </subscribe>
          <unsubscribe>
-            http://lists.sourceforge.net/lists/listinfo/dspace-tech
+            https://groups.google.com/d/forum/dspace-tech
          </unsubscribe>
-         <post>dspace-tech AT lists.sourceforge.net</post>
+         <post>dspace-tech AT googlegroups.com</post>
          <archive>
-            http://sourceforge.net/mailarchive/forum.php?forum_name=dspace-tech
+            https://groups.google.com/d/forum/dspace-tech
          </archive>
       </mailingList>
       <mailingList>
          <name>DSpace Developers List</name>
          <subscribe>
-            http://lists.sourceforge.net/lists/listinfo/dspace-devel
+            https://groups.google.com/d/forum/dspace-devel
          </subscribe>
          <unsubscribe>
-            http://lists.sourceforge.net/lists/listinfo/dspace-devel
+            https://groups.google.com/d/forum/dspace-devel
          </unsubscribe>
-         <post>dspace-devel AT lists.sourceforge.net</post>
+         <post>dspace-devel AT googlegroups.com</post>
          <archive>
-            http://sourceforge.net/mailarchive/forum.php?forum_name=dspace-devel
+            https://groups.google.com/d/forum/dspace-devel
          </archive>
       </mailingList>
       <mailingList>
-         <name>DSpace General Issues List</name>
+         <name>DSpace Community List</name>
          <subscribe>
-            http://lists.sourceforge.net/lists/listinfo/dspace-general
+            https://groups.google.com/d/forum/dspace-community
          </subscribe>
          <unsubscribe>
-            http://lists.sourceforge.net/lists/listinfo/dspace-general
+            https://groups.google.com/d/forum/dspace-community
          </unsubscribe>
-         <post>dspace-general AT lists.sourceforge.net</post>
+         <post>dspace-community AT googlegroups.com</post>
          <archive>
-            http://sourceforge.net/mailarchive/forum.php?forum_name=dspace-general
+            https://groups.google.com/d/forum/dspace-community
          </archive>
       </mailingList>
       <mailingList>
-         <name>DSpace SCM Commit Change-Log</name>
+         <name>DSpace Commit Change-Log</name>
          <subscribe>
-            http://lists.sourceforge.net/lists/listinfo/dspace-changelog
+            https://groups.google.com/d/forum/dspace-changelog
          </subscribe>
          <unsubscribe>
-            http://lists.sourceforge.net/lists/listinfo/dspace-changelog
+            https://groups.google.com/d/forum/dspace-changelog
          </unsubscribe>
-         <post>noreply AT lists.sourceforge.net</post>
          <archive>
-            http://sourceforge.net/mailarchive/forum.php?forum_name=dspace-changelog
+            https://groups.google.com/d/forum/dspace-changelog
          </archive>
       </mailingList>
    </mailingLists>
@@ -1609,7 +1608,7 @@
       <connection>scm:git:git@github.com:DSpace/DSpace.git</connection>
       <developerConnection>scm:git:git@github.com:DSpace/DSpace.git</developerConnection>
       <url>git@github.com:DSpace/DSpace.git</url>
-      <tag>dspace-5.1-SNAPSHOT</tag>
+      <tag>HEAD</tag>
    </scm>
 
     <!--

--- a/pom.xml
+++ b/pom.xml
@@ -234,6 +234,7 @@
                         <exclude>**/src/test/resources/**</exclude>
                         <exclude>**/src/test/data/**</exclude>
                         <exclude>**/src/main/license/**</exclude>
+                        <exclude>**/src/main/docker-compose/**</exclude>
                         <exclude>**/testEnvironment.properties</exclude>
                         <exclude>**/META-INF/**</exclude>
                         <exclude>**/robots.txt</exclude>


### PR DESCRIPTION
## Description
This PR is to prepare for a 5.11 release.  It includes a number of small fixes/improvements to make to the `dspace-5_x` branch in order to release a 5.11.  This branch has not had updates to its release process since 5.10 (released in 2018).

Summary of all changes:
* Updated Parent POM to use the new Sonatype release process. See 059d6f6
* Update LICENSE and NOTICE to resync with changes on `main` and `dspace-6_x`. See 6220bcd
* Replaced all usages of DuraSpace (text and links) with LYRASIS & to link to the new locations for mailings lists (Google Groups) and issue tickets (GitHub Issues). See 349773a
* Fix Mirage 2 build issue (reliant on RubyGems) by downloading RubyGems in a different manner: 0428da8
* Add `docker-compose` scripts to make it easy to test changes to 5.x. These 5.x scripts were mostly migrated from https://github.com/DSpace-Labs/DSpace-Docker-Images/ (but required some updates/bug fixes). They were also updated to align with / work similar to the `dspace-6.x` docker compose scripts.  See ff0809a and c1c042e
* Fix line endings issues on `dspace-5_x` scripts (linux scripts should have LF, windows scripts should have CRLF). This is required by the `docker-compose` scripts. It is a simple backport of #2705 and #2586 to `dspace-5_x`