### PR TITLE
pom.xml: bump tika from 2.3.0 to 2.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <pdfbox-version>2.0.28</pdfbox-version>
         <rome.version>1.19.0</rome.version>
         <slf4j.version>1.7.36</slf4j.version>
-        <tika.version>2.3.0</tika.version>
+        <tika.version>2.5.0</tika.version>
         <!-- Sync with whatever version Tika uses -->
         <bouncycastle.version>1.70</bouncycastle.version>
 


### PR DESCRIPTION
# Description
A handful of bug fixes, improvements to PDF parsing, and updates to dependencies. This is the highest we can go right now without hitting dependency convergence issues related to bouncycastle.

See: https://github.com/apache/tika/blob/2.5.0/CHANGES.txt

_Note:_ for the future, you can reference `tika-parent/pom.xml` in versions up to 2.8.0, and `tika-parser-modules/pom.xml` in later 2.x versions to see the latest bouncycastle version. We must keep the version used by tika in sync with our `pom.xml`.

# Instructions for Reviewers
Tika is used for extracting text from PDFs, so you can try to force `filter-media` to run on items containing PDF bitstreams.