### PR TITLE
improve migration of community subscriptions: set dspace_object_id to community UUID

### DIFF
--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V7.7_2023.07.19__subscription_add_dspace_object_ids_of_communities.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V7.7_2023.07.19__subscription_add_dspace_object_ids_of_communities.sql
@@ -1,0 +1,13 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+-----------------------------------------------------------------------------------
+-- add community UUIDs to dspace_object_ids (in community subscriptions)
+-----------------------------------------------------------------------------------
+
+UPDATE subscription SET dspace_object_id = (SELECT uuid FROM community WHERE community_id = subscription.community_id) WHERE community_id IS NOT NULL;

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.7_2023.07.19__subscription_add_dspace_object_ids_of_communities.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.7_2023.07.19__subscription_add_dspace_object_ids_of_communities.sql
@@ -1,0 +1,13 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+-----------------------------------------------------------------------------------
+-- add community UUIDs to dspace_object_ids (in community subscriptions)
+-----------------------------------------------------------------------------------
+
+UPDATE subscription SET dspace_object_id = (SELECT uuid FROM community WHERE community_id = subscription.community_id) WHERE community_id IS NOT NULL;


### PR DESCRIPTION
## Description

This PR handles community subscriptions: it adds the community UUID to column `dspace_object_id`. This corresponds to the management of new community subscriptions (added in DS 7.0+).

It is unclear if the column `community_id` in the `subscription` table is still further required.
