### PR TITLE
Fix #8963: Remove deletion constraint from Groomer

### DIFF
--- a/dspace-api/src/main/java/org/dspace/eperson/Groomer.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/Groomer.java
@@ -141,20 +141,10 @@ public class Groomer {
             System.out.println();
 
             if (delete) {
-                List<String> whyNot = ePersonService.getDeleteConstraints(myContext, account);
-                if (!whyNot.isEmpty()) {
-                    System.out.print("\tCannot be deleted; referenced in");
-                    for (String table : whyNot) {
-                        System.out.print(' ');
-                        System.out.print(table);
-                    }
-                    System.out.println();
-                } else {
-                    try {
-                        ePersonService.delete(myContext, account);
-                    } catch (AuthorizeException | IOException ex) {
-                        System.err.println(ex.getMessage());
-                    }
+                try {
+                    ePersonService.delete(myContext, account);
+                } catch (AuthorizeException | IOException ex) {
+                    System.err.println(ex.getMessage());
                 }
             }
         }


### PR DESCRIPTION
## References
* Fixes #8963
* Related to DSpace #2229 

## Description
As we can now delete EPersons in DSpace 7, even if they are referenced elsewhere, the Groomer tool does not have to sort out those, and can instead use the standard delete procedure for all EPersons matching it's date constraints.

## Instructions for Reviewers
List of changes in this PR:
* Remove the call of `ePersonService.getDeleteConstraints` because in DSpace 7, all EPersons can be deleted, and the constraints get handled correctly in `ePersonService.delete`.

To test the feature, try to delete an EPerson that has one of the constraints tested for in `EPersonService`>`getDeleteConstraints`. Before, the tool would refuse to delete those. Now, they get handled in the same way, as if you would try to delete them e.g. via the AngularUI, that means, they get deleted and all references will be removed.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
