### PR TITLE
Fix user authorization issues with admin sidebar

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -1076,9 +1076,9 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
     }
 
     /**
-     * Finds all Indexed Items where the current user has submit rights. If the user is an Admin,
+     * Finds all Indexed Items where the current user has edit rights. If the user is an Admin,
      * this is all Indexed Items. Otherwise, it includes those Items where
-     * an indexed "submit" policy lists either the eperson or one of the eperson's groups
+     * an indexed "edit" policy lists either the eperson or one of the eperson's groups
      *
      * @param context                    DSpace context
      * @param discoverQuery

--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -1100,6 +1100,7 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
         return searchService.search(context, discoverQuery);
     }
 
+    @Override
     public List<Item> findItemsWithEdit(Context context, int offset, int limit)
         throws SQLException, SearchServiceException {
         DiscoverQuery discoverQuery = new DiscoverQuery();
@@ -1112,6 +1113,7 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
             .collect(Collectors.toList());
     }
 
+    @Override
     public int countItemsWithEdit(Context context) throws SQLException, SearchServiceException {
         DiscoverQuery discoverQuery = new DiscoverQuery();
         discoverQuery.setMaxResults(0);

--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -51,8 +51,14 @@ import org.dspace.content.virtual.VirtualMetadataPopulator;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.core.LogHelper;
+import org.dspace.discovery.DiscoverQuery;
+import org.dspace.discovery.DiscoverResult;
+import org.dspace.discovery.SearchService;
+import org.dspace.discovery.SearchServiceException;
+import org.dspace.discovery.indexobject.IndexableItem;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
+import org.dspace.eperson.service.GroupService;
 import org.dspace.event.Event;
 import org.dspace.harvest.HarvestedItem;
 import org.dspace.harvest.service.HarvestedItemService;
@@ -93,6 +99,8 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
     @Autowired(required = true)
     protected CommunityService communityService;
     @Autowired(required = true)
+    protected GroupService groupService;
+    @Autowired(required = true)
     protected AuthorizeService authorizeService;
     @Autowired(required = true)
     protected BundleService bundleService;
@@ -104,6 +112,8 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
     protected BitstreamService bitstreamService;
     @Autowired(required = true)
     protected InstallItemService installItemService;
+    @Autowired(required = true)
+    protected SearchService searchService;
     @Autowired(required = true)
     protected ResourcePolicyService resourcePolicyService;
     @Autowired(required = true)
@@ -1063,6 +1073,51 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
         }
 
         return collectionService.canEditBoolean(context, item.getOwningCollection(), false);
+    }
+
+    /**
+     * Finds all Indexed Items where the current user has submit rights. If the user is an Admin,
+     * this is all Indexed Items. Otherwise, it includes those Items where
+     * an indexed "submit" policy lists either the eperson or one of the eperson's groups
+     *
+     * @param context                    DSpace context
+     * @param discoverQuery
+     * @return                           discovery search result objects
+     * @throws SQLException              if something goes wrong
+     * @throws SearchServiceException    if search error
+     */
+    private DiscoverResult retrieveItemsWithEdit(Context context, DiscoverQuery discoverQuery)
+        throws SQLException, SearchServiceException {
+        EPerson currentUser = context.getCurrentUser();
+        if (!authorizeService.isAdmin(context)) {
+            String userId = currentUser != null ? "e" + currentUser.getID().toString() : "e";
+            Stream<String> groupIds = groupService.allMemberGroupsSet(context, currentUser).stream()
+                .map(group -> "g" + group.getID());
+            String query = Stream.concat(Stream.of(userId), groupIds)
+                .collect(Collectors.joining(" OR ", "edit:(", ")"));
+            discoverQuery.addFilterQueries(query);
+        }
+        return searchService.search(context, discoverQuery);
+    }
+
+    public List<Item> findItemsWithEdit(Context context, int offset, int limit)
+        throws SQLException, SearchServiceException {
+        DiscoverQuery discoverQuery = new DiscoverQuery();
+        discoverQuery.setDSpaceObjectFilter(IndexableItem.TYPE);
+        discoverQuery.setStart(offset);
+        discoverQuery.setMaxResults(limit);
+        DiscoverResult resp = retrieveItemsWithEdit(context, discoverQuery);
+        return resp.getIndexableObjects().stream()
+            .map(solrItems -> ((IndexableItem) solrItems).getIndexedObject())
+            .collect(Collectors.toList());
+    }
+
+    public int countItemsWithEdit(Context context) throws SQLException, SearchServiceException {
+        DiscoverQuery discoverQuery = new DiscoverQuery();
+        discoverQuery.setMaxResults(0);
+        discoverQuery.setDSpaceObjectFilter(IndexableItem.TYPE);
+        DiscoverResult resp = retrieveItemsWithEdit(context, discoverQuery);
+        return (int) resp.getTotalSearchResults();
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/content/service/ItemService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/ItemService.java
@@ -28,6 +28,7 @@ import org.dspace.content.MetadataValue;
 import org.dspace.content.Thumbnail;
 import org.dspace.content.WorkspaceItem;
 import org.dspace.core.Context;
+import org.dspace.discovery.SearchServiceException;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
 
@@ -767,6 +768,27 @@ public interface ItemService
      * @throws SQLException if database error
      */
     int countWithdrawnItems(Context context) throws SQLException;
+
+    /**
+     * finds all items for which the current user has editing rights
+     * @param context DSpace context object
+     * @param offset page offset
+     * @param limit  page size limit
+     * @return list of items for which the current user has editing rights
+     * @throws SQLException
+     * @throws SearchServiceException
+     */
+    public List<Item> findItemsWithEdit(Context context, int offset, int limit)
+        throws SQLException, SearchServiceException;
+
+    /**
+     * counts all items for which the current user has editing rights
+     * @param context DSpace context object
+     * @return list of items for which the current user has editing rights
+     * @throws SQLException
+     * @throws SearchServiceException
+     */
+    public int countItemsWithEdit(Context context) throws SQLException, SearchServiceException;
 
     /**
      * Check if the supplied item is an inprogress submission

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexingUtils.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexingUtils.java
@@ -34,8 +34,6 @@ public class IndexingUtils {
      * Retrieve all ancestor communities of a given community, with the first one being the given community and the
      * last one being the root.
      * <p>
-     * TODO: can be done in a single SQL query with recursive common table expressions
-     * TODO: should probably be moved to CommunityService
      *
      * @param context   DSpace context object
      * @param community Community for which we search the ancestors

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexingUtils.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexingUtils.java
@@ -9,7 +9,6 @@ package org.dspace.discovery;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -64,6 +63,7 @@ public class IndexingUtils {
      */
     static List<UUID> findTransitiveAdminGroupIds(Context context, Community community) throws SQLException {
         return getAncestorCommunities(context, community).stream()
+            .filter(parent -> parent.getAdministrators() != null)
             .map(parent -> parent.getAdministrators().getID())
             .collect(Collectors.toList());
     }
@@ -79,7 +79,10 @@ public class IndexingUtils {
      * @throws SQLException if database error
      */
     static List<UUID> findTransitiveAdminGroupIds(Context context, Collection collection) throws SQLException {
-        List<UUID> ids = Arrays.asList(collection.getAdministrators().getID());
+        List<UUID> ids = new ArrayList<>();
+        if (collection.getAdministrators() != null) {
+            ids.add(collection.getAdministrators().getID());
+        }
         for (Community community : collection.getCommunities()) {
             for (UUID id : findTransitiveAdminGroupIds(context, community)) {
                 ids.add(id);

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexingUtils.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexingUtils.java
@@ -12,16 +12,14 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Stream;
+import java.util.stream.Collectors;
 
 import org.dspace.authorize.ResourcePolicy;
 import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.DSpaceObject;
-import org.dspace.content.Item;
 import org.dspace.content.factory.ContentServiceFactory;
-import org.dspace.core.Constants;
 import org.dspace.core.Context;
 
 /**
@@ -29,27 +27,30 @@ import org.dspace.core.Context;
  *
  * @author Koen Pauwels (koen.pauwels at atmire dot com)
  */
-public abstract class IndexingUtils {
+public class IndexingUtils {
+    private IndexingUtils() {
+    }
+
     /**
      * Retrieve all ancestor communities of a given community, with the first one being the given community and the
      * last one being the root.
-     *
+     * <p>
      * TODO: can be done in a single SQL query with recursive common table expressions
      * TODO: should probably be moved to CommunityService
      *
      * @param context   DSpace context object
      * @param community Community for which we search the ancestors
-     * @return A stream of ancestor communities.
+     * @return A list of ancestor communities.
      * @throws SQLException if database error
      */
-    static Stream<Community> getAncestorCommunities(Context context, Community community) throws SQLException {
+    static List<Community> getAncestorCommunities(Context context, Community community) throws SQLException {
         ArrayList<Community> communities = new ArrayList<>();
         while (community != null) {
             communities.add(community);
             community = (Community) ContentServiceFactory.getInstance().getDSpaceObjectService(community)
                 .getParentObject(context, community);
         }
-        return communities.stream();
+        return communities;
     }
 
     /**
@@ -58,12 +59,13 @@ public abstract class IndexingUtils {
      *
      * @param context   DSpace context object
      * @param community Community for which we search the admin group IDs
-     * @return A stream of admin group IDs
+     * @return A list of admin group IDs
      * @throws SQLException if database error
      */
-    static Stream<UUID> findTransitiveAdminGroupIds(Context context, Community community) throws SQLException {
-        return getAncestorCommunities(context, community)
-            .map(parent -> parent.getAdministrators().getID());
+    static List<UUID> findTransitiveAdminGroupIds(Context context, Community community) throws SQLException {
+        return getAncestorCommunities(context, community).stream()
+            .map(parent -> parent.getAdministrators().getID())
+            .collect(Collectors.toList());
     }
 
     /**
@@ -71,42 +73,19 @@ public abstract class IndexingUtils {
      * (through direct resource policy) or indirectly (through a policy on its community, or one of
      * its ancestor communities).
      *
-     * @param context   DSpace context object
+     * @param context    DSpace context object
      * @param collection Collection for which we search the admin group IDs
-     * @return A stream of admin group IDs
+     * @return A list of admin group IDs
      * @throws SQLException if database error
      */
-    static Stream<UUID> findTransitiveAdminGroupIds(Context context, Collection collection) throws SQLException {
-        UUID directAdminGroupId = collection.getAdministrators().getID();
-        List<Stream<UUID>> subResults = Arrays.asList(Stream.of(directAdminGroupId));
+    static List<UUID> findTransitiveAdminGroupIds(Context context, Collection collection) throws SQLException {
+        List<UUID> ids = Arrays.asList(collection.getAdministrators().getID());
         for (Community community : collection.getCommunities()) {
-            subResults.add(findTransitiveAdminGroupIds(context, community));
+            for (UUID id : findTransitiveAdminGroupIds(context, community)) {
+                ids.add(id);
+            }
         }
-        return sequence(subResults);
-    }
-
-    /**
-     * Retrieve the ids of all groups that have ADMIN rights on the given item, either directly
-     * (through direct resource policy) or indirectly (through a policy on the owning collection, or on
-     * the owning collection's community, or on any of that community's ancestor communities).
-     *
-     * @param authService   The authentication service
-     * @param context       DSpace context object
-     * @param item          Item for which we search the admin group IDs
-     * @return A stream of admin group IDs
-     * @throws SQLException if database error
-     */
-    static Stream<UUID> findTransitiveAdminGroupIds(AuthorizeService authService, Context context, Item item)
-        throws SQLException {
-        Stream<UUID> directAdminGroupIds = authService.getPoliciesActionFilter(context, item, Constants.ADMIN)
-            .stream()
-            .filter(policy -> policy.getGroup() != null)
-            .map(policy -> policy.getGroup().getID());
-        List<Stream<UUID>> subResults = Arrays.asList(directAdminGroupIds);
-        for (Collection coll : item.getCollections()) {
-            subResults.add(findTransitiveAdminGroupIds(context, coll));
-        }
-        return sequence(subResults);
+        return ids;
     }
 
     /**
@@ -114,11 +93,11 @@ public abstract class IndexingUtils {
      * on the given DSpaceObject. The resulting IDs are prefixed with "e" in the case of an eperson ID, and "g" in the
      * case of a group ID.
      *
-     * @param authService   The authentication service
-     * @param context       DSpace context object
-     * @param obj           DSpaceObject for which we search the admin group IDs
-     * @return  A stream of admin group IDs as Strings, prefixed with either "e" or "g", depending on whether it is a
-     *          group or eperson ID.
+     * @param authService The authentication service
+     * @param context     DSpace context object
+     * @param obj         DSpaceObject for which we search the admin group IDs
+     * @return A stream of admin group IDs as Strings, prefixed with either "e" or "g", depending on whether it is a
+     * group or eperson ID.
      * @throws SQLException if database error
      */
     static List<String> findDirectlyAuthorizedGroupAndEPersonPrefixedIds(
@@ -135,9 +114,5 @@ public abstract class IndexingUtils {
             }
         }
         return prefixedIds;
-    }
-
-    private static <T> Stream<T> sequence(List<Stream<T>> subResults) {
-        return subResults.stream().flatMap(x -> x);
     }
 }

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexingUtils.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexingUtils.java
@@ -1,0 +1,146 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.discovery;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.DSpaceObject;
+import org.dspace.content.Item;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+
+/**
+ * Util methods used by indexing.
+ *
+ * @author Koen Pauwels (koen.pauwels at atmire dot com)
+ */
+public abstract class IndexingUtils {
+    /**
+     * Retrieve all ancestor communities of a given community, with the first one being the given community and the
+     * last one being the root.
+     *
+     * TODO: can be done in a single SQL query with recursive common table expressions
+     * TODO: should probably be moved to CommunityService
+     *
+     * @param context   DSpace context object
+     * @param community Community for which we search the ancestors
+     * @return A stream of ancestor communities.
+     * @throws SQLException if database error
+     */
+    static Stream<Community> getAncestorCommunities(Context context, Community community) throws SQLException {
+        ArrayList<Community> communities = new ArrayList<>();
+        while (community != null) {
+            communities.add(community);
+            community = (Community) ContentServiceFactory.getInstance().getDSpaceObjectService(community)
+                .getParentObject(context, community);
+        }
+        return communities.stream();
+    }
+
+    /**
+     * Retrieve the ids of all groups that have ADMIN rights to the given community, either directly
+     * (through direct resource policy) or indirectly (through a policy on an ancestor community).
+     *
+     * @param context   DSpace context object
+     * @param community Community for which we search the admin group IDs
+     * @return A stream of admin group IDs
+     * @throws SQLException if database error
+     */
+    static Stream<UUID> findTransitiveAdminGroupIds(Context context, Community community) throws SQLException {
+        return getAncestorCommunities(context, community)
+            .map(parent -> parent.getAdministrators().getID());
+    }
+
+    /**
+     * Retrieve the ids of all groups that have ADMIN rights to the given collection, either directly
+     * (through direct resource policy) or indirectly (through a policy on its community, or one of
+     * its ancestor communities).
+     *
+     * @param context   DSpace context object
+     * @param collection Collection for which we search the admin group IDs
+     * @return A stream of admin group IDs
+     * @throws SQLException if database error
+     */
+    static Stream<UUID> findTransitiveAdminGroupIds(Context context, Collection collection) throws SQLException {
+        UUID directAdminGroupId = collection.getAdministrators().getID();
+        List<Stream<UUID>> subResults = Arrays.asList(Stream.of(directAdminGroupId));
+        for (Community community : collection.getCommunities()) {
+            subResults.add(findTransitiveAdminGroupIds(context, community));
+        }
+        return sequence(subResults);
+    }
+
+    /**
+     * Retrieve the ids of all groups that have ADMIN rights on the given item, either directly
+     * (through direct resource policy) or indirectly (through a policy on the owning collection, or on
+     * the owning collection's community, or on any of that community's ancestor communities).
+     *
+     * @param authService
+     * @param context
+     * @param item
+     * @return
+     * @throws SQLException
+     *
+     * @param authService   The authentication service
+     * @param context       DSpace context object
+     * @param item          Item for which we search the admin group IDs
+     * @return A stream of admin group IDs
+     * @throws SQLException if database error
+     */
+    static Stream<UUID> findTransitiveAdminGroupIds(AuthorizeService authService, Context context, Item item)
+        throws SQLException {
+        Stream<UUID> directAdminGroupIds = authService.getPoliciesActionFilter(context, item, Constants.ADMIN)
+            .stream()
+            .filter(policy -> policy.getGroup() != null)
+            .map(policy -> policy.getGroup().getID());
+        List<Stream<UUID>> subResults = Arrays.asList(directAdminGroupIds);
+        for (Collection coll : item.getCollections()) {
+            subResults.add(findTransitiveAdminGroupIds(context, coll));
+        }
+        return sequence(subResults);
+    }
+
+    /**
+     * Retrieve group and eperson IDs for all groups and eperson who have _any_ of the given authorizations
+     * on the given DSpaceObject. The resulting IDs are prefixed with "e" in the case of an eperson ID, and "g" in the
+     * case of a group ID.
+     *
+     * @param authService   The authentication service
+     * @param context       DSpace context object
+     * @param obj           DSpaceObject for which we search the admin group IDs
+     * @return  A stream of admin group IDs as Strings, prefixed with either "e" or "g", depending on whether it is a
+     *          group or eperson ID.
+     * @throws SQLException if database error
+     */
+    static Stream<String> findDirectAuthorizedGroupsAndEPersonsPrefixedIds(AuthorizeService authService,
+        Context context, DSpaceObject obj, int[] authorizations) throws SQLException {
+
+        ArrayList<Stream<String>> subResults = new ArrayList<>();
+        for (int auth : authorizations) {
+            Stream<String> subResult = authService.getPoliciesActionFilter(context, obj, auth).stream()
+                .map(policy -> policy.getGroup() == null ? "e" + policy.getEPerson().getID()
+                                                         : "g" + policy.getGroup().getID());
+            subResults.add(subResult);
+            // TODO: context.uncacheEntitiy(policy);
+        }
+        return sequence(subResults);
+    }
+
+    private static <T> Stream<T> sequence(List<Stream<T>> subResults) {
+        return subResults.stream().flatMap(x -> x);
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceIndexCollectionSubmittersPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceIndexCollectionSubmittersPlugin.java
@@ -12,6 +12,7 @@ import static org.dspace.discovery.IndexingUtils.findTransitiveAdminGroupIds;
 
 import java.sql.SQLException;
 import java.util.List;
+import java.util.UUID;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.solr.common.SolrInputDocument;
@@ -47,12 +48,13 @@ public class SolrServiceIndexCollectionSubmittersPlugin implements SolrServiceIn
                     // Community.
                     // TODO: Strictly speaking we should also check for epersons who received admin rights directly,
                     //       without being part of the admin group. Finding them may be a lot slower though.
-                    findTransitiveAdminGroupIds(context, col)
-                        .forEach(unprefixedId -> document.addField("submit", "g" + unprefixedId));
+                    for (UUID unprefixedId : findTransitiveAdminGroupIds(context, col)) {
+                        document.addField("submit", "g" + unprefixedId);
+                    }
 
-                    // Index groups and epersons with ADD rights on the Collection.
+                    // Index groups and epersons with ADD or ADMIN rights on the Collection.
                     List<String> prefixedIds = findDirectlyAuthorizedGroupAndEPersonPrefixedIds(
-                        authorizeService, context, col, new int[] {Constants.ADD}
+                        authorizeService, context, col, new int[] {Constants.ADD, Constants.ADMIN}
                     );
                     for (String prefixedId : prefixedIds) {
                         document.addField("submit", prefixedId);

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceIndexItemEditorsPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceIndexItemEditorsPlugin.java
@@ -32,7 +32,7 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 public class SolrServiceIndexItemEditorsPlugin implements SolrServiceIndexPlugin {
     private static final Logger log = org.apache.logging.log4j.LogManager
-        .getLogger(SolrServiceIndexCollectionSubmittersPlugin.class);
+        .getLogger(SolrServiceIndexItemEditorsPlugin.class);
 
     @Autowired(required = true)
     protected AuthorizeService authorizeService;

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceIndexItemEditorsPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceIndexItemEditorsPlugin.java
@@ -7,10 +7,11 @@
  */
 package org.dspace.discovery;
 
-import static org.dspace.discovery.IndexingUtils.findDirectAuthorizedGroupsAndEPersonsPrefixedIds;
+import static org.dspace.discovery.IndexingUtils.findDirectlyAuthorizedGroupAndEPersonPrefixedIds;
 import static org.dspace.discovery.IndexingUtils.findTransitiveAdminGroupIds;
 
 import java.sql.SQLException;
+import java.util.List;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.solr.common.SolrInputDocument;
@@ -49,10 +50,12 @@ public class SolrServiceIndexItemEditorsPlugin implements SolrServiceIndexPlugin
                         .forEach(unprefixedId -> document.addField("edit", "g" + unprefixedId));
 
                     // Index groups and epersons with WRITE rights on the Item.
-                    findDirectAuthorizedGroupsAndEPersonsPrefixedIds(
+                    List<String> prefixedIds = findDirectlyAuthorizedGroupAndEPersonPrefixedIds(
                         authorizeService, context, item, new int[] {Constants.WRITE}
-                    ).forEach(prefixedId -> document.addField("edit", prefixedId));
-
+                    );
+                    for (String prefixedId : prefixedIds) {
+                        document.addField("edit", prefixedId);
+                    }
                 } catch (SQLException e) {
                     log.error(LogHelper.getHeader(context, "Error while indexing resource policies",
                         "Item: (id " + item.getID() + " name " + item.getName() + ")" ));

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceIndexItemEditorsPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceIndexItemEditorsPlugin.java
@@ -1,0 +1,63 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.discovery;
+
+import static org.dspace.discovery.IndexingUtils.findDirectAuthorizedGroupsAndEPersonsPrefixedIds;
+import static org.dspace.discovery.IndexingUtils.findTransitiveAdminGroupIds;
+
+import java.sql.SQLException;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.solr.common.SolrInputDocument;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.content.Item;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+import org.dspace.core.LogHelper;
+import org.dspace.discovery.indexobject.IndexableItem;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Indexes policies that yield write access to items.
+ *
+ * @author Koen Pauwels at atmire.com
+ */
+public class SolrServiceIndexItemEditorsPlugin implements SolrServiceIndexPlugin {
+    private static final Logger log = org.apache.logging.log4j.LogManager
+        .getLogger(SolrServiceIndexCollectionSubmittersPlugin.class);
+
+    @Autowired(required = true)
+    protected AuthorizeService authorizeService;
+
+    @Override
+    public void additionalIndex(Context context, IndexableObject idxObj, SolrInputDocument document) {
+        if (idxObj instanceof IndexableItem) {
+            Item item = ((IndexableItem) idxObj).getIndexedObject();
+            if (item != null) {
+                try {
+                    // Index groups with ADMIN rights on the Item, on Collections containing the Item, on
+                    // Communities containing those Collections, and recursively on any Community containing ssuch a
+                    // Community.
+                    // TODO: Strictly speaking we should also check for epersons who received admin rights directly,
+                    //       without being part of the admin group. Finding them may be a lot slower though.
+                    findTransitiveAdminGroupIds(authorizeService, context, item)
+                        .forEach(unprefixedId -> document.addField("edit", "g" + unprefixedId));
+
+                    // Index groups and epersons with WRITE rights on the Item.
+                    findDirectAuthorizedGroupsAndEPersonsPrefixedIds(
+                        authorizeService, context, item, new int[] {Constants.WRITE}
+                    ).forEach(prefixedId -> document.addField("edit", prefixedId));
+
+                } catch (SQLException e) {
+                    log.error(LogHelper.getHeader(context, "Error while indexing resource policies",
+                        "Item: (id " + item.getID() + " name " + item.getName() + ")" ));
+                }
+            }
+        }
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/AuthorizationFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/AuthorizationFeature.java
@@ -13,6 +13,7 @@ import org.dspace.app.rest.model.BaseObjectRest;
 import org.dspace.app.rest.model.RestAddressableModel;
 import org.dspace.app.rest.model.SiteRest;
 import org.dspace.core.Context;
+import org.dspace.discovery.SearchServiceException;
 import org.springframework.core.annotation.AnnotationUtils;
 
 /**
@@ -33,7 +34,7 @@ public interface AuthorizationFeature {
      *            wide feature
      * @return true if the user associated with the context has access to the feature for the specified object
      */
-    boolean isAuthorized(Context context, BaseObjectRest object) throws SQLException;
+    boolean isAuthorized(Context context, BaseObjectRest object) throws SQLException, SearchServiceException;
 
     /**
      * Return the name of the feature

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/AuthorizationFeatureService.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/AuthorizationFeatureService.java
@@ -13,6 +13,7 @@ import java.util.List;
 import org.dspace.app.rest.model.BaseObjectRest;
 import org.dspace.app.rest.model.SiteRest;
 import org.dspace.core.Context;
+import org.dspace.discovery.SearchServiceException;
 
 /**
  * This service provides access to the Authorization Features and check if the feature is allowed or not in a specific
@@ -34,7 +35,8 @@ public interface AuthorizationFeatureService {
      *            feature pass the {@link SiteRest} object
      * @return true if the user associated with the context has access to the feature
      */
-    boolean isAuthorized(Context context, AuthorizationFeature feature, BaseObjectRest object) throws SQLException;
+    boolean isAuthorized(Context context, AuthorizationFeature feature, BaseObjectRest object)
+        throws SQLException, SearchServiceException;
 
     /**
      * Get all the authorization features defined in the system

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/AuthorizationFeatureServiceImpl.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/AuthorizationFeatureServiceImpl.java
@@ -18,6 +18,7 @@ import org.dspace.app.rest.authorization.AuthorizationFeatureService;
 import org.dspace.app.rest.model.BaseObjectRest;
 import org.dspace.app.rest.utils.Utils;
 import org.dspace.core.Context;
+import org.dspace.discovery.SearchServiceException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -38,7 +39,7 @@ public class AuthorizationFeatureServiceImpl implements AuthorizationFeatureServ
 
     @Override
     public boolean isAuthorized(Context context, AuthorizationFeature feature, BaseObjectRest object)
-            throws SQLException {
+        throws SQLException, SearchServiceException {
         if (object == null) {
             // the authorization interface require that the object is not null
             return false;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/EditItemFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/EditItemFeature.java
@@ -28,7 +28,7 @@ import org.springframework.stereotype.Component;
 @AuthorizationFeatureDocumentation(name = EditItemFeature.NAME,
     description = "It can be used to verify if a user has rights to edit any item.")
 public class EditItemFeature implements AuthorizationFeature {
-    public static final String NAME = "canEdit";
+    public static final String NAME = "canEditItem";
     @Autowired
     AuthorizeService authService;
     @Autowired

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/EditItemFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/EditItemFeature.java
@@ -1,0 +1,58 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.authorization.impl;
+
+import java.sql.SQLException;
+
+import org.dspace.app.rest.authorization.AuthorizationFeature;
+import org.dspace.app.rest.authorization.AuthorizationFeatureDocumentation;
+import org.dspace.app.rest.model.BaseObjectRest;
+import org.dspace.app.rest.model.ItemRest;
+import org.dspace.app.rest.model.SiteRest;
+import org.dspace.app.rest.utils.Utils;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.content.Item;
+import org.dspace.content.service.ItemService;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+import org.dspace.discovery.SearchServiceException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+@AuthorizationFeatureDocumentation(name = EditItemFeature.NAME,
+    description = "It can be used to verify if a user has rights to edit any item.")
+public class EditItemFeature implements AuthorizationFeature {
+    public static final String NAME = "canEdit";
+    @Autowired
+    AuthorizeService authService;
+    @Autowired
+    ItemService itemService;
+
+    @Autowired
+    Utils utils;
+
+    @Override
+    public boolean isAuthorized(Context context, BaseObjectRest object) throws SQLException, SearchServiceException {
+        if (object instanceof SiteRest) {
+            return itemService.countItemsWithEdit(context) > 0;
+        } else if (object instanceof ItemRest) {
+            Item item = (Item) utils.getDSpaceAPIObjectFromRest(context, object);
+            return authService.authorizeActionBoolean(context, item, Constants.WRITE);
+        }
+        return false;
+    }
+
+    @Override
+    public String[] getSupportedTypes() {
+        return new String[] {
+            ItemRest.CATEGORY + "." + ItemRest.NAME,
+            SiteRest.CATEGORY + "." + SiteRest.NAME
+        };
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/SubmitFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/SubmitFeature.java
@@ -13,6 +13,7 @@ import org.dspace.app.rest.authorization.AuthorizationFeature;
 import org.dspace.app.rest.authorization.AuthorizationFeatureDocumentation;
 import org.dspace.app.rest.model.BaseObjectRest;
 import org.dspace.app.rest.model.CollectionRest;
+import org.dspace.app.rest.model.SiteRest;
 import org.dspace.app.rest.utils.Utils;
 import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.content.Collection;
@@ -40,7 +41,7 @@ public class SubmitFeature implements AuthorizationFeature {
 
     @Override
     public boolean isAuthorized(Context context, BaseObjectRest object) throws SQLException, SearchServiceException {
-        if (object == null) {
+        if (object instanceof SiteRest) {
             // Check whether the user has permission to add to any collection
             return collectionService.countCollectionsWithSubmit("", context, null) > 0;
         } else if (object instanceof CollectionRest) {
@@ -53,6 +54,9 @@ public class SubmitFeature implements AuthorizationFeature {
 
     @Override
     public String[] getSupportedTypes() {
-        return new String[0];
+        return new String[] {
+            CollectionRest.CATEGORY + "." + CollectionRest.NAME,
+            SiteRest.CATEGORY + "." + SiteRest.NAME
+        };
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/SubmitFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/SubmitFeature.java
@@ -1,0 +1,58 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.authorization.impl;
+
+import java.sql.SQLException;
+
+import org.dspace.app.rest.authorization.AuthorizationFeature;
+import org.dspace.app.rest.authorization.AuthorizationFeatureDocumentation;
+import org.dspace.app.rest.model.BaseObjectRest;
+import org.dspace.app.rest.model.CollectionRest;
+import org.dspace.app.rest.utils.Utils;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.content.Collection;
+import org.dspace.content.service.CollectionService;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+import org.dspace.discovery.SearchServiceException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+@AuthorizationFeatureDocumentation(name = SubmitFeature.NAME,
+    description = "It can be used to verify if a user has rights to submit anything.")
+public class SubmitFeature implements AuthorizationFeature {
+    public static final String NAME = "canSubmit";
+
+    @Autowired
+    AuthorizeService authService;
+
+    @Autowired
+    CollectionService collectionService;
+
+    @Autowired
+    Utils utils;
+
+    @Override
+    public boolean isAuthorized(Context context, BaseObjectRest object) throws SQLException, SearchServiceException {
+        if (object == null) {
+            // Check whether the user has permission to add to any collection
+            return collectionService.countCollectionsWithSubmit("", context, null) > 0;
+        } else if (object instanceof CollectionRest) {
+            // Check whether the user has permission to add to the given collection
+            Collection collection = (Collection) utils.getDSpaceAPIObjectFromRest(context, object);
+            return authService.authorizeActionBoolean(context, collection, Constants.ADD);
+        }
+        return false;
+    }
+
+    @Override
+    public String[] getSupportedTypes() {
+        return new String[0];
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/AuthorizationRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/AuthorizationRestRepository.java
@@ -31,6 +31,7 @@ import org.dspace.app.rest.model.BaseObjectRest;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.core.Context;
+import org.dspace.discovery.SearchServiceException;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.service.EPersonService;
 import org.slf4j.Logger;
@@ -124,7 +125,7 @@ public class AuthorizationRestRepository extends DSpaceRestRepository<Authorizat
                 // restore the real current user
                 context.restoreContextUser();
             }
-        } catch (SQLException e) {
+        } catch (SQLException | SearchServiceException e) {
             throw new RuntimeException(e.getMessage(), e);
         }
 
@@ -151,7 +152,7 @@ public class AuthorizationRestRepository extends DSpaceRestRepository<Authorizat
     @SearchRestMethod(name = "object")
     public Page<AuthorizationRest> findByObject(@Parameter(value = "uri", required = true) String uri,
             @Parameter(value = "eperson") UUID epersonUuid, @Parameter(value = "feature") String featureName,
-            Pageable pageable) throws AuthorizeException, SQLException {
+            Pageable pageable) throws AuthorizeException, SQLException, SearchServiceException {
 
         Context context = obtainContext();
 
@@ -234,7 +235,7 @@ public class AuthorizationRestRepository extends DSpaceRestRepository<Authorizat
         Context context,
         EPerson user,
         String uri,
-        String featureName) throws SQLException {
+        String featureName) throws SQLException, SearchServiceException {
 
         BaseObjectRest restObject = utils.getBaseObjectRestFromUri(context, uri);
         return authorizationsForObject(context, user, featureName, restObject);
@@ -244,7 +245,7 @@ public class AuthorizationRestRepository extends DSpaceRestRepository<Authorizat
         Context context,
         EPerson user, String featureName,
         BaseObjectRest obj)
-        throws SQLException {
+        throws SQLException, SearchServiceException {
 
         if (obj == null) {
             return new ArrayList<>();
@@ -269,7 +270,7 @@ public class AuthorizationRestRepository extends DSpaceRestRepository<Authorizat
 
     private List<Authorization> findByObjectAndFeature(
             Context context, EPerson user, BaseObjectRest obj, String featureName
-    ) throws SQLException {
+    ) throws SQLException, SearchServiceException {
 
         AuthorizationFeature feature = authorizationFeatureService.find(featureName);
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/EditItemFeatureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/EditItemFeatureIT.java
@@ -1,0 +1,279 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.authorization;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.concurrent.Callable;
+
+import org.dspace.app.rest.authorization.impl.EditItemFeature;
+import org.dspace.app.rest.converter.ItemConverter;
+import org.dspace.app.rest.converter.SiteConverter;
+import org.dspace.app.rest.model.ItemRest;
+import org.dspace.app.rest.model.SiteRest;
+import org.dspace.app.rest.projection.DefaultProjection;
+import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.app.rest.utils.Utils;
+import org.dspace.authorize.ResourcePolicy;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.GroupBuilder;
+import org.dspace.builder.ItemBuilder;
+import org.dspace.builder.ResourcePolicyBuilder;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.Item;
+import org.dspace.content.Site;
+import org.dspace.content.service.SiteService;
+import org.dspace.core.Constants;
+import org.dspace.eperson.Group;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.ResultActions;
+
+public class EditItemFeatureIT extends AbstractControllerIntegrationTest {
+    @Autowired
+    private AuthorizationFeatureService authorizationFeatureService;
+    @Autowired
+    private SiteService siteService;
+    @Autowired
+    private ItemConverter itemConverter;
+    @Autowired
+    private SiteConverter siteConverter;
+    @Autowired
+    private Utils utils;
+
+    private Group group;
+    private String siteUri;
+    private String epersonToken;
+    private AuthorizationFeature editItemFeature;
+    private Community communityA;
+
+    private Collection collectionA1;
+    private Collection collectionA2;
+
+    private Item itemA1X;
+    private Item itemA2X;
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+
+        withSuppressedAuthorization(() -> {
+            communityA = CommunityBuilder.createCommunity(context).withName("Community A").build();
+            collectionA1 = CollectionBuilder.createCollection(context, communityA).withName("Collection A1").build();
+            collectionA2 = CollectionBuilder.createCollection(context, communityA).withName("Collection A2").build();
+            itemA1X = ItemBuilder.createItem(context, collectionA1).withTitle("Item A1X").build();
+            itemA2X = ItemBuilder.createItem(context, collectionA2).withTitle("Item A2X").build();
+            group = GroupBuilder.createGroup(context)
+                .withName("group")
+                .addMember(eperson)
+                .build();
+            return null;
+        });
+        editItemFeature = authorizationFeatureService.find(EditItemFeature.NAME);
+
+        Site site = siteService.findSite(context);
+        SiteRest siteRest = siteConverter.convert(site, DefaultProjection.DEFAULT);
+        siteUri = utils.linkToSingleResource(siteRest, "self").getHref();
+    }
+
+    @Test
+    public void testNoRights() throws Exception {
+        expectZeroResults(requestSitewideEditItemFeature());
+    }
+
+    @Test
+    public void testDirectEPersonWritePolicy() throws Exception {
+        ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context)
+            .withUser(eperson)
+            .withDspaceObject(itemA1X)
+            .withAction(Constants.WRITE)
+            .build();
+        expectSomeResults(requestSitewideEditItemFeature());
+        expectSomeResults(requestEditItemFeature(itemA1X));
+        expectZeroResults(requestEditItemFeature(itemA2X));
+    }
+
+    @Test
+    public void testDirectGroupWritePolicy() throws Exception {
+        ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context)
+            .withGroup(group)
+            .withDspaceObject(itemA1X)
+            .withAction(Constants.WRITE)
+            .build();
+        expectSomeResults(requestSitewideEditItemFeature());
+        expectSomeResults(requestEditItemFeature(itemA1X));
+        expectZeroResults(requestEditItemFeature(itemA2X));
+    }
+
+    @Test
+    public void testDirectEPersonAdminPolicy() throws Exception {
+        ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context)
+            .withUser(eperson)
+            .withDspaceObject(itemA1X)
+            .withAction(Constants.ADMIN)
+            .build();
+        expectSomeResults(requestSitewideEditItemFeature());
+        expectSomeResults(requestEditItemFeature(itemA1X));
+        expectZeroResults(requestEditItemFeature(itemA2X));
+    }
+
+    @Test
+    public void testDirectGroupAdminPolicy() throws Exception {
+        ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context)
+            .withGroup(group)
+            .withDspaceObject(itemA1X)
+            .withAction(Constants.ADMIN)
+            .build();
+        expectSomeResults(requestSitewideEditItemFeature());
+        expectSomeResults(requestEditItemFeature(itemA1X));
+        expectZeroResults(requestEditItemFeature(itemA2X));
+    }
+
+    @Test
+    public void testNonemptyCollectionAdmin() throws Exception {
+        Item item = withSuppressedAuthorization(() -> {
+            Collection col = CollectionBuilder
+                .createCollection(context, communityA)
+                .withName("nonempty collection")
+                .withAdminGroup(eperson)
+                .build();
+            return ItemBuilder
+                .createItem(context, col)
+                .withTitle("item in nonempty collection")
+                .build();
+        });
+        expectSomeResults(requestSitewideEditItemFeature());
+        expectSomeResults(requestEditItemFeature(item));
+        expectZeroResults(requestEditItemFeature(itemA1X));
+        expectZeroResults(requestEditItemFeature(itemA2X));
+    }
+
+    @Test
+    public void testEmptyCollectionAdmin() throws Exception {
+        withSuppressedAuthorization(() -> {
+            Collection col = CollectionBuilder
+                .createCollection(context, communityA)
+                .withName("nonempty collection")
+                .withAdminGroup(eperson)
+                .build();
+            return null;
+        });
+        expectZeroResults(requestSitewideEditItemFeature());
+    }
+
+    @Test
+    public void testCommunityWithEmptyCollectionAdmin() throws Exception {
+        withSuppressedAuthorization(() -> {
+            Community comm = CommunityBuilder
+                .createCommunity(context)
+                .withName("This community contains a collection")
+                .withAdminGroup(eperson)
+                .build();
+            Collection coll = CollectionBuilder
+                .createCollection(context, comm)
+                .withName("This collection contains no items")
+                .build();
+            return null;
+        });
+        expectZeroResults(requestSitewideEditItemFeature());
+    }
+
+    @Test
+    public void testCommunityWithNonemptyCollectionAdmin() throws Exception {
+        Item item = withSuppressedAuthorization(() -> {
+            Community comm = CommunityBuilder
+                .createCommunity(context)
+                .withName("This community contains a collection")
+                .withAdminGroup(eperson)
+                .build();
+            Collection coll = CollectionBuilder
+                .createCollection(context, comm)
+                .withName("This collection contains an item")
+                .build();
+            return ItemBuilder
+                .createItem(context, coll)
+                .withTitle("This is an item")
+                .build();
+        });
+        expectSomeResults(requestSitewideEditItemFeature());
+        expectSomeResults(requestEditItemFeature(item));
+    }
+
+    @Test
+    public void testNestedCommunitiesWithNonemptyCollectionAdmin() throws Exception {
+        Item item = withSuppressedAuthorization(() -> {
+            Community parent = CommunityBuilder
+                .createCommunity(context)
+                .withName("parent community")
+                .withAdminGroup(eperson)
+                .build();
+            Community child = CommunityBuilder
+                .createSubCommunity(context, parent)
+                .withName("child community")
+                .withAdminGroup(eperson)
+                .build();
+            Collection coll = CollectionBuilder
+                .createCollection(context, child)
+                .withName("This collection contains an item")
+                .build();
+            return ItemBuilder
+                .createItem(context, coll)
+                .withTitle("This is an item")
+                .build();
+        });
+        expectSomeResults(requestSitewideEditItemFeature());
+        expectSomeResults(requestEditItemFeature(item));
+    }
+
+    private ResultActions requestSitewideEditItemFeature() throws Exception {
+        return requestEditItemFeature(siteUri);
+    }
+
+    private ResultActions requestEditItemFeature(Item item) throws Exception {
+        return requestEditItemFeature(getItemUri(item));
+    }
+    private ResultActions requestEditItemFeature(String uri) throws Exception {
+        epersonToken = getAuthToken(eperson.getEmail(), password);
+        return getClient(epersonToken).perform(get("/api/authz/authorizations/search/object?")
+            .param("uri", uri)
+            .param("feature", editItemFeature.getName())
+            .param("embed", "feature"));
+    }
+
+    private ResultActions expectSomeResults(ResultActions actions) throws Exception {
+        return actions
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", greaterThan(0)));
+    }
+
+    private ResultActions expectZeroResults(ResultActions actions) throws Exception {
+        return actions
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
+    }
+
+    private <T> T withSuppressedAuthorization(Callable<T> fn) throws Exception {
+        context.turnOffAuthorisationSystem();
+        T result = fn.call();
+        context.restoreAuthSystemState();
+        return result;
+    }
+
+    private String getItemUri(Item item) {
+        ItemRest itemRest = itemConverter.convert(item, DefaultProjection.DEFAULT);
+        return utils.linkToSingleResource(itemRest, "self").getHref();
+    }
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/SubmitFeatureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/SubmitFeatureIT.java
@@ -1,0 +1,328 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.authorization;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.concurrent.Callable;
+
+import org.dspace.app.rest.authorization.impl.SubmitFeature;
+import org.dspace.app.rest.converter.CollectionConverter;
+import org.dspace.app.rest.converter.SiteConverter;
+import org.dspace.app.rest.model.CollectionRest;
+import org.dspace.app.rest.model.SiteRest;
+import org.dspace.app.rest.projection.DefaultProjection;
+import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.app.rest.utils.Utils;
+import org.dspace.authorize.ResourcePolicy;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.GroupBuilder;
+import org.dspace.builder.ResourcePolicyBuilder;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.Site;
+import org.dspace.content.service.SiteService;
+import org.dspace.core.Constants;
+import org.dspace.eperson.Group;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.ResultActions;
+
+public class SubmitFeatureIT extends AbstractControllerIntegrationTest {
+    @Autowired
+    private AuthorizationFeatureService authorizationFeatureService;
+    @Autowired
+    private SiteService siteService;
+    @Autowired
+    private CollectionConverter collectionConverter;
+    @Autowired
+    private SiteConverter siteConverter;
+    @Autowired
+    private Utils utils;
+
+    private Group group;
+    private String siteUri;
+    private String epersonToken;
+    private AuthorizationFeature submitFeature;
+    private Community communityA;
+
+    private Collection collectionA1;
+    private Collection collectionA2;
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+
+        withSuppressedAuthorization(() -> {
+            communityA = CommunityBuilder.createCommunity(context).withName("Community A").build();
+            collectionA1 = CollectionBuilder.createCollection(context, communityA).withName("Collection A1").build();
+            collectionA2 = CollectionBuilder.createCollection(context, communityA).withName("Collection A2").build();
+            group = GroupBuilder.createGroup(context)
+                .withName("group")
+                .addMember(eperson)
+                .build();
+            return null;
+        });
+        submitFeature = authorizationFeatureService.find(SubmitFeature.NAME);
+
+        Site site = siteService.findSite(context);
+        SiteRest siteRest = siteConverter.convert(site, DefaultProjection.DEFAULT);
+        siteUri = utils.linkToSingleResource(siteRest, "self").getHref();
+    }
+
+    @Test
+    public void testNoRights() throws Exception {
+        expectZeroResults(requestSitewideSubmitFeature());
+    }
+
+    @Test
+    public void testDirectEPersonAddPolicy() throws Exception {
+        ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context)
+                .withUser(eperson)
+                .withDspaceObject(collectionA1)
+                .withAction(Constants.ADD)
+                .build();
+        expectSomeResults(requestSitewideSubmitFeature());
+    }
+
+    @Test
+    public void testDirectGroupAddPolicy() throws Exception {
+        ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context)
+            .withGroup(group)
+            .withDspaceObject(collectionA1)
+            .withAction(Constants.ADD)
+            .build();
+        expectSomeResults(requestSitewideSubmitFeature());
+    }
+
+    @Test
+    public void testDirectEPersonAdminPolicy() throws Exception {
+        ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context)
+            .withUser(eperson)
+            .withDspaceObject(collectionA1)
+            .withAction(Constants.ADMIN)
+            .build();
+        expectSomeResults(requestSitewideSubmitFeature());
+    }
+
+    @Test
+    public void testDirectGroupAdminPolicy() throws Exception {
+        ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context)
+            .withGroup(group)
+            .withDspaceObject(collectionA1)
+            .withAction(Constants.ADMIN)
+            .build();
+        expectSomeResults(requestSitewideSubmitFeature());
+    }
+
+    @Test
+    public void testCollectionAdmin() throws Exception {
+        withSuppressedAuthorization(() -> {
+            Collection col = CollectionBuilder
+                .createCollection(context, communityA)
+                .withName("this is another test collection")
+                .withAdminGroup(eperson)
+                .build();
+            return null;
+        });
+        expectSomeResults(requestSitewideSubmitFeature());
+    }
+
+    @Test
+    public void testCommunityWithoutCollectionsAdmin() throws Exception {
+        withSuppressedAuthorization(() -> {
+            Community comm = CommunityBuilder
+                .createCommunity(context)
+                .withName("This community contains no collections")
+                .withAdminGroup(eperson)
+                .build();
+            return null;
+        });
+        expectZeroResults(requestSitewideSubmitFeature());
+    }
+
+    @Test
+    public void testCommunityWithCollectionsAdmin() throws Exception {
+        withSuppressedAuthorization(() -> {
+            Community comm = CommunityBuilder
+                .createCommunity(context)
+                .withName("This community contains a collection")
+                .withAdminGroup(eperson)
+                .build();
+            Collection coll = CollectionBuilder
+                .createCollection(context, comm)
+                .withName("Contained collection")
+                .build();
+            return null;
+        });
+        expectSomeResults(requestSitewideSubmitFeature());
+    }
+
+    @Test
+    public void testCommunityWithSubCommunityWithCollectionsAdmin() throws Exception {
+        withSuppressedAuthorization(() -> {
+            Community parent = CommunityBuilder
+                .createCommunity(context)
+                .withName("This community contains no collections")
+                .withAdminGroup(eperson)
+                .build();
+            Community child = CommunityBuilder
+                .createSubCommunity(context, parent)
+                .withName("This community contains a collection")
+                .build();
+            Collection coll = CollectionBuilder
+                .createCollection(context, child)
+                .withName("Contained collection")
+                .build();
+            return null;
+        });
+        expectSomeResults(requestSitewideSubmitFeature());
+    }
+
+    @Test
+    public void testNoRightsOnCollection() throws Exception {
+        expectZeroResults(requestSubmitFeature(getCollectionUri(collectionA1)));
+        expectZeroResults(requestSubmitFeature(getCollectionUri(collectionA2)));
+    }
+
+    @Test
+    public void testDirectEPersonWritePolicyOnCollection() throws Exception {
+        ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context)
+                .withUser(eperson)
+                .withDspaceObject(collectionA1)
+                .withAction(Constants.ADD)
+                .build();
+        expectSomeResults(requestSubmitFeature(getCollectionUri(collectionA1)));
+        expectZeroResults(requestSubmitFeature(getCollectionUri(collectionA2)));
+    }
+
+    @Test
+    public void testDirectGroupWritePolicyOnCollection() throws Exception {
+        ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context)
+            .withGroup(group)
+            .withDspaceObject(collectionA1)
+            .withAction(Constants.ADD)
+            .build();
+        expectSomeResults(requestSubmitFeature(getCollectionUri(collectionA1)));
+        expectZeroResults(requestSubmitFeature(getCollectionUri(collectionA2)));
+    }
+
+    @Test
+    public void testDirectEPersonAdminPolicyOnCollection() throws Exception {
+        ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context)
+            .withUser(eperson)
+            .withDspaceObject(collectionA1)
+            .withAction(Constants.ADMIN)
+            .build();
+        expectSomeResults(requestSubmitFeature(getCollectionUri(collectionA1)));
+        expectZeroResults(requestSubmitFeature(getCollectionUri(collectionA2)));
+    }
+
+    @Test
+    public void testDirectGroupAdminPolicyOnCollection() throws Exception {
+        ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context)
+            .withGroup(group)
+            .withDspaceObject(collectionA1)
+            .withAction(Constants.ADMIN)
+            .build();
+        expectSomeResults(requestSubmitFeature(getCollectionUri(collectionA1)));
+        expectZeroResults(requestSubmitFeature(getCollectionUri(collectionA2)));
+    }
+
+    @Test
+    public void testCollectionAdminOnCollection() throws Exception {
+        Collection col = withSuppressedAuthorization(() -> {
+            return CollectionBuilder
+                .createCollection(context, communityA)
+                .withName("this is another test collection")
+                .withAdminGroup(eperson)
+                .build();
+        });
+        expectSomeResults(requestSubmitFeature(getCollectionUri(col)));
+        expectZeroResults(requestSubmitFeature(getCollectionUri(collectionA1)));
+    }
+
+    @Test
+    public void testCommunityWithCollectionsAdminOnCollection() throws Exception {
+        Collection coll = withSuppressedAuthorization(() -> {
+            Community comm = CommunityBuilder
+                .createCommunity(context)
+                .withName("This community contains a collection")
+                .withAdminGroup(eperson)
+                .build();
+            return CollectionBuilder
+                .createCollection(context, comm)
+                .withName("Contained collection")
+                .build();
+        });
+        expectSomeResults(requestSubmitFeature(getCollectionUri(coll)));
+    }
+
+    @Test
+    public void testCommunityWithSubCommunityWithCollectionsAdminOnCollection() throws Exception {
+        Collection coll = withSuppressedAuthorization(() -> {
+            Community parent = CommunityBuilder
+                .createCommunity(context)
+                .withName("This community contains no collections")
+                .withAdminGroup(eperson)
+                .build();
+            Community child = CommunityBuilder
+                .createSubCommunity(context, parent)
+                .withName("This community contains a collection")
+                .build();
+            return CollectionBuilder
+                .createCollection(context, child)
+                .withName("Contained collection")
+                .build();
+        });
+        expectSomeResults(requestSubmitFeature(getCollectionUri(coll)));
+    }
+
+    private ResultActions requestSitewideSubmitFeature() throws Exception {
+        return requestSubmitFeature(siteUri);
+    }
+
+    private ResultActions requestSubmitFeature(String uri) throws Exception {
+        epersonToken = getAuthToken(eperson.getEmail(), password);
+        return getClient(epersonToken).perform(get("/api/authz/authorizations/search/object?")
+            .param("uri", uri)
+            .param("feature", submitFeature.getName())
+            .param("embed", "feature"));
+    }
+
+    private ResultActions expectSomeResults(ResultActions actions) throws Exception {
+        return actions
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", greaterThan(0)));
+    }
+
+    private ResultActions expectZeroResults(ResultActions actions) throws Exception {
+        return actions
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
+    }
+
+    private <T> T withSuppressedAuthorization(Callable<T> fn) throws Exception {
+        context.turnOffAuthorisationSystem();
+        T result = fn.call();
+        context.restoreAuthSystemState();
+        return result;
+    }
+
+    private String getCollectionUri(Collection collection) {
+        CollectionRest collectionRest = collectionConverter.convert(collection, DefaultProjection.DEFAULT);
+        return utils.linkToSingleResource(collectionRest, "self").getHref();
+    }
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/SubmitFeatureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/SubmitFeatureIT.java
@@ -198,7 +198,7 @@ public class SubmitFeatureIT extends AbstractControllerIntegrationTest {
     }
 
     @Test
-    public void testDirectEPersonWritePolicyOnCollection() throws Exception {
+    public void testDirectEPersonAddPolicyOnCollection() throws Exception {
         ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context)
                 .withUser(eperson)
                 .withDspaceObject(collectionA1)
@@ -209,7 +209,7 @@ public class SubmitFeatureIT extends AbstractControllerIntegrationTest {
     }
 
     @Test
-    public void testDirectGroupWritePolicyOnCollection() throws Exception {
+    public void testDirectGroupAddPolicyOnCollection() throws Exception {
         ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context)
             .withGroup(group)
             .withDspaceObject(collectionA1)

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -31,6 +31,7 @@
     <bean id="solrServicePrivateItemPlugin" class="org.dspace.discovery.SolrServicePrivateItemPlugin" scope="prototype"/>
     <bean id="SolrServiceParentObjectIndexingPlugin" class="org.dspace.discovery.SolrServiceParentObjectIndexingPlugin" scope="prototype"/>
     <bean id="SolrServiceIndexCollectionSubmittersPlugin" class="org.dspace.discovery.SolrServiceIndexCollectionSubmittersPlugin" scope="prototype"/>
+    <bean id="SolrServiceIndexItemEditorsPlugin" class="org.dspace.discovery.SolrServiceIndexItemEditorsPlugin" scope="prototype"/>
 
     <alias name="solrServiceResourceIndexPlugin" alias="org.dspace.discovery.SolrServiceResourceRestrictionPlugin"/>
 

--- a/dspace/solr/search/conf/schema.xml
+++ b/dspace/solr/search/conf/schema.xml
@@ -264,6 +264,9 @@
     <!-- used to track which group(s) have submit permissions -->
     <field name="submit" type="string" indexed="true" stored="true" omitNorms="true" multiValued="true" docValues="true" />
 
+    <!-- used to track which eperson(s) have edit permissions on items -->
+    <field name="edit" type="string" indexed="true" stored="true" omitNorms="true" multiValued="true" docValues="true" />
+
     <!-- used to track entity type of collections -->
     <field name="search.entitytype" type="string" indexed="true" stored="true" required="false" />
    


### PR DESCRIPTION
## References
* Fixes [#1643](https://github.com/DSpace/dspace-angular/issues/1643)
* Lays groundwork for [#1331](https://github.com/DSpace/dspace-angular/issues/1331)
* [Related frontend PR](https://github.com/DSpace/dspace-angular/pull/1999)

## Description
* Frontend: hides admin sidebar sections for users who lack relevant permissions.
* Backend: adds authorization features to support the frontend changes.

## Instructions for Reviewers
In order to decide whether or not to display the "New->Item" and "Edit->Item" options in the admin sidebar, the frontend needs to know (respectively):

1. Are there any collections for which the user has permission to add new items?
2. Does the user have permission to edit at least one item?

On the backend, this patch adds two new authorization features: "canSubmit" and "canEditItem". On the frontend, the menu resolver now requests these permissions to determine whether to add the corresponding sections to the menu.

### Backend overview
Checking directly whether a user has, for instance, edit rights on at least one item is a fairly expensive operation to perform directly. The user can obtain these rights in any one of the following ways:

1. Have a direct WRITE resource policy on an item.
2. Have a direct ADMIN resource policy on an item.
3. Have ADMIN rights on a collection containing at least one item (either through a resource policy or by being a member of the collection's ADMIN group).
4. Have ADMIN rights on a community containing at least one collection that contains at least one item (either through a resource policy or by being a member of the collection's ADMIN group). Or having ADMIN rights on a community containing such a community. Or...

We don't want to hammer the DB with running the full exhaustive check every time the frontend needs this information (which is every time a user logs in), so we add this information to the index instead.

The patch introduces a new indexer plugin "SolrServiceIndexItemEditorsPlugin", and it also refactors the existing indexer plugin "SolrServiceIndexCollectionSubmittersPlugin". This means the check described above (mostly -- see Known Issues) is run on every index update instead of every time a user logs in.

### Known Issues
#### Integration test
The patch fails `CreateMissingIdentifiersIT.testPerform` in CI but not locally. However this is known to be a flaky test and seems to have been fixed [here](https://github.com/DSpace/DSpace/pull/8597).

#### Performance
The current implementation is not as fast as it could be. For one, the two plugins are run for every item (for the canEditItem plugin) and every collection (for the canSubmit plugin), even though in both cases only a single item/collection needs to be found.

In particular, this makes recursive discovery of an ancestor community/collection for which the user has ADMIN rights less efficient. One can picture this process as a tree where the ADMIN rights "trickle down" to all descendants. The current implementation, however, computes bottom-up, starting from every collection (for the canSubmit plugin) or every item (for the canEditItem plugin), thereby potentially repeatedly exploring the same paths over and over. What's more is that, not only do we run a separate SQL query for every such item/collection involved, but every step of the recursive upward search process requires a separate DB query.

#### Known bug
The new item editing plugin was modeled on the existing collection submitters plugin, and it replicates a bug in that plugin: when recursively traversing ancestor collections/communities, it only collects the ADMIN groups that are directly registered as "the admin group" of the collections/communities, ignoring resource policies (either for groups or directly for epersons). This behavior was retained out of performance concerns with searching for research policies for every ancestor in the tree (often multiple times, as explained in the Performance subsection).

#### Proposed solutions
The known bug is easy to fix if the performance of the plugins is improved.

At the beginning of an index update, it should be possible to perform a single, relatively cheap SQL query to recursively trace out admin permissions (that is, yield a table `(group_or_eperson_id, dso_id)` and to put the result in an in-memory hash table which lives for the duration of the index update). This avoids duplicate work (because it is performed once for the entire index update, rather than for each updated object in the index) and should be relatively cheap (because in real workloads, we’d expect admin permissions to be rare compared to the number of items/collections).

Implementing these changes would require some rearchitecting; we recommend accepting this patch in the mean time.


## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
