### PR TITLE
Option to skip bitstreams on import, like 'export -x'

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
@@ -67,6 +67,7 @@ public class ItemImport extends DSpaceRunnable<ItemImportScriptConfiguration> {
     protected String eperson = null;
     protected String[] collections = null;
     protected boolean isTest = false;
+    protected boolean isExcludeContent = false;
     protected boolean isResume = false;
     protected boolean useWorkflow = false;
     protected boolean useWorkflowSendEmail = false;
@@ -118,6 +119,8 @@ public class ItemImport extends DSpaceRunnable<ItemImportScriptConfiguration> {
             isTest = true;
             handler.logInfo("**Test Run** - not actually importing items.");
         }
+
+        isExcludeContent = commandLine.hasOption('x');
 
         if (commandLine.hasOption('p')) {
             template = true;
@@ -204,6 +207,7 @@ public class ItemImport extends DSpaceRunnable<ItemImportScriptConfiguration> {
                 .getItemImportService();
         try {
             itemImportService.setTest(isTest);
+            itemImportService.setExcludeContent(isExcludeContent);
             itemImportService.setResume(isResume);
             itemImportService.setUseWorkflow(useWorkflow);
             itemImportService.setUseWorkflowSendEmail(useWorkflowSendEmail);

--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportCLIScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportCLIScriptConfiguration.java
@@ -13,7 +13,7 @@ import org.dspace.scripts.configuration.ScriptConfiguration;
 
 /**
  * The {@link ScriptConfiguration} for the {@link ItemImportCLI} script
- * 
+ *
  * @author Francesco Pio Scognamiglio (francescopio.scognamiglio at 4science.com)
  */
 public class ItemImportCLIScriptConfiguration extends ItemImportScriptConfiguration<ItemImportCLI> {
@@ -55,7 +55,7 @@ public class ItemImportCLIScriptConfiguration extends ItemImportScriptConfigurat
         options.addOption(Option.builder("v").longOpt("validate")
                 .desc("test run - do not actually import items")
                 .hasArg(false).required(false).build());
-        options.addOption(Option.builder("x").longOpt("exclude_content")
+        options.addOption(Option.builder("x").longOpt("exclude-bitstreams")
                 .desc("do not load or expect content bitstreams")
                 .hasArg(false).required(false).build());
         options.addOption(Option.builder("p").longOpt("template")

--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportCLIScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportCLIScriptConfiguration.java
@@ -55,6 +55,9 @@ public class ItemImportCLIScriptConfiguration extends ItemImportScriptConfigurat
         options.addOption(Option.builder("v").longOpt("validate")
                 .desc("test run - do not actually import items")
                 .hasArg(false).required(false).build());
+        options.addOption(Option.builder("x").longOpt("exclude_content")
+                .desc("do not load or expect content bitstreams")
+                .hasArg(false).required(false).build());
         options.addOption(Option.builder("p").longOpt("template")
                 .desc("apply template")
                 .hasArg(false).required(false).build());

--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportScriptConfiguration.java
@@ -19,7 +19,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * The {@link ScriptConfiguration} for the {@link ItemImport} script
- * 
+ *
  * @author Francesco Pio Scognamiglio (francescopio.scognamiglio at 4science.com)
  */
 public class ItemImportScriptConfiguration<T extends ItemImport> extends ScriptConfiguration<T> {
@@ -80,6 +80,9 @@ public class ItemImportScriptConfiguration<T extends ItemImport> extends ScriptC
                 .hasArg(false).required(false).build());
         options.addOption(Option.builder("v").longOpt("validate")
                 .desc("test run - do not actually import items")
+                .hasArg(false).required(false).build());
+        options.addOption(Option.builder("x").longOpt("exclude-bitstreams")
+                .desc("do not load or expect content bitstreams")
                 .hasArg(false).required(false).build());
         options.addOption(Option.builder("p").longOpt("template")
                 .desc("apply template")

--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
@@ -62,6 +62,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.itemimport.service.ItemImportService;
 import org.dspace.app.util.LocalSchemaFilenameFilter;
@@ -135,7 +136,7 @@ import org.xml.sax.SAXException;
  * allow the registration of files (bitstreams) into DSpace.
  */
 public class ItemImportServiceImpl implements ItemImportService, InitializingBean {
-    private final Logger log = org.apache.logging.log4j.LogManager.getLogger(ItemImportServiceImpl.class);
+    private final Logger log = LogManager.getLogger();
 
     private DSpaceRunnableHandler handler;
 
@@ -181,6 +182,7 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
     protected String tempWorkDir;
 
     protected boolean isTest = false;
+    protected boolean isExcludeContent = false;
     protected boolean isResume = false;
     protected boolean useWorkflow = false;
     protected boolean useWorkflowSendEmail = false;
@@ -1403,6 +1405,10 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
     protected void processContentFileEntry(Context c, Item i, String path,
                                            String fileName, String bundleName, boolean primary) throws SQLException,
         IOException, AuthorizeException {
+        if (isExcludeContent) {
+            return;
+        }
+
         String fullpath = path + File.separatorChar + fileName;
 
         // get an input stream
@@ -2340,6 +2346,11 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
     @Override
     public void setTest(boolean isTest) {
         this.isTest = isTest;
+    }
+
+    @Override
+    public void setExcludeContent(boolean isExcludeContent) {
+        this.isExcludeContent = isExcludeContent;
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/app/itemimport/service/ItemImportService.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/service/ItemImportService.java
@@ -212,6 +212,13 @@ public interface ItemImportService {
     public void setTest(boolean isTest);
 
     /**
+     * Set exclude-content flag.
+     *
+     * @param isExcludeContent true or false
+     */
+    public void setExcludeContent(boolean isExcludeContent);
+
+    /**
      * Set resume flag
      *
      * @param isResume true or false


### PR DESCRIPTION
## References
* Fixes #8561

## Description
This patch adds an option to `dspace import` which skips the importation of the actual bitstreams.  This was created as a complement to `dspace export -x` which creates import packages without bitstream data, so that those packages can be loaded.

## Instructions for Reviewers
List of changes in this PR:
* Define a `-x` option to eXclude bitstreams from the import operation.
* If `-x` then do not even look for the bitstreams named in the manifest.  Bitstream files will still be mentioned in the console output.

To test, you might create a small export package using `dspace export -x` and then attempt to load it to a different collection.  The unpatched code should throw an IOException:  file not found.  The patched code should succeed.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.