### PR TITLE
Switch GitHub action for labeling merge conflicts

### DIFF
--- a/.github/workflows/label_merge_conflicts.yml
+++ b/.github/workflows/label_merge_conflicts.yml
@@ -5,21 +5,29 @@ name: Check for merge conflicts
 # NOTE: This means merge conflicts are only checked for when a PR is merged to main.
 on:
   push:
-    branches:
-      - main
+    branches: [ main ]
+    # So that the `conflict_label_name` is removed if conflicts are resolved,
+    # we allow this to run for `pull_request_target` so that github secrets are available.
+    pull_request_target:
+      types: [ synchronize ]
 
 jobs:
   triage:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
-      # See: https://github.com/mschilde/auto-label-merge-conflicts/
+      # See: https://github.com/prince-chrismc/label-merge-conflicts-action
       - name: Auto-label PRs with merge conflicts
-        uses: mschilde/auto-label-merge-conflicts@v2.0
+        uses: prince-chrismc/label-merge-conflicts-action@v2
         # Add "merge conflict" label if a merge conflict is detected. Remove it when resolved.
         # Note, the authentication token is created automatically
         # See: https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token
         with:
-          CONFLICT_LABEL_NAME: 'merge conflict'
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # Ignore errors
-        continue-on-error: true
+          conflict_label_name: 'merge conflict'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          conflict_comment: |
+            Hi @${author},
+            Conflicts have been detected against the base branch.
+            Please [resolve these conflicts](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/addressing-merge-conflicts/about-merge-conflicts) as soon as you can. Thanks!


### PR DESCRIPTION
## Description
Small PR switches to using a different GitHub action for labeling PRs which have merge conflicts.

Our existing GitHub action does a good job of adding the `merge conflict` label to any PR which has a merge conflict.  However, it doesn't remove that label automatically.

This new action (https://github.com/prince-chrismc/label-merge-conflicts-action) appears to support automatic removal of the `merge conflict` label.  It also can support adding an automated comment pinging the developer whenever a merge conflict is detected.

Therefore, this small PR simply switches which "plugin" we are using to see if it's behavior is better than the current plugin.