### PR TITLE
Make workflow curation tasks actually work.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/curate/XmlWorkflowCuratorServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/curate/XmlWorkflowCuratorServiceImpl.java
@@ -102,10 +102,15 @@ public class XmlWorkflowCuratorServiceImpl
         Curator curator = new Curator();
         curator.setReporter(reporter);
         c.turnOffAuthorisationSystem();
+        boolean wasAnonymous = false;
         if (null == c.getCurrentUser()) { // We need someone to email
-            c.setCurrentUser(ePersonService.findAnAdministrator(c));
+            wasAnonymous = true;
+            c.setCurrentUser(ePersonService.getSystemEPerson(c));
         }
         boolean failedP = curate(curator, c, wfi);
+        if (wasAnonymous) {
+            c.setCurrentUser(null);
+        }
         c.restoreAuthSystemState();
         return failedP;
     }

--- a/dspace-api/src/main/java/org/dspace/curate/XmlWorkflowCuratorServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/curate/XmlWorkflowCuratorServiceImpl.java
@@ -31,6 +31,7 @@ import org.dspace.workflow.CurationTaskConfig;
 import org.dspace.workflow.FlowStep;
 import org.dspace.workflow.Task;
 import org.dspace.workflow.TaskSet;
+import org.dspace.xmlworkflow.Role;
 import org.dspace.xmlworkflow.RoleMembers;
 import org.dspace.xmlworkflow.WorkflowConfigurationException;
 import org.dspace.xmlworkflow.factory.XmlWorkflowFactory;
@@ -276,12 +277,17 @@ public class XmlWorkflowCuratorServiceImpl
                             String.valueOf(wfi.getID()), e);
                     return epList;
                 }
-                RoleMembers roleMembers = step.getRole().getMembers(c, wfi);
-                for (EPerson ep : roleMembers.getEPersons()) {
-                    epList.add(ep);
-                }
-                for (Group group : roleMembers.getGroups()) {
-                    epList.addAll(group.getMembers());
+                Role role = step.getRole();
+                if (null != role) {
+                    RoleMembers roleMembers = role.getMembers(c, wfi);
+                    for (EPerson ep : roleMembers.getEPersons()) {
+                        epList.add(ep);
+                    }
+                    for (Group group : roleMembers.getGroups()) {
+                        epList.addAll(group.getMembers());
+                    }
+                } else {
+                    epList.add(ePersonService.getSystemEPerson(c));
                 }
             } else if ("$colladmin".equals(contact)) {
                 // special literal for collection administrators

--- a/dspace-api/src/main/java/org/dspace/curate/XmlWorkflowCuratorServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/curate/XmlWorkflowCuratorServiceImpl.java
@@ -13,6 +13,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Collection;
@@ -47,14 +48,17 @@ import org.springframework.stereotype.Service;
  * Manage interactions between curation and workflow.  A curation task can be
  * attached to a workflow step, to be executed during the step.
  *
+ * <p>
+ * <strong>NOTE:</strong> when run in workflow, curation tasks <em>run with
+ * authorization disabled</em>.
+ *
  * @see CurationTaskConfig
  * @author mwood
  */
 @Service
 public class XmlWorkflowCuratorServiceImpl
         implements XmlWorkflowCuratorService {
-    private static final Logger LOG
-            = org.apache.logging.log4j.LogManager.getLogger();
+    private static final Logger LOG = LogManager.getLogger();
 
     @Autowired(required = true)
     protected XmlWorkflowFactory workflowFactory;
@@ -97,7 +101,13 @@ public class XmlWorkflowCuratorServiceImpl
             throws AuthorizeException, IOException, SQLException {
         Curator curator = new Curator();
         curator.setReporter(reporter);
-        return curate(curator, c, wfi);
+        c.turnOffAuthorisationSystem();
+        if (null == c.getCurrentUser()) { // We need someone to email
+            c.setCurrentUser(ePersonService.findAnAdministrator(c));
+        }
+        boolean failedP = curate(curator, c, wfi);
+        c.restoreAuthSystemState();
+        return failedP;
     }
 
     @Override
@@ -123,7 +133,7 @@ public class XmlWorkflowCuratorServiceImpl
             item.setOwningCollection(wfi.getCollection());
             for (Task task : step.tasks) {
                 curator.addTask(task.name);
-                curator.curate(item);
+                curator.curate(c, item);
                 int status = curator.getStatus(task.name);
                 String result = curator.getResult(task.name);
                 String action = "none";
@@ -223,8 +233,12 @@ public class XmlWorkflowCuratorServiceImpl
             String status, String action, String message)
             throws AuthorizeException, IOException, SQLException {
         List<EPerson> epa = resolveContacts(c, task.getContacts(status), wfi);
-        if (epa.size() > 0) {
+        if (!epa.isEmpty()) {
             workflowService.notifyOfCuration(c, wfi, epa, task.name, action, message);
+        } else {
+            LOG.warn("No contacts were found for workflow item {}:  "
+                    + "task {} returned action {} with message {}",
+                    wfi.getID(), task.name, action, message);
         }
     }
 
@@ -247,8 +261,7 @@ public class XmlWorkflowCuratorServiceImpl
             // decode contacts
             if ("$flowgroup".equals(contact)) {
                 // special literal for current flowgoup
-                ClaimedTask claimedTask = claimedTaskService.findByWorkflowIdAndEPerson(c, wfi, c.getCurrentUser());
-                String stepID = claimedTask.getStepID();
+                String stepID = getFlowStep(c, wfi).step;
                 Step step;
                 try {
                     Workflow workflow = workflowFactory.getWorkflow(wfi.getCollection());
@@ -266,11 +279,13 @@ public class XmlWorkflowCuratorServiceImpl
                     epList.addAll(group.getMembers());
                 }
             } else if ("$colladmin".equals(contact)) {
+                // special literal for collection administrators
                 Group adGroup = wfi.getCollection().getAdministrators();
                 if (adGroup != null) {
                     epList.addAll(groupService.allMembers(c, adGroup));
                 }
             } else if ("$siteadmin".equals(contact)) {
+                // special literal for site administrator
                 EPerson siteEp = ePersonService.findByEmail(c,
                         configurationService.getProperty("mail.admin"));
                 if (siteEp != null) {

--- a/dspace-api/src/main/java/org/dspace/curate/service/XmlWorkflowCuratorService.java
+++ b/dspace-api/src/main/java/org/dspace/curate/service/XmlWorkflowCuratorService.java
@@ -42,9 +42,9 @@ public interface XmlWorkflowCuratorService {
      *
      * @param c the context
      * @param wfi the workflow item
-     * @return true if curation was completed or not required,
+     * @return true if curation was completed or not required;
      *         false if tasks were queued for later completion,
-     *         or item was rejected
+     *         or item was rejected.
      * @throws AuthorizeException if authorization error
      * @throws IOException if IO error
      * @throws SQLException if database error
@@ -58,7 +58,9 @@ public interface XmlWorkflowCuratorService {
      * @param curator the curation context
      * @param c the user context
      * @param wfId the workflow item's ID
-     * @return true if curation failed.
+     * @return true if curation curation was completed or not required;
+     *         false if tasks were queued for later completion,
+     *         or item was rejected.
      * @throws AuthorizeException if authorization error
      * @throws IOException if IO error
      * @throws SQLException if database error
@@ -72,7 +74,9 @@ public interface XmlWorkflowCuratorService {
      * @param curator the curation context
      * @param c the user context
      * @param wfi the workflow item
-     * @return true if curation failed.
+     * @return true if workflow curation was completed or not required;
+     *         false if tasks were queued for later completion,
+     *         or item was rejected.
      * @throws AuthorizeException if authorization error
      * @throws IOException if IO error
      * @throws SQLException if database error

--- a/dspace-api/src/main/java/org/dspace/eperson/EPersonServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/EPersonServiceImpl.java
@@ -47,6 +47,7 @@ import org.dspace.eperson.service.GroupService;
 import org.dspace.eperson.service.SubscribeService;
 import org.dspace.event.Event;
 import org.dspace.orcid.service.OrcidTokenService;
+import org.dspace.services.ConfigurationService;
 import org.dspace.util.UUIDUtils;
 import org.dspace.versioning.Version;
 import org.dspace.versioning.VersionHistory;
@@ -101,6 +102,8 @@ public class EPersonServiceImpl extends DSpaceObjectServiceImpl<EPerson> impleme
     protected VersionDAO versionDAO;
     @Autowired(required = true)
     protected ClaimedTaskService claimedTaskService;
+    @Autowired(required = true)
+    protected ConfigurationService configurationService;
     @Autowired
     protected OrcidTokenService orcidTokenService;
 
@@ -111,6 +114,21 @@ public class EPersonServiceImpl extends DSpaceObjectServiceImpl<EPerson> impleme
     @Override
     public EPerson find(Context context, UUID id) throws SQLException {
         return ePersonDAO.findByID(context, EPerson.class, id);
+    }
+
+    @Override
+    public EPerson findAnAdministrator(Context c)
+            throws SQLException {
+        List<EPerson> contacts = groupService.findByName(c, Group.ADMIN).getMembers();
+        EPerson currentUser;
+        if (contacts.isEmpty()) {
+            log.warn("Administrators group is empty");
+            currentUser = findByEmail(c, configurationService.getProperty("mail.admin"));
+            // Null if no such EPerson
+        } else {
+            currentUser = contacts.get(0);
+        }
+        return currentUser;
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/eperson/EPersonServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/EPersonServiceImpl.java
@@ -116,19 +116,28 @@ public class EPersonServiceImpl extends DSpaceObjectServiceImpl<EPerson> impleme
         return ePersonDAO.findByID(context, EPerson.class, id);
     }
 
+    /**
+     * Create a fake EPerson which can receive email.  Its address will be the
+     * value of "mail.admin", or "postmaster" if all else fails.
+     * @param c
+     * @return
+     * @throws SQLException
+     */
     @Override
-    public EPerson findAnAdministrator(Context c)
+    public EPerson getSystemEPerson(Context c)
             throws SQLException {
-        List<EPerson> contacts = groupService.findByName(c, Group.ADMIN).getMembers();
-        EPerson currentUser;
-        if (contacts.isEmpty()) {
-            log.warn("Administrators group is empty");
-            currentUser = findByEmail(c, configurationService.getProperty("mail.admin"));
-            // Null if no such EPerson
-        } else {
-            currentUser = contacts.get(0);
+        String adminEmail = configurationService.getProperty("mail.admin");
+        if (null == adminEmail) {
+            adminEmail = "postmaster"; // Last-ditch attempt to send *somewhere*
         }
-        return currentUser;
+        EPerson systemEPerson = findByEmail(c, adminEmail);
+
+        if (null == systemEPerson) {
+            systemEPerson = new EPerson();
+            systemEPerson.setEmail(adminEmail);
+        }
+
+        return systemEPerson;
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/eperson/service/EPersonService.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/service/EPersonService.java
@@ -13,6 +13,7 @@ import java.sql.SQLException;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
+import javax.validation.constraints.NotNull;
 
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Item;
@@ -158,15 +159,16 @@ public interface EPersonService extends DSpaceObjectService<EPerson>, DSpaceObje
         throws SQLException;
 
     /**
-     * Try very hard to find an administrator's account.  Might return a member
-     * of the Administrators group, or an account with a configured email
-     * address.
+     * The "System EPerson" is a fake account that exists only to receive email.
+     * It has an email address that should be presumed usable.  It does not
+     * exist in the database and is not complete.
      *
      * @param context current DSpace session.
-     * @return a presumed administrator account, or null if none could be found.
+     * @return an EPerson that can presumably receive email.
      * @throws SQLException
      */
-    public EPerson findAnAdministrator(Context context)
+    @NotNull
+    public EPerson getSystemEPerson(Context context)
             throws SQLException;
 
     /**

--- a/dspace-api/src/main/java/org/dspace/eperson/service/EPersonService.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/service/EPersonService.java
@@ -158,6 +158,18 @@ public interface EPersonService extends DSpaceObjectService<EPerson>, DSpaceObje
         throws SQLException;
 
     /**
+     * Try very hard to find an administrator's account.  Might return a member
+     * of the Administrators group, or an account with a configured email
+     * address.
+     *
+     * @param context current DSpace session.
+     * @return a presumed administrator account, or null if none could be found.
+     * @throws SQLException
+     */
+    public EPerson findAnAdministrator(Context context)
+            throws SQLException;
+
+    /**
      * Create a new eperson
      *
      * @param context The relevant DSpace Context.


### PR DESCRIPTION
When curation runs in workflow, there was no "current user" and no claimed task, so the code broke when trying to find people to notify about curation failures.

## Description
Set the current user, and find the "flow group" in a different way.

## Instructions for Reviewers
List of changes in this PR:
* Set the current user in the Context used for curation.
* For good measure, disable authorization during curation.  This curation is being run by "the system".
* Reuse existing code to find the current flow step, since it works in this context.

For testing, I enabled the `vscan` task and attached it to a workflow step, then submitted an item containing the EICAR test virus.  DSpace should log a warning about the virus, tell the submitter that "something went wrong" in the UI, and send an email notice that a virus was found in a submission.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
