### PR TITLE
[Issue: #8888] Fixing the hostname parsing for the shibboleth auth

### DIFF
--- a/dspace-api/src/main/java/org/dspace/core/Utils.java
+++ b/dspace-api/src/main/java/org/dspace/core/Utils.java
@@ -16,8 +16,6 @@ import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
@@ -447,14 +445,14 @@ public final class Utils {
      */
     public static String getHostName(String uriString) {
         try {
-            URI uri = new URI(uriString);
-            String hostname = uri.getHost();
+            URL url = new URL(uriString);
+            String hostname = url.getHost();
             // remove the "www." from hostname, if it exists
             if (hostname != null) {
                 return hostname.startsWith("www.") ? hostname.substring(4) : hostname;
             }
             return null;
-        } catch (URISyntaxException e) {
+        } catch (MalformedURLException e) {
             return null;
         }
     }

--- a/dspace-api/src/test/java/org/dspace/core/UtilsTest.java
+++ b/dspace-api/src/test/java/org/dspace/core/UtilsTest.java
@@ -75,6 +75,12 @@ public class UtilsTest extends AbstractUnitTest {
         assertEquals("Test keep other prefixes", "demo.dspace.org",
                      Utils.getHostName("https://demo.dspace.org"));
 
+        assertEquals("Test with parameter", "demo.dspace.org",
+                     Utils.getHostName("https://demo.dspace.org/search?query=test"));
+
+        assertEquals("Test with parameter with space", "demo.dspace.org",
+                     Utils.getHostName("https://demo.dspace.org/search?query=test turbine"));
+
         // This uses a bunch of reserved URI characters
         assertNull("Test invalid URI returns null", Utils.getHostName("&+,?/@="));
     }


### PR DESCRIPTION
## References
* Fixes #8888

## Description
A small fix in the parsing of the hostname

## Instructions for Reviewers
This can be tested with a shibboleth, perform a search with a space in it & try to login. The hostname should be parsed resulting in a successful login.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [X] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
