### PR TITLE
Replace all old Docker "dspace-7_x" tags with "latest" on main

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,15 @@
 # This image will be published as dspace/dspace
 # See https://github.com/DSpace/DSpace/tree/main/dspace/src/main/docker for usage details
 #
-# - note: default tag for branch: dspace/dspace: dspace/dspace:dspace-7_x
+# - note: default tag for branch: dspace/dspace: dspace/dspace:latest
 
 # This Dockerfile uses JDK11 by default, but has also been tested with JDK17.
 # To build with JDK17, use "--build-arg JDK_VERSION=17"
 ARG JDK_VERSION=11
+ARG DSPACE_VERSION=latest
 
 # Step 1 - Run Maven Build
-FROM dspace/dspace-dependencies:dspace-7_x as build
+FROM dspace/dspace-dependencies:${DSPACE_VERSION} as build
 ARG TARGET_DIR=dspace-installer
 WORKDIR /app
 # The dspace-installer directory will be written to /install

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -1,14 +1,15 @@
 # This image will be published as dspace/dspace-cli
 # See https://github.com/DSpace/DSpace/tree/main/dspace/src/main/docker for usage details
 #
-# - note: default tag for branch: dspace/dspace-cli: dspace/dspace-cli:dspace-7_x
+# - note: default tag for branch: dspace/dspace-cli: dspace/dspace-cli:latest
 
 # This Dockerfile uses JDK11 by default, but has also been tested with JDK17.
 # To build with JDK17, use "--build-arg JDK_VERSION=17"
 ARG JDK_VERSION=11
+ARG DSPACE_VERSION=latest
 
 # Step 1 - Run Maven Build
-FROM dspace/dspace-dependencies:dspace-7_x as build
+FROM dspace/dspace-dependencies:${DSPACE_VERSION} as build
 ARG TARGET_DIR=dspace-installer
 WORKDIR /app
 # The dspace-installer directory will be written to /install

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,16 +1,17 @@
 # This image will be published as dspace/dspace
 # See https://github.com/DSpace/DSpace/tree/main/dspace/src/main/docker for usage details
 #
-# - note: default tag for branch: dspace/dspace: dspace/dspace:dspace-7_x-test
+# - note: default tag for branch: dspace/dspace: dspace/dspace:latest-test
 #
 # This image is meant for TESTING/DEVELOPMENT ONLY as it deploys the old v6 REST API under HTTP (not HTTPS)
 
 # This Dockerfile uses JDK11 by default, but has also been tested with JDK17.
 # To build with JDK17, use "--build-arg JDK_VERSION=17"
 ARG JDK_VERSION=11
+ARG DSPACE_VERSION=latest
 
 # Step 1 - Run Maven Build
-FROM dspace/dspace-dependencies:dspace-7_x as build
+FROM dspace/dspace-dependencies:${DSPACE_VERSION} as build
 ARG TARGET_DIR=dspace-installer
 WORKDIR /app
 # The dspace-installer directory will be written to /install

--- a/docker-compose-cli.yml
+++ b/docker-compose-cli.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   dspace-cli:
-    image: "${DOCKER_OWNER:-dspace}/dspace-cli:${DSPACE_VER:-dspace-7_x}"
+    image: "${DOCKER_OWNER:-dspace}/dspace-cli:${DSPACE_VER:-latest}"
     container_name: dspace-cli
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       # proxies.trusted.ipranges: This setting is required for a REST API running in Docker to trust requests
       # from the host machine. This IP range MUST correspond to the 'dspacenet' subnet defined above.
       proxies__P__trusted__P__ipranges: '172.23.0'
-    image: "${DOCKER_OWNER:-dspace}/dspace:${DSPACE_VER:-dspace-7_x-test}"
+    image: "${DOCKER_OWNER:-dspace}/dspace:${DSPACE_VER:-latest-test}"
     build:
       context: .
       dockerfile: Dockerfile.test
@@ -66,7 +66,7 @@ services:
   dspacedb:
     container_name: dspacedb
     # Uses a custom Postgres image with pgcrypto installed
-    image: "${DOCKER_OWNER:-dspace}/dspace-postgres-pgcrypto:${DSPACE_VER:-dspace-7_x}"
+    image: "${DOCKER_OWNER:-dspace}/dspace-postgres-pgcrypto:${DSPACE_VER:-latest}"
     build:
       # Must build out of subdirectory to have access to install script for pgcrypto
       context: ./dspace/src/main/docker/dspace-postgres-pgcrypto/
@@ -86,7 +86,7 @@ services:
   # DSpace Solr container
   dspacesolr:
     container_name: dspacesolr
-    image: "${DOCKER_OWNER:-dspace}/dspace-solr:${DSPACE_VER:-dspace-7_x}"
+    image: "${DOCKER_OWNER:-dspace}/dspace-solr:${DSPACE_VER:-latest}"
     build:
       context: .
       dockerfile: ./dspace/src/main/docker/dspace-solr/Dockerfile

--- a/dspace/src/main/docker-compose/README.md
+++ b/dspace/src/main/docker-compose/README.md
@@ -268,8 +268,8 @@ Here's how to fix those issues by migrating your old Postgres data to the new ve
         * Pull down an older version of the image from Dockerhub (using a tag)
         * Or, temporarily rebuild your local image with the old version of Postgres. For example:
           ```
-          # This command will rebuild using PostgreSQL v11 & tag it locally as "dspace-7_x"
-          docker build --build-arg POSTGRES_VERSION=11 -t dspace/dspace-postgres-pgcrypto:dspace-7_x ./dspace/src/main/docker/dspace-postgres-pgcrypto/
+          # This command will rebuild using PostgreSQL v11 & tag it locally as "latest"
+          docker build --build-arg POSTGRES_VERSION=11 -t dspace/dspace-postgres-pgcrypto:latest ./dspace/src/main/docker/dspace-postgres-pgcrypto/
           # Then restart container with that image
           docker-compose -p d7 up -d
           ```

--- a/dspace/src/main/docker-compose/db.entities.yml
+++ b/dspace/src/main/docker-compose/db.entities.yml
@@ -10,7 +10,7 @@ version: "3.7"
 
 services:
   dspacedb:
-    image: dspace/dspace-postgres-pgcrypto:dspace-7_x-loadsql
+    image: dspace/dspace-postgres-pgcrypto:${DSPACE_VER:-latest}-loadsql
     environment:
       # This SQL is available from https://github.com/DSpace-Labs/AIP-Files/releases/tag/demo-entities-data
       - LOADSQL=https://github.com/DSpace-Labs/AIP-Files/releases/download/demo-entities-data/dspace7-entities-data.sql

--- a/dspace/src/main/docker-compose/db.restore.yml
+++ b/dspace/src/main/docker-compose/db.restore.yml
@@ -14,7 +14,7 @@ version: "3.7"
 # This can be used to restore a "dspacedb" container from a pg_dump, or during upgrade to a new version of PostgreSQL.
 services:
   dspacedb:
-    image: dspace/dspace-postgres-pgcrypto:dspace-7_x-loadsql
+    image: dspace/dspace-postgres-pgcrypto:${DSPACE_VER:-latest}-loadsql
     environment:
       # Location where the dump SQL file will be available on the running container
       - LOCALSQL=/tmp/pgdump.sql

--- a/dspace/src/main/docker-compose/docker-compose-angular.yml
+++ b/dspace/src/main/docker-compose/docker-compose-angular.yml
@@ -23,7 +23,7 @@ services:
       DSPACE_REST_HOST: localhost
       DSPACE_REST_PORT: 8080
       DSPACE_REST_NAMESPACE: /server
-    image: dspace/dspace-angular:dspace-7_x
+    image: dspace/dspace-angular:${DSPACE_VER:-latest}
     networks:
       dspacenet:
     ports:

--- a/dspace/src/main/docker/README.md
+++ b/dspace/src/main/docker/README.md
@@ -16,7 +16,7 @@ Caching these Maven dependencies provides a speed increase to all later builds b
 are only downloaded once.
 
 ```
-docker build -t dspace/dspace-dependencies:dspace-7_x -f Dockerfile.dependencies .
+docker build -t dspace/dspace-dependencies:latest -f Dockerfile.dependencies .
 ```
 
 This image is built *automatically* after each commit is made to the `main` branch.
@@ -25,7 +25,7 @@ A corresponding image exists for DSpace 4-6.
 
 Admins to our DockerHub repo can manually publish with the following command.
 ```
-docker push dspace/dspace-dependencies:dspace-7_x
+docker push dspace/dspace-dependencies:latest
 ```
 
 ## Dockerfile.test (in root folder)
@@ -37,7 +37,7 @@ This image deploys two DSpace webapps to Tomcat running in Docker:
 This image also sets up debugging in Tomcat for development.
 
 ```
-docker build -t dspace/dspace:dspace-7_x-test -f Dockerfile.test .
+docker build -t dspace/dspace:latest-test -f Dockerfile.test .
 ```
 
 This image is built *automatically* after each commit is made to the `main` branch.
@@ -46,7 +46,7 @@ A corresponding image exists for DSpace 4-6.
 
 Admins to our DockerHub repo can manually publish with the following command.
 ```
-docker push dspace/dspace:dspace-7_x-test
+docker push dspace/dspace:latest-test
 ```
 
 ## Dockerfile (in root folder)
@@ -56,7 +56,7 @@ This image deploys one DSpace webapp to Tomcat running in Docker:
 1. The DSpace 7 REST API (at `http://localhost:8080/server`)
 
 ```
-docker build -t dspace/dspace:dspace-7_x -f Dockerfile .
+docker build -t dspace/dspace:latest -f Dockerfile .
 ```
 
 This image is built *automatically* after each commit is made to the `main` branch.
@@ -65,14 +65,14 @@ A corresponding image exists for DSpace 4-6.
 
 Admins to our DockerHub repo can publish with the following command.
 ```
-docker push dspace/dspace:dspace-7_x
+docker push dspace/dspace:latest
 ```
 
 ## Dockerfile.cli (in root folder)
 
 This Dockerfile builds a DSpace 7 CLI (command line interface) image, which can be used to run DSpace's commandline tools via Docker.
 ```
-docker build -t dspace/dspace-cli:dspace-7_x -f Dockerfile.cli .
+docker build -t dspace/dspace-cli:latest -f Dockerfile.cli .
 ```
 
 This image is built *automatically* after each commit is made to the `main` branch.
@@ -81,7 +81,7 @@ A corresponding image exists for DSpace 6.
 
 Admins to our DockerHub repo can publish with the following command.
 ```
-docker push dspace/dspace-cli:dspace-7_x
+docker push dspace/dspace-cli:latest
 ```
 
 ## ./dspace-postgres-pgcrypto/Dockerfile
@@ -92,20 +92,20 @@ This image is built *automatically* after each commit is made to the `main` bran
 How to build manually:
 ```
 cd dspace/src/main/docker/dspace-postgres-pgcrypto
-docker build -t dspace/dspace-postgres-pgcrypto:dspace-7_x .
+docker build -t dspace/dspace-postgres-pgcrypto:latest .
 ```
 
 It is also possible to change the version of PostgreSQL or the PostgreSQL user's password during the build:
 ```
 cd dspace/src/main/docker/dspace-postgres-pgcrypto
-docker build -t dspace/dspace-postgres-pgcrypto:dspace-7_x --build-arg POSTGRES_VERSION=11 --build-arg POSTGRES_PASSWORD=mypass .
+docker build -t dspace/dspace-postgres-pgcrypto:latest --build-arg POSTGRES_VERSION=11 --build-arg POSTGRES_PASSWORD=mypass .
 ```
 
 A copy of this file exists in the DSpace 6 branch.  A specialized version of this file exists for DSpace 4 in DSpace-Docker-Images.
 
 Admins to our DockerHub repo can (manually) publish with the following command.
 ```
-docker push dspace/dspace-postgres-pgcrypto:dspace-7_x
+docker push dspace/dspace-postgres-pgcrypto:latest
 ```
 
 ## ./dspace-postgres-pgcrypto-curl/Dockerfile
@@ -118,7 +118,7 @@ This image is built *automatically* after each commit is made to the `main` bran
 How to build manually:
 ```
 cd dspace/src/main/docker/dspace-postgres-pgcrypto-curl
-docker build -t dspace/dspace-postgres-pgcrypto:dspace-7_x-loadsql .
+docker build -t dspace/dspace-postgres-pgcrypto:latest-loadsql .
 ```
 
 Similar to `dspace-postgres-pgcrypto` above, you can also modify the version of PostgreSQL or the PostgreSQL user's password.
@@ -128,7 +128,7 @@ A copy of this file exists in the DSpace 6 branch.
 
 Admins to our DockerHub repo can (manually) publish with the following command.
 ```
-docker push dspace/dspace-postgres-pgcrypto:dspace-7_x-loadsql
+docker push dspace/dspace-postgres-pgcrypto:latest-loadsql
 ```
 
 ## ./dspace-shibboleth/Dockerfile


### PR DESCRIPTION
## References
* Follow-up to #8942

## Description
Currently, our Docker scripts on `main` are still referencing the `dspace-7_x` tagged Docker images.  However in #8942, we updated `main` branch to generate Docker images with the `latest` tag.  (The `dspace-7_x` tag in DockerHub is to be used for the `dspace-7_x` branch in GitHub.)

In other words:
* `main` branch in GitHub should always use `latest` tag in DockerHub
* `dspace-7_x` branch in GitHub should always use `dspace-7_x` tag in DockerHub

This PR ensures that our Docker scripts on `main` are always referencing the tag `latest` from DockerHub.  (This ensures that `main` isn't accidentally using Docker images from our `dspace-7_x` brach)

(Corresponding PR was submitted to frontend as well: https://github.com/DSpace/dspace-angular/pull/2394)

## Instructions for Reviewers
* Assuming Docker images build properly, then this is ready to merge.  I've tested it locally to ensure local builds from `main` now use `latest` images from DockerHub.