### PR TITLE
fix: add default HandleIdentifierProvider for disabled versioning

### DIFF
--- a/dspace/config/spring/api/identifier-service.xml
+++ b/dspace/config/spring/api/identifier-service.xml
@@ -4,13 +4,20 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans
            http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
 
-    <!-- Identifier Service Application Interface.  Will be autowired with
+    <!-- Identifier Service Application Interface. Will be autowired with
          any Identifier Providers present in Spring context.
     -->
     <bean id="org.dspace.identifier.service.IdentifierService"
           class="org.dspace.identifier.IdentifierServiceImpl"
           autowire="byType"
           scope="singleton"/>
+
+    <!-- If you disable versioning, you need to use the default HandleIdentifierProvider. -->
+    <!--
+    <bean id="org.dspace.identifier.HandleIdentifierProvider" class="org.dspace.identifier.HandleIdentifierProvider" scope="singleton">
+        <property name="configurationService" ref="org.dspace.services.ConfigurationService"/>
+    </bean>
+    -->
 
       <!-- If you enabled versioning, you should use one of the versioned
            handle identifier provider instead of the default one.
@@ -26,7 +33,7 @@
            a new version is created the previous version gets a new
            handle. This leads to a handle that points always to the
            newest version, but there is no permanent handle, that
-           will always keep pointing to the acutal newest one.
+           will always keep pointing to the actual newest one.
            -->
     <!--
     <bean id="org.dspace.identifier.HandleIdentifierProvider" class="org.dspace.identifier.VersionedHandleIdentifierProviderWithCanonicalHandles" scope="singleton">


### PR DESCRIPTION
## References
* Fixes #8985 

## Description
Setting versioning.enabled = false in versioning.cfg is not enough to disable versioning. It is also required to replace the bean class VersionedHandleIdentifierProvider with a HandleIdentifierProvider in identifier-service.xml. I've added one that is commented out as by default versioning is enabled.

## Instructions for Reviewers
A default HandleIdentifierProvider bean is added (but commented out) to identifier-service.xml.

List of changes in this PR:
* Default HandleIdentifierProvider bean for disabled versioning
* Typos fixed

**Include guidance for how to test or review your PR.**
This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 
To reproduce:
* set `versioning.enabled = false`
  * Build will fail because version is disabled but VersionedHandleIdentifierProvider enabled
* comment out VersionedHandleIdentifierProvider bean
  * Build will fail because no HandleIdentifierProvider is available
  * 
To test
* disable versioning and replace the VersionedHandleIdentifierProvider with the HandleIdentifierProvider bean.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
