### PR TITLE
Fix for "All of DSpace" browse menu has odd behavior for Community/Collection Admins

### DIFF
--- a/dspace-api/src/main/java/org/dspace/browse/SolrBrowseDAO.java
+++ b/dspace-api/src/main/java/org/dspace/browse/SolrBrowseDAO.java
@@ -8,7 +8,6 @@
 package org.dspace.browse;
 
 import java.io.Serializable;
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -179,7 +178,6 @@ public class SolrBrowseDAO implements BrowseDAO {
             DiscoverQuery query = new DiscoverQuery();
             addLocationScopeFilter(query);
             addDefaultFilterQueries(query);
-            addStatusFilter(query);
             if (distinct) {
                 DiscoverFacetField dff;
                 if (StringUtils.isNotBlank(startsWith)) {
@@ -228,18 +226,6 @@ public class SolrBrowseDAO implements BrowseDAO {
             }
         }
         return sResponse;
-    }
-
-    private void addStatusFilter(DiscoverQuery query) {
-        try {
-            if (!authorizeService.isAdmin(context)
-                && (authorizeService.isCommunityAdmin(context)
-                || authorizeService.isCollectionAdmin(context))) {
-                query.addFilterQueries(searcher.createLocationQueryForAdministrableItems(context));
-            }
-        } catch (SQLException ex) {
-            log.error("Error looking up authorization rights of current user", ex);
-        }
     }
 
     private void addLocationScopeFilter(DiscoverQuery query) {
@@ -346,7 +332,6 @@ public class SolrBrowseDAO implements BrowseDAO {
         DiscoverQuery query = new DiscoverQuery();
         addLocationScopeFilter(query);
         addDefaultFilterQueries(query);
-        addStatusFilter(query);
         query.setMaxResults(0);
         query.addFilterQueries("search.resourcetype:" + IndexableItem.TYPE);
 


### PR DESCRIPTION
## References
* Fixes #8512

## Description

Remove a Solr filterquery applied to browse-by indexes queries that prevents local admins view the same items that view an anonymous user.

## Instructions for Reviewers

The filterquery added by the function `addStatusFilter` was added in previous versions to allow local admins browse non-discoverable/withdrawn items. See: 

https://github.com/DSpace/DSpace/blob/dspace-6_x/dspace-api/src/main/java/org/dspace/browse/SolrBrowseDAO.java#L212-L237

This function was refactored in version 7.x and some clauses were removed. After this refactoring the filter query doesn't works properly.

On the other hand, another change has been applied recently to prevent show non-discoverable/withdrawn items in browse-by indexes. See:  #8610 / #8642

After this change, the originally filterquery added is not needed and we can safely remove it.

For testing, check that a local admin can view the same items that an anonymous user can view in browse-by indexes.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
