### PR TITLE
Fixed start-handle-server.bat (Windows version)

### DIFF
--- a/dspace/bin/start-handle-server.bat
+++ b/dspace/bin/start-handle-server.bat
@@ -31,8 +31,8 @@ REM Assume log directory is a subdirectory of DSPACEDIR.
 REM If you want your handle server logs stored elsewhere, change this value
 set LOGDIR=%DSPACEDIR%/log
 
-REM Build a CLASSPATH including all classes in oai webapp, all libraries in [dspace]/lib and the config folder.
-set DSPACE_CLASSPATH=%CLASSPATH%;%DSPACEDIR%\config;%DSPACEDIR%\webapps\oai\WEB-INF\classes\;%DSPACEDIR%\lib\*
+REM Build a CLASSPATH including all libraries in [dspace]/lib and the config folder.
+set DSPACE_CLASSPATH=%CLASSPATH%;%DSPACEDIR%\config;%DSPACEDIR%\lib\*
 
 REM If JAVA_OPTS specified, use those options
 REM Otherwise, default Java to using 256MB of memory

--- a/dspace/bin/start-handle-server.bat
+++ b/dspace/bin/start-handle-server.bat
@@ -32,8 +32,7 @@ REM If you want your handle server logs stored elsewhere, change this value
 set LOGDIR=%DSPACEDIR%/log
 
 REM Build a CLASSPATH including all classes in oai webapp, all libraries in [dspace]/lib and the config folder.
-set DSPACE_CLASSPATH=%CLASSPATH%;%DSPACEDIR%\config;%DSPACEDIR%\webapps\oai\WEB-INF\classes\
-for %%f in (%DSPACEDIR%\lib\*.jar) DO CALL %BINDIR%\buildpath.bat %%f
+set DSPACE_CLASSPATH=%CLASSPATH%;%DSPACEDIR%\config;%DSPACEDIR%\webapps\oai\WEB-INF\classes\;%DSPACEDIR%\lib\*
 
 REM If JAVA_OPTS specified, use those options
 REM Otherwise, default Java to using 256MB of memory


### PR DESCRIPTION
This is a fix for start-handle-server.bat (Windows version). The issue was in the way the build path was generated, resulting in a command line that was too long.