### PR TITLE
maven build speed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,7 @@
                             <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
                             <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
                             <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
+                            <arg>-Xpkginfo:always</arg>
                         </compilerArgs>
                         <annotationProcessorPaths>
                             <path>


### PR DESCRIPTION
## References
Short [discussion in slack](https://dspace-org.slack.com/archives/C3SG47SGY/p1658726253385359)

## Description
Improves build (`mvn package`) time when no code is changed by about half.
(1:51 vs  0:56 for me).

## Instructions for Reviewers
Added argument for java compiler `-Xpkginfo:always` in `pom.xml`.

I didn't manage to think of any problems this could cause.

## Explanation

### The problem
There are quite a few `package-info.java` files in Dspace code.
Those don't get their `.class` files generated by default. 
However, that means maven considers those sources stale, even though they
just contain package comment. 
Since there is no equivalent `.class`, file is considered changed and 
compilation for whole package is triggered. This happens for every 
module (that contains any `package-info.java`). This is obviously not
necessary.

### The fix
Easiest fix is to generate `.class` files for every `package-info.java`,
so that maven doesn't consider it stale and does not trigger  
recompilation. Argument `-Xpkginfo:always` for java compiler does just 
that.  It's added to parent `pom.xml` as `<arg>-Xpkginfo:always</arg>`.

### Note
As stated in description, this change improves build (`mvn package`) time when nothing is changed by about half.
(1:51 vs  0:56 for me).

This is just illustration, the real benefit is when you make changes
in only one or few modules and call `mvn package`. Unchanged modules
affected by this don't get unnecesarily recompiled, shortening the time.

Note the speed up is only when no `mvn clean` is used and when code in
at least a few modules is not changed. However, changing code in one
module should not trigger recompilation of all modules.