### PR TITLE
Remove useless log.info

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/BundleServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BundleServiceImpl.java
@@ -194,7 +194,6 @@ public class BundleServiceImpl extends DSpaceObjectServiceImpl<Bundle> implement
                 List<Group> defaultBitstreamReadGroups =
                         authorizeService.getAuthorizedGroups(context, owningCollection,
                                 Constants.DEFAULT_BITSTREAM_READ);
-                log.info(defaultBitstreamReadGroups.size());
                 // If this collection is configured with a DEFAULT_BITSTREAM_READ group, overwrite the READ policy
                 // inherited from the bundle with this policy.
                 if (!defaultBitstreamReadGroups.isEmpty()) {


### PR DESCRIPTION
# Description

Removes a useless `log.info` statement that logs the number of `DEFAULT_BITSTREAM_READ` groups.  It appears to have been used for debugging, but is useless in production.