### PR TITLE
code cleanup: remove obsolete code fragments in ItemIndexFactoryImpl

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/indexobject/ItemIndexFactoryImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/indexobject/ItemIndexFactoryImpl.java
@@ -172,13 +172,6 @@ public class ItemIndexFactoryImpl extends DSpaceObjectIndexFactoryImpl<Indexable
             addNamedResourceTypeIndex(doc, acvalue);
         }
 
-        // write the index and close the inputstreamreaders
-        try {
-            log.info("Wrote Item: " + item.getID() + " to Index");
-        } catch (RuntimeException e) {
-            log.error("Error while writing item to discovery index: " + item.getID() + " message:"
-                    + e.getMessage(), e);
-        }
         return doc;
     }
 


### PR DESCRIPTION
## Description

This PR suggests the removal of code fragments that IMHO are not / no longer appropriate.

The `index-discovery` job currently writes two log messages when indexing a new DS item:

```
2023-07-11 14:55:23,489 INFO  unknown unknown org.dspace.discovery.indexobject.ItemIndexFactoryImpl @ Wrote Item: a2720594-cba0-4868-9a95-0cb449b24133 to Index
2023-07-11 14:55:23,497 INFO  unknown unknown org.dspace.discovery.SolrServiceImpl @ anonymous::indexed_object:Item-a2720594-cba0-4868-9a95-0cb449b24133
```

The first log message is redundant. Furthermore, as the part of the code that generates this line is not responsible for writing the actual Solr document to the index, the successful addition of the document to the Solr index is not guaranteed (at this point of execution).
