### PR TITLE
Prevent NPE during indexing if bitstream is null

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/FullTextContentStreams.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/FullTextContentStreams.java
@@ -76,7 +76,6 @@ public class FullTextContentStreams extends ContentStreamBase {
             if (StringUtils.equals(FULLTEXT_BUNDLE, myBundle.getName())) {
                 // a-ha! grab the text out of the bitstreams
                 List<Bitstream> bitstreams = myBundle.getBitstreams();
-
                 log.debug("Processing full-text bitstreams. Item handle: " + sourceInfo);
 
                 for (Bitstream fulltextBitstream : emptyIfNull(bitstreams)) {
@@ -164,16 +163,16 @@ public class FullTextContentStreams extends ContentStreamBase {
         }
 
         public String getContentType(final Context context) throws SQLException {
-            BitstreamFormat format = bitstream.getFormat(context);
+            BitstreamFormat format = bitstream != null ? bitstream.getFormat(context) : null;
             return format == null ? null : StringUtils.trimToEmpty(format.getMIMEType());
         }
 
         public String getFileName() {
-            return StringUtils.trimToEmpty(bitstream.getName());
+            return bitstream != null ? StringUtils.trimToEmpty(bitstream.getName()) : null;
         }
 
         public long getSize() {
-            return bitstream.getSizeBytes();
+            return bitstream != null ? bitstream.getSizeBytes() : -1;
         }
 
         public InputStream getInputStream() throws SQLException, IOException, AuthorizeException {

--- a/dspace-api/src/main/java/org/dspace/discovery/FullTextContentStreams.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/FullTextContentStreams.java
@@ -77,13 +77,19 @@ public class FullTextContentStreams extends ContentStreamBase {
                 // a-ha! grab the text out of the bitstreams
                 List<Bitstream> bitstreams = myBundle.getBitstreams();
 
+                log.debug("Processing full-text bitstreams. Item handle: " + sourceInfo);
+
                 for (Bitstream fulltextBitstream : emptyIfNull(bitstreams)) {
                     fullTextStreams.add(new FullTextBitstream(sourceInfo, fulltextBitstream));
 
-                    log.debug("Added BitStream: "
-                                  + fulltextBitstream.getStoreNumber() + " "
-                                  + fulltextBitstream.getSequenceID() + " "
-                                  + fulltextBitstream.getName());
+                    if (fulltextBitstream != null) {
+                        log.debug("Added BitStream: "
+                                + fulltextBitstream.getStoreNumber() + " "
+                                + fulltextBitstream.getSequenceID() + " "
+                                + fulltextBitstream.getName());
+                    } else {
+                        log.error("Found a NULL bitstream when processing full-text files: item handle:" + sourceInfo);
+                    }
                 }
             }
         }

--- a/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
@@ -103,6 +103,11 @@ public class ItemUtils {
             bundle.getElement().add(bitstreams);
             List<Bitstream> bits = b.getBitstreams();
             for (Bitstream bit : bits) {
+                // Check if bitstream is null and log the error
+                if (bit == null) {
+                    log.error("Null bitstream found, check item uuid: " + item.getID());
+                    break;
+                }
                 Element bitstream = create("bitstream");
                 bitstreams.getElement().add(bitstream);
                 String url = "";


### PR DESCRIPTION
Fix NPE if bitstream is null

## References
* Fixes #8954

## Description
Add better logging and avoids NPE if bitstream is null

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
