### PR TITLE
Use translations of Creative Commons API

### DIFF
--- a/dspace-api/src/main/java/org/dspace/license/CCLicenseConnectorServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/license/CCLicenseConnectorServiceImpl.java
@@ -106,7 +106,7 @@ public class CCLicenseConnectorServiceImpl implements CCLicenseConnectorService,
 
         for (String license : licenses) {
 
-            String licenseUri = ccLicenseUrl + "/license/" + license;
+            String licenseUri = ccLicenseUrl + "/license/" + license + "?locale=" + language;
             HttpGet licenseHttpGet = new HttpGet(licenseUri);
             try (CloseableHttpResponse response = client.execute(licenseHttpGet)) {
                 CCLicense ccLicense = retrieveLicenseObject(license, response);

--- a/dspace-api/src/main/java/org/dspace/license/CreativeCommonsServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/license/CreativeCommonsServiceImpl.java
@@ -430,9 +430,10 @@ public class CreativeCommonsServiceImpl implements CreativeCommonsService, Initi
 
     }
 
-    private void addLicenseField(Context context, Item item, String field, String value) throws SQLException {
+    private void addLicenseField(Context context, Item item, String field, String language, String value)
+        throws SQLException {
         String[] params = splitField(field);
-        itemService.addMetadata(context, item, params[0], params[1], params[2], params[3], value);
+        itemService.addMetadata(context, item, params[0], params[1], params[2], language, value);
 
     }
 
@@ -688,12 +689,12 @@ public class CreativeCommonsServiceImpl implements CreativeCommonsService, Initi
         String uriField = getCCField("uri");
         String nameField = getCCField("name");
 
-        addLicenseField(context, item, uriField, licenseUri);
+        addLicenseField(context, item, uriField, null, licenseUri);
         if (configurationService.getBooleanProperty("cc.submit.addbitstream")) {
             setLicenseRDF(context, item, fetchLicenseRDF(doc));
         }
         if (configurationService.getBooleanProperty("cc.submit.setname")) {
-            addLicenseField(context, item, nameField, licenseName);
+            addLicenseField(context, item, nameField, "en", licenseName);
         }
     }
 

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1008,7 +1008,7 @@ cc.license.jurisdiction = us
 
 # Locale for CC dialogs
 # A locale in the form language or language-country.
-# If no default locale is defined the CC default locale will be used
+# If no default locale is defined the current supported locale will be used
 cc.license.locale = en
 
 


### PR DESCRIPTION
## Description

Creative Commons API can provide translations of the questions displayed to the user when the standard Creative Commons license is selected. This PR includes the changes to use these translations for displaying the questions in the user-selected language.

Also includes a change to correct the language code assigned to CC metadata `dc.rights.uri` and `dc.rights`. Currently, an asterisk is assigned(see issue #7165 ,  already closed by inactivity).

## Instructions for Reviewers

Although the CC API provides translations, these are not always complete. Normally, it returns translations for questions but not for answers. View image:

![imagen](https://user-images.githubusercontent.com/3812525/198003614-8bea3b0e-a78c-4b2b-9729-bf6525c1034e.png)

For this reason, if a default CC locale is set (`cc.license.locale`) it will use this default locale in case you don't want to display a partial translation.

List of changes in this PR:
* Add the parameter `locale` when retrieving the dialogs of a license from CC API.
* Use the current supported locale if no default CC locale is set when retrieving CC information from API REST.
* Change a comment of dspace.cfg
* Correct the language code assigned to CC metadata.

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

* Activate the cclicense step in item-submission.xml
* Comment or set blank the configuration key `cc.license.locale`
* Configure the configuration key `webui.supported.locales` . For example:

`webui.supported.locales = en, de, es `

* Start a new submission and change the UI language to one of the supported locales. 
* Select a standard Creative Commons and check that the questions are translated.
* Finish the submission selecting one standard CC license and check that the language code assigned to `dc.rights.uri` and `dc.rights` is not an asterisk.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
