### PR TITLE
Require javadocs for all public methods. Fix checkstyle errors.

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -92,9 +92,7 @@ For more information on CheckStyle configurations below, see: http://checkstyle.
         <!-- Requirements for Javadocs for methods -->
         <module name="JavadocMethod">
             <!-- All public methods MUST HAVE Javadocs -->
-            <!-- <property name="scope" value="public"/> -->
-            <!-- TODO: Above rule has been disabled because of large amount of missing public method Javadocs -->
-            <property name="scope" value="nothing"/>
+            <property name="scope" value="public"/>
             <!-- Allow params, throws and return tags to be optional -->
             <property name="allowMissingParamTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>

--- a/dspace-api/src/main/java/org/dspace/external/OpenAIRERestConnector.java
+++ b/dspace-api/src/main/java/org/dspace/external/OpenAIRERestConnector.java
@@ -335,7 +335,7 @@ public class OpenAIRERestConnector {
     /**
      * tokenUsage true to enable the usage of an access token
      * 
-     * @param tokenUsage
+     * @param tokenEnabled true/false
      */
     @Autowired(required = false)
     public void setTokenEnabled(boolean tokenEnabled) {

--- a/dspace-api/src/main/java/org/dspace/external/provider/impl/LiveImportDataProvider.java
+++ b/dspace-api/src/main/java/org/dspace/external/provider/impl/LiveImportDataProvider.java
@@ -57,7 +57,7 @@ public class LiveImportDataProvider extends AbstractExternalDataProvider {
 
     /**
      * This method set the MetadataSource for the ExternalDataProvider
-     * @param metadataSource {@link org.dspace.importer.external.service.components.MetadataSource} implementation used to process the input data
+     * @param querySource Source {@link org.dspace.importer.external.service.components.QuerySource} implementation used to process the input data
      */
     public void setMetadataSource(QuerySource querySource) {
         this.querySource = querySource;

--- a/dspace-api/src/main/java/org/dspace/importer/external/bibtex/service/BibtexImportMetadataSourceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/bibtex/service/BibtexImportMetadataSourceServiceImpl.java
@@ -105,10 +105,10 @@ public class BibtexImportMetadataSourceServiceImpl extends AbstractPlainMetadata
 
 
     /**
-     * Retrieve the MetadataFieldMapping containing the mapping between RecordType
+     * Set the MetadataFieldMapping containing the mapping between RecordType
      * (in this case PlainMetadataSourceDto.class) and Metadata
      *
-     * @return The configured MetadataFieldMapping
+     * @param metadataFieldMap The configured MetadataFieldMapping
      */
     @Override
     @SuppressWarnings("unchecked")

--- a/dspace-api/src/main/java/org/dspace/importer/external/liveimportclient/service/LiveImportClient.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/liveimportclient/service/LiveImportClient.java
@@ -21,7 +21,7 @@ public interface LiveImportClient {
      * 
      * @param timeout        The connect timeout in milliseconds
      * @param URL            URL
-     * @param requestParams  This map contains the parameters to be included in the request.
+     * @param params         This map contains the parameters to be included in the request.
      *                       Each parameter will be added to the url?(key=value)
      * @return               The response in String type converted from InputStream
      */

--- a/dspace-api/src/main/java/org/dspace/importer/external/metadatamapping/contributor/EpoIdMetadataContributor.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/metadatamapping/contributor/EpoIdMetadataContributor.java
@@ -156,7 +156,7 @@ public class EpoIdMetadataContributor implements MetadataContributor<Element> {
      * Depending on the retrieved node (using the query), different types of values will be added to the MetadatumDTO
      * list
      *
-     * @param t A class to retrieve metadata from.
+     * @param element A class to retrieve metadata from.
      * @return a collection of import records. Only the identifier of the found records may be put in the record.
      */
     @Override

--- a/dspace-api/src/main/java/org/dspace/importer/external/metadatamapping/contributor/SimpleJsonPathMetadataContributor.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/metadatamapping/contributor/SimpleJsonPathMetadataContributor.java
@@ -118,7 +118,7 @@ public class SimpleJsonPathMetadataContributor implements MetadataContributor<St
      * Retrieve the metadata associated with the given object.
      * The toString() of the resulting object will be used.
      * 
-     * @param t A class to retrieve metadata from.
+     * @param fullJson A class to retrieve metadata from.
      * @return a collection of import records. Only the identifier of the found records may be put in the record.
      */
     @Override

--- a/dspace-api/src/main/java/org/dspace/importer/external/ris/service/RisImportMetadataSourceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/ris/service/RisImportMetadataSourceServiceImpl.java
@@ -126,10 +126,10 @@ public class RisImportMetadataSourceServiceImpl extends AbstractPlainMetadataSou
     }
 
     /**
-     * Retrieve the MetadataFieldMapping containing the mapping between RecordType
+     * Set the MetadataFieldMapping containing the mapping between RecordType
      * (in this case PlainMetadataSourceDto.class) and Metadata
      *
-     * @return The configured MetadataFieldMapping
+     * @param metadataFieldMap The configured MetadataFieldMapping
      */
     @Override
     @SuppressWarnings("unchecked")

--- a/dspace-api/src/main/java/org/dspace/importer/external/service/components/AbstractPlainMetadataSource.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/service/components/AbstractPlainMetadataSource.java
@@ -42,7 +42,7 @@ public abstract class AbstractPlainMetadataSource
     /**
      * Set the file extensions supported by this metadata service
      * 
-     * @param supportedExtensionsthe file extensions (xml,txt,...) supported by this service
+     * @param supportedExtensions the file extensions (xml,txt,...) supported by this service
      */
     public void setSupportedExtensions(List<String> supportedExtensions) {
         this.supportedExtensions = supportedExtensions;
@@ -57,7 +57,7 @@ public abstract class AbstractPlainMetadataSource
      * Return a list of ImportRecord constructed from input file. This list is based on
      * the results retrieved from the file (InputStream) parsed through abstract method readData
      *
-     * @param InputStream The inputStream of the file
+     * @param is The inputStream of the file
      * @return A list of {@link ImportRecord}
      * @throws FileSourceException if, for any reason, the file is not parsable
      */
@@ -76,7 +76,7 @@ public abstract class AbstractPlainMetadataSource
      * the result retrieved from the file (InputStream) parsed through abstract method
      * "readData" implementation
      *
-     * @param InputStream The inputStream of the file
+     * @param is The inputStream of the file
      * @return An {@link ImportRecord} matching the file content
      * @throws FileSourceException if, for any reason, the file is not parsable
      * @throws FileMultipleOccurencesException if the file contains more than one entry

--- a/dspace-api/src/main/java/org/dspace/importer/external/service/components/FileSource.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/service/components/FileSource.java
@@ -30,7 +30,7 @@ public interface FileSource extends MetadataSource {
     /**
      * Return a list of ImportRecord constructed from input file.
      *
-     * @param InputStream The inputStream of the file
+     * @param inputStream The inputStream of the file
      * @return A list of {@link ImportRecord}
      * @throws FileSourceException if, for any reason, the file is not parsable
      */
@@ -40,7 +40,7 @@ public interface FileSource extends MetadataSource {
     /**
      * Return an ImportRecord constructed from input file.
      *
-     * @param InputStream The inputStream of the file
+     * @param inputStream The inputStream of the file
      * @return An {@link ImportRecord} matching the file content
      * @throws FileSourceException if, for any reason, the file is not parsable
      * @throws FileMultipleOccurencesException if the file contains more than one entry

--- a/dspace-api/src/main/java/org/dspace/scripts/Process.java
+++ b/dspace-api/src/main/java/org/dspace/scripts/Process.java
@@ -225,15 +225,15 @@ public class Process implements ReloadableEntity<Integer> {
     }
 
     /**
-     * This method sets the special groups associated with the Process.
+     * This method will return the special groups associated with the Process.
      */
     public List<Group> getGroups() {
         return groups;
     }
 
     /**
-     * This method will return special groups associated with the Process.
-     * @return The special groups of this process.
+     * This method sets the special groups associated with the Process.
+     * @param groups  The special groups of this process.
      */
     public void setGroups(List<Group> groups) {
         this.groups = groups;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/RestAuthenticationService.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/RestAuthenticationService.java
@@ -53,7 +53,7 @@ public interface RestAuthenticationService {
      * Checks the current request for a valid authentication token. If found, extracts that token and obtains the
      * currently logged in EPerson.
      * @param request current request
-     * @param request current response
+     * @param response current response
      * @param context current DSpace Context
      * @return EPerson of the logged in user (if auth token found), or null if no auth token is found
      */

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/ClaimedTaskMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/ClaimedTaskMatcher.java
@@ -28,8 +28,8 @@ public class ClaimedTaskMatcher {
     /**
      * Check if the returned json expose all the required links and properties
      * 
-     * @param ptask
-     *            the pool task
+     * @param cTask
+     *            the claimed task
      * @param step
      *            the step name
      * @return

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/PoolTaskMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/PoolTaskMatcher.java
@@ -28,7 +28,7 @@ public class PoolTaskMatcher {
     /**
      * Check if the returned json expose all the required links and properties
      * 
-     * @param ptask
+     * @param pTask
      *            the pool task
      * @param step
      *            the step name

--- a/dspace-services/src/main/java/org/dspace/services/RequestService.java
+++ b/dspace-services/src/main/java/org/dspace/services/RequestService.java
@@ -111,7 +111,7 @@ public interface RequestService {
     /**
      * Set the ID of the current authenticated user
      *
-     * @return the id of the user associated with the current thread OR null if there is no user
+     * @param epersonId the id of the user associated with the current thread OR null if there is no user
      */
     public void setCurrentUserId(UUID epersonId);
 


### PR DESCRIPTION
## Description
Small PR which requires Javadocs exist for all `public` methods via our `checkstyle.xml`.  In v7, these mostly exist, but I fixed up a few checkstyle errors which occurred after enabling this. 

(NOTE: I did not closely check the text of all the Javadoc...just cleaned up a few obviously incorrect text.)

## Instructions for Reviewers
* Simply review the PR & verify that `checkstyle` succeeds (in GitHub CI)