### PR TITLE
Downgrade Creative Commons transformation stylesheet version 

### DIFF
--- a/dspace-api/src/main/resources/org/dspace/license/CreativeCommons.xsl
+++ b/dspace-api/src/main/resources/org/dspace/license/CreativeCommons.xsl
@@ -8,7 +8,7 @@
     http://www.dspace.org/license/
 
 -->
-<xsl:stylesheet version="1.1"
+<xsl:stylesheet version="1.0"
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:cc="http://creativecommons.org/ns#"
 	xmlns:old-cc="http://web.resource.org/cc/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	exclude-result-prefixes="old-cc">

--- a/dspace-api/src/main/resources/org/dspace/license/LicenseCleanup.xsl
+++ b/dspace-api/src/main/resources/org/dspace/license/LicenseCleanup.xsl
@@ -8,7 +8,7 @@
     http://www.dspace.org/license/
 
 -->
-<xsl:stylesheet version="1.1"
+<xsl:stylesheet version="1.0"
    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:old-cc="http://web.resource.org/cc/"


### PR DESCRIPTION
## References
* Fixes #8661

## Description
Has @mwoodiupui stated «default JRE XSL library, forked from Xalan I believe, which doesn't implement XSL-T 1.1». 
This PR downgrades the Stylesheet version.

## Instructions for Reviewers
This is a minor change that intends to fix #8661 suppressing the warning related with the unsupported version when doing a 

`[dspace]/bin/dspace oai import -c`
