### PR TITLE
Avoid double slashes in sitemap paths.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/sitemap/GenerateSitemaps.java
+++ b/dspace-api/src/main/java/org/dspace/app/sitemap/GenerateSitemaps.java
@@ -189,7 +189,10 @@ public class GenerateSitemaps {
      */
     public static void generateSitemaps(boolean makeHTMLMap, boolean makeSitemapOrg) throws SQLException, IOException {
         String uiURLStem = configurationService.getProperty("dspace.ui.url");
-        String sitemapStem = uiURLStem + "/sitemap";
+        if (!uiURLStem.endsWith("/")) {
+            uiURLStem = uiURLStem + '/';
+        }
+        String sitemapStem = uiURLStem + "sitemap";
 
         File outputDir = new File(configurationService.getProperty("sitemap.dir"));
         if (!outputDir.exists() && !outputDir.mkdir()) {
@@ -212,7 +215,7 @@ public class GenerateSitemaps {
         List<Community> comms = communityService.findAll(c);
 
         for (Community comm : comms) {
-            String url = uiURLStem + "/communities/" + comm.getID();
+            String url = uiURLStem + "communities/" + comm.getID();
 
             if (makeHTMLMap) {
                 html.addURL(url, null);
@@ -227,7 +230,7 @@ public class GenerateSitemaps {
         List<Collection> colls = collectionService.findAll(c);
 
         for (Collection coll : colls) {
-            String url = uiURLStem + "/collections/" + coll.getID();
+            String url = uiURLStem + "collections/" + coll.getID();
 
             if (makeHTMLMap) {
                 html.addURL(url, null);
@@ -259,11 +262,11 @@ public class GenerateSitemaps {
                     && StringUtils.isNotBlank(discoverResult.getSearchDocument(
                         discoverResult.getIndexableObjects().get(0)).get(0).getSearchFieldValues("entityType").get(0))
                 ) {
-                    url = uiURLStem + "/entities/" + StringUtils.lowerCase(discoverResult.getSearchDocument(
+                    url = uiURLStem + "entities/" + StringUtils.lowerCase(discoverResult.getSearchDocument(
                             discoverResult.getIndexableObjects().get(0))
                         .get(0).getSearchFieldValues("entityType").get(0)) + "/" + i.getID();
                 } else {
-                    url = uiURLStem + "/items/" + i.getID();
+                    url = uiURLStem + "items/" + i.getID();
                 }
                 Date lastMod = i.getLastModified();
 


### PR DESCRIPTION
## Description
When composing sitemap URLs, adjust the root path to avoid double slashes in the path when `dspace.ui.url` ends in a slash.

## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* Ensure that the root path *does* a trailing slash.
* Remove leading slashes from constant path elements.

To test:  ensure that `dspace.ui.url` has a trailing slash, and run `bin/dspace generate-sitemaps`.  Without the patch, the host and first path element will be separated by double slashes; with the patch, a single slash.  Also verify that paths are correct when the UI url does *not* have a trailing slash.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).