### PR TITLE
Require commons-text 1.10.0 in dependencyManagement

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -589,13 +589,6 @@
             <artifactId>solr-core</artifactId>
             <scope>test</scope>
             <version>${solr.client.version}</version>
-            <exclusions>
-                <!-- Newer version brought in by opencsv -->
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-text</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>
@@ -846,11 +839,6 @@
           <!-- for mockserver -->
           <!-- Solve dependency convergence issues related to
                'mockserver-junit-rule' by selecting the versions we want to use. -->
-          <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-text</artifactId>
-            <version>1.9</version>
-          </dependency>
           <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-buffer</artifactId>

--- a/dspace-server-webapp/pom.xml
+++ b/dspace-server-webapp/pom.xml
@@ -430,11 +430,6 @@
             <artifactId>commons-collections4</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-text</artifactId>
-            <version>1.9</version>
-        </dependency>
-        <dependency>
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>
         </dependency>
@@ -527,13 +522,6 @@
             <artifactId>solr-core</artifactId>
             <version>${solr.client.version}</version>
             <scope>test</scope>
-            <exclusions>
-                <!-- Newer version brought in by opencsv -->
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-text</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>

--- a/dspace/modules/additions/pom.xml
+++ b/dspace/modules/additions/pom.xml
@@ -266,13 +266,6 @@
          <artifactId>solr-core</artifactId>
          <version>${solr.client.version}</version>
          <scope>test</scope>
-         <exclusions>
-            <!-- Newer version brought in by opencsv -->
-            <exclusion>
-               <groupId>org.apache.commons</groupId>
-               <artifactId>commons-text</artifactId>
-            </exclusion>
-         </exclusions>
       </dependency>
       <dependency>
          <groupId>org.apache.lucene</groupId>

--- a/dspace/modules/server/pom.xml
+++ b/dspace/modules/server/pom.xml
@@ -336,13 +336,6 @@ just adding new jar in the classloader</description>
             <artifactId>solr-core</artifactId>
             <version>${solr.client.version}</version>
             <scope>test</scope>
-            <exclusions>
-                <!-- Newer version brought in by opencsv -->
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-text</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1509,6 +1509,11 @@
                 <version>2.11.1</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-text</artifactId>
+                <version>1.10.0</version>
+            </dependency>
+            <dependency>
                 <groupId>commons-validator</groupId>
                 <artifactId>commons-validator</artifactId>
                 <version>1.5.0</version>


### PR DESCRIPTION
## References
* Patches CVE-2022-42889 vulnerability in `commons-text`, even though DSpace does not appear to be vulnerable (see below).

## Description
Updates our Parent POM to *require* commons-text version 1.10.0 to patch CVE-2022-42889. Also, removes unnecessary references to commons-text elsewhere in POMs.

### Is DSpace vulnerable?

#### DSpace Version 7.x
At this time, **we do not believe DSpace 7.x is vulnerable** as it only uses `commons-text` in a very limited manner during configuration initialization. 

DSpace never uses the (vulnerable) default interpolator (`StringSubstitutor.createInterpolator()`) and never passes any user input or untrusted data to `commons-text` in general. So, it is not possible [to trigger the vulnerability as currently described](https://securitylab.github.com/advisories/GHSL-2022-018_Apache_Commons_Text/).

`commons-text` is also used by a few of our dependencies. But, at this time, none of these other dependencies claim to be vulnerable.

#### DSpace versions 1.x.x, 3.x, 4.x, 5.x and 6.x
At this time, **we do not believe any version of DSpace is vulnerable**.  DSpace 1.x.x, 3.x, 4.x, 5.x and 6.x did not include  `commons-text` at all.