### PR TITLE
Fix broken OrcidQueueConsumerIT & several other flakey tests

### DIFF
--- a/dspace-api/src/test/java/org/dspace/builder/ItemBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/ItemBuilder.java
@@ -397,12 +397,17 @@ public class ItemBuilder extends AbstractDSpaceObjectBuilder<Item> {
        try (Context c = new Context()) {
             c.setDispatcher("noindex");
             c.turnOffAuthorisationSystem();
+            // If the workspaceItem used to create this item still exists, delete it
+            workspaceItem = c.reloadEntity(workspaceItem);
+            if (workspaceItem != null) {
+                workspaceItemService.deleteAll(c, workspaceItem);
+            }
             // Ensure object and any related objects are reloaded before checking to see what needs cleanup
             item = c.reloadEntity(item);
             if (item != null) {
                  delete(c, item);
-                 c.complete();
             }
+            c.complete();
        }
     }
 

--- a/dspace-api/src/test/java/org/dspace/ctask/general/CreateMissingIdentifiersIT.java
+++ b/dspace-api/src/test/java/org/dspace/ctask/general/CreateMissingIdentifiersIT.java
@@ -17,6 +17,7 @@ import org.dspace.builder.CommunityBuilder;
 import org.dspace.builder.ItemBuilder;
 import org.dspace.content.Collection;
 import org.dspace.content.Item;
+import org.dspace.core.factory.CoreServiceFactory;
 import org.dspace.curate.Curator;
 import org.dspace.identifier.VersionedHandleIdentifierProviderWithCanonicalHandles;
 import org.dspace.services.ConfigurationService;
@@ -38,10 +39,11 @@ public class CreateMissingIdentifiersIT
     @Test
     public void testPerform()
             throws IOException {
-        ConfigurationService configurationService
-                = DSpaceServicesFactory.getInstance().getConfigurationService();
-        configurationService.setProperty(P_TASK_DEF, null);
-        configurationService.addPropertyValue(P_TASK_DEF,
+        // Must remove any cached named plugins before creating a new one
+        CoreServiceFactory.getInstance().getPluginService().clearNamedPluginClasses();
+        ConfigurationService configurationService = kernelImpl.getConfigurationService();
+        // Define a new task dynamically
+        configurationService.setProperty(P_TASK_DEF,
                 CreateMissingIdentifiers.class.getCanonicalName() + " = " + TASK_NAME);
 
         Curator curator = new Curator();
@@ -49,11 +51,11 @@ public class CreateMissingIdentifiersIT
 
         context.setCurrentUser(admin);
         parentCommunity = CommunityBuilder.createCommunity(context)
-                .build();
+                                          .build();
         Collection collection = CollectionBuilder.createCollection(context, parentCommunity)
-                .build();
+                                                 .build();
         Item item = ItemBuilder.createItem(context, collection)
-                .build();
+                               .build();
 
         /*
          * Curate with regular test configuration -- should succeed.

--- a/dspace-api/src/test/java/org/dspace/orcid/OrcidQueueConsumerIT.java
+++ b/dspace-api/src/test/java/org/dspace/orcid/OrcidQueueConsumerIT.java
@@ -30,7 +30,6 @@ import java.util.Date;
 import java.util.List;
 
 import org.dspace.AbstractIntegrationTestWithDatabase;
-import org.dspace.authorize.AuthorizeException;
 import org.dspace.builder.CollectionBuilder;
 import org.dspace.builder.CommunityBuilder;
 import org.dspace.builder.EntityTypeBuilder;
@@ -70,7 +69,9 @@ public class OrcidQueueConsumerIT extends AbstractIntegrationTestWithDatabase {
     private Collection profileCollection;
 
     @Before
-    public void setup() {
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
 
         context.turnOffAuthorisationSystem();
 
@@ -84,12 +85,15 @@ public class OrcidQueueConsumerIT extends AbstractIntegrationTestWithDatabase {
     }
 
     @After
-    public void after() throws SQLException, AuthorizeException {
+    @Override
+    public void destroy() throws Exception {
         List<OrcidQueue> records = orcidQueueService.findAll(context);
         for (OrcidQueue record : records) {
             orcidQueueService.delete(context, record);
         }
         context.setDispatcher(null);
+
+        super.destroy();
     }
 
     @Test

--- a/dspace-api/src/test/java/org/dspace/orcid/OrcidQueueConsumerIT.java
+++ b/dspace-api/src/test/java/org/dspace/orcid/OrcidQueueConsumerIT.java
@@ -143,6 +143,8 @@ public class OrcidQueueConsumerIT extends AbstractIntegrationTestWithDatabase {
 
     @Test
     public void testOrcidQueueRecordCreationForProfile() throws Exception {
+        // Set a fake handle prefix for this test which we will use to assign handles below
+        configurationService.setProperty("handle.prefix", "fake-handle");
         context.turnOffAuthorisationSystem();
 
         Item profile = ItemBuilder.createItem(context, profileCollection)
@@ -150,7 +152,7 @@ public class OrcidQueueConsumerIT extends AbstractIntegrationTestWithDatabase {
             .withOrcidIdentifier("0000-1111-2222-3333")
             .withOrcidAccessToken("ab4d18a0-8d9a-40f1-b601-a417255c8d20", eperson)
             .withSubject("test")
-            .withHandle("123456789/200")
+            .withHandle("fake-handle/190")
             .withOrcidSynchronizationProfilePreference(BIOGRAPHICAL)
             .withOrcidSynchronizationProfilePreference(IDENTIFIERS)
             .build();
@@ -163,8 +165,8 @@ public class OrcidQueueConsumerIT extends AbstractIntegrationTestWithDatabase {
         assertThat(queueRecords, hasItem(matches(profile, profile, "KEYWORDS", null,
             "dc.subject::test", "test", INSERT)));
         assertThat(queueRecords, hasItem(matches(profile, "RESEARCHER_URLS", null,
-            "dc.identifier.uri::http://localhost:4000/handle/123456789/200",
-            "http://localhost:4000/handle/123456789/200", INSERT)));
+            "dc.identifier.uri::http://localhost:4000/handle/fake-handle/190",
+            "http://localhost:4000/handle/fake-handle/190", INSERT)));
 
         addMetadata(profile, "person", "name", "variant", "User Test", null);
         context.commit();
@@ -174,8 +176,8 @@ public class OrcidQueueConsumerIT extends AbstractIntegrationTestWithDatabase {
         assertThat(queueRecords, hasItem(
             matches(profile, profile, "KEYWORDS", null, "dc.subject::test", "test", INSERT)));
         assertThat(queueRecords, hasItem(matches(profile, "RESEARCHER_URLS", null,
-            "dc.identifier.uri::http://localhost:4000/handle/123456789/200",
-            "http://localhost:4000/handle/123456789/200", INSERT)));
+            "dc.identifier.uri::http://localhost:4000/handle/fake-handle/190",
+            "http://localhost:4000/handle/fake-handle/190", INSERT)));
         assertThat(queueRecords, hasItem(matches(profile, profile, "OTHER_NAMES",
             null, "person.name.variant::User Test", "User Test", INSERT)));
     }
@@ -644,7 +646,8 @@ public class OrcidQueueConsumerIT extends AbstractIntegrationTestWithDatabase {
 
     @Test
     public void testOrcidQueueRecalculationOnProfilePreferenceUpdate() throws Exception {
-
+        // Set a fake handle prefix for this test which we will use to assign handles below
+        configurationService.setProperty("handle.prefix", "fake-handle");
         context.turnOffAuthorisationSystem();
 
         Item profile = ItemBuilder.createItem(context, profileCollection)
@@ -652,7 +655,7 @@ public class OrcidQueueConsumerIT extends AbstractIntegrationTestWithDatabase {
             .withOrcidIdentifier("0000-0000-0012-2345")
             .withOrcidAccessToken("ab4d18a0-8d9a-40f1-b601-a417255c8d20", eperson)
             .withSubject("Math")
-            .withHandle("123456789/200")
+            .withHandle("fake-handle/200")
             .withOrcidSynchronizationProfilePreference(BIOGRAPHICAL)
             .build();
 
@@ -673,8 +676,8 @@ public class OrcidQueueConsumerIT extends AbstractIntegrationTestWithDatabase {
         assertThat(records, hasItem(matches(profile, "KEYWORDS", null, "dc.subject::Math", "Math", INSERT)));
         assertThat(records, hasItem(matches(profile, "EXTERNAL_IDS", null, "person.identifier.rid::ID", "ID", INSERT)));
         assertThat(records, hasItem(matches(profile, "RESEARCHER_URLS", null,
-            "dc.identifier.uri::http://localhost:4000/handle/123456789/200",
-            "http://localhost:4000/handle/123456789/200", INSERT)));
+            "dc.identifier.uri::http://localhost:4000/handle/fake-handle/200",
+            "http://localhost:4000/handle/fake-handle/200", INSERT)));
 
         removeMetadata(profile, "dspace", "orcid", "sync-profile");
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ExternalSourcesRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ExternalSourcesRestControllerIT.java
@@ -153,23 +153,19 @@ public class ExternalSourcesRestControllerIT extends AbstractControllerIntegrati
         getClient().perform(get("/api/integration/externalsources/search/findByEntityType")
                    .param("entityType", "Publication"))
                    .andExpect(status().isOk())
-                   // Expect *at least* 3 Publication sources
-                   .andExpect(jsonPath("$._embedded.externalsources", Matchers.hasItems(
-                              ExternalSourceMatcher.matchExternalSource(publicationProviders.get(0)),
-                              ExternalSourceMatcher.matchExternalSource(publicationProviders.get(1))
-                              )))
+                   // Expect that Publication sources match (check a max of 20 as that is default page size)
+                   .andExpect(jsonPath("$._embedded.externalsources",
+                                       ExternalSourceMatcher.matchAllExternalSources(publicationProviders, 20)
+                              ))
                    .andExpect(jsonPath("$.page.totalElements", Matchers.is(publicationProviders.size())));
 
         getClient().perform(get("/api/integration/externalsources/search/findByEntityType")
                    .param("entityType", "Journal"))
                    .andExpect(status().isOk())
-                   // Expect *at least* 5 Journal sources
-                   .andExpect(jsonPath("$._embedded.externalsources", Matchers.hasItems(
-                              ExternalSourceMatcher.matchExternalSource(journalProviders.get(0)),
-                              ExternalSourceMatcher.matchExternalSource(journalProviders.get(1)),
-                              ExternalSourceMatcher.matchExternalSource(journalProviders.get(2)),
-                              ExternalSourceMatcher.matchExternalSource(journalProviders.get(3))
-                              )))
+                   // Check that Journal sources match (check a max of 20 as that is default page size)
+                   .andExpect(jsonPath("$._embedded.externalsources",
+                                       ExternalSourceMatcher.matchAllExternalSources(journalProviders, 20)
+                             ))
                    .andExpect(jsonPath("$.page.totalElements", Matchers.is(journalProviders.size())));
     }
 
@@ -193,10 +189,9 @@ public class ExternalSourcesRestControllerIT extends AbstractControllerIntegrati
                    .param("entityType", "Journal")
                    .param("size", String.valueOf(pageSize)))
                    .andExpect(status().isOk())
-                   .andExpect(jsonPath("$._embedded.externalsources", Matchers.contains(
-                              ExternalSourceMatcher.matchExternalSource(journalProviders.get(0)),
-                              ExternalSourceMatcher.matchExternalSource(journalProviders.get(1))
-                              )))
+                   .andExpect(jsonPath("$._embedded.externalsources",
+                                       ExternalSourceMatcher.matchAllExternalSources(journalProviders, pageSize)
+                             ))
                    .andExpect(jsonPath("$.page.totalPages", Matchers.is(numberOfPages)))
                    .andExpect(jsonPath("$.page.totalElements", Matchers.is(numJournalProviders)));
 
@@ -205,10 +200,12 @@ public class ExternalSourcesRestControllerIT extends AbstractControllerIntegrati
                    .param("page", "1")
                    .param("size", String.valueOf(pageSize)))
                    .andExpect(status().isOk())
-                   .andExpect(jsonPath("$._embedded.externalsources", Matchers.contains(
-                              ExternalSourceMatcher.matchExternalSource(journalProviders.get(2)),
-                              ExternalSourceMatcher.matchExternalSource(journalProviders.get(3))
-                              )))
+                   // Check that second page has journal sources starting at index 2.
+                   .andExpect(jsonPath("$._embedded.externalsources",
+                                       ExternalSourceMatcher.matchAllExternalSources(
+                                           journalProviders.subList(2, journalProviders.size()),
+                                           pageSize)
+                              ))
                    .andExpect(jsonPath("$.page.totalPages", Matchers.is(numberOfPages)))
                    .andExpect(jsonPath("$.page.totalElements", Matchers.is(numJournalProviders)));
     }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/ExternalSourceMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/ExternalSourceMatcher.java
@@ -10,7 +10,11 @@ package org.dspace.app.rest.matcher;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static org.dspace.app.rest.test.AbstractControllerIntegrationTest.REST_SERVER_URL;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import org.dspace.external.provider.ExternalDataProvider;
 import org.hamcrest.Matcher;
@@ -18,6 +22,28 @@ import org.hamcrest.Matcher;
 public class ExternalSourceMatcher {
 
     private ExternalSourceMatcher() {
+    }
+
+    /**
+     * Matcher which checks if all external source providers are listed (in exact order), up to the maximum number
+     * @param providers List of providers to check against
+     * @param max maximum number to check
+     * @return Matcher for this list of providers
+     */
+    public static Matcher<Iterable<? extends List<Matcher>>> matchAllExternalSources(
+        List<ExternalDataProvider> providers, int max) {
+        List<Matcher> matchers = new ArrayList<>();
+        int count = 0;
+        for (ExternalDataProvider provider: providers) {
+            count++;
+            if (count > max) {
+                break;
+            }
+            matchers.add(matchExternalSource(provider));
+        }
+
+        // Make sure all providers exist in this exact order
+        return contains(matchers.toArray(new Matcher[0]));
     }
 
     public static Matcher<? super Object> matchExternalSource(ExternalDataProvider provider) {


### PR DESCRIPTION
## Description
Recently the `OrcidQueueConsumerIT` began consistently failing after recent changes in GitHub _changed the default ordering in which ITs execute_.  This specific IT is now failing in multiple new PRs and also on `main`: https://github.com/DSpace/DSpace/actions/runs/3596471686/jobs/6058914958

At a glance, it appears there is something "flakey" with this IT which is causing a consistent failure in GitHub actions.

This PR is an attempt to fix the flakey-ness of this IT (and possibly others as needed). 

## Changes made in this PR
* Fixed broken `OrcidQueueConsumerIT` which was failing because it was attempting to assign Handles which already existed (generated by chance by other tests). Fix was to use a (temporary) fake handle prefix.
    * In debugging this issue, I fixed an issue in `ItemBuilder` where it wasn't cleaning up WorkspaceItem objects if the Item failed to build/install properly.
* Fixed a flakey test in `CreateMissingIdentifiersIT` which was not clearing out previously loaded NamedPlugin classes (if any)
* Fixed two flakey tests in `ExternalSourcesRestControllerIT` which occasionally would fail if the expected number of external sources did not exist.  These tests were fixed by ensuring they no longer make any assumptions on external resources count. Instead tests just ensure the number & ordering of resources returned by REST endpoint match exactly the number reported by Java API.

## Instructions for Reviewers
* Verify all ITs succeed again.