### PR TITLE
Update Apache commons-dbcp2 and commons-pool2 dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1479,7 +1479,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-dbcp2</artifactId>
-                <version>2.8.0</version>
+                <version>2.9.0</version>
             </dependency>
             <dependency>
                 <groupId>commons-fileupload</groupId>
@@ -1506,7 +1506,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-pool2</artifactId>
-                <version>2.9.0</version>
+                <version>2.11.1</version>
             </dependency>
             <dependency>
                 <groupId>commons-validator</groupId>


### PR DESCRIPTION
## Description
Update commons-dbcp2 and commons-pool2 to latest stable versions. Currently DSpace 7.x is using 2.8.0 and 2.9.0, respectively.

See the changelogs for each here:

- commons-dbcp2 2.9.0: https://dlcdn.apache.org//commons/dbcp/RELEASE-NOTES.txt
- commons-pool2 2.11.1: https://dlcdn.apache.org//commons/pool/RELEASE-NOTES.txt

I don't see any changes labeled as breaking, but there are a handful of bug fixes, etc.

## Instructions for Reviewers
Make sure database connectivity is working.

See earlier discussion and PR for these dependencies in DSpace 6.4 here: https://github.com/DSpace/DSpace/pull/3162