### PR TITLE
CreateMissingIdentifiersIT affecting other tests fix

### DIFF
--- a/dspace-api/src/test/java/org/dspace/ctask/general/CreateMissingIdentifiersIT.java
+++ b/dspace-api/src/test/java/org/dspace/ctask/general/CreateMissingIdentifiersIT.java
@@ -21,6 +21,7 @@ import org.dspace.curate.Curator;
 import org.dspace.identifier.VersionedHandleIdentifierProviderWithCanonicalHandles;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
+import org.junit.After;
 import org.junit.Test;
 
 /**
@@ -75,5 +76,12 @@ public class CreateMissingIdentifiersIT
                 curator.getResult(TASK_NAME));
         assertEquals("Curation should fail", Curator.CURATE_ERROR,
                 curator.getStatus(TASK_NAME));
+    }
+
+    @Override
+    @After
+    public void destroy() throws Exception {
+        super.destroy();
+        DSpaceServicesFactory.getInstance().getServiceManager().getApplicationContext().refresh();
     }
 }


### PR DESCRIPTION
## References
Fixes #8533

## Description
`CreateMissingIdentifiersIT`'s test case manually installs a bean for testing purposes which carries over to other tests and potentially influences those. For example, `WorkflowCurationIT`'s test fails if it runs after `CreateMissingIdentifiersIT` due to this manually installed bean (makes curation tasks fail on purpose).

## Instructions for Reviewers
Changes made:
* Added a `destroy()` call in `CreateMissingIdentifiersIT`, calling `refresh()` on the service-manager's application-context. This should reset the loaded beans back to their original state, unaffected by the tests.

How to test:
* Without these changes, if you run `CreateMissingIdentifiersIT` before `WorkflowCurationIT`, the last one will fail.
* After these changes, both should succeed when run in that order

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
