### PR TITLE
DS-8935. webui.browse.link CrossLinks - Fix for multiple exact matches

### DIFF
--- a/dspace-api/src/main/java/org/dspace/browse/CrossLinks.java
+++ b/dspace-api/src/main/java/org/dspace/browse/CrossLinks.java
@@ -108,7 +108,7 @@ public class CrossLinks {
             } else {
                 // Exact match, if the key field has no .* wildcard
                 if (links.containsKey(metadata)) {
-                    return links.get(key);
+                    return links.get(metadata);
                 }
             }
         }

--- a/dspace-api/src/test/java/org/dspace/browse/CrossLinksTest.java
+++ b/dspace-api/src/test/java/org/dspace/browse/CrossLinksTest.java
@@ -1,0 +1,103 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.browse;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.dspace.AbstractDSpaceTest;
+import org.dspace.services.ConfigurationService;
+import org.dspace.utils.DSpace;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test class for {@link CrossLinks}
+ */
+public class CrossLinksTest extends AbstractDSpaceTest {
+    protected ConfigurationService configurationService;
+
+
+    @Before
+    public void setUp() {
+      configurationService = new DSpace().getConfigurationService();
+    }
+
+    @Test
+    public void testFindLinkType_Null() throws Exception {
+        CrossLinks crossLinks = new CrossLinks();
+        assertNull(crossLinks.findLinkType(null));
+    }
+
+    @Test
+    public void testFindLinkType_NoMatch() throws Exception {
+        CrossLinks crossLinks = new CrossLinks();
+        String metadataField = "foo.bar.baz.does.not.exist";
+        assertNull(crossLinks.findLinkType(metadataField));
+    }
+
+    @Test
+    public void testFindLinkType_WildcardMatch() throws Exception {
+        configurationService.setProperty("webui.browse.link.1", "author:dc.contributor.*");
+        CrossLinks crossLinks = new CrossLinks();
+
+        String metadataField = "dc.contributor.author";
+        assertEquals("author",crossLinks.findLinkType(metadataField));
+    }
+
+    @Test
+    public void testFindLinkType_SingleExactMatch_Author() throws Exception {
+        configurationService.setProperty("webui.browse.link.1", "author:dc.contributor.author");
+        CrossLinks crossLinks = new CrossLinks();
+
+        assertEquals("type",crossLinks.findLinkType("dc.genre"));
+        assertEquals("author",crossLinks.findLinkType("dc.contributor.author"));
+    }
+
+    @Test
+    public void testFindLinkType_SingleExactMatch_Type() throws Exception {
+        configurationService.setProperty("webui.browse.link.1", "type:dc.genre");
+        CrossLinks crossLinks = new CrossLinks();
+
+        assertEquals("type",crossLinks.findLinkType("dc.genre"));
+    }
+
+    @Test
+    public void testFindLinkType_MultipleExactMatches_DifferentIndexes() throws Exception {
+        configurationService.setProperty("webui.browse.link.1", "author:dc.contributor.author");
+        configurationService.setProperty("webui.browse.link.2", "type:dc.genre");
+        CrossLinks crossLinks = new CrossLinks();
+
+        assertEquals("author",crossLinks.findLinkType("dc.contributor.author"));
+        assertEquals("type",crossLinks.findLinkType("dc.genre"));
+    }
+
+    @Test
+    public void testFindLinkType_MultipleWildcardMatches_DifferentIndexes() throws Exception {
+        configurationService.setProperty("webui.browse.link.1", "author:dc.contributor.*");
+        configurationService.setProperty("webui.browse.link.2", "subject:dc.subject.*");
+        CrossLinks crossLinks = new CrossLinks();
+
+        assertEquals("author",crossLinks.findLinkType("dc.contributor.author"));
+        assertEquals("subject",crossLinks.findLinkType("dc.subject.lcsh"));
+    }
+
+    @Test
+    public void testFindLinkType_MultiplExactAndWildcardMatches_DifferentIndexes() throws Exception {
+        configurationService.setProperty("webui.browse.link.1", "author:dc.contributor.*");
+        configurationService.setProperty("webui.browse.link.2", "subject:dc.subject.*");
+        configurationService.setProperty("webui.browse.link.3", "type:dc.genre");
+        configurationService.setProperty("webui.browse.link.4", "dateissued:dc.date.issued");
+        CrossLinks crossLinks = new CrossLinks();
+
+        assertEquals("author",crossLinks.findLinkType("dc.contributor.author"));
+        assertEquals("subject",crossLinks.findLinkType("dc.subject.lcsh"));
+        assertEquals("type",crossLinks.findLinkType("dc.genre"));
+        assertEquals("dateissued",crossLinks.findLinkType("dc.date.issued"));
+    }
+}


### PR DESCRIPTION
 when multiple exact match "webui.browse.link" configuration entries are present that point to different indexes.


https://github.com/DSpace/DSpace/issues/8935

## References

* Fixes #8935

## Description

Modified the code to return the index associated with the given metadata (which is used as the key in the hash map), instead of the key from the keySet (which may not actually be the metadata value being searched for).

## Instructions for Reviewers

I have included JUnit tests to verify the above change.

Note: This change is the *minimal* change that fixes the issue. The "findLinkType" method could likely be improved with additional refactoring (such as moving the "exact match" test out of the loop), but went with this smaller change in case there are functionality issues I am not aware of.

List of changes in this PR:

* In line 111, changed `return links.get(key);` to `return links.get(metadata);` This is necessary because the "key" variable refers to the current key being processed from the HashMap's "keySet" which may not in any way a match for the metadata being searched for.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
