### PR TITLE
Off-by-one in solr-upgrade-statistics-6x #8706

### DIFF
--- a/dspace-api/src/main/java/org/dspace/util/SolrUpgradePre6xStatistics.java
+++ b/dspace-api/src/main/java/org/dspace/util/SolrUpgradePre6xStatistics.java
@@ -447,7 +447,7 @@ public class SolrUpgradePre6xStatistics {
         runReport();
         logTime(false);
         for (int processed = updateRecords(MIGQUERY); (processed != 0)
-                && (numProcessed < numRec); processed = updateRecords(MIGQUERY)) {
+                && (numProcessed <= numRec); processed = updateRecords(MIGQUERY)) {
             printTime(numProcessed, false);
             batchUpdateStats();
             if (context.getCacheSize() > CACHE_LIMIT) {


### PR DESCRIPTION
## References
* Fixes #8706 

## Description
Fixes off-by-one bug where the total size to process is an even multiple of the batch size, where it would not commit the last batch.

## Instructions for Reviewers
Steps to reproduce the behavior:

1. Have a statistics core with over 100 items with legacy ids left to migrate
2. /dspace/bin/dspace solr-upgrade-statistics-6x -n 100 -b 10
3. 90 items will have changed in Solr and the TOTAL report will show 90 only fewer legacy items.

With this change, it will commit the last batch will commit and 100 items will be migrated.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
