### PR TITLE
Migrate from Joda-Time to java.time

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -704,10 +704,6 @@
         </dependency>
 
         <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-        </dependency>
-        <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
             <version>1</version>

--- a/dspace-api/src/main/java/org/dspace/access/status/AccessStatusServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/access/status/AccessStatusServiceImpl.java
@@ -8,6 +8,8 @@
 package org.dspace.access.status;
 
 import java.sql.SQLException;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.Date;
 
 import org.dspace.access.status.service.AccessStatusService;
@@ -15,7 +17,6 @@ import org.dspace.content.Item;
 import org.dspace.core.Context;
 import org.dspace.core.service.PluginService;
 import org.dspace.services.ConfigurationService;
-import org.joda.time.LocalDate;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -55,7 +56,10 @@ public class AccessStatusServiceImpl implements AccessStatusService {
             int month = configurationService.getIntProperty("access.status.embargo.forever.month");
             int day = configurationService.getIntProperty("access.status.embargo.forever.day");
 
-            forever_date = new LocalDate(year, month, day).toDate();
+            forever_date = Date.from(LocalDate.of(year, month, day)
+                    .atStartOfDay()
+                    .atZone(ZoneId.systemDefault())
+                    .toInstant());
         }
     }
 

--- a/dspace-api/src/main/java/org/dspace/importer/external/crossref/CrossRefDateMetadataProcessor.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/crossref/CrossRefDateMetadataProcessor.java
@@ -7,7 +7,8 @@
  */
 package org.dspace.importer.external.crossref;
 
-import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -18,12 +19,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.importer.external.metadatamapping.contributor.JsonPathMetadataProcessor;
-import org.joda.time.LocalDate;
 
 /**
  * This class is used for CrossRef's Live-Import to extract
  * issued attribute.
- * Beans are configured in the crossref-integration.xml file.
+ * Beans are configured in the {@code crossref-integration.xml} file.
  *
  * @author Francesco Pio Scognamiglio (francescopio.scognamiglio at 4science.com)
  */
@@ -41,22 +41,25 @@ public class CrossRefDateMetadataProcessor implements JsonPathMetadataProcessor 
         while (dates.hasNext()) {
             JsonNode date = dates.next();
             LocalDate issuedDate = null;
-            SimpleDateFormat issuedDateFormat = null;
+            DateTimeFormatter issuedDateFormat = null;
             if (date.has(0) && date.has(1) && date.has(2)) {
-                issuedDate = new LocalDate(
+                issuedDate = LocalDate.of(
                         date.get(0).numberValue().intValue(),
                         date.get(1).numberValue().intValue(),
                         date.get(2).numberValue().intValue());
-                issuedDateFormat = new SimpleDateFormat("yyyy-MM-dd");
+                issuedDateFormat = DateTimeFormatter.ISO_LOCAL_DATE;
             } else if (date.has(0) && date.has(1)) {
-                issuedDate = new LocalDate().withYear(date.get(0).numberValue().intValue())
-                        .withMonthOfYear(date.get(1).numberValue().intValue());
-                issuedDateFormat = new SimpleDateFormat("yyyy-MM");
+                issuedDate = LocalDate.of(date.get(0).numberValue().intValue(),
+                        date.get(1).numberValue().intValue(),
+                        1);
+                issuedDateFormat = DateTimeFormatter.ofPattern("yyyy-MM");
             } else if (date.has(0)) {
-                issuedDate = new LocalDate().withYear(date.get(0).numberValue().intValue());
-                issuedDateFormat = new SimpleDateFormat("yyyy");
+                issuedDate = LocalDate.of(date.get(0).numberValue().intValue(),
+                        1,
+                        1);
+                issuedDateFormat = DateTimeFormatter.ofPattern("yyyy");
             }
-            values.add(issuedDateFormat.format(issuedDate.toDate()));
+            values.add(issuedDate.format(issuedDateFormat));
         }
         return values;
     }

--- a/dspace-api/src/test/java/org/dspace/access/status/DefaultAccessStatusHelperTest.java
+++ b/dspace-api/src/test/java/org/dspace/access/status/DefaultAccessStatusHelperTest.java
@@ -14,6 +14,8 @@ import static org.junit.Assert.fail;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -42,7 +44,6 @@ import org.dspace.core.Constants;
 import org.dspace.eperson.Group;
 import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.eperson.service.GroupService;
-import org.joda.time.LocalDate;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -129,7 +130,7 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
             fail("SQL Error in init: " + ex.getMessage());
         }
         helper = new DefaultAccessStatusHelper();
-        threshold = new LocalDate(10000, 1, 1).toDate();
+        threshold = dateFrom(10000, 1, 1);
     }
 
     /**
@@ -266,7 +267,7 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         Group group = groupService.findByName(context, Group.ANONYMOUS);
         policy.setGroup(group);
         policy.setAction(Constants.READ);
-        policy.setStartDate(new LocalDate(9999, 12, 31).toDate());
+        policy.setStartDate(dateFrom(9999, 12, 31));
         policies.add(policy);
         authorizeService.removeAllPolicies(context, bitstream);
         authorizeService.addPolicies(context, policies, bitstream);
@@ -293,7 +294,7 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         Group group = groupService.findByName(context, Group.ANONYMOUS);
         policy.setGroup(group);
         policy.setAction(Constants.READ);
-        policy.setStartDate(new LocalDate(10000, 1, 1).toDate());
+        policy.setStartDate(dateFrom(10000, 1, 1));
         policies.add(policy);
         authorizeService.removeAllPolicies(context, bitstream);
         authorizeService.addPolicies(context, policies, bitstream);
@@ -383,7 +384,7 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         Group group = groupService.findByName(context, Group.ANONYMOUS);
         policy.setGroup(group);
         policy.setAction(Constants.READ);
-        policy.setStartDate(new LocalDate(9999, 12, 31).toDate());
+        policy.setStartDate(dateFrom(9999, 12, 31));
         policies.add(policy);
         authorizeService.removeAllPolicies(context, primaryBitstream);
         authorizeService.addPolicies(context, policies, primaryBitstream);
@@ -412,12 +413,27 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         Group group = groupService.findByName(context, Group.ANONYMOUS);
         policy.setGroup(group);
         policy.setAction(Constants.READ);
-        policy.setStartDate(new LocalDate(9999, 12, 31).toDate());
+        policy.setStartDate(dateFrom(9999, 12, 31));
         policies.add(policy);
         authorizeService.removeAllPolicies(context, anotherBitstream);
         authorizeService.addPolicies(context, policies, anotherBitstream);
         context.restoreAuthSystemState();
         String status = helper.getAccessStatusFromItem(context, itemWithoutPrimaryAndMultipleBitstreams, threshold);
         assertThat("testWithNoPrimaryAndMultipleBitstreams 0", status, equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
+    }
+
+    /**
+     * Create a Date from local year, month, day.
+     *
+     * @param year the year.
+     * @param month the month.
+     * @param day the day.
+     * @return the assembled date.
+     */
+    private Date dateFrom(int year, int month, int day) {
+        return Date.from(LocalDate.of(year, month, day)
+                .atStartOfDay()
+                .atZone(ZoneId.systemDefault())
+                .toInstant());
     }
 }

--- a/dspace-api/src/test/java/org/dspace/app/util/GoogleMetadataTest.java
+++ b/dspace-api/src/test/java/org/dspace/app/util/GoogleMetadataTest.java
@@ -16,11 +16,15 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
+import java.time.Period;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
 import com.google.common.base.Splitter;
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.AbstractUnitTest;
 import org.dspace.authorize.AuthorizeException;
@@ -41,10 +45,6 @@ import org.dspace.core.Constants;
 import org.dspace.eperson.Group;
 import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.eperson.service.GroupService;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.joda.time.MutablePeriod;
-import org.joda.time.format.PeriodFormat;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -54,7 +54,7 @@ public class GoogleMetadataTest extends AbstractUnitTest {
     /**
      * log4j category
      */
-    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(GoogleMetadataTest.class);
+    private static final Logger log = LogManager.getLogger();
 
     /**
      * Item instance for the tests
@@ -319,6 +319,7 @@ public class GoogleMetadataTest extends AbstractUnitTest {
 
     /**
      * Test empty bitstreams
+     * @throws java.lang.Exception passed through.
      */
     @Test
     public void testGetPDFURLWithEmptyBitstreams() throws Exception {
@@ -348,8 +349,9 @@ public class GoogleMetadataTest extends AbstractUnitTest {
     }
 
     /**
-     * Verify there is no mapping for {@link GoogleMetadata#PDF} if there are only embargoed (non-publically accessible
-     * bitstream) files
+     * Verify there is no mapping for {@link GoogleMetadata#PDF} if there are
+     * only embargoed (non-publicly accessible bitstream) files.
+     * @throws java.lang.Exception passed through.
      */
     @Test
     public void testGetPdfUrlOfEmbargoed() throws Exception {
@@ -363,8 +365,10 @@ public class GoogleMetadataTest extends AbstractUnitTest {
         b.getFormat(context).setMIMEType("unknown");
         bundleService.addBitstream(context, bundle, b);
         // Set 3 month embargo on pdf
-        MutablePeriod period = PeriodFormat.getDefault().parseMutablePeriod("3 months");
-        Date embargoDate = DateTime.now(DateTimeZone.UTC).plus(period).toDate();
+        Period period = Period.ofMonths(3);
+        Date embargoDate = Date.from(ZonedDateTime.now(ZoneOffset.UTC)
+                .plus(period)
+                .toInstant());
         Group anonGroup = groupService.findByName(context, Group.ANONYMOUS);
         authorizeService.removeAllPolicies(context, b);
         resourcePolicyService.removeAllPolicies(context, b);

--- a/dspace-api/src/test/java/org/dspace/authority/AuthorityValueTest.java
+++ b/dspace-api/src/test/java/org/dspace/authority/AuthorityValueTest.java
@@ -1,7 +1,10 @@
 package org.dspace.authority;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import static org.junit.Assert.assertNull;
 
 import java.util.Date;
@@ -28,7 +31,7 @@ public class AuthorityValueTest {
 
         // Test a date-time without zone or offset.
         expected = Date.from(LocalDateTime.of(1957, 01, 27, 01, 23, 45)
-                .atZone(ZoneOffset.of("-05"))
+                .atZone(ZoneId.systemDefault())
                 .toInstant());
         actual = AuthorityValue.stringToDate("1957-01-27T01:23:45");
         assertEquals("Local date-time should convert", expected, actual);

--- a/dspace-api/src/test/java/org/dspace/authority/AuthorityValueTest.java
+++ b/dspace-api/src/test/java/org/dspace/authority/AuthorityValueTest.java
@@ -1,0 +1,44 @@
+package org.dspace.authority;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import static org.junit.Assert.assertNull;
+
+import java.util.Date;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+/**
+ *
+ * @author mwood
+ */
+public class AuthorityValueTest {
+    /**
+     * Test of stringToDate method, of class AuthorityValue.
+     */
+    @Test
+    public void testStringToDate() {
+        Date expected;
+        Date actual;
+
+        // Test an invalid date.
+        actual = AuthorityValue.stringToDate("not a date");
+        assertNull("Unparseable date should return null", actual);
+
+        // Test a date-time without zone or offset.
+        expected = Date.from(LocalDateTime.of(1957, 01, 27, 01, 23, 45)
+                .atZone(ZoneOffset.of("-05"))
+                .toInstant());
+        actual = AuthorityValue.stringToDate("1957-01-27T01:23:45");
+        assertEquals("Local date-time should convert", expected, actual);
+
+        // Test a date-time with milliseconds and offset from UTC.
+        expected = Date.from(LocalDateTime.of(1957, 01, 27, 01, 23, 45, 678_000_000)
+                .atZone(ZoneOffset.of("-05"))
+                .toInstant());
+        actual = AuthorityValue.stringToDate("1957-01-27T01:23:45.678-05");
+        assertEquals("Zoned date-time with milliseconds should convert",
+                expected, actual);
+    }
+}

--- a/dspace-api/src/test/java/org/dspace/authority/AuthorityValueTest.java
+++ b/dspace-api/src/test/java/org/dspace/authority/AuthorityValueTest.java
@@ -7,16 +7,14 @@
  */
 package org.dspace.authority;
 
-import java.time.Instant;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import static org.junit.Assert.assertNull;
-
 import java.util.Date;
 
-import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 
 /**

--- a/dspace-api/src/test/java/org/dspace/authority/AuthorityValueTest.java
+++ b/dspace-api/src/test/java/org/dspace/authority/AuthorityValueTest.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package org.dspace.authority;
 
 import java.time.Instant;

--- a/dspace-api/src/test/java/org/dspace/builder/AbstractDSpaceObjectBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/AbstractDSpaceObjectBuilder.java
@@ -8,6 +8,8 @@
 package org.dspace.builder;
 
 import java.sql.SQLException;
+import java.time.Instant;
+import java.time.Period;
 import java.util.Date;
 
 import org.apache.logging.log4j.Logger;
@@ -20,11 +22,6 @@ import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.joda.time.MutablePeriod;
-import org.joda.time.format.PeriodFormat;
-import org.joda.time.format.PeriodFormatter;
 
 /**
  * Abstract builder to construct DSpace Objects
@@ -112,21 +109,22 @@ public abstract class AbstractDSpaceObjectBuilder<T extends DSpaceObject>
     }
 
     /**
-     * Support method to grant the {@link Constants#READ} permission over an object only to the {@link Group#ANONYMOUS}
-     * after the specified embargoPeriod. Any other READ permissions will be removed
+     * Support method to grant the {@link Constants#READ} permission over an
+     * object only to the {@link Group#ANONYMOUS} after the specified
+     * embargoPeriod.  Any other READ permissions will be removed.
      *
+     * @param <B> type of this Builder.
      * @param embargoPeriod
-     *            the embargo period after which the READ permission will be active. It is parsed using the
-     *            {@link PeriodFormatter#parseMutablePeriod(String)} method of the joda library
-     * @param dso
-     *            the DSpaceObject on which grant the permission
-     * @return the builder properly configured to retain read permission on the object only for the specified group
+     *            the embargo period after which the READ permission will be
+     *            active.
+     * @param dso the DSpaceObject on which to grant the permission.
+     * @return the builder properly configured to retain read permission on the
+     *         object only for the specified group.
      */
-    protected <B extends AbstractDSpaceObjectBuilder<T>> B setEmbargo(String embargoPeriod, DSpaceObject dso) {
+    protected <B extends AbstractDSpaceObjectBuilder<T>> B setEmbargo(Period embargoPeriod, DSpaceObject dso) {
         // add policy just for anonymous
         try {
-            MutablePeriod period = PeriodFormat.getDefault().parseMutablePeriod(embargoPeriod);
-            Date embargoDate = DateTime.now(DateTimeZone.UTC).plus(period).toDate();
+            Date embargoDate = Date.from(Instant.now().plus(embargoPeriod));
 
             return setOnlyReadPermission(dso, groupService.findByName(context, Group.ANONYMOUS), embargoDate);
         } catch (Exception e) {
@@ -135,14 +133,19 @@ public abstract class AbstractDSpaceObjectBuilder<T extends DSpaceObject>
     }
 
     /**
-     * Support method to grant the {@link Constants#READ} permission over an object only to a specific group. Any other
-     * READ permissions will be removed
+     * Support method to grant the {@link Constants#READ} permission over an
+     * object only to a specific group.Any other READ permissions will be
+     * removed.
      *
+     * @param <B> type of this Builder.
      * @param dso
      *            the DSpaceObject on which grant the permission
      * @param group
      *            the EPersonGroup that will be granted of the permission
-     * @return the builder properly configured to retain read permission on the object only for the specified group
+     * @param startDate
+     *            the date on which access begins.
+     * @return the builder properly configured to retain read permission on the
+     *            object only for the specified group.
      */
     protected <B extends AbstractDSpaceObjectBuilder<T>> B setOnlyReadPermission(DSpaceObject dso, Group group,
                                                                                  Date startDate) {
@@ -161,15 +164,20 @@ public abstract class AbstractDSpaceObjectBuilder<T extends DSpaceObject>
         }
         return (B) this;
     }
+
     /**
-     * Support method to grant the {@link Constants#ADMIN} permission over an object only to a specific eperson.
-     * If another ADMIN policy is in place for an eperson it will be replaced
+     * Support method to grant the {@link Constants#READ} permission over an
+     * object only to a specific EPerson.  Any other READ permissions will be
+     * removed.
      *
+     * @param <B> type of this Builder.
      * @param dso
      *            the DSpaceObject on which grant the permission
      * @param eperson
-     *            the eperson that will be granted of the permission
-     * @return the builder properly configured to build the object with the additional admin permission
+     *            the EPerson that will be granted of the permission
+     * @param startDate the date on which access begins.
+     * @return the builder properly configured to build the object with the
+     *            additional admin permission.
      */
     protected <B extends AbstractDSpaceObjectBuilder<T>> B setAdminPermission(DSpaceObject dso, EPerson eperson,
                                                                                  Date startDate) {
@@ -191,6 +199,7 @@ public abstract class AbstractDSpaceObjectBuilder<T extends DSpaceObject>
     /**
      * Support method to grant {@link Constants#REMOVE} permission to a specific eperson
      *
+     * @param <B> type of this Builder.
      * @param dso
      *            the DSpaceObject on which grant the permission
      * @param eperson
@@ -220,6 +229,7 @@ public abstract class AbstractDSpaceObjectBuilder<T extends DSpaceObject>
     /**
      * Support method to grant {@link Constants#ADD} permission to a specific eperson
      *
+     * @param <B> type of this Builder.
      * @param dso
      *            the DSpaceObject on which grant the permission
      * @param eperson
@@ -249,6 +259,7 @@ public abstract class AbstractDSpaceObjectBuilder<T extends DSpaceObject>
     /**
      * Support method to grant {@link Constants#WRITE} permission to a specific eperson
      *
+     * @param <B> type of this Builder.
      * @param dso
      *            the DSpaceObject on which grant the permission
      * @param eperson

--- a/dspace-api/src/test/java/org/dspace/builder/AbstractDSpaceObjectBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/AbstractDSpaceObjectBuilder.java
@@ -9,7 +9,9 @@ package org.dspace.builder;
 
 import java.sql.SQLException;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.Period;
+import java.time.ZoneId;
 import java.util.Date;
 
 import org.apache.logging.log4j.Logger;
@@ -28,6 +30,7 @@ import org.dspace.eperson.Group;
  *
  * @author Tom Desair (tom dot desair at atmire dot com)
  * @author Raf Ponsaerts (raf dot ponsaerts at atmire dot com)
+ * @param <T> concrete type of DSpaceObject
  */
 public abstract class AbstractDSpaceObjectBuilder<T extends DSpaceObject>
     extends AbstractBuilder<T, DSpaceObjectService> {
@@ -124,7 +127,12 @@ public abstract class AbstractDSpaceObjectBuilder<T extends DSpaceObject>
     protected <B extends AbstractDSpaceObjectBuilder<T>> B setEmbargo(Period embargoPeriod, DSpaceObject dso) {
         // add policy just for anonymous
         try {
-            Date embargoDate = Date.from(Instant.now().plus(embargoPeriod));
+            Instant embargoInstant = LocalDate.now()
+                    .plus(embargoPeriod)
+                    .atStartOfDay()
+                    .atZone(ZoneId.systemDefault())
+                    .toInstant();
+            Date embargoDate = Date.from(embargoInstant);
 
             return setOnlyReadPermission(dso, groupService.findByName(context, Group.ANONYMOUS), embargoDate);
         } catch (Exception e) {

--- a/dspace-api/src/test/java/org/dspace/builder/BitstreamBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/BitstreamBuilder.java
@@ -10,6 +10,7 @@ package org.dspace.builder;
 import java.io.IOException;
 import java.io.InputStream;
 import java.sql.SQLException;
+import java.time.Period;
 import java.util.List;
 
 import org.dspace.authorize.AuthorizeException;
@@ -171,7 +172,7 @@ public class BitstreamBuilder extends AbstractDSpaceObjectBuilder<Bitstream> {
         return targetBundle;
     }
 
-    public BitstreamBuilder withEmbargoPeriod(String embargoPeriod) {
+    public BitstreamBuilder withEmbargoPeriod(Period embargoPeriod) {
         return setEmbargo(embargoPeriod, bitstream);
     }
 

--- a/dspace-api/src/test/java/org/dspace/builder/ItemBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/ItemBuilder.java
@@ -13,6 +13,7 @@ import static org.dspace.content.authority.Choices.CF_ACCEPTED;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.time.Period;
 import java.util.UUID;
 
 import org.dspace.authorize.AuthorizeException;
@@ -291,7 +292,7 @@ public class ItemBuilder extends AbstractDSpaceObjectBuilder<Item> {
         return this;
     }
 
-    public ItemBuilder withEmbargoPeriod(String embargoPeriod) {
+    public ItemBuilder withEmbargoPeriod(Period embargoPeriod) {
         return setEmbargo(embargoPeriod, item);
     }
 

--- a/dspace-api/src/test/java/org/dspace/builder/ItemBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/ItemBuilder.java
@@ -282,8 +282,8 @@ public class ItemBuilder extends AbstractDSpaceObjectBuilder<Item> {
     }
 
     /**
-     * Withdrawn the item under build. Please note that an user need to be loggedin the context to avoid NPE during the
-     * creation of the provenance metadata
+     * Withdraw the item under build. Please note that the Context must be
+     * logged in to avoid NPE during the creation of the provenance metadata.
      *
      * @return the ItemBuilder
      */
@@ -292,6 +292,12 @@ public class ItemBuilder extends AbstractDSpaceObjectBuilder<Item> {
         return this;
     }
 
+    /**
+     * Set an embargo to end after some time from "now".
+     *
+     * @param embargoPeriod embargo starting "now", for this long.
+     * @return the ItemBuilder.
+     */
     public ItemBuilder withEmbargoPeriod(Period embargoPeriod) {
         return setEmbargo(embargoPeriod, item);
     }

--- a/dspace-api/src/test/java/org/dspace/importer/external/crossref/CrossRefDateMetadataProcessorTest.java
+++ b/dspace-api/src/test/java/org/dspace/importer/external/crossref/CrossRefDateMetadataProcessorTest.java
@@ -7,12 +7,11 @@
  */
 package org.dspace.importer.external.crossref;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.Collection;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
+
 import org.junit.Test;
-import static org.junit.Assert.*;
 
 /**
  *

--- a/dspace-api/src/test/java/org/dspace/importer/external/crossref/CrossRefDateMetadataProcessorTest.java
+++ b/dspace-api/src/test/java/org/dspace/importer/external/crossref/CrossRefDateMetadataProcessorTest.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package org.dspace.importer.external.crossref;
 
 import java.util.Collection;

--- a/dspace-api/src/test/java/org/dspace/importer/external/crossref/CrossRefDateMetadataProcessorTest.java
+++ b/dspace-api/src/test/java/org/dspace/importer/external/crossref/CrossRefDateMetadataProcessorTest.java
@@ -1,0 +1,32 @@
+package org.dspace.importer.external.crossref;
+
+import java.util.Collection;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ *
+ * @author mwood
+ */
+public class CrossRefDateMetadataProcessorTest {
+    /**
+     * Test of processMetadata method, of class CrossRefDateMetadataProcessor.
+     */
+    @Test
+    public void testProcessMetadata() {
+        CrossRefDateMetadataProcessor unit = new CrossRefDateMetadataProcessor();
+        unit.setPathToArray("/dates");
+        Collection metadata = unit.processMetadata("{\"dates\": ["
+                + "[1957, 1, 27],"
+                + "[1957, 1],"
+                + "[1957]"
+                + "]}");
+        String[] metadataValues = (String[]) metadata.toArray(new String[3]);
+        assertEquals("[yyyy, MM, dd] should parse", "1957-01-27", metadataValues[0]);
+        assertEquals("[yyyy, MM] should parse", "1957-01", metadataValues[1]);
+        assertEquals("[yyyy] should parse", "1957", metadataValues[2]);
+    }
+}

--- a/dspace-server-webapp/pom.xml
+++ b/dspace-server-webapp/pom.xml
@@ -434,10 +434,6 @@
             <artifactId>commons-validator</artifactId>
         </dependency>
         <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
@@ -49,6 +49,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.time.Period;
 import java.util.UUID;
 
 import org.apache.commons.io.IOUtils;
@@ -393,7 +394,7 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
                 .withName("Test Embargoed Bitstream")
                 .withDescription("This bitstream is embargoed")
                 .withMimeType("text/plain")
-                .withEmbargoPeriod("6 months")
+                .withEmbargoPeriod(Period.ofMonths(6))
                 .build();
         }
         context.restoreAuthSystemState();
@@ -437,7 +438,7 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
                 .withName("Test Embargoed Bitstream")
                 .withDescription("This bitstream is embargoed")
                 .withMimeType("text/plain")
-                .withEmbargoPeriod("3 months")
+                .withEmbargoPeriod(Period.ofMonths(3))
                 .build();
         }
             context.restoreAuthSystemState();
@@ -480,7 +481,7 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
                 .withName("Test Embargoed Bitstream")
                 .withDescription("This bitstream is embargoed")
                 .withMimeType("text/plain")
-                .withEmbargoPeriod("-3 months")
+                .withEmbargoPeriod(Period.ofMonths(-3))
                 .build();
         }
             context.restoreAuthSystemState();
@@ -558,7 +559,7 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
                     .withName("Bitstream")
                     .withDescription("Description")
                     .withMimeType("text/plain")
-                    .withEmbargoPeriod("2 week")
+                    .withEmbargoPeriod(Period.ofWeeks(2))
                     .build();
         }
         context.restoreAuthSystemState();

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestRepositoryIT.java
@@ -25,6 +25,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.io.InputStream;
+import java.time.Period;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -310,7 +311,7 @@ public class BitstreamRestRepositoryIT extends AbstractControllerIntegrationTest
                 .withName("Test Embargoed Bitstream")
                 .withDescription("This bitstream is embargoed")
                 .withMimeType("text/plain")
-                .withEmbargoPeriod("3 months")
+                .withEmbargoPeriod(Period.ofMonths(3))
                 .build();
         }
         context.restoreAuthSystemState();
@@ -363,7 +364,7 @@ public class BitstreamRestRepositoryIT extends AbstractControllerIntegrationTest
                 .withName("Test Embargoed Bitstream")
                 .withDescription("This bitstream is embargoed")
                 .withMimeType(bitstreamFormat.getMIMEType())
-                .withEmbargoPeriod("3 months")
+                .withEmbargoPeriod(Period.ofMonths(3))
                 .build();
         }
         context.restoreAuthSystemState();
@@ -517,7 +518,7 @@ public class BitstreamRestRepositoryIT extends AbstractControllerIntegrationTest
                 .withName("Test Embargoed Bitstream")
                 .withDescription("This bitstream is embargoed")
                 .withMimeType("text/plain")
-                .withEmbargoPeriod("3 months")
+                .withEmbargoPeriod(Period.ofMonths(3))
                 .build();
         }
 
@@ -577,7 +578,7 @@ public class BitstreamRestRepositoryIT extends AbstractControllerIntegrationTest
                 .withName("Test Embargoed Bitstream")
                 .withDescription("This bitstream is embargoed")
                 .withMimeType(bitstreamFormat.getMIMEType())
-                .withEmbargoPeriod("3 months")
+                .withEmbargoPeriod(Period.ofMonths(3))
                 .build();
         }
 
@@ -638,7 +639,7 @@ public class BitstreamRestRepositoryIT extends AbstractControllerIntegrationTest
                 .withName("Test Embargoed Bitstream")
                 .withDescription("This bitstream is embargoed")
                 .withMimeType("text/plain")
-                .withEmbargoPeriod("3 months")
+                .withEmbargoPeriod(Period.ofMonths(3))
                 .build();
         }
 
@@ -701,7 +702,7 @@ public class BitstreamRestRepositoryIT extends AbstractControllerIntegrationTest
                 .withName("Test Embargoed Bitstream")
                 .withDescription("This bitstream is embargoed")
                 .withMimeType(bitstreamFormat.getMIMEType())
-                .withEmbargoPeriod("3 months")
+                .withEmbargoPeriod(Period.ofMonths(3))
                 .build();
         }
 
@@ -768,7 +769,7 @@ public class BitstreamRestRepositoryIT extends AbstractControllerIntegrationTest
                 .withName("Test Embargoed Bitstream")
                 .withDescription("This bitstream is embargoed")
                 .withMimeType("text/plain")
-                .withEmbargoPeriod("3 months")
+                .withEmbargoPeriod(Period.ofMonths(3))
                 .build();
         }
 
@@ -826,7 +827,7 @@ public class BitstreamRestRepositoryIT extends AbstractControllerIntegrationTest
                 .withName("Test Embargoed Bitstream")
                 .withDescription("This bitstream is embargoed")
                 .withMimeType("text/plain")
-                .withEmbargoPeriod("3 months")
+                .withEmbargoPeriod(Period.ofMonths(3))
                 .build();
         }
 
@@ -1899,7 +1900,7 @@ public class BitstreamRestRepositoryIT extends AbstractControllerIntegrationTest
                                       .withTitle("Test")
                                       .withIssueDate("2010-10-17")
                                       .withAuthor("Smith, Donald")
-                                      .withEmbargoPeriod("6 months")
+                                      .withEmbargoPeriod(Period.ofMonths(6))
                                       .build();
 
         String bitstreamContent = "This is an archived bitstream";
@@ -2372,7 +2373,7 @@ public class BitstreamRestRepositoryIT extends AbstractControllerIntegrationTest
                 .withName("Test Embargoed Bitstream")
                 .withDescription("This bitstream is embargoed")
                 .withMimeType("text/plain")
-                .withEmbargoPeriod("3 months")
+                .withEmbargoPeriod(Period.ofMonths(3))
                 .build();
         }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BrowsesResourceControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BrowsesResourceControllerIT.java
@@ -21,6 +21,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.time.Period;
+
 import org.dspace.app.rest.matcher.BrowseEntryResourceMatcher;
 import org.dspace.app.rest.matcher.BrowseIndexMatcher;
 import org.dspace.app.rest.matcher.ItemMatcher;
@@ -776,7 +778,7 @@ public class BrowsesResourceControllerIT extends AbstractControllerIntegrationTe
                                         .withIssueDate("2017-08-10")
                                         .withAuthor("Mouse, Mickey")
                                         .withSubject("Cartoons").withSubject("Mice")
-                                        .withEmbargoPeriod("12 months")
+                                        .withEmbargoPeriod(Period.ofMonths(12))
                                         .build();
 
         //5. An item that is only readable for an internal groups
@@ -909,7 +911,7 @@ public class BrowsesResourceControllerIT extends AbstractControllerIntegrationTe
                                         .withIssueDate("2017-08-10")
                                         .withAuthor("Mouse, Mickey")
                                         .withSubject("Cartoons").withSubject("Mice")
-                                        .withEmbargoPeriod("12 months")
+                                        .withEmbargoPeriod(Period.ofMonths(12))
                                         .build();
 
         //5. An item that is only readable for an internal groups

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -26,6 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.io.InputStream;
+import java.time.Period;
 import java.util.UUID;
 
 import com.jayway.jsonpath.matchers.JsonPathMatchers;
@@ -2413,7 +2414,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                 .withAuthor("test2, test2").withAuthor("Maybe, Maybe")
                 .withSubject("AnotherTest").withSubject("TestingForMore")
                 .withSubject("ExtraEntry")
-                .withEmbargoPeriod("12 months")
+                .withEmbargoPeriod(Period.ofMonths(12))
                 .build();
 
         //Turn on the authorization again
@@ -2714,7 +2715,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
     /**
      * This test verifies that
      * {@link org.dspace.discovery.indexobject.InprogressSubmissionIndexFactoryImpl#storeInprogressItemFields}
-     * indexes the owning collection of workspace items
+     * indexes the owning collection of workspace items.
+     *
+     * @throws java.lang.Exception passed through.
      */
     @Test
     public void discoverSearchObjectsTestForWorkspaceItemInCollectionScope() throws Exception {
@@ -2765,7 +2768,8 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
     /**
      * This test verifies that
      * {@link org.dspace.discovery.indexobject.InprogressSubmissionIndexFactoryImpl#storeInprogressItemFields}
-     * indexes the owning collection of workflow items
+     * indexes the owning collection of workflow items.
+     * @throws java.lang.Exception passed through.
      */
     @Test
     public void discoverSearchObjectsTestForWorkflowItemInCollectionScope() throws Exception {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
@@ -36,6 +36,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.io.InputStream;
 import java.sql.SQLException;
+import java.time.Period;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -313,7 +314,6 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
                    .andExpect(jsonPath("$.page.totalPages", is(2)))
                    .andExpect(jsonPath("$.page.number", is(0)))
                    .andExpect(jsonPath("$.page.totalElements", is(3)));
-        ;
 
         getClient(token).perform(get("/api/core/items")
                    .param("size", "2")
@@ -596,7 +596,7 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         // is used in the provenance note.
         String token = getAuthToken(admin.getEmail(), password);
 
-        List<Operation> ops = new ArrayList<Operation>();
+        List<Operation> ops = new ArrayList<>();
         ReplaceOperation replaceOperation = new ReplaceOperation("/withdrawn", true);
         ops.add(replaceOperation);
         String patchBody = getPatchContent(ops);
@@ -651,7 +651,7 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
                                .build();
 
         context.restoreAuthSystemState();
-        List<Operation> ops = new ArrayList<Operation>();
+        List<Operation> ops = new ArrayList<>();
         ReplaceOperation replaceOperation = new ReplaceOperation("/withdrawn", true);
         ops.add(replaceOperation);
         String patchBody = getPatchContent(ops);
@@ -700,7 +700,7 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         // try to use an unauthorized user
         String token = getAuthToken(eperson.getEmail(), password);
 
-        List<Operation> ops = new ArrayList<Operation>();
+        List<Operation> ops = new ArrayList<>();
         ReplaceOperation replaceOperation = new ReplaceOperation("/withdrawn", true);
         ops.add(replaceOperation);
         String patchBody = getPatchContent(ops);
@@ -760,7 +760,7 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.restoreAuthSystemState();
         String token = getAuthToken(admin.getEmail(), password);
 
-        List<Operation> ops = new ArrayList<Operation>();
+        List<Operation> ops = new ArrayList<>();
         ReplaceOperation replaceOperation = new ReplaceOperation("/withdrawn", null);
         ops.add(replaceOperation);
         String patchBody = getPatchContent(ops);
@@ -822,7 +822,7 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         // is used in the provenance note.
         String token = getAuthToken(admin.getEmail(), password);
 
-        List<Operation> ops = new ArrayList<Operation>();
+        List<Operation> ops = new ArrayList<>();
         ReplaceOperation replaceOperation = new ReplaceOperation("/withdrawn", false);
         ops.add(replaceOperation);
         String patchBody = getPatchContent(ops);
@@ -882,7 +882,7 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.restoreAuthSystemState();
         String tokenAdmin = getAuthToken(admin.getEmail(), password);
 
-        List<Operation> ops = new ArrayList<Operation>();
+        List<Operation> ops = new ArrayList<>();
         ReplaceOperation replaceOperation = new ReplaceOperation("/withdrawn", false);
         ops.add(replaceOperation);
         String patchBody = getPatchContent(ops);
@@ -932,7 +932,7 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         String token = getAuthToken(eperson.getEmail(), password);
         String tokenAdmin = getAuthToken(admin.getEmail(), password);
 
-        List<Operation> ops = new ArrayList<Operation>();
+        List<Operation> ops = new ArrayList<>();
         ReplaceOperation replaceOperation = new ReplaceOperation("/withdrawn", false);
         ops.add(replaceOperation);
         String patchBody = getPatchContent(ops);
@@ -977,7 +977,7 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.restoreAuthSystemState();
         String token = getAuthToken(admin.getEmail(), password);
 
-        List<Operation> ops = new ArrayList<Operation>();
+        List<Operation> ops = new ArrayList<>();
         ReplaceOperation replaceOperation = new ReplaceOperation("/discoverable", true);
         ops.add(replaceOperation);
         String patchBody = getPatchContent(ops);
@@ -1031,7 +1031,7 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.restoreAuthSystemState();
         String token = getAuthToken(admin.getEmail(), password);
 
-        List<Operation> ops = new ArrayList<Operation>();
+        List<Operation> ops = new ArrayList<>();
         ReplaceOperation replaceOperation = new ReplaceOperation("/discoverable", true);
         ops.add(replaceOperation);
         String patchBody = getPatchContent(ops);
@@ -1076,7 +1076,7 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         String token = getAuthToken(eperson.getEmail(), password);
         String tokenAdmin = getAuthToken(admin.getEmail(), password);
 
-        List<Operation> ops = new ArrayList<Operation>();
+        List<Operation> ops = new ArrayList<>();
         ReplaceOperation replaceOperation = new ReplaceOperation("/discoverable", true);
         ops.add(replaceOperation);
         String patchBody = getPatchContent(ops);
@@ -1119,7 +1119,7 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.restoreAuthSystemState();
         String token = getAuthToken(admin.getEmail(), password);
 
-        List<Operation> ops = new ArrayList<Operation>();
+        List<Operation> ops = new ArrayList<>();
         ReplaceOperation replaceOperation = new ReplaceOperation("/discoverable", false);
         ops.add(replaceOperation);
         String patchBody = getPatchContent(ops);
@@ -1165,7 +1165,7 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.restoreAuthSystemState();
         String token = getAuthToken(admin.getEmail(), password);
 
-        List<Operation> ops = new ArrayList<Operation>();
+        List<Operation> ops = new ArrayList<>();
         // String value should work.
         ReplaceOperation replaceOperation = new ReplaceOperation("/discoverable", "false");
         ops.add(replaceOperation);
@@ -1212,7 +1212,7 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.restoreAuthSystemState();
         String token = getAuthToken(admin.getEmail(), password);
 
-        List<Operation> ops = new ArrayList<Operation>();
+        List<Operation> ops = new ArrayList<>();
         ReplaceOperation replaceOperation = new ReplaceOperation("/discoverable", false);
         ops.add(replaceOperation);
         String patchBody = getPatchContent(ops);
@@ -1257,7 +1257,7 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         String token = getAuthToken(eperson.getEmail(), password);
         String tokenAdmin = getAuthToken(admin.getEmail(), password);
 
-        List<Operation> ops = new ArrayList<Operation>();
+        List<Operation> ops = new ArrayList<>();
         ReplaceOperation replaceOperation = new ReplaceOperation("/discoverable", false);
         ops.add(replaceOperation);
         String patchBody = getPatchContent(ops);
@@ -1311,7 +1311,7 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.restoreAuthSystemState();
         String token = getAuthToken(admin.getEmail(), password);
 
-        List<Operation> ops = new ArrayList<Operation>();
+        List<Operation> ops = new ArrayList<>();
         ReplaceOperation replaceOperation = new ReplaceOperation("/discoverable", null);
         ops.add(replaceOperation);
         String patchBody = getPatchContent(ops);
@@ -1638,7 +1638,7 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
                                          .withIssueDate("2017-12-18")
                                          .withAuthor("Smith, Donald").withAuthor("Doe, John")
                                          .withSubject("ExtraEntry")
-                                         .withEmbargoPeriod("6 months")
+                                         .withEmbargoPeriod(Period.ofMonths(6))
                                          .build();
 
         //3. a public item
@@ -1729,7 +1729,7 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
                 .withIssueDate("2015-10-21")
                 .withAuthor("Smith, Donald")
                 .withSubject("ExtraEntry")
-                .withEmbargoPeriod("1 week")
+                .withEmbargoPeriod(Period.ofWeeks(1))
                 .build();
 
         context.restoreAuthSystemState();
@@ -1778,7 +1778,7 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
                 .withTitle("embargoed item 1")
                 .withIssueDate("2017-11-18")
                 .withAuthor("Smith, Donald")
-                .withEmbargoPeriod("-2 week")
+                .withEmbargoPeriod(Period.ofWeeks(-2))
                 .build();
 
         context.restoreAuthSystemState();
@@ -2069,7 +2069,7 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.restoreAuthSystemState();
 
         UUID idRef = null;
-        AtomicReference<UUID> idRefNoEmbeds = new AtomicReference<UUID>();
+        AtomicReference<UUID> idRefNoEmbeds = new AtomicReference<>();
         try {
         ObjectMapper mapper = new ObjectMapper();
         ItemRest itemRest = new ItemRest();
@@ -3895,7 +3895,7 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         createOrcidQueue(context, firstProfile, publication).build();
         createOrcidQueue(context, secondProfile, publication).build();
 
-        List<OrcidHistory> historyRecords = new ArrayList<OrcidHistory>();
+        List<OrcidHistory> historyRecords = new ArrayList<>();
         historyRecords.add(createOrcidHistory(context, firstProfile, publication).build());
         historyRecords.add(createOrcidHistory(context, firstProfile, publication).withPutCode("12345").build());
         historyRecords.add(createOrcidHistory(context, secondProfile, publication).build());
@@ -3982,7 +3982,7 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         createOrcidQueue(context, firstProfile, funding).build();
         createOrcidQueue(context, secondProfile, funding).build();
 
-        List<OrcidHistory> historyRecords = new ArrayList<OrcidHistory>();
+        List<OrcidHistory> historyRecords = new ArrayList<>();
         historyRecords.add(createOrcidHistory(context, firstProfile, funding).build());
         historyRecords.add(createOrcidHistory(context, firstProfile, funding).withPutCode("12345").build());
         historyRecords.add(createOrcidHistory(context, secondProfile, funding).build());
@@ -4081,7 +4081,7 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         String tokenAdmin = getAuthToken(admin.getEmail(), password);
         String tokenEperson = getAuthToken(eperson.getEmail(), password);
 
-        List<Operation> ops = new ArrayList<Operation>();
+        List<Operation> ops = new ArrayList<>();
         ReplaceOperation replaceOperation = new ReplaceOperation("/withdrawn", true);
         ops.add(replaceOperation);
         String patchBody = getPatchContent(ops);
@@ -4131,7 +4131,7 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
                              .param("projection", "full"))
                              .andExpect(status().isOk())
                              .andExpect(jsonPath("$", CollectionMatcher.matchCollectionEntryFullProjection(
-                                        col1.getName(), col1.getID(), col1.getHandle())));;
+                                        col1.getName(), col1.getID(), col1.getHandle())));
 
         // try to spoof information as a logged in eperson using embedding, verify that no embedds are included
         getClient(tokenEperson).perform(get("/api/core/items/" + item.getID())

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/signposting/controller/LinksetRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/signposting/controller/LinksetRestControllerIT.java
@@ -18,8 +18,8 @@ import java.io.InputStream;
 import java.text.DateFormat;
 import java.text.MessageFormat;
 import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.time.Period;
+import java.util.Date;
 
 import org.apache.commons.codec.CharEncoding;
 import org.apache.commons.io.IOUtils;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/signposting/controller/LinksetRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/signposting/controller/LinksetRestControllerIT.java
@@ -19,6 +19,7 @@ import java.text.DateFormat;
 import java.text.MessageFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.time.Period;
 
 import org.apache.commons.codec.CharEncoding;
 import org.apache.commons.io.IOUtils;
@@ -466,7 +467,7 @@ public class LinksetRestControllerIT extends AbstractControllerIntegrationTest {
                 .withTitle("Withdrawn Item")
                 .withMetadata("dc", "identifier", "doi", doi)
                 .withIssueDate("2017-11-18")
-                .withEmbargoPeriod("2 week")
+                .withEmbargoPeriod(Period.ofWeeks(2))
                 .build();
         context.restoreAuthSystemState();
 
@@ -837,7 +838,7 @@ public class LinksetRestControllerIT extends AbstractControllerIntegrationTest {
                     .withName("Bitstream")
                     .withDescription("description")
                     .withMimeType(bitstreamMimeType)
-                    .withEmbargoPeriod("6 months")
+                    .withEmbargoPeriod(Period.ofMonths(6))
                     .build();
         }
         context.restoreAuthSystemState();
@@ -949,7 +950,7 @@ public class LinksetRestControllerIT extends AbstractControllerIntegrationTest {
                 .withTitle("Withdrawn Item")
                 .withMetadata("dc", "identifier", "doi", doi)
                 .withIssueDate("2017-11-18")
-                .withEmbargoPeriod("2 week")
+                .withEmbargoPeriod(Period.ofWeeks(2))
                 .build();
         context.restoreAuthSystemState();
 


### PR DESCRIPTION
## References
* Fixes #8886

## Description
All uses of Joda Time classes have been replaced with JSR 310 `java.time` classes.

## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* Construction of Date from year/month/day uses `java.time.LocalDate`.
* Date parsing uses `ZonedDateTime` etc.
* Use `Period.ofMonths(3)` instead of `PeriodFormat.parseMutablePeriod("3 months")` and similar changes when creating adjusted dates.
* New unit tests to prove that some changes work.
* Usual cleanup of formatting, warnings and suggestions from IDE, etc. and a bit more documentation.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).