### PR TITLE
Enable and fix `MetadataExportSearchIT`

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/SearchUtils.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SearchUtils.java
@@ -52,12 +52,25 @@ public class SearchUtils {
      */
     private SearchUtils() { }
 
+    /**
+     * Return an instance of the {@link SearchService}.
+     */
     public static SearchService getSearchService() {
         if (searchService == null) {
             org.dspace.kernel.ServiceManager manager = DSpaceServicesFactory.getInstance().getServiceManager();
             searchService = manager.getServiceByName(SearchService.class.getName(), SearchService.class);
         }
         return searchService;
+    }
+
+    /**
+     * Clear the cached {@link SearchService} instance, forcing it to be retrieved from the service manager again
+     * next time {@link SearchUtils#getSearchService} is called.
+     * In practice, this is only necessary for integration tests in some environments
+     * where the cached version may no longer be up to date between tests.
+     */
+    public static void clearCachedSearchService() {
+        searchService = null;
     }
 
     public static DiscoveryConfiguration getDiscoveryConfiguration() {

--- a/dspace-api/src/test/java/org/dspace/AbstractDSpaceIntegrationTest.java
+++ b/dspace-api/src/test/java/org/dspace/AbstractDSpaceIntegrationTest.java
@@ -18,6 +18,7 @@ import java.util.TimeZone;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.builder.AbstractBuilder;
+import org.dspace.discovery.SearchUtils;
 import org.dspace.servicemanager.DSpaceKernelImpl;
 import org.dspace.servicemanager.DSpaceKernelInit;
 import org.junit.AfterClass;
@@ -104,6 +105,7 @@ public class AbstractDSpaceIntegrationTest {
 
         // Unload DSpace services
         AbstractBuilder.destroy();
+        SearchUtils.clearCachedSearchService();
 
         // NOTE: We explicitly do NOT stop/destroy the kernel, as it is cached
         // in the Spring ApplicationContext. By default, to speed up tests,

--- a/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataExportSearchIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataExportSearchIT.java
@@ -53,12 +53,14 @@ public class MetadataExportSearchIT extends AbstractIntegrationTestWithDatabase 
     private Collection collection;
     private Logger logger = Logger.getLogger(MetadataExportSearchIT.class);
     private ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
-    private SearchService searchService = SearchUtils.getSearchService();
+    private SearchService searchService;
 
     @Override
     @Before
     public void setUp() throws Exception {
         super.setUp();
+
+        searchService = SearchUtils.getSearchService();
 
         // dummy search so that the SearchService gets called in a test context first
         DiscoverQuery query = new DiscoverQuery();

--- a/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataExportSearchIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataExportSearchIT.java
@@ -39,10 +39,8 @@ import org.dspace.discovery.SearchUtils;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
-@Ignore
 public class MetadataExportSearchIT extends AbstractIntegrationTestWithDatabase {
 
     private String subject1 = "subject1";

--- a/dspace-api/src/test/java/org/dspace/discovery/DiscoveryIT.java
+++ b/dspace-api/src/test/java/org/dspace/discovery/DiscoveryIT.java
@@ -60,6 +60,7 @@ import org.dspace.xmlworkflow.storedcomponents.ClaimedTask;
 import org.dspace.xmlworkflow.storedcomponents.PoolTask;
 import org.dspace.xmlworkflow.storedcomponents.XmlWorkflowItem;
 import org.dspace.xmlworkflow.storedcomponents.service.ClaimedTaskService;
+import org.junit.Before;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 
@@ -69,7 +70,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
 public class DiscoveryIT extends AbstractIntegrationTestWithDatabase {
 
     protected WorkspaceItemService workspaceItemService = ContentServiceFactory.getInstance().getWorkspaceItemService();
-    protected SearchService searchService = SearchUtils.getSearchService();
+    protected SearchService searchService;
 
     XmlWorkflowService workflowService = XmlWorkflowServiceFactory.getInstance().getXmlWorkflowService();
 
@@ -92,9 +93,11 @@ public class DiscoveryIT extends AbstractIntegrationTestWithDatabase {
                                                                                       .getMetadataAuthorityService();
 
     @Override
+    @Before
     public void setUp() throws Exception {
         super.setUp();
         configurationService.setProperty("solr-database-resync.time-until-reindex", 1);
+        searchService = SearchUtils.getSearchService();
     }
 
     @Test


### PR DESCRIPTION
## References

* Fixes #8355



## Description

This PR enables `MetadataExportSearchIT` and fixes it's current issues when running alongside `DiscoveryIT`



## Instructions for Reviewers

`MetadataExportSearchIT` was previously because it failed with 

```
org.dspace.discovery.SearchServiceException: No such core: search
```

We attempted some fixes in #8037, but this lead to `DiscoveryIT` failing instead.

The underlying issue appears to be that the cached `SearchService` instance in `SearchUtils` bleeds over between test suites and becomes invalid. 

This PR adds a method to `SearchUtils` to clear the cached service and calls it when tearing down integration test classes -- this ensures that we can add new test suites that use `SearchService` in the same way as the two existing ones.



**Reviewing**
* Confirm that integration tests now pass with `MetadataExportSearchIT` enabled
* Evaluate the solution (maybe we shouldn't use `SearchUtils` in ITs in the first place?)



## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.