### PR TITLE
Fix grunt version for Mirage 2 build on Node.js v14

### DIFF
--- a/dspace-xmlui-mirage2/src/main/webapp/package.json
+++ b/dspace-xmlui-mirage2/src/main/webapp/package.json
@@ -9,7 +9,7 @@
     "handlebars": "4.0.11",
     "holderjs": "2.6.0",
     "html5shiv": "3.7.3",
-    "grunt": "^1.5.2",
+    "grunt": "~1.5.3",
     "grunt-cli": "^1.4.3",
     "grunt-contrib-coffee": "^2.1.0",
     "grunt-contrib-concat": "^2.1.0",


### PR DESCRIPTION
## References
* Fixes #8676

## Description
Grunt 1.6.0 updated its Node.js dependency to version 16. Mirage 2 is a legacy theme that is stuck on Node.js 14, so this breaks the build. Pin the grunt version to the last 1.5.x release providing support for Node.js 14 using a `~1.5.3` semver specifier.

## Instructions for Reviewers
Test that maven package works for Mirage 2, ie:

```console
$ mvn -U -Dmirage2.on=true clean package
```

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.