### PR TITLE
Fix broken handle server for Java 1.8 (DSpace 6.x version) - WIP

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -655,6 +655,16 @@
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>
             <version>1.4.0</version>
+            <exclusions>
+              <exclusion>
+                  <groupId>org.ow2.asm</groupId>
+                  <artifactId>asm</artifactId>
+              </exclusion>
+              <exclusion>
+                  <groupId>org.ow2.asm</groupId>
+                  <artifactId>asm-commons</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -766,6 +776,13 @@
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
             <version>${jersey.version}</version>
+            <exclusions>
+                <!-- newer version pulled in by jetty server-->
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- S3 -->
         <dependency>

--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -315,8 +315,45 @@
             <artifactId>spring-orm</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.dspace</groupId>
+            <groupId>net.handle</groupId>
             <artifactId>handle</artifactId>
+            <version>9.3.0</version>
+            <exclusions>
+                <!-- A later version is brought in by google-oauth-client -->
+                <exclusion>
+                    <groupId>com.google.code.gson</groupId>
+                    <artifactId>gson</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>net.cnri</groupId>
+            <artifactId>cnri-servlet-container</artifactId>
+            <exclusions>
+                <!-- Newer versions provided in our parent POM -->
+                <exclusion>
+                    <groupId>org.ow2.asm</groupId>
+                    <artifactId>asm-commons</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcpkix-jdk15on</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk15on</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>net.cnri</groupId>
+            <artifactId>cnri-servlet-container</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+        <!-- Jetty is needed to run Handle Server -->
+        <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-server</artifactId>
         </dependency>
         <dependency>
             <groupId>org.dspace</groupId>
@@ -423,7 +460,11 @@
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15</artifactId>
+            <artifactId>bcprov-jdk15on</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk15on</artifactId>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
@@ -751,5 +792,16 @@
             <version>20180130</version>
         </dependency>
     </dependencies>
+
+    <repositories>
+        <repository>
+            <id>maven-central</id>
+            <url>https://repo.maven.apache.org/maven2</url>
+        </repository>
+        <repository>
+            <id>handle.net</id>
+            <url>https://handle.net/maven</url>
+        </repository>
+    </repositories>
 
 </project>

--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -318,13 +318,6 @@
             <groupId>net.handle</groupId>
             <artifactId>handle</artifactId>
             <version>9.3.0</version>
-            <exclusions>
-                <!-- A later version is brought in by google-oauth-client -->
-                <exclusion>
-                    <groupId>com.google.code.gson</groupId>
-                    <artifactId>gson</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>net.cnri</groupId>

--- a/dspace-api/src/main/java/org/dspace/handle/HandlePlugin.java
+++ b/dspace-api/src/main/java/org/dspace/handle/HandlePlugin.java
@@ -20,7 +20,7 @@ import net.handle.hdllib.HandleStorage;
 import net.handle.hdllib.HandleValue;
 import net.handle.hdllib.ScanCallback;
 import net.handle.hdllib.Util;
-import net.handle.util.StreamTable;
+import net.cnri.util.StreamTable;
 
 import org.apache.log4j.Logger;
 import org.dspace.core.Context;

--- a/dspace-api/src/test/java/org/dspace/statistics/util/DummyHttpServletRequest.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/util/DummyHttpServletRequest.java
@@ -12,14 +12,12 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.security.Principal;
+import java.util.Collection;
 import java.util.Enumeration;
 import java.util.Locale;
 import java.util.Map;
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletInputStream;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
+import javax.servlet.*;
+import javax.servlet.http.*;
 
 /**
  * A mock request for testing.
@@ -235,6 +233,11 @@ class DummyHttpServletRequest implements HttpServletRequest
         return null;
     }
 
+    @Override
+    public String changeSessionId() {
+        return null;
+    }
+
     /* (non-Javadoc)
      * @see javax.servlet.http.HttpServletRequest#getSession(boolean)
      */
@@ -283,6 +286,36 @@ class DummyHttpServletRequest implements HttpServletRequest
     {
         // TODO Auto-generated method stub
         return false;
+    }
+
+    @Override
+    public boolean authenticate(HttpServletResponse httpServletResponse) throws IOException, ServletException {
+        return false;
+    }
+
+    @Override
+    public void login(String s, String s1) throws ServletException {
+
+    }
+
+    @Override
+    public void logout() throws ServletException {
+
+    }
+
+    @Override
+    public Collection<Part> getParts() throws IOException, ServletException {
+        return null;
+    }
+
+    @Override
+    public Part getPart(String s) throws IOException, ServletException {
+        return null;
+    }
+
+    @Override
+    public <T extends HttpUpgradeHandler> T upgrade(Class<T> aClass) throws IOException, ServletException {
+        return null;
     }
 
     /* (non-Javadoc)
@@ -342,6 +375,11 @@ class DummyHttpServletRequest implements HttpServletRequest
     public int getContentLength()
     {
         // TODO Auto-generated method stub
+        return 0;
+    }
+
+    @Override
+    public long getContentLengthLong() {
         return 0;
     }
 
@@ -573,6 +611,41 @@ class DummyHttpServletRequest implements HttpServletRequest
     public int getLocalPort()
     {
         throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public ServletContext getServletContext() {
+        return null;
+    }
+
+    @Override
+    public AsyncContext startAsync() throws IllegalStateException {
+        return null;
+    }
+
+    @Override
+    public AsyncContext startAsync(ServletRequest servletRequest, ServletResponse servletResponse) throws IllegalStateException {
+        return null;
+    }
+
+    @Override
+    public boolean isAsyncStarted() {
+        return false;
+    }
+
+    @Override
+    public boolean isAsyncSupported() {
+        return false;
+    }
+
+    @Override
+    public AsyncContext getAsyncContext() {
+        return null;
+    }
+
+    @Override
+    public DispatcherType getDispatcherType() {
+        return null;
     }
 
 }

--- a/dspace-oai/pom.xml
+++ b/dspace-oai/pom.xml
@@ -182,6 +182,12 @@
         <dependency>
             <groupId>org.dspace</groupId>
             <artifactId>dspace-api</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.cnri</groupId>
+                    <artifactId>cnri-servlet-container</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Solr (Datasource) -->

--- a/dspace-rest/pom.xml
+++ b/dspace-rest/pom.xml
@@ -217,6 +217,10 @@
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-annotations</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>net.cnri</groupId>
+                    <artifactId>cnri-servlet-container</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/dspace-xmlui/pom.xml
+++ b/dspace-xmlui/pom.xml
@@ -92,6 +92,14 @@
                     <groupId>xml-apis</groupId>
                     <artifactId>xml-apis</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-server</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>net.cnri</groupId>
+                    <artifactId>cnri-servlet-container</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/dspace-xmlui/pom.xml
+++ b/dspace-xmlui/pom.xml
@@ -266,7 +266,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.6.1</version>
+            <version>${gson.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/dspace/bin/make-handle-config
+++ b/dspace/bin/make-handle-config
@@ -16,9 +16,16 @@ BINDIR=`dirname $0`
 
 echo "Writing simple Handle server configuration"
 
-# Read parameters from DSpace config
-dshostname=`$BINDIR/dspace dsprop --property dspace.hostname`
+# Read server URL from DSpace config
+dsurl=`$BINDIR/dspace dsprop --property dspace.server.url`
+# Parse hostname from URL
+dshostname=`echo $dsurl | awk -F/ '{ print $3; exit }'`
+# Determine IP address from hostname
 dshostip=`host $dshostname | awk '/has address/ { print $4; exit }'`
+if [ "$dshostip" = "127.0.0.1" ]; then
+  # Just use default. SimpleSetup will fail when trying to bind to localhost addresses.
+  dshostip=""
+fi
 dsname=`$BINDIR/dspace dsprop --property dspace.name`
 handle=`$BINDIR/dspace dsprop --property handle.prefix`
 handledir=`$BINDIR/dspace dsprop --property handle.dir`
@@ -26,13 +33,13 @@ tempfile=/tmp/handleconfig$$
 contactemail=`$BINDIR/dspace dsprop --property mail.admin`
 
 # Write the options to a file we can pipe into the setup tool
-echo "1" >$tempfile   # 1 = non-caching server, 2 = caching server
-echo "" >>$tempfile   # Primary server?  Default = y (n = mirror server)
+echo "" >$tempfile   # Primary server?  Default = y (n = mirror server)
+echo "" >>$tempfile   # Dual-stack (IPv4 and IPv6)? (default=n)
 echo $dshostip >>$tempfile   # IP address
+echo "" >>$tempfile   # DBind address (default=same as IP)
 echo "" >>$tempfile   # Port to listen to (default=2641)
 echo "" >>$tempfile   # Port for HTTP i/f to listen to (default=8000)
-echo "" >>$tempfile   # Log all accesses?  ("y" or "n", default=n)
-echo "" >>$tempfile   # Rotate logs? (default=No)
+echo "n" >>$tempfile   # Log all accesses?  ("y" or "n", default=y)
 echo "" >>$tempfile   # Version/serial no. of site (default=1)
 echo $dsname Handle Server >>$tempfile  # Server description
 echo $dsname >>$tempfile # Server descriptive name
@@ -46,29 +53,29 @@ echo "n" >>$tempfile  # Do not encrypt admin private key
                       # OR do not overwrite old admin private key
 
 # Now run Handle server config tool, and pipe our config in
-$BINDIR/dspace dsrun net.handle.server.SimpleSetup $handledir < $tempfile >/dev/null
+$BINDIR/dspace dsrun net.handle.server.SimpleSetup $handledir < $tempfile >/dev/null 2>&1
 
 # Remove temp file
 rm -f $tempfile
 
 # Now update server configuration (config.dct) with our handle prefix and the
 # DSpace Handle plugin
-sed 's/YOUR_NAMING_AUTHORITY/'$handle'/' <$handledir/config.dct >$tempfile
+sed 's/YOUR_PREFIX/'$handle'/' <$handledir/config.dct >$tempfile
 
 # Remove original config file - will replace
 rm -f $handledir/config.dct
 
-# Insert our HandlePlugin - this awk script inserts these lines in the
-# server_config section:
+# Insert our HandlePlugin and turn off transaction queue.
+# This awk script inserts these lines in the server_config section:
 #   "storage_type" = "CUSTOM"
 #   "storage_class" = "org.dspace.handle.HandlePlugin"
-awk '/.*/ {print $0} /"server_config" = {/ {printf "\"storage_type\" = \"CUSTOM\"\n\"storage_class\" = \"org.dspace.handle.HandlePlugin\"\n\n",$0}' <$tempfile >$handledir/config.dct
+#   "enable_txn_queue" = "n"
+awk '/.*/ {print $0} /"server_config" = {/ {printf "\"storage_type\" = \"CUSTOM\"\n\"storage_class\" = \"org.dspace.handle.HandlePlugin\"\n\"enable_txn_queue\" = \"no\"\n\n",$0}' <$tempfile >$handledir/config.dct
 
 
 #sed 's/"server_config" = {/"server_config" = {\n"storage_type" = "CUSTOM"\n"storage_class" = "org.dspace.handle.HandlePlugin"/'  <$tempfile >$handledir/config.dct
 
 
-#awk 'NR==1 {printf "%s\n\"storage_type\" = \"CUSTOM\"\n\"storage_class\" = \"org.dspace.handle.HandlePlugin\"\n\n",$0} NR!=1 {print $0}' <$tempfile >$handledir/config.dct
 
 # Remove temp file
 rm -f $tempfile

--- a/dspace/bin/make-handle-config
+++ b/dspace/bin/make-handle-config
@@ -76,6 +76,7 @@ awk '/.*/ {print $0} /"server_config" = {/ {printf "\"storage_type\" = \"CUSTOM\
 #sed 's/"server_config" = {/"server_config" = {\n"storage_type" = "CUSTOM"\n"storage_class" = "org.dspace.handle.HandlePlugin"/'  <$tempfile >$handledir/config.dct
 
 
+#awk 'NR==1 {printf "%s\n\"storage_type\" = \"CUSTOM\"\n\"storage_class\" = \"org.dspace.handle.HandlePlugin\"\n\n",$0} NR!=1 {print $0}' <$tempfile >$handledir/config.dct
 
 # Remove temp file
 rm -f $tempfile

--- a/dspace/modules/additions/pom.xml
+++ b/dspace/modules/additions/pom.xml
@@ -51,6 +51,12 @@
       <dependency>
          <groupId>org.dspace</groupId>
          <artifactId>dspace-api</artifactId>
+         <exclusions>
+            <exclusion>
+               <groupId>net.cnri</groupId>
+               <artifactId>cnri-servlet-container</artifactId>
+            </exclusion>
+         </exclusions>
       </dependency>
       <dependency>
          <groupId>org.dspace</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
         <jackson.version>2.8.11</jackson.version>
         <jersey.version>2.22.1</jersey.version>
         <java.version>1.7</java.version>
+        <jetty.version>9.4.15.v20190215</jetty.version>
         <postgresql.driver.version>42.2.1</postgresql.driver.version>
         <solr.version>4.10.4</solr.version>
         <jena.version>2.13.0</jena.version>
@@ -1098,9 +1099,26 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>org.dspace</groupId>
+                <groupId>net.handle</groupId>
                 <artifactId>handle</artifactId>
-                <version>6.2</version>
+                <version>9.3.0</version>
+            </dependency>
+            <!-- Required to run Handle Server -->
+            <dependency>
+                <groupId>net.cnri</groupId>
+                <artifactId>cnri-servlet-container</artifactId>
+                <version>3.0.0</version>
+            </dependency>
+            <!-- Jetty is needed to run Handle Server (and tests in some modules) -->
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-server</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-util</artifactId>
+                <version>${jetty.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.dspace</groupId>
@@ -1229,9 +1247,14 @@
             </dependency>
             <dependency>
 	        <groupId>org.bouncycastle</groupId>
-	        <artifactId>bcprov-jdk15</artifactId>
-	        <version>1.46</version>
+	        <artifactId>bcprov-jdk15on</artifactId>
+	        <version>1.70</version>
 	    </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcpkix-jdk15on</artifactId>
+                <version>1.70</version>
+            </dependency>
 	    <dependency>
 	        <groupId>org.bouncycastle</groupId>
 	        <artifactId>bcmail-jdk15</artifactId>
@@ -1611,6 +1634,10 @@
         <repository>
             <id>restlet-mirror</id>
             <url>https://maven.restlet.talend.com</url>
+        </repository>
+        <repository>
+            <id>handle.net</id>
+            <url>https://handle.net/maven</url>
         </repository>
     </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1425,7 +1425,7 @@
             <dependency>
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
-                <version>2.6.1</version>
+                <version>2.8.1</version>
                 <scope>compile</scope>
             </dependency>
             <!-- Google Analytics -->

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>${project.build.sourceEncoding}</project.reporting.outputEncoding>
-        
+        <gson.version>2.8.1</gson.version>
         <!--  See https://github.com/DSpace/DSpace/issues/7250 for a discussion of the version of jackson that is needed -->
         <jackson.version>2.8.11</jackson.version>
         <jersey.version>2.22.1</jersey.version>
@@ -1425,7 +1425,7 @@
             <dependency>
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
-                <version>2.8.1</version>
+                <version>${gson.version}</version>
                 <scope>compile</scope>
             </dependency>
             <!-- Google Analytics -->


### PR DESCRIPTION
## References

* See #8557
* Related to Handle Server

## Description
Updates to dependencies for dspace-handle server for the `dspace-6_x` branch, currently fails during build, with mismatch when pulling in dependencies. Handle server not tested for 6_x branch.

## Instructions for Reviewers

List of changes in this PR:
Based on DSpace 7 handle changes

* Update handle dependency from dspace artifact to handle.net (add the maven handle repo) and upgrade version to 9.3.0.
* Change `Streamtable` implementation to `net.cnri.util.StreamTable` (DS7 PR)
* Update and change to packages `bcpkix-jdk15on`, `bcprov-jdk15on` dependencies (from DS7 PRs) used by handle server.
* Add new dependencies `net.cnri:cnri-servlet-container` and `òrg.eclipse.jetty:jetty-server` for handle package (DS7 PRs)
* Exclusion of `jetty-server` and `cnri-servlet-container` from `dspace-api` dependency in *dspace-xmlui* for resolving dependency collision.
* Exclusion of `cnri-servlet-container` from `dspace-api` dependency in  `dspace-oai`, `dspace-rest` and `dspace-modules-additions`. 
* Exclusion of `asm-commons` and `asm` from `elasticsearch` dependency for resolving dependency collision in `dspace-api`.  
```
Warning:  Rule 0: org.apache.maven.plugins.enforcer.DependencyConvergence failed with message:
Failed while enforcing releasability the error(s) are [
Dependency convergence error for org.ow2.asm:asm:7.0 paths to dependency are:
+-org.dspace:dspace-api:6.5-SNAPSHOT
  +-net.cnri:cnri-servlet-container:3.0.0
    +-org.eclipse.jetty:jetty-annotations:9.4.15.v20190215
      +-org.ow2.asm:asm:7.0
and
+-org.dspace:dspace-api:6.5-SNAPSHOT
  +-org.elasticsearch:elasticsearch:1.4.0
    +-org.ow2.asm:asm:4.1
``` 
* Exclusion of `javax.annotation-api` from `jersey-client` in `dspace-api`.
```
Dependency convergence error for javax.annotation:javax.annotation-api:1.3 paths to dependency are:
+-org.dspace:dspace-api:6.5-SNAPSHOT
  +-net.cnri:cnri-servlet-container:3.0.0
    +-org.eclipse.jetty:jetty-annotations:9.4.15.v20190215
      +-javax.annotation:javax.annotation-api:1.3
and
+-org.dspace:dspace-api:6.5-SNAPSHOT
  +-org.glassfish.jersey.core:jersey-client:2.22.1
    +-org.glassfish.jersey.core:jersey-common:2.22.1
      +-javax.annotation:javax.annotation-api:1.2
```

* Patch `make-handle-config` to be identical to version in 7.4.
* Update DummyHttpServletRequest.java test with boilerplate code generated from IntelliJ to add missing stubs after upgrade.
* Add a `gson.version` property and use same version for `dspace-xmlui` and `dspace-api`.

```
Warning:  
Dependency convergence error for com.google.code.gson:gson:2.8.1 paths to dependency are:
+-org.dspace:dspace-xmlui:6.5-SNAPSHOT
  +-org.dspace:dspace-api:6.5-SNAPSHOT
    +-gr.ekt.bte:bte-io:0.9.3.5
      +-com.google.code.gson:gson:2.8.1
and
+-org.dspace:dspace-xmlui:6.5-SNAPSHOT
  +-org.dspace:dspace-api:6.5-SNAPSHOT
    +-com.google.code.gson:gson:2.8.1
and
+-org.dspace:dspace-xmlui:6.5-SNAPSHOT
  +-com.google.code.gson:gson:2.6.1
```

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or 
description of a new feature, or reasons behind specific changes. See failing job above.

* Run the `make-handle-config` script and insert dummy settings
* Start the `handle-server` script
* review the output of `handle-server/logs` error and access files.
* Especially test the components which exclude older versions to check if they still work.

** Some questions for @tdonohue 
* Should annotation-api be added as a dependency for 1.3, when cnri-servlet-container is excluded from multiple modules and annotation api is excluded from jersey-client, there `annotation-api` could not be present in the classpath at all?
* There is a big jump between the asm and asm-commons versions in elasticsearch and jetty-annotations, so they are probably not compatible. I tried to figure out what the dependencies are used for, and I think it is for generating bytecode for the lucene expression language. Is this used by the module or could it be excluded and ignored?
* Since the handle server and dependencies run as a standalone application, I assume that the colliding dependencies can be excluded from the different modules. Does this hold?
* Should `bcmail-jdk15` also be updated or removed?

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
