### PR TITLE
Update to use GitHub CodeQL for code scanning

### DIFF
--- a/.github/workflows/codescan.yml
+++ b/.github/workflows/codescan.yml
@@ -1,0 +1,59 @@
+# DSpace CodeQL code scanning configuration for GitHub
+# https://docs.github.com/en/code-security/code-scanning
+#
+# NOTE: Code scanning must be run separate from our default build.yml
+# because CodeQL requires a fresh build with all tests *disabled*.
+name: "Code Scanning"
+
+# Run this code scan for all pushes / PRs to main branch. Also run once a week.
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+    # Don't run if PR is only updating static documentation
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.txt'
+  schedule:
+    - cron: "37 0 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze Code
+    runs-on: ubuntu-latest
+    # Limit permissions of this GitHub action. Can only write to security-events
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      # https://github.com/actions/checkout
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # https://github.com/actions/setup-java
+      - name: Install JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: 'temurin'
+
+      # Initializes the CodeQL tools for scanning.
+      # https://github.com/github/codeql-action
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          # Codescan Javascript as well since a few JS files exist in REST API's interface
+          languages: java, javascript
+
+      # Autobuild attempts to build any compiled languages
+      # NOTE: Based on testing, this autobuild process works well for DSpace. A custom
+      # DSpace build w/caching (like in build.yml) was about the same speed as autobuild.
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
+
+      # Perform GitHub Code Scanning.
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
## Description
Enables GitHub [Code Scanning](https://docs.github.com/en/code-security/code-scanning) via a new GitHub Action defined in `codescan.yml`

This will (eventually) replace our usage of LGTM.com, as LGTM is retiring later this year (after being integrated into GitHub).  See https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/

Currently, Code Scanning is configured with default settings & enabled for all PRs and all commits to `main`.

I've tested these changes in my fork of DSpace/DSpace and it seems to be working well.  The results from GitHub Code Scanning are quite different from LGTM, so that we may need to tweak the default Code Scanning settings in the future after we see how it is working for us.  Once we are satisfied, we can turn off LGTM checks of our codebase.

~~**The only way to fully test this PR is to merge it into `main`.**  Then an initial code scan will be run and the results will be visible to developers in the "Security" tab of this project.~~

**It appears this PR has run it's own initial scan** which can be found in the "Code scanning results" in the checks below.  This can be used to review this PR is working, and it shows that we have some code cleanup/analysis to do. It is also possible some of these are false positives, as we occasionally hit those with LGTM (and this code scanner works similar to LGTM).