### PR TITLE
use org.jbibtex.LaTeXParser to handle BibTeX diacritics

### DIFF
--- a/dspace-api/src/main/java/org/dspace/importer/external/bibtex/service/BibtexImportMetadataSourceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/bibtex/service/BibtexImportMetadataSourceServiceImpl.java
@@ -73,8 +73,17 @@ public class BibtexImportMetadataSourceServiceImpl extends AbstractPlainMetadata
                 if (entry.getValue().getFields() != null) {
                     for (Entry<Key,Value> subentry : entry.getValue().getFields().entrySet()) {
                         PlainMetadataKeyValueItem innerItem = new PlainMetadataKeyValueItem();
-                        innerItem.setKey(subentry.getKey().getValue());
-                        innerItem.setValue(subentry.getValue().toUserString());
+                        innerItem.setKey(subentry.getKey().getValue().toLowerCase());
+                        String latexString = subentry.getValue().toUserString();
+                        try {
+                            org.jbibtex.LaTeXParser laTeXParser = new org.jbibtex.LaTeXParser();
+                            List<org.jbibtex.LaTeXObject> latexObjects = laTeXParser.parse(latexString);
+                            org.jbibtex.LaTeXPrinter laTeXPrinter = new org.jbibtex.LaTeXPrinter();
+                            String plainTextString = laTeXPrinter.print(latexObjects);
+                            innerItem.setValue(plainTextString.replaceAll("\n", " "));
+                        } catch (ParseException e) {
+                            innerItem.setValue(latexString);
+                        }
                         keyValues.add(innerItem);
                     }
                 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkspaceItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkspaceItemRestRepositoryIT.java
@@ -996,6 +996,97 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
     }
 
     @Test
+    public void createSingleWorkspaceItemFromBibtexFileWithDiacriticsTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+        //1. A community-collection structure with one parent community with sub-community and two collections.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                .withName("Sub Community")
+                .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1)
+                .withName("Collection 1")
+                .withSubmitterGroup(eperson)
+                .build();
+        Collection col2 = CollectionBuilder.createCollection(context, child1)
+                .withName("Collection 2")
+                .withSubmitterGroup(eperson)
+                .build();
+
+        InputStream bibtex = getClass().getResourceAsStream("bibtex-test-diacritics.bib");
+        final MockMultipartFile bibtexFile = new MockMultipartFile("file", "/local/path/bibtex-test-diacritics.bib",
+                "application/x-bibtex", bibtex);
+
+        context.restoreAuthSystemState();
+
+        AtomicReference<List<Integer>> idRef = new AtomicReference<>();
+        String authToken = getAuthToken(eperson.getEmail(), password);
+        try {
+            // create a workspaceitem from a single bibliographic entry file explicitly in the default collection (col1)
+            getClient(authToken).perform(multipart("/api/submission/workspaceitems")
+                            .file(bibtexFile))
+                    // create should return 200, 201 (created) is better for single resource
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$._embedded.workspaceitems[0].sections." +
+                                    "traditionalpageone['dc.title'][0].value",
+                            is("The German umlauts: ÄÖüß")))
+                    .andExpect(
+                            jsonPath("$._embedded.workspaceitems[0]._embedded.collection.id",
+                                    is(col1.getID().toString())))
+                    .andExpect(jsonPath("$._embedded.workspaceitems[0].sections.upload.files[0]"
+                                    + ".metadata['dc.source'][0].value",
+                            is("/local/path/bibtex-test-diacritics.bib")))
+                    .andExpect(jsonPath("$._embedded.workspaceitems[0].sections.upload.files[0]"
+                                    + ".metadata['dc.title'][0].value",
+                            is("bibtex-test-diacritics.bib")))
+                    .andExpect(
+                            jsonPath("$._embedded.workspaceitems[*]._embedded.upload").doesNotExist())
+                    .andDo(result -> idRef.set(read(result.getResponse().getContentAsString(),
+                            "$._embedded.workspaceitems[*].id")));
+        } finally {
+            if (idRef != null && idRef.get() != null) {
+                for (int i : idRef.get()) {
+                    WorkspaceItemBuilder.deleteWorkspaceItem(i);
+                }
+            }
+        }
+
+        // create a workspaceitem from a single bibliographic entry file explicitly in the col2
+        try {
+            getClient(authToken).perform(multipart("/api/submission/workspaceitems")
+                            .file(bibtexFile)
+                            .param("owningCollection", col2.getID().toString()))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$._embedded.workspaceitems[0].sections." +
+                                    "traditionalpageone['dc.title'][0].value",
+                            is("The German umlauts: ÄÖüß")))
+                    .andExpect(
+                            jsonPath("$._embedded.workspaceitems[0]._embedded.collection.id",
+                                    is(col2.getID().toString())))
+                    .andExpect(jsonPath("$._embedded.workspaceitems[0].sections.upload.files[0]"
+                                    + ".metadata['dc.source'][0].value",
+                            is("/local/path/bibtex-test-diacritics.bib")))
+                    .andExpect(jsonPath("$._embedded.workspaceitems[0].sections.upload"
+                                    + ".files[0].metadata['dc.title'][0].value",
+                            is("bibtex-test-diacritics.bib")))
+                    .andExpect(
+                            jsonPath("$._embedded.workspaceitems[*]._embedded.upload").doesNotExist())
+                    .andDo(result -> idRef.set(read(result.getResponse().getContentAsString(),
+                            "$._embedded.workspaceitems[*].id")));
+        } finally {
+            if (idRef != null && idRef.get() != null) {
+                for (int i : idRef.get()) {
+                    WorkspaceItemBuilder.deleteWorkspaceItem(i);
+                }
+            }
+        }
+        bibtex.close();
+    }
+
+    @Test
     /**
      * Test the creation of workspaceitems POSTing to the resource collection endpoint a csv file
      *

--- a/dspace-server-webapp/src/test/resources/org/dspace/app/rest/bibtex-test-diacritics.bib
+++ b/dspace-server-webapp/src/test/resources/org/dspace/app/rest/bibtex-test-diacritics.bib
@@ -1,0 +1,4 @@
+@misc{ Nobody01,
+       author = "Mo\ss",
+       title = { The German umlauts: \"A{\"O}{\"{u}}\ss },
+       year = "2006" }


### PR DESCRIPTION
## References
* Fixes #8453

## Description
Use org.jbibtex.LaTeXParser to handle BibTeX diacritics; also handle mixed-case BibTeX keys.

## Instructions for Reviewers
List of changes in this PR:
* Use LaTeXParser to handle, for example, BibTeX diacritics (still common in Germany)
* convert BibTeX keys to lower case to handle some input files we've seen

An example file is included in #8453.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- n/a My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- n/a If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- n/a If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
