### PR TITLE
Expose BibTeX document type as PlainMetadataKeyValueItem during import

### DIFF
--- a/dspace-api/src/main/java/org/dspace/importer/external/bibtex/service/BibtexImportMetadataSourceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/bibtex/service/BibtexImportMetadataSourceServiceImpl.java
@@ -70,6 +70,10 @@ public class BibtexImportMetadataSourceServiceImpl extends AbstractPlainMetadata
                 keyValueItem.setKey(entry.getValue().getType().getValue());
                 keyValueItem.setValue(entry.getKey().getValue());
                 keyValues.add(keyValueItem);
+                PlainMetadataKeyValueItem typeItem = new PlainMetadataKeyValueItem();
+                typeItem.setKey("type");
+                typeItem.setValue(entry.getValue().getType().getValue());
+                keyValues.add(typeItem);
                 if (entry.getValue().getFields() != null) {
                     for (Entry<Key,Value> subentry : entry.getValue().getFields().entrySet()) {
                         PlainMetadataKeyValueItem innerItem = new PlainMetadataKeyValueItem();

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkspaceItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkspaceItemRestRepositoryIT.java
@@ -994,6 +994,107 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
         }
         bibtex.close();
     }
+    @Test
+    /**
+     * Test the creation of workspaceitems POSTing to the resource collection endpoint a bibtex file
+     *
+     * @throws Exception
+     */
+    public void createSingleWorkspaceItemFromBibtexArticleFileWithOneEntryTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+        //1. A community-collection structure with one parent community with sub-community and two collections.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                .withName("Sub Community")
+                .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1)
+                .withName("Collection 1")
+                .withSubmitterGroup(eperson)
+                .build();
+        Collection col2 = CollectionBuilder.createCollection(context, child1)
+                .withName("Collection 2")
+                .withSubmitterGroup(eperson)
+                .build();
+
+        InputStream bibtex = getClass().getResourceAsStream("bibtex-test-article.bib");
+        final MockMultipartFile bibtexFile = new MockMultipartFile("file", "/local/path/bibtex-test-article.bib",
+                "application/x-bibtex", bibtex);
+
+        context.restoreAuthSystemState();
+
+        AtomicReference<List<Integer>> idRef = new AtomicReference<>();
+        String authToken = getAuthToken(eperson.getEmail(), password);
+        try {
+            // create a workspaceitem from a single bibliographic entry file explicitly in the default collection (col1)
+            getClient(authToken).perform(multipart("/api/submission/workspaceitems")
+                            .file(bibtexFile))
+                    // create should return 200, 201 (created) is better for single resource
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$._embedded.workspaceitems[0]" +
+                                    ".sections.traditionalpageone['dc.title'][0].value",
+                            is("My Article")))
+                    .andExpect(jsonPath("$._embedded.workspaceitems[0]" +
+                                    ".sections.traditionalpageone['dc.type'][0].value",
+                            is("article")))
+                    .andExpect(
+                            jsonPath("$._embedded.workspaceitems[0]._embedded.collection.id",
+                                    is(col1.getID().toString())))
+                    .andExpect(jsonPath("$._embedded.workspaceitems[0].sections.upload.files[0]"
+                                    + ".metadata['dc.source'][0].value",
+                            is("/local/path/bibtex-test-article.bib")))
+                    .andExpect(jsonPath("$._embedded.workspaceitems[0].sections.upload.files[0]"
+                                    + ".metadata['dc.title'][0].value",
+                            is("bibtex-test-article.bib")))
+                    .andExpect(
+                            jsonPath("$._embedded.workspaceitems[*]._embedded.upload").doesNotExist())
+                    .andDo(result -> idRef.set(read(result.getResponse().getContentAsString(),
+                            "$._embedded.workspaceitems[*].id")));
+        } finally {
+            if (idRef != null && idRef.get() != null) {
+                for (int i : idRef.get()) {
+                    WorkspaceItemBuilder.deleteWorkspaceItem(i);
+                }
+            }
+        }
+
+        // create a workspaceitem from a single bibliographic entry file explicitly in the col2
+        try {
+            getClient(authToken).perform(multipart("/api/submission/workspaceitems")
+                            .file(bibtexFile)
+                            .param("owningCollection", col2.getID().toString()))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$._embedded.workspaceitems[0]" +
+                                    ".sections.traditionalpageone['dc.title'][0].value",
+                            is("My Article")))
+                    .andExpect(jsonPath("$._embedded.workspaceitems[0]" +
+                                    ".sections.traditionalpageone['dc.type'][0].value",
+                            is("article")))
+                    .andExpect(
+                            jsonPath("$._embedded.workspaceitems[0]._embedded.collection.id",
+                                    is(col2.getID().toString())))
+                    .andExpect(jsonPath("$._embedded.workspaceitems[0].sections.upload.files[0]"
+                                    + ".metadata['dc.source'][0].value",
+                            is("/local/path/bibtex-test-article.bib")))
+                    .andExpect(jsonPath("$._embedded.workspaceitems[0].sections.upload"
+                                    + ".files[0].metadata['dc.title'][0].value",
+                            is("bibtex-test-article.bib")))
+                    .andExpect(
+                            jsonPath("$._embedded.workspaceitems[*]._embedded.upload").doesNotExist())
+                    .andDo(result -> idRef.set(read(result.getResponse().getContentAsString(),
+                            "$._embedded.workspaceitems[*].id")));
+        } finally {
+            if (idRef != null && idRef.get() != null) {
+                for (int i : idRef.get()) {
+                    WorkspaceItemBuilder.deleteWorkspaceItem(i);
+                }
+            }
+        }
+        bibtex.close();
+    }
 
     @Test
     /**

--- a/dspace-server-webapp/src/test/resources/org/dspace/app/rest/bibtex-test-article.bib
+++ b/dspace-server-webapp/src/test/resources/org/dspace/app/rest/bibtex-test-article.bib
@@ -1,0 +1,4 @@
+@article{ Nobody01,
+       author = "Nobody Jr",
+       title = "My Article",
+       year = "2006" }

--- a/dspace/config/spring/api/bibtex-integration.xml
+++ b/dspace/config/spring/api/bibtex-integration.xml
@@ -17,6 +17,7 @@
             only matters here for postprocessing of the value. The mapped MetadatumContributor has full control over
             what metadatafield is generated.
         </description>
+        <entry key-ref="dcType" value-ref="bibtexTypeContrib" />
         <entry key-ref="dcTitle" value-ref="bibtexTitleContrib" />
         <entry key-ref="dcAuthors" value-ref="bibtexAuthorsContrib" />
         <entry key-ref="dcJournal" value-ref="bibtexJournalContrib" />
@@ -48,5 +49,10 @@
         <property name="field" ref="dcTitle"/>
         <property name="key" value="title" />
     </bean>
-    
+
+    <bean id="bibtexTypeContrib" class="org.dspace.importer.external.metadatamapping.contributor.SimpleMetadataContributor">
+        <property name="field" ref="dcType"/>
+        <property name="key" value="type" />
+    </bean>
+
 </beans>

--- a/dspace/config/spring/api/dublicore-metadata-mapper.xml
+++ b/dspace/config/spring/api/dublicore-metadata-mapper.xml
@@ -26,6 +26,9 @@
  	<bean id="dcTitle" class="org.dspace.importer.external.metadatamapping.MetadataFieldConfig">
         <constructor-arg value="dc.title"/>
     </bean>
+    <bean id="dcType" class="org.dspace.importer.external.metadatamapping.MetadataFieldConfig">
+        <constructor-arg value="dc.type"/>
+    </bean>
  	<bean id="dcAuthors" class="org.dspace.importer.external.metadatamapping.MetadataFieldConfig">
         <constructor-arg value="dc.contributor.author"/>
     </bean>


### PR DESCRIPTION
## References
* Fixes #8455 

## Description
Exposes BibTeX document type as the value of a `PlainMetadataKeyValueItem`. Code by @johannastaudinger (@uniba-ub).

## Instructions for Reviewers
Please let us know if further tests or configuration changes would be helpful.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- n/a My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- n/a If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- n/a If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.