### PR TITLE
Update Apache Commons BCEL and add "test" scope

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -806,10 +806,11 @@
             <scope>test</scope>
         </dependency>
 
-       <dependency>
+        <dependency>
             <groupId>org.apache.bcel</groupId>
             <artifactId>bcel</artifactId>
-            <version>6.4.0</version>
+            <version>6.6.0</version>
+            <scope>test</scope>
         </dependency>
 
         <!-- required for openaire api integration -->


### PR DESCRIPTION
## References
* Patches CVE-2022-42920 vulnerability in Apache Commons BCEL, even though DSpace does not appear to be vulnerable (see below)

## Description
Updates our `dspace-api` POM to the Apache BCEL version 6.6.0.  Also corrects the `scope` to `test`, as we only use BCEL in a single unit test: https://github.com/DSpace/DSpace/blob/main/dspace-api/src/test/java/org/dspace/core/PathsClassLoaderTest.java

### Is DSpace vulnerable?

No. Apache Commons BCEL is included in DSpace 5.x, 6.x and 7.x.  However, it is only used in a single Unit Test.  Therefore the vulnerability cannot be triggered as the Apache Commons BCEL API is never called in production scenarios.