### PR TITLE
DS-4488: Log views statistics even when MaxMind DatabaseReader isn't fully configured

### DIFF
--- a/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java
@@ -197,7 +197,7 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
     @Override
     public void postView(DSpaceObject dspaceObject, HttpServletRequest request,
                          EPerson currentUser) {
-        if (solr == null || locationService == null) {
+        if (solr == null) {
             return;
         }
         initSolrYearCores();
@@ -238,7 +238,7 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
     @Override
     public void postView(DSpaceObject dspaceObject,
                          String ip, String userAgent, String xforwardedfor, EPerson currentUser) {
-        if (solr == null || locationService == null) {
+        if (solr == null) {
             return;
         }
         initSolrYearCores();


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes https://github.com/DSpace/DSpace/issues/7822

## Description
This small PR removes the requirement that the MaxMind GeoIP location service be configured with its database file in order to log usage statistics. 

## Instructions for Reviewers
1. Leave the `usage-statistics.dbfile` parameter commented out in [dspace]/config/modules/usage-statistics.cfg
2. Deploy DSpace and view a few items and bitstreams
3. Observe in the statistics Solr core that the views haven't been logged
4. Deploy this PR and view a few items and bitstreams
5. Confirm that the views are now being recorded in the statistics core.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
