### PR TITLE
Update to latest Jetty v9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <jaxb-runtime.version>2.3.1</jaxb-runtime.version>
         <jcache-version>1.1.0</jcache-version>
         <!-- NOTE: Jetty needed for Solr, Handle Server & tests -->
-        <jetty.version>9.4.48.v20220622</jetty.version>
+        <jetty.version>9.4.51.v20230217</jetty.version>
         <log4j.version>2.17.1</log4j.version>
         <pdfbox-version>2.0.27</pdfbox-version>
         <rome.version>1.18.0</rome.version>


### PR DESCRIPTION
## References
* Fixes CVE-2023-26048
* Fixes CVE-2023-26049
* Replaces #8790

## Description
This PR replaces the automated PR generated by dependabot by simply updating us to the latest version of Jetty v9 (which contains the same security update as v10.0.14).  This is a minor update.

## Instructions for Reviewers
Jetty is used by Solr, our tests and Handle Server.  This should be a minor update and tests are likely good enough to verify nothing has broken.  But, you could also spin up the backend and verify Solr / Handle Server are working as well.