### PR TITLE
Update PDFBox dependency to version 2.0.27

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <!-- NOTE: Jetty needed for Solr, Handle Server & tests -->
         <jetty.version>9.4.48.v20220622</jetty.version>
         <log4j.version>2.17.1</log4j.version>
-        <pdfbox-version>2.0.24</pdfbox-version>
+        <pdfbox-version>2.0.27</pdfbox-version>
         <rome.version>1.18.0</rome.version>
         <slf4j.version>1.7.25</slf4j.version>
         <tika.version>2.3.0</tika.version>


### PR DESCRIPTION
## Description
This updates the PDFBox dependency to its latest patch level. See the release notes for versions from the current 2.0.24 until 2.0.27 here:

- 2.0.25: https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12310760&version=12350196
- 2.0.26: https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12310760&version=12350925
- 2.0.27: https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12310760&version=12351648

After a quick review of the changelogs above I have not seen any breaking changes, but there are dozens of fixes for performance, security, and correctness.

## Instructions for Reviewers
As of DSpace 7.3 PDFBox is only [used by the filter-media script](https://wiki.lyrasis.org/display/DSDOC7x/Mediafilters+for+Transforming+DSpace+Content) to create PDF thumbnails (unless configured otherwise) so you only need to check to make sure that is working correctly.

A suggestion for testing filter-media could be in this earlier 6.x pull request: https://github.com/DSpace/DSpace/pull/2742