### PR TITLE
Downloading restricted bitstreams does not work when opening a new tab/window

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/AuthenticationRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/AuthenticationRestController.java
@@ -34,7 +34,6 @@ import org.dspace.app.rest.projection.Projection;
 import org.dspace.app.rest.security.RestAuthenticationService;
 import org.dspace.app.rest.utils.ContextUtil;
 import org.dspace.app.rest.utils.Utils;
-import org.dspace.authorize.AuthorizeException;
 import org.dspace.core.Context;
 import org.dspace.service.ClientInfoService;
 import org.slf4j.Logger;
@@ -210,33 +209,7 @@ public class AuthenticationRestController implements InitializingBean {
     }
 
     /**
-     * This method will generate a short lived token to be used for bitstream downloads among other things.
-     *
-     * For security reasons, this endpoint only responds to a explicitly defined list of ips.
-     *
-     * curl -v -X GET https://{dspace-server.url}/api/authn/shortlivedtokens -H "Authorization: Bearer eyJhbG...COdbo"
-     *
-     * Example:
-     * <pre>
-     * {@code
-     * curl -v -X GET https://{dspace-server.url}/api/authn/shortlivedtokens -H "Authorization: Bearer eyJhbG...COdbo"
-     * }
-     * </pre>
-     * @param request The StandardMultipartHttpServletRequest
-     * @return        The created short lived token
-     */
-    @PreAuthorize("hasAuthority('AUTHENTICATED')")
-    @RequestMapping(value = "/shortlivedtokens", method = RequestMethod.GET)
-    public AuthenticationTokenResource shortLivedTokenViaGet(HttpServletRequest request) throws AuthorizeException {
-        if (!clientInfoService.isRequestFromTrustedProxy(request.getRemoteAddr())) {
-            throw new AuthorizeException("Requests to this endpoint should be made from a trusted IP address.");
-        }
-
-        return shortLivedTokenResponse(request);
-    }
-
-    /**
-     * See {@link #shortLivedToken} and {@link #shortLivedTokenViaGet}
+     * See {@link #shortLivedToken}
      */
     private AuthenticationTokenResource shortLivedTokenResponse(HttpServletRequest request) {
         Projection projection = utils.obtainProjection();


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/DSpace/issues/8378
* Fixes https://github.com/DSpace/dspace-angular/issues/1809
* Replaced by https://github.com/DSpace/dspace-angular/pull/2076

## Description
**UPDATE: This removes the ability to `GET /api/authn/shortlivedtokens`, as now POST is used at all times.**

Since [this change](https://github.com/DSpace/dspace-angular/commit/ff4bd59de0d280121420d5fd4721891ac30f7e6f) the server side angular rendering now uses the GET endpoint for `/api/authn/shortlivedtokens` instead of the POST, so the
[POST endpoint](https://github.com/DSpace/DSpace/blob/main/dspace-server-webapp/src/main/java/org/dspace/app/rest/AuthenticationRestController.java#L209): no trusted proxy check
[GET endpoint](https://github.com/DSpace/DSpace/blob/main/dspace-server-webapp/src/main/java/org/dspace/app/rest/AuthenticationRestController.java#L231): trusted proxy check

The IP of the node process/angular that is in trusted proxies list may get added to this request when sent from the node server in the `X-forwarded-for` heading, testing on servers (with apache setup before tomcat) showed that once it reached this endpoint the IP of node/angular was no longer present in the request, not in remote address, nor in `X-forwarded-for` header.

Since previously the proxy check was not done either (since used POST endpoint), and we saw no real reason to keep it, the proxy check has been removed.

## Instructions for Reviewers
- During submission add a file, clicking the download button in submission form should now again successfully open file in new tab
- Set a bitstream as restricted (e.g. embargoed) => On item page open the file in new tab by shift clicking => should again open successfully in new tab

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
