### PR TITLE
dspace-api: allow overriding ImageMagick density (6.x)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickThumbnailFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickThumbnailFilter.java
@@ -139,6 +139,19 @@ public abstract class ImageMagickThumbnailFilter extends MediaFilter {
                 f2.deleteOnExit();
                 ConvertCmd cmd = new ConvertCmd();
                 IMOperation op = new IMOperation();
+
+                // Optionally override ImageMagick's default density of 72 DPI to use a
+                // "supersample" when creating the PDF thumbnail. Note that I prefer to
+                // use the getProperty() method here instead of getIntPropert() because
+                // the latter always returns an integer (0 in the case it's not set). I
+                // would prefer to keep ImageMagick's default to itself rather than for
+                // us to set one. Also note that the density option *must* come before
+                // we open the input file.
+                String density = ConfigurationManager.getProperty("org.dspace.app.mediafilter.ImageMagickThumbnailFilter.density");
+                if (density != null) {
+                    op.density(Integer.valueOf(density));
+                }
+
                 String s = "[" + page + "]";
                 op.addImage(f.getAbsolutePath() + s);
                 if (flatten) {

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -422,6 +422,12 @@ filter.org.dspace.app.mediafilter.PDFBoxThumbnail.inputFormats = Adobe PDF
 # org.dspace.app.mediafilter.ImageMagickThumbnailFilter.cmyk_profile = /usr/share/ghostscript/9.18/iccprofiles/default_cmyk.icc
 # org.dspace.app.mediafilter.ImageMagickThumbnailFilter.srgb_profile = /usr/share/ghostscript/9.18/iccprofiles/default_rgb.icc
 
+# Optional: override ImageMagick's default density of 72 when creating PDF thum-
+# bnails. Greatly increases quality of resulting thumbnails, at the expense of
+# slightly longer execution times and higher memory usage. Any integer over 72
+# will help, but recommend 144 for a "2x" supersample.
+# org.dspace.app.mediafilter.ImageMagickThumbnailFilter.density = 144
+
 #### Crosswalk and Packager Plugin Settings ####
 # Crosswalks are used to translate external metadata formats into DSpace's internal format (DIM)
 # Packagers are used to ingest/export 'packages' (both content files and metadata)


### PR DESCRIPTION
Allow users to override ImageMagick's default density of 72 DPI for creating PDF thumbnails. In this case a density of 144 will perform a "2x" supersample, which greatly increases the quality of the resulting images at the expense of slightly longer execution time and higher memory usage.

## References
* 6.x port of #8553
* Fixes #8514