### PR TITLE
Ensure Local Filter services are autowired

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/logic/condition/AbstractCondition.java
+++ b/dspace-api/src/main/java/org/dspace/content/logic/condition/AbstractCondition.java
@@ -32,9 +32,9 @@ public abstract class AbstractCondition implements Condition {
     private Map<String, Object> parameters;
 
     // Declare and instantiate spring services
-    //@Autowired(required = true)
+    @Autowired(required = true)
     protected ItemService itemService = ContentServiceFactory.getInstance().getItemService();
-    //@Autowired(required = true)
+    @Autowired(required = true)
     protected CollectionService collectionService = ContentServiceFactory.getInstance().getCollectionService();
     @Autowired(required = true)
     protected HandleService handleService;

--- a/dspace-api/src/main/java/org/dspace/content/logic/condition/AbstractCondition.java
+++ b/dspace-api/src/main/java/org/dspace/content/logic/condition/AbstractCondition.java
@@ -12,7 +12,6 @@ import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.content.Item;
-import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.logic.LogicalStatementException;
 import org.dspace.content.service.CollectionService;
 import org.dspace.content.service.ItemService;

--- a/dspace-api/src/main/java/org/dspace/content/logic/condition/AbstractCondition.java
+++ b/dspace-api/src/main/java/org/dspace/content/logic/condition/AbstractCondition.java
@@ -33,9 +33,9 @@ public abstract class AbstractCondition implements Condition {
 
     // Declare and instantiate spring services
     @Autowired(required = true)
-    protected ItemService itemService = ContentServiceFactory.getInstance().getItemService();
+    protected ItemService itemService;
     @Autowired(required = true)
-    protected CollectionService collectionService = ContentServiceFactory.getInstance().getCollectionService();
+    protected CollectionService collectionService;
     @Autowired(required = true)
     protected HandleService handleService;
 

--- a/dspace-api/src/test/java/org/dspace/content/logic/LogicalFilterTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/logic/LogicalFilterTest.java
@@ -408,6 +408,7 @@ public class LogicalFilterTest extends AbstractUnitTest {
 
         // Create condition to match pattern on dc.title metadata
         Condition condition = new MetadataValuesMatchCondition();
+        condition.setItemService(ContentServiceFactory.getInstance().getItemService());
         Map<String, Object> parameters = new HashMap<>();
         // Match on the dc.title field
         parameters.put("field", "dc.title");
@@ -461,6 +462,7 @@ public class LogicalFilterTest extends AbstractUnitTest {
         // Instantiate new filter for testing this condition
         DefaultFilter filter = new DefaultFilter();
         Condition condition = new InCollectionCondition();
+        condition.setItemService(ContentServiceFactory.getInstance().getItemService());
         Map<String, Object> parameters = new HashMap<>();
 
         // Add collectionOne handle to the collections parameter - ie. we are testing to see if the item is


### PR DESCRIPTION
There is a bug in the instantiation / autowiring of Item and Collection spring services in the AbstractCondition class extended by other condition classes. I think it was accidentally introduced during some Unit and Integration test work in the final stages before merging the Logical Item Filtering pull request.

I have tested and confirmed this simple change (re-enabling the autowired annotation) fixes the issue.

To test:
* Build this PR
* Run the CLI command against an item using the "simple-demo_filter" (or another filter if you prefer - any will test the fix legitimitely) like this:
`${dspace.dir}/bin/dspace dsrun org.dspace.content.logic.TestLogicRunner -f simple-demo_filter -i 123456789/3` 

If using the *simple-demo_filter*, it looks for a title containing 'demo', case insensitive. The launcher command should return **false** if the title does not contain demo, and **true** if the title does contain demo.

If this fix doesn't work, you will get a NullPointerException when the condition tries to access `ItemService.getMetadata()`