### PR TITLE
Fix to prevent workflow tasks configured to be queued from running automatically

### DIFF
--- a/dspace-api/src/main/java/org/dspace/curate/Curation.java
+++ b/dspace-api/src/main/java/org/dspace/curate/Curation.java
@@ -152,17 +152,10 @@ public class Curation extends DSpaceRunnable<CurationScriptConfiguration> {
                 super.handler.logInfo("Curating id: " + entry.getObjectId());
             }
             curator.clear();
-            // does entry relate to a DSO or workflow object?
-            if (entry.getObjectId().indexOf('/') > 0) {
-                for (String taskName : entry.getTaskNames()) {
-                    curator.addTask(taskName);
-                }
-                curator.curate(context, entry.getObjectId());
-            } else {
-                // TODO: Remove this exception once curation tasks are supported by configurable workflow
-                // e.g. see https://github.com/DSpace/DSpace/pull/3157
-                throw new IllegalArgumentException("curation for workflow items is no longer supported");
+            for (String taskName : entry.getTaskNames()) {
+                curator.addTask(taskName);
             }
+            curator.curate(context, entry.getObjectId());
         }
         queue.release(this.queue, ticket, true);
         return ticket;

--- a/dspace-api/src/main/java/org/dspace/curate/XmlWorkflowCuratorServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/curate/XmlWorkflowCuratorServiceImpl.java
@@ -13,6 +13,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Collection;
@@ -123,40 +124,47 @@ public class XmlWorkflowCuratorServiceImpl
             item.setOwningCollection(wfi.getCollection());
             for (Task task : step.tasks) {
                 curator.addTask(task.name);
-                curator.curate(item);
-                int status = curator.getStatus(task.name);
-                String result = curator.getResult(task.name);
-                String action = "none";
-                switch (status) {
-                    case Curator.CURATE_FAIL:
-                        // task failed - notify any contacts the task has assigned
-                        if (task.powers.contains("reject")) {
-                            action = "reject";
-                        }
-                        notifyContacts(c, wfi, task, "fail", action, result);
-                        // if task so empowered, reject submission and terminate
-                        if ("reject".equals(action)) {
-                            workflowService.sendWorkflowItemBackSubmission(c, wfi,
-                                    c.getCurrentUser(), null,
-                                    task.name + ": " + result);
-                            return false;
-                        }
-                        break;
-                    case Curator.CURATE_SUCCESS:
-                        if (task.powers.contains("approve")) {
-                            action = "approve";
-                        }
-                        notifyContacts(c, wfi, task, "success", action, result);
-                        if ("approve".equals(action)) {
-                            // cease further task processing and advance submission
-                            return true;
-                        }
-                        break;
-                    case Curator.CURATE_ERROR:
-                        notifyContacts(c, wfi, task, "error", action, result);
-                        break;
-                    default:
-                        break;
+                // Check whether the task is configured to be queued rather than automatically run
+                if (StringUtils.isNotEmpty(step.queue)) {
+                    // queue attribute has been set in the FlowStep configuration: add task to configured queue
+                    curator.queue(c, item.getID().toString(), step.queue);
+                } else {
+                    // Task is configured to be run automatically
+                    curator.curate(item);
+                    int status = curator.getStatus(task.name);
+                    String result = curator.getResult(task.name);
+                    String action = "none";
+                    switch (status) {
+                        case Curator.CURATE_FAIL:
+                            // task failed - notify any contacts the task has assigned
+                            if (task.powers.contains("reject")) {
+                                action = "reject";
+                            }
+                            notifyContacts(c, wfi, task, "fail", action, result);
+                            // if task so empowered, reject submission and terminate
+                            if ("reject".equals(action)) {
+                                workflowService.sendWorkflowItemBackSubmission(c, wfi,
+                                        c.getCurrentUser(), null,
+                                        task.name + ": " + result);
+                                return false;
+                            }
+                            break;
+                        case Curator.CURATE_SUCCESS:
+                            if (task.powers.contains("approve")) {
+                                action = "approve";
+                            }
+                            notifyContacts(c, wfi, task, "success", action, result);
+                            if ("approve".equals(action)) {
+                                // cease further task processing and advance submission
+                                return true;
+                            }
+                            break;
+                        case Curator.CURATE_ERROR:
+                            notifyContacts(c, wfi, task, "error", action, result);
+                            break;
+                        default:
+                            break;
+                    }
                 }
                 curator.clear();
             }


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #9070 

## Description
A missing check has been added to XmlWorkflowCuratorServiceImpl so that the queue attribute in flowstep is checked (workflow-curation.xml) and the task is queued instead of run if a queue name is present

## Instructions for Reviewers

List of changes in this PR:
* XmlWorkflowCuratorServiceImpl: queue name presence check to trigger a task being queued instead of run
* Curator.java has also been updated to remove obsolete code that was preventing queued workflow tasks from running give that the following issue https://github.com/DSpace/DSpace/pull/3157 is now implemented

To test this PR workflow-curation.xml needs to be modified to include a workflow task with a queue name configured within flow-step.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [X] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
