### PR TITLE
Add missing unzip command to CLI container

### DIFF
--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -33,9 +33,9 @@ WORKDIR /dspace-src
 ENV ANT_VERSION 1.10.13
 ENV ANT_HOME /tmp/ant-$ANT_VERSION
 ENV PATH $ANT_HOME/bin:$PATH
-# Need wget to install ant
+# Need wget to install ant, and unzip for managing AIPs
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends wget \
+    && apt-get install -y --no-install-recommends wget unzip \
     && apt-get purge -y --auto-remove \
     && rm -rf /var/lib/apt/lists/*
 # Download and install 'ant'


### PR DESCRIPTION
## References
n/a

## Description
The unzip command is called in cli.ingest.yml, however, that command is not part of the base image. This PR installs the unzip command, so that cli.ingest.yml can function correctly.

## Instructions for Reviewers

1. build and tag a new local version of the dspace-cli image, with:

`docker build . -f Dockerfile.cli -t dspace/dspace-cli:dspace-7_x`

2. attempt to ingest content by [following the instructions in the Docker-Compose README](https://github.com/DSpace/DSpace/tree/main/dspace/src/main/docker-compose#ingesting-test-content-from-aip-files)

3. Clean up: in step 1, you created a local variant of the dspace-cli image. If you'd like to remove that, here's how:
 ```
 docker image rm dspace/dspace-cli:dspace-7_x
 docker-compose -f docker-compose.yml -f docker-compose-cli.yml pull
 ```

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
