### PR TITLE
Bump dependencies

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -632,7 +632,7 @@
         <dependency>
             <groupId>dnsjava</groupId>
             <artifactId>dnsjava</artifactId>
-            <version>2.1.7</version>
+            <version>2.1.9</version>
         </dependency>
 
         <dependency>

--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -791,7 +791,7 @@
         <dependency>
             <groupId>com.opencsv</groupId>
             <artifactId>opencsv</artifactId>
-            <version>5.6</version>
+            <version>5.7.1</version>
         </dependency>
 
         <!-- Email templating -->

--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -818,6 +818,13 @@
             <groupId>eu.openaire</groupId>
             <artifactId>funders-model</artifactId>
             <version>2.0.0</version>
+            <exclusions>
+                <!-- Newer version pulled in via Jersey below -->
+                <exclusion>
+                    <groupId>org.javassist</groupId>
+                    <artifactId>javassist</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -803,7 +803,7 @@
         <dependency>
             <groupId>org.apache.bcel</groupId>
             <artifactId>bcel</artifactId>
-            <version>6.6.0</version>
+            <version>6.7.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -923,7 +923,7 @@
           <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
-            <version>2.13.9</version>
+            <version>2.13.11</version>
             <scope>test</scope>
           </dependency>
         </dependencies>

--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -668,7 +668,7 @@
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
-            <version>8.4.4</version>
+            <version>8.5.13</version>
         </dependency>
 
         <!-- Google Analytics -->

--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -492,12 +492,6 @@
         <dependency>
             <groupId>jaxen</groupId>
             <artifactId>jaxen</artifactId>
-            <exclusions>
-                <exclusion>
-                    <artifactId>xom</artifactId>
-                    <groupId>xom</groupId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jdom</groupId>

--- a/dspace-iiif/pom.xml
+++ b/dspace-iiif/pom.xml
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>de.digitalcollections.iiif</groupId>
             <artifactId>iiif-apis</artifactId>
-            <version>0.3.9</version>
+            <version>0.3.10</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.javassist</groupId>

--- a/dspace-server-webapp/pom.xml
+++ b/dspace-server-webapp/pom.xml
@@ -288,7 +288,7 @@
         <dependency>
             <groupId>com.flipkart.zjsonpatch</groupId>
             <artifactId>zjsonpatch</artifactId>
-            <version>0.4.6</version>
+            <version>0.4.14</version>
         </dependency>
 
         <!-- HAL Browser (via WebJars) : https://github.com/mikekelly/hal-browser -->

--- a/dspace-server-webapp/pom.xml
+++ b/dspace-server-webapp/pom.xml
@@ -308,7 +308,7 @@
         <dependency>
             <groupId>org.webjars.bowergithub.jquery</groupId>
             <artifactId>jquery-dist</artifactId>
-            <version>3.6.0</version>
+            <version>3.7.0</version>
         </dependency>
         <!-- Pull in current version of Toastr (toastrjs.com) via WebJars
              Made available at: webjars/toastr/build/toastr.min.js -->

--- a/dspace-server-webapp/pom.xml
+++ b/dspace-server-webapp/pom.xml
@@ -541,7 +541,7 @@
         <dependency>
             <groupId>org.exparity</groupId>
             <artifactId>hamcrest-date</artifactId>
-            <version>2.0.7</version>
+            <version>2.0.8</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/dspace-server-webapp/pom.xml
+++ b/dspace-server-webapp/pom.xml
@@ -322,7 +322,7 @@
         <dependency>
             <groupId>org.webjars.bowergithub.medialize</groupId>
             <artifactId>uri.js</artifactId>
-            <version>1.19.10</version>
+            <version>1.19.11</version>
         </dependency>
         <!-- Pull in current version of Underscore.js (https://underscorejs.org/) via WebJars
              Made available at: webjars/underscore/underscore-min.js -->

--- a/dspace-sword/pom.xml
+++ b/dspace-sword/pom.xml
@@ -104,7 +104,7 @@
         <dependency>
             <groupId>xom</groupId>
             <artifactId>xom</artifactId>
-            <version>1.3.7</version>
+            <version>1.3.9</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1752,7 +1752,7 @@
             <dependency>
                 <groupId>com.fasterxml</groupId>
                 <artifactId>classmate</artifactId>
-                <version>1.3.0</version>
+                <version>1.5.1</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1358,7 +1358,7 @@
             <dependency>
                 <groupId>net.handle</groupId>
                 <artifactId>handle</artifactId>
-                <version>9.3.0</version>
+                <version>9.3.1</version>
 		<exclusions>
                     <!-- A later version is brought in by google-oauth-client -->
                     <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -1336,7 +1336,7 @@
             <dependency>
                 <groupId>org.apache.ant</groupId>
                 <artifactId>ant</artifactId>
-                <version>1.10.11</version>
+                <version>1.10.13</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.jena</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <!--=== GENERAL / DSPACE-API DEPENDENCIES ===-->
         <java.version>11</java.version>
-        <spring.version>5.3.27</spring.version>
+        <spring.version>5.3.28</spring.version>
         <spring-boot.version>2.7.13</spring-boot.version>
         <spring-security.version>5.7.9</spring-security.version> <!-- sync with version used by spring-boot-->
         <hibernate.version>5.6.15.Final</hibernate.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1626,17 +1626,17 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpcore</artifactId>
-                <version>4.4.15</version>
+                <version>4.4.16</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
-                <version>4.5.13</version>
+                <version>4.5.14</version>
             </dependency>
             <dependency>
               <groupId>org.apache.httpcomponents</groupId>
               <artifactId>httpmime</artifactId>
-              <version>4.5.13</version>
+              <version>4.5.14</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1538,13 +1538,7 @@
             <dependency>
                 <groupId>jaxen</groupId>
                 <artifactId>jaxen</artifactId>
-                <version>1.1.6</version>
-                <exclusions>
-                    <exclusion>
-                        <artifactId>xom</artifactId>
-                        <groupId>xom</groupId>
-                    </exclusion>
-                </exclusions>
+                <version>2.0.0</version>
             </dependency>
             <dependency>
                 <groupId>org.jdom</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1451,7 +1451,7 @@
             <dependency>
                 <groupId>commons-cli</groupId>
                 <artifactId>commons-cli</artifactId>
-                <version>1.4</version>
+                <version>1.5.0</version>
             </dependency>
             <dependency>
                 <groupId>commons-codec</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1521,7 +1521,7 @@
             <dependency>
                 <groupId>joda-time</groupId>
                 <artifactId>joda-time</artifactId>
-                <version>2.9.2</version>
+                <version>2.12.5</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.mail</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1489,7 +1489,7 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.12.0</version>
+                <version>2.13.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1516,7 +1516,7 @@
             <dependency>
                 <groupId>commons-validator</groupId>
                 <artifactId>commons-validator</artifactId>
-                <version>1.5.0</version>
+                <version>1.7</version>
             </dependency>
             <dependency>
                 <groupId>joda-time</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1784,7 +1784,7 @@
             <dependency>
                 <groupId>xom</groupId>
                 <artifactId>xom</artifactId>
-                <version>1.2.5</version>
+                <version>1.3.9</version>
             </dependency>
 
             <!-- json-path is needed by Spring HATEOAS -->

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <postgresql.driver.version>42.6.0</postgresql.driver.version>
         <solr.client.version>8.11.2</solr.client.version>
 
-        <ehcache.version>3.4.0</ehcache.version>
+        <ehcache.version>3.10.8</ehcache.version>
         <errorprone.version>2.10.0</errorprone.version>
         <!-- NOTE: when updating jackson.version, also sync jackson-databind.version below -->
         <jackson.version>2.13.4</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1456,7 +1456,7 @@
             <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
-                <version>1.10</version>
+                <version>1.15</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,8 @@
         <!--=== GENERAL / DSPACE-API DEPENDENCIES ===-->
         <java.version>11</java.version>
         <spring.version>5.3.27</spring.version>
-        <spring-boot.version>2.7.12</spring-boot.version>
-        <spring-security.version>5.7.8</spring-security.version> <!-- sync with version used by spring-boot-->
+        <spring-boot.version>2.7.13</spring-boot.version>
+        <spring-security.version>5.7.9</spring-security.version> <!-- sync with version used by spring-boot-->
         <hibernate.version>5.6.15.Final</hibernate.version>
         <hibernate-validator.version>6.2.5.Final</hibernate-validator.version>
         <postgresql.driver.version>42.6.0</postgresql.driver.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1738,7 +1738,7 @@
             <dependency>
                 <groupId>com.google.code.findbugs</groupId>
                 <artifactId>jsr305</artifactId>
-                <version>3.0.1</version>
+                <version>3.0.2</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1489,7 +1489,7 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.7</version>
+                <version>2.12.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1456,7 +1456,7 @@
             <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
-                <version>1.15</version>
+                <version>1.16.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1669,7 +1669,7 @@
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.13.1</version>
+                <version>4.13.2</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1302,7 +1302,7 @@
             <dependency>
                 <groupId>org.apache.james</groupId>
                 <artifactId>apache-mime4j-core</artifactId>
-                <version>0.8.4</version>
+                <version>0.8.9</version>
             </dependency>
             <!-- Tika and solr-core disagree on versions of ASM -->
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
              https://jena.apache.org/documentation/migrate_jena2_jena3.html -->
         <jena.version>2.13.0</jena.version>
         <!-- Used by (now obsolete) 'dspace-rest' WAR -->
-        <jersey.version>2.35</jersey.version>
+        <jersey.version>2.39.1</jersey.version>
 
         <!--=== MAVEN SETTINGS ===-->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <javax-annotation.version>1.3.2</javax-annotation.version>
         <jaxb-api.version>2.3.1</jaxb-api.version>
         <jaxb-runtime.version>2.3.1</jaxb-runtime.version>
-        <jcache-version>1.1.0</jcache-version>
+        <jcache-version>1.1.1</jcache-version>
         <!-- NOTE: Jetty needed for Solr, Handle Server & tests -->
         <jetty.version>9.4.51.v20230217</jetty.version>
         <log4j.version>2.20.0</log4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1694,7 +1694,7 @@
             <dependency>
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
-                <version>2.1.210</version>
+                <version>2.1.214</version>
                 <scope>test</scope>
             </dependency>
             <!-- Google Analytics -->

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <jackson-databind.version>2.13.4.2</jackson-databind.version>
         <javax-annotation.version>1.3.2</javax-annotation.version>
         <jaxb-api.version>2.3.1</jaxb-api.version>
-        <jaxb-runtime.version>2.3.1</jaxb-runtime.version>
+        <jaxb-runtime.version>2.3.8</jaxb-runtime.version>
         <jcache-version>1.1.1</jcache-version>
         <!-- NOTE: Jetty needed for Solr, Handle Server & tests -->
         <jetty.version>9.4.51.v20230217</jetty.version>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <!-- NOTE: Jetty needed for Solr, Handle Server & tests -->
         <jetty.version>9.4.51.v20230217</jetty.version>
         <log4j.version>2.20.0</log4j.version>
-        <pdfbox-version>2.0.28</pdfbox-version>
+        <pdfbox-version>2.0.29</pdfbox-version>
         <rome.version>1.19.0</rome.version>
         <slf4j.version>1.7.36</slf4j.version>
         <tika.version>2.5.0</tika.version>


### PR DESCRIPTION
## Description
Bump a handful of dependencies in various `pom.xml` files. I used the [renovate bot](https://docs.renovatebot.com/) in a fork of the DSpace repository to unearth viable dependency updates. In most cases these are _minor_ and _patch_ level updates (ie 2.x.x) , as I specifically excluded major ones. In many cases they updates fix bugs, improve performance, improve compatibility with newer Java versions, and update transitive dependencies (for example, this resolves one old transitive dependency from Jaxen / xom, but introduces a new one with javassist).

**Note:** while the unit and integration tests are passing, and I have verified that basic functionality like browsing, submitting new items, Flyway migrations, etc are working, we might want to wait to merge this once 7.6 is released.

## Instructions for Reviewers

List of changes in this PR:
* Try building DSpace with `mvn -U -Pdspace-rest clean package` to make sure you don't use any old packages
* Try running DSpace
* Try various normal actions in the web interface, command line, HAL browser, and various APIs.