### PR TITLE
Typo fix in dspace.cfg

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -843,7 +843,7 @@ plugin.single.org.dspace.embargo.EmbargoSetter = org.dspace.embargo.DefaultEmbar
 plugin.single.org.dspace.embargo.EmbargoLifter = org.dspace.embargo.DefaultEmbargoLifter
 
 # values for the forever embargo date threshold
-# This threshold date is used in the default access status helper to dermine if an item is
+# This threshold date is used in the default access status helper to determine if an item is
 # restricted or embargoed based on the start date of the primary (or first) file policies.
 # In this case, if the policy start date is inferior to the threshold date, the status will
 # be embargo, else it will be restricted.

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -880,7 +880,7 @@ org.dspace.app.itemexport.life.span.hours = 48
 
 # The maximum size in Megabytes the export should be.  This is enforced before the
 # compression.  Each bitstream's size in each item being exported is added up, if their
-# cummulative sizes are more than this entry the export is not kicked off
+# cumulative sizes are more than this entry the export is not kicked off
 org.dspace.app.itemexport.max.size = 200
 
 ### Batch Item import settings ###


### PR DESCRIPTION
## References
None

## Description
Fixed typo "dermine" to "determine" and "cummulative" to "cumulative" in `dspace/config/dspace.cfg` file

## Instructions for Reviewers
- Changed two comments in a `config` file
