### PR TITLE
Request a Copy sends same email regardless of accept or reject

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/requestitem/RequestItemEmailNotifier.java
+++ b/dspace-api/src/main/java/org/dspace/app/requestitem/RequestItemEmailNotifier.java
@@ -176,7 +176,7 @@ public class RequestItemEmailNotifier {
 
         // Build an email back to the requester.
         Email email = Email.getEmail(I18nUtil.getEmailFilename(context.getCurrentLocale(),
-                "request_item.granted"));
+                ri.isAccept_request() ? "request_item.granted" : "request_item.rejected"));
         email.addArgument(ri.getReqName()); // {0} requestor's name
         email.addArgument(handleService.getCanonicalForm(ri.getItem().getHandle())); // {1} URL of the requested Item
         email.addArgument(ri.getItem().getName()); // {2} title of the requested Item

--- a/dspace-api/src/test/java/org/dspace/app/requestitem/RequestItemEmailNotifierTest.java
+++ b/dspace-api/src/test/java/org/dspace/app/requestitem/RequestItemEmailNotifierTest.java
@@ -48,6 +48,13 @@ public class RequestItemEmailNotifierTest
 
     public static final String TRANSPORT_CLASS_KEY = "mail.smtp.class";
 
+    private static final String REQUESTOR_ADDRESS = "mhwood@wood.net";
+    private static final String REQUESTOR_NAME = "Mark Wood";
+    private static final String HELPDESK_ADDRESS = "help@example.com";
+    private static final String HELPDESK_NAME = "Help Desk";
+    private static final String TEST_MESSAGE = "Message";
+    private static final String DUMMY_PROTO = "dummy";
+
     private static ConfigurationService configurationService;
     private static BitstreamService bitstreamService;
     private static HandleService handleService;
@@ -86,13 +93,6 @@ public class RequestItemEmailNotifierTest
      */
     @Test
     public void testSendResponse() throws Exception {
-        final String REQUESTOR_ADDRESS = "mhwood@wood.net";
-        final String REQUESTOR_NAME = "Mark Wood";
-        final String HELPDESK_ADDRESS = "help@example.com";
-        final String HELPDESK_NAME = "Help Desk";
-        final String TEST_MESSAGE = "Message";
-        final String DUMMY_PROTO = "dummy";
-
         // Create some content to send.
         context.turnOffAuthorisationSystem();
         Community com = CommunityBuilder.createCommunity(context)
@@ -169,6 +169,95 @@ public class RequestItemEmailNotifierTest
 
         assertThat("Should contain the test custom message",
                 (String)content, containsString(TEST_MESSAGE));
+    }
+
+    /**
+     * Test of sendResponse method -- rejection case.
+     * @throws java.lang.Exception passed through.
+     */
+    @Test
+    public void testSendRejection()
+        throws Exception {
+        // Create some content to send.
+        context.turnOffAuthorisationSystem();
+        Community com = CommunityBuilder.createCommunity(context)
+                .withName("Top Community")
+                .build();
+        Collection col = CollectionBuilder.createCollection(context, com)
+                .build();
+        Item item = ItemBuilder.createItem(context, col)
+                .withTitle("Test Item")
+                .build();
+        context.restoreAuthSystemState();
+
+        // Create a request to which we can respond.
+        RequestItem ri = new RequestItem();
+        ri.setAccept_request(false);
+        ri.setItem(item);
+        ri.setAllfiles(true);
+        ri.setReqEmail(REQUESTOR_ADDRESS);
+        ri.setReqName(REQUESTOR_NAME);
+
+        // Install a fake transport for RFC2822 email addresses.
+        Session session = DSpaceServicesFactory.getInstance().getEmailService().getSession();
+        Provider transportProvider = new Provider(Provider.Type.TRANSPORT,
+                DUMMY_PROTO, JavaMailTestTransport.class.getCanonicalName(),
+                "DSpace", "1.0");
+        session.addProvider(transportProvider);
+        session.setProvider(transportProvider);
+        session.setProtocolForAddress("rfc822", DUMMY_PROTO);
+
+        // Configure the help desk strategy.
+        configurationService.setProperty("mail.helpdesk", HELPDESK_ADDRESS);
+        configurationService.setProperty("mail.helpdesk.name", HELPDESK_NAME);
+        configurationService.setProperty("request.item.helpdesk.override", "true");
+
+        // Ensure that mail is "sent".
+        configurationService.setProperty("mail.server.disabled", "false");
+
+        // Instantiate and initialize the unit, using the "help desk" strategy.
+        RequestItemEmailNotifier requestItemEmailNotifier
+                = new RequestItemEmailNotifier(
+                        DSpaceServicesFactory.getInstance()
+                                .getServiceManager()
+                                .getServiceByName(RequestItemHelpdeskStrategy.class.getName(),
+                                        RequestItemAuthorExtractor.class));
+        requestItemEmailNotifier.bitstreamService = bitstreamService;
+        requestItemEmailNotifier.configurationService = configurationService;
+        requestItemEmailNotifier.handleService = handleService;
+        requestItemEmailNotifier.requestItemService = requestItemService;
+
+        // Test the unit.  Template supplies the Subject: value
+        requestItemEmailNotifier.sendResponse(context, ri, null, TEST_MESSAGE);
+
+        // Evaluate the test results.
+
+        // Check the To: address.
+        Address[] myAddresses = JavaMailTestTransport.getAddresses();
+        assertEquals("Should have one To: address.",
+                myAddresses.length, 1);
+        assertThat("To: should be an Internet address",
+                myAddresses[0], instanceOf(InternetAddress.class));
+        String address = ((InternetAddress)myAddresses[0]).getAddress();
+        assertEquals("To: address should match requestor.",
+                ri.getReqEmail(), address);
+
+        // Check the message body.
+        Message myMessage = JavaMailTestTransport.getMessage();
+
+        Object content = myMessage.getContent();
+        assertThat("Body should be a single text bodypart",
+                content, instanceOf(String.class));
+
+        assertThat("Should contain the helpdesk name",
+                (String)content, containsString(HELPDESK_NAME));
+
+        assertThat("Should contain the test custom message",
+                (String)content, containsString(TEST_MESSAGE));
+
+        // FIXME Note that this depends on the content of the rejection template!
+        assertThat("Should contain the word 'denied'.",
+                (String)content, containsString("denied"));
     }
 
     /**

--- a/dspace/config/emails/request_item.rejected
+++ b/dspace/config/emails/request_item.rejected
@@ -1,0 +1,26 @@
+## Sent to the person requesting a copy of a restricted document when the
+## request is denied.
+##
+## Parameters:
+##  {0} name of the requestor
+##  {1} Handle URL of the requested Item
+##  {2} title of the requested Item
+##  {3} name of the grantor
+##  {4} email address of the grantor (unused)
+##  {5} custom message sent by the grantor.
+#set($subject = 'Request for Copy of Restricted Document is Denied')
+Dear ${params[0]}:
+
+Your request for a copy of the file(s) from the below document has been denied by ${params[3]}.
+
+    ${params[2]}
+    ${params[1]} 
+#if( $params[5] )
+
+An additional message from ${params[3]} follows:
+
+${params[5]}
+#end
+
+Best regards,
+The ${config.get('dspace.name')} Team


### PR DESCRIPTION
## References
* Fixes #8907

## Description
Created a copy request rejection letter, and logic to send it when the request is rejected.

## Instructions for Reviewers
List of changes in this PR:
* New email template for rejected requests.
* Email code tests for rejection and selects the appropriate template.
* New unit test for the rejection case.

See #8907 for a test procedure.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
