### PR TITLE
Fixes #8528, refreshing spider files causes null pointer.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/statistics/util/StatisticsClient.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/util/StatisticsClient.java
@@ -16,6 +16,7 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.logging.log4j.Logger;
+import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Get;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.statistics.factory.StatisticsServiceFactory;
@@ -136,6 +137,7 @@ public class StatisticsClient {
                 URL url = new URL(value);
 
                 Get get = new Get();
+                get.setProject(new Project());
                 get.setDest(new File(spiders, url.getHost() + url.getPath().replace("/", "-")));
                 get.setSrc(url);
                 get.setUseTimestamp(true);


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #8528 

## Description
The Get Request was missing the required project. That lead to a NullPointerException. This pull request fixes that.

## Instructions for Reviewers
To check if this is working run:

`/dspace/bin/dspace stats-util -u` before and after applying this pull request.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
