### PR TITLE
Fast fail error when creating administrator, if there is no database connection

### DIFF
--- a/dspace-api/src/main/java/org/dspace/administer/CreateAdministrator.java
+++ b/dspace-api/src/main/java/org/dspace/administer/CreateAdministrator.java
@@ -116,6 +116,17 @@ public final class CreateAdministrator {
     protected CreateAdministrator()
             throws Exception {
         context = new Context();
+        try {
+            context.getDBConfig();
+        } catch (NullPointerException npr) {
+            // if database is null, there is no point in continuing. Prior to this exception and catch,
+            // NullPointerException was thrown, that wasn't very helpful.
+            throw new IllegalStateException("Problem connecting to database. This " +
+                    "indicates issue with either network or version (or possibly some other). " +
+                    "If you are running this in docker-compose, please make sure dspace-cli was " +
+                    "built from the same sources as running dspace container AND that they are in " +
+                    "the same project/network.");
+        }
         groupService = EPersonServiceFactory.getInstance().getGroupService();
         ePersonService = EPersonServiceFactory.getInstance().getEPersonService();
     }


### PR DESCRIPTION
## Description
Create-administrator failed with NullPointerException which was not very helpful.
We added Illegal state error, when dbConnection is null.

## Instructions for Reviewers
command `[dspace-installation-folder]/bin/dspace create-administrator`
should always work as expected, make sure it works as previously.
(It creates new user that is admin, you will be able to log in with it)

List of changes in this PR:
Added Illegal state error, when dbConnection is null.

We observed errors only while using dockerized dspace.
Using dspace container (from docker-compose.yml) and dspace-cli container (from docker-compose-cli.yml) 
of DIFFERENT versions produced this error. We observed it in 7.2 vs 7.5.

Another possibility is when they were not started in the same project, e.g.:
docker-compose -p first-project -f docker-compose.yml up -d
docker-compose -p second-project -f docker-compose-cli.yml run dspace-cli create-administrator

This second scenario is much simpler to test and should be sufficient. New error (IllegalStateException) should be shown.

I think mentioning docker in the error description is good idea, since that is the only way we encountered this error,
even if most dspace installations are not yet running in docker.
