### PR TITLE
Bug fixes for actions:  Run PR porting action as 'dspace-bot'.  Ignore errors from label_merge_conflicts

### DIFF
--- a/.github/workflows/label_merge_conflicts.yml
+++ b/.github/workflows/label_merge_conflicts.yml
@@ -25,6 +25,8 @@ jobs:
       # See: https://github.com/prince-chrismc/label-merge-conflicts-action
       - name: Auto-label PRs with merge conflicts
         uses: prince-chrismc/label-merge-conflicts-action@v3
+        # Ignore any failures -- may occur (randomly?) for older, outdated PRs.
+        continue-on-error: true
         # Add "merge conflict" label if a merge conflict is detected. Remove it when resolved.
         # Note, the authentication token is created automatically
         # See: https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token

--- a/.github/workflows/port_merged_pull_request.yml
+++ b/.github/workflows/port_merged_pull_request.yml
@@ -36,3 +36,9 @@ jobs:
           pull_title: '[Port ${target_branch}] ${pull_title}'
           # Description to add to the (newly created) port PR
           pull_description: 'Port of #${pull_number} by @${pull_author} to `${target_branch}`.'
+          # Copy all labels from original PR to (newly created) port PR
+          # NOTE: The labels matching 'label_pattern' are automatically excluded
+          copy_labels_pattern: '*'
+          # Use a personal access token (PAT) to create PR as 'dspace-bot' user.
+          # A PAT is required in order for the new PR to trigger its own actions (for CI checks)
+          github_token: ${{ secrets.PR_PORT_TOKEN }}


### PR DESCRIPTION
## References
* Follow-up to #8988 

## Description
This small PR provides minor bug fixes to two of our GitHub Actions

1. Follow-up to #8988 to update the configuration of our new `port_merged_pull_request` action
    * Run this action as the @dspace-bot account (via a personal access token).  This ensures that newly created (port) PRs will be created as this user account, and also ensures those new PRs can trigger our CI checks.  See comments in #8992 for details on why this is needed
    * Update configuration to ensure labels are copied from original PR to the port PR (excluding any `port to *` label).
2. Minor bug fix to the existing `label_merge_conflicts` action to ignore any errors thrown
    * I've noticed recently that this action sometimes fails on very old, outdated PRs (which already have the `merge_conflict` label).  These seem like harmless failures, but can be misleading.  So, I've ignored errors for now.

