### PR TITLE
Fix ClassCastException (Collection cannot be cast to Item) in some Handle classes which cause random IT failures

### DIFF
--- a/dspace-api/src/main/java/org/dspace/identifier/HandleIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/HandleIdentifierProvider.java
@@ -88,8 +88,7 @@ public class HandleIdentifierProvider extends IdentifierProvider {
         try {
             handleService.createHandle(context, dso, identifier);
             if (dso instanceof Item || dso instanceof Collection || dso instanceof Community) {
-                Item item = (Item) dso;
-                populateHandleMetadata(context, item, identifier);
+                populateHandleMetadata(context, dso, identifier);
             }
         } catch (IOException | IllegalStateException | SQLException | AuthorizeException e) {
             log.error(LogHelper.getHeader(context,

--- a/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProviderWithCanonicalHandles.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProviderWithCanonicalHandles.java
@@ -182,10 +182,10 @@ public class VersionedHandleIdentifierProviderWithCanonicalHandles extends Ident
         try {
             if (dso instanceof Item) {
                 Item item = (Item) dso;
-                // if for this identifier is already present a record in the Handle table and the corresponding item
-                // has an history someone is trying to restore the latest version for the item. When
-                // trying to restore the latest version the identifier in input doesn't have the for 1234/123.latestVersion
-                // it is the canonical 1234/123
+                // if this identifier is already present in the Handle table and the corresponding item
+                // has a history, then someone is trying to restore the latest version for the item. When
+                // trying to restore the latest version, the identifier in input doesn't have the
+                // 1234/123.latestVersion. Instead, it is the canonical 1234/123
                 VersionHistory itemHistory = getHistory(context, identifier);
                 if (!identifier.matches(".*/.*\\.\\d+") && itemHistory != null) {
 

--- a/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProviderWithCanonicalHandles.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProviderWithCanonicalHandles.java
@@ -180,45 +180,46 @@ public class VersionedHandleIdentifierProviderWithCanonicalHandles extends Ident
     @Override
     public void register(Context context, DSpaceObject dso, String identifier) {
         try {
+            if (dso instanceof Item) {
+                Item item = (Item) dso;
+                // if for this identifier is already present a record in the Handle table and the corresponding item
+                // has an history someone is trying to restore the latest version for the item. When
+                // trying to restore the latest version the identifier in input doesn't have the for 1234/123.latestVersion
+                // it is the canonical 1234/123
+                VersionHistory itemHistory = getHistory(context, identifier);
+                if (!identifier.matches(".*/.*\\.\\d+") && itemHistory != null) {
 
-            Item item = (Item) dso;
+                    int newVersionNumber = versionHistoryService.getLatestVersion(context, itemHistory)
+                                                                .getVersionNumber() + 1;
+                    String canonical = identifier;
+                    identifier = identifier.concat(".").concat("" + newVersionNumber);
+                    restoreItAsVersion(context, dso, identifier, item, canonical, itemHistory);
+                } else if (identifier.matches(".*/.*\\.\\d+")) {
+                    // if identifier == 1234.5/100.4 reinstate the version 4 in the version table if absent
 
-            // if for this identifier is already present a record in the Handle table and the corresponding item
-            // has an history someone is trying to restore the latest version for the item. When
-            // trying to restore the latest version the identifier in input doesn't have the for 1234/123.latestVersion
-            // it is the canonical 1234/123
-            VersionHistory itemHistory = getHistory(context, identifier);
-            if (!identifier.matches(".*/.*\\.\\d+") && itemHistory != null) {
-
-                int newVersionNumber = versionHistoryService.getLatestVersion(context, itemHistory)
-                                                            .getVersionNumber() + 1;
-                String canonical = identifier;
-                identifier = identifier.concat(".").concat("" + newVersionNumber);
-                restoreItAsVersion(context, dso, identifier, item, canonical, itemHistory);
-            } else if (identifier.matches(".*/.*\\.\\d+")) {
-                // if identifier == 1234.5/100.4 reinstate the version 4 in the version table if absent
-
-                // if it is a version of an item is needed to put back the record
-                // in the versionitem table
-                String canonical = getCanonical(identifier);
-                DSpaceObject canonicalItem = this.resolve(context, canonical);
-                if (canonicalItem == null) {
-                    restoreItAsCanonical(context, dso, identifier, item, canonical);
-                } else {
-                    VersionHistory history = versionHistoryService.findByItem(context, (Item) canonicalItem);
-                    if (history == null) {
+                    // if it is a version of an item is needed to put back the record
+                    // in the versionitem table
+                    String canonical = getCanonical(identifier);
+                    DSpaceObject canonicalItem = this.resolve(context, canonical);
+                    if (canonicalItem == null) {
                         restoreItAsCanonical(context, dso, identifier, item, canonical);
                     } else {
-                        restoreItAsVersion(context, dso, identifier, item, canonical, history);
+                        VersionHistory history = versionHistoryService.findByItem(context, (Item) canonicalItem);
+                        if (history == null) {
+                            restoreItAsCanonical(context, dso, identifier, item, canonical);
+                        } else {
+                            restoreItAsVersion(context, dso, identifier, item, canonical, history);
 
+                        }
                     }
-                }
-            } else {
-                //A regular handle
-                createNewIdentifier(context, dso, identifier);
-                if (dso instanceof Item) {
+                } else {
+                    // A regular handle to create for an Item
+                    createNewIdentifier(context, dso, identifier);
                     modifyHandleMetadata(context, item, getCanonical(identifier));
                 }
+            } else {
+                // Handle being registered for a different type of object (e.g. Collection or Community)
+                createNewIdentifier(context, dso, identifier);
             }
         } catch (IOException | SQLException | AuthorizeException e) {
             log.error(LogHelper.getHeader(context,


### PR DESCRIPTION
## Description

Occasionally, during Integration Tests, you'll see errors like these coming from the `XmlWorkflowServiceIT`:
```
Error:  Tests run: 7, Failures: 0, Errors: 6, Skipped: 0, Time elapsed: 1.695 s <<< FAILURE! - in org.dspace.xmlworkflow.XmlWorkflowServiceIT
Error:  workflowUserMultipleSelectedReviewer_ItemShouldBeEditable(org.dspace.xmlworkflow.XmlWorkflowServiceIT)  Time elapsed: 0.164 s  <<< ERROR!
java.lang.NullPointerException
	at org.dspace.xmlworkflow.XmlWorkflowServiceIT.workflowUserMultipleSelectedReviewer_ItemShouldBeEditable(XmlWorkflowServiceIT.java:170)
...
Error:  workflowUserSingleSelectedReviewer_ItemShouldBeEditable(org.dspace.xmlworkflow.XmlWorkflowServiceIT)  Time elapsed: 0.199 s  <<< ERROR!
java.lang.NullPointerException
	at org.dspace.xmlworkflow.XmlWorkflowServiceIT.workflowUserSingleSelectedReviewer_ItemShouldBeEditable(XmlWorkflowServiceIT.java:128)
```

When looking at the underlying error logs behind the tests, the issue is in initializing the Collections needed for these tests. When attempting to create the Collection (using `CollectionBuilder`), this error occurs in the logs:
```
2023-09-13 15:35:41,127 ERROR org.dspace.builder.AbstractDSpaceObjectBuilder @ class org.dspace.content.Collection cannot be cast to class org.dspace.content.Item (org.dspace.content.Collection and org.dspace.content.Item are in unnamed module of loader 'app')
java.lang.ClassCastException: class org.dspace.content.Collection cannot be cast to class org.dspace.content.Item (org.dspace.content.Collection and org.dspace.content.Item are in unnamed module of loader 'app')
	at org.dspace.identifier.VersionedHandleIdentifierProviderWithCanonicalHandles.register(VersionedHandleIdentifierProviderWithCanonicalHandles.java:184) ~[dspace-api-8.0-SNAPSHOT.jar:?]
	at org.dspace.identifier.IdentifierServiceImpl.register(IdentifierServiceImpl.java:213) ~[dspace-api-8.0-SNAPSHOT.jar:?]
	at org.dspace.content.CollectionServiceImpl.create(CollectionServiceImpl.java:176) ~[dspace-api-8.0-SNAPSHOT.jar:?]
	at org.dspace.content.CollectionServiceImpl.create(CollectionServiceImpl.java:137) ~[dspace-api-8.0-SNAPSHOT.jar:?]
	at org.dspace.builder.CollectionBuilder.create(CollectionBuilder.java:89) [test-classes/:?]
	at org.dspace.builder.CollectionBuilder.createCollection(CollectionBuilder.java:70) [test-classes/:?]
	at org.dspace.xmlworkflow.XmlWorkflowServiceIT.workflowUserSingleSelectedReviewer_ItemShouldBeEditable(XmlWorkflowServiceIT.java:127) [test-classes/:?]
```

The issue appears to be that we are sometimes casting a `Collection` improperly to an `Item` in our IdentifierService classes.

This PR fixes the issue by ensuring we patch the `register()` methods with this improper behavior.  Now we only cast to an `Item` if we are sure the object is an `instanceOf Item`.

## Instructions for Reviewers
Unfortunately this is difficult to test for.  It seems to strangely not always fail in the same manner in our ITs.  But, obviously tests should still pass with these changes in place

The code itself should be easy to review.  I've just ensured that any casts into `Item` are now surrounded by an `if` to ensure it is a valid cast.  The overall code logic is unchanged.