### PR TITLE
dspace: capture publisher from CrossRef live import

### DIFF
--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CrossRefImportMetadataSourceServiceIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CrossRefImportMetadataSourceServiceIT.java
@@ -153,6 +153,8 @@ public class CrossRefImportMetadataSourceServiceIT extends AbstractLiveImportInt
         MetadatumDTO issn = createMetadatumDTO("dc", "identifier", "issn", "2415-3060");
         MetadatumDTO volume = createMetadatumDTO("oaire", "citation", "volume", "1");
         MetadatumDTO issue = createMetadatumDTO("oaire", "citation", "issue", "2");
+        MetadatumDTO publisher = createMetadatumDTO("dc", "publisher", null,
+                "Petro Mohyla Black Sea National University");
 
         metadatums.add(title);
         metadatums.add(author);
@@ -163,6 +165,7 @@ public class CrossRefImportMetadataSourceServiceIT extends AbstractLiveImportInt
         metadatums.add(issn);
         metadatums.add(volume);
         metadatums.add(issue);
+        metadatums.add(publisher);
 
         ImportRecord firstrRecord = new ImportRecord(metadatums);
 
@@ -179,6 +182,8 @@ public class CrossRefImportMetadataSourceServiceIT extends AbstractLiveImportInt
         MetadatumDTO issn2 = createMetadatumDTO("dc", "identifier", "issn", "2415-3060");
         MetadatumDTO volume2 = createMetadatumDTO("oaire", "citation", "volume", "1");
         MetadatumDTO issue2 = createMetadatumDTO("oaire", "citation", "issue", "2");
+        MetadatumDTO publisher2 = createMetadatumDTO("dc", "publisher", null,
+                "Petro Mohyla Black Sea National University");
 
         metadatums2.add(title2);
         metadatums2.add(author2);
@@ -189,6 +194,7 @@ public class CrossRefImportMetadataSourceServiceIT extends AbstractLiveImportInt
         metadatums2.add(issn2);
         metadatums2.add(volume2);
         metadatums2.add(issue2);
+        metadatums2.add(publisher2);
 
         ImportRecord secondRecord = new ImportRecord(metadatums2);
         records.add(firstrRecord);

--- a/dspace/config/spring/api/crossref-integration.xml
+++ b/dspace/config/spring/api/crossref-integration.xml
@@ -30,6 +30,7 @@
         <entry key-ref="crossref.volume" value-ref="crossrefVolume" />
         <entry key-ref="crossref.issue" value-ref="crossrefIssue" />
         <entry key-ref="crossref.abstract" value-ref="crossrefAbstract" />
+        <entry key-ref="crossref.publisher" value-ref="crossrefPublisher" />
     </util:map>
 
     <bean id="crossrefIDContrib" class="org.dspace.importer.external.metadatamapping.contributor.SimpleJsonPathMetadataContributor">
@@ -135,6 +136,14 @@
     </bean>
     <bean id="crossref.abstract" class="org.dspace.importer.external.metadatamapping.MetadataFieldConfig">
         <constructor-arg value="dc.description.abstract"/>
+    </bean>
+
+    <bean id="crossrefPublisher" class="org.dspace.importer.external.metadatamapping.contributor.SimpleJsonPathMetadataContributor">
+        <property name="field" ref="crossref.publisher"/>
+        <property name="query" value="/publisher"/>
+    </bean>
+    <bean id="crossref.publisher" class="org.dspace.importer.external.metadatamapping.MetadataFieldConfig">
+        <constructor-arg value="dc.publisher"/>
     </bean>
 
     <bean class="java.lang.Integer" id="maxRetry">


### PR DESCRIPTION
## Description
Publisher is a [required field on CrossRef](https://github.com/CrossRef/rest-api-doc/blob/master/api_format.md) so we can always rely on capturing this information when doing a live import.

* Requires: https://github.com/DSpace/dspace-angular/pull/2272

## Instructions for Reviewers
This pull request adds publisher to the list of metadata harvested from CrossRef. To test this pull request you should try starting a new submission using CrossRef as the live import source and seeing that publisher is added to the list of metadata captured.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).