### PR TITLE
Common Extendend Regex Parser

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/DCInput.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/DCInput.java
@@ -208,7 +208,7 @@ public class DCInput {
         visibility = fieldMap.get("visibility");
         readOnly = fieldMap.get("readonly");
         vocabulary = fieldMap.get("vocabulary");
-        regex = fieldMap.get("regex");
+        regex = extractRegexField(fieldMap);
         String closedVocabularyStr = fieldMap.get("closedVocabulary");
         closedVocabulary = "true".equalsIgnoreCase(closedVocabularyStr)
             || "yes".equalsIgnoreCase(closedVocabularyStr);
@@ -239,7 +239,7 @@ public class DCInput {
 
     }
 
-    public String extractRegex(Map<String, String> fieldMap) {
+    private String extractRegexField(Map<String, String> fieldMap) {
         String regex = fieldMap.get("regex");
         Pattern generatedPattern = null;
         if (regex != null) {

--- a/dspace-api/src/main/java/org/dspace/app/util/DCInput.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/DCInput.java
@@ -7,9 +7,12 @@
  */
 package org.dspace.app.util;
 
+import static org.apache.commons.lang3.StringUtils.equalsAnyIgnoreCase;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import javax.annotation.Nullable;
@@ -236,6 +239,21 @@ public class DCInput {
             }
         }
 
+    }
+
+    public String extractRegex(Map<String, String> fieldMap) {
+        String regex = fieldMap.get("regex");
+        Pattern generatedPattern = null;
+        if (regex != null) {
+            try {
+                generatedPattern = RegexPatternUtils.computePattern(regex);
+            } catch (PatternSyntaxException e) {
+                log.warn("The regex field of input {} with value {} is invalid!", this.label, regex);
+            }
+        }
+        return Optional.ofNullable(generatedPattern)
+                .map(pattern -> regex)
+                .orElse(null);
     }
 
     /**
@@ -547,7 +565,7 @@ public class DCInput {
         if (StringUtils.isNotBlank(value)) {
             try {
                 if (StringUtils.isNotBlank(regex)) {
-                    Pattern pattern = Pattern.compile(regex);
+                    Pattern pattern = RegexPatternUtils.computePattern(regex);
                     if (!pattern.matcher(value).matches()) {
                         return false;
                     }

--- a/dspace-api/src/main/java/org/dspace/app/util/DCInput.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/DCInput.java
@@ -7,8 +7,6 @@
  */
 package org.dspace.app.util;
 
-import static org.apache.commons.lang3.StringUtils.equalsAnyIgnoreCase;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -194,7 +192,7 @@ public class DCInput {
         repeatable = "true".equalsIgnoreCase(repStr)
             || "yes".equalsIgnoreCase(repStr);
         String nameVariantsString = fieldMap.get("name-variants");
-        nameVariants = (StringUtils.isNotBlank(nameVariantsString)) ?
+        nameVariants = StringUtils.isNotBlank(nameVariantsString) ?
                 nameVariantsString.equalsIgnoreCase("true") : false;
         label = fieldMap.get("label");
         inputType = fieldMap.get("input-type");
@@ -206,7 +204,7 @@ public class DCInput {
         }
         hint = fieldMap.get("hint");
         warning = fieldMap.get("required");
-        required = (warning != null && warning.length() > 0);
+        required = warning != null && warning.length() > 0;
         visibility = fieldMap.get("visibility");
         readOnly = fieldMap.get("readonly");
         vocabulary = fieldMap.get("vocabulary");
@@ -266,7 +264,7 @@ public class DCInput {
      * @return whether the input should be displayed or not
      */
     public boolean isVisible(String scope) {
-        return (visibility == null || visibility.equals(scope));
+        return visibility == null || visibility.equals(scope);
     }
 
     /**
@@ -399,7 +397,7 @@ public class DCInput {
 
     /**
      * Get the style for this form field
-     * 
+     *
      * @return the style
      */
     public String getStyle() {

--- a/dspace-api/src/main/java/org/dspace/app/util/RegexPatternUtils.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/RegexPatternUtils.java
@@ -1,0 +1,65 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.util;
+
+import static java.util.regex.Pattern.CASE_INSENSITIVE;
+
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Utility class useful for check regex and patterns.
+ *
+ * @author Vincenzo Mecca (vins01-4science - vincenzo.mecca at 4science.com)
+ *
+ */
+public class RegexPatternUtils {
+
+    // checks input having the format /{pattern}/{flags}
+    // allowed flags are: g,i,m,s,u,y
+    public static final String REGEX_INPUT_VALIDATOR = "(/?)(.+)\\1([gimsuy]*)";
+    // flags usable inside regex definition using format (?i|m|s|u|y)
+    public static final String REGEX_FLAGS = "(?%s)";
+    public static final Pattern PATTERN_REGEX_INPUT_VALIDATOR =
+        Pattern.compile(REGEX_INPUT_VALIDATOR, CASE_INSENSITIVE);
+
+    /**
+     * Computes a pattern starting from a regex definition with flags that
+     * uses the standard format: <code>/{regex}/{flags}</code>.
+     * If it's a valid regex a non-null {@code Pattern} will be retrieved,
+     * an exception will be thrown otherwise.
+     *
+     * @param regex with format <code>/{regex}/{flags}</code>
+     * @return {@code Pattern} regex pattern instance
+     * @throws PatternSyntaxException
+     */
+    public static final Pattern computePattern(String regex) throws PatternSyntaxException {
+        Matcher inputMatcher = PATTERN_REGEX_INPUT_VALIDATOR.matcher(regex);
+        Pattern pattern = null;
+        if (inputMatcher.matches()) {
+            String regexPattern = inputMatcher.group(2);
+            String regexFlags =
+                Optional.ofNullable(inputMatcher.group(3))
+                .filter(StringUtils::isNotBlank)
+                .map(flags -> String.format(REGEX_FLAGS, flags))
+                .orElse("")
+                .replaceAll("g", "");
+            pattern = Pattern.compile(regexFlags + regexPattern);
+        } else {
+            pattern = Pattern.compile(regex);
+        }
+        return pattern;
+    }
+
+    private RegexPatternUtils() {}
+
+}

--- a/dspace-api/src/main/java/org/dspace/app/util/RegexPatternUtils.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/RegexPatternUtils.java
@@ -34,7 +34,9 @@ public class RegexPatternUtils {
 
     /**
      * Computes a pattern starting from a regex definition with flags that
-     * uses the standard format: <code>/{regex}/{flags}</code>.
+     * uses the standard format: <code>/{regex}/{flags}</code> (ECMAScript format).
+     * This method can transform an ECMAScript regex into a java {@code Pattern} object
+     * wich can be used to validate strings.
      * <br/>
      * If regex is null, empty or blank a null {@code Pattern} will be retrieved
      * If it's a valid regex, then a non-null {@code Pattern} will be retrieved,

--- a/dspace-api/src/main/java/org/dspace/app/util/RegexPatternUtils.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/RegexPatternUtils.java
@@ -35,14 +35,19 @@ public class RegexPatternUtils {
     /**
      * Computes a pattern starting from a regex definition with flags that
      * uses the standard format: <code>/{regex}/{flags}</code>.
-     * If it's a valid regex a non-null {@code Pattern} will be retrieved,
-     * a {@link PatternSyntaxException} exception will be thrown otherwise.
+     * <br/>
+     * If regex is null, empty or blank a null {@code Pattern} will be retrieved
+     * If it's a valid regex, then a non-null {@code Pattern} will be retrieved,
+     * an exception will be thrown otherwise.
      *
      * @param regex with format <code>/{regex}/{flags}</code>
      * @return {@code Pattern} regex pattern instance
      * @throws PatternSyntaxException
      */
     public static final Pattern computePattern(String regex) throws PatternSyntaxException {
+        if (StringUtils.isBlank(regex)) {
+            return null;
+        }
         Matcher inputMatcher = PATTERN_REGEX_INPUT_VALIDATOR.matcher(regex);
         Pattern pattern = null;
         if (inputMatcher.matches()) {

--- a/dspace-api/src/main/java/org/dspace/app/util/RegexPatternUtils.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/RegexPatternUtils.java
@@ -51,20 +51,21 @@ public class RegexPatternUtils {
             return null;
         }
         Matcher inputMatcher = PATTERN_REGEX_INPUT_VALIDATOR.matcher(regex);
-        Pattern pattern = null;
+        String regexPattern = regex;
+        String regexFlags = "";
         if (inputMatcher.matches()) {
-            String regexPattern = inputMatcher.group(2);
-            String regexFlags =
+            regexPattern =
+                Optional.of(inputMatcher.group(2))
+                    .filter(StringUtils::isNotBlank)
+                    .orElse(regex);
+            regexFlags =
                 Optional.ofNullable(inputMatcher.group(3))
-                .filter(StringUtils::isNotBlank)
-                .map(flags -> String.format(REGEX_FLAGS, flags))
-                .orElse("")
-                .replaceAll("g", "");
-            pattern = Pattern.compile(regexFlags + regexPattern);
-        } else {
-            pattern = Pattern.compile(regex);
+                    .filter(StringUtils::isNotBlank)
+                    .map(flags -> String.format(REGEX_FLAGS, flags))
+                    .orElse("")
+                    .replaceAll("g", "");
         }
-        return pattern;
+        return Pattern.compile(regexFlags + regexPattern);
     }
 
     private RegexPatternUtils() {}

--- a/dspace-api/src/main/java/org/dspace/app/util/RegexPatternUtils.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/RegexPatternUtils.java
@@ -36,7 +36,7 @@ public class RegexPatternUtils {
      * Computes a pattern starting from a regex definition with flags that
      * uses the standard format: <code>/{regex}/{flags}</code>.
      * If it's a valid regex a non-null {@code Pattern} will be retrieved,
-     * an exception will be thrown otherwise.
+     * a {@link PatternSyntaxException} exception will be thrown otherwise.
      *
      * @param regex with format <code>/{regex}/{flags}</code>
      * @return {@code Pattern} regex pattern instance

--- a/dspace-api/src/test/java/org/dspace/app/util/RegexPatternUtilsTest.java
+++ b/dspace-api/src/test/java/org/dspace/app/util/RegexPatternUtilsTest.java
@@ -9,10 +9,13 @@ package org.dspace.app.util;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 import org.dspace.AbstractUnitTest;
 import org.junit.Test;
@@ -157,5 +160,29 @@ public class RegexPatternUtilsTest extends AbstractUnitTest {
         assertFalse(matcher.matches());
         matcher = computePattern.matcher("Hello");
         assertFalse(matcher.matches());
+    }
+
+    @Test
+    public void testInvalidRegex() {
+        String invalidSensitive = "[a-z+";
+        assertThrows(PatternSyntaxException.class, () -> RegexPatternUtils.computePattern(invalidSensitive));
+
+        String invalidRange = "a{1-";
+        assertThrows(PatternSyntaxException.class, () -> RegexPatternUtils.computePattern(invalidRange));
+
+        String invalidGroupPattern = "(abc";
+        assertThrows(PatternSyntaxException.class, () -> RegexPatternUtils.computePattern(invalidGroupPattern));
+
+        String emptyPattern = "";
+        Pattern computePattern = RegexPatternUtils.computePattern(emptyPattern);
+        assertNull(computePattern);
+
+        String blankPattern = "                      ";
+        computePattern = RegexPatternUtils.computePattern(blankPattern);
+        assertNull(computePattern);
+
+        String nullPattern = null;
+        computePattern = RegexPatternUtils.computePattern(nullPattern);
+        assertNull(computePattern);
     }
 }

--- a/dspace-api/src/test/java/org/dspace/app/util/RegexPatternUtilsTest.java
+++ b/dspace-api/src/test/java/org/dspace/app/util/RegexPatternUtilsTest.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.app.util;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -184,5 +185,30 @@ public class RegexPatternUtilsTest extends AbstractUnitTest {
         String nullPattern = null;
         computePattern = RegexPatternUtils.computePattern(nullPattern);
         assertNull(computePattern);
+    }
+
+    @Test
+    public void testMultiFlagRegex() {
+        String multilineSensitive = "/[a-z]+/gi";
+        Pattern computePattern = RegexPatternUtils.computePattern(multilineSensitive);
+        assertNotNull(computePattern);
+        Matcher matcher = computePattern.matcher("hello");
+        assertTrue(matcher.matches());
+        matcher = computePattern.matcher("Hello");
+        assertTrue(matcher.matches());
+
+        multilineSensitive = "/[a-z]+/gim";
+        computePattern = RegexPatternUtils.computePattern(multilineSensitive);
+        assertNotNull(computePattern);
+        matcher = computePattern.matcher("Hello" + System.lineSeparator() + "Everyone");
+        assertTrue(matcher.find());
+        assertEquals("Hello", matcher.group());
+        assertTrue(matcher.find());
+        assertEquals("Everyone", matcher.group());
+
+        matcher = computePattern.matcher("hello");
+        assertTrue(matcher.matches());
+        matcher = computePattern.matcher("HELLO");
+        assertTrue(matcher.matches());
     }
 }

--- a/dspace-api/src/test/java/org/dspace/app/util/RegexPatternUtilsTest.java
+++ b/dspace-api/src/test/java/org/dspace/app/util/RegexPatternUtilsTest.java
@@ -1,0 +1,161 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.util;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.dspace.AbstractUnitTest;
+import org.junit.Test;
+
+/**
+ * Tests for RegexPatternUtils
+ *
+ * @author Vincenzo Mecca (vins01-4science - vincenzo.mecca at 4science.com)
+ *
+ */
+public class RegexPatternUtilsTest extends AbstractUnitTest {
+
+    @Test
+    public void testValidRegexWithFlag() {
+        final String insensitiveWord = "/[a-z]+/i";
+        Pattern computePattern = Pattern.compile(insensitiveWord);
+        assertNotNull(computePattern);
+
+        Matcher matcher = computePattern.matcher("Hello");
+        assertFalse(matcher.matches());
+        matcher = computePattern.matcher("DSpace");
+        assertFalse(matcher.matches());
+        matcher = computePattern.matcher("Community");
+        assertFalse(matcher.matches());
+        matcher = computePattern.matcher("/wrongpattern/i");
+        assertTrue(matcher.matches());
+        matcher = computePattern.matcher("001");
+        assertFalse(matcher.matches());
+        matcher = computePattern.matcher("?/'`}{][<>.,");
+        assertFalse(matcher.matches());
+        computePattern = RegexPatternUtils.computePattern(insensitiveWord);
+        assertNotNull(computePattern);
+
+        matcher = computePattern.matcher("Hello");
+        assertTrue(matcher.matches());
+        matcher = computePattern.matcher("DSpace");
+        assertTrue(matcher.matches());
+        matcher = computePattern.matcher("Community");
+        assertTrue(matcher.matches());
+        matcher = computePattern.matcher("/wrong-pattern/i");
+        assertFalse(matcher.matches());
+        matcher = computePattern.matcher("001");
+        assertFalse(matcher.matches());
+        matcher = computePattern.matcher("?/'`}{][<>.,");
+        assertFalse(matcher.matches());
+    }
+
+    @Test
+    public void testRegexWithoutFlag() {
+        final String sensitiveWord = "[a-z]+";
+        Pattern computePattern = RegexPatternUtils.computePattern(sensitiveWord);
+        assertNotNull(computePattern);
+
+        Matcher matcher = computePattern.matcher("hello");
+        assertTrue(matcher.matches());
+        matcher = computePattern.matcher("dspace");
+        assertTrue(matcher.matches());
+        matcher = computePattern.matcher("community");
+        assertTrue(matcher.matches());
+        matcher = computePattern.matcher("Hello");
+        assertFalse(matcher.matches());
+        matcher = computePattern.matcher("DSpace");
+        assertFalse(matcher.matches());
+        matcher = computePattern.matcher("Community");
+        assertFalse(matcher.matches());
+        matcher = computePattern.matcher("/wrongpattern/i");
+        assertFalse(matcher.matches());
+        matcher = computePattern.matcher("001");
+        assertFalse(matcher.matches());
+        matcher = computePattern.matcher("?/'`}{][<>.,");
+        assertFalse(matcher.matches());
+
+        final String sensitiveWordWithDelimiter = "/[a-z]+/";
+        computePattern = RegexPatternUtils.computePattern(sensitiveWordWithDelimiter);
+        assertNotNull(computePattern);
+
+        matcher = computePattern.matcher("hello");
+        assertTrue(matcher.matches());
+        matcher = computePattern.matcher("dspace");
+        assertTrue(matcher.matches());
+        matcher = computePattern.matcher("community");
+        assertTrue(matcher.matches());
+        matcher = computePattern.matcher("Hello");
+        assertFalse(matcher.matches());
+        matcher = computePattern.matcher("DSpace");
+        assertFalse(matcher.matches());
+        matcher = computePattern.matcher("Community");
+        assertFalse(matcher.matches());
+        matcher = computePattern.matcher("/wrongpattern/i");
+        assertFalse(matcher.matches());
+        matcher = computePattern.matcher("001");
+        assertFalse(matcher.matches());
+        matcher = computePattern.matcher("?/'`}{][<>.,");
+        assertFalse(matcher.matches());
+    }
+
+    @Test
+    public void testWithFuzzyRegex() {
+        String fuzzyRegex = "/[a-z]+";
+        Pattern computePattern = RegexPatternUtils.computePattern(fuzzyRegex);
+        assertNotNull(computePattern);
+
+        Matcher matcher = computePattern.matcher("/hello");
+        assertTrue(matcher.matches());
+        matcher = computePattern.matcher("hello");
+        assertFalse(matcher.matches());
+        matcher = computePattern.matcher("Hello");
+        assertFalse(matcher.matches());
+
+        fuzzyRegex = "[a-z]+/";
+        computePattern = RegexPatternUtils.computePattern(fuzzyRegex);
+        matcher = computePattern.matcher("hello/");
+        assertTrue(matcher.matches());
+        matcher = computePattern.matcher("/hello");
+        assertFalse(matcher.matches());
+        matcher = computePattern.matcher("hello");
+        assertFalse(matcher.matches());
+        matcher = computePattern.matcher("Hello");
+        assertFalse(matcher.matches());
+
+        // equals to pattern \\[a-z]+\\ -> searching for a word delimited by '\'
+        fuzzyRegex = "\\\\[a-z]+\\\\";
+        computePattern = RegexPatternUtils.computePattern(fuzzyRegex);
+        // equals to '\hello\'
+        matcher = computePattern.matcher("\\hello\\");
+        assertTrue(matcher.matches());
+        matcher = computePattern.matcher("/hello");
+        assertFalse(matcher.matches());
+        matcher = computePattern.matcher("hello");
+        assertFalse(matcher.matches());
+        matcher = computePattern.matcher("Hello");
+        assertFalse(matcher.matches());
+
+        // equals to pattern /[a-z]+/ -> searching for a string delimited by '/'
+        fuzzyRegex = "\\/[a-z]+\\/";
+        computePattern = RegexPatternUtils.computePattern(fuzzyRegex);
+        matcher = computePattern.matcher("/hello/");
+        assertTrue(matcher.matches());
+        matcher = computePattern.matcher("/hello");
+        assertFalse(matcher.matches());
+        matcher = computePattern.matcher("hello");
+        assertFalse(matcher.matches());
+        matcher = computePattern.matcher("Hello");
+        assertFalse(matcher.matches());
+    }
+}


### PR DESCRIPTION
## References
* Fixes #8563 
* Requires DSpace/dspace-angular#1976

## Description
Parses the submission-forms and checks for a valid regex that could have flags declared in this way: `/{regex}/{flags}`.

## Instructions for Reviewers
Without the Frontend part you can test it by inserting some `regex` inside the `<regex>` tag of the submission form and try to save it with a valid / invalid value.

List of changes in this PR:
* New utility class for regex parsing and generation;
* New method inside DCInput to correctly retrieve the regex pattern.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
