### PR TITLE
Update Spring & Spring Boot versions

### DIFF
--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -6473,7 +6473,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                    .andExpect(jsonPath("$.facetType", equalTo("authority")))
                    //There always needs to be a self link available
                    .andExpect(jsonPath("$._links.self.href",
-                       containsString("api/discover/facets/supervisedBy?prefix=group%2520B&configuration=supervision")))
+                       containsString("api/discover/facets/supervisedBy?prefix=group%20B&configuration=supervision")))
                    //This is how the page object must look like because it's the default with size 20
                    .andExpect(jsonPath("$.page",
                        is(PageMatcher.pageEntry(0, 20))))

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,8 @@
     <properties>
         <!--=== GENERAL / DSPACE-API DEPENDENCIES ===-->
         <java.version>11</java.version>
-        <spring.version>5.3.25</spring.version>
-        <spring-boot.version>2.7.9</spring-boot.version>
+        <spring.version>5.3.26</spring.version>
+        <spring-boot.version>2.7.10</spring-boot.version>
         <spring-security.version>5.7.7</spring-security.version> <!-- sync with version used by spring-boot-->
         <hibernate.version>5.6.5.Final</hibernate.version>
         <hibernate-validator.version>6.0.23.Final</hibernate-validator.version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,9 @@
     <properties>
         <!--=== GENERAL / DSPACE-API DEPENDENCIES ===-->
         <java.version>11</java.version>
-        <spring.version>5.3.20</spring.version>
-        <spring-boot.version>2.6.8</spring-boot.version>
-        <spring-security.version>5.6.5</spring-security.version> <!-- sync with version used by spring-boot-->
+        <spring.version>5.3.25</spring.version>
+        <spring-boot.version>2.7.9</spring-boot.version>
+        <spring-security.version>5.7.7</spring-security.version> <!-- sync with version used by spring-boot-->
         <hibernate.version>5.6.5.Final</hibernate.version>
         <hibernate-validator.version>6.0.23.Final</hibernate-validator.version>
         <postgresql.driver.version>42.4.3</postgresql.driver.version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,9 @@
     <properties>
         <!--=== GENERAL / DSPACE-API DEPENDENCIES ===-->
         <java.version>11</java.version>
-        <spring.version>5.3.26</spring.version>
-        <spring-boot.version>2.7.10</spring-boot.version>
-        <spring-security.version>5.7.7</spring-security.version> <!-- sync with version used by spring-boot-->
+        <spring.version>5.3.27</spring.version>
+        <spring-boot.version>2.7.11</spring-boot.version>
+        <spring-security.version>5.7.8</spring-security.version> <!-- sync with version used by spring-boot-->
         <hibernate.version>5.6.5.Final</hibernate.version>
         <hibernate-validator.version>6.0.23.Final</hibernate-validator.version>
         <postgresql.driver.version>42.4.3</postgresql.driver.version>


### PR DESCRIPTION
* Fixes #8333
* Patches CVE-2023-20861 and CVE-2023-20863 by updating to latest Spring / Spring Boot version.

## Description
This small PR simply updates us to the latest version of Spring Boot v2 (along with corresponding versions of Spring + Spring Security).  This just ensures we are keeping up-to-date with Spring fixes (especially security fixes).

Other minor changes:
*  I've found this minor upgrade **also** fixes #8333  It appears this double-encoding issue was a bug in Spring Boot itself, and it's no longer reproducible after this upgrade.  This is why `DiscoveryRestControllerIT` requires a minor update to no longer check for a double-encoded self link.

## Instructions for Reviewers
* Review code changes
* Ensure tests succeed
* Spin up and give the backend & UI a test to verify no behavior changes.  (I've already done this myself and have found no adverse affects... all these upgrades are minor)
    * Verify that #8333 is no longer reproducible (Attempt to reproduce the example given in that PR)