### PR TITLE
dspace-api: allow overriding ImageMagick density

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickThumbnailFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickThumbnailFilter.java
@@ -119,6 +119,19 @@ public abstract class ImageMagickThumbnailFilter extends MediaFilter {
         f2.deleteOnExit();
         ConvertCmd cmd = new ConvertCmd();
         IMOperation op = new IMOperation();
+
+        // Optionally override ImageMagick's default density of 72 DPI to use a
+        // "supersample" when creating the PDF thumbnail. Note that I prefer to
+        // use the getProperty() method here instead of getIntPropert() because
+        // the latter always returns an integer (0 in the case it's not set). I
+        // would prefer to keep ImageMagick's default to itself rather than for
+        // us to set one. Also note that the density option *must* come before
+        // we open the input file.
+        String density = configurationService.getProperty(PRE + ".density");
+        if (density != null) {
+            op.density(Integer.valueOf(density));
+        }
+
         String s = "[" + page + "]";
         op.addImage(f.getAbsolutePath() + s);
         if (configurationService.getBooleanProperty(PRE + ".flatten", true)) {

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -547,6 +547,12 @@ filter.org.dspace.app.mediafilter.PDFBoxThumbnail.inputFormats = Adobe PDF
 # org.dspace.app.mediafilter.ImageMagickThumbnailFilter.cmyk_profile = /usr/share/ghostscript/9.18/iccprofiles/default_cmyk.icc
 # org.dspace.app.mediafilter.ImageMagickThumbnailFilter.srgb_profile = /usr/share/ghostscript/9.18/iccprofiles/default_rgb.icc
 
+# Optional: override ImageMagick's default density of 72 when creating PDF thum-
+# bnails. Greatly increases quality of resulting thumbnails, at the expense of
+# slightly longer execution times and higher memory usage. Any integer over 72
+# will help, but recommend 144 for a "2x" supersample.
+# org.dspace.app.mediafilter.ImageMagickThumbnailFilter.density = 144
+
 #### Crosswalk and Packager Plugin Settings ####
 # Crosswalks are used to translate external metadata formats into DSpace's internal format (DIM)
 # Packagers are used to ingest/export 'packages' (both content files and metadata)


### PR DESCRIPTION
Allow users to override ImageMagick's default density of 72 DPI for creating PDF thumbnails. In this case a density of 144 will perform a "2x" supersample, which greatly increases the quality and accuracy of the resulting images:

<p align="center">
  <img width="300" alt="Default DSpace thumbnail for 10568/3149" src="https://user-images.githubusercontent.com/191754/198520246-9f339501-5bef-4b3d-b060-2fa5c35ef8e0.jpg">
  <img width="300" alt="Default DSpace thumbnail for 10568/3149 with density 144" src="https://user-images.githubusercontent.com/191754/198520252-a596ca18-4de8-411d-8793-92dc2e9a6665.jpg">
</p>

There is a performance impact to this change:

- Roughly *two times* longer execution time, for example: from 200ms to 400ms for one PDF (measured with `time`).
- Roughly *three to four times* as much memory allocated, for example: from 20MiB to 60MiB for one PDF (measured with Valgrind and Massif).

I've made a microsite with detailed technical discussion and visual comparisons for a handful of real PDF bitstreams from our institutional repository here: https://alanorth.github.io/improved-dspace-thumbnails/

## References
* Fixes: https://github.com/DSpace/DSpace/issues/8514
* Obsoletes: https://github.com/DSpace/DSpace/issues/8515

## Instructions for Reviewers

List of changes in this PR:
* Add a new optional configuration property to `dspace.cfg`: `org.dspace.app.mediafilter.ImageMagickThumbnailFilter.density`
* Modify `ImageMagickThumbnailFilter.java` to use this new property if present

**Include guidance for how to test or review your PR.**
Force generation of thumbnails for a few bitstreams containing PDFs, ie:

```console
$ dspace filter-media -p 'ImageMagick PDF Thumbnail' -v -f -i 10568/120157
```

Then check the resulting thumbnail before and after.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).