### PR TITLE
Remove/replace gendered language in code comments

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/requestitem/RequestItemMetadataStrategy.java
+++ b/dspace-api/src/main/java/org/dspace/app/requestitem/RequestItemMetadataStrategy.java
@@ -63,7 +63,7 @@ public class RequestItemMetadataStrategy extends RequestItemSubmitterStrategy {
         } else {
             // Uses the basic strategy to look for the original submitter
             author = super.getRequestItemAuthor(context, item);
-            // Is the author or his email  null, so get the help desk or admin name and email
+            // Is the author or their email null. If so get the help desk or admin name and email
             if (null == author || null == author.getEmail()) {
                 String email = null;
                 String name = null;

--- a/dspace-api/src/main/java/org/dspace/browse/BrowseDAO.java
+++ b/dspace-api/src/main/java/org/dspace/browse/BrowseDAO.java
@@ -346,7 +346,7 @@ public interface BrowseDAO {
     public String getFilterValueField();
 
     /**
-     * Set he name of the field in which the value to constrain results is
+     * Set the name of the field in which the value to constrain results is
      * contained
      *
      * @param valueField the name of the field

--- a/dspace-api/src/main/java/org/dspace/content/LicenseUtils.java
+++ b/dspace-api/src/main/java/org/dspace/content/LicenseUtils.java
@@ -59,7 +59,7 @@ public class LicenseUtils {
      * {6} the eperson object that will be formatted using the appropriate
      * LicenseArgumentFormatter plugin (if defined)<br>
      * {x} any addition argument supplied wrapped in the
-     * LicenseArgumentFormatter based on his type (map key)
+     * LicenseArgumentFormatter based on its type (map key)
      *
      * @param locale         Formatter locale
      * @param collection     collection to get license from

--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -718,7 +718,7 @@ public class Context implements AutoCloseable {
     }
 
     /**
-     * Restore the user bound to the context and his special groups
+     * Restore the user bound to the context and their special groups
      *
      * @throws IllegalStateException if no switch was performed before
      */

--- a/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProviderWithCanonicalHandles.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProviderWithCanonicalHandles.java
@@ -117,7 +117,7 @@ public class VersionedHandleIdentifierProviderWithCanonicalHandles extends Ident
                 // check if we have a previous item
                 if (previous != null) {
                     try {
-                        // If we have a reviewer he/she might not have the
+                        // If we have a reviewer they might not have the
                         // rights to edit the metadata of thes previous item.
                         // Temporarly grant them:
                         context.turnOffAuthorisationSystem();

--- a/dspace-api/src/main/java/org/dspace/statistics/content/DatasetTimeGenerator.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/content/DatasetTimeGenerator.java
@@ -187,7 +187,7 @@ public class DatasetTimeGenerator extends DatasetGenerator {
             cal2.clear(Calendar.HOUR);
             cal1.clear(Calendar.HOUR_OF_DAY);
             cal2.clear(Calendar.HOUR_OF_DAY);
-            //yet i know calendar just won't clear his hours
+            //yet i know calendar just won't clear its hours
             cal1.set(Calendar.HOUR_OF_DAY, 0);
             cal2.set(Calendar.HOUR_OF_DAY, 0);
         }

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/WorkflowRequirementsServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/WorkflowRequirementsServiceImpl.java
@@ -100,7 +100,7 @@ public class WorkflowRequirementsServiceImpl implements WorkflowRequirementsServ
         //Then remove the current user from the inProgressUsers
         inProgressUserService.delete(context, inProgressUserService.findByWorkflowItemAndEPerson(context, wfi, user));
 
-        //Make sure the removed user has his custom rights removed
+        //Make sure the removed user has their custom rights removed
         xmlWorkflowService.removeUserItemPolicies(context, wfi.getItem(), user);
 
         Workflow workflow = workflowFactory.getWorkflow(wfi.getCollection());

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowServiceImpl.java
@@ -447,7 +447,7 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
                                               enteredNewStep);
                     }
                 } else if (enteredNewStep) {
-                    // If the user finished his/her step, we keep processing until there is a UI step action or no
+                    // If the user finished their step, we keep processing until there is a UI step action or no
                     // step at all
                     nextStep = workflow.getNextStep(c, wfi, currentStep, currentOutcome.getResult());
                     c.turnOffAuthorisationSystem();
@@ -938,7 +938,7 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
                     authorizeService.removeEPersonPolicies(context, bitstream, e);
                 }
             }
-            // Ensure that the submitter always retains his resource policies
+            // Ensure that the submitter always retains their resource policies
             if (e.getID().equals(item.getSubmitter().getID())) {
                 grantSubmitterReadPolicies(context, item);
             }

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/processingaction/SelectReviewerAction.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/processingaction/SelectReviewerAction.java
@@ -89,7 +89,7 @@ public class SelectReviewerAction extends ProcessingAction {
             //Retrieve the identifier of the eperson which will do the reviewing
             UUID reviewerId = UUID.fromString(submitButton.substring(submitButton.lastIndexOf("_") + 1));
             EPerson reviewer = ePersonService.find(c, reviewerId);
-            //We have a reviewer, assign him, the workflowitemrole will be translated into a task in the autoassign
+            //Assign the reviewer. The workflowitemrole will be translated into a task in the autoassign
             WorkflowItemRole workflowItemRole = workflowItemRoleService.create(c);
             workflowItemRole.setEPerson(reviewer);
             workflowItemRole.setRoleId(getRole().getId());

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/processingaction/SingleUserReviewAction.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/processingaction/SingleUserReviewAction.java
@@ -25,7 +25,7 @@ import org.dspace.xmlworkflow.storedcomponents.XmlWorkflowItem;
 
 /**
  * Processing class of an action where a single user has
- * been assigned and he can either accept/reject the workflow item
+ * been assigned and they can either accept/reject the workflow item
  * or reject the task
  *
  * @author Bram De Schouwer (bram.deschouwer at dot com)
@@ -90,7 +90,7 @@ public class SingleUserReviewAction extends ProcessingAction {
             } else {
                 request.setAttribute("page", REJECT_PAGE);
             }
-            // We have pressed reject item, so take the user to a page where he can reject
+            // We have pressed reject item, so take the user to a page where they can reject
             return new ActionResult(ActionResult.TYPE.TYPE_PAGE);
         } else if (request.getParameter(SUBMIT_DECLINE_TASK) != null) {
             return new ActionResult(ActionResult.TYPE.TYPE_OUTCOME, OUTCOME_REJECT);

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/storedcomponents/PoolTaskServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/storedcomponents/PoolTaskServiceImpl.java
@@ -92,7 +92,7 @@ public class PoolTaskServiceImpl implements PoolTaskService {
             return poolTask;
         } else {
             //If the user has a is processing or has finished the step for a workflowitem, there is no need to look
-            // for pooltasks for one of his
+            // for pooltasks for one of their
             //groups because the user already has the task claimed
             if (inProgressUserService.findByWorkflowItemAndEPerson(context, workflowItem, ePerson) != null) {
                 return null;

--- a/dspace-api/src/test/java/org/dspace/authorize/AuthorizeServiceTest.java
+++ b/dspace-api/src/test/java/org/dspace/authorize/AuthorizeServiceTest.java
@@ -27,7 +27,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 /**
- * Created by pbecker as he wanted to write a test against DS-3572.
+ * Created by pbecker to write a test against DS-3572.
  * This definitely needs to be extended, but it's at least a start.
  */
 public class AuthorizeServiceTest extends AbstractUnitTest {
@@ -80,7 +80,7 @@ public class AuthorizeServiceTest extends AbstractUnitTest {
         }
 
         try {
-            // eperson1 should be able to write as he is member of a group that has write permissions
+            // eperson1 should be able to write as it is a member of a group that has write permissions
             Assert.assertTrue(authorizeService.authorizeActionBoolean(context, eperson1, dso, Constants.WRITE, true));
             // person2 shouldn't have write access
             Assert.assertFalse(authorizeService.authorizeActionBoolean(context, eperson2, dso, Constants.WRITE, true));

--- a/dspace-api/src/test/java/org/dspace/content/packager/ITDSpaceAIP.java
+++ b/dspace-api/src/test/java/org/dspace/content/packager/ITDSpaceAIP.java
@@ -194,7 +194,7 @@ public class ITDSpaceAIP extends AbstractIntegrationTest {
             ePersonService.update(context, submitter);
             context.setCurrentUser(submitter);
 
-            //Make our test ePerson an admin so he can perform deletes and restores
+            //Make our test ePerson an admin so it can perform deletes and restores
             GroupService groupService = EPersonServiceFactory.getInstance().getGroupService();
             Group adminGroup = groupService.findByName(context, Group.ADMIN);
             groupService.addMember(context, adminGroup, submitter);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/CanChangePasswordFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/CanChangePasswordFeature.java
@@ -18,11 +18,11 @@ import org.dspace.core.Context;
 import org.springframework.stereotype.Component;
 
 /**
- * The canChangePassword feature. It can be used to verify if the user can change his password.
+ * The canChangePassword feature. It can be used to verify if the user can change their password.
  */
 @Component
 @AuthorizationFeatureDocumentation(name = CanChangePasswordFeature.NAME,
-        description = "It can be used to verify if the user can change his password")
+        description = "It can be used to verify if the user can change their password")
 public class CanChangePasswordFeature implements AuthorizationFeature {
 
     public static final String NAME = "canChangePassword";

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SearchFilterToAppliedFilterConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SearchFilterToAppliedFilterConverter.java
@@ -29,7 +29,7 @@ public class SearchFilterToAppliedFilterConverter {
         AuthorityValue authorityValue = null;
         if (searchFilter.hasAuthorityOperator()) {
             // FIXME this is obviously wrong as it assumes that the authorityValueService is able to retrieve the label
-            // for each Authority. Indeed, the AuthorityValueService regardless to his name is specific of the
+            // for each Authority. Indeed, the AuthorityValueService regardless of its name is specific of the
             // "SOLRAuthority" implementation and should not have a prominent role.
             // Moreover, it is not possible to discover which authority is responsible for the value selected in the
             // facet as the authority is bind at the metadata level and so a facet could contains values from multiple

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/ClaimedTaskRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/ClaimedTaskRestPermissionEvaluatorPlugin.java
@@ -27,7 +27,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
 /**
- * An authenticated user is allowed to interact with a claimed task only if he own it
+ * An authenticated user is allowed to interact with a claimed task only if they own it
  * claim.
  * 
  * @author Andrea Bollini (andrea.bollini at 4science.it)

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/EPersonRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/EPersonRestPermissionEvaluatorPlugin.java
@@ -34,7 +34,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
 /**
- * An authenticated user is allowed to view, update or delete his or her own data. This {@link RestPermissionEvaluatorPlugin}
+ * An authenticated user is allowed to view, update or delete their own data. This {@link RestPermissionEvaluatorPlugin}
  * implements that requirement.
  */
 @Component

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/GroupRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/GroupRestPermissionEvaluatorPlugin.java
@@ -29,7 +29,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
 /**
- * An authenticated user is allowed to view information on all the groups he or she is a member of (READ permission).
+ * An authenticated user is allowed to view information on all the groups they are a member of (READ permission).
  * This {@link RestPermissionEvaluatorPlugin} implements that requirement by validating the group membership.
  */
 @Component

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/PoolTaskRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/PoolTaskRestPermissionEvaluatorPlugin.java
@@ -30,7 +30,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
 /**
- * An authenticated user is allowed to interact with a pool task only if it is in his list.
+ * An authenticated user is allowed to interact with a pool task only if it is in their list.
  *
  * @author Andrea Bollini (andrea.bollini at 4science.it)
  */

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/ResearcherProfileRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/ResearcherProfileRestPermissionEvaluatorPlugin.java
@@ -29,7 +29,7 @@ import org.springframework.stereotype.Component;
 
 /**
  *
- * An authenticated user is allowed to view, update or delete his or her own
+ * An authenticated user is allowed to view, update or delete their own
  * data. This {@link RestPermissionEvaluatorPlugin} implements that requirement.
  *
  * @author Luca Giamminonni (luca.giamminonni at 4science.it)

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/WorkflowRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/WorkflowRestPermissionEvaluatorPlugin.java
@@ -31,7 +31,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
 /**
- * An authenticated user is allowed to interact with workflow item only if they belong to a task that she own or could
+ * An authenticated user is allowed to interact with workflow item only if they belong to a task that they own or could
  * claim.
  * 
  * @author Andrea Bollini (andrea.bollini at 4science.it)

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/AuthorizationRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/AuthorizationRestRepositoryIT.java
@@ -895,25 +895,25 @@ public class AuthorizationRestRepositoryIT extends AbstractControllerIntegration
         configurationService.setProperty("org.dspace.app.rest.authorization.AlwaysThrowExceptionFeature.turnoff", true);
         String anotherToken = getAuthToken(anotherEperson.getEmail(), password);
 
-        // verify that he cannot search the admin authorizations - by using the eperson parameter
+        // verify that admin cannot search the admin authorizations - by using the eperson parameter
         getClient(anotherToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("eperson", admin.getID().toString()))
             .andExpect(status().isForbidden());
 
-        // verify that he cannot search the admin authorizations - by assuming login
+        // verify that admin cannot search the admin authorizations - by assuming login
         getClient(anotherToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .header("X-On-Behalf-Of", admin.getID()))
             .andExpect(status().isForbidden());
 
-        // verify that he cannot search the authorizations of another "normal" eperson - by using the eperson parameter
+        // verify that eperson cannot search the authorizations of another "normal" eperson - by using the parameter
         getClient(anotherToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("eperson", eperson.getID().toString()))
             .andExpect(status().isForbidden());
 
-        // verify that he cannot search the authorizations of another "normal" eperson - by assuming login
+        // verify that eperson cannot search the authorizations of another "normal" eperson - by assuming login
         getClient(anotherToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .header("X-On-Behalf-Of", eperson.getID()))
@@ -1452,28 +1452,28 @@ public class AuthorizationRestRepositoryIT extends AbstractControllerIntegration
         configurationService.setProperty("org.dspace.app.rest.authorization.AlwaysThrowExceptionFeature.turnoff", true);
         String anotherToken = getAuthToken(anotherEperson.getEmail(), password);
 
-        // verify that he cannot search the admin authorizations - by using the eperson parameter
+        // verify that admin cannot search the admin authorizations - by using the eperson parameter
         getClient(anotherToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("feature", alwaysTrue.getName())
                 .param("eperson", admin.getID().toString()))
             .andExpect(status().isForbidden());
 
-        // verify that he cannot search the admin authorizations - by assuming login
+        // verify that admin cannot search the admin authorizations - by assuming login
         getClient(anotherToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("feature", alwaysTrue.getName())
                 .header("X-On-Behalf-Of", admin.getID()))
             .andExpect(status().isForbidden());
 
-        // verify that he cannot search the authorizations of another "normal" eperson - by using the eperson parameter
+        // verify that eperson cannot search the authorizations of another "normal" eperson - by using the parameter
         getClient(anotherToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("feature", alwaysTrue.getName())
                 .param("eperson", eperson.getID().toString()))
             .andExpect(status().isForbidden());
 
-        // verify that he cannot search the authorizations of another "normal" eperson - by assuming login
+        // verify that eperson cannot search the authorizations of another "normal" eperson - by assuming login
         getClient(anotherToken).perform(get("/api/authz/authorizations/search/object")
                 .param("uri", siteUri)
                 .param("feature", alwaysTrue.getName())
@@ -2508,7 +2508,7 @@ public class AuthorizationRestRepositoryIT extends AbstractControllerIntegration
         configurationService.setProperty("org.dspace.app.rest.authorization.AlwaysThrowExceptionFeature.turnoff", true);
         String anotherToken = getAuthToken(anotherEperson.getEmail(), password);
 
-        // verify that he cannot search the admin authorizations - by using the eperson parameter
+        // verify that admin cannot search the admin authorizations - by using the eperson parameter
         getClient(anotherToken).perform(get("/api/authz/authorizations/search/objects")
             .param("type", "core.site")
             .param("uuid", siteId)
@@ -2517,7 +2517,7 @@ public class AuthorizationRestRepositoryIT extends AbstractControllerIntegration
             .param("eperson", admin.getID().toString()))
             .andExpect(status().isForbidden());
 
-        // verify that he cannot search the admin authorizations - by assuming login
+        // verify that admin cannot search the admin authorizations - by assuming login
         getClient(anotherToken).perform(get("/api/authz/authorizations/search/objects")
             .param("type", "core.site")
             .param("uuid", siteId)
@@ -2526,7 +2526,7 @@ public class AuthorizationRestRepositoryIT extends AbstractControllerIntegration
             .header("X-On-Behalf-Of", admin.getID()))
             .andExpect(status().isForbidden());
 
-        // verify that he cannot search the authorizations of another "normal" eperson - by using the eperson parameter
+        // verify that eperson cannot search the authorizations of another "normal" eperson - by using the parameter
         getClient(anotherToken).perform(get("/api/authz/authorizations/search/objects")
             .param("type", "core.site")
             .param("uuid", siteId)
@@ -2535,7 +2535,7 @@ public class AuthorizationRestRepositoryIT extends AbstractControllerIntegration
             .param("eperson", eperson.getID().toString()))
             .andExpect(status().isForbidden());
 
-        // verify that he cannot search the authorizations of another "normal" eperson - by assuming login
+        // verify that eperson cannot search the authorizations of another "normal" eperson - by assuming login
         getClient(anotherToken).perform(get("/api/authz/authorizations/search/objects")
             .param("type", "core.site")
             .param("uuid", siteId)
@@ -2691,7 +2691,7 @@ public class AuthorizationRestRepositoryIT extends AbstractControllerIntegration
                 .param("feature", trueForUsersInGroupTest.getName())
                 .param("eperson", normalUser.getID().toString()))
             .andExpect(jsonPath("$.page.totalElements", is(0)));
-        // but he should have the authorization if loggedin directly
+        // but user should have the authorization if loggedin directly
         getClient(normalUserToken).perform(get("/api/authz/authorizations/" + authNormalUserSite.getID()))
             .andExpect(status().isOk());
         getClient(normalUserToken).perform(get("/api/authz/authorizations/search/object")

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CollectionRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CollectionRestRepositoryIT.java
@@ -2678,7 +2678,7 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
         context.restoreAuthSystemState();
         String token = getAuthToken(topLevelCommunityAAdmin.getEmail(), password);
 
-        // Verify the community admin gets all the communities he's admin for
+        // Verify the community admin gets all the communities they are admin for
         getClient(token).perform(get("/api/core/collections/search/findAdminAuthorized"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$._embedded.collections", Matchers.containsInAnyOrder(
@@ -2723,7 +2723,7 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
 
         String token = getAuthToken(subCommunityAAdmin.getEmail(), password);
 
-        // Verify the subcommunity admin gets all the communities he's admin for
+        // Verify the subcommunity admin gets all the communities they are admin for
         getClient(token).perform(get("/api/core/collections/search/findAdminAuthorized"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$._embedded.collections", Matchers.containsInAnyOrder(
@@ -2769,7 +2769,7 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
 
         String token = getAuthToken(collectionAAdmin.getEmail(), password);
 
-        // Verify the collection admin gets all the communities he's admin for
+        // Verify the collection admin gets all the communities they are admin for
         getClient(token).perform(get("/api/core/collections/search/findAdminAuthorized"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$._embedded.collections", Matchers.containsInAnyOrder(
@@ -2908,7 +2908,7 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
 
         String token = getAuthToken(eperson.getEmail(), password);
 
-        // Verify an ePerson in a subgroup of a community admin group gets all the collections he's admin for
+        // Verify an ePerson in a subgroup of a community admin group gets all the collections they are admin for
         getClient(token).perform(get("/api/core/collections/search/findAdminAuthorized"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$._embedded.collections", Matchers.containsInAnyOrder(
@@ -2964,7 +2964,7 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
 
         String token = getAuthToken(eperson.getEmail(), password);
 
-        // Verify an ePerson in a subgroup of a subcommunity admin group gets all the collections he's admin for
+        // Verify an ePerson in a subgroup of a subcommunity admin group gets all the collections they are admin for
         getClient(token).perform(get("/api/core/collections/search/findAdminAuthorized"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$._embedded.collections", Matchers.containsInAnyOrder(
@@ -3020,7 +3020,7 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
 
         String token = getAuthToken(eperson.getEmail(), password);
 
-        // Verify an ePerson in a subgroup of a collection admin group gets all the collections he's admin for
+        // Verify an ePerson in a subgroup of a collection admin group gets all the collections they are admin for
         getClient(token).perform(get("/api/core/collections/search/findAdminAuthorized"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$._embedded.collections", Matchers.containsInAnyOrder(

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
@@ -2089,7 +2089,7 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
 
         String token = getAuthToken(topLevelCommunityAAdmin.getEmail(), password);
 
-        // Verify the community admin gets all the communities he's admin for
+        // Verify the community admin gets all the communities they are admin for
         getClient(token).perform(get("/api/core/communities/search/findAdminAuthorized"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$._embedded.communities", Matchers.containsInAnyOrder(
@@ -2142,7 +2142,7 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
 
         String token = getAuthToken(subCommunityAAdmin.getEmail(), password);
 
-        // Verify the community admin gets all the communities he's admin for
+        // Verify the community admin gets all the communities they are admin for
         getClient(token).perform(get("/api/core/communities/search/findAdminAuthorized"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$._embedded.communities", Matchers.containsInAnyOrder(
@@ -2302,7 +2302,7 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
 
         String token = getAuthToken(eperson.getEmail(), password);
 
-        // Verify the community admins' subgroup users get all the communities he's admin for
+        // Verify the community admins' subgroup users get all the communities they are admin for
         getClient(token).perform(get("/api/core/communities/search/findAdminAuthorized"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$._embedded.communities", Matchers.containsInAnyOrder(
@@ -2355,7 +2355,7 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
 
         String token = getAuthToken(eperson.getEmail(), password);
 
-        // Verify the sub-community admins' subgroup users get all the communities he's admin for
+        // Verify the sub-community admins' subgroup users get all the communities they are admin for
         getClient(token).perform(get("/api/core/communities/search/findAdminAuthorized"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$._embedded.communities", Matchers.containsInAnyOrder(

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -4460,7 +4460,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
 
         // admin should see two pool items and a claimed task,
         // one pool item from the submitter and one from herself
-        // because the admin is in the reviewer group for step 1, not because she is an admin
+        // because the admin is in the reviewer group for step 1, not because they are an admin
         getClient(adminToken).perform(get("/api/discover/search/objects").param("configuration", "workflow"))
                 //** THEN **
                 //The status has to be 200 OK
@@ -4683,7 +4683,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                 .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
         ;
 
-        // reviewer1 should not see pool items, as he is not an administrator
+        // reviewer1 should not see pool items, as it is not an administrator
         getClient(reviewer1Token).perform(get("/api/discover/search/objects").param("configuration", "workflowAdmin"))
                 //** THEN **
                 //The status has to be 200 OK
@@ -4755,7 +4755,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                 .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
         ;
 
-        // reviewer2 should not see pool items, as he is not an administrator
+        // reviewer2 should not see pool items, as it is not an administrator
         getClient(reviewer2Token).perform(get("/api/discover/search/objects").param("configuration", "workflowAdmin"))
                 //** THEN **
                 //The status has to be 200 OK

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -4165,7 +4165,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
 
         context.restoreAuthSystemState();
         //** WHEN **
-        // each submitter, including the administrator should see only her submission
+        // each submitter, including the administrator should see only their submission
         String submitterToken = getAuthToken(submitter.getEmail(), password);
         String adminToken = getAuthToken(admin.getEmail(), password);
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -4459,7 +4459,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         ;
 
         // admin should see two pool items and a claimed task,
-        // one pool item from the submitter and one from herself
+        // one pool item from the submitter and one from the admin
         // because the admin is in the reviewer group for step 1, not because they are an admin
         getClient(adminToken).perform(get("/api/discover/search/objects").param("configuration", "workflow"))
                 //** THEN **
@@ -4701,7 +4701,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
 
 
         // admin should see three pool items and a claimed task
-        // one pool item from the submitter and two from herself
+        // one pool item from the submitter and two from the admin
         getClient(adminToken).perform(get("/api/discover/search/objects").param("configuration", "workflowAdmin"))
                 //** THEN **
                 //The status has to be 200 OK

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/EPersonRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/EPersonRestRepositoryIT.java
@@ -395,7 +395,7 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         getClient(epersonToken).perform(get("/api/eperson/epersons/" + ePerson2.getID()))
                                .andExpect(status().isForbidden());
 
-        // Verify an unprivilegd user can access information about himself/herself
+        // Verify an unprivileged user can access their own information
         getClient(epersonToken).perform(get("/api/eperson/epersons/" + eperson.getID()))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(contentType))

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResearcherProfileRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResearcherProfileRestRepositoryIT.java
@@ -520,7 +520,7 @@ public class ResearcherProfileRestRepositoryIT extends AbstractControllerIntegra
     }
 
     /**
-     * Verify that a user can delete his profile using the delete endpoint.
+     * Verify that a user can delete their profile using the delete endpoint.
      *
      * @throws Exception
      */
@@ -558,7 +558,7 @@ public class ResearcherProfileRestRepositoryIT extends AbstractControllerIntegra
     }
 
     /**
-     * Verify that a user can hard delete his profile using the delete endpoint.
+     * Verify that a user can hard delete their profile using the delete endpoint.
      *
      * @throws Exception
      */
@@ -667,7 +667,7 @@ public class ResearcherProfileRestRepositoryIT extends AbstractControllerIntegra
     }
 
     /**
-     * Verify that an user can delete his profile using the delete endpoint even if
+     * Verify that an user can delete their profile using the delete endpoint even if
      * was created by an admin.
      *
      * @throws Exception
@@ -859,7 +859,7 @@ public class ResearcherProfileRestRepositoryIT extends AbstractControllerIntegra
     }
 
     /**
-     * Verify that an user can change the visibility of his profile using the patch
+     * Verify that an user can change the visibility of their profile using the patch
      * endpoint even if was created by an admin.
      *
      * @throws Exception

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/TaskRestRepositoriesIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/TaskRestRepositoriesIT.java
@@ -1511,7 +1511,7 @@ public class TaskRestRepositoriesIT extends AbstractControllerIntegrationTest {
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED))
             .andExpect(status().isForbidden());
 
-        // nor the administrator can approve a task that he doesn't own
+        // nor the administrator can approve a task that it doesn't own
         getClient(adminToken).perform(post("/api/workflow/claimedtasks/" + claimedTask.getID())
                 .param("submit_approve", "true")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED))
@@ -1687,7 +1687,7 @@ public class TaskRestRepositoriesIT extends AbstractControllerIntegrationTest {
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED))
             .andExpect(status().isForbidden());
 
-        // nor the administrator can approve a task that he doesn't own
+        // nor the administrator can approve a task that it doesn't own
         getClient(adminToken).perform(post("/api/workflow/claimedtasks/" + claimedTask.getID())
                 .param("submit_reject", "true")
                 .param("reason", "I need to test the reject")

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/EnrollAdministratorIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/EnrollAdministratorIT.java
@@ -34,7 +34,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * test that the enroll process for a new administrator, i.e. create an user and
- * add him to the administrators group, will result in the Administrator Feature(s) to be available to such user.
+ * add user to the administrators group, will result in the Administrator Feature(s) to be available to such user.
  * 
  * @author Mykhaylo Boychuk (mykhaylo.boychuk at 4science.it)
  *

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -335,48 +335,50 @@ handle.dir = ${dspace.dir}/handle-server
 ##### Authorization system configuration - Delegate ADMIN #####
 
 # COMMUNITY ADMIN configuration
-# subcommunities and collections
+# Authorize community administrators to create/delete subcommunties or collections
 #core.authorization.community-admin.create-subelement = true
 #core.authorization.community-admin.delete-subelement = true
-# his community
+# Authorize community administrators to manage community policies or community admin group
 #core.authorization.community-admin.policies = true
 #core.authorization.community-admin.admin-group = true
-# collections in his community
+# Authorize community administrators to manage collection settings (for collections under the community)
 #core.authorization.community-admin.collection.policies = true
 #core.authorization.community-admin.collection.template-item = true
 #core.authorization.community-admin.collection.submitters = true
 #core.authorization.community-admin.collection.workflows = true
 #core.authorization.community-admin.collection.admin-group = true
-# item owned by collections in his community
+# Authorize community administrators to manage item settings (for items owned by collections under the community)
 #core.authorization.community-admin.item.delete = true
 #core.authorization.community-admin.item.withdraw = true
 #core.authorization.community-admin.item.reinstatiate = true
 #core.authorization.community-admin.item.policies = true
-# also bundle...
+# Authorize community administrators to manage bundles/bitstreams of those items
 #core.authorization.community-admin.item.create-bitstream = true
 #core.authorization.community-admin.item.delete-bitstream = true
 #core.authorization.community-admin.item-admin.cc-license = true
 
 # COLLECTION ADMIN
+# Authorize collection administrators to manage collection settings
 #core.authorization.collection-admin.policies = true
 #core.authorization.collection-admin.template-item = true
 #core.authorization.collection-admin.submitters = true
 #core.authorization.collection-admin.workflows = true
 #core.authorization.collection-admin.admin-group = true
-# item owned by his collection
+# Authorize collection administrators to manage item settings (for items owned by the collection)
 #core.authorization.collection-admin.item.delete = true
 #core.authorization.collection-admin.item.withdraw = true
 #core.authorization.collection-admin.item.reinstatiate = true
 #core.authorization.collection-admin.item.policies = true
-# also bundle...
+# Authorize collection administrators to manage bundles/bitstreams of those items (owned by the collection)
 #core.authorization.collection-admin.item.create-bitstream = true
 #core.authorization.collection-admin.item.delete-bitstream = true
 #core.authorization.collection-admin.item-admin.cc-license = true
 
 # ITEM ADMIN
+# Authorize item administrators to manage item settings
 #core.authorization.item-admin.policies = true
 #core.authorization.installitem.inheritance-read.append-mode = false
-# also bundle...
+# Authorize item administrators to manage bundles/bitstreams of the item
 #core.authorization.item-admin.create-bitstream = true
 #core.authorization.item-admin.delete-bitstream = true
 #core.authorization.item-admin.cc-license = true

--- a/dspace/src/main/config/build.xml
+++ b/dspace/src/main/config/build.xml
@@ -66,7 +66,7 @@ Common usage:
     <property name="irus-config" value="config/modules/irus-statistics.cfg" />
 
     <!-- Give user a chance to override without editing this file
-       (and without typing -D each time s/he compiles it) -->
+       (and without typing -D each time they compiles it) -->
     <property file="${user.home}/.dspace.properties" />
 
     <!-- Load the configurations -->


### PR DESCRIPTION
## Description

Small PR to replace all gendered (e.g. his/her) language in code comments.  Also cleanup/enhance the descriptions of the delegated administration settings in `dspace.cfg`, which included "his" in several places.

## Instructions for Reviewers

This PR only involves changes to code comments.  No code or config changes were made.  Therefore, I'll merge it after the PR successfully passes CI.