### PR TITLE
subscription email: do not send email if nothing has changed

### DIFF
--- a/dspace-api/src/main/java/org/dspace/subscriptions/ContentGenerator.java
+++ b/dspace-api/src/main/java/org/dspace/subscriptions/ContentGenerator.java
@@ -78,9 +78,9 @@ public class ContentGenerator implements SubscriptionGenerator<IndexableObject> 
         if (indexableObjects == null) {
             return EMPTY;
         }
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        out.write("\n".getBytes(UTF_8));
         try {
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            out.write("\n".getBytes(UTF_8));
             for (IndexableObject indexableObject : indexableObjects) {
                 out.write("\n".getBytes(UTF_8));
                 Item item = (Item) indexableObject.getIndexedObject();
@@ -88,11 +88,12 @@ public class ContentGenerator implements SubscriptionGenerator<IndexableObject> 
                 Optional.ofNullable(entityType2Disseminator.get(entityType))
                         .orElseGet(() -> entityType2Disseminator.get("Item"))
                         .disseminate(context, item, out);
-            }            
+            }
+            return out.toString();
         } catch (Exception e) {
             log.error(e.getMessage(), e);
         }
-        return out.toString();
+        return EMPTY;
     }
 
     public void setEntityType2Disseminator(Map<String, StreamDisseminationCrosswalk> entityType2Disseminator) {

--- a/dspace-api/src/main/java/org/dspace/subscriptions/ContentGenerator.java
+++ b/dspace-api/src/main/java/org/dspace/subscriptions/ContentGenerator.java
@@ -57,14 +57,14 @@ public class ContentGenerator implements SubscriptionGenerator<IndexableObject> 
                 Email email = Email.getEmail(I18nUtil.getEmailFilename(supportedLocale, "subscriptions_content"));
                 email.addRecipient(ePerson.getEmail());
 
-                String bodyCommunitites = generateBodyMail(context, indexableComm);
+                String bodyCommunities = generateBodyMail(context, indexableComm);
                 String bodyCollections = generateBodyMail(context, indexableColl);
-                if (bodyCommunitites.equals(EMPTY) && bodyCollections.equals(EMPTY)) {
+                if (bodyCommunities.equals(EMPTY) && bodyCollections.equals(EMPTY)) {
                     log.debug("subscription(s) of eperson {} do(es) not match any new items: nothing to send" +
                             " - exit silently", ePerson::getID);
                     return;
                 }
-                email.addArgument(bodyCommunitites);
+                email.addArgument(bodyCommunities);
                 email.addArgument(bodyCollections);
                 email.send();
             }

--- a/dspace-api/src/main/java/org/dspace/subscriptions/ContentGenerator.java
+++ b/dspace-api/src/main/java/org/dspace/subscriptions/ContentGenerator.java
@@ -78,7 +78,7 @@ public class ContentGenerator implements SubscriptionGenerator<IndexableObject> 
         try {
             ByteArrayOutputStream out = new ByteArrayOutputStream();
             out.write("\n".getBytes(UTF_8));
-            if (indexableObjects != null && !indexableObjects.isEmpty()) {
+            if (indexableObjects != null) {
                 for (IndexableObject indexableObject : indexableObjects) {
                     out.write("\n".getBytes(UTF_8));
                     Item item = (Item) indexableObject.getIndexedObject();

--- a/dspace-api/src/main/java/org/dspace/subscriptions/ContentGenerator.java
+++ b/dspace-api/src/main/java/org/dspace/subscriptions/ContentGenerator.java
@@ -75,24 +75,24 @@ public class ContentGenerator implements SubscriptionGenerator<IndexableObject> 
     }
 
     private String generateBodyMail(Context context, List<IndexableObject> indexableObjects) {
+        if (indexableObjects == null) {
+            return EMPTY;
+        }
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.write("\n".getBytes(UTF_8));
         try {
-            ByteArrayOutputStream out = new ByteArrayOutputStream();
-            out.write("\n".getBytes(UTF_8));
-            if (indexableObjects != null) {
-                for (IndexableObject indexableObject : indexableObjects) {
-                    out.write("\n".getBytes(UTF_8));
-                    Item item = (Item) indexableObject.getIndexedObject();
-                    String entityType = itemService.getEntityTypeLabel(item);
-                    Optional.ofNullable(entityType2Disseminator.get(entityType))
-                            .orElseGet(() -> entityType2Disseminator.get("Item"))
-                            .disseminate(context, item, out);
-                }
-                return out.toString();
-            }
+            for (IndexableObject indexableObject : indexableObjects) {
+                out.write("\n".getBytes(UTF_8));
+                Item item = (Item) indexableObject.getIndexedObject();
+                String entityType = itemService.getEntityTypeLabel(item);
+                Optional.ofNullable(entityType2Disseminator.get(entityType))
+                        .orElseGet(() -> entityType2Disseminator.get("Item"))
+                        .disseminate(context, item, out);
+            }            
         } catch (Exception e) {
             log.error(e.getMessage(), e);
         }
-        return EMPTY;
+        return out.toString();
     }
 
     public void setEntityType2Disseminator(Map<String, StreamDisseminationCrosswalk> entityType2Disseminator) {

--- a/dspace-api/src/main/java/org/dspace/subscriptions/ContentGenerator.java
+++ b/dspace-api/src/main/java/org/dspace/subscriptions/ContentGenerator.java
@@ -60,12 +60,12 @@ public class ContentGenerator implements SubscriptionGenerator<IndexableObject> 
                 String bodyCommunitites = generateBodyMail(context, indexableComm);
                 String bodyCollections = generateBodyMail(context, indexableColl);
                 if (bodyCommunitites.equals(EMPTY) && bodyCollections.equals(EMPTY)) {
-                    log.debug("subscription(s) of eperson {} do(es) not match any new items: nothing to send - exit silently", ePerson::getID);
+                    log.debug("subscription(s) of eperson {} do(es) not match any new items: nothing to send" +
+                            " - exit silently", ePerson::getID);
                     return;
                 }
                 email.addArgument(bodyCommunitites);
                 email.addArgument(bodyCollections);
-                
                 email.send();
             }
         } catch (Exception e) {

--- a/dspace-api/src/main/java/org/dspace/subscriptions/ContentGenerator.java
+++ b/dspace-api/src/main/java/org/dspace/subscriptions/ContentGenerator.java
@@ -75,7 +75,7 @@ public class ContentGenerator implements SubscriptionGenerator<IndexableObject> 
     }
 
     private String generateBodyMail(Context context, List<IndexableObject> indexableObjects) {
-        if (indexableObjects == null) {
+        if (indexableObjects == null || indexableObjects.isEmpty()) {
             return EMPTY;
         }
         try {

--- a/dspace/config/emails/subscriptions_content
+++ b/dspace/config/emails/subscriptions_content
@@ -2,15 +2,17 @@
 ##
 ## Parameters: {0} Collections updates
 ##             {1} Communities updates
-#set($subject = "${config.get('dspace.name')} Subscription")
-
+#set($subject = "${config.get('dspace.name')} Subscriptions")
 This email is sent from ${config.get('dspace.name')} based on the chosen subscription preferences.
 
-Communities
------------
+#if ("$params[0]" != "")
+Community Subscriptions:
+------------------------
 List of changed items : ${params[0]}
 
-Collections
------------
+#end
+#if ("$params[1]" != "")
+Collection Subscriptions:
+-------------------------
 List of changed items : ${params[1]}
-
+#end

--- a/dspace/config/emails/subscriptions_content
+++ b/dspace/config/emails/subscriptions_content
@@ -5,13 +5,13 @@
 #set($subject = "${config.get('dspace.name')} Subscriptions")
 This email is sent from ${config.get('dspace.name')} based on the chosen subscription preferences.
 
-#if ("$params[0]" != "")
+#if( not( "$params[0]" == "" ))
 Community Subscriptions:
 ------------------------
 List of changed items : ${params[0]}
 
 #end
-#if ("$params[1]" != "")
+#if( not( "$params[1]" == "" ))
 Collection Subscriptions:
 -------------------------
 List of changed items : ${params[1]}


### PR DESCRIPTION
## Description

This PR makes the email subscription mechanism more robust. It adds a check whether the subscription email contains at least one item. In case it does not find any new items the subscription email is not sent to the subscriber.

Furthermore, this PR improves the Velocity template by adding checks for empty strings to improve readability of the generated subscription email.