### PR TITLE
"Browse By" fixes

### DIFF
--- a/dspace-api/src/main/java/org/dspace/browse/BrowseEngine.java
+++ b/dspace-api/src/main/java/org/dspace/browse/BrowseEngine.java
@@ -221,7 +221,9 @@ public class BrowseEngine {
 
                 // make sure the incoming value is normalised
                 value = OrderFormat.makeSortString(value, scope.getFilterValueLang(),
-                                                   scope.getBrowseIndex().getDataType());
+                                                   scope.getBrowseIndex().getSortOption() == null ?
+                                                           scope.getBrowseIndex().getDataType() :
+                                                           scope.getBrowseIndex().getSortOption().getType());
 
                 dao.setAuthorityValue(scope.getAuthorityValue());
 

--- a/dspace-api/src/main/java/org/dspace/browse/BrowseIndex.java
+++ b/dspace-api/src/main/java/org/dspace/browse/BrowseIndex.java
@@ -256,7 +256,11 @@ public class BrowseIndex {
      * @return Returns the datatype.
      */
     public String getDataType() {
-        if (sortOption != null) {
+        // Check if sortOption.getType() is not equal to BI's datatype, in which case we return the BI's
+        // else we get error, check https://github.com/DSpace/DSpace/issues/8651 for details
+        if (datatype != null && (sortOption == null || !sortOption.getType().equals(datatype))) {
+            return datatype;
+        } else if (sortOption != null) {
             return sortOption.getType();
         }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/BrowseIndexRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/BrowseIndexRest.java
@@ -165,4 +165,11 @@ public class BrowseIndexRest extends BaseObjectRest<String> {
             return metadata;
         }
     }
+
+    @Override
+    public boolean isLinkAllowed(LinkRest link) {
+        return !( ( browseType.equals(BROWSE_TYPE_FLAT) && link.name().equals(LINK_ENTRIES)) ||
+                  ( browseType.equals(BROWSE_TYPE_HIERARCHICAL) &&
+                          (link.name().equals(LINK_ITEMS) || link.name().equals(LINK_ENTRIES)) ) );
+    }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/RestAddressableModel.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/RestAddressableModel.java
@@ -56,4 +56,14 @@ public abstract class RestAddressableModel implements RestModel {
     public String getUniqueType() {
         return getCategory() + "." + getType();
     }
+
+    /**
+     * Check if the <pre>link</pre> is allowed. This is intended to be overridden by subclasses that this feature is
+     * relevant
+     * @param link the link to be allowed
+     * @return
+     */
+    public boolean isLinkAllowed(LinkRest link) {
+        return true;
+    }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/hateoas/BrowseIndexResource.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/hateoas/BrowseIndexResource.java
@@ -34,17 +34,6 @@ public class BrowseIndexResource extends DSpaceResource<BrowseIndexRest> {
 
     public BrowseIndexResource(BrowseIndexRest bix, Utils utils) {
         super(bix, utils);
-        // TODO: the following code will force the embedding of items and
-        // entries in the browseIndex we need to find a way to populate the rels
-        // array from the request/projection right now it is always null
-        // super(bix, utils, "items", "entries");
-        if (bix.getBrowseType().equals(BrowseIndexRest.BROWSE_TYPE_VALUE_LIST)) {
-            add(utils.linkToSubResource(bix, BrowseIndexRest.LINK_ENTRIES));
-            add(utils.linkToSubResource(bix, BrowseIndexRest.LINK_ITEMS));
-        }
-        if (bix.getBrowseType().equals(BrowseIndexRest.BROWSE_TYPE_FLAT)) {
-            add(utils.linkToSubResource(bix, BrowseIndexRest.LINK_ITEMS));
-        }
         if (bix.getBrowseType().equals(BrowseIndexRest.BROWSE_TYPE_HIERARCHICAL)) {
             ChoiceAuthorityService choiceAuthorityService =
                     ContentAuthorityServiceFactory.getInstance().getChoiceAuthorityService();

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BrowseItemLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BrowseItemLinkRepository.java
@@ -137,7 +137,8 @@ public class BrowseItemLinkRepository extends AbstractDSpaceRestRepository
 
         // For second level browses on metadata indexes, we need to adjust the default sorting
         if (bi.isMetadataIndex() && bs.isSecondLevel() && bs.getSortBy() <= 0) {
-            bs.setSortBy(1);
+            //use bi.sortOption if available
+            bs.setSortBy(bi.getSortOption() != null ? bi.getSortOption().getNumber() : 1);
         }
 
         BrowseInfo binfo = be.browse(bs);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/Utils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/Utils.java
@@ -671,6 +671,9 @@ public class Utils {
         Projection projection = halResource.getContent().getProjection();
         getLinkRests(halResource.getContent().getClass()).stream().forEach((linkRest) -> {
             Link link = linkToSubResource(halResource.getContent(), linkRest.name());
+            if (!halResource.getContent().isLinkAllowed(linkRest)) {
+                return;
+            }
             if (projection.allowEmbedding(halResource, linkRest, oldLinks)) {
                 embedRelFromRepository(halResource, linkRest.name(), link, linkRest, oldLinks);
                 halResource.add(link); // unconditionally link if embedding was allowed

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/BrowseIndexMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/BrowseIndexMatcher.java
@@ -8,6 +8,7 @@
 package org.dspace.app.rest.matcher;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasNoJsonPath;
 import static org.dspace.app.rest.model.BrowseIndexRest.BROWSE_TYPE_FLAT;
 import static org.dspace.app.rest.model.BrowseIndexRest.BROWSE_TYPE_HIERARCHICAL;
 import static org.dspace.app.rest.model.BrowseIndexRest.BROWSE_TYPE_VALUE_LIST;
@@ -53,6 +54,7 @@ public class BrowseIndexMatcher {
             hasJsonPath("$.order", equalToIgnoringCase(order)),
             hasJsonPath("$.sortOptions[*].name", containsInAnyOrder("title", "dateissued", "dateaccessioned")),
             hasJsonPath("$._links.self.href", is(REST_SERVER_URL + "discover/browses/title")),
+            hasNoJsonPath("$._links.entries"),
             hasJsonPath("$._links.items.href", is(REST_SERVER_URL + "discover/browses/title/items"))
         );
     }
@@ -80,6 +82,7 @@ public class BrowseIndexMatcher {
             hasJsonPath("$.order", equalToIgnoringCase(order)),
             hasJsonPath("$.sortOptions[*].name", containsInAnyOrder("title", "dateissued", "dateaccessioned")),
             hasJsonPath("$._links.self.href", is(REST_SERVER_URL + "discover/browses/dateissued")),
+            hasNoJsonPath("$._links.entries"),
             hasJsonPath("$._links.items.href", is(REST_SERVER_URL + "discover/browses/dateissued/items"))
         );
     }
@@ -93,10 +96,8 @@ public class BrowseIndexMatcher {
             hasJsonPath("$.vocabulary", equalToIgnoringCase(vocabulary)),
             hasJsonPath("$._links.vocabulary.href",
                         is(REST_SERVER_URL + String.format("submission/vocabularies/%s/", vocabulary))),
-            hasJsonPath("$._links.items.href",
-                        is(REST_SERVER_URL + String.format("discover/browses/%s/items", vocabulary))),
-            hasJsonPath("$._links.entries.href",
-                        is(REST_SERVER_URL + String.format("discover/browses/%s/entries", vocabulary))),
+            hasNoJsonPath("$._links.entries"),
+            hasNoJsonPath("$._links.items.href"),
             hasJsonPath("$._links.self.href",
                         is(REST_SERVER_URL + String.format("discover/browses/%s", vocabulary)))
         );

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1186,8 +1186,10 @@ webui.browse.index.4 = subject:metadata:dc.subject.*:text
 # HIDE the option from the sorting controls in the user interface. This can be useful if
 # you need to define a specific date sort for use by the recent items lists,
 # but otherwise don't want users to choose that option.
-# NOTE: These options are now only effective in "Browse by" feature, to modify sort options for other features
-#       (mydspace, workflow, etc) please check out spring/api/discovery.xml
+# NOTE: These options now take effects only in "Browse by" feature.
+#       Sort options for other features (mydspace, workflow, etc) is now managed by Discovery feature, which is
+#       configured at 'spring/api/discovery.xml' - look for properties named "searchSortConfiguration" (should
+#       be present for each Discovery configuration).
 #
 webui.itemlist.sort-option.1 = title:dc.title:title
 webui.itemlist.sort-option.2 = dateissued:dc.date.issued:date

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1186,6 +1186,8 @@ webui.browse.index.4 = subject:metadata:dc.subject.*:text
 # HIDE the option from the sorting controls in the user interface. This can be useful if
 # you need to define a specific date sort for use by the recent items lists,
 # but otherwise don't want users to choose that option.
+# NOTE: These options are now only effective in "Browse by" feature, to modify sort options for other features
+#       (mydspace, workflow, etc) please check out spring/api/discovery.xml
 #
 webui.itemlist.sort-option.1 = title:dc.title:title
 webui.itemlist.sort-option.2 = dateissued:dc.date.issued:date


### PR DESCRIPTION
## References
Fix #8651
Fix #8646
Fix #8879

Corresponding frontend PR: DSpace/dspace-angular#2324

## Description



1. For #8651: This PR slightly changes how `BrowseIndex.getDataType()` works, which now accounts for when`webui.browse.index.<X>` uses a sort option that is not of the same data type as the BrowseIndex's own data type by prioritizing the BrowseIndex's. Some other changes also need to be made to follow suit.

    Originally, with config

```
webui.browse.index.2 = author:metadata:dc.contributor.*\,dc.creator:text:desc:dateissued
```
    

  The issue is that we try to sort by "date" type (`dateissued`) while the index itself is of type "text". The "Browse" component does not account for such a case so our changes are needed to ensure Angular call for `/entries` instead of `/items`, which will produce _dspace.log error_ `The requested browse doesn't provide direct access to items you must specify a filter
` when we first access "Browse by Author" via the UI.

2. In addition, we add some comments in `dspace.cfg` to clarify the limitations of `webui.itemlist.sort-option._` for #8646 

3. For #8879: Old code was not updated to use org.dspace.app.rest.utils.Utils#embedOrLinkClassLevelRels as the correct link generator. The update makes sure it is so.


### List of changes in this PR:
1. Updated `BrowseIndex.getDataType()`
2. Changed `org/dspace/browse/BrowseEngine.java:223` so that now it has to use explicit `scope.getBrowseIndex().getSortOption().getType()` if possible:
```java
                value = OrderFormat.makeSortString(value, scope.getFilterValueLang(),
                                                   scope.getBrowseIndex().getSortOption() == null ?
                                                           scope.getBrowseIndex().getDataType() :
                                                           scope.getBrowseIndex().getSortOption().getType());
```
3. Use `bi.getSortOption().getNumber()` if available when we do second level search (check code change for context & details, this is hard to explain properly here).
4. For #8879: Added method RestAddressableModel#isLinkAllowed to check whether a link is valid against an object of type RestAddressableModel. This method is then overridden by org.dspace.app.rest.model.BrowseIndexRest#isLinkAllowed, which validates provided LinkRestagainst its objects. Running this method inUtils#embedOrLinkClassLevelRelsmakes sure we get only valid links for a browse type (_entries_ forvalueListand _items_ forflatBrowse`).

### For Testing:
1. Added the following test case:
- `org.dspace.app.rest.BrowsesResourceControllerIT#testBrowseAuthorByEntriesSortByDateIssued`:  verify that with configuration `webui.browse.index.2 = author:metadata:dc.contributor.*\,dc.creator:text:desc:dateissued`, we can get a list of entries and a list of items sorted by `dateissued` with filtered value "Universe2"
- Modified test `BrowsesResourceControllerIT#findAll` to ensure correct result following the fix for 8879.

2. Testing on a functioning DSpace Installtion:
a. In `dspace.cfg`, change the following config as such:
```
webui.browse.index.2 = author:metadata:dc.contributor.*\,dc.creator:text:desc:dateissued
```
b. On dspace-angular, check Top Navigation bar -> menu **"All of DSpace"** (Browse by) -> **"By Author"**
 - The list of authors should be shown
 - Click on an author should show a list of their items, sorted by `dc.dateissued`, in descending order

c. For 8879: no more 500 error from requests from **[dspace.server.url]/api/discover/browses/*** endpoints


## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).