### PR TITLE
Fix "Site cannot be indexed" error which appears in ITs and sometimes in logs

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/IndexEventConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexEventConsumer.java
@@ -154,7 +154,11 @@ public class IndexEventConsumer implements Consumer {
 
             case Event.REMOVE:
             case Event.ADD:
-                if (object == null) {
+                // At this time, ADD and REMOVE actions are ignored on SITE object. They are only triggered for
+                // top-level communities. No action is necessary as Community itself is indexed (or deleted) separately.
+                if (event.getSubjectType() == Constants.SITE) {
+                    log.debug(event.getEventTypeAsString() + " event triggered for Site object. Skipping it.");
+                } else if (object == null) {
                     log.warn(event.getEventTypeAsString() + " event, could not get object for "
                                  + event.getObjectTypeAsString() + " id="
                                  + event.getObjectID()


### PR DESCRIPTION
## References
* Fixes #8249  (This "Site cannot be indexed" error was previous reported in this old ticket, but closed by the reporter.  It is still reproducible on `main` however in some scenarios.)

## Description
When a new Top-Level Community is created (or removed), events are triggered on the Site object:
* After top-level community creation, an `ADD` to SITE is triggered here: https://github.com/DSpace/DSpace/blob/main/dspace-api/src/main/java/org/dspace/content/CommunityServiceImpl.java#L140-L144
* After top-level community deletion, a `REMOVE` to SITE is triggered here: https://github.com/DSpace/DSpace/blob/main/dspace-api/src/main/java/org/dspace/content/CommunityServiceImpl.java#L527-L529

These actions are potentially useful in the future, but currently only result in an error in your `dspace.log` file like this:
```
2023-09-13 15:35:41,395 ERROR org.dspace.event.BasicDispatcher @ Consumer("discovery").consume threw: java.lang.IllegalArgumentException: The object: org.dspace.content.Site cannot be indexed
java.lang.IllegalArgumentException: The object: org.dspace.content.Site cannot be indexed
	at org.dspace.discovery.indexobject.factory.IndexObjectFactoryFactory.getIndexableObjects(IndexObjectFactoryFactory.java:90) ~[dspace-api-8.0-SNAPSHOT.jar:8.0-SNAPSHOT]
	at org.dspace.discovery.IndexEventConsumer.consume(IndexEventConsumer.java:164) ~[dspace-api-8.0-SNAPSHOT.jar:8.0-SNAPSHOT]
	at org.dspace.event.BasicDispatcher.dispatch(BasicDispatcher.java:104) [dspace-api-8.0-SNAPSHOT.jar:8.0-SNAPSHOT]
	at org.dspace.core.Context.dispatchEvents(Context.java:466) [dspace-api-8.0-SNAPSHOT.jar:8.0-SNAPSHOT]
	at org.dspace.builder.CommunityBuilder.build(CommunityBuilder.java:118) [test-classes/:?]
	at org.dspace.xmlworkflow.XmlWorkflowServiceIT.workflowUserMultipleSelectedReviewer_ItemShouldBeEditable(XmlWorkflowServiceIT.java:168) [test-classes/:?]
```

As the above error shows, it's easiest to find these errors in ITs.  But, it can also occur in logs of a production site.


## Instructions for Reviewers
* The above error is most easily reproduced in ITs.  Just run an IT which creates a top-level community, for example:
```
mvn install -DskipIntegrationTests=false -Dit.test=XmlWorkflowServiceIT -DfailIfNoTests=false
```
* Then, look at contents of logs from that test (in `[dspace-src]/dspace-api/target/failsafe-reports/org.dspace.xmlworkflow.XmlWorkflowServiceIT-output.txt`)
* In those logs, you'll see the above error stacktrace after each top-level community is created.  It's a harmless error, but it's pointless in logs.
