### PR TITLE
[NOT FIXED] Deleting all the workflow groups too, when a collection is deleted.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
@@ -796,6 +796,28 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
             collection.setSubmitters(null);
             groupService.delete(context, g);
         }
+        
+        // Remove all workflow groups
+        g = collection.getWorkflowStep1(context);
+		if (g != null) {
+            collection.setWorkflowGroup(context, 1, null);
+            this.groupService.delete(context, g);
+        }
+        g = collection.getWorkflowStep2(context);
+        if (g != null) {
+            collection.setWorkflowGroup(context, 2, null);
+            this.groupService.delete(context, g);
+        }
+        g = collection.getWorkflowStep3(context);
+        if (g != null) {
+            collection.setWorkflowGroup(context, 3, null);
+            this.groupService.delete(context, g);
+        }
+        
+        for (final Community owningCommunity : collection.getCommunities()) {
+            collection.removeCommunity(owningCommunity);
+            owningCommunity.removeCollection(collection);
+        }
 
         Iterator<Community> owningCommunities = collection.getCommunities().iterator();
         while (owningCommunities.hasNext()) {


### PR DESCRIPTION
This pull request has been made to get my code reviewed. The code added in this pull request does not work as it should. 

## References
* Refereced to issue #8063

## Description
No new functions are created in this pull request.


## Instructions for Reviewers
When I am trying to fetch any collection's workflow group, I am getting a NULL value wherever the function `collection.getWorkflowStep1(context)` is called. 
I wish to understand what's wrong with my code and why it does not work. 


## Steps to reproduce 
* Merge the pull request in your local instance
* Create a new collection.
* Edit the collection and create all the workflow groups
* Delete the newly created collection.

I am getting NULL values on line 801, 806, 811. 
**NOTE** - Workflow groups are fetched using the same function `collection.getWorkflowStep1(context)` when edit collection page is shown in the UI but I am still getting NULL values on its use.

List of changes in this PR:
* Code to delete all workflow groups has been added in `CollectionServiceImpl.java`.


## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
