### PR TITLE
Provide a script to delete old processes

### DIFF
--- a/dspace-api/src/main/java/org/dspace/administer/ProcessCleaner.java
+++ b/dspace-api/src/main/java/org/dspace/administer/ProcessCleaner.java
@@ -34,17 +34,18 @@ import org.dspace.utils.DSpace;
  */
 public class ProcessCleaner extends DSpaceRunnable<ProcessCleanerConfiguration<ProcessCleaner>> {
 
-
     private ConfigurationService configurationService;
 
     private ProcessService processService;
 
 
-    boolean cleanCompleted = false;
+    private boolean cleanCompleted = false;
 
-    boolean cleanFailed = false;
+    private boolean cleanFailed = false;
 
-    boolean cleanRunning = false;
+    private boolean cleanRunning = false;
+
+    private boolean help = false;
 
     private Integer days;
 
@@ -55,6 +56,7 @@ public class ProcessCleaner extends DSpaceRunnable<ProcessCleanerConfiguration<P
         this.configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
         this.processService = ScriptServiceFactory.getInstance().getProcessService();
 
+        this.help = commandLine.hasOption('h');
         this.cleanFailed = commandLine.hasOption('f');
         this.cleanRunning = commandLine.hasOption('r');
         this.cleanCompleted = commandLine.hasOption('c') || (!cleanFailed && !cleanRunning);
@@ -69,6 +71,11 @@ public class ProcessCleaner extends DSpaceRunnable<ProcessCleanerConfiguration<P
 
     @Override
     public void internalRun() throws Exception {
+
+        if (help) {
+            printHelp();
+            return;
+        }
 
         Context context = new Context();
 

--- a/dspace-api/src/main/java/org/dspace/administer/ProcessCleaner.java
+++ b/dspace-api/src/main/java/org/dspace/administer/ProcessCleaner.java
@@ -62,7 +62,7 @@ public class ProcessCleaner extends DSpaceRunnable<ProcessCleanerConfiguration<P
         this.days = configurationService.getIntProperty("process-cleaner.days", 14);
 
         if (this.days <= 0) {
-            throw new IllegalArgumentException("The number of days must be a positive integer.");
+            throw new IllegalStateException("The number of days must be a positive integer.");
         }
 
     }
@@ -82,12 +82,16 @@ public class ProcessCleaner extends DSpaceRunnable<ProcessCleanerConfiguration<P
 
     }
 
+    /**
+     * Delete the processes based on the specified statuses and the configured days
+     * from their creation.
+     */
     private void performDeletion(Context context) throws SQLException, IOException, AuthorizeException {
 
         List<ProcessStatus> statuses = getProcessToDeleteStatuses();
         Date creationDate = calculateCreationDate();
 
-        handler.logInfo("Searching for processes with one of the following status: " + statuses);
+        handler.logInfo("Searching for processes with status: " + statuses);
         List<Process> processes = processService.findByStatusAndCreationTimeOlderThan(context, statuses, creationDate);
         handler.logInfo("Found " + processes.size() + " processes to be deleted");
         for (Process process : processes) {
@@ -98,6 +102,9 @@ public class ProcessCleaner extends DSpaceRunnable<ProcessCleanerConfiguration<P
 
     }
 
+    /**
+     * Returns the list of Process statuses do be deleted.
+     */
     private List<ProcessStatus> getProcessToDeleteStatuses() {
         List<ProcessStatus> statuses = new ArrayList<ProcessStatus>();
         if (cleanCompleted) {

--- a/dspace-api/src/main/java/org/dspace/administer/ProcessCleaner.java
+++ b/dspace-api/src/main/java/org/dspace/administer/ProcessCleaner.java
@@ -1,0 +1,126 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.administer;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.apache.commons.cli.ParseException;
+import org.apache.commons.lang.time.DateUtils;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.content.ProcessStatus;
+import org.dspace.core.Context;
+import org.dspace.scripts.DSpaceRunnable;
+import org.dspace.scripts.Process;
+import org.dspace.scripts.factory.ScriptServiceFactory;
+import org.dspace.scripts.service.ProcessService;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.utils.DSpace;
+
+/**
+ * Script to cleanup the old processes in the specified state.
+ *
+ * @author Luca Giamminonni (luca.giamminonni at 4science.it)
+ *
+ */
+public class ProcessCleaner extends DSpaceRunnable<ProcessCleanerConfiguration<ProcessCleaner>> {
+
+
+    private ConfigurationService configurationService;
+
+    private ProcessService processService;
+
+
+    boolean cleanCompleted = false;
+
+    boolean cleanFailed = false;
+
+    boolean cleanRunning = false;
+
+    private Integer days;
+
+
+    @Override
+    public void setup() throws ParseException {
+
+        this.configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
+        this.processService = ScriptServiceFactory.getInstance().getProcessService();
+
+        this.cleanFailed = commandLine.hasOption('f');
+        this.cleanRunning = commandLine.hasOption('r');
+        this.cleanCompleted = commandLine.hasOption('c') || (!cleanFailed && !cleanRunning);
+
+        this.days = configurationService.getIntProperty("process-cleaner.days", 14);
+
+        if (this.days <= 0) {
+            throw new IllegalArgumentException("The number of days must be a positive integer.");
+        }
+
+    }
+
+    @Override
+    public void internalRun() throws Exception {
+
+        Context context = new Context();
+
+        try {
+            context.turnOffAuthorisationSystem();
+            performDeletion(context);
+        } finally {
+            context.restoreAuthSystemState();
+            context.complete();
+        }
+
+    }
+
+    private void performDeletion(Context context) throws SQLException, IOException, AuthorizeException {
+
+        List<ProcessStatus> statuses = getProcessToDeleteStatuses();
+        Date creationDate = calculateCreationDate();
+
+        handler.logInfo("Searching for processes with one of the following status: " + statuses);
+        List<Process> processes = processService.findByStatusAndCreationTimeOlderThan(context, statuses, creationDate);
+        handler.logInfo("Found " + processes.size() + " processes to be deleted");
+        for (Process process : processes) {
+            processService.delete(context, process);
+        }
+
+        handler.logInfo("Process cleanup completed");
+
+    }
+
+    private List<ProcessStatus> getProcessToDeleteStatuses() {
+        List<ProcessStatus> statuses = new ArrayList<ProcessStatus>();
+        if (cleanCompleted) {
+            statuses.add(ProcessStatus.COMPLETED);
+        }
+        if (cleanFailed) {
+            statuses.add(ProcessStatus.FAILED);
+        }
+        if (cleanRunning) {
+            statuses.add(ProcessStatus.RUNNING);
+        }
+        return statuses;
+    }
+
+    private Date calculateCreationDate() {
+        return DateUtils.addDays(new Date(), -days);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public ProcessCleanerConfiguration<ProcessCleaner> getScriptConfiguration() {
+        return new DSpace().getServiceManager()
+            .getServiceByName("process-cleaner", ProcessCleanerConfiguration.class);
+    }
+
+}

--- a/dspace-api/src/main/java/org/dspace/administer/ProcessCleanerCli.java
+++ b/dspace-api/src/main/java/org/dspace/administer/ProcessCleanerCli.java
@@ -1,0 +1,18 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.administer;
+
+/**
+ * The {@link ProcessCleaner} for CLI.
+ *
+ * @author Luca Giamminonni (luca.giamminonni at 4science.it)
+ *
+ */
+public class ProcessCleanerCli extends ProcessCleaner {
+
+}

--- a/dspace-api/src/main/java/org/dspace/administer/ProcessCleanerCliConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/administer/ProcessCleanerCliConfiguration.java
@@ -1,0 +1,18 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.administer;
+
+/**
+ * The {@link ProcessCleanerConfiguration} for CLI.
+ *
+ * @author Luca Giamminonni (luca.giamminonni at 4science.it)
+ *
+ */
+public class ProcessCleanerCliConfiguration extends ProcessCleanerConfiguration<ProcessCleanerCli> {
+
+}

--- a/dspace-api/src/main/java/org/dspace/administer/ProcessCleanerConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/administer/ProcessCleanerConfiguration.java
@@ -40,6 +40,8 @@ public class ProcessCleanerConfiguration<T extends ProcessCleaner> extends Scrip
 
             Options options = new Options();
 
+            options.addOption("h", "help", false, "help");
+
             options.addOption("r", "running", false, "delete the process with RUNNING status");
             options.getOption("r").setType(boolean.class);
 

--- a/dspace-api/src/main/java/org/dspace/administer/ProcessCleanerConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/administer/ProcessCleanerConfiguration.java
@@ -1,0 +1,68 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.administer;
+
+import java.sql.SQLException;
+
+import org.apache.commons.cli.Options;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.core.Context;
+import org.dspace.scripts.configuration.ScriptConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * The {@link ScriptConfiguration} for the {@link ProcessCleaner} script.
+ */
+public class ProcessCleanerConfiguration<T extends ProcessCleaner> extends ScriptConfiguration<T> {
+
+    @Autowired
+    private AuthorizeService authorizeService;
+
+    private Class<T> dspaceRunnableClass;
+
+    @Override
+    public boolean isAllowedToExecute(Context context) {
+        try {
+            return authorizeService.isAdmin(context);
+        } catch (SQLException e) {
+            throw new RuntimeException("SQLException occurred when checking if the current user is an admin", e);
+        }
+    }
+
+    @Override
+    public Options getOptions() {
+        if (options == null) {
+
+            Options options = new Options();
+
+            options.addOption("r", "running", false, "delete the process with RUNNING status");
+            options.getOption("r").setType(boolean.class);
+
+            options.addOption("f", "failed", false, "delete the process with FAILED status");
+            options.getOption("f").setType(boolean.class);
+
+            options.addOption("c", "completed", false,
+                "delete the process with COMPLETED status (default if no statuses are specified)");
+            options.getOption("c").setType(boolean.class);
+
+            super.options = options;
+        }
+        return options;
+    }
+
+    @Override
+    public Class<T> getDspaceRunnableClass() {
+        return dspaceRunnableClass;
+    }
+
+    @Override
+    public void setDspaceRunnableClass(Class<T> dspaceRunnableClass) {
+        this.dspaceRunnableClass = dspaceRunnableClass;
+    }
+
+}

--- a/dspace-api/src/main/java/org/dspace/content/dao/ProcessDAO.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/ProcessDAO.java
@@ -14,7 +14,6 @@ import java.util.List;
 import org.dspace.content.ProcessStatus;
 import org.dspace.core.Context;
 import org.dspace.core.GenericDAO;
-import org.dspace.eperson.EPerson;
 import org.dspace.scripts.Process;
 import org.dspace.scripts.ProcessQueryParameterContainer;
 

--- a/dspace-api/src/main/java/org/dspace/content/dao/ProcessDAO.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/ProcessDAO.java
@@ -8,10 +8,13 @@
 package org.dspace.content.dao;
 
 import java.sql.SQLException;
+import java.util.Date;
 import java.util.List;
 
+import org.dspace.content.ProcessStatus;
 import org.dspace.core.Context;
 import org.dspace.core.GenericDAO;
+import org.dspace.eperson.EPerson;
 import org.dspace.scripts.Process;
 import org.dspace.scripts.ProcessQueryParameterContainer;
 
@@ -81,4 +84,18 @@ public interface ProcessDAO extends GenericDAO<Process> {
 
     int countTotalWithParameters(Context context, ProcessQueryParameterContainer processQueryParameterContainer)
         throws SQLException;
+
+    /**
+     * Find all the processes with one of the given status and with a creation time
+     * older than the specified date.
+     *
+     * @param  context      The relevant DSpace context
+     * @param  statuses     the statuses of the processes to search for
+     * @param  date         the creation date to search for
+     * @return              The list of all Processes which match requirements
+     * @throws SQLException If something goes wrong
+     */
+    List<Process> findByStatusAndCreationTimeOlderThan(Context context, List<ProcessStatus> statuses, Date date)
+        throws SQLException;
+
 }

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/ProcessDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/ProcessDAOImpl.java
@@ -7,7 +7,10 @@
  */
 package org.dspace.content.dao.impl;
 
+import static org.dspace.scripts.Process_.CREATION_TIME;
+
 import java.sql.SQLException;
+import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -17,6 +20,7 @@ import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
 import org.apache.commons.lang3.StringUtils;
+import org.dspace.content.ProcessStatus;
 import org.dspace.content.dao.ProcessDAO;
 import org.dspace.core.AbstractHibernateDAO;
 import org.dspace.core.Context;
@@ -146,6 +150,23 @@ public class ProcessDAOImpl extends AbstractHibernateDAO<Process> implements Pro
         return count(context, criteriaQuery, criteriaBuilder, processRoot);
     }
 
+
+    @Override
+    public List<Process> findByStatusAndCreationTimeOlderThan(Context context, List<ProcessStatus> statuses,
+        Date date) throws SQLException {
+
+        CriteriaBuilder criteriaBuilder = getCriteriaBuilder(context);
+        CriteriaQuery<Process> criteriaQuery = getCriteriaQuery(criteriaBuilder, Process.class);
+
+        Root<Process> processRoot = criteriaQuery.from(Process.class);
+        criteriaQuery.select(processRoot);
+
+        Predicate creationTimeLessThanGivenDate = criteriaBuilder.lessThan(processRoot.get(CREATION_TIME), date);
+        Predicate statusIn = processRoot.get(Process_.PROCESS_STATUS).in(statuses);
+        criteriaQuery.where(criteriaBuilder.and(creationTimeLessThanGivenDate, statusIn));
+
+        return list(context, criteriaQuery, false, Process.class, -1, -1);
+    }
 
 }
 

--- a/dspace-api/src/main/java/org/dspace/scripts/ProcessServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/scripts/ProcessServiceImpl.java
@@ -305,6 +305,12 @@ public class ProcessServiceImpl implements ProcessService {
         tempFile.delete();
     }
 
+    @Override
+    public List<Process> findByStatusAndCreationTimeOlderThan(Context context, List<ProcessStatus> statuses,
+        Date date) throws SQLException {
+        return this.processDAO.findByStatusAndCreationTimeOlderThan(context, statuses, date);
+    }
+
     private String formatLogLine(int processId, String scriptName, String output, ProcessLogLevel processLogLevel) {
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
         StringBuilder sb = new StringBuilder();

--- a/dspace-api/src/main/java/org/dspace/scripts/service/ProcessService.java
+++ b/dspace-api/src/main/java/org/dspace/scripts/service/ProcessService.java
@@ -10,11 +10,13 @@ package org.dspace.scripts.service;
 import java.io.IOException;
 import java.io.InputStream;
 import java.sql.SQLException;
+import java.util.Date;
 import java.util.List;
 import java.util.Set;
 
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Bitstream;
+import org.dspace.content.ProcessStatus;
 import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
@@ -240,4 +242,17 @@ public interface ProcessService {
      */
     void createLogBitstream(Context context, Process process)
              throws IOException, SQLException, AuthorizeException;
+
+    /**
+     * Find all the processes with one of the given status and with a creation time
+     * older than the specified date.
+     *
+     * @param  context            The relevant DSpace context
+     * @param  statuses           the statuses of the processes to search for
+     * @param  date               the creation date to search for
+     * @return                    The list of all Processes which match requirements
+     * @throws AuthorizeException If something goes wrong
+     */
+    List<Process> findByStatusAndCreationTimeOlderThan(Context context, List<ProcessStatus> statuses, Date date)
+        throws SQLException;
 }

--- a/dspace-api/src/test/data/dspaceFolder/config/spring/api/scripts.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/spring/api/scripts.xml
@@ -64,7 +64,12 @@
         <property name="description" value="Perform the bulk synchronization of all the BATCH configured ORCID entities placed in the ORCID queue"/>
         <property name="dspaceRunnableClass" value="org.dspace.orcid.script.OrcidBulkPush"/>
     </bean>
-    
+
+    <bean id="process-cleaner" class="org.dspace.administer.ProcessCleanerCliConfiguration">
+        <property name="description" value="Cleanup all the old processes in the specified state"/>
+        <property name="dspaceRunnableClass" value="org.dspace.administer.ProcessCleanerCli"/>
+    </bean>
+
     <!-- Keep as last script; for test ScriptRestRepository#findOneScriptByNameTest -->
     <bean id="mock-script" class="org.dspace.scripts.MockDSpaceRunnableScriptConfiguration" scope="prototype">
         <property name="description" value="Mocking a script for testing purposes" />

--- a/dspace-api/src/test/java/org/dspace/administer/ProcessCleanerIT.java
+++ b/dspace-api/src/test/java/org/dspace/administer/ProcessCleanerIT.java
@@ -1,0 +1,380 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.administer;
+
+import static org.apache.commons.lang.time.DateUtils.addDays;
+import static org.dspace.content.ProcessStatus.COMPLETED;
+import static org.dspace.content.ProcessStatus.FAILED;
+import static org.dspace.content.ProcessStatus.RUNNING;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.sql.SQLException;
+import java.util.Date;
+import java.util.List;
+
+import org.dspace.AbstractIntegrationTestWithDatabase;
+import org.dspace.app.launcher.ScriptLauncher;
+import org.dspace.app.scripts.handler.impl.TestDSpaceRunnableHandler;
+import org.dspace.builder.ProcessBuilder;
+import org.dspace.content.ProcessStatus;
+import org.dspace.scripts.Process;
+import org.dspace.scripts.factory.ScriptServiceFactory;
+import org.dspace.scripts.service.ProcessService;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
+import org.junit.Test;
+
+/**
+ * Integration tests for {@link ProcessCleaner}.
+ *
+ * @author Luca Giamminonni (luca.giamminonni at 4science.it)
+ *
+ */
+public class ProcessCleanerIT extends AbstractIntegrationTestWithDatabase {
+
+    private ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
+
+    private ProcessService processService = ScriptServiceFactory.getInstance().getProcessService();
+
+    @Test
+    public void testWithoutProcessToDelete() throws Exception {
+
+        Process process_1 = buildProcess(COMPLETED, addDays(new Date(), -2));
+        Process process_2 = buildProcess(RUNNING, addDays(new Date(), -1));
+        Process process_3 = buildProcess(FAILED, addDays(new Date(), -3));
+
+        configurationService.setProperty("process-cleaner.days", 5);
+
+        TestDSpaceRunnableHandler testDSpaceRunnableHandler = new TestDSpaceRunnableHandler();
+
+        String[] args = new String[] { "process-cleaner" };
+        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), testDSpaceRunnableHandler, kernelImpl);
+
+        assertThat(testDSpaceRunnableHandler.getErrorMessages(), empty());
+        assertThat(testDSpaceRunnableHandler.getWarningMessages(), empty());
+
+        List<String> messages = testDSpaceRunnableHandler.getInfoMessages();
+        assertThat(messages, hasSize(3));
+        assertThat(messages, hasItem("Searching for processes with status: [COMPLETED]"));
+        assertThat(messages, hasItem("Found 0 processes to be deleted"));
+        assertThat(messages, hasItem("Process cleanup completed"));
+
+        assertThat(processService.find(context, process_1.getID()), notNullValue());
+        assertThat(processService.find(context, process_2.getID()), notNullValue());
+        assertThat(processService.find(context, process_3.getID()), notNullValue());
+
+    }
+
+    @Test
+    public void testWithoutSpecifiedStatus() throws Exception {
+
+        Process process_1 = buildProcess(COMPLETED, addDays(new Date(), -2));
+        Process process_2 = buildProcess(RUNNING, addDays(new Date(), -1));
+        Process process_3 = buildProcess(FAILED, addDays(new Date(), -3));
+        Process process_4 = buildProcess(COMPLETED, addDays(new Date(), -6));
+        Process process_5 = buildProcess(COMPLETED, addDays(new Date(), -8));
+        Process process_6 = buildProcess(RUNNING, addDays(new Date(), -7));
+        Process process_7 = buildProcess(FAILED, addDays(new Date(), -8));
+
+        configurationService.setProperty("process-cleaner.days", 5);
+
+        TestDSpaceRunnableHandler testDSpaceRunnableHandler = new TestDSpaceRunnableHandler();
+
+        String[] args = new String[] { "process-cleaner" };
+        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), testDSpaceRunnableHandler, kernelImpl);
+
+        assertThat(testDSpaceRunnableHandler.getErrorMessages(), empty());
+        assertThat(testDSpaceRunnableHandler.getWarningMessages(), empty());
+
+        List<String> messages = testDSpaceRunnableHandler.getInfoMessages();
+        assertThat(messages, hasSize(3));
+        assertThat(messages, hasItem("Searching for processes with status: [COMPLETED]"));
+        assertThat(messages, hasItem("Found 2 processes to be deleted"));
+        assertThat(messages, hasItem("Process cleanup completed"));
+
+        assertThat(processService.find(context, process_1.getID()), notNullValue());
+        assertThat(processService.find(context, process_2.getID()), notNullValue());
+        assertThat(processService.find(context, process_3.getID()), notNullValue());
+        assertThat(processService.find(context, process_4.getID()), nullValue());
+        assertThat(processService.find(context, process_5.getID()), nullValue());
+        assertThat(processService.find(context, process_6.getID()), notNullValue());
+        assertThat(processService.find(context, process_7.getID()), notNullValue());
+
+    }
+
+    @Test
+    public void testWithCompletedStatus() throws Exception {
+
+        Process process_1 = buildProcess(COMPLETED, addDays(new Date(), -2));
+        Process process_2 = buildProcess(RUNNING, addDays(new Date(), -1));
+        Process process_3 = buildProcess(FAILED, addDays(new Date(), -3));
+        Process process_4 = buildProcess(COMPLETED, addDays(new Date(), -6));
+        Process process_5 = buildProcess(COMPLETED, addDays(new Date(), -8));
+        Process process_6 = buildProcess(RUNNING, addDays(new Date(), -7));
+        Process process_7 = buildProcess(FAILED, addDays(new Date(), -8));
+
+        configurationService.setProperty("process-cleaner.days", 5);
+
+        TestDSpaceRunnableHandler testDSpaceRunnableHandler = new TestDSpaceRunnableHandler();
+
+        String[] args = new String[] { "process-cleaner", "-c" };
+        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), testDSpaceRunnableHandler, kernelImpl);
+
+        assertThat(testDSpaceRunnableHandler.getErrorMessages(), empty());
+        assertThat(testDSpaceRunnableHandler.getWarningMessages(), empty());
+
+        List<String> messages = testDSpaceRunnableHandler.getInfoMessages();
+        assertThat(messages, hasSize(3));
+        assertThat(messages, hasItem("Searching for processes with status: [COMPLETED]"));
+        assertThat(messages, hasItem("Found 2 processes to be deleted"));
+        assertThat(messages, hasItem("Process cleanup completed"));
+
+        assertThat(processService.find(context, process_1.getID()), notNullValue());
+        assertThat(processService.find(context, process_2.getID()), notNullValue());
+        assertThat(processService.find(context, process_3.getID()), notNullValue());
+        assertThat(processService.find(context, process_4.getID()), nullValue());
+        assertThat(processService.find(context, process_5.getID()), nullValue());
+        assertThat(processService.find(context, process_6.getID()), notNullValue());
+        assertThat(processService.find(context, process_7.getID()), notNullValue());
+
+    }
+
+    @Test
+    public void testWithRunningStatus() throws Exception {
+
+        Process process_1 = buildProcess(COMPLETED, addDays(new Date(), -2));
+        Process process_2 = buildProcess(RUNNING, addDays(new Date(), -1));
+        Process process_3 = buildProcess(FAILED, addDays(new Date(), -3));
+        Process process_4 = buildProcess(COMPLETED, addDays(new Date(), -6));
+        Process process_5 = buildProcess(COMPLETED, addDays(new Date(), -8));
+        Process process_6 = buildProcess(RUNNING, addDays(new Date(), -7));
+        Process process_7 = buildProcess(FAILED, addDays(new Date(), -8));
+        Process process_8 = buildProcess(RUNNING, addDays(new Date(), -9));
+
+        configurationService.setProperty("process-cleaner.days", 5);
+
+        TestDSpaceRunnableHandler testDSpaceRunnableHandler = new TestDSpaceRunnableHandler();
+
+        String[] args = new String[] { "process-cleaner", "-r" };
+        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), testDSpaceRunnableHandler, kernelImpl);
+
+        assertThat(testDSpaceRunnableHandler.getErrorMessages(), empty());
+        assertThat(testDSpaceRunnableHandler.getWarningMessages(), empty());
+
+        List<String> messages = testDSpaceRunnableHandler.getInfoMessages();
+        assertThat(messages, hasSize(3));
+        assertThat(messages, hasItem("Searching for processes with status: [RUNNING]"));
+        assertThat(messages, hasItem("Found 2 processes to be deleted"));
+        assertThat(messages, hasItem("Process cleanup completed"));
+
+        assertThat(processService.find(context, process_1.getID()), notNullValue());
+        assertThat(processService.find(context, process_2.getID()), notNullValue());
+        assertThat(processService.find(context, process_3.getID()), notNullValue());
+        assertThat(processService.find(context, process_4.getID()), notNullValue());
+        assertThat(processService.find(context, process_5.getID()), notNullValue());
+        assertThat(processService.find(context, process_6.getID()), nullValue());
+        assertThat(processService.find(context, process_7.getID()), notNullValue());
+        assertThat(processService.find(context, process_8.getID()), nullValue());
+
+    }
+
+    @Test
+    public void testWithFailedStatus() throws Exception {
+
+        Process process_1 = buildProcess(COMPLETED, addDays(new Date(), -2));
+        Process process_2 = buildProcess(RUNNING, addDays(new Date(), -1));
+        Process process_3 = buildProcess(FAILED, addDays(new Date(), -3));
+        Process process_4 = buildProcess(COMPLETED, addDays(new Date(), -6));
+        Process process_5 = buildProcess(COMPLETED, addDays(new Date(), -8));
+        Process process_6 = buildProcess(RUNNING, addDays(new Date(), -7));
+        Process process_7 = buildProcess(FAILED, addDays(new Date(), -8));
+        Process process_8 = buildProcess(FAILED, addDays(new Date(), -9));
+
+        configurationService.setProperty("process-cleaner.days", 5);
+
+        TestDSpaceRunnableHandler testDSpaceRunnableHandler = new TestDSpaceRunnableHandler();
+
+        String[] args = new String[] { "process-cleaner", "-f" };
+        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), testDSpaceRunnableHandler, kernelImpl);
+
+        assertThat(testDSpaceRunnableHandler.getErrorMessages(), empty());
+        assertThat(testDSpaceRunnableHandler.getWarningMessages(), empty());
+
+        List<String> messages = testDSpaceRunnableHandler.getInfoMessages();
+        assertThat(messages, hasSize(3));
+        assertThat(messages, hasItem("Searching for processes with status: [FAILED]"));
+        assertThat(messages, hasItem("Found 2 processes to be deleted"));
+        assertThat(messages, hasItem("Process cleanup completed"));
+
+        assertThat(processService.find(context, process_1.getID()), notNullValue());
+        assertThat(processService.find(context, process_2.getID()), notNullValue());
+        assertThat(processService.find(context, process_3.getID()), notNullValue());
+        assertThat(processService.find(context, process_4.getID()), notNullValue());
+        assertThat(processService.find(context, process_5.getID()), notNullValue());
+        assertThat(processService.find(context, process_6.getID()), notNullValue());
+        assertThat(processService.find(context, process_7.getID()), nullValue());
+        assertThat(processService.find(context, process_8.getID()), nullValue());
+
+    }
+
+    @Test
+    public void testWithCompletedAndFailedStatus() throws Exception {
+
+        Process process_1 = buildProcess(COMPLETED, addDays(new Date(), -2));
+        Process process_2 = buildProcess(RUNNING, addDays(new Date(), -1));
+        Process process_3 = buildProcess(FAILED, addDays(new Date(), -3));
+        Process process_4 = buildProcess(COMPLETED, addDays(new Date(), -6));
+        Process process_5 = buildProcess(COMPLETED, addDays(new Date(), -8));
+        Process process_6 = buildProcess(RUNNING, addDays(new Date(), -7));
+        Process process_7 = buildProcess(FAILED, addDays(new Date(), -8));
+        Process process_8 = buildProcess(FAILED, addDays(new Date(), -9));
+
+        configurationService.setProperty("process-cleaner.days", 5);
+
+        TestDSpaceRunnableHandler testDSpaceRunnableHandler = new TestDSpaceRunnableHandler();
+
+        String[] args = new String[] { "process-cleaner", "-c", "-f" };
+        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), testDSpaceRunnableHandler, kernelImpl);
+
+        List<String> messages = testDSpaceRunnableHandler.getInfoMessages();
+        assertThat(messages, hasSize(3));
+        assertThat(messages, hasItem("Searching for processes with status: [COMPLETED, FAILED]"));
+        assertThat(messages, hasItem("Found 4 processes to be deleted"));
+        assertThat(messages, hasItem("Process cleanup completed"));
+
+        assertThat(processService.find(context, process_1.getID()), notNullValue());
+        assertThat(processService.find(context, process_2.getID()), notNullValue());
+        assertThat(processService.find(context, process_3.getID()), notNullValue());
+        assertThat(processService.find(context, process_4.getID()), nullValue());
+        assertThat(processService.find(context, process_5.getID()), nullValue());
+        assertThat(processService.find(context, process_6.getID()), notNullValue());
+        assertThat(processService.find(context, process_7.getID()), nullValue());
+        assertThat(processService.find(context, process_8.getID()), nullValue());
+
+    }
+
+    @Test
+    public void testWithCompletedAndRunningStatus() throws Exception {
+
+        Process process_1 = buildProcess(COMPLETED, addDays(new Date(), -2));
+        Process process_2 = buildProcess(RUNNING, addDays(new Date(), -1));
+        Process process_3 = buildProcess(FAILED, addDays(new Date(), -3));
+        Process process_4 = buildProcess(COMPLETED, addDays(new Date(), -6));
+        Process process_5 = buildProcess(COMPLETED, addDays(new Date(), -8));
+        Process process_6 = buildProcess(RUNNING, addDays(new Date(), -7));
+        Process process_7 = buildProcess(FAILED, addDays(new Date(), -8));
+        Process process_8 = buildProcess(RUNNING, addDays(new Date(), -9));
+
+        configurationService.setProperty("process-cleaner.days", 5);
+
+        TestDSpaceRunnableHandler testDSpaceRunnableHandler = new TestDSpaceRunnableHandler();
+
+        String[] args = new String[] { "process-cleaner", "-c", "-r" };
+        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), testDSpaceRunnableHandler, kernelImpl);
+
+        List<String> messages = testDSpaceRunnableHandler.getInfoMessages();
+        assertThat(messages, hasSize(3));
+        assertThat(messages, hasItem("Searching for processes with status: [COMPLETED, RUNNING]"));
+        assertThat(messages, hasItem("Found 4 processes to be deleted"));
+        assertThat(messages, hasItem("Process cleanup completed"));
+
+        assertThat(processService.find(context, process_1.getID()), notNullValue());
+        assertThat(processService.find(context, process_2.getID()), notNullValue());
+        assertThat(processService.find(context, process_3.getID()), notNullValue());
+        assertThat(processService.find(context, process_4.getID()), nullValue());
+        assertThat(processService.find(context, process_5.getID()), nullValue());
+        assertThat(processService.find(context, process_6.getID()), nullValue());
+        assertThat(processService.find(context, process_7.getID()), notNullValue());
+        assertThat(processService.find(context, process_8.getID()), nullValue());
+
+    }
+
+    @Test
+    public void testWithFailedAndRunningStatus() throws Exception {
+
+        Process process_1 = buildProcess(COMPLETED, addDays(new Date(), -2));
+        Process process_2 = buildProcess(RUNNING, addDays(new Date(), -1));
+        Process process_3 = buildProcess(FAILED, addDays(new Date(), -3));
+        Process process_4 = buildProcess(COMPLETED, addDays(new Date(), -6));
+        Process process_5 = buildProcess(COMPLETED, addDays(new Date(), -8));
+        Process process_6 = buildProcess(RUNNING, addDays(new Date(), -7));
+        Process process_7 = buildProcess(FAILED, addDays(new Date(), -8));
+        Process process_8 = buildProcess(RUNNING, addDays(new Date(), -9));
+
+        configurationService.setProperty("process-cleaner.days", 5);
+
+        TestDSpaceRunnableHandler testDSpaceRunnableHandler = new TestDSpaceRunnableHandler();
+
+        String[] args = new String[] { "process-cleaner", "-f", "-r" };
+        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), testDSpaceRunnableHandler, kernelImpl);
+
+        List<String> messages = testDSpaceRunnableHandler.getInfoMessages();
+        assertThat(messages, hasSize(3));
+        assertThat(messages, hasItem("Searching for processes with status: [FAILED, RUNNING]"));
+        assertThat(messages, hasItem("Found 3 processes to be deleted"));
+        assertThat(messages, hasItem("Process cleanup completed"));
+
+        assertThat(processService.find(context, process_1.getID()), notNullValue());
+        assertThat(processService.find(context, process_2.getID()), notNullValue());
+        assertThat(processService.find(context, process_3.getID()), notNullValue());
+        assertThat(processService.find(context, process_4.getID()), notNullValue());
+        assertThat(processService.find(context, process_5.getID()), notNullValue());
+        assertThat(processService.find(context, process_6.getID()), nullValue());
+        assertThat(processService.find(context, process_7.getID()), nullValue());
+        assertThat(processService.find(context, process_8.getID()), nullValue());
+
+    }
+
+    @Test
+    public void testWithCompletedFailedAndRunningStatus() throws Exception {
+
+        Process process_1 = buildProcess(COMPLETED, addDays(new Date(), -2));
+        Process process_2 = buildProcess(RUNNING, addDays(new Date(), -1));
+        Process process_3 = buildProcess(FAILED, addDays(new Date(), -3));
+        Process process_4 = buildProcess(COMPLETED, addDays(new Date(), -6));
+        Process process_5 = buildProcess(COMPLETED, addDays(new Date(), -8));
+        Process process_6 = buildProcess(RUNNING, addDays(new Date(), -7));
+        Process process_7 = buildProcess(FAILED, addDays(new Date(), -8));
+        Process process_8 = buildProcess(RUNNING, addDays(new Date(), -9));
+
+        configurationService.setProperty("process-cleaner.days", 5);
+
+        TestDSpaceRunnableHandler testDSpaceRunnableHandler = new TestDSpaceRunnableHandler();
+
+        String[] args = new String[] { "process-cleaner", "-f", "-r", "-c" };
+        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), testDSpaceRunnableHandler, kernelImpl);
+
+        List<String> messages = testDSpaceRunnableHandler.getInfoMessages();
+        assertThat(messages, hasSize(3));
+        assertThat(messages, hasItem("Searching for processes with status: [COMPLETED, FAILED, RUNNING]"));
+        assertThat(messages, hasItem("Found 5 processes to be deleted"));
+        assertThat(messages, hasItem("Process cleanup completed"));
+
+        assertThat(processService.find(context, process_1.getID()), notNullValue());
+        assertThat(processService.find(context, process_2.getID()), notNullValue());
+        assertThat(processService.find(context, process_3.getID()), notNullValue());
+        assertThat(processService.find(context, process_4.getID()), nullValue());
+        assertThat(processService.find(context, process_5.getID()), nullValue());
+        assertThat(processService.find(context, process_6.getID()), nullValue());
+        assertThat(processService.find(context, process_7.getID()), nullValue());
+        assertThat(processService.find(context, process_8.getID()), nullValue());
+
+    }
+
+    private Process buildProcess(ProcessStatus processStatus, Date creationTime) throws SQLException {
+        return ProcessBuilder.createProcess(context, admin, "test", List.of())
+            .withProcessStatus(processStatus)
+            .withCreationTime(creationTime)
+            .build();
+    }
+}

--- a/dspace-api/src/test/java/org/dspace/builder/ProcessBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/ProcessBuilder.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.List;
 import java.util.Set;
 
@@ -57,6 +58,11 @@ public class ProcessBuilder extends AbstractBuilder<Process, ProcessService> {
 
     public ProcessBuilder withProcessStatus(ProcessStatus processStatus) {
         process.setProcessStatus(processStatus);
+        return this;
+    }
+
+    public ProcessBuilder withCreationTime(Date creationTime) {
+        process.setCreationTime(creationTime);
         return this;
     }
 

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1542,6 +1542,10 @@ solr-database-resync.time-until-reindex = 600000
 # Keep in mind, changing the schedule requires rebooting your servlet container, e.g. Tomcat.
 solr-database-resync.cron = 0 15 2 * * ?
 
+## PROCESS CLEANER SCRIPT
+# Defines how many days to go back from the current date to find out which old processes to delete (default is 14)
+# process-cleaner.days = 14
+
 #------------------------------------------------------------------#
 #-------------------MODULE CONFIGURATIONS--------------------------#
 #------------------------------------------------------------------#

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1542,8 +1542,11 @@ solr-database-resync.time-until-reindex = 600000
 # Keep in mind, changing the schedule requires rebooting your servlet container, e.g. Tomcat.
 solr-database-resync.cron = 0 15 2 * * ?
 
-## PROCESS CLEANER SCRIPT
-# Defines how many days to go back from the current date to find out which old processes to delete (default is 14)
+#----------------------------------------------------------#
+#----------PROCESS CLEANER SCRIPT CONFIGURATION------------#
+#----------------------------------------------------------#
+# Processes older than this number of days will be deleted when the "process-cleaner" script is next run.
+# Default is 14 (i.e. processes that are two weeks or older will be deleted)
 # process-cleaner.days = 14
 
 #------------------------------------------------------------------#

--- a/dspace/config/spring/api/scripts.xml
+++ b/dspace/config/spring/api/scripts.xml
@@ -50,6 +50,11 @@
         <property name="description" value="Manage the OAI-PMH harvesting of external collections"/>
         <property name="dspaceRunnableClass" value="org.dspace.app.harvest.HarvestCli"/>
     </bean>
+        
+    <bean id="process-cleaner" class="org.dspace.administer.ProcessCleanerCliConfiguration">
+        <property name="description" value="Cleanup all the old processes in the specified state"/>
+        <property name="dspaceRunnableClass" value="org.dspace.administer.ProcessCleanerCli"/>
+    </bean>
 
     <bean id="filter-media" class="org.dspace.app.mediafilter.MediaFilterScriptConfiguration">
         <property name="description" value="Perform the media filtering to extract full text from documents and to create thumbnails"/>

--- a/dspace/config/spring/rest/scripts.xml
+++ b/dspace/config/spring/rest/scripts.xml
@@ -39,6 +39,11 @@
         <property name="dspaceRunnableClass" value="org.dspace.app.harvest.Harvest"/>
     </bean>
     
+    <bean id="process-cleaner" class="org.dspace.administer.ProcessCleanerConfiguration" primary="true">
+        <property name="description" value="Cleanup all the old processes in the specified state"/>
+        <property name="dspaceRunnableClass" value="org.dspace.administer.ProcessCleaner"/>
+    </bean>
+    
     <bean id="orcid-bulk-push" class="org.dspace.orcid.script.OrcidBulkPushScriptConfiguration" primary="true">
         <property name="description" value="Perform the bulk synchronization of all the BATCH configured ORCID entities placed in the ORCID queue"/>
         <property name="dspaceRunnableClass" value="org.dspace.orcid.script.OrcidBulkPush"/>


### PR DESCRIPTION
## References
* Fixes [#7974](https://github.com/DSpace/DSpace/issues/7974)

## Description
This PR introduces a new script named process-cleaner that deletes from the database all processes with the specified statuses older than the configured days.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
