### PR TITLE
Build, use, publish dspace/dspace-solr imgs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,5 @@ dspace/modules/*/target/
 Dockerfile.*
 dspace/src/main/docker/dspace-postgres-pgcrypto
 dspace/src/main/docker/dspace-postgres-pgcrypto-curl
-dspace/src/main/docker/solr
 dspace/src/main/docker/README.md
 dspace/src/main/docker-compose/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -170,3 +170,29 @@ jobs:
           # Use tags / labels provided by 'docker/metadata-action' above
           tags: ${{ steps.meta_build_cli.outputs.tags }}
           labels: ${{ steps.meta_build_cli.outputs.labels }}
+
+      ###########################################
+      # Build/Push the 'dspace/dspace-solr' image
+      ###########################################
+      # Get Metadata for docker_build_solr step below
+      - name: Sync metadata (tags, labels) from GitHub to Docker for 'dspace-solr' image
+        id: meta_build_solr
+        uses: docker/metadata-action@v4
+        with:
+          images: dspace/dspace-solr
+          tags: ${{ env.IMAGE_TAGS }}
+          flavor: ${{ env.TAGS_FLAVOR }}
+
+      - name: Build and push 'dspace-solr' image
+        id: docker_build_solr
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ./dspace/src/main/docker/dspace-solr/Dockerfile
+          platforms: ${{ env.PLATFORMS }}
+          # For pull requests, we run the Docker build (to ensure no PR changes break the build),
+          # but we ONLY do an image push to DockerHub if it's NOT a PR
+          push: ${{ github.event_name != 'pull_request' }}
+          # Use tags / labels provided by 'docker/metadata-action' above
+          tags: ${{ steps.meta_build_solr.outputs.tags }}
+          labels: ${{ steps.meta_build_solr.outputs.labels }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,8 +81,12 @@ services:
   # DSpace Solr container
   dspacesolr:
     container_name: dspacesolr
-    # Uses official Solr image at https://hub.docker.com/_/solr/
-    image: solr:8.11-slim
+    image: "${DOCKER_OWNER:-dspace}/dspace-solr:${DSPACE_VER:-dspace-7_x}"
+    build:
+      context: .
+      dockerfile: ./dspace/src/main/docker/dspace-solr/Dockerfile
+      args:
+        SOLR_VERSION: "${SOLR_VER:-8.11}"
     networks:
       dspacenet:
     ports:
@@ -92,30 +96,25 @@ services:
     tty: true
     working_dir: /var/solr/data
     volumes:
-    # Mount our local Solr core configs so that they are available as Solr configsets on container
-    - ./dspace/solr/authority:/opt/solr/server/solr/configsets/authority
-    - ./dspace/solr/oai:/opt/solr/server/solr/configsets/oai
-    - ./dspace/solr/search:/opt/solr/server/solr/configsets/search
-    - ./dspace/solr/statistics:/opt/solr/server/solr/configsets/statistics
     # Keep Solr data directory between reboots
     - solr_data:/var/solr/data
-    # Initialize all DSpace Solr cores using the mounted local configsets (see above), then start Solr
+    # Initialize all DSpace Solr cores then start Solr:
     # * First, run precreate-core to create the core (if it doesn't yet exist). If exists already, this is a no-op
-    # * Second, copy updated configs from mounted configsets to this core. If it already existed, this updates core
-    #   to the latest configs. If it's a newly created core, this is a no-op.
+    # * Second, copy configsets to this core:
+    #   Updates to Solr configs require the container to be rebuilt/restarted: `docker compose -p d7 up -d --build dspacesolr`
     entrypoint:
     - /bin/bash
     - '-c'
     - |
       init-var-solr
       precreate-core authority /opt/solr/server/solr/configsets/authority
-      cp -r -u /opt/solr/server/solr/configsets/authority/* authority
+      cp -r /opt/solr/server/solr/configsets/authority/* authority
       precreate-core oai /opt/solr/server/solr/configsets/oai
-      cp -r -u /opt/solr/server/solr/configsets/oai/* oai
+      cp -r /opt/solr/server/solr/configsets/oai/* oai
       precreate-core search /opt/solr/server/solr/configsets/search
-      cp -r -u /opt/solr/server/solr/configsets/search/* search
+      cp -r /opt/solr/server/solr/configsets/search/* search
       precreate-core statistics /opt/solr/server/solr/configsets/statistics
-      cp -r -u /opt/solr/server/solr/configsets/statistics/* statistics
+      cp -r /opt/solr/server/solr/configsets/statistics/* statistics
       exec solr -f
 volumes:
   assetstore:

--- a/dspace/src/main/docker/README.md
+++ b/dspace/src/main/docker/README.md
@@ -130,6 +130,23 @@ docker run -i -t -d -p 80:80 -p 443:443 dspace/dspace-shibboleth
 
 This image can also be rebuilt using the `../docker-compose/docker-compose-shibboleth.yml` script.
 
+## dspace/src/main/docker/dspace-solr/Dockerfile
+
+This Dockerfile builds a Solr image with DSpace Solr configsets included. It
+can be pulled / built following the [docker compose resources](../docker-compose/README.md)
+documentation. Or, to just build and/or run Solr:
+
+```bash
+docker-compose build dspacesolr
+docker-compose -p d7 up -d dspacesolr
+```
+
+If you're making iterative changes to the DSpace Solr configsets you'll need to rebuild /
+restart the `dspacesolr` container for the changes to be deployed. From DSpace root:
+
+```bash
+docker-compose -p d7 up --detach --build dspacesolr
+```
 
 ## test/ folder
 

--- a/dspace/src/main/docker/dspace-solr/Dockerfile
+++ b/dspace/src/main/docker/dspace-solr/Dockerfile
@@ -1,0 +1,36 @@
+#
+# The contents of this file are subject to the license and copyright
+# detailed in the LICENSE and NOTICE files at the root of the source
+# tree and available online at
+#
+# http://www.dspace.org/license/
+#
+
+# To build use root as context for (easier) access to solr cfgs
+# docker build --build-arg SOLR_VERSION=8.11 -f ./dspace/src/main/docker/dspace-solr/Dockerfile .
+# This will be published as dspace/dspace-solr:$DSPACE_VERSION
+
+ARG SOLR_VERSION=8.11
+
+FROM solr:${SOLR_VERSION}-slim
+
+ENV AUTHORITY_CONFIGSET_PATH=/opt/solr/server/solr/configsets/authority/conf \
+    OAI_CONFIGSET_PATH=/opt/solr/server/solr/configsets/oai/conf \
+    SEARCH_CONFIGSET_PATH=/opt/solr/server/solr/configsets/search/conf \
+    STATISTICS_CONFIGSET_PATH=/opt/solr/server/solr/configsets/statistics/conf
+
+USER root
+
+RUN mkdir -p $AUTHORITY_CONFIGSET_PATH && \
+    mkdir -p $OAI_CONFIGSET_PATH && \
+    mkdir -p $SEARCH_CONFIGSET_PATH && \
+    mkdir -p $STATISTICS_CONFIGSET_PATH
+
+COPY dspace/solr/authority/conf/* $AUTHORITY_CONFIGSET_PATH/
+COPY dspace/solr/oai/conf/* $OAI_CONFIGSET_PATH/
+COPY dspace/solr/search/conf/* $SEARCH_CONFIGSET_PATH/
+COPY dspace/solr/statistics/conf/* $STATISTICS_CONFIGSET_PATH/
+
+RUN chown -R solr:solr /opt/solr/server/solr/configsets
+
+USER solr


### PR DESCRIPTION
## Description

Adds a simple Dockerfile for bundling the DSpace Solr configs.

The primary motivation for this is to simplify DSpace Solr docker deployments for non-production sites i.e. in test environments where docker is being used but direct access to the source files is not expected or particularly desirable and pulling rather than building is faster & simpler.

The docker compose file has been updated to remove the default host volume mounting of the Solr configs with rebuild/restart instructions for integrating changes in the local dspace-solr img. The `-u` was dropped from `cp` in `entrypoint` to ensure that the current img's files are always in place when the container starts. The idea is that this is more reflective of what is required when running the img in remote environments while not introducing any "additional" requirements for local usage (where it appears restarts to integrate changes to Solr config is already required when using docker).

For publishing this PR calls for reviving the use of: https://hub.docker.com/r/dspace/dspace-solr -- but for images that only add DSpace config to the official Solr image, rather than providing a custom build of Solr.

## Instructions for Reviewers

As there are no (relevant) dspace/dspace-solr imgs `docker compose ... pull` will generate a warning. To test builds:

```
docker compose build dspacesolr
```

To run it:

```
docker compose up -d dspacesolr
```

Make some changes to `dspace/solr/search/schema.xml`. Rebuild to integrate those changes:

```
docker compose up --detach --build dspacesolr
```

Confirm the changes at: http://localhost:8983/solr/#/search/files?file=schema.xml

Stop / remove everything. Run the standard documented docker steps:

```
docker compose -f docker-compose.yml -f docker-compose-cli.yml build
docker compose -p d7 up -d
```

You may need to use `docker-compose` rather than `docker compose` depending on how compose is installed.

Everything should be normal.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
