### PR TITLE
Rename test suites that are really integration testing.

### DIFF
--- a/dspace-api/src/test/java/org/dspace/authorize/RegexPasswordValidatorIT.java
+++ b/dspace-api/src/test/java/org/dspace/authorize/RegexPasswordValidatorIT.java
@@ -26,7 +26,7 @@ import org.mockito.junit.MockitoJUnitRunner;
  * @author Luca Giamminonni (luca.giamminonni at 4science.it)
  */
 @RunWith(MockitoJUnitRunner.class)
-public class RegexPasswordValidatorTest extends AbstractIntegrationTest {
+public class RegexPasswordValidatorIT extends AbstractIntegrationTest {
 
     @Mock
     private ConfigurationService configurationService;

--- a/dspace-api/src/test/java/org/dspace/content/RelationshipServiceImplVersioningIT.java
+++ b/dspace-api/src/test/java/org/dspace/content/RelationshipServiceImplVersioningIT.java
@@ -26,7 +26,7 @@ import org.dspace.services.factory.DSpaceServicesFactory;
 import org.junit.Before;
 import org.junit.Test;
 
-public class RelationshipServiceImplVersioningTest extends AbstractIntegrationTestWithDatabase {
+public class RelationshipServiceImplVersioningIT extends AbstractIntegrationTestWithDatabase {
 
     private RelationshipService relationshipService;
     private RelationshipDAO relationshipDAO;

--- a/dspace-api/src/test/java/org/dspace/content/VersioningWithRelationshipsIT.java
+++ b/dspace-api/src/test/java/org/dspace/content/VersioningWithRelationshipsIT.java
@@ -70,7 +70,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 
-public class VersioningWithRelationshipsTest extends AbstractIntegrationTestWithDatabase {
+public class VersioningWithRelationshipsIT extends AbstractIntegrationTestWithDatabase {
 
     private final RelationshipService relationshipService =
         ContentServiceFactory.getInstance().getRelationshipService();

--- a/dspace-api/src/test/java/org/dspace/content/dao/RelationshipDAOImplIT.java
+++ b/dspace-api/src/test/java/org/dspace/content/dao/RelationshipDAOImplIT.java
@@ -35,9 +35,13 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-public class RelationshipTypeDAOImplTest extends AbstractIntegrationTest {
+/**
+ * Created by: Andrew Wood
+ * Date: 20 Sep 2019
+ */
+public class RelationshipDAOImplIT extends AbstractIntegrationTest {
 
-    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(RelationshipTypeDAOImplTest.class);
+    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(RelationshipDAOImplIT.class);
 
     private Relationship relationship;
 
@@ -51,7 +55,7 @@ public class RelationshipTypeDAOImplTest extends AbstractIntegrationTest {
 
     private RelationshipType relationshipType;
 
-    private List<RelationshipType> relationshipTypeList = new ArrayList<>();
+    private List<Relationship> relationshipsList = new ArrayList<>();
 
     private EntityType entityTypeOne;
 
@@ -75,6 +79,7 @@ public class RelationshipTypeDAOImplTest extends AbstractIntegrationTest {
     public void init() {
         super.init();
         try {
+            // Create objects for testing
             context.turnOffAuthorisationSystem();
             owningCommunity = communityService.create(null, context);
             collection = collectionService.create(context, owningCommunity);
@@ -92,7 +97,7 @@ public class RelationshipTypeDAOImplTest extends AbstractIntegrationTest {
                     "isAuthorOfPublication", "isPublicationOfAuthor",0,10,0,10);
             relationship = relationshipService.create(context, itemOne, itemTwo, relationshipType, 0, 0);
             relationshipService.update(context, relationship);
-            relationshipTypeList.add(relationshipType);
+            relationshipsList.add(relationship);
             context.restoreAuthSystemState();
         } catch (Exception e) {
             log.error(e);
@@ -107,7 +112,6 @@ public class RelationshipTypeDAOImplTest extends AbstractIntegrationTest {
     @Override
     public void destroy() {
         try {
-            // Cleanup newly created objects
             context.turnOffAuthorisationSystem();
             relationshipService.delete(context, relationship);
             relationshipTypeService.delete(context, relationshipType);
@@ -124,38 +128,38 @@ public class RelationshipTypeDAOImplTest extends AbstractIntegrationTest {
     }
 
     /**
-     * Test findbyTypesAndLabels should return our defined RelationshipType given our test Entities entityTypeTwo and
-     * entityTypeOne with the affiliated labels isAuthorOfPublication and isPublicationOfAuthor
+     * Test findItem should return our defined relationshipsList given our test Item itemOne.
      *
      * @throws Exception
      */
     @Test
-    public void testFindByTypesAndLabels() throws Exception {
-        assertEquals("TestFindbyTypesAndLabels 0", relationshipType, relationshipTypeService
-                .findbyTypesAndTypeName(context, entityTypeTwo, entityTypeOne, "isAuthorOfPublication",
-                        "isPublicationOfAuthor"));
+    public void testFindByItem() throws Exception {
+        assertEquals("TestFindByItem 0", relationshipsList, relationshipService.findByItem(context, itemOne,
+                -1, -1, false));
     }
 
     /**
-     * Test findByLeftOrRightLabel should return our defined relationshipTypeList given one of our affiliated labels
+     * Test findByRelationshipType should return our defined relationshipsList given our test RelationshipType
+     * relationshipType
      *
      * @throws Exception
      */
     @Test
-    public void testFindByLeftOrRightLabel() throws Exception {
-        assertEquals("TestFindByLeftOrRightLabel 0", relationshipTypeList, relationshipTypeService.
-                findByLeftwardOrRightwardTypeName(context, "isAuthorOfPublication", -1, -1));
+    public void testFindByRelationshipType() throws Exception {
+        assertEquals("TestByRelationshipType 0", relationshipsList, relationshipService.findByRelationshipType(context,
+                relationshipType));
     }
 
     /**
-     * Test findByEntityType should return our defined relationshipsList given one our defined EntityTypes
-     * entityTypeOne
+     * Test countTotal should return our defined relationshipsList's size given our test Context
+     * context
      *
      * @throws Exception
      */
     @Test
-    public void testFindByEntityType() throws Exception {
-        assertEquals("TestFindByEntityType 0", relationshipTypeList, relationshipTypeService.findByEntityType(context,
-                entityTypeOne));
+    public void testCountRows() throws Exception {
+        assertEquals("TestByRelationshipType 0", relationshipsList.size(), relationshipService.countTotal(context));
     }
+
+
 }

--- a/dspace-api/src/test/java/org/dspace/content/dao/RelationshipTypeDAOImplIT.java
+++ b/dspace-api/src/test/java/org/dspace/content/dao/RelationshipTypeDAOImplIT.java
@@ -35,13 +35,9 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-/**
- * Created by: Andrew Wood
- * Date: 20 Sep 2019
- */
-public class RelationshipDAOImplTest extends AbstractIntegrationTest {
+public class RelationshipTypeDAOImplIT extends AbstractIntegrationTest {
 
-    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(RelationshipDAOImplTest.class);
+    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(RelationshipTypeDAOImplIT.class);
 
     private Relationship relationship;
 
@@ -55,7 +51,7 @@ public class RelationshipDAOImplTest extends AbstractIntegrationTest {
 
     private RelationshipType relationshipType;
 
-    private List<Relationship> relationshipsList = new ArrayList<>();
+    private List<RelationshipType> relationshipTypeList = new ArrayList<>();
 
     private EntityType entityTypeOne;
 
@@ -79,7 +75,6 @@ public class RelationshipDAOImplTest extends AbstractIntegrationTest {
     public void init() {
         super.init();
         try {
-            // Create objects for testing
             context.turnOffAuthorisationSystem();
             owningCommunity = communityService.create(null, context);
             collection = collectionService.create(context, owningCommunity);
@@ -97,7 +92,7 @@ public class RelationshipDAOImplTest extends AbstractIntegrationTest {
                     "isAuthorOfPublication", "isPublicationOfAuthor",0,10,0,10);
             relationship = relationshipService.create(context, itemOne, itemTwo, relationshipType, 0, 0);
             relationshipService.update(context, relationship);
-            relationshipsList.add(relationship);
+            relationshipTypeList.add(relationshipType);
             context.restoreAuthSystemState();
         } catch (Exception e) {
             log.error(e);
@@ -112,6 +107,7 @@ public class RelationshipDAOImplTest extends AbstractIntegrationTest {
     @Override
     public void destroy() {
         try {
+            // Cleanup newly created objects
             context.turnOffAuthorisationSystem();
             relationshipService.delete(context, relationship);
             relationshipTypeService.delete(context, relationshipType);
@@ -128,38 +124,38 @@ public class RelationshipDAOImplTest extends AbstractIntegrationTest {
     }
 
     /**
-     * Test findItem should return our defined relationshipsList given our test Item itemOne.
+     * Test findbyTypesAndLabels should return our defined RelationshipType given our test Entities entityTypeTwo and
+     * entityTypeOne with the affiliated labels isAuthorOfPublication and isPublicationOfAuthor
      *
      * @throws Exception
      */
     @Test
-    public void testFindByItem() throws Exception {
-        assertEquals("TestFindByItem 0", relationshipsList, relationshipService.findByItem(context, itemOne,
-                -1, -1, false));
+    public void testFindByTypesAndLabels() throws Exception {
+        assertEquals("TestFindbyTypesAndLabels 0", relationshipType, relationshipTypeService
+                .findbyTypesAndTypeName(context, entityTypeTwo, entityTypeOne, "isAuthorOfPublication",
+                        "isPublicationOfAuthor"));
     }
 
     /**
-     * Test findByRelationshipType should return our defined relationshipsList given our test RelationshipType
-     * relationshipType
+     * Test findByLeftOrRightLabel should return our defined relationshipTypeList given one of our affiliated labels
      *
      * @throws Exception
      */
     @Test
-    public void testFindByRelationshipType() throws Exception {
-        assertEquals("TestByRelationshipType 0", relationshipsList, relationshipService.findByRelationshipType(context,
-                relationshipType));
+    public void testFindByLeftOrRightLabel() throws Exception {
+        assertEquals("TestFindByLeftOrRightLabel 0", relationshipTypeList, relationshipTypeService.
+                findByLeftwardOrRightwardTypeName(context, "isAuthorOfPublication", -1, -1));
     }
 
     /**
-     * Test countTotal should return our defined relationshipsList's size given our test Context
-     * context
+     * Test findByEntityType should return our defined relationshipsList given one our defined EntityTypes
+     * entityTypeOne
      *
      * @throws Exception
      */
     @Test
-    public void testCountRows() throws Exception {
-        assertEquals("TestByRelationshipType 0", relationshipsList.size(), relationshipService.countTotal(context));
+    public void testFindByEntityType() throws Exception {
+        assertEquals("TestFindByEntityType 0", relationshipTypeList, relationshipTypeService.findByEntityType(context,
+                entityTypeOne));
     }
-
-
 }

--- a/dspace-api/src/test/java/org/dspace/content/service/ItemServiceIT.java
+++ b/dspace-api/src/test/java/org/dspace/content/service/ItemServiceIT.java
@@ -54,8 +54,8 @@ import org.dspace.versioning.service.VersioningService;
 import org.junit.Before;
 import org.junit.Test;
 
-public class ItemServiceTest extends AbstractIntegrationTestWithDatabase {
-    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ItemServiceTest.class);
+public class ItemServiceIT extends AbstractIntegrationTestWithDatabase {
+    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ItemServiceIT.class);
 
     protected RelationshipService relationshipService = ContentServiceFactory.getInstance().getRelationshipService();
     protected RelationshipTypeService relationshipTypeService = ContentServiceFactory.getInstance()

--- a/dspace-api/src/test/java/org/dspace/identifier/VersionedHandleIdentifierProviderIT.java
+++ b/dspace-api/src/test/java/org/dspace/identifier/VersionedHandleIdentifierProviderIT.java
@@ -27,7 +27,7 @@ import org.dspace.services.factory.DSpaceServicesFactory;
 import org.junit.Before;
 import org.junit.Test;
 
-public class VersionedHandleIdentifierProviderTest extends AbstractIntegrationTestWithDatabase {
+public class VersionedHandleIdentifierProviderIT extends AbstractIntegrationTestWithDatabase {
     private ServiceManager serviceManager;
     private IdentifierServiceImpl identifierService;
 


### PR DESCRIPTION
## Description
Several test suites that are named `*Test` actually extend `AbstractIntegrationTest` or a subtype thereof.  This causes long-running integration tests to run with the unit tests.  Unit testing already takes so long as to discourage its routine use -- we don't need to make it worse.  This patch renames these classes so that they run with the integration tests.

## Instructions for Reviewers
List of changes in this PR:
* Renamed several integration tests that had names which caused them to be run by surefire and not by failsafe.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).