### PR TITLE
Fix typo. Config must be a valid regex

### DIFF
--- a/.github/workflows/port_merged_pull_request.yml
+++ b/.github/workflows/port_merged_pull_request.yml
@@ -38,7 +38,7 @@ jobs:
           pull_description: 'Port of #${pull_number} by @${pull_author} to `${target_branch}`.'
           # Copy all labels from original PR to (newly created) port PR
           # NOTE: The labels matching 'label_pattern' are automatically excluded
-          copy_labels_pattern: '*'
+          copy_labels_pattern: '.*'
           # Use a personal access token (PAT) to create PR as 'dspace-bot' user.
           # A PAT is required in order for the new PR to trigger its own actions (for CI checks)
           github_token: ${{ secrets.PR_PORT_TOKEN }}


### PR DESCRIPTION
## Description
Fixes a very small typo in #8994 

The `copy_labels_pattern` config in our `port_merged_pull_request` action MUST be a valid regular expression. 

This PR also serves as another test that our PR porting action is working properly.
