### PR TITLE
Replace invalid dc.terms.references with a proper dcterms.references

### DIFF
--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -910,9 +910,9 @@
             </row>
             <row>
                 <field>
-                    <dc-schema>dc</dc-schema>
-                    <dc-element>dcterms</dc-element>
-                    <dc-qualifier>references</dc-qualifier>
+                    <dc-schema>dcterms</dc-schema>
+                    <dc-element>references</dc-element>
+                    <dc-qualifier></dc-qualifier>
                     <repeatable>false</repeatable>
                     <label>Related Dataset</label>
                     <input-type>onebox</input-type>


### PR DESCRIPTION
## Description
Has revised here: https://github.com/DSpace/DSpace/pull/2608#discussion_r356597352
the proper metadata field should be: `dcterms.references`, but an incorrect `dc.terms.references` is specified.

`dc.terms.references` doesn't exist neither is supported as a metadata registry entry.

## Instructions for Reviewers
This PR just add a minor fix for the proper metadata field - `dcterms.references` at `openAIREPublicationPageoneForm`.

List of changes in this PR:
* Replace `dc.terms.references` with `dcterms.references`