### PR TITLE
On media filter failure log the name of the assetstore file and trace causes of exception

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
@@ -40,6 +40,7 @@ import org.dspace.eperson.Group;
 import org.dspace.eperson.service.GroupService;
 import org.dspace.scripts.handler.DSpaceRunnableHandler;
 import org.dspace.services.ConfigurationService;
+import org.dspace.util.ThrowableUtils;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -240,8 +241,9 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
                     sb.append("\tFile Size: ").append(size);
                     sb.append("\tChecksum: ").append(checksum);
                     sb.append("\tAsset Store: ").append(assetstore);
+                    sb.append("\tInternal ID: ").append(myBitstream.getInternalId());
                     logError(sb.toString());
-                    logError(e.getMessage(), e);
+                    logError(ThrowableUtils.formatCauseChain(e));
                 }
             } else if (filterClass instanceof SelfRegisterInputFormats) {
                 // Filter implements self registration, so check to see if it should be applied
@@ -319,10 +321,10 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
 
         // check if destination bitstream exists
         Bundle existingBundle = null;
-        List<Bitstream> existingBitstreams = new ArrayList<Bitstream>();
+        List<Bitstream> existingBitstreams = new ArrayList<>();
         List<Bundle> bundles = itemService.getBundles(item, formatFilter.getBundleName());
 
-        if (bundles.size() > 0) {
+        if (!bundles.isEmpty()) {
             // only finds the last matching bundle and all matching bitstreams in the proper bundle(s)
             for (Bundle bundle : bundles) {
                 List<Bitstream> bitstreams = bundle.getBitstreams();
@@ -337,7 +339,7 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
         }
 
         // if exists and overwrite = false, exit
-        if (!overWrite && (existingBitstreams.size() > 0)) {
+        if (!overWrite && (!existingBitstreams.isEmpty())) {
             if (!isQuiet) {
                 logInfo("SKIPPED: bitstream " + source.getID()
                                        + " (item: " + item.getHandle() + ") because '" + newName + "' already exists");
@@ -370,7 +372,7 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
             }
 
             Bundle targetBundle; // bundle we're modifying
-            if (bundles.size() < 1) {
+            if (bundles.isEmpty()) {
                 // create new bundle if needed
                 targetBundle = bundleService.create(context, item, formatFilter.getBundleName());
             } else {

--- a/dspace-api/src/main/java/org/dspace/util/ThrowableUtils.java
+++ b/dspace-api/src/main/java/org/dspace/util/ThrowableUtils.java
@@ -33,7 +33,9 @@ public class ThrowableUtils {
         trace.append(throwable.getMessage());
         Throwable cause = throwable.getCause();
         while (null != cause) {
-            trace.append("\nCaused by:  ").append(cause.getMessage());
+            trace.append("\nCaused by:  ")
+                    .append(cause.getClass().getCanonicalName()).append(' ')
+                    .append(cause.getMessage());
             cause = cause.getCause();
         }
         return trace.toString();

--- a/dspace-api/src/main/java/org/dspace/util/ThrowableUtils.java
+++ b/dspace-api/src/main/java/org/dspace/util/ThrowableUtils.java
@@ -1,0 +1,41 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.util;
+
+/**
+ * Things you wish {@link Throwable} or some logging package would do for you.
+ *
+ * @author mwood
+ */
+public class ThrowableUtils {
+    /**
+     * Utility class:  do not instantiate.
+     */
+    private ThrowableUtils() { }
+
+    /**
+     * Trace a chain of {@code Throwable}s showing only causes.
+     * Less voluminous than a stack trace.  Useful if you just want to know
+     * what caused third-party code to return an uninformative exception
+     * message.
+     *
+     * @param throwable the exception or whatever.
+     * @return list of messages from each {@code Throwable} in the chain,
+     *          separated by '\n'.
+     */
+    static public String formatCauseChain(Throwable throwable) {
+        StringBuilder trace = new StringBuilder();
+        trace.append(throwable.getMessage());
+        Throwable cause = throwable.getCause();
+        while (null != cause) {
+            trace.append("\nCaused by:  ").append(cause.getMessage());
+            cause = cause.getCause();
+        }
+        return trace.toString();
+    }
+}


### PR DESCRIPTION
## Description
If a file could not be filtered, report the name of the file as found in the assetstore, to make it easier to diagnose the problem.  Also, if the failure was caused by an exception thrown out of a filter, report the chain of exception messages.

This patch includes a utility class to format a list of the causes of a chain of `Throwable`s.  It may be generally useful when working with third-party code, because a full stack trace of dependency code is often much more than we want.

## Instructions for Reviewers
List of changes in this PR:
* Add the Internal ID of a Bitstream to the error report, so that the backing file can be readily found and examined.
* Report the entire chain of Throwable messages, because Tika doesn't tell us much that is useful when an extractor throws.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
