### PR TITLE
Autowire ConfigurationService in UploadConfiguration instead of requiring explicit configuration

### DIFF
--- a/dspace-api/src/main/java/org/dspace/submit/model/UploadConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/submit/model/UploadConfiguration.java
@@ -18,14 +18,22 @@ import org.dspace.services.ConfigurationService;
  */
 public class UploadConfiguration {
 
-    @Inject
-    private ConfigurationService configurationService;
+    private final ConfigurationService configurationService;
 
     private String metadataDefinition;
     private List<AccessConditionOption> options;
     private Long maxSize;
     private Boolean required;
     private String name;
+
+    /**
+     * Construct a bitstream uploading configuration.
+     * @param configurationService DSpace configuration provided by the DI container.
+     */
+    @Inject
+    public UploadConfiguration(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
+    }
 
     /**
      * The list of access restriction types from which a submitter may choose.

--- a/dspace-api/src/main/java/org/dspace/submit/model/UploadConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/submit/model/UploadConfiguration.java
@@ -8,6 +8,7 @@
 package org.dspace.submit.model;
 
 import java.util.List;
+import javax.inject.Inject;
 
 import org.dspace.services.ConfigurationService;
 
@@ -16,6 +17,7 @@ import org.dspace.services.ConfigurationService;
  */
 public class UploadConfiguration {
 
+    @Inject
     private ConfigurationService configurationService;
 
     private String metadataDefinition;
@@ -62,14 +64,6 @@ public class UploadConfiguration {
 
     public void setRequired(Boolean required) {
         this.required = required;
-    }
-
-    public ConfigurationService getConfigurationService() {
-        return configurationService;
-    }
-
-    public void setConfigurationService(ConfigurationService configurationService) {
-        this.configurationService = configurationService;
     }
 
     public String getName() {

--- a/dspace-api/src/main/java/org/dspace/submit/model/UploadConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/submit/model/UploadConfiguration.java
@@ -13,6 +13,7 @@ import javax.inject.Inject;
 import org.dspace.services.ConfigurationService;
 
 /**
+ * A collection of conditions to be met when uploading Bitstreams.
  * @author Luigi Andrea Pascarelli (luigiandrea.pascarelli at 4science.it)
  */
 public class UploadConfiguration {
@@ -26,22 +27,43 @@ public class UploadConfiguration {
     private Boolean required;
     private String name;
 
+    /**
+     * The list of access restriction types from which a submitter may choose.
+     * @return choices for restricting access to Bitstreams.
+     */
     public List<AccessConditionOption> getOptions() {
         return options;
     }
 
+    /**
+     * Set the list of access restriction types from which to choose.
+     * Required.  May be empty.
+     * @param options choices for restricting access to Bitstreams.
+     */
     public void setOptions(List<AccessConditionOption> options) {
         this.options = options;
     }
 
+    /**
+     * Name of the submission form to which these conditions are attached.
+     * @return the form's name.
+     */
     public String getMetadata() {
         return metadataDefinition;
     }
 
+    /**
+     * Name the submission form to which these conditions are attached.
+     * @param metadata the form's name.
+     */
     public void setMetadata(String metadata) {
         this.metadataDefinition = metadata;
     }
 
+    /**
+     * Limit on the maximum size of an uploaded Bitstream.
+     * @return maximum upload size in bytes.
+     */
     public Long getMaxSize() {
         if (maxSize == null) {
             maxSize = configurationService.getLongProperty("upload.max");
@@ -49,10 +71,18 @@ public class UploadConfiguration {
         return maxSize;
     }
 
+    /**
+     * Limit the maximum size of an uploaded Bitstream.
+     * @param maxSize maximum upload size in bytes.
+     */
     public void setMaxSize(Long maxSize) {
         this.maxSize = maxSize;
     }
 
+    /**
+     * Is at least one Bitstream required when submitting a new Item?
+     * @return true if a Bitstream is required.
+     */
     public Boolean isRequired() {
         if (required == null) {
             //defaults to true
@@ -62,17 +92,27 @@ public class UploadConfiguration {
         return required;
     }
 
+    /**
+     * Is at least one Bitstream required when submitting a new Item?
+     * @param required true if a Bitstream is required.
+     */
     public void setRequired(Boolean required) {
         this.required = required;
     }
 
+    /**
+     * The unique name of this configuration.
+     * @return configuration's name.
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * Give this configuration a unique name.  Required.
+     * @param name configuration's name.
+     */
     public void setName(String name) {
         this.name = name;
     }
-
-
 }

--- a/dspace-api/src/test/data/dspaceFolder/config/spring/api/access-conditions.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/spring/api/access-conditions.xml
@@ -3,10 +3,9 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
            http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
-	
+
 	<bean id="uploadConfigurationDefault" class="org.dspace.submit.model.UploadConfiguration">
-		<property name="name" value="upload"></property>
-		<property name="configurationService" ref="org.dspace.services.ConfigurationService"/>
+		<property name="name" value="upload"/>
 		<property name="metadata" value="bitstream-metadata" />
         <property name="options">
             <list>
@@ -18,7 +17,7 @@
             </list>
         </property>
     </bean>
-  
+
     <bean id="openAccess" class="org.dspace.submit.model.AccessConditionOption">
         <property name="groupName" value="Anonymous"/>
         <property name="name" value="openaccess"/>
@@ -31,7 +30,7 @@
         <property name="hasStartDate" value="false"/>
         <property name="hasEndDate" value="true"/>
         <property name="endDateLimit" value="+6MONTHS"/>
-    </bean> 
+    </bean>
     <bean id="embargoed" class="org.dspace.submit.model.AccessConditionOption">
         <property name="groupName" value="Anonymous"/>
         <property name="name" value="embargo"/>
@@ -43,13 +42,13 @@
         <property name="groupName" value="Administrator"/>
         <property name="name" value="administrator"/>
         <property name="hasStartDate" value="false"/>
-        <property name="hasEndDate" value="false"/>       
+        <property name="hasEndDate" value="false"/>
     </bean>
 <!--     <bean id="networkAdministration" class="org.dspace.submit.model.AccessConditionOption">
     	<property name="groupName" value="INSTITUTIONAL_NETWORK"/>
         <property name="name" value="networkAdministration"/>
         <property name="hasStartDate" value="false"/>
-        <property name="hasEndDate" value="false"/>                
+        <property name="hasEndDate" value="false"/>
     </bean> -->
 
     <bean id="uploadConfigurationService" class="org.dspace.submit.model.UploadConfigurationService">

--- a/dspace/config/spring/api/access-conditions.xml
+++ b/dspace/config/spring/api/access-conditions.xml
@@ -3,7 +3,7 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
            http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
-	
+
 	<bean id="uploadConfigurationDefault" class="org.dspace.submit.model.UploadConfiguration">
 		<property name="name" value="upload"/>
 		<property name="metadata" value="bitstream-metadata" />
@@ -17,7 +17,7 @@
             </list>
         </property>
     </bean>
-  
+
     <bean id="openAccess" class="org.dspace.submit.model.AccessConditionOption">
         <property name="groupName" value="Anonymous"/>
         <property name="name" value="openaccess"/>
@@ -30,26 +30,25 @@
         <property name="hasStartDate" value="false"/>
         <property name="hasEndDate" value="true"/>
         <property name="endDateLimit" value="+6MONTHS"/>
-    </bean> 
+    </bean>
     <bean id="embargoed" class="org.dspace.submit.model.AccessConditionOption">
         <property name="groupName" value="Anonymous"/>
         <property name="name" value="embargo"/>
         <property name="hasStartDate" value="true"/>
         <property name="startDateLimit" value="+36MONTHS"/>
         <property name="hasEndDate" value="false"/>
-        
-    </bean> 
+    </bean>
     <bean id="administrator" class="org.dspace.submit.model.AccessConditionOption">
         <property name="groupName" value="Administrator"/>
         <property name="name" value="administrator"/>
         <property name="hasStartDate" value="false"/>
-        <property name="hasEndDate" value="false"/>       
+        <property name="hasEndDate" value="false"/>
     </bean>
 <!--     <bean id="networkAdministration" class="org.dspace.submit.model.AccessConditionOption">
     	<property name="groupName" value="INSTITUTIONAL_NETWORK"/>
         <property name="name" value="networkAdministration"/>
         <property name="hasStartDate" value="false"/>
-        <property name="hasEndDate" value="false"/>                
+        <property name="hasEndDate" value="false"/>
     </bean> -->
 
     <bean id="uploadConfigurationService" class="org.dspace.submit.model.UploadConfigurationService">

--- a/dspace/config/spring/api/access-conditions.xml
+++ b/dspace/config/spring/api/access-conditions.xml
@@ -5,8 +5,7 @@
            http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
 	
 	<bean id="uploadConfigurationDefault" class="org.dspace.submit.model.UploadConfiguration">
-		<property name="name" value="upload"></property>
-		<property name="configurationService" ref="org.dspace.services.ConfigurationService"/>
+		<property name="name" value="upload"/>
 		<property name="metadata" value="bitstream-metadata" />
         <property name="options">
             <list>


### PR DESCRIPTION
## Description
UploadConfiguration requires a reference to the ConfigurationService.  The unpatched code makes it an explicit property in the application context configuration.  This is never going to change, so it shouldn't be configured -- it's just an opportunity to break something, and requires documentation.  It should just be automatically injected by the DI container.

## Instructions for Reviewers
List of changes in this PR:
* Removed accessors.
* Added constructor marked for injection, with appropriate parameter.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
