### PR TITLE
Fix: Collection's admin cannot edit its template item.

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/ItemTemplateRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/ItemTemplateRestController.java
@@ -120,7 +120,7 @@ public class ItemTemplateRestController {
      * @throws SQLException
      * @throws AuthorizeException
      */
-    @PreAuthorize("hasPermission(#uuid, 'ITEM', 'WRITE')")
+    @PreAuthorize("hasPermission(#uuid, 'ITEMTEMPLATE', 'WRITE')")
     @RequestMapping(method = RequestMethod.PATCH)
     public ResponseEntity<RepresentationModel<?>> patch(HttpServletRequest request, @PathVariable UUID uuid,
                                                         @RequestBody(required = true) JsonNode jsonNode)
@@ -153,7 +153,7 @@ public class ItemTemplateRestController {
      * @throws AuthorizeException
      * @throws IOException
      */
-    @PreAuthorize("hasPermission(#uuid, 'ITEM', 'DELETE')")
+    @PreAuthorize("hasPermission(#uuid, 'ITEMTEMPLATE', 'DELETE')")
     @RequestMapping(method = RequestMethod.DELETE)
     public ResponseEntity<RepresentationModel<?>> deleteTemplateItem(HttpServletRequest request,
                                                                      @PathVariable UUID uuid)

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/TemplateItemRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/TemplateItemRestPermissionEvaluatorPlugin.java
@@ -1,0 +1,83 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.security;
+
+import java.io.Serializable;
+import java.sql.SQLException;
+import java.util.UUID;
+
+import org.apache.commons.lang3.StringUtils;
+import org.dspace.app.rest.model.TemplateItemRest;
+import org.dspace.app.rest.utils.ContextUtil;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.content.Collection;
+import org.dspace.content.service.ItemService;
+import org.dspace.core.Context;
+import org.dspace.eperson.EPerson;
+import org.dspace.services.RequestService;
+import org.dspace.services.model.Request;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+/**
+ * {@link RestObjectPermissionEvaluatorPlugin} class that evaluate WRITE and DELETE permission over a TemplateItem
+ *
+ * @author Bui Thai Hai (thaihai.bui@dlcorp.com.vn)
+ */
+@Component
+public class TemplateItemRestPermissionEvaluatorPlugin extends RestObjectPermissionEvaluatorPlugin {
+
+    private static final Logger log = LoggerFactory.getLogger(TemplateItemRestPermissionEvaluatorPlugin.class);
+
+    @Autowired
+    private RequestService requestService;
+
+    @Autowired
+    ItemService its;
+
+    @Autowired
+    private AuthorizeService authorizeService;
+
+    @Override
+    public boolean hasDSpacePermission(Authentication authentication, Serializable targetId, String targetType,
+            DSpaceRestPermission permission) {
+
+        DSpaceRestPermission restPermission = DSpaceRestPermission.convert(permission);
+        if (!DSpaceRestPermission.WRITE.equals(restPermission) &&
+                !DSpaceRestPermission.DELETE.equals(restPermission)) {
+            return false;
+        }
+        if (!StringUtils.equalsIgnoreCase(targetType, TemplateItemRest.NAME)) {
+            return false;
+        }
+
+        Request request = requestService.getCurrentRequest();
+        Context context = ContextUtil.obtainContext(request.getHttpServletRequest());
+
+        EPerson ePerson = context.getCurrentUser();
+        if (ePerson == null) {
+            return false;
+        }
+        // Allow collection's admin to edit/delete the template
+
+        UUID dsoId = UUID.fromString(targetId.toString());
+        requestService.getCurrentRequest().getHttpServletRequest().getRequestURL();
+        try {
+            Collection coll = its.find(context, dsoId).getTemplateItemOf();
+            if (authorizeService.isAdmin(context, coll)) {
+                return true;
+            }
+        } catch (SQLException e) {
+            log.error(e.getMessage(), e);
+        }
+        return false;
+    }
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemTemplateRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemTemplateRestControllerIT.java
@@ -33,6 +33,7 @@ import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
 import org.dspace.authorize.service.ResourcePolicyService;
 import org.dspace.builder.CollectionBuilder;
 import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.ResourcePolicyBuilder;
 import org.dspace.content.Collection;
 import org.dspace.core.Constants;
 import org.hamcrest.Matchers;
@@ -243,6 +244,35 @@ public class ItemTemplateRestControllerIT extends AbstractControllerIntegrationT
                                      )))));
     }
 
+    /* Similar to patchTemplateItem(), except it is for collection admin, not repository admin
+        Test case was simplified, since it does not do anything else.
+     */
+    @Test
+    public void patchTemplateItemAsCollectionAdmin() throws Exception {
+        setupTestTemplate();
+
+        String itemId = installTestTemplate();
+
+        ResourcePolicyBuilder.createResourcePolicy(context).withUser(eperson)
+                .withAction(Constants.ADMIN)
+                .withDspaceObject(childCollection).build();
+        String collAdminToken = getAuthToken(eperson.getEmail(), password);
+
+        getClient(collAdminToken).perform(patch(getTemplateItemUrlTemplate(itemId))
+                        .content(patchBody)
+                        .contentType(contentType))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", Matchers.allOf(
+                        hasJsonPath("$.type", is("itemtemplate"))
+                        )));
+
+        getClient(collAdminToken).perform(get(getCollectionTemplateItemUrlTemplate(childCollection.getID().toString())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", Matchers.allOf(
+                        hasJsonPath("$.type", is("itemtemplate"))
+                        )));
+    }
+
     @Test
     public void patchIllegalInArchiveTemplateItem() throws Exception {
         setupTestTemplate();
@@ -335,6 +365,22 @@ public class ItemTemplateRestControllerIT extends AbstractControllerIntegrationT
 
         getClient(adminAuthToken).perform(delete(getTemplateItemUrlTemplate(itemId)))
                                  .andExpect(status().isNoContent());
+    }
+
+    /*Similar to deleteTemplateItem(), except it is for collection admin, not repository admin
+     */
+    @Test
+    public void deleteTemplateItemAsCollectionAdmin() throws Exception {
+        setupTestTemplate();
+        String itemId = installTestTemplate();
+
+        ResourcePolicyBuilder.createResourcePolicy(context).withUser(eperson)
+                .withAction(Constants.ADMIN)
+                .withDspaceObject(childCollection).build();
+        String collAdminToken = getAuthToken(eperson.getEmail(), password);
+
+        getClient(collAdminToken).perform(delete(getTemplateItemUrlTemplate(itemId)))
+                .andExpect(status().isNoContent());
     }
 
     @Test


### PR DESCRIPTION
## References
Fix [#8832](https://github.com/DSpace/DSpace/issues/8832)

## Description
This fixes the error at step 6 of #8832.
- Please follow the instructed steps to reproduce and verify the fix

In addition, this PR also applies to Template Item removal action.

## Instructions for Reviewers

List of changes in this PR:
- First, I create a new `RestObjectPermissionEvaluatorPlugin` for `TemplateItem` to perform extra evaluations when editing or deleting a template item.
  - Making use of an existing `RestObjectPermissionEvaluatorPlugin` would be ideal, but none suffices. The best candidate I found is `WorkspaceItemRestPermissionEvaluatorPlugin` but it is too specific to WorkspaceItem to rewrite easily.
- Second, I changed the parameter from `'ITEM'` to `'ITEMTEMPLATE'` in `@PreAuthorize("hasPermission(...)")` of methods `patch()` and `deleteTemplateItem()` to take advantage of existing `TemplateItemRest` class, in order to distinguish it further from the generic `Item` term.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204642791317001