### PR TITLE
Send email even if copy request is refused

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/requestitem/RequestItemEmailNotifier.java
+++ b/dspace-api/src/main/java/org/dspace/app/requestitem/RequestItemEmailNotifier.java
@@ -178,8 +178,16 @@ public class RequestItemEmailNotifier {
                             bitstream.getName(),
                             bitstream.getFormat(context).getMIMEType());
                 }
+                email.send();
+            } else {
+                boolean sendRejectEmail = configurationService
+                    .getBooleanProperty("request.item.reject.email", true);
+                // Not all sites want the "refusal" to be sent back to the requester via
+                // email. However, by default, the rejection email is sent back.
+                if (sendRejectEmail) {
+                    email.send();
+                }
             }
-            email.send();
         } catch (MessagingException | IOException | SQLException | AuthorizeException e) {
             LOG.warn(LogHelper.getHeader(context,
                     "error_mailing_requestItem", e.getMessage()));

--- a/dspace-api/src/main/java/org/dspace/app/requestitem/RequestItemEmailNotifier.java
+++ b/dspace-api/src/main/java/org/dspace/app/requestitem/RequestItemEmailNotifier.java
@@ -154,9 +154,9 @@ public class RequestItemEmailNotifier {
         email.setContent("body", message);
         email.setSubject(subject);
         email.addRecipient(ri.getReqEmail());
-        if (ri.isAccept_request()) {
-            // Attach bitstreams.
-            try {
+        // Attach bitstreams.
+        try {
+            if (ri.isAccept_request()) {
                 if (ri.isAllfiles()) {
                     Item item = ri.getItem();
                     List<Bundle> bundles = item.getBundles("ORIGINAL");
@@ -178,12 +178,12 @@ public class RequestItemEmailNotifier {
                             bitstream.getName(),
                             bitstream.getFormat(context).getMIMEType());
                 }
-                email.send();
-            } catch (MessagingException | IOException | SQLException | AuthorizeException e) {
-                LOG.warn(LogHelper.getHeader(context,
-                        "error_mailing_requestItem", e.getMessage()));
-                throw new IOException("Reply not sent:  " + e.getMessage());
             }
+            email.send();
+        } catch (MessagingException | IOException | SQLException | AuthorizeException e) {
+            LOG.warn(LogHelper.getHeader(context,
+                    "error_mailing_requestItem", e.getMessage()));
+            throw new IOException("Reply not sent:  " + e.getMessage());
         }
         LOG.info(LogHelper.getHeader(context,
                 "sent_attach_requestItem", "token={}"), ri.getToken());

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1542,6 +1542,10 @@ log.report.dir = ${dspace.dir}/log
 request.item.type = all
 # Should all Request Copy emails go to the helpdesk instead of the item submitter?
 request.item.helpdesk.override = false
+# Should a rejection of a copy request send an email back to the requester?
+# Defaults to "true", which means a rejection email is sent back.
+# Setting it to "false" results in a silent rejection.
+request.item.reject.email = true
 
 #------------------------------------------------------------------#
 #------------------SUBMISSION CONFIGURATION------------------------#


### PR DESCRIPTION
## References
* Fixes #8451

## Description
Allow the email to be sent even when the copy request is rejected.

## Instructions for Reviewers
List of changes in this PR:
* Placed the `email.send();` method outside of the `ri.isAccept_request()` condition.

**@pilasou already described how to reproduce the problem, see #8451**

## Checklist
- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
