### PR TITLE
Implement default description for Community/Collection for OpenSearch

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/SyndicationFeed.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/SyndicationFeed.java
@@ -91,6 +91,7 @@ public class SyndicationFeed {
 
     // default DC fields for entry
     protected String defaultTitleField = "dc.title";
+    protected String defaultDescriptionField = "dc.description";
     protected String defaultAuthorField = "dc.contributor.author";
     protected String defaultDateField = "dc.date.issued";
     private static final String[] defaultDescriptionFields =
@@ -196,15 +197,15 @@ public class SyndicationFeed {
         // dso is null for the whole site, or a search without scope
         if (dso == null) {
             defaultTitle = configurationService.getProperty("dspace.name");
-            feed.setDescription(localize(labels, MSG_FEED_DESCRIPTION));
+            defaultDescriptionField = localize(labels, MSG_FEED_DESCRIPTION);
             objectURL = resolveURL(request, null);
         } else {
             Bitstream logo = null;
             if (dso instanceof IndexableCollection) {
                 Collection col = ((IndexableCollection) dso).getIndexedObject();
                 defaultTitle = col.getName();
-                feed.setDescription(collectionService.getMetadataFirstValue(col,
-                        CollectionService.MD_SHORT_DESCRIPTION, Item.ANY));
+                defaultDescriptionField = collectionService.getMetadataFirstValue(col,
+                        CollectionService.MD_SHORT_DESCRIPTION, Item.ANY);
                 logo = col.getLogo();
                 String cols = configurationService.getProperty("webui.feed.podcast.collections");
                 if (cols != null && cols.length() > 1 && cols.contains(col.getHandle())) {
@@ -214,8 +215,8 @@ public class SyndicationFeed {
             } else if (dso instanceof IndexableCommunity) {
                 Community comm = ((IndexableCommunity) dso).getIndexedObject();
                 defaultTitle = comm.getName();
-                feed.setDescription(communityService.getMetadataFirstValue(comm,
-                        CommunityService.MD_SHORT_DESCRIPTION, Item.ANY));
+                defaultDescriptionField = communityService.getMetadataFirstValue(comm,
+                        CommunityService.MD_SHORT_DESCRIPTION, Item.ANY);
                 logo = comm.getLogo();
                 String comms = configurationService.getProperty("webui.feed.podcast.communities");
                 if (comms != null && comms.length() > 1 && comms.contains(comm.getHandle())) {
@@ -230,6 +231,12 @@ public class SyndicationFeed {
         }
         feed.setTitle(labels.containsKey(MSG_FEED_TITLE) ?
                           localize(labels, MSG_FEED_TITLE) : defaultTitle);
+
+        if (defaultDescriptionField == null || defaultDescriptionField == "") {
+            defaultDescriptionField = "No Description";
+        }
+
+        feed.setDescription(defaultDescriptionField);
         feed.setLink(objectURL);
         feed.setPublishedDate(new Date());
         feed.setUri(objectURL);

--- a/dspace-api/src/main/java/org/dspace/app/util/SyndicationFeed.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/SyndicationFeed.java
@@ -51,6 +51,7 @@ import org.dspace.content.service.CollectionService;
 import org.dspace.content.service.CommunityService;
 import org.dspace.content.service.ItemService;
 import org.dspace.core.Context;
+import org.dspace.core.I18nUtil;
 import org.dspace.discovery.IndexableObject;
 import org.dspace.discovery.indexobject.IndexableCollection;
 import org.dspace.discovery.indexobject.IndexableCommunity;
@@ -233,7 +234,7 @@ public class SyndicationFeed {
                           localize(labels, MSG_FEED_TITLE) : defaultTitle);
 
         if (defaultDescriptionField == null || defaultDescriptionField == "") {
-            defaultDescriptionField = "No Description";
+            defaultDescriptionField = I18nUtil.getMessage("org.dspace.app.util.SyndicationFeed.no-description");
         }
 
         feed.setDescription(defaultDescriptionField);

--- a/dspace-api/src/main/resources/Messages.properties
+++ b/dspace-api/src/main/resources/Messages.properties
@@ -51,6 +51,7 @@ metadata.bitstream.iiif-virtual.bytes            = File size
 metadata.bitstream.iiif-virtual.checksum         = Checksum
 
 org.dspace.app.itemexport.no-result = The DSpaceObject that you specified has no items.
+org.dspace.app.util.SyndicationFeed.no-description = No Description
 org.dspace.checker.ResultsLogger.bitstream-format                               = Bitstream format
 org.dspace.checker.ResultsLogger.bitstream-found                                = Bitstream found
 org.dspace.checker.ResultsLogger.bitstream-id                                   = Bitstream ID

--- a/dspace-server-webapp/src/test/java/org/dspace/app/opensearch/OpenSearchControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/opensearch/OpenSearchControllerIT.java
@@ -249,4 +249,24 @@ public class OpenSearchControllerIT extends AbstractControllerIntegrationTest {
             </OpenSearchDescription>
         */
     }
+
+    @Test
+    public void emptyDescriptionTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                                           .withName("Sub Community")
+                                           .build();
+        Collection collection1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1")
+                                           .build();
+
+        getClient().perform(get("/opensearch/search")
+                   .param("format", "rss")
+                   .param("scope", collection1.getID().toString())
+                   .param("query", "*"))
+                   .andExpect(status().isOk())
+                   .andExpect(xpath("rss/channel/description").string("No Description"));
+    }
 }


### PR DESCRIPTION
## References
* Fixes #8728

## Description
Implemented default description as "No Description" for Community/Collection.

## Instructions for Reviewers
- Implemented default description as "No Description" for Community/Collection.
- Now if we ping `https://api7.dspace.org/server/opensearch/search?format=rss&scope=<UUID>&query=*` with a Community/Collection - UUID we will get a 200 response with default description.

List of changes in this PR:
* Implemented default description as "No Description" for Community/Collection.
* Added test case to to check default description.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
