### PR TITLE
New ImageMagick-based media filter to generate video thumbnails [Invalid]

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickVideoThumbnailFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickVideoThumbnailFilter.java
@@ -25,8 +25,8 @@ import org.im4java.core.IMOperation;
  * no bigger than. Creates only JPEGs.
  */
 public class ImageMagickVideoThumbnailFilter extends ImageMagickThumbnailFilter {
-    private static final int DEFAULT_WIDTH = 340;
-    private static final int DEFAULT_HEIGHT = 280;
+    private static final int DEFAULT_WIDTH = 180;
+    private static final int DEFAULT_HEIGHT = 120;
     private static final int FRAME_NUMBER = 100;
 
     /**

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickVideoThumbnailFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickVideoThumbnailFilter.java
@@ -1,0 +1,74 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.mediafilter;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import org.dspace.content.Item;
+import org.im4java.core.ConvertCmd;
+import org.im4java.core.IM4JavaException;
+import org.im4java.core.IMOperation;
+
+
+/**
+ * Filter video bitstreams, scaling the image to be within the bounds of
+ * thumbnail.maxwidth, thumbnail.maxheight, the size we want our thumbnail to be
+ * no bigger than. Creates only JPEGs.
+ */
+public class ImageMagickVideoThumbnailFilter extends ImageMagickThumbnailFilter {
+    private static final int DEFAULT_WIDTH = 340;
+    private static final int DEFAULT_HEIGHT = 280;
+
+    /**
+     * @param currentItem item
+     * @param source      source input stream
+     * @param verbose     verbose mode
+     * @return InputStream the resulting input stream
+     * @throws Exception if error
+     */
+    @Override
+    public InputStream getDestinationStream(Item currentItem, InputStream source, boolean verbose)
+        throws Exception {
+        File f = inputStreamToTempFile(source, "imthumb", ".tmp");
+        File f2 = null;
+        try {
+            f2 = getThumbnailFile(f, verbose);
+            byte[] bytes = Files.readAllBytes(f2.toPath());
+            return new ByteArrayInputStream(bytes);
+        } finally {
+            //noinspection ResultOfMethodCallIgnored
+            f.delete();
+            if (f2 != null) {
+                //noinspection ResultOfMethodCallIgnored
+                f2.delete();
+            }
+        }
+    }
+
+    public File getThumbnailFile(File f, boolean verbose)
+        throws IOException, InterruptedException, IM4JavaException {
+        File f2 = new File(f.getParentFile(), f.getName() + ".jpg");
+        f2.deleteOnExit();
+        ConvertCmd cmd = new ConvertCmd();
+        IMOperation op = new IMOperation();
+        op.autoOrient();
+        op.addImage("VIDEO:" + f.getAbsolutePath() + "[100]");
+        op.thumbnail(configurationService.getIntProperty("thumbnail.maxwidth", DEFAULT_WIDTH),
+                        configurationService.getIntProperty("thumbnail.maxheight", DEFAULT_HEIGHT));
+        op.addImage(f2.getAbsolutePath());
+        if (verbose) {
+            System.out.println("IM Thumbnail Param: " + op);
+        }
+        cmd.run(op);
+        return f2;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickVideoThumbnailFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickVideoThumbnailFilter.java
@@ -9,8 +9,8 @@ package org.dspace.app.mediafilter;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.InputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 
 import org.dspace.content.Item;

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickVideoThumbnailFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickVideoThumbnailFilter.java
@@ -54,6 +54,7 @@ public class ImageMagickVideoThumbnailFilter extends ImageMagickThumbnailFilter 
         }
     }
 
+    @Override
     public File getThumbnailFile(File f, boolean verbose)
         throws IOException, InterruptedException, IM4JavaException {
         File f2 = new File(f.getParentFile(), f.getName() + ".jpg");

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickVideoThumbnailFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickVideoThumbnailFilter.java
@@ -27,6 +27,7 @@ import org.im4java.core.IMOperation;
 public class ImageMagickVideoThumbnailFilter extends ImageMagickThumbnailFilter {
     private static final int DEFAULT_WIDTH = 340;
     private static final int DEFAULT_HEIGHT = 280;
+    private static final int FRAME_NUMBER = 100;
 
     /**
      * @param currentItem item
@@ -62,7 +63,7 @@ public class ImageMagickVideoThumbnailFilter extends ImageMagickThumbnailFilter 
         ConvertCmd cmd = new ConvertCmd();
         IMOperation op = new IMOperation();
         op.autoOrient();
-        op.addImage("VIDEO:" + f.getAbsolutePath() + "[100]");
+        op.addImage("VIDEO:" + f.getAbsolutePath() + "[" + FRAME_NUMBER + "]");
         op.thumbnail(configurationService.getIntProperty("thumbnail.maxwidth", DEFAULT_WIDTH),
                         configurationService.getIntProperty("thumbnail.maxheight", DEFAULT_HEIGHT));
         op.addImage(f2.getAbsolutePath());

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -465,6 +465,9 @@ filter.plugins = PDFBox JPEG Thumbnail
 #    remove "JPEG Thumbnail" from the plugin list
 #    uncomment and insert the following line into the plugin list
 #                ImageMagick Image Thumbnail, ImageMagick PDF Thumbnail, \
+# [To enable ImageMagick Video Thumbnails (requires both ImageMagick and ffmpeg installed)]:
+#    uncomment and insert the following line into the plugin list
+#                ImageMagick Video Thumbnail, \
 
 #Assign 'human-understandable' names to each filter
 plugin.named.org.dspace.app.mediafilter.FormatFilter = org.dspace.app.mediafilter.TikaTextExtractionFilter = Text Extractor
@@ -473,6 +476,7 @@ plugin.named.org.dspace.app.mediafilter.FormatFilter = org.dspace.app.mediafilte
 plugin.named.org.dspace.app.mediafilter.FormatFilter = org.dspace.app.mediafilter.PDFBoxThumbnail = PDFBox JPEG Thumbnail
 plugin.named.org.dspace.app.mediafilter.FormatFilter = org.dspace.app.mediafilter.ImageMagickImageThumbnailFilter = ImageMagick Image Thumbnail
 plugin.named.org.dspace.app.mediafilter.FormatFilter = org.dspace.app.mediafilter.ImageMagickPdfThumbnailFilter = ImageMagick PDF Thumbnail
+plugin.named.org.dspace.app.mediafilter.FormatFilter = org.dspace.app.mediafilter.ImageMagickVideoThumbnailFilter = ImageMagick Video Thumbnail
 
 #Configure each filter's input format(s)
 # NOTE: The TikaTextExtractionFilter can support any file formats that are supported by Apache Tika. So, you can easily
@@ -496,6 +500,7 @@ filter.org.dspace.app.mediafilter.JPEGFilter.inputFormats = BMP, GIF, JPEG, imag
 filter.org.dspace.app.mediafilter.BrandedPreviewJPEGFilter.inputFormats = BMP, GIF, JPEG, image/png
 filter.org.dspace.app.mediafilter.ImageMagickImageThumbnailFilter.inputFormats = BMP, GIF, image/png, JPG, TIFF, JPEG, JPEG 2000
 filter.org.dspace.app.mediafilter.ImageMagickPdfThumbnailFilter.inputFormats = Adobe PDF
+filter.org.dspace.app.mediafilter.ImageMagickVideoThumbnailFilter.inputFormats = Video MP4
 filter.org.dspace.app.mediafilter.PDFBoxThumbnail.inputFormats = Adobe PDF
 
 #Publicly accessible thumbnails of restricted content.

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -468,6 +468,9 @@ filter.plugins = PDFBox JPEG Thumbnail
 # [To enable ImageMagick Video Thumbnails (requires both ImageMagick and ffmpeg installed)]:
 #    uncomment and insert the following line into the plugin list
 #                ImageMagick Video Thumbnail, \
+#    NOTE: pay attention to the ImageMagick policies and reource limits in its policy.xml
+#          configuration file. The limits may have to be increased if a "cache resources
+#          exhausted" error is thrown.
 
 #Assign 'human-understandable' names to each filter
 plugin.named.org.dspace.app.mediafilter.FormatFilter = org.dspace.app.mediafilter.TikaTextExtractionFilter = Text Extractor


### PR DESCRIPTION
## Description
This PR provides a simple filter, based on the existing ImageMagick filter, to automatically create thumbnails for MP4 videos. In order to generate the thumbnail, ImageMagick only needs to modify how the input file of the conversion is specified:

* First, we specify the VIDEO _format specifier_ before the full path of the input file (see https://imagemagick.org/script/formats.php#supported). VIDEO supports, APNG, AVI, MP4, and WEBM, among other video formats.
* Second, we specify between brackets the frame we want to use as the thumbnail after the full path of the input file. We use 100, to avoid black thumbnails if the video starts with a a fade-in effect.

## Instructions for Reviewers

The changes are minimal: 

* A new `ImageMagickVideoThumbnailFilter` class, based on `ImageMagickImageThumbnailFilter` and also overriding the `getThumbnailFile` method from the `ImageMagickThumbnailFilter`abstract class.
* The corresponding configuration options un `dspace.cfg`. The filter is disabled by default, as other ImageMagick-based filters are.

The filter may be enabled as any other ImageMagick-based filters. The only additional pre-requisite is also installing `ffmpeg`, since ImageMagick relies on it. 

## Checklist

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods. -> **No new methods have been added, the code only overrides existing methods.**
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide). -> **No tests are affected, and previous ImageMagick filters didn't have specific tests so that has been left as it was.**
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation. -> **No new libraries have been included.**
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change. -> **No endpoints have been modified.**
- [X] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
