### PR TITLE
Fix for Creative Commons jurisdiction chosen is ignored (REST API)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/license/CreativeCommonsServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/license/CreativeCommonsServiceImpl.java
@@ -605,7 +605,10 @@ public class CreativeCommonsServiceImpl implements CreativeCommonsService, Initi
             }
         }
 
-        updateJurisdiction(fullParamMap);
+        // Replace the jurisdiction unless default value is set to none
+        if (!"none".equals(jurisdiction)) {
+            updateJurisdiction(fullParamMap);
+        }
 
         return fullParamMap;
     }

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1004,6 +1004,7 @@ cc.license.classfilter = recombo, mark
 # http://api.creativecommons.org/rest/1.5/support/jurisdictions
 # Commented out means the license is unported.
 # (e.g. nz = New Zealand, uk = England and Wales, jp = Japan)
+# or set value none for user-selected jurisdiction
 cc.license.jurisdiction = us
 
 # Locale for CC dialogs

--- a/dspace/config/modules/rest.cfg
+++ b/dspace/config/modules/rest.cfg
@@ -45,6 +45,7 @@ rest.properties.exposed = submit.type-bind.field
 rest.properties.exposed = google.recaptcha.key.site
 rest.properties.exposed = google.recaptcha.version
 rest.properties.exposed = google.recaptcha.mode
+rest.properties.exposed = cc.license.jurisdiction
 
 #---------------------------------------------------------------#
 # These configs are used by the deprecated REST (v4-6) module   #


### PR DESCRIPTION
## References
* Required by DSpace/dspace-angular#1930

## Description

This PR includes the API changes needed to solve the issue DSpace/dspace-angular#1836 by exposing the key cc.license.jurisdiction and using the user-selected value if the configuration key is set to none.

## Instructions for Reviewers

List of changes in this PR:
* Expose configuration key `cc.license.jurisdiction`
* Update the jurisdiction used to create the CC URL when the key is not set to none
* Add a comment to dspace.cfg

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
