### PR TITLE
[DURACOM-128] Unable to delete a profile

### DIFF
--- a/dspace-api/src/main/java/org/dspace/identifier/doi/DOIConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/doi/DOIConsumer.java
@@ -141,7 +141,6 @@ public class DOIConsumer implements Consumer {
                             + item.getID() + " and DOI " + doi + ".", ex);
                 }
             }
-            ctx.commit();
         }
     }
 


### PR DESCRIPTION
### References
Fixes #8749

### Description
Unable to delete profile, endless loading appears instead.
Look at #8749 for step by step guide to reproduce the issue.
From the stack trace (you can find it in #8749) we can see that DOIConsumer was recursively spawning another event.

Explicitly calling a ctx.commit() will call a new dispatcher that will go through all the consumers again. At some point a consumer may appear which can generate new events, and the system will go into a loop.