### PR TITLE
Avoid requiring git as a build dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN ant init_installation update_configs update_code update_webapps
 FROM tomcat:9-jdk${JDK_VERSION}
 # NOTE: DSPACE_INSTALL must align with the "dspace.dir" default configuration.
 ENV DSPACE_INSTALL=/dspace
-# Copy the /dspace directory from 'ant_build' containger to /dspace in this container
+# Copy the /dspace directory from 'ant_build' container to /dspace in this container
 COPY --from=ant_build /dspace $DSPACE_INSTALL
 # Expose Tomcat port and AJP port
 EXPOSE 8080 8009

--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -102,7 +102,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.4.0</version>
                 <executions>
                     <execution>
                         <phase>validate</phase>
@@ -116,7 +116,10 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>buildnumber-maven-plugin</artifactId>
-                <version>1.4</version>
+                <version>3.2.0</version>
+                <configuration>
+                    <revisionOnScmFailure>UNKNOWN_REVISION</revisionOnScmFailure>
+                </configuration>
                 <executions>
                     <execution>
                         <phase>validate</phase>


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #6772 

## Description
This PR just bumps up version numbers of two maven plugins:
- [buildnumber-maven-plugin](https://central.sonatype.com/artifact/org.codehaus.mojo/buildnumber-maven-plugin/3.2.0) to 3.2.0
- [build-helper-maven-plugin](https://central.sonatype.com/artifact/org.codehaus.mojo/build-helper-maven-plugin/3.4.0) to 3.4.0

And also adds a string "UNKNOWN_REVISION" to fall back as the value for SCM revision if git is not present. (see [docs](https://www.mojohaus.org/buildnumber-maven-plugin/create-metadata-mojo.html#revisionOnScmFailure))

Maven build output should include:
```
[WARNING] Cannot get the branch information from the git repository: 
Error while executing command.
[INFO] Executing: /bin/sh -c cd '/DSpace-dspace-7.6/dspace-api' && 'git' 'rev-parse' '--verify' 'HEAD'
[INFO] Working directory: /DSpace-dspace-7.6/dspace-api
[WARNING] Cannot get the branch information from the scm repository, proceeding with UNKNOWN_BRANCH : 
Exception while executing SCM command.
[INFO] Storing scmBranch: UNKNOWN_BRANCH
```


![image](https://github.com/DSpace/DSpace/assets/5488106/cddc60d2-cf2e-400d-82de-aaf09cc340c5)

## Instructions for Reviewers
I tested this by commenting out lines 19-22 in `Dockerfile.dependencies` and then running `docker compose up --build`.

It built fine and above is a screenshot of the printout from `./dspace version`

Building without git will result in the following:

![image](https://github.com/DSpace/DSpace/assets/5488106/9689a196-7584-4fb1-b679-a01e92b14638)

