### PR TITLE
DURACOM-86 Add html support to opensearch, fix misconfiguration

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/OpenSearchServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/OpenSearchServiceImpl.java
@@ -97,7 +97,7 @@ public class OpenSearchServiceImpl implements OpenSearchService {
      * Get base search UI URL (websvc.opensearch.uicontext)
      */
     protected String getBaseSearchUIURL() {
-        return configurationService.getProperty("dspace.server.url") + "/" +
+        return configurationService.getProperty("dspace.ui.url") + "/" +
             configurationService.getProperty("websvc.opensearch.uicontext");
     }
 

--- a/dspace-api/src/main/java/org/dspace/app/util/OpenSearchServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/OpenSearchServiceImpl.java
@@ -20,7 +20,6 @@ import com.rometools.modules.opensearch.OpenSearchModule;
 import com.rometools.modules.opensearch.entity.OSQuery;
 import com.rometools.modules.opensearch.impl.OpenSearchModuleImpl;
 import com.rometools.rome.io.FeedException;
-
 import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.util.service.OpenSearchService;
@@ -179,9 +178,9 @@ public class OpenSearchServiceImpl implements OpenSearchService {
         OSQuery osq = new OSQuery();
         osq.setRole("request");
         try {
-        	if (StringUtils.isNotBlank(query)) {
-        		osq.setSearchTerms(URLEncoder.encode(query, "UTF-8"));
-        	}
+            if (StringUtils.isNotBlank(query)) {
+                osq.setSearchTerms(URLEncoder.encode(query, "UTF-8"));
+            }
         } catch (UnsupportedEncodingException e) {
             log.error(e);
         }

--- a/dspace-api/src/main/java/org/dspace/app/util/OpenSearchServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/OpenSearchServiceImpl.java
@@ -20,6 +20,8 @@ import com.rometools.modules.opensearch.OpenSearchModule;
 import com.rometools.modules.opensearch.entity.OSQuery;
 import com.rometools.modules.opensearch.impl.OpenSearchModuleImpl;
 import com.rometools.rome.io.FeedException;
+
+import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.util.service.OpenSearchService;
 import org.dspace.content.DSpaceObject;
@@ -177,7 +179,9 @@ public class OpenSearchServiceImpl implements OpenSearchService {
         OSQuery osq = new OSQuery();
         osq.setRole("request");
         try {
-            osq.setSearchTerms(URLEncoder.encode(query, "UTF-8"));
+        	if (StringUtils.isNotBlank(query)) {
+        		osq.setSearchTerms(URLEncoder.encode(query, "UTF-8"));
+        	}
         } catch (UnsupportedEncodingException e) {
             log.error(e);
         }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/opensearch/OpenSearchControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/opensearch/OpenSearchControllerIT.java
@@ -54,20 +54,7 @@ public class OpenSearchControllerIT extends AbstractControllerIntegrationTest {
         ;
     }
 
-    // HTML is an open issue in OpenSearch, so skip this test at the moment
-    @Test
-    @Ignore
-    public void searchHtmlTest() throws Exception {
-        //When we call the root endpoint
-        getClient().perform(get("/opensearch/search")
-                                .param("query", "cats")
-                                .param("format", "html"))
-                   //The status has to be 200 OK
-                   .andExpect(status().isOk())
-                   //We expect the content type to be "application/atom+xml;charset=UTF-8"
-                   .andExpect(content().contentType("text/html;charset=UTF-8"))
-        ;
-    }
+    // there is no searchHtmlTest here as the html search is redirected to the angular UI
 
     @Test
     public void searchRssTest() throws Exception {
@@ -201,17 +188,23 @@ public class OpenSearchControllerIT extends AbstractControllerIntegrationTest {
     public void serviceDocumentTest() throws Exception {
         //When we call the root endpoint
         getClient().perform(get("/opensearch/service"))
-                   //The status has to be 200 OK
-                   .andExpect(status().isOk())
-                   // and the contentType has to be an opensearchdescription
-                   .andExpect(content().contentType("application/opensearchdescription+xml;charset=UTF-8"))
-                   // and there need to be some values taken from the test configuration
-                   .andExpect(xpath("OpenSearchDescription/ShortName").string("DSpace"))
-                   .andExpect(xpath("OpenSearchDescription/LongName").string("DSpace at My University"))
-                   .andExpect(xpath("OpenSearchDescription/Description")
-                       .string("DSpace at My University DSpace repository")
-        )
-        ;
+                // The status has to be 200 OK
+                .andExpect(status().isOk())
+                // and the contentType has to be an opensearchdescription
+                .andExpect(content().contentType("application/opensearchdescription+xml;charset=UTF-8"))
+                // and there need to be some values taken from the test configuration
+                .andExpect(xpath("OpenSearchDescription/ShortName").string("DSpace"))
+                .andExpect(xpath("OpenSearchDescription/LongName").string("DSpace at My University"))
+                .andExpect(xpath("OpenSearchDescription/Description")
+                        .string("DSpace at My University DSpace repository"))
+                .andExpect(xpath("OpenSearchDescription/Url[@type='text/html']/@template")
+                        .string("http://localhost:4000/search?query={searchTerms}"))
+                .andExpect(xpath("OpenSearchDescription/Url[@type='application/atom+xml; charset=UTF-8']/@template")
+                        .string("http://localhost/opensearch/search?"
+                                + "query={searchTerms}&start={startIndex?}&rpp={count?}&format=atom"))
+                .andExpect(xpath("OpenSearchDescription/Url[@type='application/rss+xml; charset=UTF-8']/@template")
+                        .string("http://localhost/opensearch/search?"
+                                + "query={searchTerms}&start={startIndex?}&rpp={count?}&format=rss"));
         /* Expected response for the service document is:
             <?xml version="1.0" encoding="UTF-8"?>
             <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
@@ -224,9 +217,9 @@ public class OpenSearchControllerIT extends AbstractControllerIntegrationTest {
                 <Tags>IR DSpace</Tags>
                 <Contact>dspace-help@myu.edu</Contact>
                 <Image height="16" width="16" type="image/vnd.microsoft.icon">http://www.dspace.org/images/favicon.ico</Image>
-                <Url type="text/html" template="http://localhost:8080/simple-search?query={searchTerms}" />
-                <Url type="application/atom+xml; charset=UTF-8" template="http://localhost:8080/open-search/?query={searchTerms}&amp;start={startIndex?}&amp;rpp={count?}&amp;format=atom" />
-                <Url type="application/rss+xml; charset=UTF-8" template="http://localhost:8080/open-search/?query={searchTerms}&amp;start={startIndex?}&amp;rpp={count?}&amp;format=rss" />
+                <Url type="text/html" template="http://localhost:4000/search?query={searchTerms}" />
+                <Url type="application/atom+xml; charset=UTF-8" template="http://localhost:8080/server/opensearch/search?query={searchTerms}&amp;start={startIndex?}&amp;rpp={count?}&amp;format=atom" />
+                <Url type="application/rss+xml; charset=UTF-8" template="http://localhost:8080/server/opensearch/search?query={searchTerms}&amp;start={startIndex?}&amp;rpp={count?}&amp;format=rss" />
             </OpenSearchDescription>
         */
     }

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1313,8 +1313,6 @@ webui.feed.item.author = dc.contributor.author
 # so even if Syndication Feeds are not enabled, they must be configured
 # enable open search
 websvc.opensearch.enable = true
-# url used in service document
-websvc.opensearch.svccontext = opensearch
 # context for html request URLs - change only for non-standard servlet mapping
 websvc.opensearch.uicontext = search
 # context for xml request URLs - change only for non-standard servlet mapping

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1316,7 +1316,9 @@ websvc.opensearch.enable = true
 # url used in service document
 websvc.opensearch.svccontext = opensearch
 # context for html request URLs - change only for non-standard servlet mapping
-websvc.opensearch.uicontext = simple-search
+websvc.opensearch.uicontext = search
+# context for xml request URLs - change only for non-standard servlet mapping
+websvc.opensearch.svccontext = opensearch/search
 # present autodiscovery link in every page head
 websvc.opensearch.autolink = true
 # number of hours to retain results before recalculating
@@ -1335,8 +1337,8 @@ websvc.opensearch.samplequery = photosynthesis
 # tags used to describe search service
 websvc.opensearch.tags = IR DSpace
 # result formats offered - use 1 or more comma-separated from: html,atom,rss
-# NB: html is not supported in DSpace7, use normal search module instead
-websvc.opensearch.formats = atom,rss
+# html uses the normal search module
+websvc.opensearch.formats = html,atom,rss
 
 
 #### Content Inline Disposition Threshold ####


### PR DESCRIPTION
## References
* Fixes #2869

## Description
Other than configuring by default the html format for opensearch, redirecting to the standard search module as in previous dspace versions, this PR address a small configuration bug that leads to a wrong opensearch service document.

## Instructions for Reviewers
Enable the opensearch support and look to the opensearch service document before and after applying this PR.
You should note the following changes:
* the html format should be listed in the service document and the URL should point to the public search
* the other formats (atom, rss) should include the proper link to the opensearch controller (before it contains /null)
* run an empty opensearch search will not longer throws a NPE ${dspace.url}/server/opensearch/search

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [n/a] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [n/a] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [n/a] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [n/a] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
