### PR TITLE
Add a configuration key to disable hierarchical browse indexes

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/authority/ChoiceAuthorityServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/ChoiceAuthorityServiceImpl.java
@@ -17,6 +17,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.util.DCInput;
@@ -557,6 +558,15 @@ public final class ChoiceAuthorityServiceImpl implements ChoiceAuthorityService 
             init();
             ChoiceAuthority source = this.getChoiceAuthorityByAuthorityName(nameVocab);
             if (source != null && source instanceof DSpaceControlledVocabulary) {
+
+                // First, check if this vocabulary index is disabled
+                String[] vocabulariesDisabled = configurationService
+                    .getArrayProperty("webui.browse.vocabularies.disabled");
+                if (vocabulariesDisabled != null && ArrayUtils.contains(vocabulariesDisabled, nameVocab)) {
+                    // Discard this vocabulary browse index
+                    return null;
+                }
+
                 Set<String> metadataFields = new HashSet<>();
                 Map<String, List<String>> formsToFields = this.authoritiesFormDefinitions.get(nameVocab);
                 for (Map.Entry<String, List<String>> formToField : formsToFields.entrySet()) {

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1160,7 +1160,8 @@ webui.browse.index.4 = subject:metadata:dc.subject.*:text
 
 # By default, browse hierarchical indexes are created based on the used controlled
 # vocabularies in the submission forms. These could be disabled adding the name of
-# the vocabularies to exclude in this comma-separated property:
+# the vocabularies to exclude in this comma-separated property.
+# (Requires reboot of servlet container, e.g. Tomcat, to reload)
 # webui.browse.vocabularies.disabled = srsc
 
 # Enable/Disable tag cloud in browsing.

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1158,6 +1158,11 @@ webui.browse.index.4 = subject:metadata:dc.subject.*:text
 ## example of authority-controlled browse category - see authority control config
 #webui.browse.index.5 = lcAuthor:metadataAuthority:dc.contributor.author:authority
 
+# By default, browse hierarchical indexes are created based on the used controlled
+# vocabularies in the submission forms. These could be disabled adding the name of
+# the vocabularies to exclude in this comma-separated property:
+# webui.browse.vocabularies.disabled = srsc
+
 # Enable/Disable tag cloud in browsing.
 # webui.browse.index.tagcloud.<n> = true | false
 # where n is the index number from the above options


### PR DESCRIPTION
## References
* Fixes #8947 

## Description

This PR adds a new configuration key to be able to disable the creation of hierarchical browse indexes by vocabulary name.

If instead of excluding vocabularies to be created it is better to configure which ones to create specifically, let me know, I can change the logic of the configuration key.

## Instructions for Reviewers

Uncomment the configuration key and check that the srsc browse index is not generated.

If this is accepted, the documentation should be modified to add this new configuration key: https://wiki.lyrasis.org/display/DSDOC7x/Configuration+Reference#ConfigurationReference-HierarchicalBrowseIndexes

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
