### PR TITLE
Item/Collection admin can't create new version item

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/VersionRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/VersionRestRepository.java
@@ -111,7 +111,7 @@ public class VersionRestRepository extends DSpaceRestRepository<VersionRest, Int
         }
 
         EPerson submitter = item.getSubmitter();
-        boolean isAdmin = authorizeService.isAdmin(context);
+        boolean isAdmin = authorizeService.isAdmin(context, item);
         boolean canCreateVersion = configurationService.getBooleanProperty("versioning.submitterCanCreateNewVersion");
 
         if (!isAdmin && !(canCreateVersion && Objects.equals(submitter, context.getCurrentUser()))) {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/VersionRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/VersionRestRepositoryIT.java
@@ -877,7 +877,6 @@ public class VersionRestRepositoryIT extends AbstractControllerIntegrationTest {
                 .build();
 
         item.setSubmitter(eperson);
-        System.out.println(item.getSubmitter().getEmail().toString());
 
         context.restoreAuthSystemState();
 
@@ -895,7 +894,6 @@ public class VersionRestRepositoryIT extends AbstractControllerIntegrationTest {
                             hasJsonPath("$.type", is("version"))
                     )))
                     .andDo(result -> idRef.set(read(result.getResponse().getContentAsString(), "$.id")));
-            System.out.println("version 2: " + item.getSubmitter().getEmail().toString());
         } finally {
             VersionBuilder.delete(idRef.get());
         }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/VersionRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/VersionRestRepositoryIT.java
@@ -851,6 +851,57 @@ public class VersionRestRepositoryIT extends AbstractControllerIntegrationTest {
     }
 
     @Test
+    public void createNewVersionItemByCollectionAdminTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Community rootCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+
+        EPerson colAdmin = EPersonBuilder.createEPerson(context)
+                .withCanLogin(true)
+                .withEmail("coladmin@email.com")
+                .withPassword(password)
+                .withNameInMetadata("Collection", "Admin")
+                .build();
+        Collection col = CollectionBuilder
+                .createCollection(context, rootCommunity)
+                .withName("Collection 1")
+                .withAdminGroup(colAdmin)
+                .build();
+
+        Item item = ItemBuilder.createItem(context, col)
+                .withTitle("Public test item")
+                .withIssueDate("2022-12-19")
+                .withAuthor("Doe, John")
+                .withSubject("ExtraEntry")
+                .build();
+
+        item.setSubmitter(eperson);
+        System.out.println(item.getSubmitter().getEmail().toString());
+
+        context.restoreAuthSystemState();
+
+        AtomicReference<Integer> idRef = new AtomicReference<Integer>();
+        String token = getAuthToken(colAdmin.getEmail(), password);
+        try {
+            getClient(token).perform(post("/api/versioning/versions")
+                            .param("summary", "test summary!")
+                            .contentType(MediaType.parseMediaType(RestMediaTypes.TEXT_URI_LIST_VALUE))
+                            .content("/api/core/items/" + item.getID()))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$", Matchers.allOf(
+                            hasJsonPath("$.version", is(2)),
+                            hasJsonPath("$.summary", is("test summary!")),
+                            hasJsonPath("$.type", is("version"))
+                    )))
+                    .andDo(result -> idRef.set(read(result.getResponse().getContentAsString(), "$.id")));
+            System.out.println("version 2: " + item.getSubmitter().getEmail().toString());
+        } finally {
+            VersionBuilder.delete(idRef.get());
+        }
+    }
+
+    @Test
     public void patchReplaceSummaryTest() throws Exception {
         context.turnOffAuthorisationSystem();
 


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* None

## Description
Collection admin should create a new version as well if the property "versioning.submitterCanCreateNewVersion" set to false. Therefore the authorization to create new version should be checked in the item level, instead of system site.

## How to test this PR:
User login with role of collection admin, open an item, can create a new version.

## Checklist
This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!

- [X]  My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for all new (or modified) public methods and classes. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new, third-party dependencies (in any pom.xml), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
