### PR TITLE
dspace-api: tell ImageMagick about the PDF CropBox

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickThumbnailFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickThumbnailFilter.java
@@ -14,6 +14,9 @@ import java.io.InputStream;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Bundle;
 import org.dspace.content.Item;
@@ -130,6 +133,26 @@ public abstract class ImageMagickThumbnailFilter extends MediaFilter {
         String density = configurationService.getProperty(PRE + ".density");
         if (density != null) {
             op.density(Integer.valueOf(density));
+        }
+
+        // Check the PDF's MediaBox and CropBox to see if they are the same.
+        // If not, then tell ImageMagick to use the CropBox when generating
+        // the thumbnail because the CropBox is generally used to define the
+        // area displayed when a user opens the PDF on a screen, whereas the
+        // MediaBox is used for print. Not all PDFs set these correctly, so
+        // we can use ImageMagick's default behavior unless we see an explit
+        // CropBox. Note: we don't need to do anything special to detect if
+        // the CropBox is missing or empty because pdfbox will set it to the
+        // same size as the MediaBox if it doesn't exist. Also note that we
+        // only need to check the first page, since that's what we use for
+        // generating the thumbnail (PDDocument uses a zero-based index).
+        PDPage pdfPage = PDDocument.load(f).getPage(0);
+        PDRectangle pdfPageMediaBox = pdfPage.getMediaBox();
+        PDRectangle pdfPageCropBox = pdfPage.getCropBox();
+
+        // This option must come *before* we open the input file.
+        if (pdfPageCropBox != pdfPageMediaBox) {
+            op.define("pdf:use-cropbox=true");
         }
 
         String s = "[" + page + "]";


### PR DESCRIPTION
## References
* Fixes: https://github.com/DSpace/DSpace/issues/8549

## Description
ImageMagick uses the `MediaBox` by default when rasterizing PDFs because the PDF specification says that all PDFs *must* contain one. This page box is the parent for all other boxes that a PDF *may* contain, for example a `CropBox`, `ArtBox`, etc. In many cases these are the same, but when they are not the `CropBox` is generally used to define the area displayed to a user when they open the PDF on screen (as opposed to when printing on paper). Using the wrong page box can result in strange-looking thumbnails.

If a PDF has a `CropBox` that has a different size than its `MediaBox` then we should tell ImageMagick to use it because it more accurately resembles what the user would see if they opened the PDF.

**Before (open the image to see the blank white space):**

<p align="center">
  <img width="400" src="https://user-images.githubusercontent.com/191754/198273645-198155ca-1765-47fa-8887-53cbcf2cca6d.jpg">
</p>

**After:**

<p align="center">
  <img width="300" src="https://user-images.githubusercontent.com/191754/198274172-21e8b6d6-1730-4b45-b979-091bddc41613.jpg">
</p>

And example PDF can be found in our repository: https://hdl.handle.net/10568/116598

## Instructions for Reviewers
Test generating an ImageMagick PDF thumbnail for several items before and after this patch, ie:

```console
$ dspace filter-media -p 'ImageMagick PDF Thumbnail' -v -f -i 10568/120157
```

List of changes in this PR:
* Include several imports from pdfbox (which we are already using elsewhere) in `dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickThumbnailFilter.java`
* Add logic to check the `MediaBox` and `CropBox`
* Add logic to pass the `-define pdf:use-cropbox=true` option to ImageMagick

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).