### PR TITLE
Disable DTD parsing in all external source plugins

### DIFF
--- a/dspace-api/src/main/java/org/dspace/ctask/general/MetadataWebService.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/MetadataWebService.java
@@ -207,9 +207,10 @@ public class MetadataWebService extends AbstractCurationTask implements Namespac
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         factory.setNamespaceAware(true);
         try {
-            // disallow DTD parsing to ensure no XXE attacks can occur.
+            // disallow DTD parsing to ensure no XXE attacks can occur
             // See https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html
             factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setXIncludeAware(false);
             docBuilder = factory.newDocumentBuilder();
         } catch (ParserConfigurationException pcE) {
             log.error("caught exception: " + pcE);

--- a/dspace-api/src/main/java/org/dspace/external/provider/orcid/xml/Converter.java
+++ b/dspace-api/src/main/java/org/dspace/external/provider/orcid/xml/Converter.java
@@ -12,6 +12,9 @@ import java.net.URISyntaxException;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
 
 import org.xml.sax.SAXException;
 
@@ -28,11 +31,16 @@ public abstract class Converter<T> {
 
     protected Object unmarshall(InputStream input, Class<?> type) throws SAXException, URISyntaxException {
         try {
+            XMLInputFactory xmlInputFactory = XMLInputFactory.newFactory();
+            // disallow DTD parsing to ensure no XXE attacks can occur
+            xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+            XMLStreamReader xmlStreamReader = xmlInputFactory.createXMLStreamReader(input);
+
             JAXBContext context = JAXBContext.newInstance(type);
             Unmarshaller unmarshaller = context.createUnmarshaller();
-            return unmarshaller.unmarshal(input);
-        } catch (JAXBException e) {
-            throw new RuntimeException("Unable to unmarshall orcid message" + e);
+            return unmarshaller.unmarshal(xmlStreamReader);
+        } catch (JAXBException | XMLStreamException e) {
+            throw new RuntimeException("Unable to unmarshall orcid message: " + e);
         }
     }
 }

--- a/dspace-api/src/main/java/org/dspace/importer/external/cinii/CiniiImportMetadataSourceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/cinii/CiniiImportMetadataSourceServiceImpl.java
@@ -303,6 +303,8 @@ public class CiniiImportMetadataSourceServiceImpl extends AbstractImportMetadata
     private List<Element> splitToRecords(String recordsSrc) {
         try {
             SAXBuilder saxBuilder = new SAXBuilder();
+            // disallow DTD parsing to ensure no XXE attacks can occur
+            saxBuilder.setFeature("http://apache.org/xml/features/disallow-doctype-decl",true);
             Document document = saxBuilder.build(new StringReader(recordsSrc));
             Element root = document.getRootElement();
             return root.getChildren();
@@ -356,6 +358,8 @@ public class CiniiImportMetadataSourceServiceImpl extends AbstractImportMetadata
             String response = liveImportClient.executeHttpGetRequest(1000, uriBuilder.toString(), params);
             int url_len = this.url.length() - 1;
             SAXBuilder saxBuilder = new SAXBuilder();
+            // disallow DTD parsing to ensure no XXE attacks can occur
+            saxBuilder.setFeature("http://apache.org/xml/features/disallow-doctype-decl",true);
             Document document = saxBuilder.build(new StringReader(response));
             Element root = document.getRootElement();
             List<Namespace> namespaces = Arrays.asList(
@@ -418,6 +422,8 @@ public class CiniiImportMetadataSourceServiceImpl extends AbstractImportMetadata
             String response = liveImportClient.executeHttpGetRequest(1000, uriBuilder.toString(), params);
 
             SAXBuilder saxBuilder = new SAXBuilder();
+            // disallow DTD parsing to ensure no XXE attacks can occur
+            saxBuilder.setFeature("http://apache.org/xml/features/disallow-doctype-decl",true);
             Document document = saxBuilder.build(new StringReader(response));
             Element root = document.getRootElement();
             List<Namespace> namespaces = Arrays

--- a/dspace-api/src/main/java/org/dspace/importer/external/epo/service/EpoImportMetadataSourceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/epo/service/EpoImportMetadataSourceServiceImpl.java
@@ -398,6 +398,8 @@ public class EpoImportMetadataSourceServiceImpl extends AbstractImportMetadataSo
             String response = liveImportClient.executeHttpGetRequest(1000, uriBuilder.toString(), params);
 
             SAXBuilder saxBuilder = new SAXBuilder();
+            // disallow DTD parsing to ensure no XXE attacks can occur
+            saxBuilder.setFeature("http://apache.org/xml/features/disallow-doctype-decl",true);
             Document document = saxBuilder.build(new StringReader(response));
             Element root = document.getRootElement();
 
@@ -435,6 +437,8 @@ public class EpoImportMetadataSourceServiceImpl extends AbstractImportMetadataSo
             String response = liveImportClient.executeHttpGetRequest(1000, uriBuilder.toString(), params);
 
             SAXBuilder saxBuilder = new SAXBuilder();
+            // disallow DTD parsing to ensure no XXE attacks can occur
+            saxBuilder.setFeature("http://apache.org/xml/features/disallow-doctype-decl",true);
             Document document = saxBuilder.build(new StringReader(response));
             Element root = document.getRootElement();
 
@@ -486,6 +490,8 @@ public class EpoImportMetadataSourceServiceImpl extends AbstractImportMetadataSo
     private List<Element> splitToRecords(String recordsSrc) {
         try {
             SAXBuilder saxBuilder = new SAXBuilder();
+            // disallow DTD parsing to ensure no XXE attacks can occur
+            saxBuilder.setFeature("http://apache.org/xml/features/disallow-doctype-decl",true);
             Document document = saxBuilder.build(new StringReader(recordsSrc));
             Element root = document.getRootElement();
             List<Namespace> namespaces = Arrays.asList(Namespace.getNamespace("ns", "http://www.epo.org/exchange"));

--- a/dspace-api/src/main/java/org/dspace/importer/external/pubmed/service/PubmedImportMetadataSourceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/pubmed/service/PubmedImportMetadataSourceServiceImpl.java
@@ -351,6 +351,11 @@ public class PubmedImportMetadataSourceServiceImpl extends AbstractImportMetadat
     private List<Element> splitToRecords(String recordsSrc) {
         try {
             SAXBuilder saxBuilder = new SAXBuilder();
+            // Disallow external entities & entity expansion to protect against XXE attacks
+            // (NOTE: We receive errors if we disable all DTDs for PubMed, so this is the best we can do)
+            saxBuilder.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            saxBuilder.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            saxBuilder.setExpandEntities(false);
             Document document = saxBuilder.build(new StringReader(recordsSrc));
             Element root = document.getRootElement();
 

--- a/dspace-api/src/main/java/org/dspace/importer/external/pubmedeurope/PubmedEuropeMetadataSourceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/pubmedeurope/PubmedEuropeMetadataSourceServiceImpl.java
@@ -294,6 +294,8 @@ public class PubmedEuropeMetadataSourceServiceImpl extends AbstractImportMetadat
             String response = liveImportClient.executeHttpGetRequest(1000, buildURI(1, query), params);
 
             SAXBuilder saxBuilder = new SAXBuilder();
+            // disallow DTD parsing to ensure no XXE attacks can occur
+            saxBuilder.setFeature("http://apache.org/xml/features/disallow-doctype-decl",true);
             Document document = saxBuilder.build(new StringReader(response));
             Element root = document.getRootElement();
             Element element = root.getChild("hitCount");
@@ -365,6 +367,8 @@ public class PubmedEuropeMetadataSourceServiceImpl extends AbstractImportMetadat
                 String cursorMark = StringUtils.EMPTY;
                 if (StringUtils.isNotBlank(response)) {
                     SAXBuilder saxBuilder = new SAXBuilder();
+                    // disallow DTD parsing to ensure no XXE attacks can occur
+                    saxBuilder.setFeature("http://apache.org/xml/features/disallow-doctype-decl",true);
                     Document document = saxBuilder.build(new StringReader(response));
                     XPathFactory xpfac = XPathFactory.instance();
                     XPathExpression<Element> xPath = xpfac.compile("//responseWrapper/resultList/result",

--- a/dspace-api/src/main/java/org/dspace/importer/external/scopus/service/ScopusImportMetadataSourceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/scopus/service/ScopusImportMetadataSourceServiceImpl.java
@@ -202,6 +202,8 @@ public class ScopusImportMetadataSourceServiceImpl extends AbstractImportMetadat
                 String response = liveImportClient.executeHttpGetRequest(timeout, url, params);
 
                 SAXBuilder saxBuilder = new SAXBuilder();
+                // disallow DTD parsing to ensure no XXE attacks can occur
+                saxBuilder.setFeature("http://apache.org/xml/features/disallow-doctype-decl",true);
                 Document document = saxBuilder.build(new StringReader(response));
                 Element root = document.getRootElement();
 
@@ -377,6 +379,8 @@ public class ScopusImportMetadataSourceServiceImpl extends AbstractImportMetadat
     private List<Element> splitToRecords(String recordsSrc) {
         try {
             SAXBuilder saxBuilder = new SAXBuilder();
+            // disallow DTD parsing to ensure no XXE attacks can occur
+            saxBuilder.setFeature("http://apache.org/xml/features/disallow-doctype-decl",true);
             Document document = saxBuilder.build(new StringReader(recordsSrc));
             Element root = document.getRootElement();
             List<Element> records = root.getChildren("entry",Namespace.getNamespace("http://www.w3.org/2005/Atom"));

--- a/dspace-api/src/main/java/org/dspace/importer/external/wos/service/WOSImportMetadataSourceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/wos/service/WOSImportMetadataSourceServiceImpl.java
@@ -147,6 +147,8 @@ public class WOSImportMetadataSourceServiceImpl extends AbstractImportMetadataSo
                 String response = liveImportClient.executeHttpGetRequest(timeout, url, params);
 
                 SAXBuilder saxBuilder = new SAXBuilder();
+                // disallow DTD parsing to ensure no XXE attacks can occur
+                saxBuilder.setFeature("http://apache.org/xml/features/disallow-doctype-decl",true);
                 Document document = saxBuilder.build(new StringReader(response));
                 Element root = document.getRootElement();
                 XPathExpression<Element> xpath = XPathFactory.instance().compile("//*[@name=\"RecordsFound\"]",
@@ -285,6 +287,8 @@ public class WOSImportMetadataSourceServiceImpl extends AbstractImportMetadataSo
     private List<Element> splitToRecords(String recordsSrc) {
         try {
             SAXBuilder saxBuilder = new SAXBuilder();
+            // disallow DTD parsing to ensure no XXE attacks can occur
+            saxBuilder.setFeature("http://apache.org/xml/features/disallow-doctype-decl",true);
             Document document = saxBuilder.build(new StringReader(recordsSrc));
             Element root = document.getRootElement();
             String cData = XPathFactory.instance().compile("//*[@name=\"Records\"]",


### PR DESCRIPTION
## References
Fixes a number of _potential_ XXE vulnerabilities (reported by GitHub's code scanning) in our codebase with regards to importing metadata from external sources (PubMed, Web of Science, etc).  

Keep in mind, the risk of these vulnerabilities being exploited is extremely low since these external sources are all trusted APIs.  That said, we obviously should patch our codebase to avoid a scenario where, if the trusted API is exploited, DSpace could also be exploited.

## Description
Per recommendations of OWASP, patched our XML parsing to disable DTD (except in one scenario, PubMed, as noted below).

The patched code was borrowed directly from the OWASP cheat sheet: https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html

In all scenarios, DTDs are disabled **except** for PubMed (`PubMedImportMetadataSourceServiceImpl`).  When DTDs were fully disabled, errors occurred with the PubMed import process.  So, I went with the second best approach from OWASP which was to disallow external entities & entity expansion.  (Somewhat oddly PubMed Europe works fine with DTDs disabled, this only occurred for PubMed)

## Instructions for Reviewers
* Review code changes
* Attempt a new Import from these external sources (these were all patched).  These imports can all be done from MyDSpace:
    * Import -> Person -> ORCID
    * Import -> Item/Publication -> PubMed
    * Import -> Item/Publication -> CiNii  (requires free api key) 
    * Import -> Item/Publication -> European Patent Office (EPO) (requires free api key) 
    * Import -> Item/Publication -> PubMed Europe
    * Import -> Item/Publication -> Scopus (requires free api key) 
    * Import -> Item/Publication -> Web Of Science (*) (UNFORTUNATELY, I cannot test this one. Requires a **paid** api key.)
* NOTE: You do **not** need to complete a submission for each of these scenarios. You just need to verify that the search returns results from the external service & you can click on a result to *start a submission*.  That will verify that XML parsing of the API is unaffected by the patching.
* For those sources that require an API key, see our [documentation](https://wiki.lyrasis.org/pages/viewpage.action?pageId=104566672#ImportingItemsviabasicbibliographicformats(Endnote,BibTex,RIS,CSV,etc)andonlineservices(arXiv,PubMed,CrossRef,CiNii,etc)-SupportedExternalSources)

I have successfully tested all of the modified sources **except** for Web of Science.  I do not have access to a paid API key, and they have been unwilling to provide me with a free one.