### PR TITLE
Enable GitHub code scanning with CodeQL (to replace the soon-to-be-deprecated LGTM.com)

### DIFF
--- a/.github/workflows/codeql-code-scanning.yml
+++ b/.github/workflows/codeql-code-scanning.yml
@@ -2,7 +2,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main", "dspace-1_4_x", "dspace-1_5_x", "dspace-1_6_x", "dspace-1_7_x", "dspace-1_8_x", "dspace-3_x", "dspace-4_x", "dspace-5_x", "dspace-6_x", "sj-enable-codeql-code-scanning-replace-lgtm" ]
+    branches: [ "main", "dspace-1_4_x", "dspace-1_5_x", "dspace-1_6_x", "dspace-1_7_x", "dspace-1_8_x", "dspace-3_x", "dspace-4_x", "dspace-5_x", "dspace-6_x" ]
   pull_request:
     branches: [ "main" ]
   schedule:

--- a/.github/workflows/codeql-code-scanning.yml
+++ b/.github/workflows/codeql-code-scanning.yml
@@ -32,6 +32,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         java-version: 11
+        distribution: 'temurin'
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2

--- a/.github/workflows/codeql-code-scanning.yml
+++ b/.github/workflows/codeql-code-scanning.yml
@@ -38,7 +38,6 @@ jobs:
       uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
-        queries: +security-and-quality
           
     - name: Autobuild
       uses: github/codeql-action/autobuild@v2

--- a/.github/workflows/codeql-code-scanning.yml
+++ b/.github/workflows/codeql-code-scanning.yml
@@ -1,0 +1,48 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "main", "dspace-1_4_x", "dspace-1_5_x", "dspace-1_6_x", "dspace-1_7_x", "dspace-1_8_x", "dspace-3_x", "dspace-4_x", "dspace-5_x", "dspace-6_x", "sj-enable-codeql-code-scanning-replace-lgtm" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '45 16 * * 4'
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'java', 'javascript' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      
+    - name: Setup Java
+      if: ${{ matrix.language == 'java' }}
+      uses: actions/setup-java@v3
+      with:
+        java-version: 11
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+        queries: +security-and-quality
+          
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:${{matrix.language}}"


### PR DESCRIPTION
Hi team!

You might have seen that LGTM.com will go off-line [later this month](https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/). The team that built LGTM (including me!) [joined GitHub](https://github.blog/2019-09-18-github-welcomes-semmle/) a couple of years ago, and we've natively integrated the CodeQL engine that powers LGTM into GitHub.

This PR enables the CodeQL analysis for DSpace. Just like with LGTM, alerts will show up in pull requests (but [better](https://github.blog/changelog/2022-06-02-users-can-view-and-comment-on-code-scanning-alerts-on-the-conversation-tab-in-a-pull-request/)). In addition, all alerts can be browsed on the "Security" tab of the repository.

I tried to configure GitHub code scanning as similarly/closely as possible to the original LGTM configuration — do feel free to tweak and adjust as you see fit. If you have any questions, check out the FAQ below, and I'm of course happy to help as well. 


### FAQ
<details>
<summary>Click here to expand the FAQ section</summary>

#### How often will the code scanning analysis run?
By default, code scanning will trigger a scan with the CodeQL engine on the following events:
On every pull request — to flag up potential security problems for you to investigate before merging a PR.
On every push to your default branch and other protected branches — this keeps the analysis results on your repository’s *Security* tab up to date.
Once a week at a fixed time — to make sure you benefit from the latest updated security analysis even when no code was committed or PRs were opened.

#### What will this cost?
Nothing! The CodeQL engine will run inside GitHub Actions, making use of your [unlimited free compute minutes for public repositories](https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#about-billing-for-github-actions).

#### What types of problems does CodeQL find?
The CodeQL engine that powers GitHub code scanning is the exact same engine that powers LGTM.com. The exact set of rules has been tweaked slightly, but you should see almost exactly the same types of alerts as you were used to on LGTM.com: we’ve enabled the [`security-and-quality` query suite](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs) for you.

#### How do I upgrade my CodeQL engine?
No need! New versions of the CodeQL analysis are constantly deployed on GitHub.com; your repository will automatically benefit from the most recently released version.

#### The analysis doesn’t seem to be working
If you get an error in GitHub Actions that indicates that CodeQL wasn’t able to analyze your code, please [follow the instructions here](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/troubleshooting-the-codeql-workflow) to debug the analysis.

#### How do I disable LGTM.com?
If you have LGTM’s automatic pull request analysis enabled, then you can [follow these steps to disable the LGTM pull request analysis](https://lgtm.com/help/lgtm/managing-automated-code-review#disabling-pr-integration). You don’t actually need to remove your repository from LGTM.com; it will automatically be removed in the next few months as part of the deprecation of LGTM.com ([more info here](https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/)).

#### Which source code hosting platforms does code scanning support?
GitHub code scanning is deeply integrated within GitHub itself. If you’d like to scan source code that is hosted elsewhere, we suggest that you create a mirror of that code on GitHub.

#### How do I know this PR is legitimate?
This PR is filed by the official LGTM.com GitHub App, in line with the [deprecation timeline that was announced on the official GitHub Blog](https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/). The proposed GitHub Action workflow uses the [official open source GitHub CodeQL Action](https://github.com/github/codeql-action). If you have any other questions or concerns, please join the discussion [here](https://github.com/orgs/community/discussions/29534) in the official GitHub community!

#### I have another question / how do I get in touch?
Please join the discussion [here](https://github.com/orgs/community/discussions/29534) to ask further questions and send us suggestions!


</details>


## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies the REST API, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.

(I don't think any of the above applies)