### PR TITLE
Fix hardcoded `workflow.score` comparison in MetadatafieldRestRepositoryIT

### DIFF
--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadatafieldRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadatafieldRestRepositoryIT.java
@@ -1052,7 +1052,8 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
                    // Metadata fields are returned alphabetically.
                    // So, on the last page we'll just ensure it *at least* includes the last field alphabetically
                    .andExpect(jsonPath("$._embedded.metadatafields", Matchers.hasItems(
-                              MetadataFieldMatcher.matchMetadataFieldByKeys("workflow", "score", null)
+                              MetadataFieldMatcher.matchMetadataField(
+                                  alphabeticMdFields.get(alphabeticMdFields.size() - 1))
                               )))
                    .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
                            Matchers.containsString("/api/core/metadatafields?"),


### PR DESCRIPTION
## References
* Fixes #8501
* Overlooked in #7925

## Description
This PR fixes the issue where `MetadatafieldRestRepositoryIT#findAllPaginationTest` would expect `workflow.score` to be the last MDF in the registry.

Thi IT used to fail when a repository defined any MDF that would be sorted _behind_ `workflow.score`.

## Reviewing
Confirm that this change solves the original issue

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
