### PR TITLE
Added input validation for new metadata field submissions & fixed some other bugs related to metadata fields

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/indexobject/MetadataFieldIndexFactoryImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/indexobject/MetadataFieldIndexFactoryImpl.java
@@ -64,6 +64,7 @@ public class MetadataFieldIndexFactoryImpl extends IndexFactoryImpl<IndexableMet
         Group anonymousGroup = groupService.findByName(context, Group.ANONYMOUS);
         // add read permission on doc for anonymous group
         doc.addField("read", "g" + anonymousGroup.getID());
+        doc.addField(FIELD_NAME_VARIATIONS + "_sort", fieldName);
         return doc;
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataFieldRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataFieldRestRepository.java
@@ -210,6 +210,7 @@ public class MetadataFieldRestRepository extends DSpaceRestRepository<MetadataFi
 
         DiscoverQuery discoverQuery = new DiscoverQuery();
         discoverQuery.addFilterQueries(filterQueries.toArray(new String[filterQueries.size()]));
+        discoverQuery.setSortField("fieldName_sort", DiscoverQuery.SORT_ORDER.asc);
         return discoverQuery;
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataFieldRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataFieldRestRepository.java
@@ -253,10 +253,14 @@ public class MetadataFieldRestRepository extends DSpaceRestRepository<MetadataFi
 
         if (isBlank(metadataFieldRest.getElement())) {
             throw new UnprocessableEntityException("metadata element (in request body) cannot be blank");
+        } else if (metadataFieldRest.getElement().contains(".")) {
+            throw new DSpaceBadRequestException("metadata element (in request body) cannot contain dots");
         }
 
         if (isBlank(metadataFieldRest.getQualifier())) {
             metadataFieldRest.setQualifier(null);
+        } else if (metadataFieldRest.getQualifier().contains(".")) {
+            throw new DSpaceBadRequestException("metadata qualifier (in request body) cannot contain dots");
         }
 
         // create

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataFieldRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataFieldRestRepository.java
@@ -313,21 +313,23 @@ public class MetadataFieldRestRepository extends DSpaceRestRepository<MetadataFi
             throw new UnprocessableEntityException("Cannot parse JSON in request body", e);
         }
 
-        if (metadataFieldRest == null || isBlank(metadataFieldRest.getElement())) {
-            throw new UnprocessableEntityException("metadata element (in request body) cannot be blank");
+        MetadataField metadataField = metadataFieldService.find(context, id);
+        if (metadataField == null) {
+            throw new ResourceNotFoundException("metadata field with id: " + id + " not found");
+        }
+
+        if (!Objects.equals(metadataFieldRest.getElement(), metadataField.getElement())) {
+            throw new UnprocessableEntityException("Metadata element cannot be updated.");
+        }
+
+        if (!Objects.equals(metadataFieldRest.getQualifier(), metadataField.getQualifier())) {
+            throw new UnprocessableEntityException("Metadata qualifier cannot be updated.");
         }
 
         if (!Objects.equals(id, metadataFieldRest.getId())) {
             throw new UnprocessableEntityException("ID in request body doesn't match path ID");
         }
 
-        MetadataField metadataField = metadataFieldService.find(context, id);
-        if (metadataField == null) {
-            throw new ResourceNotFoundException("metadata field with id: " + id + " not found");
-        }
-
-        metadataField.setElement(metadataFieldRest.getElement());
-        metadataField.setQualifier(metadataFieldRest.getQualifier());
         metadataField.setScopeNote(metadataFieldRest.getScopeNote());
 
         try {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataFieldRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataFieldRestRepository.java
@@ -260,14 +260,18 @@ public class MetadataFieldRestRepository extends DSpaceRestRepository<MetadataFi
 
         if (isBlank(metadataFieldRest.getElement())) {
             throw new UnprocessableEntityException("metadata element (in request body) cannot be blank");
-        } else if (metadataFieldRest.getElement().contains(".")) {
-            throw new UnprocessableEntityException("metadata element (in request body) cannot contain dots");
+        } else if (!metadataFieldRest.getElement().matches("^[^. ,]{1,64}$")) {
+            throw new UnprocessableEntityException(
+                "metadata element (in request body) cannot contain dots, commas or spaces and should be smaller than" +
+                    " 64 characters");
         }
 
         if (isBlank(metadataFieldRest.getQualifier())) {
             metadataFieldRest.setQualifier(null);
-        } else if (metadataFieldRest.getQualifier().contains(".")) {
-            throw new UnprocessableEntityException("metadata qualifier (in request body) cannot contain dots");
+        } else if (!metadataFieldRest.getQualifier().matches("^[^. ,]{1,64}$")) {
+            throw new UnprocessableEntityException(
+                "metadata qualifier (in request body) cannot contain dots, commas or spaces and should be smaller" +
+                    " than 64 characters");
         }
 
         // create

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataSchemaRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataSchemaRestRepository.java
@@ -93,11 +93,11 @@ public class MetadataSchemaRestRepository extends DSpaceRestRepository<MetadataS
         // validate fields
         if (isBlank(metadataSchemaRest.getPrefix())) {
             throw new UnprocessableEntityException("metadata schema name cannot be blank");
+        } else if (metadataSchemaRest.getPrefix().contains(".")) {
+            throw new UnprocessableEntityException("metadata schema namespace cannot contain dots");
         }
         if (isBlank(metadataSchemaRest.getNamespace())) {
             throw new UnprocessableEntityException("metadata schema namespace cannot be blank");
-        } else if (metadataSchemaRest.getNamespace().contains(".")) {
-            throw new UnprocessableEntityException("metadata schema namespace cannot contain dots");
         }
 
         // create
@@ -144,7 +144,7 @@ public class MetadataSchemaRestRepository extends DSpaceRestRepository<MetadataS
         try {
             metadataSchemaRest = new ObjectMapper().readValue(jsonNode.toString(), MetadataSchemaRest.class);
         } catch (JsonProcessingException e) {
-            throw new UnprocessableEntityException("Cannot parse JSON in request body", e);
+            throw new DSpaceBadRequestException("Cannot parse JSON in request body", e);
         }
 
         MetadataSchema metadataSchema = metadataSchemaService.find(context, id);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataSchemaRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataSchemaRestRepository.java
@@ -147,8 +147,13 @@ public class MetadataSchemaRestRepository extends DSpaceRestRepository<MetadataS
             throw new UnprocessableEntityException("Cannot parse JSON in request body", e);
         }
 
-        if (metadataSchemaRest == null || isBlank(metadataSchemaRest.getPrefix())) {
-            throw new UnprocessableEntityException("metadata schema name cannot be blank");
+        MetadataSchema metadataSchema = metadataSchemaService.find(context, id);
+        if (metadataSchema == null) {
+            throw new ResourceNotFoundException("metadata schema with id: " + id + " not found");
+        }
+
+        if (!Objects.equals(metadataSchemaRest.getPrefix(), metadataSchema.getName())) {
+            throw new UnprocessableEntityException("Metadata schema name cannot be updated.");
         }
         if (isBlank(metadataSchemaRest.getNamespace())) {
             throw new UnprocessableEntityException("metadata schema namespace cannot be blank");
@@ -158,12 +163,6 @@ public class MetadataSchemaRestRepository extends DSpaceRestRepository<MetadataS
             throw new UnprocessableEntityException("ID in request doesn't match path ID");
         }
 
-        MetadataSchema metadataSchema = metadataSchemaService.find(context, id);
-        if (metadataSchema == null) {
-            throw new ResourceNotFoundException("metadata schema with id: " + id + " not found");
-        }
-
-        metadataSchema.setName(metadataSchemaRest.getPrefix());
         metadataSchema.setNamespace(metadataSchemaRest.getNamespace());
 
         try {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataSchemaRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataSchemaRestRepository.java
@@ -96,6 +96,8 @@ public class MetadataSchemaRestRepository extends DSpaceRestRepository<MetadataS
         }
         if (isBlank(metadataSchemaRest.getNamespace())) {
             throw new UnprocessableEntityException("metadata schema namespace cannot be blank");
+        } else if (metadataSchemaRest.getNamespace().contains(".")) {
+            throw new UnprocessableEntityException("metadata schema namespace cannot contain dots");
         }
 
         // create

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataSchemaRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataSchemaRestRepository.java
@@ -93,8 +93,10 @@ public class MetadataSchemaRestRepository extends DSpaceRestRepository<MetadataS
         // validate fields
         if (isBlank(metadataSchemaRest.getPrefix())) {
             throw new UnprocessableEntityException("metadata schema name cannot be blank");
-        } else if (metadataSchemaRest.getPrefix().contains(".")) {
-            throw new UnprocessableEntityException("metadata schema namespace cannot contain dots");
+        } else if (!metadataSchemaRest.getPrefix().matches("^[^. ,]{1,32}$")) {
+            throw new UnprocessableEntityException(
+                "metadata schema namespace cannot contain dots, commas or spaces and should be smaller than" +
+                    " 32 characters");
         }
         if (isBlank(metadataSchemaRest.getNamespace())) {
             throw new UnprocessableEntityException("metadata schema namespace cannot be blank");

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataSchemaRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataSchemaRestRepositoryIT.java
@@ -202,7 +202,7 @@ public class MetadataSchemaRestRepositoryIT extends AbstractControllerIntegratio
 
         MetadataSchemaRest metadataSchemaRest = new MetadataSchemaRest();
         metadataSchemaRest.setId(metadataSchema.getID());
-        metadataSchemaRest.setPrefix(TEST_NAME_UPDATED);
+        metadataSchemaRest.setPrefix(TEST_NAME);
         metadataSchemaRest.setNamespace(TEST_NAMESPACE_UPDATED);
 
         getClient(getAuthToken(admin.getEmail(), password))
@@ -214,7 +214,33 @@ public class MetadataSchemaRestRepositoryIT extends AbstractControllerIntegratio
         getClient().perform(get("/api/core/metadataschemas/" + metadataSchema.getID()))
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$", MetadataschemaMatcher
-                       .matchEntry(TEST_NAME_UPDATED, TEST_NAMESPACE_UPDATED)));
+                       .matchEntry(TEST_NAME, TEST_NAMESPACE_UPDATED)));
+    }
+
+    @Test
+    public void update_schemaNameShouldThrowError() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        MetadataSchema metadataSchema = MetadataSchemaBuilder.createMetadataSchema(context, TEST_NAME, TEST_NAMESPACE)
+            .build();
+
+        context.restoreAuthSystemState();
+
+        MetadataSchemaRest metadataSchemaRest = new MetadataSchemaRest();
+        metadataSchemaRest.setId(metadataSchema.getID());
+        metadataSchemaRest.setPrefix(TEST_NAME_UPDATED);
+        metadataSchemaRest.setNamespace(TEST_NAMESPACE_UPDATED);
+
+        getClient(getAuthToken(admin.getEmail(), password))
+            .perform(put("/api/core/metadataschemas/" + metadataSchema.getID())
+                         .content(new ObjectMapper().writeValueAsBytes(metadataSchemaRest))
+                         .contentType(contentType))
+            .andExpect(status().isUnprocessableEntity());
+
+        getClient().perform(get("/api/core/metadataschemas/" + metadataSchema.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", MetadataschemaMatcher
+                .matchEntry(TEST_NAME, TEST_NAMESPACE)));
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataSchemaRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataSchemaRestRepositoryIT.java
@@ -117,7 +117,7 @@ public class MetadataSchemaRestRepositoryIT extends AbstractControllerIntegratio
     }
 
     @Test
-    public void createUnprocessableEntity_prefixContainingDots() throws Exception {
+    public void createUnprocessableEntity_prefixContainingInvalidCharacters() throws Exception {
         context.turnOffAuthorisationSystem();
 
         MetadataSchema metadataSchema = MetadataSchemaBuilder.createMetadataSchema(context, "ATest", "ANamespace")
@@ -130,6 +130,20 @@ public class MetadataSchemaRestRepositoryIT extends AbstractControllerIntegratio
 
         String authToken = getAuthToken(admin.getEmail(), password);
 
+        getClient(authToken)
+            .perform(post("/api/core/metadataschemas")
+                         .content(new ObjectMapper().writeValueAsBytes(metadataSchemaRest))
+                         .contentType(contentType))
+            .andExpect(status().isUnprocessableEntity());
+
+        metadataSchemaRest.setPrefix("test,SchemaName");
+        getClient(authToken)
+            .perform(post("/api/core/metadataschemas")
+                         .content(new ObjectMapper().writeValueAsBytes(metadataSchemaRest))
+                         .contentType(contentType))
+            .andExpect(status().isUnprocessableEntity());
+
+        metadataSchemaRest.setPrefix("test SchemaName");
         getClient(authToken)
             .perform(post("/api/core/metadataschemas")
                          .content(new ObjectMapper().writeValueAsBytes(metadataSchemaRest))

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataSchemaRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataSchemaRestRepositoryIT.java
@@ -88,7 +88,7 @@ public class MetadataSchemaRestRepositoryIT extends AbstractControllerIntegratio
         context.turnOffAuthorisationSystem();
 
         MetadataSchema metadataSchema = MetadataSchemaBuilder.createMetadataSchema(context, "ATest", "ANamespace")
-                                                             .build();
+            .build();
         context.restoreAuthSystemState();
 
         MetadataSchemaRest metadataSchemaRest = metadataSchemaConverter.convert(metadataSchema, Projection.DEFAULT);
@@ -114,6 +114,27 @@ public class MetadataSchemaRestRepositoryIT extends AbstractControllerIntegratio
         } finally {
             MetadataSchemaBuilder.deleteMetadataSchema(idRef.get());
         }
+    }
+
+    @Test
+    public void createUnprocessableEntity_prefixContainingDots() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        MetadataSchema metadataSchema = MetadataSchemaBuilder.createMetadataSchema(context, "ATest", "ANamespace")
+            .build();
+        context.restoreAuthSystemState();
+
+        MetadataSchemaRest metadataSchemaRest = metadataSchemaConverter.convert(metadataSchema, Projection.DEFAULT);
+        metadataSchemaRest.setPrefix("test.SchemaName");
+        metadataSchemaRest.setNamespace(TEST_NAMESPACE);
+
+        String authToken = getAuthToken(admin.getEmail(), password);
+
+        getClient(authToken)
+            .perform(post("/api/core/metadataschemas")
+                         .content(new ObjectMapper().writeValueAsBytes(metadataSchemaRest))
+                         .contentType(contentType))
+            .andExpect(status().isUnprocessableEntity());
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadatafieldRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadatafieldRestRepositoryIT.java
@@ -50,12 +50,12 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegrationTest {
 
-    private static final String ELEMENT = "test element";
-    private static final String QUALIFIER = "test qualifier";
+    private static final String ELEMENT = "test_element";
+    private static final String QUALIFIER = "test_qualifier";
     private static final String SCOPE_NOTE = "test scope_note";
 
-    private static final String ELEMENT_UPDATED = "test element updated";
-    private static final String QUALIFIER_UPDATED = "test qualifier updated";
+    private static final String ELEMENT_UPDATED = "test_element_updated";
+    private static final String QUALIFIER_UPDATED = "test_qualifier_updated";
     private static final String SCOPE_NOTE_UPDATED = "test scope_note updated";
 
     private MetadataSchema metadataSchema;
@@ -758,7 +758,7 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
     }
 
     @Test
-    public void createUnprocessableEntity_elementContainingDots() throws Exception {
+    public void createUnprocessableEntity_elementContainingInvalidCharacters() throws Exception {
         MetadataFieldRest metadataFieldRest = new MetadataFieldRest();
         metadataFieldRest.setElement("testElement.ForCreate");
         metadataFieldRest.setQualifier(QUALIFIER);
@@ -775,16 +775,64 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
                          .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
                          .contentType(contentType))
             .andExpect(status().isUnprocessableEntity());
+
+        metadataFieldRest.setElement("testElement,ForCreate");
+        assertThat(metadataFieldService.findByElement(context, metadataSchema, metadataFieldRest.getElement(),
+                                                      metadataFieldRest.getQualifier()), nullValue());
+
+        getClient(authToken)
+            .perform(post("/api/core/metadatafields")
+                         .param("schemaId", String.valueOf(metadataSchema.getID()))
+                         .param("projection", "full")
+                         .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
+                         .contentType(contentType))
+            .andExpect(status().isUnprocessableEntity());
+
+        metadataFieldRest.setElement("testElement ForCreate");
+        assertThat(metadataFieldService.findByElement(context, metadataSchema, metadataFieldRest.getElement(),
+                                                      metadataFieldRest.getQualifier()), nullValue());
+
+        getClient(authToken)
+            .perform(post("/api/core/metadatafields")
+                         .param("schemaId", String.valueOf(metadataSchema.getID()))
+                         .param("projection", "full")
+                         .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
+                         .contentType(contentType))
+            .andExpect(status().isUnprocessableEntity());
     }
 
     @Test
-    public void createUnprocessableEntity_qualifierContainingDots() throws Exception {
+    public void createUnprocessableEntity_qualifierContainingInvalidCharacters() throws Exception {
         MetadataFieldRest metadataFieldRest = new MetadataFieldRest();
         metadataFieldRest.setElement(ELEMENT);
         metadataFieldRest.setQualifier("testQualifier.ForCreate");
         metadataFieldRest.setScopeNote(SCOPE_NOTE);
 
         String authToken = getAuthToken(admin.getEmail(), password);
+        assertThat(metadataFieldService.findByElement(context, metadataSchema, metadataFieldRest.getElement(),
+                                                      metadataFieldRest.getQualifier()), nullValue());
+
+        getClient(authToken)
+            .perform(post("/api/core/metadatafields")
+                         .param("schemaId", String.valueOf(metadataSchema.getID()))
+                         .param("projection", "full")
+                         .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
+                         .contentType(contentType))
+            .andExpect(status().isUnprocessableEntity());
+
+        metadataFieldRest.setQualifier("testQualifier,ForCreate");
+        assertThat(metadataFieldService.findByElement(context, metadataSchema, metadataFieldRest.getElement(),
+                                                      metadataFieldRest.getQualifier()), nullValue());
+
+        getClient(authToken)
+            .perform(post("/api/core/metadatafields")
+                         .param("schemaId", String.valueOf(metadataSchema.getID()))
+                         .param("projection", "full")
+                         .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
+                         .contentType(contentType))
+            .andExpect(status().isUnprocessableEntity());
+
+        metadataFieldRest.setQualifier("testQualifier ForCreate");
         assertThat(metadataFieldService.findByElement(context, metadataSchema, metadataFieldRest.getElement(),
                                                       metadataFieldRest.getQualifier()), nullValue());
 


### PR DESCRIPTION
## References
* Fixes #8753
* Fixes #8754
* Related to DSpace/dspace-angular#2177
* Related to DSpace/RestContract#228

## Description
Added backend validation that checks if a dot is present in either the schema, element or qualifier. Sorted the retrieved metadata fields from the `/core/metadatafields/search/byFieldName` rest endpoint, to prevent the exact match from not being shown int the suggestion list (which lead to an error on Angular which prevents you from submitting a value for that field). And fixed pagination issues from `/core/metadatafields/search/byFieldName`.

While creating the rest contract PR I also saw that for both update schema and update metadata field the JSON parse exceptions threw `UnprocessableEntityException`, I changed this to `DSpaceBadRequestException` to be more consitent with the other endpoints.

## Instructions for Reviewers
List of changes in this PR:
* `MetadataFieldIndexFactoryImpl`
  * I added a new Solr field `fieldName_sort` that I used to sort the metadata fields retrieved by the `/core/metadatafields/search/byFieldName` rest endpoint (previously when you added more than 10 fields and completely rebuild Solr the exact match was always shown as the last field. Because Angular only checks if the field is present in the list of 10 fields who match the closest to the input you provided, and that the 11th metadata field is not send back to the user, the code marked the metadata field as invalid)
* `MetadataFieldRestRepository`
  * `findByFieldName()`
    * Replaced the value from `totalElements` with the actual value from the number of metadata fields who matched on Solr, instead of the size of the page (which is by default 10).
    * Fixed the `/core/metadatafields/search/byFieldName` pagination issues which made it impossible to change the size and the page you were on.
  * Added validation in the `createAndReturn` function to also check that the given string does not contain any dots.
  * Made `put` return 422 errors when the Element or Qualifier is being updated
* `MetadataSchemaRestRepository`
  * Added validation in the `createAndReturn` function to also check that the given string does not contain any dots.
  * Made `put` return 422 errors when the Schema name (prefix) is being updated

**Guidance for how to test and review this PR:**
- Add a lot of `dc.subject.*` fields (so that you have more than 10 fields (or 20 if you don't use the linked Angular PR)) and rebuild the whole Solr index again.
- Test the [/core/metadatafields/search/byFieldName](http://localhost:8080/server/api/core/metadatafields/search/byFieldName?schema=dc&element=subject&qualifier=&query=&exactName=&embed=schema&size=2&page=1) rest endpoint and check that you can now change the current page and the page size. Also check that the `totalElements` is correct.
- In the UI go to `Edit Item > Metadata` check that the `dc.subject` field is shown as the first field.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).