### PR TITLE
Minor improvements to ImageMagick thumbnail filters

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickPdfThumbnailFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickPdfThumbnailFilter.java
@@ -22,7 +22,7 @@ public class ImageMagickPdfThumbnailFilter extends ImageMagickThumbnailFilter {
         File f2 = null;
         File f3 = null;
         try {
-            f2 = getImageFile(f, 0, verbose);
+            f2 = getImageFile(f, verbose);
             f3 = getThumbnailFile(f2, verbose);
             byte[] bytes = Files.readAllBytes(f3.toPath());
             return new ByteArrayInputStream(bytes);

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickPdfThumbnailFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickPdfThumbnailFilter.java
@@ -22,7 +22,9 @@ public class ImageMagickPdfThumbnailFilter extends ImageMagickThumbnailFilter {
         File f2 = null;
         File f3 = null;
         try {
+            // Step 1: get an image from our PDF file, with PDF-specific processing options
             f2 = getImageFile(f, verbose);
+            // Step 2: use the image above to create the final resized and rotated thumbnail
             f3 = getThumbnailFile(f2, verbose);
             byte[] bytes = Files.readAllBytes(f3.toPath());
             return new ByteArrayInputStream(bytes);

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickThumbnailFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickThumbnailFilter.java
@@ -116,7 +116,7 @@ public abstract class ImageMagickThumbnailFilter extends MediaFilter {
         return f2;
     }
 
-    public File getImageFile(File f, int page, boolean verbose)
+    public File getImageFile(File f, boolean verbose)
         throws IOException, InterruptedException, IM4JavaException {
         File f2 = new File(f.getParentFile(), f.getName() + ".jpg");
         f2.deleteOnExit();
@@ -155,7 +155,7 @@ public abstract class ImageMagickThumbnailFilter extends MediaFilter {
             op.define("pdf:use-cropbox=true");
         }
 
-        String s = "[" + page + "]";
+        String s = "[0]";
         op.addImage(f.getAbsolutePath() + s);
         if (configurationService.getBooleanProperty(PRE + ".flatten", true)) {
             op.flatten();

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickThumbnailFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickThumbnailFilter.java
@@ -116,6 +116,13 @@ public abstract class ImageMagickThumbnailFilter extends MediaFilter {
         return f2;
     }
 
+    /**
+     * Return an image from a bitstream with specific processing options for
+     * PDFs. This is only used by ImageMagickPdfThumbnailFilter in order to
+     * generate an intermediate image file for use with getThumbnailFile. It
+     * is unfortunate that this means we convert from PDF to JPEG to JPEG,
+     * which incurs generation loss.
+     */
     public File getImageFile(File f, boolean verbose)
         throws IOException, InterruptedException, IM4JavaException {
         File f2 = new File(f.getParentFile(), f.getName() + ".jpg");

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickThumbnailFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickThumbnailFilter.java
@@ -119,13 +119,14 @@ public abstract class ImageMagickThumbnailFilter extends MediaFilter {
     /**
      * Return an image from a bitstream with specific processing options for
      * PDFs. This is only used by ImageMagickPdfThumbnailFilter in order to
-     * generate an intermediate image file for use with getThumbnailFile. It
-     * is unfortunate that this means we convert from PDF to JPEG to JPEG,
-     * which incurs generation loss.
+     * generate an intermediate image file for use with getThumbnailFile.
      */
     public File getImageFile(File f, boolean verbose)
         throws IOException, InterruptedException, IM4JavaException {
-        File f2 = new File(f.getParentFile(), f.getName() + ".jpg");
+        // Writing an intermediate file to disk is inefficient, but since we're
+        // doing it anyway, we should use a lossless format. IM's internal MIFF
+        // is lossless like PNG and TIFF, but much faster.
+        File f2 = new File(f.getParentFile(), f.getName() + ".miff");
         f2.deleteOnExit();
         ConvertCmd cmd = new ConvertCmd();
         IMOperation op = new IMOperation();

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickThumbnailFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickThumbnailFilter.java
@@ -209,14 +209,14 @@ public abstract class ImageMagickThumbnailFilter extends MediaFilter {
                     if (replaceRegex.matcher(description).matches()) {
                         if (verbose) {
                             System.out.format("%s %s matches pattern and is replaceable.%n",
-                                    description, nsrc);
+                                    description, n);
                         }
                         continue;
                     }
                     if (description.equals(getDescription())) {
                         if (verbose) {
                             System.out.format("%s %s is replaceable.%n",
-                                    getDescription(), nsrc);
+                                    getDescription(), n);
                         }
                         continue;
                     }

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickThumbnailFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickThumbnailFilter.java
@@ -221,7 +221,7 @@ public abstract class ImageMagickThumbnailFilter extends MediaFilter {
                         continue;
                     }
                 }
-                System.out.format("Custom Thumbnail exists for %s for item %s.  Thumbnail will not be generated.%n",
+                System.out.format("Custom thumbnail exists for %s for item %s. Thumbnail will not be generated.%n",
                         nsrc, item.getHandle());
                 return false;
             }

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickThumbnailFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickThumbnailFilter.java
@@ -208,7 +208,7 @@ public abstract class ImageMagickThumbnailFilter extends MediaFilter {
                 if (description != null) {
                     if (replaceRegex.matcher(description).matches()) {
                         if (verbose) {
-                            System.out.format("%s %s matches pattern and is replacable.%n",
+                            System.out.format("%s %s matches pattern and is replaceable.%n",
                                     description, nsrc);
                         }
                         continue;


### PR DESCRIPTION
## References
* Related to #8849

## Description
Minor documentation and logging fixes to the ImageMagick thumbnail filters—these are not documented very well and have some logical errors. Also includes a minor optimization for PDF thumbnail generation, which changes the intermediate temp file format to MIFF instead of JPEG so we don't lose quality.

In the long term we will have to re-factor these filters, but for now I want to address some minor issues.

## Instructions for Reviewers
Test running the filter-media script on an item with PDF bitstreams. Use verbose and force to make sure the process works as expected:

```console
$ dspace filter-media -i 10568/130406 -v -f
```

List of changes in this PR:
* Add comments to ImageMagick Thumbnail filters because they are a bit confusing
* Improve verbose logging by fixing typos, style, and using the actual thumbnail name instead of the parent bitstream's name where appropriate
* Simplify logic in `getImageFile()` by removing the `page` parameter (we *always* use page 0 and this is not configurable so there is no need to use this parameter)

See the commit messages for more information.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
