### PR TITLE
Update to oclc-harvester2 v1.0.0 and remove Xalan

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -548,16 +548,10 @@
             <groupId>com.ibm.icu</groupId>
             <artifactId>icu4j</artifactId>
         </dependency>
-        <!-- Codebase at https://github.com/OCLC-Research/oaiharvester2/ -->
+        <!-- Codebase at https://github.com/DSpace/oclc-harvester2 -->
         <dependency>
             <groupId>org.dspace</groupId>
             <artifactId>oclc-harvester2</artifactId>
-        </dependency>
-        <!-- Xalan is REQUIRED by 'oclc-harvester2' listed above (OAI harvesting fails without it).
-             Please do NOT use Xalan in DSpace codebase as it is not well maintained. -->
-        <dependency>
-            <groupId>xalan</groupId>
-            <artifactId>xalan</artifactId>
         </dependency>
         <dependency>
             <groupId>org.dspace</groupId>

--- a/dspace-api/src/main/java/org/dspace/harvest/HarvestedCollectionServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/harvest/HarvestedCollectionServiceImpl.java
@@ -21,8 +21,6 @@ import java.util.List;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPathExpressionException;
 
-import org.oclc.oai.harvester2.verb.Identify;
-import org.oclc.oai.harvester2.verb.ListIdentifiers;
 import org.dspace.content.Collection;
 import org.dspace.core.Context;
 import org.dspace.harvest.dao.HarvestedCollectionDAO;
@@ -33,6 +31,8 @@ import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.Namespace;
 import org.jdom2.input.DOMBuilder;
+import org.oclc.oai.harvester2.verb.Identify;
+import org.oclc.oai.harvester2.verb.ListIdentifiers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.w3c.dom.DOMException;
 import org.xml.sax.SAXException;

--- a/dspace-api/src/main/java/org/dspace/harvest/HarvestedCollectionServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/harvest/HarvestedCollectionServiceImpl.java
@@ -19,10 +19,10 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.TransformerException;
+import javax.xml.xpath.XPathExpressionException;
 
-import ORG.oclc.oai.harvester2.verb.Identify;
-import ORG.oclc.oai.harvester2.verb.ListIdentifiers;
+import org.oclc.oai.harvester2.verb.Identify;
+import org.oclc.oai.harvester2.verb.ListIdentifiers;
 import org.dspace.content.Collection;
 import org.dspace.core.Context;
 import org.dspace.harvest.dao.HarvestedCollectionDAO;
@@ -198,7 +198,7 @@ public class HarvestedCollectionServiceImpl implements HarvestedCollectionServic
         // First, see if we can contact the target server at all.
         try {
             new Identify(oaiSource);
-        } catch (IOException | ParserConfigurationException | TransformerException | SAXException ex) {
+        } catch (IOException | ParserConfigurationException | XPathExpressionException | SAXException ex) {
             errorSet.add(OAI_ADDRESS_ERROR + ": OAI server could not be reached.");
             return errorSet;
         }
@@ -216,7 +216,7 @@ public class HarvestedCollectionServiceImpl implements HarvestedCollectionServic
         try {
             OREOAIPrefix = OAIHarvester.oaiResolveNamespaceToPrefix(oaiSource, OAIHarvester.getORENamespace().getURI());
             DMDOAIPrefix = OAIHarvester.oaiResolveNamespaceToPrefix(oaiSource, DMD_NS.getURI());
-        } catch (IOException | ParserConfigurationException | TransformerException | SAXException ex) {
+        } catch (IOException | ParserConfigurationException | XPathExpressionException | SAXException ex) {
             errorSet.add(OAI_ADDRESS_ERROR
                 + ": OAI did not respond to ListMetadataFormats query  ("
                 + ORE_NS.getPrefix() + ":" + OREOAIPrefix + " ; "
@@ -260,7 +260,8 @@ public class HarvestedCollectionServiceImpl implements HarvestedCollectionServic
                     }
                 }
             }
-        } catch (IOException | ParserConfigurationException | TransformerException | DOMException | SAXException e) {
+        } catch (IOException | ParserConfigurationException | XPathExpressionException | DOMException |
+                 SAXException e) {
             errorSet.add(OAI_ADDRESS_ERROR + ": OAI server could not be reached");
             return errorSet;
         } catch (RuntimeException re) {

--- a/dspace-api/src/main/java/org/dspace/harvest/OAIHarvester.java
+++ b/dspace-api/src/main/java/org/dspace/harvest/OAIHarvester.java
@@ -28,12 +28,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
 import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.TransformerException;
+import javax.xml.xpath.XPathExpressionException;
 
-import ORG.oclc.oai.harvester2.verb.GetRecord;
-import ORG.oclc.oai.harvester2.verb.Identify;
-import ORG.oclc.oai.harvester2.verb.ListMetadataFormats;
-import ORG.oclc.oai.harvester2.verb.ListRecords;
+import org.oclc.oai.harvester2.verb.GetRecord;
+import org.oclc.oai.harvester2.verb.Identify;
+import org.oclc.oai.harvester2.verb.ListMetadataFormats;
+import org.oclc.oai.harvester2.verb.ListRecords;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -493,11 +493,11 @@ public class OAIHarvester {
      * @throws HarvestingException          if harvesting error
      * @throws ParserConfigurationException XML parsing error
      * @throws SAXException                 if XML processing error
-     * @throws TransformerException         if XML transformer error
+     * @throws XPathExpressionException     if XPath error
      */
     protected void processRecord(Element record, String OREPrefix, final long currentRecord, long totalListSize)
         throws SQLException, AuthorizeException, IOException, CrosswalkException, HarvestingException,
-        ParserConfigurationException, SAXException, TransformerException {
+        ParserConfigurationException, SAXException, XPathExpressionException {
         WorkspaceItem wi = null;
         Date timeStart = new Date();
 
@@ -769,10 +769,10 @@ public class OAIHarvester {
      * @throws IOException                  if IO error
      * @throws SAXException                 if XML processing error
      * @throws ParserConfigurationException XML parsing error
-     * @throws TransformerException         if XML transformer error
+     * @throws XPathExpressionException     if XPath error
      */
     private String oaiGetDateGranularity(String oaiSource)
-        throws IOException, ParserConfigurationException, SAXException, TransformerException {
+        throws IOException, ParserConfigurationException, SAXException, XPathExpressionException {
         Identify iden = new Identify(oaiSource);
         return iden.getDocument().getElementsByTagNameNS(OAI_NS.getURI(), "granularity").item(0).getTextContent();
     }
@@ -789,11 +789,11 @@ public class OAIHarvester {
      *                                      operations.
      * @throws ParserConfigurationException XML parsing error
      * @throws SAXException                 if XML processing error
-     * @throws TransformerException         if XML transformer error
+     * @throws XPathExpressionException     if XPath error
      * @throws ConnectException             if could not connect to OAI server
      */
     public static String oaiResolveNamespaceToPrefix(String oaiSource, String MDNamespace)
-        throws IOException, ParserConfigurationException, SAXException, TransformerException, ConnectException {
+        throws IOException, ParserConfigurationException, SAXException, XPathExpressionException, ConnectException {
         String metaPrefix = null;
 
         // Query the OAI server for the metadata
@@ -866,11 +866,11 @@ public class OAIHarvester {
      *                                      operations.
      * @throws ParserConfigurationException XML parsing error
      * @throws SAXException                 if XML processing error
-     * @throws TransformerException         if XML transformer error
+     * @throws XPathExpressionException     if XPath error
      * @throws HarvestingException          if harvesting error
      */
     protected List<Element> getMDrecord(String oaiSource, String itemOaiId, String metadataPrefix)
-        throws IOException, ParserConfigurationException, SAXException, TransformerException, HarvestingException {
+        throws IOException, ParserConfigurationException, SAXException, XPathExpressionException, HarvestingException {
         GetRecord getRecord = new GetRecord(oaiSource, itemOaiId, metadataPrefix);
         Set<String> errorSet = new HashSet<>();
         // If the metadata is not available for this item, can the whole thing

--- a/dspace-api/src/main/java/org/dspace/harvest/OAIHarvester.java
+++ b/dspace-api/src/main/java/org/dspace/harvest/OAIHarvester.java
@@ -30,10 +30,6 @@ import java.util.TimeZone;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPathExpressionException;
 
-import org.oclc.oai.harvester2.verb.GetRecord;
-import org.oclc.oai.harvester2.verb.Identify;
-import org.oclc.oai.harvester2.verb.ListMetadataFormats;
-import org.oclc.oai.harvester2.verb.ListRecords;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -76,6 +72,10 @@ import org.jdom2.Element;
 import org.jdom2.Namespace;
 import org.jdom2.input.DOMBuilder;
 import org.jdom2.output.XMLOutputter;
+import org.oclc.oai.harvester2.verb.GetRecord;
+import org.oclc.oai.harvester2.verb.Identify;
+import org.oclc.oai.harvester2.verb.ListMetadataFormats;
+import org.oclc.oai.harvester2.verb.ListRecords;
 import org.xml.sax.SAXException;
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -1575,18 +1575,11 @@
                 <artifactId>ojdbc6</artifactId>
                 <version>11.2.0.4.0</version>
             </dependency>
-            <!-- Codebase at https://github.com/OCLC-Research/oaiharvester2/ -->
+            <!-- Codebase at https://github.com/DSpace/oclc-harvester2 -->
             <dependency>
                 <groupId>org.dspace</groupId>
                 <artifactId>oclc-harvester2</artifactId>
-                <version>0.1.12</version>
-            </dependency>
-            <!-- Xalan is REQUIRED by 'oclc-harvester2' listed above (OAI harvesting fails without it).
-                 Please do NOT use Xalan in DSpace codebase as it is not well maintained. -->
-            <dependency>
-                <groupId>xalan</groupId>
-                <artifactId>xalan</artifactId>
-                <version>2.7.2</version>
+                <version>1.0.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
## References
* Fixes #8351 
* Fixes CVE-2022-34169 (by removing Xalan)

## Description
This PR uses an updated version of `oclc-harvester2` which no longer relies on older dependencies like Xalan and log4j v1.  This updated version can be found in https://github.com/DSpace/oclc-harvester2 (This project was based heavily on a fork of the original OCLC harvester code, see project README for more details).

(NOTE: After verifying everything works on my end, I released v1.0.0 of the new `oclc-harvester2`.  It's available in Maven Central and at https://github.com/DSpace/oclc-harvester2/releases/tag/oclc-harvester2-1.0.0)

This PR allows us to completely remove Xalan again, fixing CVE-2022-34169

I've tested this PR locally with the updated version of `oclc-harvester2` and verified that we don't reintroduce #8347.

## Instructions for Reviewers
* Spin up this PR with the new version of `oclc-harvester2`
* Verify OAI Harvesting works from the DSpace 7 UI: (1) create a collection, (2) change it's "Content Source" to a harvesting collection & (3) harvest from an OAI endpoint (you can use `http://demo.dspace.org/oai/request` with set id `col_10673_52` as an example).
* Verify that OAI harvest works from commandline.  The easiest way is just to test the PING command, like this
```
./dspace harvest -g -a http://demo.dspace.org/oai/request -i col_10673_52
```