### PR TITLE
Fix #8714 and #8715

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/IndexClient.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexClient.java
@@ -56,37 +56,18 @@ public class IndexClient extends DSpaceRunnable<IndexDiscoveryScriptConfiguratio
          * new DSpace.getServiceManager().getServiceByName("org.dspace.discovery.SolrIndexer");
          */
 
-        if (indexClientOptions == IndexClientOptions.REMOVE) {
-            handler.logInfo("Removing " + commandLine.getOptionValue("r") + " from Index");
-            indexer.unIndexContent(context, commandLine.getOptionValue("r"));
-        } else if (indexClientOptions == IndexClientOptions.CLEAN) {
-            handler.logInfo("Cleaning Index");
-            indexer.cleanIndex();
-        } else if (indexClientOptions == IndexClientOptions.DELETE) {
-            handler.logInfo("Deleting Index");
-            indexer.deleteIndex();
-        } else if (indexClientOptions == IndexClientOptions.BUILD ||
-            indexClientOptions == IndexClientOptions.BUILDANDSPELLCHECK) {
-            handler.logInfo("(Re)building index from scratch.");
-            indexer.deleteIndex();
-            indexer.createIndex(context);
-            if (indexClientOptions == IndexClientOptions.BUILDANDSPELLCHECK) {
-                checkRebuildSpellCheck(commandLine, indexer);
-            }
-        } else if (indexClientOptions == IndexClientOptions.OPTIMIZE) {
-            handler.logInfo("Optimizing search core.");
-            indexer.optimize();
-        } else if (indexClientOptions == IndexClientOptions.SPELLCHECK) {
-            checkRebuildSpellCheck(commandLine, indexer);
-        } else if (indexClientOptions == IndexClientOptions.INDEX) {
-            final String param = commandLine.getOptionValue('i');
+        Optional<IndexableObject> indexableObject = Optional.empty();
+
+        if (indexClientOptions == IndexClientOptions.REMOVE || indexClientOptions == IndexClientOptions.INDEX) {
+            final String param = indexClientOptions == IndexClientOptions.REMOVE ? commandLine.getOptionValue('r') :
+                    commandLine.getOptionValue('i');
             UUID uuid = null;
             try {
                 uuid = UUID.fromString(param);
             } catch (Exception e) {
-                // nothing to do, it should be an handle
+                // nothing to do, it should be a handle
             }
-            Optional<IndexableObject> indexableObject = Optional.empty();
+
             if (uuid != null) {
                 final Item item = ContentServiceFactory.getInstance().getItemService().find(context, uuid);
                 if (item != null) {
@@ -118,7 +99,32 @@ public class IndexClient extends DSpaceRunnable<IndexDiscoveryScriptConfiguratio
             if (!indexableObject.isPresent()) {
                 throw new IllegalArgumentException("Cannot resolve " + param + " to a DSpace object");
             }
-            handler.logInfo("Indexing " + param + " force " + commandLine.hasOption("f"));
+        }
+
+        if (indexClientOptions == IndexClientOptions.REMOVE) {
+            handler.logInfo("Removing " + commandLine.getOptionValue("r") + " from Index");
+            indexer.unIndexContent(context, indexableObject.get().getUniqueIndexID());
+        } else if (indexClientOptions == IndexClientOptions.CLEAN) {
+            handler.logInfo("Cleaning Index");
+            indexer.cleanIndex();
+        } else if (indexClientOptions == IndexClientOptions.DELETE) {
+            handler.logInfo("Deleting Index");
+            indexer.deleteIndex();
+        } else if (indexClientOptions == IndexClientOptions.BUILD ||
+            indexClientOptions == IndexClientOptions.BUILDANDSPELLCHECK) {
+            handler.logInfo("(Re)building index from scratch.");
+            indexer.deleteIndex();
+            indexer.createIndex(context);
+            if (indexClientOptions == IndexClientOptions.BUILDANDSPELLCHECK) {
+                checkRebuildSpellCheck(commandLine, indexer);
+            }
+        } else if (indexClientOptions == IndexClientOptions.OPTIMIZE) {
+            handler.logInfo("Optimizing search core.");
+            indexer.optimize();
+        } else if (indexClientOptions == IndexClientOptions.SPELLCHECK) {
+            checkRebuildSpellCheck(commandLine, indexer);
+        } else if (indexClientOptions == IndexClientOptions.INDEX) {
+            handler.logInfo("Indexing " + commandLine.getOptionValue('i') + " force " + commandLine.hasOption("f"));
             final long startTimeMillis = System.currentTimeMillis();
             final long count = indexAll(indexer, ContentServiceFactory.getInstance().
                     getItemService(), context, indexableObject.get());
@@ -179,7 +185,7 @@ public class IndexClient extends DSpaceRunnable<IndexDiscoveryScriptConfiguratio
         indexingService.indexContent(context, dso, true, true);
         count++;
         if (dso.getIndexedObject() instanceof Community) {
-            final Community community = (Community) dso;
+            final Community community = (Community) dso.getIndexedObject();
             final String communityHandle = community.getHandle();
             for (final Community subcommunity : community.getSubcommunities()) {
                 count += indexAll(indexingService, itemService, context, new IndexableCommunity(subcommunity));

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexingUtils.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexingUtils.java
@@ -107,6 +107,10 @@ public class IndexingUtils {
         ArrayList<String> prefixedIds = new ArrayList<>();
         for (int auth : authorizations) {
             for (ResourcePolicy policy : authService.getPoliciesActionFilter(context, obj, auth)) {
+                // Avoid NPE in cases where the policy does not have group or eperson
+                if (policy.getGroup() == null && policy.getEPerson() == null) {
+                    continue;
+                }
                 String prefixedId = policy.getGroup() == null
                     ? "e" + policy.getEPerson().getID()
                     : "g" + policy.getGroup().getID();

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -256,7 +256,12 @@ public class SolrServiceImpl implements SearchService, IndexingService {
 
         try {
             if (solrSearchCore.getSolr() != null) {
-                indexObjectServiceFactory.getIndexableObjectFactory(searchUniqueID).delete(searchUniqueID);
+                IndexFactory index = indexObjectServiceFactory.getIndexableObjectFactory(searchUniqueID);
+                if (index != null) {
+                    index.delete(searchUniqueID);
+                } else {
+                    log.warn("Object not found in Solr index: " + searchUniqueID);
+                }
                 if (commit) {
                     solrSearchCore.getSolr().commit();
                 }


### PR DESCRIPTION
## References
Fixes #8714 and Fixes #8715 

## Description
Fixes IndexClient class so that index-discovery command with -r and -i options on individual communities work as expected. It also fixes a potential NPE in IndexingUtils.java class when policies with null eperson and egroup exist thus causing for the index-discovery command to fail.

List of changes in this PR:
* Refactored internalRun method in IndexClient.java so that the indexableObject is extracted for both the -i and -r options, and the relevant identifier is used for the community in the unIndex method (e.g. **Community-**UUID)
* indexAll method one attempts a Community cast using the correct object, i.e. (Community) dso.**getIndexedObject()**;

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [X] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
