### PR TITLE
Ignore diacritics when sorting community/collection list.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/comparator/NameAscendingComparator.java
+++ b/dspace-api/src/main/java/org/dspace/content/comparator/NameAscendingComparator.java
@@ -27,6 +27,9 @@ public class NameAscendingComparator implements Comparator<DSpaceObject> {
             String name1 = StringUtils.trimToEmpty(dso1.getName());
             String name2 = StringUtils.trimToEmpty(dso2.getName());
 
+            name1 = StringUtils.stripAccents(name1);
+            name2 = StringUtils.stripAccents(name2);
+
             //When two DSO's have the same name, use their UUID to put them in an order
             if (name1.equals(name2)) {
                 return ObjectUtils.compare(dso1.getID(), dso2.getID());

--- a/dspace-api/src/test/java/org/dspace/content/comparator/NameAscendingComparatorTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/comparator/NameAscendingComparatorTest.java
@@ -92,4 +92,12 @@ public class NameAscendingComparatorTest {
 
         assertTrue(comparator.compare(dso1, dso2) < 0);
     }
+
+    @Test
+    public void testCompareWithDiacritics() throws Exception {
+        when(dso1.getName()).thenReturn("á");
+        when(dso2.getName()).thenReturn("b");
+
+        assertTrue(comparator.compare(dso1, dso2) < 0);
+    }
 }


### PR DESCRIPTION
## Description
Small PR to ignore diacritics when sorting community/collection list.

## Instructions for Reviewers

List of changes in this PR:
* Strip diacritics in compare function of `NameAscendingComparator` class used to order the community and collection list.
* New test to check the change

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

In a community create one sub-community with name "Á" (accented) and another with name "B" and check the order displayed in the community page. "Á" sub-community should appears first but "B" sub-community appears first instead.

Apply the PR and check that the sort is corrected and "Á" appears first. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
