### PR TITLE
Self links returned from RestAPI do not match the request's URL & Window size for paging does not match returned results for the discovery endpoint

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/hateoas/SearchResultsResource.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/hateoas/SearchResultsResource.java
@@ -9,6 +9,7 @@ package org.dspace.app.rest.model.hateoas;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.function.Function;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.commons.collections4.CollectionUtils;
@@ -21,6 +22,7 @@ import org.dspace.app.rest.utils.Utils;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.lang.Nullable;
 
 /**
  * This class' purpose is to create a container with a list of the SearchResultEntryResources
@@ -55,11 +57,74 @@ public class SearchResultsResource extends HALResource<SearchResultsRest> {
             entryResources.add(new SearchResultEntryResource(searchResultEntry, utils));
         }
 
-        Page page = new PageImpl<>(entryResources, pageable, data.getTotalNumberOfResults());
+        // FIX for mismatched page.getTotalElements() and data.getTotalNumberOfResults()
+        Page<SearchResultEntryResource> page =
+                new SearchResultPageImpl<>(entryResources, pageable, data.getTotalNumberOfResults());
 
         SearchResultsResourceHalLinkFactory linkFactory = new SearchResultsResourceHalLinkFactory();
         EmbeddedPage embeddedPage = new EmbeddedPage(linkFactory.buildSearchBaseLink(data).toUriString(),
                 page, entryResources, "objects");
         embedResource("searchResult", embeddedPage);
+    }
+
+    /**
+     * This class is a reiteration of org.springframework.data.domain.PageImpl, for the specific purpose of providing
+     * correct 'totalElements' value for SearchResultsResource#embedSearchResults.
+     * Secondly, we override every method that use PageImpl.total with SearchResultPageImpl.totalElements,
+     * to make sure the value provided via RestAPI is correct.
+     * @author Bui Thai Hai (thaihai.bui@dlcorp.com.vn)
+     */
+    private static final class SearchResultPageImpl<T> extends PageImpl<T> {
+        private final long totalElements;
+        public SearchResultPageImpl(List<T> content, Pageable pageable, long total) {
+            super(content, pageable, total);
+
+            // Main difference from PageImpl, where we mitigate the "mitigation" from super() which sets the 'total'
+            // value with content.size()
+            this.totalElements = super.getTotalElements() != total ? total : super.getTotalElements();
+        }
+
+        @Override
+        public int getTotalPages() {
+            return getSize() == 0 ? 1 : (int) Math.ceil((double) totalElements / (double) getSize());
+        }
+
+        @Override
+        public long getTotalElements() {
+            return totalElements;
+        }
+
+        @Override
+        public <U> Page<U> map(Function<? super T, ? extends U> converter) {
+            return new SearchResultPageImpl<>(getConvertedContent(converter), getPageable(), totalElements);
+        }
+
+
+        @Override
+        public boolean equals(@Nullable Object obj) {
+
+            if (this == obj) {
+                return true;
+            }
+
+            if (!(obj instanceof SearchResultPageImpl<?>)) {
+                return false;
+            }
+
+            SearchResultPageImpl<?> that = (SearchResultPageImpl<?>) obj;
+
+            return this.totalElements == that.totalElements && super.equals(obj);
+        }
+
+        @Override
+        public int hashCode() {
+
+            int result = 17;
+
+            result += 31 * (int) (totalElements ^ totalElements >>> 32);
+            result += 31 * super.hashCode();
+
+            return result;
+        }
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/DiscoveryRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/DiscoveryRestRepository.java
@@ -86,7 +86,13 @@ public class DiscoveryRestRepository extends AbstractDSpaceRestRepository {
         DiscoveryConfiguration discoveryConfiguration = searchConfigurationService
             .getDiscoveryConfigurationByNameOrIndexableObject(context, configuration, scopeObject);
 
-        return discoverConfigurationConverter.convert(discoveryConfiguration, utils.obtainProjection());
+        // Set values for searchConfigurationRest here, since there are no possible ways to get them from
+        //   DiscoveryConfiguration object
+        SearchConfigurationRest searchConfigurationRest = discoverConfigurationConverter.convert(discoveryConfiguration,
+                utils.obtainProjection());
+        searchConfigurationRest.setConfiguration(configuration);
+        searchConfigurationRest.setScope(dsoScope);
+        return searchConfigurationRest;
     }
 
     public SearchResultsRest getSearchObjects(final String query, final List<String> dsoTypes, final String dsoScope,

--- a/dspace-server-webapp/src/main/resources/application.properties
+++ b/dspace-server-webapp/src/main/resources/application.properties
@@ -130,3 +130,6 @@ spring.servlet.multipart.max-file-size = 512MB
 
 # Maximum size of a multipart request (i.e. max total size of all files in one request) (default = 10MB)
 spring.servlet.multipart.max-request-size = 512MB
+
+## Maximum page size per request (default = 1000)
+spring.data.rest.max-page-size=9999


### PR DESCRIPTION
# References
Fixes #8576
Fixes #8723

# Description
This fixes warnings when self links returned from RestAPI do not match the requests' URLs.


1. For #8576 the reason is that the converted `searchConfigurationRest` do not hold values of request parameters `configuration` and `scope`, due to the original DiscoveryConfiguration object do not store these value. The fix is simply setting them in `DiscoveryRestRepository.getSearchConfiguration()`

3. For #8723, I added class `SearchResultPageImpl` which extends `PageImpl`, since `PageImpl` tries to "mitigate inconsistencies" among the parameter provided to its constructor, which I suggest you take a look at. All in all, this resulted in the Discovery endpoint's `totalElements` value being set to `entryResources,size()`, instead of the provided `data.getTotalNumberOfResults()` from solr response.
    `SearchResultPageImpl` suppresses `PageImpl.total` with `SearchResultPageImpl.totalElement`, since `PageImpl.total` is a private value that is only accessible from within `PageImpl`, which means we only need to override all functions that use `PageImpl.total`.
     -  A better approach would be to write `SearchResultPageImpl` properly to implement `Page`, but I find it unnecessary to go that far.

# Instructions for Reviewers
1. For 8576, run request `/server/api/discover/search?scope=abcd&configuration=default-relationships`

3. For 8723, run added test case `org.dspace.app.rest.DiscoveryRestControllerIT#discoverSearchObjectsTestForPageSizeEqualsTotalElements`
    - To see the test fail, revert line `org/dspace/app/rest/model/hateoas/SearchResultsResource.java:61`, the test should fail with error message like this:
```
Expected: is [...]
     but: is json with json path "$['totalElements']" evaluated to is <110> json path "$['totalElements']" was evaluated to <100>
```

Code Contribution Checklist
- [x] PRs _should_ be smaller in size (ideally less than 1,000 lines of code, not including comments & tests)
- [x] PRs **must** pass Checkstyle validation based on our [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] PRs **must** include Javadoc for _all new/modified public methods and classes_. Larger private methods should also have Javadoc
- [x] PRs **must** pass all automated tests and include new/updated Unit or Integration tests based on our [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If a PR includes new libraries/dependencies (in any `pom.xml`), then their software licenses **must** align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] Basic technical documentation _should_ be provided for any new features or changes to the REST API. REST API changes should be documented in our [Rest Contract](https://github.com/DSpace/RestContract).
- [x] If a PR fixes an issue ticket, please [link them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204642791316993