### PR TITLE
Use removeAllBundles, defend against ConcurrentModificationException

### DIFF
--- a/dspace-api/src/main/java/org/dspace/harvest/OAIHarvester.java
+++ b/dspace-api/src/main/java/org/dspace/harvest/OAIHarvester.java
@@ -524,11 +524,7 @@ public class OAIHarvester {
     		// Import the actual bitstreams
     		if (harvestRow.getHarvestType() == 3) {
     			log.info("Running ORE ingest on: " + item.getHandle());
-
-    			List<Bundle> allBundles = item.getBundles();
-    			for (Bundle bundle : allBundles) {
-    				itemService.removeBundle(ourContext, item, bundle);
-    			}
+				itemService.removeAllBundles(ourContext, item);
     			ORExwalk.ingest(ourContext, item, oreREM, true);
     		}
     	}


### PR DESCRIPTION
## Description
The OAI harvester codebase is probably getting a bit old. This code change introduces the use of `itemService.removeAllBundles` instead of looping through all bundles and removing each one which also risks ConcurrentModificationException.
