### PR TITLE
fix bug: reset password from Admin Panel when Captcha enabled

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RegistrationRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RegistrationRestRepository.java
@@ -87,7 +87,7 @@ public class RegistrationRestRepository extends DSpaceRestRepository<Registratio
     public Page<RegistrationRest> findAll(Context context, Pageable pageable) {
         throw new RepositoryMethodNotImplementedException("No implementation found; Method not allowed!", "");
     }
-    
+
     @Override
     public RegistrationRest createAndReturn(Context context) {
         HttpServletRequest request = requestService.getCurrentRequest().getHttpServletRequest();
@@ -136,7 +136,7 @@ public class RegistrationRestRepository extends DSpaceRestRepository<Registratio
                 log.error("Something went wrong with sending forgot password info email: "
                               + registrationRest.getEmail(), e);
             }
-           } else if (accountType.equalsIgnoreCase(TYPE_REGISTER)) {
+        } else if (accountType.equalsIgnoreCase(TYPE_REGISTER)) {
             try {
                 String email = registrationRest.getEmail();
                 if (!AuthorizeUtil.authorizeNewAccountRegistration(context, request)) {
@@ -157,7 +157,6 @@ public class RegistrationRestRepository extends DSpaceRestRepository<Registratio
         return null;
     }
 
-    
     @Override
     public Class<RegistrationRest> getDomainClass() {
         return RegistrationRest.class;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/RegistrationRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/RegistrationRestRepositoryIT.java
@@ -298,6 +298,7 @@ public class RegistrationRestRepositoryIT extends AbstractControllerIntegrationT
 
         // when reCAPTCHA enabled and request doesn't contain "X-Recaptcha-Token” header
         getClient().perform(post("/api/eperson/registrations")
+                            .param(TYPE_QUERY_PARAM, TYPE_REGISTER)
                    .content(mapper.writeValueAsBytes(registrationRest))
                    .contentType(contentType))
                    .andExpect(status().isForbidden());


### PR DESCRIPTION
## References
* Fixes #8765

## Description
Changed the method responsible to handle register and reset password.

## Instructions for Reviewers
Disable reCaptcha check if the request is to reset password (because the user was already checked at registration).

List of changes in this PR:
Refactoring the createAndReturn method.

**Include guidance for how to test or review your PR.** 
    Log in as Admin
    Go to Access Control -> People -> Edit a Person -> Reset Password
