### PR TITLE
Update bitstream format registry

### DIFF
--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V7.6_2023.03.24__Update_PNG_in_bitstream_format_registry.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V7.6_2023.03.24__Update_PNG_in_bitstream_format_registry.sql
@@ -1,0 +1,17 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+-----------------------------------------------------------------------------------
+-- Update short description for PNG mimetype in the bitstream format registry
+-- See: https://github.com/DSpace/DSpace/pull/8722
+-----------------------------------------------------------------------------------
+
+UPDATE bitstreamformatregistry
+SET short_description='PNG'
+WHERE short_description='image/png'
+  AND mimetype='image/png';

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/V7.6_2023.03.24__Update_PNG_in_bitstream_format_registry.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/V7.6_2023.03.24__Update_PNG_in_bitstream_format_registry.sql
@@ -1,0 +1,17 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+-----------------------------------------------------------------------------------
+-- Update short description for PNG mimetype in the bitstream format registry
+-- See: https://github.com/DSpace/DSpace/pull/8722
+-----------------------------------------------------------------------------------
+
+UPDATE bitstreamformatregistry
+SET short_description='PNG'
+WHERE short_description='image/png'
+  AND mimetype='image/png';

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.6_2023.03.24__Update_PNG_in_bitstream_format_registry.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.6_2023.03.24__Update_PNG_in_bitstream_format_registry.sql
@@ -1,0 +1,17 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+-----------------------------------------------------------------------------------
+-- Update short description for PNG mimetype in the bitstream format registry
+-- See: https://github.com/DSpace/DSpace/pull/8722
+-----------------------------------------------------------------------------------
+
+UPDATE bitstreamformatregistry
+SET short_description='PNG'
+WHERE short_description='image/png'
+  AND mimetype='image/png';

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamFormatRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamFormatRestRepositoryIT.java
@@ -56,7 +56,7 @@ public class BitstreamFormatRestRepositoryIT extends AbstractControllerIntegrati
     @Autowired
     private BitstreamFormatConverter bitstreamFormatConverter;
 
-    private final int DEFAULT_AMOUNT_FORMATS = 82;
+    private final int DEFAULT_AMOUNT_FORMATS = 84;
 
     @Test
     public void findAllPaginationTest() throws Exception {

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -492,9 +492,9 @@ filter.org.dspace.app.mediafilter.TikaTextExtractionFilter.inputFormats = OpenDo
 filter.org.dspace.app.mediafilter.TikaTextExtractionFilter.inputFormats = OpenDocument Text
 filter.org.dspace.app.mediafilter.TikaTextExtractionFilter.inputFormats = RTF
 filter.org.dspace.app.mediafilter.TikaTextExtractionFilter.inputFormats = Text
-filter.org.dspace.app.mediafilter.JPEGFilter.inputFormats = BMP, GIF, JPEG, image/png
-filter.org.dspace.app.mediafilter.BrandedPreviewJPEGFilter.inputFormats = BMP, GIF, JPEG, image/png
-filter.org.dspace.app.mediafilter.ImageMagickImageThumbnailFilter.inputFormats = BMP, GIF, image/png, JPG, TIFF, JPEG, JPEG 2000
+filter.org.dspace.app.mediafilter.JPEGFilter.inputFormats = BMP, GIF, JPEG, PNG
+filter.org.dspace.app.mediafilter.BrandedPreviewJPEGFilter.inputFormats = BMP, GIF, JPEG, PNG
+filter.org.dspace.app.mediafilter.ImageMagickImageThumbnailFilter.inputFormats = BMP, GIF, PNG, JPG, TIFF, JPEG, JPEG 2000
 filter.org.dspace.app.mediafilter.ImageMagickPdfThumbnailFilter.inputFormats = Adobe PDF
 filter.org.dspace.app.mediafilter.PDFBoxThumbnail.inputFormats = Adobe PDF
 

--- a/dspace/config/registries/bitstream-formats.xml
+++ b/dspace/config/registries/bitstream-formats.xml
@@ -201,7 +201,7 @@
 
   <bitstream-type>
     <mimetype>image/png</mimetype>
-    <short_description>image/png</short_description>
+    <short_description>PNG</short_description>
     <description>Portable Network Graphics</description>
     <support_level>1</support_level>
     <internal>false</internal>

--- a/dspace/config/registries/bitstream-formats.xml
+++ b/dspace/config/registries/bitstream-formats.xml
@@ -800,4 +800,22 @@
         <extension>mp3</extension>
     </bitstream-type>
 
+    <bitstream-type>
+        <mimetype>image/webp</mimetype>
+        <short_description>WebP</short_description>
+        <description>WebP is a modern image format that provides superior lossless and lossy compression for images on the web.</description>
+        <support_level>1</support_level>
+        <internal>false</internal>
+        <extension>webp</extension>
+    </bitstream-type>
+
+    <bitstream-type>
+        <mimetype>image/avif</mimetype>
+        <short_description>AVIF</short_description>
+        <description>AV1 Image File Format (AVIF) is an open, royalty-free image file format specification for storing images or image sequences compressed with AV1 in the HEIF container format.</description>
+        <support_level>1</support_level>
+        <internal>false</internal>
+        <extension>avif</extension>
+    </bitstream-type>
+
 </dspace-bitstream-types>


### PR DESCRIPTION
## Description
The DSpace bitstream format registry has not been updated with new image formats in several years, despite new image formats like WebP and AVIF gaining traction on the web. Also, the short description for the PNG format is erroneously `image/png`, which is its mime type, not its human-readable description.

This opens up the door to supporting this image formats more widely in DSpace.

List of changes in this PR:
* Change short description for PNG from "image/png" to "PNG" and update `dspace.cfg` to match
* Add WebP and AVIF image formats

## References:

- [Comparing image formats. JPEG vs WebP vs AVIF (2020)](https://fronius.me/articles/2020-10-14-comparing-image-formats-jpg-webp-avif.html)
- [Comparing AVIF vs WebP file sizes at the same DSSIM (2020)](https://www.ctrl.blog/entry/webp-avif-comparison.html)
- [Using Modern Image Formats: AVIF And WebP (2021)](https://www.smashingmagazine.com/2021/09/modern-image-formats-avif-webp/)