### PR TITLE
Calculate the correct maximum for access condition start and end dates

### DIFF
--- a/dspace-api/src/main/java/org/dspace/submit/model/AccessConditionOption.java
+++ b/dspace-api/src/main/java/org/dspace/submit/model/AccessConditionOption.java
@@ -11,6 +11,8 @@ import java.text.ParseException;
 import java.util.Date;
 import java.util.Objects;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.ResourcePolicy;
 import org.dspace.authorize.service.AuthorizeService;
@@ -21,6 +23,7 @@ import org.dspace.core.Context;
 import org.dspace.eperson.Group;
 import org.dspace.eperson.service.GroupService;
 import org.dspace.util.DateMathParser;
+import org.dspace.util.TimeHelpers;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -28,9 +31,8 @@ import org.springframework.beans.factory.annotation.Autowired;
  * set permission on a file. An option is defined by a name such as "open
  * access", "embargo", "restricted access", etc. and some optional attributes to
  * better clarify the constraints and input available to the user. For instance
- * an embargo option could allow to set a start date not longer than 3 years,
- * etc
- * 
+ * an embargo option could allow to set a start date not longer than 3 years.
+ *
  * @author Luigi Andrea Pascarelli (luigiandrea.pascarelli at 4science.it)
  */
 public class AccessConditionOption {
@@ -44,9 +46,9 @@ public class AccessConditionOption {
     @Autowired
     private ResourcePolicyService resourcePolicyService;
 
-    DateMathParser dateMathParser = new DateMathParser();
+    private static final Logger LOG = LogManager.getLogger();
 
-    /** An unique name identifying the access contion option **/
+    /** A unique name identifying the access condition option. **/
     private String name;
 
     /**
@@ -147,6 +149,9 @@ public class AccessConditionOption {
      *                  startDate should be null. Otherwise startDate may not be null.
      * @param endDate end date of the resource policy. If {@link #getHasEndDate()} returns false,
      *                endDate should be null. Otherwise endDate may not be null.
+     * @throws SQLException passed through.
+     * @throws AuthorizeException passed through.
+     * @throws ParseException passed through (indicates problem with a date).
      */
     public void createResourcePolicy(Context context, DSpaceObject obj, String name, String description,
                                      Date startDate, Date endDate)
@@ -160,7 +165,7 @@ public class AccessConditionOption {
 
     /**
      * Validate ResourcePolicy and after update it
-     * 
+     *
      * @param context               DSpace context
      * @param resourcePolicy        ResourcePolicy to update
      * @throws SQLException         If database error
@@ -175,17 +180,25 @@ public class AccessConditionOption {
     }
 
     /**
-     * Validate the policy properties, throws exceptions if any is not valid
-     * 
-     * @param context                DSpace context
-     * @param name                   Name of the resource policy
-     * @param startDate              Start date of the resource policy. If {@link #getHasStartDate()}
-     *                                    returns false, startDate should be null. Otherwise startDate may not be null.
-     * @param endDate                End date of the resource policy. If {@link #getHasEndDate()}
-     *                                    returns false, endDate should be null. Otherwise endDate may not be null.
+     * Validate the policy properties, throws exceptions if any is not valid.
+     *
+     * @param context   DSpace context.
+     * @param name      Name of the resource policy.
+     * @param startDate Start date of the resource policy. If
+     *                  {@link #getHasStartDate()} returns false, startDate
+     *                  should be null. Otherwise startDate may not be null.
+     * @param endDate   End date of the resource policy. If
+     *                  {@link #getHasEndDate()} returns false, endDate should
+     *                  be null. Otherwise endDate may not be null.
+     * @throws IllegalStateException if a date is required and absent,
+     *              a date is not required and present, or a date exceeds its
+     *              configured maximum.
+     * @throws ParseException passed through.
      */
     private void validateResourcePolicy(Context context, String name, Date startDate, Date endDate)
-           throws SQLException, AuthorizeException, ParseException {
+           throws IllegalStateException, ParseException {
+        LOG.debug("Validate policy dates:  name '{}', startDate {}, endDate {}",
+                name, startDate, endDate);
         if (getHasStartDate() && Objects.isNull(startDate)) {
             throw new IllegalStateException("The access condition " + getName() + " requires a start date.");
         }
@@ -199,29 +212,33 @@ public class AccessConditionOption {
             throw new IllegalStateException("The access condition " + getName() + " cannot contain an end date.");
         }
 
+        DateMathParser dateMathParser = new DateMathParser();
+
         Date latestStartDate = null;
         if (Objects.nonNull(getStartDateLimit())) {
-            latestStartDate = dateMathParser.parseMath(getStartDateLimit());
+            latestStartDate = TimeHelpers.toMidnightUTC(dateMathParser.parseMath(getStartDateLimit()));
         }
 
         Date latestEndDate = null;
         if (Objects.nonNull(getEndDateLimit())) {
-            latestEndDate = dateMathParser.parseMath(getEndDateLimit());
+            latestEndDate = TimeHelpers.toMidnightUTC(dateMathParser.parseMath(getEndDateLimit()));
         }
 
+        LOG.debug("  latestStartDate {}, latestEndDate {}",
+                latestStartDate, latestEndDate);
         // throw if startDate after latestStartDate
         if (Objects.nonNull(startDate) && Objects.nonNull(latestStartDate) && startDate.after(latestStartDate)) {
             throw new IllegalStateException(String.format(
-                "The start date of access condition %s should be earlier than %s from now.",
-                getName(), getStartDateLimit()
+                "The start date of access condition %s should be earlier than %s from now (%s).",
+                getName(), getStartDateLimit(), dateMathParser.getNow()
             ));
         }
 
         // throw if endDate after latestEndDate
         if (Objects.nonNull(endDate) && Objects.nonNull(latestEndDate)  && endDate.after(latestEndDate)) {
             throw new IllegalStateException(String.format(
-                "The end date of access condition %s should be earlier than %s from now.",
-                getName(), getEndDateLimit()
+                "The end date of access condition %s should be earlier than %s from now (%s).",
+                getName(), getEndDateLimit(), dateMathParser.getNow()
             ));
         }
     }

--- a/dspace-api/src/main/java/org/dspace/util/TimeHelpers.java
+++ b/dspace-api/src/main/java/org/dspace/util/TimeHelpers.java
@@ -1,0 +1,42 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.util;
+
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
+
+/**
+ * Various manipulations of dates and times.
+ *
+ * @author mwood
+ */
+public class TimeHelpers {
+    private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
+
+    /**
+     * Never instantiate this class.
+     */
+    private TimeHelpers() {}
+
+    /**
+     * Set a Date's time to midnight UTC.
+     *
+     * @param from some date-time.
+     * @return midnight UTC of the supplied date-time.
+     */
+    public static Date toMidnightUTC(Date from) {
+        GregorianCalendar calendar = new GregorianCalendar(UTC);
+        calendar.setTime(from);
+        calendar.set(GregorianCalendar.HOUR_OF_DAY, 0);
+        calendar.set(GregorianCalendar.MINUTE, 0);
+        calendar.set(GregorianCalendar.SECOND, 0);
+        calendar.set(GregorianCalendar.MILLISECOND, 0);
+        return calendar.getTime();
+    }
+}

--- a/dspace-api/src/test/java/org/dspace/util/TimeHelpersTest.java
+++ b/dspace-api/src/test/java/org/dspace/util/TimeHelpersTest.java
@@ -1,0 +1,34 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.util;
+
+import static org.junit.Assert.assertEquals;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Date;
+
+import org.junit.Test;
+
+/**
+ * Test {@link TimeHelpers}.
+ * @author Mark H. Wood <mwood@iupui.edu>
+ */
+public class TimeHelpersTest {
+    /**
+     * Test of toMidnightUTC method, of class TimeHelpers.
+     */
+    @Test
+    public void testToMidnightUTC() {
+        System.out.println("toMidnightUTC");
+        Date from = Date.from(ZonedDateTime.of(1957, 01, 27, 04, 05, 06, 007, ZoneOffset.UTC).toInstant());
+        Date expResult = Date.from(ZonedDateTime.of(1957, 01, 27, 00, 00, 00, 000, ZoneOffset.UTC).toInstant());
+        Date result = TimeHelpers.toMidnightUTC(from);
+        assertEquals(expResult, result);
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionAccessOptionConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionAccessOptionConverter.java
@@ -6,7 +6,9 @@
  * http://www.dspace.org/license/
  */
 package org.dspace.app.rest.converter;
+
 import java.text.ParseException;
+import java.util.Date;
 
 import org.apache.commons.lang3.StringUtils;
 import org.dspace.app.rest.model.AccessConditionOptionRest;
@@ -15,6 +17,7 @@ import org.dspace.app.rest.projection.Projection;
 import org.dspace.submit.model.AccessConditionConfiguration;
 import org.dspace.submit.model.AccessConditionOption;
 import org.dspace.util.DateMathParser;
+import org.dspace.util.TimeHelpers;
 import org.springframework.stereotype.Component;
 
 /**
@@ -27,21 +30,21 @@ import org.springframework.stereotype.Component;
 public class SubmissionAccessOptionConverter
         implements DSpaceConverter<AccessConditionConfiguration, SubmissionAccessOptionRest> {
 
-    DateMathParser dateMathParser = new DateMathParser();
-
     @Override
     public SubmissionAccessOptionRest convert(AccessConditionConfiguration config, Projection projection) {
         SubmissionAccessOptionRest model = new SubmissionAccessOptionRest();
         model.setId(config.getName());
         model.setCanChangeDiscoverable(config.getCanChangeDiscoverable());
         model.setProjection(projection);
+        DateMathParser dateMathParser = new DateMathParser();
         for (AccessConditionOption option : config.getOptions()) {
             AccessConditionOptionRest optionRest = new AccessConditionOptionRest();
             optionRest.setHasStartDate(option.getHasStartDate());
             optionRest.setHasEndDate(option.getHasEndDate());
             if (StringUtils.isNotBlank(option.getStartDateLimit())) {
                 try {
-                    optionRest.setMaxStartDate(dateMathParser.parseMath(option.getStartDateLimit()));
+                    Date requested = dateMathParser.parseMath(option.getStartDateLimit());
+                    optionRest.setMaxStartDate(TimeHelpers.toMidnightUTC(requested));
                 } catch (ParseException e) {
                     throw new IllegalStateException("Wrong start date limit configuration for the access condition "
                             + "option named  " + option.getName());
@@ -49,7 +52,8 @@ public class SubmissionAccessOptionConverter
             }
             if (StringUtils.isNotBlank(option.getEndDateLimit())) {
                 try {
-                    optionRest.setMaxEndDate(dateMathParser.parseMath(option.getEndDateLimit()));
+                    Date requested = dateMathParser.parseMath(option.getEndDateLimit());
+                    optionRest.setMaxEndDate(TimeHelpers.toMidnightUTC(requested));
                 } catch (ParseException e) {
                     throw new IllegalStateException("Wrong end date limit configuration for the access condition "
                             + "option named  " + option.getName());

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/AccessConditionAddPatchOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/AccessConditionAddPatchOperation.java
@@ -10,6 +10,7 @@ package org.dspace.app.rest.submit.factory.impl;
 import java.sql.SQLException;
 import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 
@@ -56,8 +57,14 @@ public class AccessConditionAddPatchOperation extends AddPatchOperation<AccessCo
 
         // Clamp access condition dates to midnight UTC
         for (AccessConditionDTO condition : accessConditions) {
-            condition.setStartDate(TimeHelpers.toMidnightUTC(condition.getStartDate()));
-            condition.setEndDate(TimeHelpers.toMidnightUTC(condition.getEndDate()));
+            Date date = condition.getStartDate();
+            if (null != date) {
+                condition.setStartDate(TimeHelpers.toMidnightUTC(date));
+            }
+            date = condition.getEndDate();
+            if (null != date) {
+                condition.setEndDate(TimeHelpers.toMidnightUTC(date));
+            }
         }
 
         verifyAccessConditions(context, configuration, accessConditions);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/AccessConditionAddPatchOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/AccessConditionAddPatchOperation.java
@@ -6,6 +6,7 @@
  * http://www.dspace.org/license/
  */
 package org.dspace.app.rest.submit.factory.impl;
+
 import java.sql.SQLException;
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -23,11 +24,12 @@ import org.dspace.content.Item;
 import org.dspace.core.Context;
 import org.dspace.submit.model.AccessConditionConfiguration;
 import org.dspace.submit.model.AccessConditionConfigurationService;
+import org.dspace.util.TimeHelpers;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * Submission "add" operation to add custom resource policies.
- * 
+ *
  * @author Mykhaylo Boychuk (mykhaylo.boychuk at 4science.com)
  */
 public class AccessConditionAddPatchOperation extends AddPatchOperation<AccessConditionDTO> {
@@ -52,6 +54,12 @@ public class AccessConditionAddPatchOperation extends AddPatchOperation<AccessCo
         String[] absolutePath = getAbsolutePath(path).split("/");
         List<AccessConditionDTO> accessConditions = parseAccessConditions(path, value, absolutePath);
 
+        // Clamp access condition dates to midnight UTC
+        for (AccessConditionDTO condition : accessConditions) {
+            condition.setStartDate(TimeHelpers.toMidnightUTC(condition.getStartDate()));
+            condition.setEndDate(TimeHelpers.toMidnightUTC(condition.getEndDate()));
+        }
+
         verifyAccessConditions(context, configuration, accessConditions);
 
         if (absolutePath.length == 1) {
@@ -65,7 +73,7 @@ public class AccessConditionAddPatchOperation extends AddPatchOperation<AccessCo
     }
 
     private List<AccessConditionDTO> parseAccessConditions(String path, Object value, String[] split) {
-        List<AccessConditionDTO> accessConditions = new ArrayList<AccessConditionDTO>();
+        List<AccessConditionDTO> accessConditions = new ArrayList<>();
         if (split.length == 1) {
             accessConditions = evaluateArrayObject((LateObjectEvaluator) value);
         } else if (split.length == 2) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/AccessConditionReplacePatchOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/AccessConditionReplacePatchOperation.java
@@ -6,6 +6,7 @@
  * http://www.dspace.org/license/
  */
 package org.dspace.app.rest.submit.factory.impl;
+
 import java.sql.SQLException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -29,6 +30,7 @@ import org.dspace.core.Context;
 import org.dspace.submit.model.AccessConditionConfiguration;
 import org.dspace.submit.model.AccessConditionConfigurationService;
 import org.dspace.submit.model.AccessConditionOption;
+import org.dspace.util.TimeHelpers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -106,7 +108,7 @@ public class AccessConditionReplacePatchOperation extends ReplacePatchOperation<
         return null;
     }
 
-    private AccessConditionDTO createDTO(ResourcePolicy rpToReplace, String attributeReplace, String valueToReplare)
+    private AccessConditionDTO createDTO(ResourcePolicy rpToReplace, String attributeReplace, String valueToReplace)
             throws ParseException {
         AccessConditionDTO accessCondition = new AccessConditionDTO();
         accessCondition.setName(rpToReplace.getRpName());
@@ -114,13 +116,13 @@ public class AccessConditionReplacePatchOperation extends ReplacePatchOperation<
         accessCondition.setEndDate(rpToReplace.getEndDate());
         switch (attributeReplace) {
             case "name":
-                accessCondition.setName(valueToReplare);
+                accessCondition.setName(valueToReplace);
                 return accessCondition;
             case "startDate":
-                accessCondition.setStartDate(parseDate(valueToReplare));
+                accessCondition.setStartDate(TimeHelpers.toMidnightUTC(parseDate(valueToReplace)));
                 return accessCondition;
             case "endDate":
-                accessCondition.setEndDate(parseDate(valueToReplare));
+                accessCondition.setEndDate(TimeHelpers.toMidnightUTC(parseDate(valueToReplace)));
                 return accessCondition;
             default:
                 throw new UnprocessableEntityException("The provided attribute: "
@@ -128,17 +130,17 @@ public class AccessConditionReplacePatchOperation extends ReplacePatchOperation<
         }
     }
 
-    private void updatePolicy(Context context, String valueToReplare, String attributeReplace,
+    private void updatePolicy(Context context, String valueToReplace, String attributeReplace,
             ResourcePolicy rpToReplace) throws SQLException, AuthorizeException {
         switch (attributeReplace) {
             case "name":
-                rpToReplace.setRpName(valueToReplare);
+                rpToReplace.setRpName(valueToReplace);
                 break;
             case "startDate":
-                rpToReplace.setStartDate(parseDate(valueToReplare));
+                rpToReplace.setStartDate(TimeHelpers.toMidnightUTC(parseDate(valueToReplace)));
                 break;
             case "endDate":
-                rpToReplace.setEndDate(parseDate(valueToReplare));
+                rpToReplace.setEndDate(TimeHelpers.toMidnightUTC(parseDate(valueToReplace)));
                 break;
             default:
                 throw new IllegalArgumentException("Attribute to replace is not valid:" + attributeReplace);


### PR DESCRIPTION
We had a strange intermittent problem in 7.4 with setting an embargo on the last date of the permitted range.  Debug logging showed that:
1. The backend was supplying peculiar maximum start dates in the middle of a seemingly random hour, perhaps several days too early.
1. Some of the datetimes being passed back and forth were off by several hours.

Problem 1 was traced to several classes' use of instance variables to hold DateMathParser.  These instances are created at startup time, and DateMathParser captures the current time when instantiated, so the DSpace startup time was always used as "now" when calculating maximum start and end times.

Problem 2 appears to be fixed in dspace-angular 7.5.  However, dspace-server-webapp should be less trusting of the front-end, which might not always *be* dspace-angular.  I've kept the truncation of dates to midnight UTC as was implemented in our local fix for 7.4.  There will be a related patch that makes the front-end less trusting of the back-end.

## References
* Related to DSpace/RestContract#`pr-number`  (if a corresponding REST Contract PR exists)

## Description
Calculate the maximum start and end dates for a ResourcePolicy based on the current time, not startup time, and truncate to midnight UTC.

## Instructions for Reviewers
List of changes in this PR:
* Move DateMathParser from instance variables to locals, so "now" is current time not startup time.
* Clamp access condition dates to midnight UTC.
* Add a lot of debug logging and a test main().

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
