### PR TITLE
Workflow's steps doesn't preserve order

### DIFF
--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/state/Workflow.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/state/Workflow.java
@@ -8,7 +8,7 @@
 package org.dspace.xmlworkflow.state;
 
 import java.sql.SQLException;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -118,7 +118,7 @@ public class Workflow implements BeanNameAware {
      * @return a map containing the roles, the role name will the key, the role itself the value
      */
     public Map<String, Role> getRoles() {
-        Map<String, Role> roles = new HashMap<>();
+        Map<String, Role> roles = new LinkedHashMap<>();
         for (Step step : steps) {
             if (step.getRole() != null) {
                 roles.put(step.getRole().getId(), step.getRole());

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/WorkflowDefinitionMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/WorkflowDefinitionMatcher.java
@@ -17,6 +17,7 @@ import java.util.UUID;
 import org.dspace.app.rest.model.WorkflowDefinitionRest;
 import org.dspace.xmlworkflow.factory.XmlWorkflowFactory;
 import org.dspace.xmlworkflow.factory.XmlWorkflowServiceFactory;
+import org.dspace.xmlworkflow.state.Step;
 import org.dspace.xmlworkflow.state.Workflow;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
@@ -59,6 +60,12 @@ public class WorkflowDefinitionMatcher {
                 hasJsonPath("$.metadata", Matchers.allOf(
                         MetadataMatcher.matchMetadata("dc.title", name)
                 ))
+        );
+    }
+
+    public static Matcher<? super Object> matchStep(Step step) {
+        return allOf(
+                hasJsonPath("$.id", is(step.getId()))
         );
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/WorkflowDefinitionMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/WorkflowDefinitionMatcher.java
@@ -63,6 +63,14 @@ public class WorkflowDefinitionMatcher {
         );
     }
 
+    /**
+     * Verifies that the content of the `json` matches
+     * the detail of the steps
+     * Actually we can checks only the identifier to assure they are the same.
+     * 
+     * @param step target step of the workflow
+     * @return Matcher
+     */
     public static Matcher<? super Object> matchStep(Step step) {
         return allOf(
                 hasJsonPath("$.id", is(step.getId()))


### PR DESCRIPTION
## References
* Fixes #8419 

## Description
The configuration file `workflow.xml` contains workflows with steps, but once readed the steps' ordering is not preserved.

## Instructions for Reviewers
List of changes in this PR:
* Changed with `LinkedHashMap` inside `Workflow.java` in order to preserve order;
* Added some new tests to verify that the order is correct.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
