### PR TITLE
remove configuration property eperson.subscription.onlynew

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -893,10 +893,6 @@ org.dspace.app.batchitemimport.work.dir = ${dspace.dir}/imports
 # default = false, (disabled)
 #org.dspace.content.Collection.findAuthorizedPerformanceOptimize = true
 
-# For backwards compatibility, the subscription emails by default include any modified items
-# uncomment the following entry for only new items to be emailed
-# eperson.subscription.onlynew = true
-
 
 # Identifier providers.
 # Following are configuration values for the EZID DOI provider, with appropriate


### PR DESCRIPTION
## Description

The new email subscription service (which was introduced in DS 7.5 with PR https://github.com/DSpace/DSpace/pull/8620) does not support the exclusion of modified items.

The previous implementation (`sub-daily`) did it by using the configuration property `eperson.subscription.onlynew`. 

As this configuration property is no longer supported, it should be removed in `dspace.cfg` to prevent confusion.