### PR TITLE
properly escape ':' in query to address #8490

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/authority/SolrAuthority.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/SolrAuthority.java
@@ -200,8 +200,8 @@ public class SolrAuthority implements ChoiceAuthority {
     }
 
     private String toQuery(String searchField, String text) {
-        return searchField + ":(" + text.toLowerCase().replaceAll(":", "\\:") + "*) or " + searchField + ":(" + text
-            .toLowerCase().replaceAll(":", "\\:") + ")";
+        return searchField + ":(" + text.toLowerCase().replaceAll(":", "\\\\:") + "*) or " + searchField + ":(" + text
+            .toLowerCase().replaceAll(":", "\\\\:") + ")";
     }
 
     @Override
@@ -225,7 +225,7 @@ public class SolrAuthority implements ChoiceAuthority {
                 log.debug("requesting label for key " + key + " using locale " + locale);
             }
             SolrQuery queryArgs = new SolrQuery();
-            queryArgs.setQuery("id:" + key);
+            queryArgs.setQuery("id:" + key.replaceAll(":", "\\\\:"));
             queryArgs.setRows(1);
             QueryResponse searchResponse = getSearchService().search(queryArgs);
             SolrDocumentList docs = searchResponse.getResults();


### PR DESCRIPTION
Fixes #8490 

existing code attempts to escape the ":" in the string "will be generated::orcid::...". But, the String.replaceAll(regex,regex) expects regex as the replacement, the \ needs to be escaped twice, once for the java string and one for the regex. This PR address this. I have tested the patch and it is working on our 7.5 instance.