### PR TITLE
OAI-PMH use Templates for compiled XSLT instead of Transformer (thread-safe)

### DIFF
--- a/dspace-oai/pom.xml
+++ b/dspace-oai/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <!-- This is the path to the root [dspace-src] directory. -->
         <root.basedir>${basedir}/..</root.basedir>
-        <xoai.version>3.3.0</xoai.version>
+        <xoai.version>3.3.1-SNAPSHOT</xoai.version>
         <jtwig.version>5.87.0.RELEASE</jtwig.version>
     </properties>
 

--- a/dspace-oai/pom.xml
+++ b/dspace-oai/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <!-- This is the path to the root [dspace-src] directory. -->
         <root.basedir>${basedir}/..</root.basedir>
-        <xoai.version>3.3.1-SNAPSHOT</xoai.version>
+        <xoai.version>3.4.0</xoai.version>
         <jtwig.version>5.87.0.RELEASE</jtwig.version>
     </properties>
 
@@ -55,41 +55,10 @@
             <artifactId>xoai</artifactId>
             <version>${xoai.version}</version>
             <exclusions>
+                <!-- Use version provided by SolrJ -->
                 <exclusion>
-                    <groupId>org.hamcrest</groupId>
-                    <artifactId>hamcrest-all</artifactId>
-                </exclusion>
-                <exclusion>
-                    <!--Hard pinned below.-->
-                    <groupId>org.mockito</groupId>
-                    <artifactId>mockito-all</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-lang3</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-                <!-- Later version provided by SolrJ -->
-                <exclusion>
-                    <groupId>org.codehaus.woodstox</groupId>
-                    <artifactId>wstx-asl</artifactId>
-                </exclusion>
-                <!-- Later version provided by Hibernate -->
-                <exclusion>
-                    <groupId>org.dom4j</groupId>
-                    <artifactId>dom4j</artifactId>
-                </exclusion>
-                <!-- We don't use this test framework & it causes dependency convergence issues -->
-                <exclusion>
-                    <groupId>com.lyncode</groupId>
-                    <artifactId>test-support</artifactId>
+                    <groupId>com.fasterxml.woodstox</groupId>
+                    <artifactId>woodstox-core</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/dspace-oai/src/main/java/org/dspace/xoai/services/impl/resources/DSpaceResourceResolver.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/impl/resources/DSpaceResourceResolver.java
@@ -12,7 +12,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import javax.xml.transform.Source;
-import javax.xml.transform.Transformer;
+import javax.xml.transform.Templates;
 import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamSource;
@@ -40,8 +40,7 @@ public class DSpaceResourceResolver implements ResourceResolver {
     }
 
     @Override
-    public Transformer getTransformer(String path) throws IOException,
-        TransformerConfigurationException {
+    public Templates getTemplates(String path) throws IOException, TransformerConfigurationException {
         // construct a Source that reads from an InputStream
         Source mySrc = new StreamSource(getResource(path));
         // specify a system ID (the path to the XSLT-file on the filesystem)
@@ -49,6 +48,6 @@ public class DSpaceResourceResolver implements ResourceResolver {
         // XSLT-files (like <xsl:import href="utils.xsl"/>)
         String systemId = basePath + "/" + path;
         mySrc.setSystemId(systemId);
-        return transformerFactory.newTransformer(mySrc);
+        return transformerFactory.newTemplates(mySrc);
     }
 }

--- a/dspace-oai/src/test/java/org/dspace/xoai/tests/integration/xoai/PipelineTest.java
+++ b/dspace-oai/src/test/java/org/dspace/xoai/tests/integration/xoai/PipelineTest.java
@@ -29,7 +29,7 @@ public class PipelineTest {
         InputStream input = PipelineTest.class.getClassLoader().getResourceAsStream("item.xml");
         InputStream xslt = PipelineTest.class.getClassLoader().getResourceAsStream("oai_dc.xsl");
         String output = FileUtils.readAllText(new XSLPipeline(input, true)
-                                                  .apply(factory.newTransformer(new StreamSource(xslt)))
+                                                  .apply(factory.newTemplates(new StreamSource(xslt)))
                                                   .getTransformed());
 
         assertThat(output, oai_dc().withXPath("/oai_dc:dc/dc:title", equalTo("Teste")));


### PR DESCRIPTION
Fixes #9043 
Fixes #8846

Requires: https://github.com/DSpace/xoai/pull/86

