### PR TITLE
Fix: default sort option for discovery

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoverySortConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoverySortConfiguration.java
@@ -9,6 +9,7 @@ package org.dspace.discovery.configuration;
 
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nullable;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -22,12 +23,25 @@ public class DiscoverySortConfiguration {
 
     private List<DiscoverySortFieldConfiguration> sortFields = new ArrayList<DiscoverySortFieldConfiguration>();
 
+    /**
+     * Default sort configuration to use when needed
+     */
+    @Nullable private DiscoverySortFieldConfiguration defaultSortField;
+
     public List<DiscoverySortFieldConfiguration> getSortFields() {
         return sortFields;
     }
 
     public void setSortFields(List<DiscoverySortFieldConfiguration> sortFields) {
         this.sortFields = sortFields;
+    }
+
+    public DiscoverySortFieldConfiguration getDefaultSortField() {
+        return defaultSortField;
+    }
+
+    public void setDefaultSortField(DiscoverySortFieldConfiguration configuration) {
+        this.defaultSortField = configuration;
     }
 
     public DiscoverySortFieldConfiguration getSortFieldConfiguration(String sortField) {

--- a/dspace-api/src/main/java/org/dspace/discovery/utils/DiscoverQueryBuilder.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/utils/DiscoverQueryBuilder.java
@@ -332,7 +332,9 @@ public class DiscoverQueryBuilder implements InitializingBean {
     }
 
     private String getDefaultSortDirection(DiscoverySortConfiguration searchSortConfiguration, String sortOrder) {
-        if (Objects.nonNull(searchSortConfiguration.getSortFields()) &&
+        if (searchSortConfiguration.getDefaultSortField() != null) {
+            sortOrder = searchSortConfiguration.getDefaultSortField().getDefaultSortOrder().name();
+        } else if (Objects.nonNull(searchSortConfiguration.getSortFields()) &&
                 !searchSortConfiguration.getSortFields().isEmpty()) {
             sortOrder = searchSortConfiguration.getSortFields().get(0).getDefaultSortOrder().name();
         }
@@ -342,7 +344,9 @@ public class DiscoverQueryBuilder implements InitializingBean {
     private String getDefaultSortField(DiscoverySortConfiguration searchSortConfiguration) {
         String sortBy;// Attempt to find the default one, if none found we use SCORE
         sortBy = "score";
-        if (Objects.nonNull(searchSortConfiguration.getSortFields()) &&
+        if (searchSortConfiguration.getDefaultSortField() != null) {
+            sortBy = searchSortConfiguration.getDefaultSortField().getMetadataField();
+        } else if (Objects.nonNull(searchSortConfiguration.getSortFields()) &&
                 !searchSortConfiguration.getSortFields().isEmpty()) {
             DiscoverySortFieldConfiguration defaultSort = searchSortConfiguration.getSortFields().get(0);
             if (StringUtils.isBlank(defaultSort.getMetadataField())) {

--- a/dspace-api/src/test/java/org/dspace/discovery/DiscoveryIT.java
+++ b/dspace-api/src/test/java/org/dspace/discovery/DiscoveryIT.java
@@ -768,6 +768,7 @@ public class DiscoveryIT extends AbstractIntegrationTestWithDatabase {
                     .withTitle("item " + i)
                     .build();
         }
+        context.restoreAuthSystemState();
 
         // Build query with default parameters (except for workspaceConf)
         DiscoverQuery discoverQuery = SearchUtils.getQueryBuilder()
@@ -776,26 +777,21 @@ public class DiscoveryIT extends AbstractIntegrationTestWithDatabase {
 
         DiscoverResult result = searchService.search(context, discoverQuery);
 
-        if (defaultSortField.getMetadataField().equals("dc_date_accessioned")) {
-            // Verify that search results are sort by dc_date_accessioned
-            LinkedList<String> dc_date_accesioneds = result.getIndexableObjects().stream()
-                    .map(o -> ((Item) o.getIndexedObject()).getMetadata())
-                    .map(l -> l.stream().filter(m -> m.getMetadataField().toString().equals("dc_date_accessioned"))
-                                    .map(m -> m.getValue()).findFirst().orElse("")
-                    )
-                    .collect(Collectors.toCollection(LinkedList::new));
-            assertFalse(dc_date_accesioneds.isEmpty());
-            for (int i = 1; i < dc_date_accesioneds.size() - 1; i++) {
-                assertTrue(dc_date_accesioneds.get(i).compareTo(dc_date_accesioneds.get(i + 1)) >= 0);
-            }
-        } else if (defaultSortField.getMetadataField().equals("lastModified")) {
-            LinkedList<String> lastModifieds = result.getIndexableObjects().stream()
-                    .map(o -> ((Item) o.getIndexedObject()).getLastModified().toString())
-                    .collect(Collectors.toCollection(LinkedList::new));
-            assertFalse(lastModifieds.isEmpty());
-            for (int i = 1; i < lastModifieds.size() - 1; i++) {
-                assertTrue(lastModifieds.get(i).compareTo(lastModifieds.get(i + 1)) >= 0);
-            }
+        /*
+        // code example for testing against sort by dc_date_accessioned
+        LinkedList<String> dc_date_accesioneds = result.getIndexableObjects().stream()
+                .map(o -> ((Item) o.getIndexedObject()).getMetadata())
+                .map(l -> l.stream().filter(m -> m.getMetadataField().toString().equals("dc_date_accessioned"))
+                                .map(m -> m.getValue()).findFirst().orElse("")
+                )
+                .collect(Collectors.toCollection(LinkedList::new));
+        }*/
+        LinkedList<String> lastModifieds = result.getIndexableObjects().stream()
+                .map(o -> ((Item) o.getIndexedObject()).getLastModified().toString())
+                .collect(Collectors.toCollection(LinkedList::new));
+        assertFalse(lastModifieds.isEmpty());
+        for (int i = 1; i < lastModifieds.size() - 1; i++) {
+            assertTrue(lastModifieds.get(i).compareTo(lastModifieds.get(i + 1)) >= 0);
         }
     }
 

--- a/dspace-api/src/test/java/org/dspace/discovery/DiscoveryIT.java
+++ b/dspace-api/src/test/java/org/dspace/discovery/DiscoveryIT.java
@@ -8,13 +8,16 @@
 package org.dspace.discovery;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 
 import org.dspace.AbstractIntegrationTestWithDatabase;
@@ -24,6 +27,7 @@ import org.dspace.authorize.AuthorizeException;
 import org.dspace.builder.ClaimedTaskBuilder;
 import org.dspace.builder.CollectionBuilder;
 import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.EPersonBuilder;
 import org.dspace.builder.ItemBuilder;
 import org.dspace.builder.PoolTaskBuilder;
 import org.dspace.builder.WorkflowItemBuilder;
@@ -39,6 +43,8 @@ import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.CollectionService;
 import org.dspace.content.service.ItemService;
 import org.dspace.content.service.WorkspaceItemService;
+import org.dspace.discovery.configuration.DiscoveryConfiguration;
+import org.dspace.discovery.configuration.DiscoverySortFieldConfiguration;
 import org.dspace.discovery.indexobject.IndexableClaimedTask;
 import org.dspace.discovery.indexobject.IndexableCollection;
 import org.dspace.discovery.indexobject.IndexableItem;
@@ -728,6 +734,68 @@ public class DiscoveryIT extends AbstractIntegrationTestWithDatabase {
         assertEquals(numberItemsSubject2, counter);
         for (Item item : itemsSubject2) {
             assertTrue(foundItems.contains(item));
+        }
+    }
+
+    /**
+     * Test designed to check if default sort option for Discovery is working, using <code>workspace</code>
+     * DiscoveryConfiguration <br/>
+     * <b>Note</b>: this test will be skipped if <code>workspace</code> do not have a default sort option set and of
+     * metadataType <code>dc_date_accessioned</code> or <code>lastModified</code>
+     * @throws SearchServiceException
+     */
+    @Test
+    public void searchWithDefaultSortServiceTest() throws SearchServiceException {
+
+        DiscoveryConfiguration workspaceConf = SearchUtils.getDiscoveryConfiguration("workspace", null);
+        // Skip if no default sort option set for workspaceConf
+        if (workspaceConf.getSearchSortConfiguration().getDefaultSortField() == null) {
+            return;
+        }
+
+        DiscoverySortFieldConfiguration defaultSortField =
+                workspaceConf.getSearchSortConfiguration().getDefaultSortField();
+
+        // Populate the testing objects: create items in eperson's workspace and perform search in it
+        int numberItems = 10;
+        context.turnOffAuthorisationSystem();
+        EPerson submitter = EPersonBuilder.createEPerson(context).withEmail("submitter@example.org").build();
+        context.setCurrentUser(submitter);
+        Community community = CommunityBuilder.createCommunity(context).build();
+        Collection collection = CollectionBuilder.createCollection(context, community).build();
+        for (int i = 0; i < numberItems; i++) {
+            ItemBuilder.createItem(context, collection)
+                    .withTitle("item " + i)
+                    .build();
+        }
+
+        // Build query with default parameters (except for workspaceConf)
+        DiscoverQuery discoverQuery = SearchUtils.getQueryBuilder()
+                .buildQuery(context, new IndexableCollection(collection), workspaceConf,"",null,"Item",null,null,
+                        null,null);
+
+        DiscoverResult result = searchService.search(context, discoverQuery);
+
+        if (defaultSortField.getMetadataField().equals("dc_date_accessioned")) {
+            // Verify that search results are sort by dc_date_accessioned
+            LinkedList<String> dc_date_accesioneds = result.getIndexableObjects().stream()
+                    .map(o -> ((Item) o.getIndexedObject()).getMetadata())
+                    .map(l -> l.stream().filter(m -> m.getMetadataField().toString().equals("dc_date_accessioned"))
+                                    .map(m -> m.getValue()).findFirst().orElse("")
+                    )
+                    .collect(Collectors.toCollection(LinkedList::new));
+            assertFalse(dc_date_accesioneds.isEmpty());
+            for (int i = 1; i < dc_date_accesioneds.size() - 1; i++) {
+                assertTrue(dc_date_accesioneds.get(i).compareTo(dc_date_accesioneds.get(i + 1)) >= 0);
+            }
+        } else if (defaultSortField.getMetadataField().equals("lastModified")) {
+            LinkedList<String> lastModifieds = result.getIndexableObjects().stream()
+                    .map(o -> ((Item) o.getIndexedObject()).getLastModified().toString())
+                    .collect(Collectors.toCollection(LinkedList::new));
+            assertFalse(lastModifieds.isEmpty());
+            for (int i = 1; i < lastModifieds.size() - 1; i++) {
+                assertTrue(lastModifieds.get(i).compareTo(lastModifieds.get(i + 1)) >= 0);
+            }
         }
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/DiscoverConfigurationConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/DiscoverConfigurationConverter.java
@@ -80,6 +80,15 @@ public class DiscoverConfigurationConverter
                 sortOption.setSortOrder(discoverySearchSortConfiguration.getDefaultSortOrder().name());
                 searchConfigurationRest.addSortOption(sortOption);
             }
+
+            DiscoverySortFieldConfiguration defaultSortField = searchSortConfiguration.getDefaultSortField();
+            if (defaultSortField != null) {
+                SearchConfigurationRest.SortOption sortOption = new SearchConfigurationRest.SortOption();
+                sortOption.setName(defaultSortField.getMetadataField());
+                sortOption.setActualName(defaultSortField.getType());
+                sortOption.setSortOrder(defaultSortField.getDefaultSortOrder().name());
+                searchConfigurationRest.setDefaultSortOption(sortOption);
+            }
         }
 
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/SearchConfigurationRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/SearchConfigurationRest.java
@@ -31,6 +31,8 @@ public class SearchConfigurationRest extends BaseObjectRest<String> {
     private List<Filter> filters = new LinkedList<>();
     private List<SortOption> sortOptions = new LinkedList<>();
 
+    private SortOption defaultSortOption;
+
     public String getCategory() {
         return CATEGORY;
     }
@@ -73,6 +75,14 @@ public class SearchConfigurationRest extends BaseObjectRest<String> {
 
     public List<SortOption> getSortOptions() {
         return sortOptions;
+    }
+
+    public SortOption getDefaultSortOption() {
+        return defaultSortOption;
+    }
+
+    public void setDefaultSortOption(SortOption defaultSortOption) {
+        this.defaultSortOption = defaultSortOption;
     }
 
     @Override

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -1286,10 +1286,8 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
 
         context.restoreAuthSystemState();
 
-        //Update this test since dc.date.accessioned is now configured for workspace configuration,
-        // which will return status 400 instead of 422 if left unchanged
         getClient().perform(get("/api/discover/search/objects")
-                   .param("sort", "person.familyName, ASC")
+                   .param("sort", "dc.date.accessioned, ASC")
                    .param("configuration", "workspace"))
                    .andExpect(status().isUnprocessableEntity());
     }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -1286,8 +1286,10 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
 
         context.restoreAuthSystemState();
 
+        //Update this test since dc.date.accessioned is now configured for workspace configuration,
+        // which will return status 400 instead of 422 if left unchanged
         getClient().perform(get("/api/discover/search/objects")
-                   .param("sort", "dc.date.accessioned, ASC")
+                   .param("sort", "person.familyName, ASC")
                    .param("configuration", "workspace"))
                    .andExpect(status().isUnprocessableEntity());
     }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/utils/RestDiscoverQueryBuilderTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/utils/RestDiscoverQueryBuilderTest.java
@@ -171,15 +171,12 @@ public class RestDiscoverQueryBuilderTest {
 
     @Test
     public void testSortByDefaultSortField() throws Exception {
-        page = PageRequest.of(2, 10, Sort.Direction.DESC, "dc.date.accessioned");
+        page = PageRequest.of(2, 10);
         restQueryBuilder.buildQuery(context, null, discoveryConfiguration, null, null, emptyList(), page);
 
         verify(discoverQueryBuilder, times(1))
                 .buildQuery(context, null, discoveryConfiguration, null, emptyList(), emptyList(),
-                        page.getPageSize(), page.getOffset(),
-                        discoveryConfiguration.getSearchSortConfiguration().getDefaultSortField().getMetadataField(),
-                        discoveryConfiguration.getSearchSortConfiguration().getDefaultSortField()
-                                .getDefaultSortOrder().name().toUpperCase());
+                        page.getPageSize(), page.getOffset(), null, null);
     }
 
     @Test(expected = DSpaceBadRequestException.class)

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/utils/RestDiscoverQueryBuilderTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/utils/RestDiscoverQueryBuilderTest.java
@@ -115,6 +115,8 @@ public class RestDiscoverQueryBuilderTest {
 
         sortConfiguration.setSortFields(listSortField);
 
+        sortConfiguration.setDefaultSortField(defaultSort);
+
         discoveryConfiguration.setSearchSortConfiguration(sortConfiguration);
 
         DiscoverySearchFilterFacet subjectFacet = new DiscoverySearchFilterFacet();
@@ -165,6 +167,19 @@ public class RestDiscoverQueryBuilderTest {
         verify(discoverQueryBuilder, times(1)).buildQuery(context, null, discoveryConfiguration, null,
                                                           emptyList(), emptyList(), page.getPageSize(),
                                                           page.getOffset(), "SCORE", "ASC");
+    }
+
+    @Test
+    public void testSortByDefaultSortField() throws Exception {
+        page = PageRequest.of(2, 10, Sort.Direction.DESC, "dc.date.accessioned");
+        restQueryBuilder.buildQuery(context, null, discoveryConfiguration, null, null, emptyList(), page);
+
+        verify(discoverQueryBuilder, times(1))
+                .buildQuery(context, null, discoveryConfiguration, null, emptyList(), emptyList(),
+                        page.getPageSize(), page.getOffset(),
+                        discoveryConfiguration.getSearchSortConfiguration().getDefaultSortField().getMetadataField(),
+                        discoveryConfiguration.getSearchSortConfiguration().getDefaultSortField()
+                                .getDefaultSortOrder().name().toUpperCase());
     }
 
     @Test(expected = DSpaceBadRequestException.class)

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -866,10 +866,10 @@
         <property name="searchSortConfiguration">
             <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
                 <!--The default sort filter to use for the initial workspace loading-->
-                <property name="defaultSortField" ref="sortDateAccessioned" />
+                <property name="defaultSortField" ref="sortLastModified" />
                 <property name="sortFields">
                     <list>
-                        <ref bean="sortDateAccessioned" />
+                        <ref bean="sortLastModified" />
                         <ref bean="sortScore" />
                         <ref bean="sortTitle" />
                         <ref bean="sortDateIssued" />

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -865,8 +865,11 @@
         <!--The sort filters for the discovery search-->
         <property name="searchSortConfiguration">
             <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
+                <!--The default sort filter to use for the initial workspace loading-->
+                <property name="defaultSortField" ref="sortDateAccessioned" />
                 <property name="sortFields">
                     <list>
+                        <ref bean="sortDateAccessioned" />
                         <ref bean="sortScore" />
                         <ref bean="sortTitle" />
                         <ref bean="sortDateIssued" />
@@ -938,6 +941,8 @@
         <!--The sort filters for the discovery search-->
         <property name="searchSortConfiguration">
             <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
+                <!--The default sort filter to use for the initial workspace loading-->
+                <property name="defaultSortField" ref="sortLastModified" />
                 <property name="sortFields">
                     <list>
                         <ref bean="sortLastModified" />
@@ -1015,6 +1020,7 @@
             <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
                 <property name="sortFields">
                     <list>
+                        <ref bean="sortLastModified" />
                         <ref bean="sortScore" />
                         <ref bean="sortTitle" />
                         <ref bean="sortDateIssued" />

--- a/dspace/solr/search/conf/schema.xml
+++ b/dspace/solr/search/conf/schema.xml
@@ -283,6 +283,7 @@
     <!-- used by the DSpace Discovery Solr Indexer to track the last time a document was indexed -->
     <field name="SolrIndexer.lastIndexed" type="date" indexed="true" stored="true" default="NOW" multiValued="false" omitNorms="true" />
     <field name="lastModified" type="date" indexed="true" stored="true" default="NOW" multiValued="false" omitNorms="true" />
+    <copyField source="lastModified" dest="lastModified_dt" />
 
     <!-- used to filter out items that are older versions of another item -->
     <field name="latestVersion" type="boolean" indexed="true" stored="true" default="true" multiValued="false" omitNorms="true"/>


### PR DESCRIPTION
## References
Fix [#8837](https://github.com/DSpace/DSpace/issues/8837)

## Description

This PR introduces a default sort option for DiscoveryConfiguration in `discovery.xml`, which replaces default sorting (by `score,DESC`)

## Instructions for Reviewers

### List of changes in this PR:
1. Added `defaultSortField` to `DiscoverySortConfiguration`, whose value is configurable in `discovery.xml` like this:
(our use case bean `workspaceConfiguration`, refer to change list for actual changes):
```xml
[...]
    <bean id="workspaceConfiguration"
        class="org.dspace.discovery.configuration.DiscoveryConfiguration"
        scope="prototype">
        [...]
        <property name="searchSortConfiguration">
            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
                <!--The default sort filter to use for the initial workspace loading-->
                <property name="defaultSortField" ref="sortDateAccessioned" />
        [...]
```
2. This leads to necessary changes in `dspace-api` and `webapp`, most notably `org.dspace.discovery.utils.DiscoverQueryBuilder#getDefaultSortDirection`, which now use `defaultSortField` if not null. In our case, DiscoverySearch for workspace configuration will sort by `sortDateAccessioned,DESC` from now on.
3. To accomodate **dspace-angular**, which sort using the first option in `<property name="sortFields"/>` in `discovery.xml`, we add reference to `<bean id="sortDateAccessioned"/>` to the list value
```xml
                <property name="sortFields">
                    <list>
                        <ref bean="sortDateAccessioned" /> <!--addition-->
                        <ref bean="sortScore" />
                        <ref bean="sortTitle" />
                        <ref bean="sortDateIssued" />
                    </list>
                </property>
```

### For Testing:
Added 2 test cases:
 - `org.dspace.app.rest.utils.RestDiscoverQueryBuilderTest#testSortByDefaultSortField`: verify that DiscoverySortConfiguration.defaultSortField is set and can be used for sorting
 - `org.dspace.discovery.DiscoveryIT#searchWithDefaultSortServiceTest`: verify that `DiscoverResult.indexableObjects` of a `DiscoverQuery` in `workspace` configuration is sorted by configured `defaultSortField`

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204642791317008