### PR TITLE
Update to latest Spring Boot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <!--=== GENERAL / DSPACE-API DEPENDENCIES ===-->
         <java.version>11</java.version>
         <spring.version>5.3.27</spring.version>
-        <spring-boot.version>2.7.11</spring-boot.version>
+        <spring-boot.version>2.7.12</spring-boot.version>
         <spring-security.version>5.7.8</spring-security.version> <!-- sync with version used by spring-boot-->
         <hibernate.version>5.6.15.Final</hibernate.version>
         <hibernate-validator.version>6.2.5.Final</hibernate-validator.version>


### PR DESCRIPTION
## References
* Patches CVE-2023-20883 (See https://spring.io/security/cve-2023-20883)

## Description
This vulnerability is not possible to exploit in DSpace 7 as we don't use the Spring Boot welcome page.  Nonetheless, this is a very minor update to the latest version of Spring Boot just in case: https://spring.io/blog/2023/05/18/spring-boot-2-7-12-available-now

## Instructions for Reviewers
* Verify tests pass
* Give backend a quick test. This is a minor update though so everything should be fine