### PR TITLE
Fix to adjusting bundle and bitstream policies (item install, embargo lift)

### DIFF
--- a/dspace-api/src/test/java/org/dspace/content/ItemTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/ItemTest.java
@@ -1393,6 +1393,78 @@ public class ItemTest extends AbstractDSpaceObjectTest {
         assertTrue("testInheritCollectionDefaultPolicies 2", equals);
     }
 
+    // Test to verify DEFAULT_*_READ policies on collection inherit properly to Item/Bundle/Bitstream
+    @Test
+    public void testInheritCollectionDefaultPolicies_custom_default_groups() throws Exception {
+        context.turnOffAuthorisationSystem();
+        // Create a new collection
+        Collection c = createCollection();
+        // Create a custom group with DEFAULT_ITEM_READ privileges in this Collection
+        Group item_read_role = collectionService.createDefaultReadGroup(context, c, "ITEM",
+                                                                        Constants.DEFAULT_ITEM_READ);
+        // Create a custom group with DEFAULT_BITSTREAM_READ privileges in this Collection
+        Group bitstream_read_role = collectionService.createDefaultReadGroup(context, c, "BITSTREAM",
+                                                                        Constants.DEFAULT_BITSTREAM_READ);
+        context.restoreAuthSystemState();
+
+        // Verify that Collection's DEFAULT_ITEM_READ now uses the newly created group.
+        List<ResourcePolicy> defaultItemReadPolicies =
+            authorizeService.getPoliciesActionFilter(context, c, Constants.DEFAULT_ITEM_READ);
+        assertEquals("One DEFAULT_ITEM_READ policy", 1, defaultItemReadPolicies.size());
+        assertEquals("DEFAULT_ITEM_READ group", item_read_role.getName(),
+                     defaultItemReadPolicies.get(0).getGroup().getName());
+
+        // Verify that Collection's DEFAULT_BITSTREAM_READ now uses the newly created group.
+        List<ResourcePolicy> defaultBitstreamReadPolicies =
+            authorizeService.getPoliciesActionFilter(context, c, Constants.DEFAULT_BITSTREAM_READ);
+        assertEquals("One DEFAULT_BITSTREAM_READ policy on Collection", 1, defaultBitstreamReadPolicies.size());
+        assertEquals("DEFAULT_BITSTREAM_READ group", bitstream_read_role.getName(),
+                     defaultBitstreamReadPolicies.get(0).getGroup().getName());
+
+        context.turnOffAuthorisationSystem();
+        // Create a new Item in this Collection
+        WorkspaceItem workspaceItem = workspaceItemService.create(context, c, false);
+        Item item = workspaceItem.getItem();
+        // Add a single Bitstream to the ORIGINAL bundle
+        File f = new File(testProps.get("test.bitstream").toString());
+        Bitstream bitstream = itemService.createSingleBitstream(context, new FileInputStream(f), item);
+        context.restoreAuthSystemState();
+
+        // Allow Item WRITE perms
+        doNothing().when(authorizeServiceSpy).authorizeAction(context, item, Constants.WRITE, true);
+        // Inherit all default policies from Collection down to new Item
+        itemService.inheritCollectionDefaultPolicies(context, item, c);
+
+        // Verify Item inherits DEFAULT_ITEM_READ group from Collection
+        List<ResourcePolicy> itemReadPolicies = authorizeService.getPoliciesActionFilter(context, item, Constants.READ);
+        assertEquals("One READ policy on Item", 1, itemReadPolicies.size());
+        assertEquals("Item's READ group", item_read_role.getName(),
+                     itemReadPolicies.get(0).getGroup().getName());
+
+        // Verify Bitstream inherits DEFAULT_BITSTREAM_READ group from Collection
+        List<ResourcePolicy> bitstreamReadPolicies = authorizeService.getPoliciesActionFilter(context, bitstream,
+                                                                                              Constants.READ);
+        assertEquals("One READ policy on Bitstream", 1, bitstreamReadPolicies.size());
+        assertEquals("Bitstream's READ group", bitstream_read_role.getName(),
+                     bitstreamReadPolicies.get(0).getGroup().getName());
+
+        // Verify ORIGINAL Bundle inherits DEFAULT_ITEM_READ group from Collection
+        // Bundles should inherit from DEFAULT_ITEM_READ so that if the item is readable, the files
+        // can be listed (even if files are access restricted or embargoed)
+        List<Bundle> bundles = item.getBundles(Constants.DEFAULT_BUNDLE_NAME);
+        Bundle originalBundle = bundles.get(0);
+        List<ResourcePolicy> bundleReadPolicies = authorizeService.getPoliciesActionFilter(context, originalBundle,
+                                                                                           Constants.READ);
+        assertEquals("One READ policy on Bundle", 1, bundleReadPolicies.size());
+        assertEquals("Bundles's READ group", item_read_role.getName(),
+                     bundleReadPolicies.get(0).getGroup().getName());
+
+        // Cleanup after ourselves. Delete created collection & all content under it
+        context.turnOffAuthorisationSystem();
+        collectionService.delete(context, c);
+        context.restoreAuthSystemState();
+    }
+
     /**
      * Test of move method, of class Item.
      */


### PR DESCRIPTION
Apply DEFAULT_ITEM_READ to bundles, not DEFAULT_BITSTREAM_READ so that files can be listed if the item / default item is readable

## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes https://github.com/DSpace/DSpace/issues/8902
* Related to a similar merged PR: https://github.com/DSpace/DSpace/pull/8783

## Description
The `adjustBundleBitstreamPolicies` method in ItemService which is called when installing a new item or lifting a legacy embargo, applies DEFAULT_BITSTREAM_READ to both bundles and bitstreams. As per recent discussion on https://github.com/DSpace/DSpace/issues/8902 we think DEFAULT_ITEM_READ should be used instead.

This PR might not yet be complete:
* I expect to have broken at least one test (this is good, will prove the changed functionality, and I will update / add a new test soon).
* I think we should possibly allow for a missing DEFAULT_ITEM_READ to fall back to inheriting Item READ? (more relevant for an embargo lift than a new install, probably)
* I added a TODO item to ask if we should throw an exception for a missing DEFAULT_ITEM_READ (sort of conflicting with the question above)

## Instructions for Reviewers
Try to reproduce the behaviour described in https://github.com/DSpace/DSpace/issues/8902 with this PR applied


## Checklist

- [ ] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
