### PR TITLE
Fix "Simultaneous deletion of multiple bitstreams from the same bundle often compromises the state of the bundle"

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamRestRepository.java
@@ -126,9 +126,6 @@ public class BitstreamRestRepository extends DSpaceObjectRestRepository<Bitstrea
             if (bit == null) {
                 throw new ResourceNotFoundException("The bitstream with uuid " + id + " could not be found");
             }
-            // if (bit.isDeleted()) {
-            //     throw new ResourceNotFoundException("The bitstream with uuid " + id + " was already deleted");
-            // }
             Community community = bit.getCommunity();
             if (community != null) {
                 communityService.setLogo(context, community, null);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamRestRepository.java
@@ -121,21 +121,14 @@ public class BitstreamRestRepository extends DSpaceObjectRestRepository<Bitstrea
     @Override
     protected void delete(Context context, UUID id) throws AuthorizeException {
         Bitstream bit = null;
-        boolean wasAllreadyDeleted = false;
         try {
             bit = bs.find(context, id);
             if (bit == null) {
                 throw new ResourceNotFoundException("The bitstream with uuid " + id + " could not be found");
             }
-             /**
-              * Deletion of bitstreams can fail, and items can get stucked. Moving the test after deletion 
-              * allow re-delete the bitstream and still return the expected error
-              * https://github.com/DSpace/DSpace/issues/8694
-              */
             if (bit.isDeleted()) {
-                wasAllreadyDeleted = true;
+                throw new ResourceNotFoundException("The bitstream with uuid " + id + " was already deleted");
             }
-            
             Community community = bit.getCommunity();
             if (community != null) {
                 communityService.setLogo(context, community, null);
@@ -151,9 +144,6 @@ public class BitstreamRestRepository extends DSpaceObjectRestRepository<Bitstrea
             bs.delete(context, bit);
         } catch (SQLException | IOException e) {
             throw new RuntimeException(e.getMessage(), e);
-        }
-        if(wasAllreadyDeleted){
-            throw new ResourceNotFoundException("The bitstream with uuid " + id + " was already deleted");
         }
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamRestRepository.java
@@ -126,9 +126,9 @@ public class BitstreamRestRepository extends DSpaceObjectRestRepository<Bitstrea
             if (bit == null) {
                 throw new ResourceNotFoundException("The bitstream with uuid " + id + " could not be found");
             }
-            if (bit.isDeleted()) {
-                throw new ResourceNotFoundException("The bitstream with uuid " + id + " was already deleted");
-            }
+            // if (bit.isDeleted()) {
+            //     throw new ResourceNotFoundException("The bitstream with uuid " + id + " was already deleted");
+            // }
             Community community = bit.getCommunity();
             if (community != null) {
                 communityService.setLogo(context, community, null);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamRestRepository.java
@@ -121,11 +121,21 @@ public class BitstreamRestRepository extends DSpaceObjectRestRepository<Bitstrea
     @Override
     protected void delete(Context context, UUID id) throws AuthorizeException {
         Bitstream bit = null;
+        boolean wasAllreadyDeleted = false;
         try {
             bit = bs.find(context, id);
             if (bit == null) {
                 throw new ResourceNotFoundException("The bitstream with uuid " + id + " could not be found");
             }
+             /**
+              * Deletion of bitstreams can fail, and items can get stucked. Moving the test after deletion 
+              * allow re-delete the bitstream and still return the expected error
+              * https://github.com/DSpace/DSpace/issues/8694
+              */
+            if (bit.isDeleted()) {
+                wasAllreadyDeleted = true;
+            }
+            
             Community community = bit.getCommunity();
             if (community != null) {
                 communityService.setLogo(context, community, null);
@@ -141,6 +151,9 @@ public class BitstreamRestRepository extends DSpaceObjectRestRepository<Bitstrea
             bs.delete(context, bit);
         } catch (SQLException | IOException e) {
             throw new RuntimeException(e.getMessage(), e);
+        }
+        if(wasAllreadyDeleted){
+            throw new ResourceNotFoundException("The bitstream with uuid " + id + " was already deleted");
         }
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/DSpaceRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/DSpaceRestRepository.java
@@ -36,8 +36,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.transaction.annotation.Isolation;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 /**

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/DSpaceRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/DSpaceRestRepository.java
@@ -36,6 +36,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 /**
@@ -195,7 +197,11 @@ public abstract class DSpaceRestRepository<T extends RestAddressableModel, ID ex
     /**
      * Delete the object identified by its ID
      */
-    public void deleteById(ID id) {
+    /**
+     * Method should be synchronized to avoid hibernate partial deletion bug when deleting multiple bitstreams:
+     * https://github.com/DSpace/DSpace/issues/8694
+     */
+    public synchronized void deleteById(ID id) {
         Context context = obtainContext();
         try {
             getThisRepository().delete(context, id);


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #8694

## Description
Workaround that partialy fix bitstream multiple deletion using synchronize methos.

## Instructions for Reviewers
Test with large number of bitstreams (100)

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ X If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
