### PR TITLE
Hide publicdomain by default since it's now the same as CC0

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -968,7 +968,7 @@ metadata.hide.person.email = true
 #### Creative Commons settings ######
 
 # The url to the web service API
-cc.api.rooturl = http://api.creativecommons.org/rest/1.5
+cc.api.rooturl = https://api.creativecommons.org/rest/1.5
 
 # Metadata field to hold CC license URI of selected license
 cc.license.uri = dc.rights.uri
@@ -985,12 +985,12 @@ cc.submit.addbitstream = true
 # A list of license classes that should be excluded from selection process
 # class names - comma-separated list -  must exactly match what service returns.
 # At time of implementation, these are:
-# publicdomain - "Public Domain"
+# publicdomain - "Public Domain" (this is now the same as CC0)
 # standard - "Creative Commons"
 # recombo - "Sampling"
 # zero - "CC0"
 # mark - "Public Domain Mark"
-cc.license.classfilter = recombo, mark
+cc.license.classfilter = publicdomain, recombo, mark
 
 # Jurisdiction of the creative commons license -- is it ported or not?
 # Use the key from the url seen in the response from the api call,


### PR DESCRIPTION
## References
* Fixes #8543

## Description
The CC License dropdown shows `CC0` twice, if you go to [their wiki](https://api.creativecommons.org/docs/readme_dev.html#changes-since-1-5l) if you read through the 1.5 release change log you can see that this was done on purpose. So I just added `publicdomain` by default to `cc.license.classfilter` to avoid further confusion.

> Added the `zero` license class and aliased the `publicdomain` class to issue a CC0 result.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
