### PR TITLE
Fix for NullPointerException when enumerating browses for vocabularies without Discovery indexes

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/authority/ChoiceAuthorityServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/ChoiceAuthorityServiceImpl.java
@@ -585,6 +585,12 @@ public final class ChoiceAuthorityServiceImpl implements ChoiceAuthorityService 
                         break;
                     }
                 }
+
+                // If there is no matching facet, return null to ignore this vocabulary index
+                if (matchingFacet == null) {
+                    return null;
+                }
+
                 DSpaceControlledVocabularyIndex vocabularyIndex =
                         new DSpaceControlledVocabularyIndex((DSpaceControlledVocabulary) source, metadataFields,
                                 matchingFacet);


### PR DESCRIPTION
## References
* Fixes #8927

## Description

This PR avoids the NullPointerException ignoring vocabulary browse indexes whose metadata field does not have a search facet defined in the discovery configuration.

## Instructions for Reviewers

To reproduce the issue add to submission-form.xml this input field (uses the dc.format metadata field which is not indexed by any discovery facets in the default discovery configuration)

```           
              <row>
                <field>
                    <dc-schema>dc</dc-schema>
                    <dc-element>format</dc-element>
                    <dc-qualifier></dc-qualifier>
                    <repeatable>true</repeatable>
                    <label>Test vocabulary without facet</label>
                    <input-type>tag</input-type>
                    <hint>Test vocabulary nsi with dc.format.</hint>
                    <required></required>
                    <vocabulary>nsi</vocabulary>
                </field>
            </row>
```
Applying this patch should avoid the NullPointerException and don't list the browse index for the vocabulary nsi.


## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
