### PR TITLE
Updated IIIF content search solr query params.

### DIFF
--- a/dspace-iiif/src/main/java/org/dspace/app/iiif/service/WordHighlightSolrSearch.java
+++ b/dspace-iiif/src/main/java/org/dspace/app/iiif/service/WordHighlightSolrSearch.java
@@ -118,7 +118,8 @@ public class WordHighlightSolrSearch implements SearchAnnotationService {
     }
 
     /**
-     * Constructs a solr search URL.
+     * Constructs a solr search URL. Compatible with solr-ocrhighlighting-0.7.2.
+     * https://github.com/dbmdz/solr-ocrhighlighting/releases/tag/0.7.2
      *
      * @param query the search terms
      * @param manifestId the id of the manifest in which to search
@@ -132,8 +133,9 @@ public class WordHighlightSolrSearch implements SearchAnnotationService {
         solrQuery.set("hl.ocr.fl", "ocr_text");
         solrQuery.set("hl.ocr.contextBlock", "line");
         solrQuery.set("hl.ocr.contextSize", "2");
-        solrQuery.set("hl.snippets", "10");
-        solrQuery.set("hl.ocr.trackPages", "off");
+        solrQuery.set("hl.snippets", "8192");
+        solrQuery.set("hl.ocr.maxPassages", "8192");
+        solrQuery.set("hl.ocr.trackPages", "on");
         solrQuery.set("hl.ocr.limitBlock","page");
         solrQuery.set("hl.ocr.absoluteHighlights", "true");
 


### PR DESCRIPTION
## Description
This updates solr query params in the `WordHighlightSolrSearch` plugin. The changes include a necessary change for solr-ocrhighlighting version 7 and to two optimizations recommended by the authors (for search in larger documents). 

@tdonohue, these changes don't have any other side effects in DSpace code so I think they are safe to merge without further testing.  l hope we can do more work in IIIF content search in 8.0 but in the meantime this allows using a more a up-to-date and bug-free version of the solr-ocrhighlighting solr plugin.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
