### PR TITLE
CST-8792 remove all thumbnails in force mode

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
@@ -315,25 +315,25 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
 
         // check if destination bitstream exists
         Bundle existingBundle = null;
-        Bitstream existingBitstream = null;
+        List<Bitstream> existingBitstreams = new ArrayList<Bitstream>();
         List<Bundle> bundles = itemService.getBundles(item, formatFilter.getBundleName());
 
         if (bundles.size() > 0) {
-            // only finds the last match (FIXME?)
+            // only finds the last matching bundle and all matching bitstreams in the proper bundle(s)
             for (Bundle bundle : bundles) {
                 List<Bitstream> bitstreams = bundle.getBitstreams();
 
                 for (Bitstream bitstream : bitstreams) {
                     if (bitstream.getName().trim().equals(newName.trim())) {
                         existingBundle = bundle;
-                        existingBitstream = bitstream;
+                        existingBitstreams.add(bitstream);
                     }
                 }
             }
         }
 
         // if exists and overwrite = false, exit
-        if (!overWrite && (existingBitstream != null)) {
+        if (!overWrite && (existingBitstreams.size() > 0)) {
             if (!isQuiet) {
                 logInfo("SKIPPED: bitstream " + source.getID()
                                        + " (item: " + item.getHandle() + ") because '" + newName + "' already exists");
@@ -408,9 +408,8 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
             logError("!!! OutOfMemoryError !!!");
         }
 
-        // fixme - set date?
         // we are overwriting, so remove old bitstream
-        if (existingBitstream != null) {
+        for (Bitstream existingBitstream : existingBitstreams) {
             bundleService.removeBitstream(context, existingBundle, existingBitstream);
         }
 


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/DSpace/issues/8683

## Description
The media-filter script only remove one existing thumbnail of bitstream with the force option.
In a normal scenario only one thumbnail of a bitstream should exists but this is not really enforced by the platform so it is possible to have multiple thumbnail if they were uploaded manually or generated via script that fails to verify that a such thumbnail already exist.
When institution migrate to DSpace 7 it could be appropriate to regenerate all the thumbnails to produce them in a different size more appropriate to the new layout.

We found an issue mainly due to mess/inconsistent data on an existing repository that have migrated through several versions so it would be impossible / ineconomic to investigate further the root cause that lead to the actual inconsinstency but would be easier to improve the media-filter script to remove all the thumbnails when executed with the force flag.

## Instructions for Reviewers
Upload multiple bitstream in the thumbnail bundle of an item naming them as appropriate (i.e <original bitstream name with extension>.jpg)
1. Run the media-filter script on this item with the -f flag
2. Without the patch only one thubmnail will be deleted and the new generated one will be added
3. With the patch all the thumbnails will be deleted and only the new generated one will be present

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
