### PR TITLE
Fix browse by title filter doesn't work with diacritics

### DIFF
--- a/dspace-api/src/main/java/org/dspace/browse/BrowseEngine.java
+++ b/dspace-api/src/main/java/org/dspace/browse/BrowseEngine.java
@@ -203,7 +203,7 @@ public class BrowseEngine {
             // get the table name that we are going to be getting our data from
             dao.setTable(browseIndex.getTableName());
 
-            if (scope.getBrowseIndex().getDataType().equals(OrderFormat.TITLE)) {
+            if (scope.getBrowseIndex() != null && OrderFormat.TITLE.equals(scope.getBrowseIndex().getDataType())) {
                 // For browsing by title, apply the same normalization applied to indexed titles
                 dao.setStartsWith(normalizeJumpToValue(scope.getStartsWith()));
             } else {

--- a/dspace-api/src/main/java/org/dspace/browse/BrowseEngine.java
+++ b/dspace-api/src/main/java/org/dspace/browse/BrowseEngine.java
@@ -203,7 +203,12 @@ public class BrowseEngine {
             // get the table name that we are going to be getting our data from
             dao.setTable(browseIndex.getTableName());
 
-            dao.setStartsWith(StringUtils.lowerCase(scope.getStartsWith()));
+            if (scope.getBrowseIndex().getDataType().equals(OrderFormat.TITLE)) {
+                // For browsing by title, apply the same normalization applied to indexed titles
+                dao.setStartsWith(normalizeJumpToValue(scope.getStartsWith()));
+            } else {
+                dao.setStartsWith(StringUtils.lowerCase(scope.getStartsWith()));
+            }
 
             // tell the browse query whether we are ascending or descending on the value
             dao.setAscending(scope.isAscending());

--- a/dspace-api/src/main/java/org/dspace/sort/OrderFormatTitle.java
+++ b/dspace-api/src/main/java/org/dspace/sort/OrderFormatTitle.java
@@ -10,6 +10,7 @@ package org.dspace.sort;
 import org.dspace.text.filter.DecomposeDiactritics;
 import org.dspace.text.filter.LowerCaseAndTrim;
 import org.dspace.text.filter.StandardInitialArticleWord;
+import org.dspace.text.filter.StripDiacritics;
 import org.dspace.text.filter.TextFilter;
 
 /**
@@ -21,6 +22,7 @@ public class OrderFormatTitle extends AbstractTextFilterOFD {
     {
         filters = new TextFilter[] {new StandardInitialArticleWord(),
             new DecomposeDiactritics(),
+            new StripDiacritics(),
             new LowerCaseAndTrim()};
     }
 }

--- a/dspace-api/src/main/java/org/dspace/sort/OrderFormatTitleMarc21.java
+++ b/dspace-api/src/main/java/org/dspace/sort/OrderFormatTitleMarc21.java
@@ -10,6 +10,7 @@ package org.dspace.sort;
 import org.dspace.text.filter.DecomposeDiactritics;
 import org.dspace.text.filter.LowerCaseAndTrim;
 import org.dspace.text.filter.MARC21InitialArticleWord;
+import org.dspace.text.filter.StripDiacritics;
 import org.dspace.text.filter.StripLeadingNonAlphaNum;
 import org.dspace.text.filter.TextFilter;
 
@@ -22,6 +23,7 @@ public class OrderFormatTitleMarc21 extends AbstractTextFilterOFD {
     {
         filters = new TextFilter[] {new MARC21InitialArticleWord(),
             new DecomposeDiactritics(),
+            new StripDiacritics(),
             new StripLeadingNonAlphaNum(),
             new LowerCaseAndTrim()};
     }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BrowsesResourceControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BrowsesResourceControllerIT.java
@@ -905,7 +905,7 @@ public class BrowsesResourceControllerIT extends AbstractControllerIntegrationTe
 
         //** WHEN **
         //An anonymous user browses the entries in the Browse by Author endpoint
-        //with startsWith set to Ú (accented)
+        //with startsWith set to Ó (accented)
         getClient().perform(get("/api/discover/browses/author/entries?startsWith=Ó"))
 
                    //** THEN **
@@ -930,7 +930,7 @@ public class BrowsesResourceControllerIT extends AbstractControllerIntegrationTe
 
         //** WHEN **
         //An anonymous user browses the entries in the Browse by Subject endpoint
-        //with startsWith set to Cana
+        //with startsWith set to Tele
         getClient().perform(get("/api/discover/browses/subject/entries?startsWith=Tele"))
 
                    //** THEN **

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BrowsesResourceControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BrowsesResourceControllerIT.java
@@ -1218,6 +1218,86 @@ public class BrowsesResourceControllerIT extends AbstractControllerIntegrationTe
                         )));
     }
 
+
+    @Test
+    public void testBrowseByTitleStartsWithAndDiacritics() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+        //1. A community-collection structure with one parent community and one collection.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+        Collection col1 = CollectionBuilder.createCollection(context, parentCommunity).withName("Collection 1").build();
+
+        //2. 2 public items that are readable by Anonymous
+        Item item1 = ItemBuilder.createItem(context, col1)
+                .withTitle("Número 1")
+                .withAuthor("Surname, Name")
+                .withIssueDate("2020")
+                .build();
+
+        Item item2 = ItemBuilder.createItem(context, col1)
+                .withTitle("Numero 2")
+                .withAuthor("Surname, Name")
+                .withIssueDate("2010")
+                .build();
+
+        context.restoreAuthSystemState();
+
+        //** WHEN **
+        //An anonymous user browses the items in the Browse by Title endpoint
+        //with startsWith set to Num (unaccented)
+        getClient().perform(get("/api/discover/browses/title/items?startsWith=Num")
+                        .param("size", "2"))
+
+                //** THEN **
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //We expect the content type to be "application/hal+json;charset=UTF-8"
+                .andExpect(content().contentType(contentType))
+
+                //We expect the totalElements to be the 1 item present in the repository
+                .andExpect(jsonPath("$.page.totalElements", is(2)))
+                //We expect to jump to page 2 in the index
+                .andExpect(jsonPath("$.page.number", is(0)))
+                .andExpect(jsonPath("$._links.self.href", containsString("startsWith=Num")))
+
+                //Verify that the index contains both items (the accented and the unaccented)
+                .andExpect(jsonPath("$._embedded.items",
+                        contains(ItemMatcher.matchItemWithTitleAndDateIssued(item1,
+                                        "Número 1", "2020"),
+                                ItemMatcher.matchItemWithTitleAndDateIssued(item2,
+                                        "Numero 2", "2010")
+                        )));
+
+        //An anonymous user browses the items in the Browse by Title endpoint
+        //with startsWith set to Núm (accented)
+        getClient().perform(get("/api/discover/browses/title/items?startsWith=Núm")
+                        .param("size", "2"))
+
+                //** THEN **
+                //The status has to be 200 OK
+                .andExpect(status().isOk())
+                //We expect the content type to be "application/hal+json;charset=UTF-8"
+                .andExpect(content().contentType(contentType))
+
+                //We expect the totalElements to be the 1 item present in the repository
+                .andExpect(jsonPath("$.page.totalElements", is(2)))
+                //We expect to jump to page 2 in the index
+                .andExpect(jsonPath("$.page.number", is(0)))
+                .andExpect(jsonPath("$._links.self.href", containsString("startsWith=Núm")))
+
+                //Verify that the index contains both items (the accented and the unaccented)
+                .andExpect(jsonPath("$._embedded.items",
+                        contains(ItemMatcher.matchItemWithTitleAndDateIssued(item1,
+                                        "Número 1", "2020"),
+                                ItemMatcher.matchItemWithTitleAndDateIssued(item2,
+                                        "Numero 2", "2010")
+                        )));
+
+    }
+
     @Test
     public void findBrowseByTitleItemsFullProjectionTest() throws Exception {
         context.turnOffAuthorisationSystem();


### PR DESCRIPTION
## References

* Fixes #8434

## Description

Change the default normalization of the indexed text used for sorting and filtering titles to strip the diacritics.

It is similar to the PR applied for filtering accented content in subject/author indexes: #2698

## Instructions for Reviewers

To test the changes:

* Publish an item with an accented title and another with an unaccented title. By example: "Número 1" and "Numero 2"
* Filter by title with value: "Número". Should return the two items.
* Filter by title with value: "Numero".  Should return the two items.

List of changes in this PR:
* Apply the StripDiacritics filter to the normalization of indexed titles
* Applies the same normalization to the user-input text when the user is filtering by title
* Include a new test to check the behavior with diacritics
* Correct two comments that I forgot to change in PR #2698

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
