### PR TITLE
LDAP Auth extended for many groups

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
@@ -11,9 +11,11 @@ import static org.dspace.eperson.service.EPersonService.MD_PHONE;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Hashtable;
+import java.util.Iterator;
 import java.util.List;
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
@@ -64,6 +66,7 @@ import org.dspace.services.factory.DSpaceServicesFactory;
  * @author Reuben Pasquini
  * @author Samuel Ottenhoff
  * @author Ivan Masár
+ * @author Michael Plate
  */
 public class LDAPAuthentication
     implements AuthenticationMethod {
@@ -391,7 +394,7 @@ public class LDAPAuthentication
         protected String ldapGivenName = null;
         protected String ldapSurname = null;
         protected String ldapPhone = null;
-        protected String ldapGroup = null;
+        protected ArrayList<String> ldapGroup = null;
 
         /**
          * LDAP settings
@@ -406,8 +409,8 @@ public class LDAPAuthentication
         final String ldap_surname_field;
         final String ldap_phone_field;
         final String ldap_group_field;
-
         final boolean useTLS;
+
 
         SpeakerToLDAP(Logger thelog) {
             ConfigurationService configurationService
@@ -547,7 +550,11 @@ public class LDAPAuthentication
                         if (attlist[4] != null) {
                             att = atts.get(attlist[4]);
                             if (att != null) {
-                                ldapGroup = (String) att.get();
+                                // loop through all groups returned by LDAP
+                                ldapGroup = new ArrayList<String>();
+                                for (NamingEnumeration val = att.getAll(); val.hasMoreElements(); )  {
+                                    ldapGroup.add((String) val.next());
+                                }
                             }
                         }
 
@@ -693,48 +700,69 @@ public class LDAPAuthentication
     /*
      * Add authenticated users to the group defined in dspace.cfg by
      * the authentication-ldap.login.groupmap.* key.
+     * 
+     * @param dn
+     *  The string containing distinguished name of the user
+     * 
+     * @param group
+     *  List of strings with LDAP dn of groups
+     * 
+     * @param context
+     *  DSpace context
      */
-    private void assignGroups(String dn, String group, Context context) {
+    private void assignGroups(String dn, ArrayList<String> group, Context context) {
         if (StringUtils.isNotBlank(dn)) {
             System.out.println("dn:" + dn);
             int i = 1;
             String groupMap = configurationService.getProperty("authentication-ldap.login.groupmap." + i);
-
             boolean cmp;
 
+
+            // groupmap contains the mapping of LDAP groups to DSpace groups
+            // outer loop with the DSpace groups
             while (groupMap != null) {
                 String t[] = groupMap.split(":");
                 String ldapSearchString = t[0];
                 String dspaceGroupName = t[1];
 
-                if (group == null) {
-                    cmp = StringUtils.containsIgnoreCase(dn, ldapSearchString + ",");
-                } else {
-                    cmp = StringUtils.equalsIgnoreCase(group, ldapSearchString);
-                }
+                // list of strings with dn from LDAP groups
+                // inner loop
+                Iterator<String> groupIterator = group.iterator();
+                while (groupIterator.hasNext())  {
 
-                if (cmp) {
-                    // assign user to this group
-                    try {
-                        Group ldapGroup = groupService.findByName(context, dspaceGroupName);
-                        if (ldapGroup != null) {
-                            groupService.addMember(context, ldapGroup, context.getCurrentUser());
-                            groupService.update(context, ldapGroup);
-                        } else {
-                            // The group does not exist
-                            log.warn(LogHelper.getHeader(context,
-                                                          "ldap_assignGroupsBasedOnLdapDn",
-                                                          "Group defined in authentication-ldap.login.groupmap." + i
-                                                              + " does not exist :: " + dspaceGroupName));
+                    // save the current entry from iterator for further use
+                    String currentGroup = groupIterator.next();
+
+                    // very much the old code from DSpace <= 7.5
+                    if (currentGroup == null) {
+                        cmp = StringUtils.containsIgnoreCase(dn, ldapSearchString + ",");
+                    } else {
+                        cmp = StringUtils.equalsIgnoreCase(currentGroup, ldapSearchString);
+                    }
+
+                    if (cmp) {
+                        // assign user to this group
+                        try {
+                            Group ldapGroup = groupService.findByName(context, dspaceGroupName);
+                            if (ldapGroup != null) {
+                                groupService.addMember(context, ldapGroup, context.getCurrentUser());
+                                groupService.update(context, ldapGroup);
+                            } else {
+                                // The group does not exist
+                                log.warn(LogHelper.getHeader(context,
+                                                            "ldap_assignGroupsBasedOnLdapDn",
+                                                            "Group defined in authentication-ldap.login.groupmap." + i
+                                                                + " does not exist :: " + dspaceGroupName));
+                            }
+                        } catch (AuthorizeException ae) {
+                            log.debug(LogHelper.getHeader(context,
+                                                        "assignGroupsBasedOnLdapDn could not authorize addition to " +
+                                                            "group",
+                                                        dspaceGroupName));
+                        } catch (SQLException e) {
+                            log.debug(LogHelper.getHeader(context, "assignGroupsBasedOnLdapDn could not find group",
+                                                            dspaceGroupName));
                         }
-                    } catch (AuthorizeException ae) {
-                        log.debug(LogHelper.getHeader(context,
-                                                       "assignGroupsBasedOnLdapDn could not authorize addition to " +
-                                                           "group",
-                                                       dspaceGroupName));
-                    } catch (SQLException e) {
-                        log.debug(LogHelper.getHeader(context, "assignGroupsBasedOnLdapDn could not find group",
-                                                       dspaceGroupName));
                     }
                 }
 


### PR DESCRIPTION
## Description
This is for authentication via LDAP.
The original LDAPAuthenticate code only honours the first group returned from LDAP server for the group map and fails if it does not match.
This patch compares all from LDAP server returned groups and matches them accordingly to DSpace groups.


## Instructions for Reviewers
You need a LDAP server configured with users belonging to one or more groups ( >2 is better to see the new function).
configure the [dspace.dir]/config/modules/authentication-ldap.cfg file with a suitable `authentication-ldap.login.groupmap.attribute` attribute and add some `authentication-ldap.login.groupmap.X` attributes with matching group names in DSpace.

A user belonging to the LDAP groups should be member of the DSpace groups automatic after next login (see My DSpace / Profile after login)

This PR only changes a small number of lines and one method param in `LDAPAuthentication.java` and need to import 2 sub packages for ArrayList and Iterator.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x ] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
There is no test in the existing code for this part of DSpace…