### PR TITLE
pom.xml: bump a handful of dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,10 +22,10 @@
         <spring.version>5.3.27</spring.version>
         <spring-boot.version>2.7.11</spring-boot.version>
         <spring-security.version>5.7.8</spring-security.version> <!-- sync with version used by spring-boot-->
-        <hibernate.version>5.6.5.Final</hibernate.version>
-        <hibernate-validator.version>6.0.23.Final</hibernate-validator.version>
-        <postgresql.driver.version>42.4.3</postgresql.driver.version>
-        <solr.client.version>8.11.1</solr.client.version>
+        <hibernate.version>5.6.15.Final</hibernate.version>
+        <hibernate-validator.version>6.2.5.Final</hibernate-validator.version>
+        <postgresql.driver.version>42.6.0</postgresql.driver.version>
+        <solr.client.version>8.11.2</solr.client.version>
 
         <ehcache.version>3.4.0</ehcache.version>
         <errorprone.version>2.10.0</errorprone.version>
@@ -38,10 +38,10 @@
         <jcache-version>1.1.0</jcache-version>
         <!-- NOTE: Jetty needed for Solr, Handle Server & tests -->
         <jetty.version>9.4.51.v20230217</jetty.version>
-        <log4j.version>2.17.1</log4j.version>
-        <pdfbox-version>2.0.27</pdfbox-version>
-        <rome.version>1.18.0</rome.version>
-        <slf4j.version>1.7.25</slf4j.version>
+        <log4j.version>2.20.0</log4j.version>
+        <pdfbox-version>2.0.28</pdfbox-version>
+        <rome.version>1.19.0</rome.version>
+        <slf4j.version>1.7.36</slf4j.version>
         <tika.version>2.3.0</tika.version>
         <!-- Sync with whatever version Tika uses -->
         <bouncycastle.version>1.70</bouncycastle.version>


### PR DESCRIPTION
All minor and patch versions with no breaking changes:

- pdfbox 2.0.27→2.0.28
  - See: https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12310760&version=12352284
- log4j 2.17.1→2.20.0
  - See: https://logging.apache.org/log4j/2.x/release-notes/2.20.0.html
- rome 1.18.0→1.19.0
  - See: https://github.com/rometools/rome/releases/tag/1.19.0
- slf4j 1.7.25→1.7.36
  - https://www.slf4j.org/news.html
- solr-client 8.11.1→8.11.2
  - https://lucene.apache.org/core/8_11_2/changes/Changes.html
- hibernate 5.6.5.Final→5.6.15.Final
  - See: https://hibernate.org/orm/releases/5.6/#whats-new
- hibernate-validator 6.0.23.Final→6.2.5.Final
  - See: https://hibernate.org/validator/documentation/migration-guide/#6-2-x
- postgresql JDBC driver 42.4.3→42.6.0
  - See: https://jdbc.postgresql.org/changelogs/

I have done basic tests:

- Submit item
- Upload/delete/filter PDF bitstreams (thumbnail and text created successfully)
- Discovery indexing
- Atom feeds for communities and collections
- Export search results as CSV

Submitting pull request to see if tests pass.