### PR TITLE
[FIX] Role inheritance during item move

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -902,8 +902,9 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
         // Remove bundles
         List<Bundle> bunds = item.getBundles();
         for (Bundle mybundle : bunds) {
-
             // if come from InstallItem: remove all submission/workflow policies
+            authorizeService.removeAllPoliciesByDSOAndType(context, mybundle, ResourcePolicy.TYPE_CUSTOM);
+            authorizeService.removeAllPoliciesByDSOAndType(context, mybundle, ResourcePolicy.TYPE_INHERITED);
             authorizeService.removeAllPoliciesByDSOAndType(context, mybundle, ResourcePolicy.TYPE_SUBMISSION);
             authorizeService.removeAllPoliciesByDSOAndType(context, mybundle, ResourcePolicy.TYPE_WORKFLOW);
             addCustomPoliciesNotInPlace(context, mybundle, defaultItemPolicies);
@@ -911,6 +912,8 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
 
             for (Bitstream bitstream : mybundle.getBitstreams()) {
                 // if come from InstallItem: remove all submission/workflow policies
+                authorizeService.removeAllPoliciesByDSOAndType(context, bitstream, ResourcePolicy.TYPE_CUSTOM);
+                authorizeService.removeAllPoliciesByDSOAndType(context, bitstream, ResourcePolicy.TYPE_INHERITED);
                 authorizeService.removeAllPoliciesByDSOAndType(context, bitstream, ResourcePolicy.TYPE_SUBMISSION);
                 authorizeService.removeAllPoliciesByDSOAndType(context, bitstream, ResourcePolicy.TYPE_WORKFLOW);
                 addCustomPoliciesNotInPlace(context, bitstream, defaultItemPolicies);
@@ -938,6 +941,8 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
             context.turnOffAuthorisationSystem();
 
             // if come from InstallItem: remove all submission/workflow policies
+            authorizeService.removeAllPoliciesByDSOAndType(context, item, ResourcePolicy.TYPE_CUSTOM);
+            authorizeService.removeAllPoliciesByDSOAndType(context, item, ResourcePolicy.TYPE_INHERITED);
             authorizeService.removeAllPoliciesByDSOAndType(context, item, ResourcePolicy.TYPE_SUBMISSION);
             authorizeService.removeAllPoliciesByDSOAndType(context, item, ResourcePolicy.TYPE_WORKFLOW);
 


### PR DESCRIPTION
## References
* Fixes #3373 in release 7.4 and above

## Description
Moving an item from a collection to another with _Inherit policies_ checked does not apply the policies of the new collection for the item.

## Instructions for Reviewers
Due to the fact that there is no REST API endpoint (PUT /api/core/items/<:uuid>/owningCollection) which would support the inheritance during item move this PR only fixes the backend side of the issue.
Checking the `Inherit policies` checkbox on the UI does not affect the backend:
![kép](https://user-images.githubusercontent.com/22575079/197977036-3edbbf62-af95-4a1a-81aa-3243f51523c6.png)
Check out the comment on the UI:
https://github.com/DSpace/dspace-angular/blob/0395480ab8ddeabe22ff1b7d2c6f678fd9830428/src/app/item-page/edit-item-page/item-move/item-move.component.ts#L29

As soon as the UI is working well the steps to check are:
 1. Create a collection where the items are open to read for Anonymous.
 2. Add another collection where the Default read access has a group which contains the Administrators group.
 3. Move an item from the open access collection to the one created in the point 2 above.
 4. Check whether the moved item is accessible by Anonymous or not. It should'nt be.

## Checklist

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
