### PR TITLE
Fixed error handling for invalid password during eperson creation

### DIFF
--- a/dspace-api/src/main/java/org/dspace/eperson/AccountServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/AccountServiceImpl.java
@@ -12,7 +12,6 @@ import java.sql.SQLException;
 import java.util.Locale;
 import javax.mail.MessagingException;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
@@ -176,14 +175,6 @@ public class AccountServiceImpl implements AccountService {
     public void deleteToken(Context context, String token)
         throws SQLException {
         registrationDataService.deleteByToken(context, token);
-    }
-
-    @Override
-    public boolean verifyPasswordStructure(String password) {
-        if (StringUtils.length(password) < 6) {
-            return false;
-        }
-        return true;
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/eperson/service/AccountService.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/service/AccountService.java
@@ -46,11 +46,4 @@ public interface AccountService {
 
     public void deleteToken(Context context, String token)
         throws SQLException;
-
-    /**
-     * This method verifies that a certain String adheres to the password rules for DSpace
-     * @param password  The String to be checked
-     * @return          A boolean indicating whether or not the given String adheres to the password rules
-     */
-    public boolean verifyPasswordStructure(String password);
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/EPersonRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/EPersonRestRepository.java
@@ -206,6 +206,10 @@ public class EPersonRestRepository extends DSpaceObjectRestRepository<EPerson, E
                 throw new EPersonNameNotProvidedException();
             }
         }
+        String password = epersonRest.getPassword();
+        if (StringUtils.isBlank(password)) {
+            throw new DSpaceBadRequestException("A password is required");
+        }
     }
 
     @Override

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/EPersonRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/EPersonRestRepository.java
@@ -206,10 +206,6 @@ public class EPersonRestRepository extends DSpaceObjectRestRepository<EPerson, E
                 throw new EPersonNameNotProvidedException();
             }
         }
-        String password = epersonRest.getPassword();
-        if (!accountService.verifyPasswordStructure(password)) {
-            throw new DSpaceBadRequestException("The given password is invalid");
-        }
     }
 
     @Override

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/EPersonRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/EPersonRestRepositoryIT.java
@@ -193,6 +193,32 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
     }
 
     @Test
+    public void testCreateWithInvalidPassword() throws Exception {
+
+        accountService.sendRegistrationInfo(context, "test@fake-email.com");
+        String token = registrationDataService.findByEmail(context, "test@fake-email.com").getToken();
+
+        String ePersonData = "{" +
+            "   \"metadata\":{" +
+            "      \"eperson.firstname\":[{\"value\":\"John\"}]," +
+            "      \"eperson.lastname\":[{\"value\":\"Doe\"}]" +
+            "   }," +
+            "   \"email\":\"test@fake-email.com\"," +
+            "   \"password\":\"1234\"," +
+            "   \"type\":\"eperson\"" +
+            "}";
+
+        getClient().perform(post("/api/eperson/epersons")
+            .content(ePersonData)
+            .contentType(contentType)
+            .param("token", token))
+            .andExpect(status().isUnprocessableEntity())
+            .andExpect(status().reason(is("New password is invalid. "
+                + "Valid passwords must be at least 8 characters long!")));
+
+    }
+
+    @Test
     public void findAllTest() throws Exception {
         context.turnOffAuthorisationSystem();
 


### PR DESCRIPTION
## References
* Partially fixes #[1859](https://github.com/DSpace/dspace-angular/issues/1859)
* Related to Angular (to be created)

## Description
With this PR I removed an old check on the password that was present on the eperson creation. In this way only the new validation service is used and if the password is not valid the correct message is returned.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
