### PR TITLE
Minor Docker fixes for 6.x. Ensure correct permissions and ensure wget installed

### DIFF
--- a/Dockerfile.cli.jdk8
+++ b/Dockerfile.cli.jdk8
@@ -15,7 +15,8 @@ WORKDIR /app
 
 # The dspace-install directory will be written to /install
 RUN mkdir /install \
-    && chown -Rv dspace: /install
+    && chown -Rv dspace: /install \
+    && chown -Rv dspace: /app
 
 USER dspace
 
@@ -38,10 +39,15 @@ WORKDIR /dspace-src
 ENV ANT_VERSION 1.10.7
 ENV ANT_HOME /tmp/ant-$ANT_VERSION
 ENV PATH $ANT_HOME/bin:$PATH
-
+# Need wget to install ant
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends wget \
+    && apt-get purge -y --auto-remove \
+    && rm -rf /var/lib/apt/lists/*
+# Download and install 'ant'
 RUN mkdir $ANT_HOME && \
     wget -qO- "https://archive.apache.org/dist/ant/binaries/apache-ant-$ANT_VERSION-bin.tar.gz" | tar -zx --strip-components=1 -C $ANT_HOME
-
+# Run necessary 'ant' deploy scripts
 RUN ant init_installation update_configs update_code
 
 # Step 3 - Run jdk

--- a/Dockerfile.dependencies
+++ b/Dockerfile.dependencies
@@ -9,7 +9,9 @@ WORKDIR /app
 # The Mirage2 build cannot run as root.  Setting the user to dspace.
 RUN useradd dspace \
     && mkdir /home/dspace \
-    && chown -Rv dspace: /home/dspace
+    && chown -Rv dspace: /home/dspace \
+    && chown -Rv dspace: /app
+
 USER dspace
 
 # Copy the DSpace source code into the workdir (excluding .dockerignore contents)

--- a/Dockerfile.jdk8
+++ b/Dockerfile.jdk8
@@ -15,7 +15,8 @@ WORKDIR /app
 
 # The dspace-install directory will be written to /install
 RUN mkdir /install \
-    && chown -Rv dspace: /install
+    && chown -Rv dspace: /install \
+    && chown -Rv dspace: /app
 
 USER dspace
 
@@ -38,10 +39,15 @@ WORKDIR /dspace-src
 ENV ANT_VERSION 1.10.7
 ENV ANT_HOME /tmp/ant-$ANT_VERSION
 ENV PATH $ANT_HOME/bin:$PATH
-
+# Need wget to install ant
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends wget \
+    && apt-get purge -y --auto-remove \
+    && rm -rf /var/lib/apt/lists/*
+# Download and install 'ant'
 RUN mkdir $ANT_HOME && \
     wget -qO- "https://archive.apache.org/dist/ant/binaries/apache-ant-$ANT_VERSION-bin.tar.gz" | tar -zx --strip-components=1 -C $ANT_HOME
-
+# Run necessary 'ant' deploy scripts
 RUN ant init_installation update_configs update_code update_webapps update_solr_indexes
 
 # Step 3 - Run tomcat

--- a/Dockerfile.jdk8-test
+++ b/Dockerfile.jdk8-test
@@ -15,7 +15,8 @@ WORKDIR /app
 
 # The dspace-install directory will be written to /install
 RUN mkdir /install \
-    && chown -Rv dspace: /install
+    && chown -Rv dspace: /install \
+    && chown -Rv dspace: /app
 
 USER dspace
 
@@ -38,10 +39,15 @@ WORKDIR /dspace-src
 ENV ANT_VERSION 1.10.7
 ENV ANT_HOME /tmp/ant-$ANT_VERSION
 ENV PATH $ANT_HOME/bin:$PATH
-
+# Need wget to install ant
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends wget \
+    && apt-get purge -y --auto-remove \
+    && rm -rf /var/lib/apt/lists/*
+# Download and install 'ant'
 RUN mkdir $ANT_HOME && \
     wget -qO- "https://archive.apache.org/dist/ant/binaries/apache-ant-$ANT_VERSION-bin.tar.gz" | tar -zx --strip-components=1 -C $ANT_HOME
-
+# Run necessary 'ant' deploy scripts
 RUN ant init_installation update_configs update_code update_webapps update_solr_indexes
 
 # Step 3 - Run tomcat


### PR DESCRIPTION
## Description
Minor fixes to the Docker build process for `dspace-6_x`, based on Docker scripts on `main`.

Without these fixes, a local build won't work anymore.  In other words, this will fail:
`docker-compose -f docker-compose.yml -f docker-compose-cli.yml build`

The fixes here are minor and just include:
* Setting proper permissions on `/app` build directory (same as on `main`)
* Ensuring `wget` installed prior to `ant` (same as on `main`).

These issues were discovered during final testing of 6.4 on Docker. 