### PR TITLE
Enable entity type to submission form mapping by default

### DIFF
--- a/dspace/config/item-submission.xml
+++ b/dspace/config/item-submission.xml
@@ -55,9 +55,7 @@
             - - - - - -
             PLEASE NOTICE THAT YOU WILL HAVE TO RESTART DSPACE
             - - - - - -
-            Uncomment if you intend to use them
-        -->  
-        <!-- 
+        -->
         <name-map collection-entity-type="Publication" submission-name="Publication"/>
         <name-map collection-entity-type="Person" submission-name="Person"/>
         <name-map collection-entity-type="Project" submission-name="Project"/>
@@ -65,8 +63,6 @@
         <name-map collection-entity-type="Journal" submission-name="Journal"/>
         <name-map collection-entity-type="JournalVolume" submission-name="JournalVolume"/>
         <name-map collection-entity-type="JournalIssue" submission-name="JournalIssue"/>
-         -->
-
     </submission-map>
 
 


### PR DESCRIPTION
## References
* Related to #8855

## Description
In DSpace 7.6, we added a commented out configuration to `item-submission.xml` which enables mapping a Collection to a submission form definition _based on the Collection's entity type field._

This PR simply uncomments that configuration by default so that it exists by default in all sites.  I've already verified uncommenting this configuration has no impact on sites which have entities *disabled* (they simply ignore this configuration).  But, it's a huge benefit to sites that have Entities *enabled* as it can ensure their Collections can be easily mapped to a submission form.

It's also a big benefit to the upcoming Demo site, as it will need this configuration for the same reason as other sites where Entities are enabled.