### PR TITLE
Unlink DOI from item on deletion even if no provider is configured

### DIFF
--- a/dspace-api/src/test/java/org/dspace/content/CollectionTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/CollectionTest.java
@@ -725,9 +725,6 @@ public class CollectionTest extends AbstractDSpaceObjectTest {
         // Allow Item REMOVE perms
         doNothing().when(authorizeServiceSpy)
                    .authorizeAction(any(Context.class), any(Item.class), eq(Constants.REMOVE));
-        // Allow Item WRITE perms (Needed to remove identifiers, e.g. DOI, before Item deletion)
-        doNothing().when(authorizeServiceSpy)
-                   .authorizeAction(any(Context.class), any(Item.class), eq(Constants.WRITE));
 
         // create & add item first
         context.turnOffAuthorisationSystem();

--- a/dspace-api/src/test/java/org/dspace/content/ItemTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/ItemTest.java
@@ -1189,8 +1189,6 @@ public class ItemTest extends AbstractDSpaceObjectTest {
         doNothing().when(authorizeServiceSpy).authorizeAction(context, item, Constants.REMOVE, true);
         // Allow Item DELETE perms
         doNothing().when(authorizeServiceSpy).authorizeAction(context, item, Constants.DELETE);
-        // Allow Item WRITE perms (required to first delete identifiers)
-        doNothing().when(authorizeServiceSpy).authorizeAction(context, item, Constants.WRITE);
 
         UUID id = item.getID();
         itemService.delete(context, item);


### PR DESCRIPTION
## Description
This small change uses the DOI service, which is always available to DSpace even if no DOI provider, connector or consumer is configured, to unlink (set dspace_object_id to NULL) an existing DOI from an item during the `deleteRaw()` method, similar to the way the handle service unbinds a handle.

This fixes a particular condition where a repository has some existing items (archived or workspace) with DOIs minted, and therefore foreign key references in the doi table, but currently does not have a DOI provider configured - perhaps it no longer registers DOIs for new items.

Without this patch, trying to delete such an item will result in a hibernate foreign key constraint error. The item will not complete deletion, but will be de-indexed.

With this patch, the DOI service will ensure that if the item has a DOI, the object ID is set to NULL, which is the usual behaviour when deleting with the provider configured.

I tried to make a unit test to test this, but since the DOIIdentifierProvider is configured in the test config, I'm not sure how to properly simulate this behaviour. Unregistering the DOI provider via service manager didn't seem to help.

## Instructions for Reviewers

Without PR applied:
1. Enable a DOI provider and connector (no need to actually perform remote registration) configured in identifier-services.xml
2. Optional: In identifiers.cfg, enable workspace registration with `identifiers.submission.register = true` (this just makes testing easier and replicates the scenario where I first detected this problem)
3. Create a new item. If you did step 2, no need to archive, just check the doi table to make sure the new doi is minted with the object uuid in dspace_object_id
4. Disable the DOI provider and connector in identifier-services.xml and restart tomcat
5. Try to delete the workspace or archived item and note the error

With PR applied:
1. Repeat the above steps. The deletion should now be successful and the doi entry in the doi table should have a null dspace_object_id

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
