### PR TITLE
DS-8759: clean up temporary work file when SAF import with zip file fails in the UI

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
@@ -233,10 +233,15 @@ public class ItemImport extends DSpaceRunnable<ItemImportScriptConfiguration> {
                 handler.logInfo("***End of Test Run***");
             }
         } finally {
-            // clean work dir
             if (zip) {
+                // clean source and work dirs
                 FileUtils.deleteDirectory(new File(sourcedir));
                 FileUtils.deleteDirectory(workDir);
+
+                // conditionally clean workFile if import was done in the UI and it still exists
+                if (workFile != null) {
+                    workFile.delete();
+                }
             }
 
             Date endTime = new Date();
@@ -311,7 +316,8 @@ public class ItemImport extends DSpaceRunnable<ItemImportScriptConfiguration> {
             workFile = new File(itemImportService.getTempWorkDir() + File.separator
                     + zipfilename + "-" + context.getCurrentUser().getID());
             FileUtils.copyInputStreamToFile(optionalFileStream.get(), workFile);
-            workDir = new File(itemImportService.getTempWorkDir() + File.separator + TEMP_DIR);
+            workDir = new File(itemImportService.getTempWorkDir() + File.separator + TEMP_DIR
+                               + File.separator + context.getCurrentUser().getID());
             sourcedir = itemImportService.unzip(workFile, workDir.getAbsolutePath());
         } else {
             throw new IllegalArgumentException(

--- a/dspace-api/src/test/java/org/dspace/app/itemimport/ItemImportCLIIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/itemimport/ItemImportCLIIT.java
@@ -8,6 +8,7 @@
 package org.dspace.app.itemimport;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -48,6 +49,7 @@ public class ItemImportCLIIT extends AbstractIntegrationTestWithDatabase {
     private static final String ZIP_NAME = "saf.zip";
     private static final String publicationTitle = "A Tale of Two Cities";
     private static final String personTitle = "Person Test";
+    private static final String TEMP_DIR = ItemImport.TEMP_DIR;
 
     private ItemService itemService = ContentServiceFactory.getInstance().getItemService();
     private RelationshipService relationshipService = ContentServiceFactory.getInstance().getRelationshipService();
@@ -226,6 +228,10 @@ public class ItemImportCLIIT extends AbstractIntegrationTestWithDatabase {
         checkMetadata();
         checkMetadataWithAnotherSchema();
         checkBitstream();
+
+        // confirm that TEMP_DIR still exists
+        File workTempDir = new File(workDir + File.separator + TEMP_DIR);
+        assertTrue(workTempDir.exists());
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/itemimport/ItemImportIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/itemimport/ItemImportIT.java
@@ -14,6 +14,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -69,6 +70,7 @@ public class ItemImportIT extends AbstractEntityIntegrationTest {
 
     private static final String publicationTitle = "A Tale of Two Cities";
     private static final String personTitle = "Person Test";
+    private static final String TEMP_DIR = ItemImport.TEMP_DIR;
 
     @Autowired
     private ItemService itemService;
@@ -126,6 +128,10 @@ public class ItemImportIT extends AbstractEntityIntegrationTest {
         checkMetadata();
         checkMetadataWithAnotherSchema();
         checkBitstream();
+
+        // confirm that TEMP_DIR still exists
+        File workTempDir = new File(workDir + File.separator + TEMP_DIR);
+        assertTrue(workTempDir.exists());
     }
 
     @Test


### PR DESCRIPTION
## References
* Fixes #8759 

## Description
This PR does two things: 
1. Removes the temporary zip file if an SAF import process fails in the UI.
2. Changes the SAF import process in the UI to create a temporary work directory the same way it's done when importing via the command line so that the "importSAF" folder is not deleted.

## Instructions for Reviewers
1. Perform an SAF import in the UI with an import file that doesn't meet the spec, so that it results in a failed import
2. Check /dspace/imports and note that the temporary zip file is gone, but the empty "importSAF" folder still exists

## Checklist
- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [X] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
