### PR TITLE
SplitMetadataContributor.java: new class to split metadata values based on a regex

### DIFF
--- a/dspace-api/src/main/java/org/dspace/importer/external/metadatamapping/contributor/SplitMetadataContributor.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/metadatamapping/contributor/SplitMetadataContributor.java
@@ -1,0 +1,65 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.importer.external.metadatamapping.contributor;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.dspace.importer.external.metadatamapping.MetadataFieldMapping;
+import org.dspace.importer.external.metadatamapping.MetadatumDTO;
+
+/**
+ * Wrapper class used to split another MetadataContributor's output into distinct values.
+ * The split is performed by matching a regular expression against the wrapped MetadataContributor's output.
+ *
+ * @author Philipp Rumpf (philipp.rumpf@uni-bamberg.de)
+ */
+
+public class SplitMetadataContributor<T> implements MetadataContributor<T> {
+    private final MetadataContributor<T> innerContributor;
+    private final String regex;
+
+    /**
+     * @param innerContributor      The MetadataContributor whose output is split
+     * @param regex                 A regular expression matching the separator between different values
+     */
+    public SplitMetadataContributor(MetadataContributor<T> innerContributor, String regex) {
+        this.innerContributor = innerContributor;
+        this.regex = regex;
+    }
+
+    @Override
+    public void setMetadataFieldMapping(MetadataFieldMapping<T, MetadataContributor<T>> rt) {
+
+    }
+
+    /**
+     * Each metadatum returned by the wrapped MetadataContributor is split into one or more metadata values
+     * based on the provided regular expression.
+     *
+     * @param t The recordType object to retrieve metadata from
+     * @return The collection of processed metadata values
+     */
+    @Override
+    public Collection<MetadatumDTO> contributeMetadata(T t) {
+        Collection<MetadatumDTO> metadata = innerContributor.contributeMetadata(t);
+        ArrayList<MetadatumDTO> splitMetadata = new ArrayList<>();
+        for (MetadatumDTO metadatumDTO : metadata) {
+            String[] split = metadatumDTO.getValue().split(regex);
+            for (String splitItem : split) {
+                MetadatumDTO splitMetadatumDTO = new MetadatumDTO();
+                splitMetadatumDTO.setSchema(metadatumDTO.getSchema());
+                splitMetadatumDTO.setElement(metadatumDTO.getElement());
+                splitMetadatumDTO.setQualifier(metadatumDTO.getQualifier());
+                splitMetadatumDTO.setValue(splitItem);
+                splitMetadata.add(splitMetadatumDTO);
+            }
+        }
+        return splitMetadata;
+    }
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkspaceItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkspaceItemRestRepositoryIT.java
@@ -994,6 +994,7 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
         }
         bibtex.close();
     }
+
     @Test
     /**
      * Test the creation of workspaceitems POSTing to the resource collection endpoint a bibtex file
@@ -1173,6 +1174,112 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
                     .andExpect(jsonPath("$._embedded.workspaceitems[0].sections.upload"
                                     + ".files[0].metadata['dc.title'][0].value",
                             is("bibtex-test-diacritics.bib")))
+                    .andExpect(
+                            jsonPath("$._embedded.workspaceitems[*]._embedded.upload").doesNotExist())
+                    .andDo(result -> idRef.set(read(result.getResponse().getContentAsString(),
+                            "$._embedded.workspaceitems[*].id")));
+        } finally {
+            if (idRef != null && idRef.get() != null) {
+                for (int i : idRef.get()) {
+                    WorkspaceItemBuilder.deleteWorkspaceItem(i);
+                }
+            }
+        }
+        bibtex.close();
+    }
+
+    @Test
+    /**
+     * Test the creation of workspaceitems POSTing to the resource collection endpoint a bibtex file
+     *
+     * @throws Exception
+     */
+    public void createSingleWorkspaceItemFromBibtexFileWithMultipleAuthorsTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+        //1. A community-collection structure with one parent community with sub-community and two collections.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                .withName("Sub Community")
+                .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1)
+                .withName("Collection 1")
+                .withSubmitterGroup(eperson)
+                .build();
+        Collection col2 = CollectionBuilder.createCollection(context, child1)
+                .withName("Collection 2")
+                .withSubmitterGroup(eperson)
+                .build();
+
+        InputStream bibtex = getClass().getResourceAsStream("bibtex-test-multiple-authors.bib");
+        final MockMultipartFile bibtexFile = new MockMultipartFile("file",
+                "/local/path/bibtex-test-multiple-authors.bib",
+                "application/x-bibtex", bibtex);
+
+        context.restoreAuthSystemState();
+
+        AtomicReference<List<Integer>> idRef = new AtomicReference<>();
+        String authToken = getAuthToken(eperson.getEmail(), password);
+        try {
+            // create a workspaceitem from a single bibliographic entry file explicitly in the default collection (col1)
+            getClient(authToken).perform(multipart("/api/submission/workspaceitems")
+                            .file(bibtexFile))
+                    // create should return 200, 201 (created) is better for single resource
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$._embedded.workspaceitems[0]" +
+                                    ".sections.traditionalpageone['dc.title'][0].value",
+                            is("My Article")))
+                    .andExpect(jsonPath("$._embedded.workspaceitems[0]" +
+                                    ".sections.traditionalpageone['dc.contributor.author'][0].value",
+                            is("A. Nauthor")))
+                    .andExpect(jsonPath("$._embedded.workspaceitems[0]" +
+                                    ".sections.traditionalpageone['dc.contributor.author'][1].value",
+                            is("A. Nother")))
+                    .andExpect(jsonPath("$._embedded.workspaceitems[0]" +
+                                    ".sections.traditionalpageone['dc.contributor.author'][2].value",
+                            is("A. Third")))
+                    .andExpect(
+                            jsonPath("$._embedded.workspaceitems[0]._embedded.collection.id",
+                                    is(col1.getID().toString())))
+                    .andExpect(jsonPath("$._embedded.workspaceitems[0].sections.upload.files[0]"
+                                    + ".metadata['dc.source'][0].value",
+                            is("/local/path/bibtex-test-multiple-authors.bib")))
+                    .andExpect(jsonPath("$._embedded.workspaceitems[0].sections.upload.files[0]"
+                                    + ".metadata['dc.title'][0].value",
+                            is("bibtex-test-multiple-authors.bib")))
+                    .andExpect(
+                            jsonPath("$._embedded.workspaceitems[*]._embedded.upload").doesNotExist())
+                    .andDo(result -> idRef.set(read(result.getResponse().getContentAsString(),
+                            "$._embedded.workspaceitems[*].id")));
+        } finally {
+            if (idRef != null && idRef.get() != null) {
+                for (int i : idRef.get()) {
+                    WorkspaceItemBuilder.deleteWorkspaceItem(i);
+                }
+            }
+        }
+
+        // create a workspaceitem from a single bibliographic entry file explicitly in the col2
+        try {
+            getClient(authToken).perform(multipart("/api/submission/workspaceitems")
+                            .file(bibtexFile)
+                            .param("owningCollection", col2.getID().toString()))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$._embedded.workspaceitems[0]" +
+                                    ".sections.traditionalpageone['dc.title'][0].value",
+                            is("My Article")))
+                    .andExpect(
+                            jsonPath("$._embedded.workspaceitems[0]._embedded.collection.id",
+                                    is(col2.getID().toString())))
+                    .andExpect(jsonPath("$._embedded.workspaceitems[0].sections.upload.files[0]"
+                                    + ".metadata['dc.source'][0].value",
+                            is("/local/path/bibtex-test-multiple-authors.bib")))
+                    .andExpect(jsonPath("$._embedded.workspaceitems[0].sections.upload"
+                                    + ".files[0].metadata['dc.title'][0].value",
+                            is("bibtex-test-multiple-authors.bib")))
                     .andExpect(
                             jsonPath("$._embedded.workspaceitems[*]._embedded.upload").doesNotExist())
                     .andDo(result -> idRef.set(read(result.getResponse().getContentAsString(),

--- a/dspace-server-webapp/src/test/resources/org/dspace/app/rest/bibtex-test-multiple-authors.bib
+++ b/dspace-server-webapp/src/test/resources/org/dspace/app/rest/bibtex-test-multiple-authors.bib
@@ -1,0 +1,4 @@
+@misc{ Nobody01,
+       author = "A. Nauthor and A. Nother and A. Third",
+       title = "My Article",
+       year = "2006" }

--- a/dspace/config/spring/api/bibtex-integration.xml
+++ b/dspace/config/spring/api/bibtex-integration.xml
@@ -40,9 +40,14 @@
         <property name="key" value="journal" />
     </bean>
     
-    <bean id="bibtexAuthorsContrib" class="org.dspace.importer.external.metadatamapping.contributor.SimpleMetadataContributor">
-        <property name="field" ref="dcAuthors"/>
-        <property name="key" value="author" />
+    <bean id="bibtexAuthorsContrib" class="org.dspace.importer.external.metadatamapping.contributor.SplitMetadataContributor">
+        <constructor-arg name="innerContributor">
+            <bean class="org.dspace.importer.external.metadatamapping.contributor.SimpleMetadataContributor">
+                <property name="field" ref="dcAuthors"/>
+                <property name="key" value="author" />
+            </bean>
+        </constructor-arg>
+        <constructor-arg name="regex" value="\sand\s"/>
     </bean>
     
     <bean id="bibtexTitleContrib" class="org.dspace.importer.external.metadatamapping.contributor.SimpleMetadataContributor">


### PR DESCRIPTION
Needed for BibTeX's convention of separating author names by " and ". Code by @johannastaudinger (@uniba-ub).

## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #7969

## Description
Based on EnhancedSimpleMetadataContributor and the MappedMetadataContributor.java file in https://github.com/4Science/DSpace.

Configuration example (bibtex-integration.xml).

```
    <bean id="bibtexAuthorsContrib" class="org.dspace.importer.external.metadatamapping.contributor.SplitMetadataContributor">
        <constructor-arg name="regex" value="[\r\n ]and[\r\n ]" />
        <constructor-arg name="innerContributor" ref="bibtexAuthorContrib" />
    </bean>

    <bean id="bibtexAuthorContrib" class="org.dspace.importer.external.metadatamapping.contributor.SimpleMetadataContributor">
        <property name="field" ref="dcAuthors"/>
        <property name="key" value="author" />
    </bean>
```

## Instructions for Reviewers

List of changes in this PR:
* create new class

Tested on DSpace-CRIS only so far. No test cases yet.

## Checklist

- n/a My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- n/a If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- n/a If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
