### PR TITLE
Remove 'cross join' from count query in `update-handle-prefix` script

### DIFF
--- a/dspace-api/src/main/java/org/dspace/handle/dao/impl/HandleDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/handle/dao/impl/HandleDAOImpl.java
@@ -90,13 +90,11 @@ public class HandleDAOImpl extends AbstractHibernateDAO<Handle> implements Handl
 
     @Override
     public long countHandlesByPrefix(Context context, String prefix) throws SQLException {
-
-
         CriteriaBuilder criteriaBuilder = getCriteriaBuilder(context);
-        CriteriaQuery<Long> criteriaQuery = criteriaBuilder.createQuery(Long.class);
+        CriteriaQuery criteriaQuery = getCriteriaQuery(criteriaBuilder, Handle.class);
 
         Root<Handle> handleRoot = criteriaQuery.from(Handle.class);
-        criteriaQuery.select(criteriaBuilder.count(criteriaQuery.from(Handle.class)));
+        criteriaQuery.select(handleRoot);
         criteriaQuery.where(criteriaBuilder.like(handleRoot.get(Handle_.handle), prefix + "%"));
         return countLong(context, criteriaQuery, criteriaBuilder, handleRoot);
     }


### PR DESCRIPTION
## References
* Fixes #9066 (Or at least improves performance on smaller databases. Uncertain if this is a complete fix as it needs more testing with larger databases)

## Description
Updates the existing `countHandlesByPrefix()` method to no longer include a `cross join` with the `handle` table.  Instead, that `countHandlesByPrefix()` method is now using the same query as `findByPrefix()` (in the same class), except counting the results. See `findByPrefix()` at https://github.com/DSpace/DSpace/blob/main/dspace-api/src/main/java/org/dspace/handle/dao/impl/HandleDAOImpl.java#L81

## Instructions for Reviewers
* Attempt to reproduce issue in #9066 
* Check to see if this change to the query results in better performance.
* On a small database with only 1,000 handles, the performance improves slightly.  Prior to this PR, the count query takes about 13 seconds.  Afterwards it only takes about 10 seconds.  Unclear if this will result in a more significant improvement for larger databases (needs more testing).