### PR TITLE
Improve performance of discovery consumer when there are many items to index

### DIFF
--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -810,6 +810,15 @@ public class Context implements AutoCloseable {
             readOnlyCache.clear();
         }
 
+        // When going to READ_ONLY, flush database changes to ensure that the current data is retrieved
+        if (newMode == Mode.READ_ONLY && mode != Mode.READ_ONLY) {
+            try {
+                dbConnection.flushSession();
+            } catch (SQLException ex) {
+                log.warn("Unable to flush database changes after switching to READ_ONLY mode", ex);
+            }
+        }
+
         //save the new mode
         mode = newMode;
     }
@@ -878,16 +887,6 @@ public class Context implements AutoCloseable {
     @SuppressWarnings("unchecked")
     public <E extends ReloadableEntity> void uncacheEntity(E entity) throws SQLException {
         dbConnection.uncacheEntity(entity);
-    }
-
-    /**
-     * Flush the current Session to synchronizes the in-memory state of the Session
-     * with the database (write changes to the database)
-     *
-     * @throws SQLException passed through.
-     */
-    public void flushDBChanges() throws SQLException {
-        dbConnection.flushSession();
     }
 
     public Boolean getCachedAuthorizationResult(DSpaceObject dspaceObject, int action, EPerson eperson) {

--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -880,6 +880,16 @@ public class Context implements AutoCloseable {
         dbConnection.uncacheEntity(entity);
     }
 
+    /**
+     * Flush the current Session to synchronizes the in-memory state of the Session
+     * with the database (write changes to the database)
+     *
+     * @throws SQLException passed through.
+     */
+    public void flushDBChanges() throws SQLException {
+        dbConnection.flushSession();
+    }
+
     public Boolean getCachedAuthorizationResult(DSpaceObject dspaceObject, int action, EPerson eperson) {
         if (isReadOnly()) {
             return readOnlyCache.getCachedAuthorizationResult(dspaceObject, action, eperson);

--- a/dspace-api/src/main/java/org/dspace/core/DBConnection.java
+++ b/dspace-api/src/main/java/org/dspace/core/DBConnection.java
@@ -148,4 +148,12 @@ public interface DBConnection<T> {
      * @throws java.sql.SQLException passed through.
      */
     public <E extends ReloadableEntity> void uncacheEntity(E entity) throws SQLException;
+
+    /**
+     * Do a manual flush. This synchronizes the in-memory state of the Session
+     * with the database (write changes to the database)
+     *
+     * @throws SQLException passed through.
+     */
+    public void flushSession() throws SQLException;
 }

--- a/dspace-api/src/main/java/org/dspace/core/HibernateDBConnection.java
+++ b/dspace-api/src/main/java/org/dspace/core/HibernateDBConnection.java
@@ -337,4 +337,17 @@ public class HibernateDBConnection implements DBConnection<Session> {
             }
         }
     }
+
+    /**
+     * Do a manual flush. This synchronizes the in-memory state of the Session
+     * with the database (write changes to the database)
+     *
+     * @throws SQLException passed through.
+     */
+    @Override
+    public void flushSession() throws SQLException {
+        if (getSession().isDirty()) {
+            getSession().flush();
+        }
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexEventConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexEventConsumer.java
@@ -201,7 +201,11 @@ public class IndexEventConsumer implements Consumer {
     @Override
     public void end(Context ctx) throws Exception {
 
-        // Change the mode to readonly to improve the performance
+        // Change the mode to readonly to improve performance
+        // First, we flush the changes to database, if session is dirty, has pending changes
+        // to synchronize with database, without this flush it could index an old version of
+        // the object
+        ctx.flushDBChanges();
         Context.Mode originalMode = ctx.getCurrentMode();
         ctx.setMode(Context.Mode.READ_ONLY);
 
@@ -234,9 +238,9 @@ public class IndexEventConsumer implements Consumer {
                 uniqueIdsToDelete.clear();
                 createdItemsToUpdate.clear();
             }
-        }
 
-        ctx.setMode(originalMode);
+            ctx.setMode(originalMode);
+        }
     }
 
     private void indexObject(Context ctx, IndexableObject iu, boolean preDb) throws SQLException {

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexEventConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexEventConsumer.java
@@ -201,6 +201,10 @@ public class IndexEventConsumer implements Consumer {
     @Override
     public void end(Context ctx) throws Exception {
 
+        // Change the mode to readonly to improve the performance
+        Context.Mode originalMode = ctx.getCurrentMode();
+        ctx.setMode(Context.Mode.READ_ONLY);
+
         try {
             for (String uid : uniqueIdsToDelete) {
                 try {
@@ -231,6 +235,8 @@ public class IndexEventConsumer implements Consumer {
                 createdItemsToUpdate.clear();
             }
         }
+
+        ctx.setMode(originalMode);
     }
 
     private void indexObject(Context ctx, IndexableObject iu, boolean preDb) throws SQLException {

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexEventConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexEventConsumer.java
@@ -202,10 +202,6 @@ public class IndexEventConsumer implements Consumer {
     public void end(Context ctx) throws Exception {
 
         // Change the mode to readonly to improve performance
-        // First, we flush the changes to database, if session is dirty, has pending changes
-        // to synchronize with database, without this flush it could index an old version of
-        // the object
-        ctx.flushDBChanges();
         Context.Mode originalMode = ctx.getCurrentMode();
         ctx.setMode(Context.Mode.READ_ONLY);
 

--- a/dspace-api/src/test/java/org/dspace/core/ContextIT.java
+++ b/dspace-api/src/test/java/org/dspace/core/ContextIT.java
@@ -18,7 +18,7 @@ import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.builder.CommunityBuilder;
 import org.junit.Test;
 
-public class ContextModeIT extends AbstractIntegrationTestWithDatabase {
+public class ContextIT extends AbstractIntegrationTestWithDatabase {
 
     AuthorizeService authorizeService = AuthorizeServiceFactory.getInstance().getAuthorizeService();
 
@@ -26,6 +26,11 @@ public class ContextModeIT extends AbstractIntegrationTestWithDatabase {
     public void testGetPoliciesNewCommunityAfterReadOnlyModeChange() throws Exception {
 
         context.turnOffAuthorisationSystem();
+
+        // First disable the index consumer. The indexing process calls the authorizeService
+        // function used in this test and may affect the test
+        context.setDispatcher("noindex");
+
         parentCommunity = CommunityBuilder.createCommunity(context)
             .withName("Parent Community")
             .build();

--- a/dspace-api/src/test/java/org/dspace/core/ContextModeIT.java
+++ b/dspace-api/src/test/java/org/dspace/core/ContextModeIT.java
@@ -1,0 +1,42 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.core;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.dspace.AbstractIntegrationTestWithDatabase;
+import org.dspace.authorize.ResourcePolicy;
+import org.dspace.authorize.factory.AuthorizeServiceFactory;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.builder.CommunityBuilder;
+import org.junit.Test;
+
+public class ContextModeIT extends AbstractIntegrationTestWithDatabase {
+
+    AuthorizeService authorizeService = AuthorizeServiceFactory.getInstance().getAuthorizeService();
+
+    @Test
+    public void testGetPoliciesNewCommunityAfterReadOnlyModeChange() throws Exception {
+
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .build();
+        context.restoreAuthSystemState();
+
+        context.setMode(Context.Mode.READ_ONLY);
+
+        List<ResourcePolicy> policies = authorizeService.getPoliciesActionFilter(context, parentCommunity,
+            Constants.READ);
+
+        assertEquals("Should return the default anonymous group read policy", 1, policies.size());
+    }
+
+}


### PR DESCRIPTION
## Description

When there are many items to reindex using a context with the READ_ONLY mode can greatly improve indexing performance. This PR add a change to use a READ_ONLY mode during the reindexing made by discovery consumer after a commit.

## Instructions for Reviewers

List of changes in this PR:

* Change the Context mode to READ_ONLY before the indexing done by discovery consumer.
* Add a new function to do a manual flush of database session before changing the Context mode. This is necessary to ensure that we index the current object.

This could be tested by running a batch process that modifies 1000 or more items in a database transaction (filter-media, a curation task, ...)

Run the process and check the performance.

I have used this curation task made for testing (it adds and removes dc.language.iso metadada). If I run it without the change against 5000 items it takes more than 30 minutes, using the change it takes 2 minutes:

https://github.com/toniprieto/DSpace/commit/f7d790d2074b281c74fa82ff997e47e39e5d21fd

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
