### PR TITLE
[GitHub Actions] When porting a PR, skip any merge commits

### DIFF
--- a/.github/workflows/port_merged_pull_request.yml
+++ b/.github/workflows/port_merged_pull_request.yml
@@ -39,6 +39,8 @@ jobs:
           # Copy all labels from original PR to (newly created) port PR
           # NOTE: The labels matching 'label_pattern' are automatically excluded
           copy_labels_pattern: '.*'
+          # Skip any merge commits in the ported PR. This means only non-merge commits are cherry-picked to the new PR
+          merge_commits: 'skip'
           # Use a personal access token (PAT) to create PR as 'dspace-bot' user.
           # A PAT is required in order for the new PR to trigger its own actions (for CI checks)
           github_token: ${{ secrets.PR_PORT_TOKEN }}


### PR DESCRIPTION
## Description
Enables a brand new feature of the `korthout/backport-action` GitHub action we are using: https://github.com/korthout/backport-action/#merge_commits

Ensures that when a ported PR is created, merge commits are skipped (i.e. not cherry picked).  Currently, if the original PR has a merge commit, the port will fail with an error.

Will merge immediately.  This PR is just to document the minor config change