### PR TITLE
Added WebVTT to default supported bitstream formats

### DIFF
--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamFormatRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamFormatRestRepositoryIT.java
@@ -56,7 +56,7 @@ public class BitstreamFormatRestRepositoryIT extends AbstractControllerIntegrati
     @Autowired
     private BitstreamFormatConverter bitstreamFormatConverter;
 
-    private final int DEFAULT_AMOUNT_FORMATS = 84;
+    private final int DEFAULT_AMOUNT_FORMATS = 85;
 
     @Test
     public void findAllPaginationTest() throws Exception {

--- a/dspace/config/registries/bitstream-formats.xml
+++ b/dspace/config/registries/bitstream-formats.xml
@@ -116,6 +116,15 @@
   </bitstream-type>
 
   <bitstream-type>
+    <mimetype>text/vtt</mimetype>
+    <short_description>WebVTT</short_description>
+    <description>Web Video Text Tracks Format</description>
+    <support_level>1</support_level>
+    <internal>false</internal>
+    <extension>vtt</extension>
+  </bitstream-type>
+
+  <bitstream-type>
     <mimetype>application/msword</mimetype>
     <short_description>Microsoft Word</short_description>
     <description>Microsoft Word</description>


### PR DESCRIPTION
## References
* Related to DSpace/dspace-angular#2156

## Description
While working on PR [2156](https://github.com/DSpace/dspace-angular/pull/2156) I saw that the WebVTT bitstream type was not listed in the default bitstreams format.

## Instructions for Reviewers

List of changes in this PR:
* Added the WebVTT bitstream type.

**Guidance for how to test or review this PR:**
- Create a new DB and run the migrations
- Check that when you upload a new `*.vtt` bitstream the WebVTT format is selected by default

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).