### PR TITLE
3331 - remove the --optimize feature of 'dspace stats-util'

### DIFF
--- a/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java
@@ -1204,22 +1204,6 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
     }
 
     @Override
-    public void optimizeSOLR() {
-        try {
-            long start = System.currentTimeMillis();
-            System.out.println("SOLR Optimize -- Process Started:" + start);
-            solr.optimize();
-            long finish = System.currentTimeMillis();
-            System.out.println("SOLR Optimize -- Process Finished:" + finish);
-            System.out.println("SOLR Optimize -- Total time taken:" + (finish - start) + " (ms).");
-        } catch (SolrServerException sse) {
-            System.err.println(sse.getMessage());
-        } catch (IOException ioe) {
-            System.err.println(ioe.getMessage());
-        }
-    }
-
-    @Override
     public void shardSolrIndex() throws IOException, SolrServerException {
         if (!(solr instanceof HttpSolrClient)) {
             return;

--- a/dspace-api/src/main/java/org/dspace/statistics/service/SolrLoggerService.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/service/SolrLoggerService.java
@@ -266,12 +266,6 @@ public interface SolrLoggerService {
      */
     public String getIgnoreSpiderIPs();
 
-    /**
-     * Maintenance to keep a SOLR index efficient.
-     * Note: This might take a long time.
-     */
-    public void optimizeSOLR();
-
     public void shardSolrIndex() throws IOException, SolrServerException;
 
     public void reindexBitstreamHits(boolean removeDeletedBitstreams) throws Exception;

--- a/dspace-api/src/main/java/org/dspace/statistics/util/StatisticsClient.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/util/StatisticsClient.java
@@ -67,7 +67,6 @@ public class StatisticsClient {
         options.addOption("m", "mark-spiders", false, "Update isBot Flag in Solr");
         options.addOption("f", "delete-spiders-by-flag", false, "Delete Spiders in Solr By isBot Flag");
         options.addOption("i", "delete-spiders-by-ip", false, "Delete Spiders in Solr By IP Address");
-        options.addOption("o", "optimize", false, "Run maintenance on the SOLR index");
         options.addOption("b", "reindex-bitstreams", false, "Reindex the bitstreams to ensure we have the bundle name");
         options.addOption("e", "export", false,
                           "Export SOLR view statistics data to usage-statistics-intermediate-format");
@@ -93,8 +92,6 @@ public class StatisticsClient {
             solrLoggerService.deleteRobotsByIsBotFlag();
         } else if (line.hasOption('i')) {
             solrLoggerService.deleteRobotsByIP();
-        } else if (line.hasOption('o')) {
-            solrLoggerService.optimizeSOLR();
         } else if (line.hasOption('b')) {
             solrLoggerService.reindexBitstreamHits(line.hasOption('r'));
         } else if (line.hasOption('e')) {


### PR DESCRIPTION
## References
* Fixes #3331

## Description
remove the --optimize feature of 'dspace stats-util'

## Instructions for Reviewers
Launching ./dspace stats-util , the optimization option is not shown.

## Checklist
- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [X] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
