### PR TITLE
[DURACOM-113] add jfif extension on bitstream formats

### DIFF
--- a/dspace/config/registries/bitstream-formats.xml
+++ b/dspace/config/registries/bitstream-formats.xml
@@ -187,6 +187,7 @@
     <internal>false</internal>
     <extension>jpeg</extension>
     <extension>jpg</extension>
+    <extension>jfif</extension>
   </bitstream-type>
   
   <bitstream-type>


### PR DESCRIPTION
Fixes #8630