### PR TITLE
fix migration problem from 6.1 to 7.0

### DIFF
--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/xmlworkflow/V6_99_2021_10_21__Enable_XMLWorkflow_Migration.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/xmlworkflow/V6_99_2021_10_21__Enable_XMLWorkflow_Migration.java
@@ -1,0 +1,28 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.storage.rdbms.xmlworkflow;
+
+/**
+ * This class automatically migrates your DSpace Database to use the XML-based
+ * Configurable Workflow system whenever it is enabled. It is just a empty
+ * extension of the v6.0 version so that, according to the version / naming
+ * mapping, flyway will pick it for whatever 6.x version
+ * <P>
+ * Because XML-based Configurable Workflow existed prior to our migration, this
+ * class first checks for the existence of the "cwf_workflowitem" table before
+ * running any migrations.
+ * <P>
+ * This class represents a Flyway DB Java Migration
+ * http://flywaydb.org/documentation/migration/java.html
+ * <P>
+ * It can upgrade any (6.0-7.0) version of DSpace to use the XMLWorkflow.
+ *
+ */
+public class V6_99_2021_10_21__Enable_XMLWorkflow_Migration
+        extends V6_0_2015_09_01__DS_2701_Enable_XMLWorkflow_Migration {
+}


### PR DESCRIPTION
## References


## Description
Short summary of changes (1-2 sentences).

We encountered problems while migrating from versions 6.1+ to 7.x in migrating workflow items. 
The problem was related to flyway not executing script `V6_0_2015_09_01__DS_2701_Enable_XMLWorkflow_Migration` as it was considered as already executed. 
We added an extension of this script, with 6.99 as version number, so that, despite of which is 6 minor version, the existence of `cwf_workflowitem` table is always checked during migration


List of changes in this PR:
* added `org.dspace.storage.rdbms.xmlworkflow.V6_99_2021_10_21__Enable_XMLWorkflow_Migration` wrapping class

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
