### PR TITLE
Add additional solr and jena-related log4j exclusions [DSpace#8143]

### DIFF
--- a/dspace-rdf/pom.xml
+++ b/dspace-rdf/pom.xml
@@ -32,6 +32,14 @@
                     <artifactId>jackson-databind</artifactId>
                     <groupId>com.fasterxml.jackson.core</groupId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
             </exclusions>
             <type>pom</type>
         </dependency>

--- a/dspace-solr/pom.xml
+++ b/dspace-solr/pom.xml
@@ -168,6 +168,14 @@
                     <artifactId>jetty-xml</artifactId>
                     <groupId>org.eclipse.jetty</groupId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
             </exclusions>              
         </dependency>
         <dependency>
@@ -223,10 +231,18 @@
                     <artifactId>jetty-xml</artifactId>
                     <groupId>org.eclipse.jetty</groupId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
-        <!-- Replace J.U.L. logging with log4j -->
+        <!-- Replace J.U.L. logging with reload4j -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jul-to-slf4j</artifactId>
@@ -236,6 +252,11 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-reload4j</artifactId>
             <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
+            <version>${reload4j.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/dspace/modules/solr/pom.xml
+++ b/dspace/modules/solr/pom.xml
@@ -130,6 +130,14 @@
                    <groupId>org.apache.zookeeper</groupId>
                    <artifactId>zookeeper</artifactId>
                </exclusion>
+               <exclusion>
+                   <groupId>org.slf4j</groupId>
+                   <artifactId>slf4j-log4j12</artifactId>
+               </exclusion>
+               <exclusion>
+                   <groupId>log4j</groupId>
+                   <artifactId>log4j</artifactId>
+               </exclusion>
            </exclusions>
        </dependency>
 


### PR DESCRIPTION
Cleans up last log4j jars from the build.

## References
* Fixes #8143
* Supplements #8144 

* ## Description
When building DSpace 6.4 release a couple of log4j jars pop up under webapps (rdf & solr). Based on mvn dependency:tree search the reason for these are dependencies in apache-jena-libs, solr-core, solr-cell, and solr-analysis-extras (under modules/solr). This patch adds exclusions to the respective poms.

## Instructions for Reviewers
Based on discussion in #8143, the issue has occurred to someone else as well. It is possible that the issue is triggered by some local DSpace customization, although I could not find no essential changes in POMs with our instance as we do not use dspace-rdf at all and solr-related customizations are only configuration-related. In addition, there may be some environment-related issue (e.g. Maven 3.3.9 was used for local builds).

However, it has been confirmed that the issue is _not_ dependent on issues with local maven repo (i.e. old log4j jars reappeared even after removing solr- and jena-related components from the local repository and doing a clean build).

List of changes in this PR:
* Added log4j exclusion to dspace-solr pom (+added reload4j reference where log4j refence wa removed earlier - without this wil not compile).
* Added log4j exclusion to dspace-rdf pom.
* Added log4j exclusion to modules/solr pom.


**Include guidance for how to test or review your PR.** 
Building and confirming that no log4j jars appear should be sufficient. In addition to checking that solr (and rdf, although I have not used this component) -related activities log as expected.