### PR TITLE
dspace-api: apply unsharp mask to ImageMagick PDF operations

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickThumbnailFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickThumbnailFilter.java
@@ -137,6 +137,15 @@ public abstract class ImageMagickThumbnailFilter extends MediaFilter {
                 op.profile(srgb_profile);
             }
         }
+        // Sharpen the thumbnail with an unsharp mask operator. Accordi-
+        // to the ImageMagick docs, the radius should be larger than the
+        // sigma, or we can use a radius of 0 to have ImageMagick select
+        // a suitable radius. Here we only override the default sigma of
+        // 1.0 with 0.5, which seems to have a good effect.
+        //
+        // See: https://imagemagick.org/script/command-line-options.php#unsharp
+        // See: https://im4java.sourceforge.net/api/org/im4java/core/IMOps.html#unsharp()
+        op.unsharp(0.0,0.5);
         op.addImage(f2.getAbsolutePath());
         if (verbose) {
             System.out.println("IM Image Param: " + op);


### PR DESCRIPTION
Applying an unsharp mask to the ImageMagick PDF thumbnail process produces a slightly better image in every case I have tested. The unsharp option takes a radius, sigma, amount, and threshold, but we can use the defaults to good effect. If we use a radius of 0 then ImageMagick will select an appropriate value automatically. We only override the sigma with 0.5 (default 1.0).

See extensive comparison gallery here: https://alanorth.github.io/improved-dspace-thumbnails/

## References
* Fixes #8514
* See ImageMagick CLI reference for `unsharp`: https://imagemagick.org/script/command-line-options.php#unsharp

## Instructions for Reviewers

List of changes in this PR:
* Adds the `unsharp 0x0.5` parameter to ImageMagick PDF thumbnail operation

Test generation of thumbnails for several PDFs to evaluate the quality.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.