### PR TITLE
Exclude non-content bitstream view events from Google Analytics 4

### DIFF
--- a/dspace-api/src/main/java/org/dspace/google/GoogleAsyncEventListener.java
+++ b/dspace-api/src/main/java/org/dspace/google/GoogleAsyncEventListener.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.content.Bitstream;
+import org.dspace.content.Bundle;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
@@ -176,26 +177,27 @@ public class GoogleAsyncEventListener extends AbstractUsageEventListener {
      * Verifies if the usage event is a content bitstream view event, by checking if:<ul>
      * <li>the usage event is a view event</li>
      * <li>the object of the usage event is a bitstream</li>
-     * <li>the bitstream belongs to the ORIGINAL bundle</li></ul>
-     * This last one can be skipped if 'google-analytics.exclude-non-content-bitstreams' is set to false.
-     * This will make it so the bundle name is completely ignored when sending events.
+     * <li>the bitstream belongs to one of the configured bundles (fallback: ORIGINAL bundle)</li></ul>
      */
     private boolean isContentBitstream(UsageEvent usageEvent) {
         // check if event is a VIEW event and object is a Bitstream
         if (usageEvent.getAction() == UsageEvent.Action.VIEW
             || usageEvent.getObject().getType() == Constants.BITSTREAM) {
-            // check if config is set to true
-            if (configurationService.getBooleanProperty("google-analytics.exclude-non-content-bitstreams")) {
-                try {
-                    // check if bitstream belongs to the ORIGINAL bundle
-                    return ((Bitstream) usageEvent.getObject())
-                        .getBundles().stream()
-                        .anyMatch(bundle -> bundle.getName().equals(Constants.CONTENT_BUNDLE_NAME));
-                } catch (SQLException e) {
-                    throw new RuntimeException(e.getMessage(), e);
-                }
+            // check if bitstream belongs to a configured bundle
+            List<String> allowedBundles = List.of(configurationService
+                      .getArrayProperty("google-analytics.bundles", new String[]{Constants.CONTENT_BUNDLE_NAME}));
+            if (allowedBundles.contains("none")) {
+                // GA events for bitstream views were turned off in config
+                return false;
             }
-            return true;
+            List<String> bitstreamBundles;
+            try {
+                bitstreamBundles = ((Bitstream) usageEvent.getObject())
+                    .getBundles().stream().map(Bundle::getName).collect(Collectors.toList());
+            } catch (SQLException e) {
+                throw new RuntimeException(e.getMessage(), e);
+            }
+            return allowedBundles.stream().anyMatch(bitstreamBundles::contains);
         }
         return false;
     }

--- a/dspace-api/src/main/java/org/dspace/google/GoogleAsyncEventListener.java
+++ b/dspace-api/src/main/java/org/dspace/google/GoogleAsyncEventListener.java
@@ -182,7 +182,7 @@ public class GoogleAsyncEventListener extends AbstractUsageEventListener {
     private boolean isContentBitstream(UsageEvent usageEvent) {
         // check if event is a VIEW event and object is a Bitstream
         if (usageEvent.getAction() == UsageEvent.Action.VIEW
-            || usageEvent.getObject().getType() == Constants.BITSTREAM) {
+            && usageEvent.getObject().getType() == Constants.BITSTREAM) {
             // check if bitstream belongs to a configured bundle
             List<String> allowedBundles = List.of(configurationService
                       .getArrayProperty("google-analytics.bundles", new String[]{Constants.CONTENT_BUNDLE_NAME}));

--- a/dspace-server-webapp/src/test/java/org/dspace/google/GoogleAsyncEventListenerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/google/GoogleAsyncEventListenerIT.java
@@ -29,12 +29,16 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.builder.BitstreamBuilder;
+import org.dspace.builder.BundleBuilder;
 import org.dspace.builder.CollectionBuilder;
 import org.dspace.builder.CommunityBuilder;
 import org.dspace.builder.ItemBuilder;
 import org.dspace.content.Bitstream;
+import org.dspace.content.Bundle;
 import org.dspace.content.Collection;
 import org.dspace.content.Item;
+import org.dspace.core.Constants;
 import org.dspace.google.client.GoogleAnalyticsClient;
 import org.dspace.services.ConfigurationService;
 import org.junit.After;
@@ -61,6 +65,8 @@ public class GoogleAsyncEventListenerIT extends AbstractControllerIntegrationTes
 
     private Bitstream bitstream;
 
+    private Item item;
+
     private List<GoogleAnalyticsClient> originalGoogleAnalyticsClients;
 
     private GoogleAnalyticsClient firstGaClientMock = mock(GoogleAnalyticsClient.class);
@@ -80,7 +86,7 @@ public class GoogleAsyncEventListenerIT extends AbstractControllerIntegrationTes
             .withName("Test collection")
             .build();
 
-        Item item = ItemBuilder.createItem(context, collection)
+        item = ItemBuilder.createItem(context, collection)
             .withTitle("Test item")
             .build();
 
@@ -238,6 +244,88 @@ public class GoogleAsyncEventListenerIT extends AbstractControllerIntegrationTes
 
     }
 
+    @Test
+    public void testOnBitstreamContentDownloadExcludeNonContentBitstreams() throws Exception {
+        configurationService.setProperty("google-analytics.exclude-non-content-bitstreams", true);
+
+        context.turnOffAuthorisationSystem();
+        Bundle licenseBundle = BundleBuilder.createBundle(context, item)
+                                            .withName(Constants.LICENSE_BUNDLE_NAME).build();
+        Bitstream license = BitstreamBuilder.createBitstream(context, licenseBundle,
+                                                             toInputStream("License", defaultCharset())).build();
+        Bundle thumbnailBundle = BundleBuilder.createBundle(context, item).withName("THUMBNAIL").build();
+        Bitstream thumbnail = BitstreamBuilder.createBitstream(context, thumbnailBundle,
+                                                               toInputStream("Thumbnail", defaultCharset())).build();
+        context.restoreAuthSystemState();
+
+        assertThat(getStoredEventsAsList(), empty());
+
+        String bitstreamUrl = "/api/core/bitstreams/" + bitstream.getID() + "/content";
+
+        downloadBitstreamContent("Postman", "123456", "REF");
+        downloadContent("Chrome", "ABCDEFG", "REF-1", license);
+        downloadContent("Chrome", "987654", "REF-2", thumbnail);
+
+        assertThat(getStoredEventsAsList(), hasSize(1));
+
+        List<GoogleAnalyticsEvent> storedEvents = getStoredEventsAsList();
+
+        assertThat(storedEvents, contains(
+            event("123456", "127.0.0.1", "Postman", "REF", bitstreamUrl, "Test item")));
+
+        googleAsyncEventListener.sendCollectedEvents();
+
+        assertThat(getStoredEventsAsList(), empty());
+
+        verify(firstGaClientMock).isAnalyticsKeySupported(ANALYTICS_KEY);
+        verify(secondGaClientMock).isAnalyticsKeySupported(ANALYTICS_KEY);
+        verify(secondGaClientMock).sendEvents(ANALYTICS_KEY, storedEvents);
+        verifyNoMoreInteractions(firstGaClientMock, secondGaClientMock);
+    }
+
+    @Test
+    public void testOnBitstreamContentDownloadIncludeNonContentBitstreams() throws Exception {
+        configurationService.setProperty("google-analytics.exclude-non-content-bitstreams", false);
+
+        context.turnOffAuthorisationSystem();
+        Bundle licenseBundle = BundleBuilder.createBundle(context, item)
+                                            .withName(Constants.LICENSE_BUNDLE_NAME).build();
+        Bitstream license = BitstreamBuilder.createBitstream(context, licenseBundle,
+                                                             toInputStream("License", defaultCharset())).build();
+        Bundle thumbnailBundle = BundleBuilder.createBundle(context, item).withName("THUMBNAIL").build();
+        Bitstream thumbnail = BitstreamBuilder.createBitstream(context, thumbnailBundle,
+                                                               toInputStream("Thumbnail", defaultCharset())).build();
+        context.restoreAuthSystemState();
+
+        assertThat(getStoredEventsAsList(), empty());
+
+        String bitstreamUrl = "/api/core/bitstreams/" + bitstream.getID() + "/content";
+        String licenseUrl = "/api/core/bitstreams/" + license.getID() + "/content";
+        String thumbnailUrl = "/api/core/bitstreams/" + thumbnail.getID() + "/content";
+
+        downloadBitstreamContent("Postman", "123456", "REF");
+        downloadContent("Chrome", "ABCDEFG", "REF-1", license);
+        downloadContent("Chrome", "987654", "REF-2", thumbnail);
+
+        assertThat(getStoredEventsAsList(), hasSize(3));
+
+        List<GoogleAnalyticsEvent> storedEvents = getStoredEventsAsList();
+
+        assertThat(storedEvents, contains(
+            event("123456", "127.0.0.1", "Postman", "REF", bitstreamUrl, "Test item"),
+            event("ABCDEFG", "127.0.0.1", "Chrome", "REF-1", licenseUrl, "Test item"),
+            event("987654", "127.0.0.1", "Chrome", "REF-2", thumbnailUrl, "Test item")));
+
+        googleAsyncEventListener.sendCollectedEvents();
+
+        assertThat(getStoredEventsAsList(), empty());
+
+        verify(firstGaClientMock).isAnalyticsKeySupported(ANALYTICS_KEY);
+        verify(secondGaClientMock).isAnalyticsKeySupported(ANALYTICS_KEY);
+        verify(secondGaClientMock).sendEvents(ANALYTICS_KEY, storedEvents);
+        verifyNoMoreInteractions(firstGaClientMock, secondGaClientMock);
+    }
+
     @SuppressWarnings("unchecked")
     private List<GoogleAnalyticsEvent> getStoredEventsAsList() {
         List<GoogleAnalyticsEvent> events = new ArrayList<>();
@@ -248,13 +336,18 @@ public class GoogleAsyncEventListenerIT extends AbstractControllerIntegrationTes
         return events;
     }
 
-    private void downloadBitstreamContent(String userAgent, String correlationId, String referrer) throws Exception {
+    private void downloadContent(String userAgent, String correlationId, String referrer, Bitstream bit)
+            throws Exception {
         getClient(getAuthToken(admin.getEmail(), password))
-            .perform(get("/api/core/bitstreams/" + bitstream.getID() + "/content")
-                .header("USER-AGENT", userAgent)
-                .header("X-CORRELATION-ID", correlationId)
-                .header("X-REFERRER", referrer))
+            .perform(get("/api/core/bitstreams/" + bit.getID() + "/content")
+                         .header("USER-AGENT", userAgent)
+                         .header("X-CORRELATION-ID", correlationId)
+                         .header("X-REFERRER", referrer))
             .andExpect(status().isOk());
+    }
+
+    private void downloadBitstreamContent(String userAgent, String correlationId, String referrer) throws Exception {
+        downloadContent(userAgent, correlationId, referrer, bitstream);
     }
 
 }

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1537,10 +1537,14 @@ log.report.dir = ${dspace.dir}/log
 # For more details see https://developers.google.com/analytics/devguides/collection/protocol/ga4
 # google.analytics.api-secret =
 
-# Ensures only views of bitstreams in the 'ORIGINAL' bundle result in a GA4 event.
-# Setting this to false may cause inflated bitstream view numbers, since requesting
-# bitstreams in the 'THUMBNAIL' and 'LICENSE' bundles, will also result in GA4 events.
-google-analytics.exclude-non-content-bitstreams=true
+# Ensures only views of bitstreams in configured bundles result in a GA4 event.
+# Config can contain multiple bundles for which the bitstream views will result in GA4 events, eg:
+# google-analytics.bundles = ORIGINAL, CONTENT
+# If config is not set or empty, the default fallback is Constants#CONTENT_BUNDLE_NAME bundle ('ORIGINAL').
+# If config contains 'LICENSE' or 'THUMBNAIL' bundles, it may cause inflated bitstream view numbers.
+# Set config to 'none' to disable GA4 bitstream events, eg:
+# google-analytics.bundles = none
+google-analytics.bundles = ORIGINAL
 
 ####################################################################
 #---------------------------------------------------------------#

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1535,7 +1535,12 @@ log.report.dir = ${dspace.dir}/log
 # Defines a Measurement Protocol API Secret to be used to track interactions which occur outside of the user's browser. 
 # For example , this is required to track downloads of bitstreams. This setting is only used by Google Analytics 4.
 # For more details see https://developers.google.com/analytics/devguides/collection/protocol/ga4
-# google.analytics.api-secret = 
+# google.analytics.api-secret =
+
+# Ensures only views of bitstreams in the 'ORIGINAL' bundle result in a GA4 event.
+# Setting this to false may cause inflated bitstream view numbers, since requesting
+# bitstreams in the 'THUMBNAIL' and 'LICENSE' bundles, will also result in GA4 events.
+google-analytics.exclude-non-content-bitstreams=true
 
 ####################################################################
 #---------------------------------------------------------------#


### PR DESCRIPTION
## References
* Fixes #8938
* PR for dspace-7_x: https://github.com/DSpace/DSpace/pull/8949

## Description
This PR adds a config option to filter out views of non-content bitstreams (e.g. thumbnails). If the config is enabled (default), an event will only be sent to GA4 if:
- it is a view event (was already the case).
- the object of the event is a bitstream (was already the case). 
- the bitstream belongs to the 'ORIGINAL' bundle (new).

## Instructions for Reviewers

#### Changes

- `isNotBitstreamViewEvent` method in `GoogleAsyncEventListener` is now `isContentBitstream` and verifies the 3 rules described above.
- Added new `google-analytics.bundles` option in dspace.cfg to control whether to exlude/include non-content bitstreams.
- Added 2 new ITs `GoogleAsyncEventListenerIT` to test this.

#### Instructions

1. Open up your realtime view in Google Analytics
2. Visit the homepage of your repository
3. No events should be registered
4. Go to an item page with bitstreams in the 'ORIGINAL', 'LICENSE' and 'THUMBNAIL' bundles
5. Download the 3 bitstreams and verify only 1 event shows up (the one for the 'ORIGINAL' bitstream)

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).