### PR TITLE
Remove unused `useProxies` to avoid NPE when debugging

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authenticate/IPAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/IPAuthentication.java
@@ -17,6 +17,7 @@ import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.core.Context;
 import org.dspace.core.LogHelper;
@@ -36,21 +37,21 @@ import org.dspace.services.factory.DSpaceServicesFactory;
  * <P>
  * e.g. {@code authentication.ip.MIT = 18., 192.25.0.0/255.255.0.0}
  * <P>
- * Negative matches can be included by prepending the range with a '-'. For example if you want
- * to include all of a class B network except for users of a contained class c network, you could use:
+ * Negative matches can be included by prepending the range with a '-'.
+ * For example if you want to include all of a class B network except for users
+ * of a contained class c network, you could use:
  * <P>
  * 111.222,-111.222.333.
  * <p>
  * For supported IP ranges see {@link org.dspace.authenticate.IPMatcher}.
  *
  * @author Robert Tansley
- * @version $Revision$
  */
 public class IPAuthentication implements AuthenticationMethod {
     /**
      * Our logger
      */
-    private static Logger log = org.apache.logging.log4j.LogManager.getLogger(IPAuthentication.class);
+    private static final Logger log = LogManager.getLogger();
 
     /**
      * Whether to look for x-forwarded headers for logging IP addresses
@@ -88,8 +89,8 @@ public class IPAuthentication implements AuthenticationMethod {
      * will never fail if the configuration is bad -- a warning will be logged.
      */
     public IPAuthentication() {
-        ipMatchers = new ArrayList<IPMatcher>();
-        ipNegativeMatchers = new ArrayList<IPMatcher>();
+        ipMatchers = new ArrayList<>();
+        ipNegativeMatchers = new ArrayList<>();
         ipMatcherGroupIDs = new HashMap<>();
         ipMatcherGroupNames = new HashMap<>();
         groupService = EPersonServiceFactory.getInstance().getGroupService();
@@ -169,7 +170,7 @@ public class IPAuthentication implements AuthenticationMethod {
         if (request == null) {
             return Collections.EMPTY_LIST;
         }
-        List<Group> groups = new ArrayList<Group>();
+        List<Group> groups = new ArrayList<>();
 
         // Get the user's IP address
         String addr = clientInfoService.getClientIp(request);
@@ -249,9 +250,8 @@ public class IPAuthentication implements AuthenticationMethod {
             }
 
             log.debug(LogHelper.getHeader(context, "authenticated",
-                                           "special_groups=" + gsb.toString()
-                                           + " (by IP=" + addr + ", useProxies=" + useProxies.toString() + ")"
-                                          ));
+                    "special_groups={} (by IP={}, useProxies={})"),
+                    gsb.toString(), addr, useProxies.toString());
         }
 
         return groups;

--- a/dspace-api/src/main/java/org/dspace/authenticate/IPAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/IPAuthentication.java
@@ -54,11 +54,6 @@ public class IPAuthentication implements AuthenticationMethod {
     private static final Logger log = LogManager.getLogger();
 
     /**
-     * Whether to look for x-forwarded headers for logging IP addresses
-     */
-    protected static Boolean useProxies;
-
-    /**
      * All the IP matchers
      */
     protected List<IPMatcher> ipMatchers;
@@ -250,8 +245,8 @@ public class IPAuthentication implements AuthenticationMethod {
             }
 
             log.debug(LogHelper.getHeader(context, "authenticated",
-                    "special_groups={} (by IP={}, useProxies={})"),
-                    gsb.toString(), addr, useProxies.toString());
+                    "special_groups={} (by IP={})"),
+                    gsb.toString(), addr);
         }
 
         return groups;


### PR DESCRIPTION
## Description
Remove unused field that causes NPE when debugging.

## Instructions for Reviewers
List of changes in this PR:
* Tidy up the code and comments.
* Remove "useProxies" which is only touched in one debug logging statement, and NPEs because it is never set.

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
