### PR TITLE
Fix Codecov settings to notify after one coverage file upload

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,13 +4,6 @@
 # Can be validated via instructions at:
 # https://docs.codecov.io/docs/codecov-yaml#validate-your-repository-yaml
 
-# Tell Codecov not to send a coverage notification until (at least) 2 builds are completed
-# Since we run Unit & Integration tests in parallel, this lets Codecov know that coverage
-# needs to be merged across those builds
-codecov:
-  notify:
-    after_n_builds: 2
-
 # Settings related to code coverage analysis
 coverage:
   status:


### PR DESCRIPTION
## References
* Small follow-up to #8780

## Description
Since #8780 was merged, I've noticed that, while our uploads to CodeCov.io are more stable, it sometimes takes CodeCov longer to respond back to GitHub and update the status of new PRs.

After digging around, I realized this may be the fault of an old setting in our `.codecov.yml` where we were telling CodeCov to wait for two uploads.  Since #8780 though, we combined everything into a *single* upload to CodeCov.

This tiny PR removes the setting telling CodeCov to wait for two uploads.  It now should only wait for one.

## Instructions for Reviewers
* If this PR passes all CI **and** CodeCov responds immediately after one upload, then that implies the problem is likely fixed.  If that occurs, I will merge this immediately.