### PR TITLE
Curation task results are not included in the output file or process output

### DIFF
--- a/dspace-api/src/main/java/org/dspace/curate/Curation.java
+++ b/dspace-api/src/main/java/org/dspace/curate/Curation.java
@@ -189,8 +189,7 @@ public class Curation extends DSpaceRunnable<CurationScriptConfiguration> {
      * @throws FileNotFoundException If file of command line variable -r reporter is not found
      */
     private Curator initCurator() throws FileNotFoundException {
-        Curator curator = new Curator();
-        curator.setLogHandler(handler);
+        Curator curator = new Curator(handler);
         OutputStream reporterStream;
         if (null == this.reporter) {
             reporterStream = new NullOutputStream();

--- a/dspace-api/src/main/java/org/dspace/curate/Curation.java
+++ b/dspace-api/src/main/java/org/dspace/curate/Curation.java
@@ -190,6 +190,7 @@ public class Curation extends DSpaceRunnable<CurationScriptConfiguration> {
      */
     private Curator initCurator() throws FileNotFoundException {
         Curator curator = new Curator();
+        curator.setLogHandler(handler);
         OutputStream reporterStream;
         if (null == this.reporter) {
             reporterStream = new NullOutputStream();

--- a/dspace-api/src/main/java/org/dspace/curate/Curator.java
+++ b/dspace-api/src/main/java/org/dspace/curate/Curator.java
@@ -9,6 +9,7 @@ package org.dspace.curate;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -92,6 +93,16 @@ public class Curator {
     protected ItemService itemService;
     protected HandleService handleService;
     protected DSpaceRunnableHandler handler;
+
+    /**
+     * constructor that uses an handler for logging
+     * 
+     * @param handler {@code DSpaceRunnableHandler} used to logs infos
+     */
+    public Curator(DSpaceRunnableHandler handler) {
+        this();
+        this.handler = handler;
+    }
 
     /**
      * No-arg constructor
@@ -607,11 +618,11 @@ public class Curator {
             return mb.toString();
         }
 
-        protected void logInfo(String id) {
+        protected void logInfo(String message) {
             if (handler == null) {
-                log.info(logMessage(id));
+                log.info(message);
             } else {
-                handler.logInfo(logMessage(id));
+                handler.logInfo(message);
             }
         }
 
@@ -629,11 +640,11 @@ public class Curator {
                 log.warn(message);
             }
         } else {
-            handler.logWarning(message);
+            if (object != null) {
+                handler.logWarning(MessageFormat.format(message, object));
+            } else {
+                handler.logWarning(message);
+            }
         }
-    }
-
-    public void setLogHandler(DSpaceRunnableHandler handler) {
-        this.handler = handler;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/curate/Curator.java
+++ b/dspace-api/src/main/java/org/dspace/curate/Curator.java
@@ -618,6 +618,11 @@ public class Curator {
             return mb.toString();
         }
 
+        /**
+         * Proxy method for logging with INFO level
+         * 
+         * @param message that needs to be logged
+         */
         protected void logInfo(String message) {
             if (handler == null) {
                 log.info(message);
@@ -628,10 +633,22 @@ public class Curator {
 
     }
 
+    /**
+     * Proxt method for logging with WARN level
+     * 
+     * @param message
+     */
     protected void logWarning(String message) {
         logWarning(message, null);
     }
 
+    /**
+     * Proxy method for logging with WARN level and a {@code Messageformatter}
+     * that generates the final log.
+     * 
+     * @param message Target message to format or print
+     * @param object  Object to use inside the message, or null
+     */
     protected void logWarning(String message, Object object) {
         if (handler == null) {
             if (object != null) {


### PR DESCRIPTION
## References
* Fixes [#1322 ](https://github.com/DSpace/dspace-angular/issues/1322)

## Description
This PR provides an handler that logs messages in output file or process output.

## Instructions for Reviewers
Mainly changed the class `Curator` to integrate the `DSpaceRunnableHandler` involved to log infos in process output.
Now the `Curation` class initialise a `Curator` using `DSpaceRunnableHandler`.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
