### PR TITLE
'null' value is passed to sendErrorResponse instead of actual exception

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
@@ -132,7 +132,7 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
                                                       Exception ex) throws IOException {
         //422 is not defined in HttpServletResponse.  Its meaning is "Unprocessable Entity".
         //Using the value from HttpStatus.
-        sendErrorResponse(request, response, null,
+        sendErrorResponse(request, response, ex,
                 "Unprocessable or invalid entity",
                 HttpStatus.UNPROCESSABLE_ENTITY.value());
     }
@@ -140,7 +140,7 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
     @ExceptionHandler( {InvalidSearchRequestException.class})
     protected void handleInvalidSearchRequestException(HttpServletRequest request, HttpServletResponse response,
                                                       Exception ex) throws IOException {
-        sendErrorResponse(request, response, null,
+        sendErrorResponse(request, response, ex,
                 "Invalid search request",
                 HttpStatus.UNPROCESSABLE_ENTITY.value());
     }
@@ -180,7 +180,7 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
                                                             TranslatableException ex) throws IOException {
         Context context = ContextUtil.obtainContext(request);
         sendErrorResponse(
-            request, response, null, ex.getLocalizedMessage(context), HttpStatus.UNPROCESSABLE_ENTITY.value()
+            request, response, (Exception) ex, ex.getLocalizedMessage(context), HttpStatus.UNPROCESSABLE_ENTITY.value()
         );
     }
 
@@ -188,7 +188,7 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
     protected void ParameterConversionException(HttpServletRequest request, HttpServletResponse response, Exception ex)
         throws IOException {
         // we want the 400 status for missing parameters, see https://jira.lyrasis.org/browse/DS-4428
-        sendErrorResponse(request, response, null,
+        sendErrorResponse(request, response, ex,
                           "A required parameter is invalid",
                           HttpStatus.BAD_REQUEST.value());
     }
@@ -197,7 +197,7 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
     protected void MissingParameterException(HttpServletRequest request, HttpServletResponse response, Exception ex)
         throws IOException {
         // we want the 400 status for missing parameters, see https://jira.lyrasis.org/browse/DS-4428
-        sendErrorResponse(request, response, null,
+        sendErrorResponse(request, response, ex,
                           "A required parameter is missing",
                           HttpStatus.BAD_REQUEST.value());
     }


### PR DESCRIPTION
## References

## Description
While running some tests on rest requests returning a 422 http error, we noticed that actual exception causing the 422 is not logged. 

In `DSpaceApiExceptionControllerAdvice.java` class there were some calls to `sendErrorResponse` method not actually passing the exception, but an hard coded "null" value.

## Instructions for Reviewers

List of changes in this PR:
* Updated `sendErrorResponse` calls having "ex" parameter set to "null" with actual exception instance, available in calling method.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
