### PR TITLE
DS-8385: Use discovery configuration to get correct sort field type for given …

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/OpenSearchController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/OpenSearchController.java
@@ -45,6 +45,8 @@ import org.dspace.discovery.SearchUtils;
 import org.dspace.discovery.configuration.DiscoveryConfiguration;
 import org.dspace.discovery.configuration.DiscoveryConfigurationService;
 import org.dspace.discovery.configuration.DiscoverySearchFilter;
+import org.dspace.discovery.configuration.DiscoverySortConfiguration;
+import org.dspace.discovery.configuration.DiscoverySortFieldConfiguration;
 import org.dspace.discovery.indexobject.IndexableItem;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -141,16 +143,34 @@ public class OpenSearchController {
             queryArgs.setStart(start);
             queryArgs.setMaxResults(count);
             queryArgs.setDSpaceObjectFilter(IndexableItem.TYPE);
+
             if (sort != null) {
-                //this is the default sort so we want to switch this to date accessioned
-                if (sortDirection != null && sortDirection.equals("DESC")) {
-                    queryArgs.setSortField(sort + "_sort", SORT_ORDER.desc);
-                } else {
-                    queryArgs.setSortField(sort + "_sort", SORT_ORDER.asc);
+                DiscoveryConfiguration discoveryConfiguration =
+                    searchConfigurationService.getDiscoveryConfiguration("");
+                if (discoveryConfiguration != null) {
+                    DiscoverySortConfiguration searchSortConfiguration = discoveryConfiguration.getSearchSortConfiguration();
+                    if (searchSortConfiguration != null) {
+                        DiscoverySortFieldConfiguration sortFieldConfiguration = searchSortConfiguration
+                            .getSortFieldConfiguration(sort);
+                        if (sortFieldConfiguration != null) {
+                            String sortField = searchService
+                                .toSortFieldIndex(sortFieldConfiguration.getMetadataField(), sortFieldConfiguration.getType());
+
+                            if (sortDirection != null && sortDirection.equals("DESC")) {
+                                queryArgs.setSortField(sortField, SORT_ORDER.desc);
+                            } else {
+                                queryArgs.setSortField(sortField, SORT_ORDER.asc);
+                            }
+                        } else {
+                            throw new IllegalArgumentException(sort + " is not a valid sort field");
+                        }
+                    }
                 }
             } else {
+                // this is the default sort so we want to switch this to date accessioned
                 queryArgs.setSortField("dc.date.accessioned_dt", SORT_ORDER.desc);
             }
+
             if (dsoObject != null) {
                 container = scopeResolver.resolveScope(context, dsoObject);
                 DiscoveryConfiguration discoveryConfiguration = searchConfigurationService

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/OpenSearchController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/OpenSearchController.java
@@ -148,13 +148,15 @@ public class OpenSearchController {
                 DiscoveryConfiguration discoveryConfiguration =
                     searchConfigurationService.getDiscoveryConfiguration("");
                 if (discoveryConfiguration != null) {
-                    DiscoverySortConfiguration searchSortConfiguration = discoveryConfiguration.getSearchSortConfiguration();
+                    DiscoverySortConfiguration searchSortConfiguration = discoveryConfiguration
+                        .getSearchSortConfiguration();
                     if (searchSortConfiguration != null) {
                         DiscoverySortFieldConfiguration sortFieldConfiguration = searchSortConfiguration
                             .getSortFieldConfiguration(sort);
                         if (sortFieldConfiguration != null) {
                             String sortField = searchService
-                                .toSortFieldIndex(sortFieldConfiguration.getMetadataField(), sortFieldConfiguration.getType());
+                                .toSortFieldIndex(sortFieldConfiguration.getMetadataField(),
+                                sortFieldConfiguration.getType());
 
                             if (sortDirection != null && sortDirection.equals("DESC")) {
                                 queryArgs.setSortField(sortField, SORT_ORDER.desc);

--- a/dspace-server-webapp/src/test/java/org/dspace/app/opensearch/OpenSearchControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/opensearch/OpenSearchControllerIT.java
@@ -185,6 +185,32 @@ public class OpenSearchControllerIT extends AbstractControllerIntegrationTest {
     }
 
     @Test
+    public void validSortTest() throws Exception {
+        //When we call the root endpoint
+        getClient().perform(get("/opensearch/search")
+                                .param("query", "")
+                                .param("sort", "dc.date.issued"))
+                   //The status has to be 200 OK
+                   .andExpect(status().isOk())
+                   //We expect the content type to be "application/atom+xml;charset=UTF-8"
+                   .andExpect(content().contentType("application/atom+xml;charset=UTF-8"))
+                   .andExpect(xpath("feed/totalResults").string("0"))
+        ;
+    }
+
+    @Test
+    public void invalidSortTest() throws Exception {
+        //When we call the root endpoint
+        getClient().perform(get("/opensearch/search")
+                                .param("query", "")
+                                .param("sort", "dc.invalid.field"))
+                   //We get an exception for such a sort field
+                   //The status has to be 400 ERROR
+                   .andExpect(status().is(400))
+        ;
+    }
+
+    @Test
     public void serviceDocumentTest() throws Exception {
         //When we call the root endpoint
         getClient().perform(get("/opensearch/service"))


### PR DESCRIPTION
…sort field

## References
* Fixes #8385 

## Description
This PR incorporates the discovery configuration into the OpenSearch controller to determine the corresponding field type for a given sort field.

## Instructions for Reviewers
Refer to instructions in #8385 to reproduce. After deploying this PR, test the OpenSearch API with `sort=dc.date.issued&sort_direction=DESC` in the URL and verify that the results now sort on dc.date.issued.

## Checklist
- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
