### PR TITLE
[TLC-387] When retrieving S3 bitstream, strip -R from internal ID if bitstream is registered

### DIFF
--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/S3BitStoreService.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/S3BitStoreService.java
@@ -62,6 +62,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 public class S3BitStoreService extends BaseBitStoreService {
     protected static final String DEFAULT_BUCKET_PREFIX = "dspace-asset-";
+    // Prefix indicating a registered bitstream
+    protected final String REGISTERED_FLAG = "-R";
     /**
      * log4j log
      */
@@ -246,6 +248,10 @@ public class S3BitStoreService extends BaseBitStoreService {
     @Override
     public InputStream get(Bitstream bitstream) throws IOException {
         String key = getFullKey(bitstream.getInternalId());
+        // Strip -R from bitstream key if it's registered
+        if (isRegisteredBitstream(key)) {
+            key = key.substring(REGISTERED_FLAG.length());
+        }
         try {
             S3Object object = s3Service.getObject(new GetObjectRequest(bucketName, key));
             return (object != null) ? object.getObjectContent() : null;
@@ -312,6 +318,10 @@ public class S3BitStoreService extends BaseBitStoreService {
     @Override
     public Map about(Bitstream bitstream, Map attrs) throws IOException {
         String key = getFullKey(bitstream.getInternalId());
+        // If this is a registered bitstream, strip the -R prefix before retrieving
+        if (isRegisteredBitstream(key)) {
+            key = key.substring(REGISTERED_FLAG.length());
+        }
         try {
             ObjectMetadata objectMetadata = s3Service.getObjectMetadata(bucketName, key);
             if (objectMetadata != null) {
@@ -587,4 +597,14 @@ public class S3BitStoreService extends BaseBitStoreService {
         store.get(id);
 */
     }
+
+    /**
+     * Is this a registered bitstream? (not stored via this service originally)
+     * @param internalId
+     * @return
+     */
+    public boolean isRegisteredBitstream(String internalId) {
+        return internalId.startsWith(REGISTERED_FLAG);
+    }
+
 }

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/S3BitStoreService.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/S3BitStoreService.java
@@ -420,13 +420,13 @@ public class S3BitStoreService extends BaseBitStoreService {
      * @param sInternalId
      * @return Computed Relative path
      */
-    private String getRelativePath(String sInternalId) {
+    public String getRelativePath(String sInternalId) {
         BitstreamStorageService bitstreamStorageService = StorageServiceFactory.getInstance()
                 .getBitstreamStorageService();
 
         String sIntermediatePath = StringUtils.EMPTY;
         if (bitstreamStorageService.isRegisteredBitstream(sInternalId)) {
-            sInternalId = sInternalId.substring(2);
+            sInternalId = sInternalId.substring(REGISTERED_FLAG.length());
         } else {
             sInternalId = sanitizeIdentifier(sInternalId);
             sIntermediatePath = getIntermediatePath(sInternalId);

--- a/dspace-api/src/test/java/org/dspace/storage/bitstore/S3BitStoreServiceTest.java
+++ b/dspace-api/src/test/java/org/dspace/storage/bitstore/S3BitStoreServiceTest.java
@@ -10,7 +10,9 @@ package org.dspace.storage.bitstore;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.startsWith;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -62,6 +64,9 @@ public class S3BitStoreServiceTest extends AbstractUnitTest {
 
     @Mock
     private Bitstream bitstream;
+
+    @Mock
+    private Bitstream externalBitstream;
 
     @Before
     public void setUp() throws Exception {
@@ -232,6 +237,24 @@ public class S3BitStoreServiceTest extends AbstractUnitTest {
                 )
         );
 
+    }
+
+    @Test
+    public void handleRegisteredIdentifierPrefixInS3() {
+        String trueBitStreamId = "012345";
+        String registeredBitstreamId = s3BitStoreService.REGISTERED_FLAG + trueBitStreamId;
+        // Should be detected as registered bitstream
+        assertTrue(this.s3BitStoreService.isRegisteredBitstream(registeredBitstreamId));
+    }
+
+    @Test
+    public void stripRegisteredBitstreamPrefixWhenCalculatingPath() {
+        // Set paths and IDs
+        String s3Path = "UNIQUE_S3_PATH/test/bitstream.pdf";
+        String registeredBitstreamId = s3BitStoreService.REGISTERED_FLAG + s3Path;
+        // Paths should be equal, since the getRelativePath method should strip the registered -R prefix
+        String relativeRegisteredPath = this.s3BitStoreService.getRelativePath(registeredBitstreamId);
+        assertEquals(s3Path, relativeRegisteredPath);
     }
 
     @Test


### PR DESCRIPTION
## Description
This small PR implements the same "strip -R internal ID prefix from bitstream" functionality to the S3BitStoreService that is already in use by DSBitStoreService, for the `get` and `about` methods.

I haven't changed `put` (possible case: replacement?) as that hasn't come up in my own testing yet.

This probably needs including in some tests as the fact that S3 couldn't deal with registered bitstreams has gone unnoticed for a long time.

Still working on test instructions - the CLI import tool might be OK but Integration Tests are probably the clearest way forward.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
