### PR TITLE
Shorten the classpath in bin/start-handle-server to address inconsistent ClassNotFound

### DIFF
--- a/dspace/bin/dspace
+++ b/dspace/bin/dspace
@@ -10,22 +10,22 @@
 # This is a Unix shell script for running a command-line DSpace tool.
 # It sets the CLASSPATH appropriately before invoking Java.
 
+# Assume that this script is in the bin subdirectory of the DSpace installation directory.
 BINDIR=`dirname $0`
 DSPACEDIR=`cd "$BINDIR/.." ; pwd`
 
-# Get the JARs in $DSPACEDIR/jsp/WEB-INF/lib, separated by ':'
+# Get the JARs in $DSPACEDIR/lib
 JARS="$DSPACEDIR/lib/*"
 
 # Class path for DSpace will be:
 #   Any existing classpath
-#   The JARs (WEB-INF/lib/*.jar)
-#   The WEB-INF/classes directory
+#   The JARs (lib/*.jar)
+#   The configuration directory
 if [ "$CLASSPATH" = "" ]; then
-    FULLPATH=$JARS:$DSPACEDIR/config
+  FULLPATH=$JARS:$DSPACEDIR/config
 else
-    FULLPATH=$CLASSPATH:$JARS:$DSPACEDIR/config
+  FULLPATH=$CLASSPATH:$JARS:$DSPACEDIR/config
 fi
-
 
 # If the user only wants the CLASSPATH, just give it now.
 if [ "$1" = "classpath" ]; then

--- a/dspace/bin/start-handle-server
+++ b/dspace/bin/start-handle-server
@@ -10,7 +10,7 @@
 # Unix shell script for starting Handle server.  WARNING this assumes any
 # previously running Handle servers have been terminated.
 
-# Assume we're in the bin subdirectory of the DSpace installation directory
+# Assume that this script is in the bin subdirectory of the DSpace installation directory.
 BINDIR=`dirname $0`
 
 # Read parameters from DSpace config
@@ -21,19 +21,23 @@ HANDLEDIR=`$BINDIR/dspace dsprop --property handle.dir`
 # If you want your handle server logs stored elsewhere, change this value
 LOGDIR=$DSPACEDIR/log
 
-# Get the JARs in $DSPACEDIR/jsp/WEB-INF/lib, separated by ':'
-JARS=`echo $DSPACEDIR/lib/*.jar | sed 's/ /\:/g'`
+# Get the JARs in $DSPACEDIR/lib
+JARS="$DSPACEDIR/lib/*"
 
 # Class path for DSpace will be:
 #   Any existing classpath
-#   The JARs (WEB-INF/lib/*.jar)
-#   The WEB-INF/classes directory
-FULLPATH=$CLASSPATH:$JARS:$DSPACEDIR/config
+#   The JARs (lib/*.jar)
+#   The configuration directory
+if [ "$CLASSPATH" = "" ]; then
+  FULLPATH=$JARS:$DSPACEDIR/config
+else
+  FULLPATH=$CLASSPATH:$JARS:$DSPACEDIR/config
+fi
 
 #Allow user to specify java options through JAVA_OPTS variable
 if [ "$JAVA_OPTS" = "" ]; then
-    #Default Java to use 256MB of memory
-    JAVA_OPTS=-Xmx256m
+  #Default Java to use 256MB of memory
+  JAVA_OPTS=-Xmx256m
 fi
 
 # Remove lock file, in case the old Handle server did not shut down properly
@@ -42,4 +46,8 @@ rm -f $HANDLEDIR/txns/lock
 # Start the Handle server, with a special log4j properties file.
 # We cannot simply write to the same logs, since log4j
 # does not support more than one JVM writing to the same rolling log.
-nohup java $JAVA_OPTS -classpath $FULLPATH -Ddspace.log.init.disable=true -Dlog4j.configuration=log4j-handle-plugin.properties net.handle.server.Main $HANDLEDIR </dev/null >> $LOGDIR/handle-server.log 2>&1 &
+nohup java $JAVA_OPTS -classpath $FULLPATH \
+    -Ddspace.log.init.disable=true \
+    -Dlog4j.configuration=log4j-handle-plugin.properties \
+    net.handle.server.Main $HANDLEDIR \
+    </dev/null >> $LOGDIR/handle-server.log 2>&1 &

--- a/dspace/bin/start-handle-server
+++ b/dspace/bin/start-handle-server
@@ -22,7 +22,7 @@ HANDLEDIR=`$BINDIR/dspace dsprop --property handle.dir`
 LOGDIR=$DSPACEDIR/log
 
 # Get the JARs in $DSPACEDIR/lib
-JARS="$DSPACEDIR/lib/*"
+JARS=`$BINDIR/dspace classpath`
 
 # Class path for DSpace will be:
 #   Any existing classpath

--- a/dspace/bin/start-handle-server
+++ b/dspace/bin/start-handle-server
@@ -10,7 +10,8 @@
 # Unix shell script for starting Handle server.  WARNING this assumes any
 # previously running Handle servers have been terminated.
 
-# Assume that this script is in the bin subdirectory of the DSpace installation directory.
+# Assume that this script is in the bin subdirectory of the DSpace
+# installation directory.
 BINDIR=`dirname $0`
 
 # Read parameters from DSpace config
@@ -20,19 +21,6 @@ HANDLEDIR=`$BINDIR/dspace dsprop --property handle.dir`
 # Assume log directory is a subdirectory of DSPACEDIR.
 # If you want your handle server logs stored elsewhere, change this value
 LOGDIR=$DSPACEDIR/log
-
-# Get the JARs in $DSPACEDIR/lib
-JARS=`$BINDIR/dspace classpath`
-
-# Class path for DSpace will be:
-#   Any existing classpath
-#   The JARs (lib/*.jar)
-#   The configuration directory
-if [ "$CLASSPATH" = "" ]; then
-  FULLPATH=$JARS:$DSPACEDIR/config
-else
-  FULLPATH=$CLASSPATH:$JARS:$DSPACEDIR/config
-fi
 
 #Allow user to specify java options through JAVA_OPTS variable
 if [ "$JAVA_OPTS" = "" ]; then
@@ -46,7 +34,7 @@ rm -f $HANDLEDIR/txns/lock
 # Start the Handle server, with a special log4j properties file.
 # We cannot simply write to the same logs, since log4j
 # does not support more than one JVM writing to the same rolling log.
-nohup java $JAVA_OPTS -classpath $FULLPATH \
+nohup java $JAVA_OPTS -classpath `$BINDIR/dspace classpath` \
     -Ddspace.log.init.disable=true \
     -Dlog4j.configuration=log4j-handle-plugin.properties \
     net.handle.server.Main $HANDLEDIR \


### PR DESCRIPTION
## References
* Related to #8507

## Description
Get the classpath from bin/dspace, which uses a special JRE feature that means "all JARs in this directory".
Note that the same issue exists on Windows.  Another patch would be welcome.

## Instructions for Reviewers
List of changes in this PR:
* call `bin/dspace classpath` instead of duplicating (old, replaced) code.
* Corrected comments, tidied up whitespace, removed unnecessary differences between `start-handle-server` and `dspace`.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
