### PR TITLE
Enable solr slow query logging

### DIFF
--- a/dspace/solr/authority/conf/solrconfig.xml
+++ b/dspace/solr/authority/conf/solrconfig.xml
@@ -79,6 +79,7 @@
         <queryResultMaxDocsCached>200</queryResultMaxDocsCached>
         <useColdSearcher>false</useColdSearcher>
         <maxWarmingSearchers>2</maxWarmingSearchers>
+        <slowQueryThresholdMillis>1000</slowQueryThresholdMillis>
     </query>
 
     <!-- Controls how the Solr HTTP RequestDispatcher responds to requests -->

--- a/dspace/solr/oai/conf/solrconfig.xml
+++ b/dspace/solr/oai/conf/solrconfig.xml
@@ -88,6 +88,7 @@
         <queryResultMaxDocsCached>200</queryResultMaxDocsCached>
         <useColdSearcher>false</useColdSearcher>
         <maxWarmingSearchers>2</maxWarmingSearchers>
+        <slowQueryThresholdMillis>1000</slowQueryThresholdMillis>
     </query>
 
     <!-- Controls how the Solr HTTP RequestDispatcher responds to requests -->

--- a/dspace/solr/search/conf/solrconfig.xml
+++ b/dspace/solr/search/conf/solrconfig.xml
@@ -99,6 +99,7 @@
         <queryResultMaxDocsCached>200</queryResultMaxDocsCached>
         <useColdSearcher>false</useColdSearcher>
         <maxWarmingSearchers>2</maxWarmingSearchers>
+        <slowQueryThresholdMillis>1000</slowQueryThresholdMillis>
     </query>
 
     <!-- Controls how the Solr HTTP RequestDispatcher responds to requests -->

--- a/dspace/solr/statistics/conf/solrconfig.xml
+++ b/dspace/solr/statistics/conf/solrconfig.xml
@@ -88,6 +88,7 @@
         <queryResultMaxDocsCached>200</queryResultMaxDocsCached>
         <useColdSearcher>false</useColdSearcher>
         <maxWarmingSearchers>2</maxWarmingSearchers>
+        <slowQueryThresholdMillis>1000</slowQueryThresholdMillis>
     </query>
 
     <!-- Controls how the Solr HTTP RequestDispatcher responds to requests -->


### PR DESCRIPTION
## Description
The purpose of this small PR is to enable SOLR slow query logging by default. In configuration, we consider slow queries all going longer than the set limit of 1s.

Setting this property is not enough. To have slow queries logged, default logging level of SOLR must be set to WARN. I would state this properly within DSpace documentation.


List of changes in this PR:
* `solrconfig.xml` files updated to log queries taking longer than 1 second



## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
