### PR TITLE
Improve performance for Groups with many EPerson members. Fix pagination on endpoints

### DIFF
--- a/dspace-api/src/main/java/org/dspace/eperson/EPersonServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/EPersonServiceImpl.java
@@ -305,10 +305,13 @@ public class EPersonServiceImpl extends DSpaceObjectServiceImpl<EPerson> impleme
             throw new AuthorizeException(
                     "You must be an admin to delete an EPerson");
         }
+        // Get all workflow-related groups that the current EPerson belongs to
         Set<Group> workFlowGroups = getAllWorkFlowGroups(context, ePerson);
         for (Group group: workFlowGroups) {
-            List<EPerson> ePeople = groupService.allMembers(context, group);
-            if (ePeople.size() == 1 && ePeople.contains(ePerson)) {
+            // Get total number of unique EPerson objs who are a member of this group (or subgroup)
+            int totalMembers = groupService.countAllMembers(context, group);
+            // If only one EPerson is a member, then we cannot delete the last member of this group.
+            if (totalMembers == 1) {
                 throw new EmptyWorkflowGroupException(ePerson.getID(), group.getID());
             }
         }

--- a/dspace-api/src/main/java/org/dspace/eperson/EPersonServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/EPersonServiceImpl.java
@@ -567,11 +567,26 @@ public class EPersonServiceImpl extends DSpaceObjectServiceImpl<EPerson> impleme
 
     @Override
     public List<EPerson> findByGroups(Context c, Set<Group> groups) throws SQLException {
+        return findByGroups(c, groups, -1, -1);
+    }
+
+    @Override
+    public List<EPerson> findByGroups(Context c, Set<Group> groups, int pageSize, int offset) throws SQLException {
         //Make sure we at least have one group, if not don't even bother searching.
         if (CollectionUtils.isNotEmpty(groups)) {
-            return ePersonDAO.findByGroups(c, groups);
+            return ePersonDAO.findByGroups(c, groups, pageSize, offset);
         } else {
             return new ArrayList<>();
+        }
+    }
+
+    @Override
+    public int countByGroups(Context c, Set<Group> groups) throws SQLException {
+        //Make sure we at least have one group, if not don't even bother counting.
+        if (CollectionUtils.isNotEmpty(groups)) {
+            return ePersonDAO.countByGroups(c, groups);
+        } else {
+            return 0;
         }
     }
 

--- a/dspace-api/src/main/java/org/dspace/eperson/Group.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/Group.java
@@ -98,7 +98,11 @@ public class Group extends DSpaceObject implements DSpaceObjectLegacySupport {
     }
 
     /**
-     * Return EPerson members of a Group
+     * Return EPerson members of a Group.
+     * <P>
+     * WARNING: This method may have bad performance for Groups with large numbers of EPerson members.
+     * Therefore, only use this when you need to access every EPerson member. Instead, consider using
+     * EPersonService.findByGroups() for a paginated list of EPersons.
      *
      * @return list of EPersons
      */
@@ -143,9 +147,13 @@ public class Group extends DSpaceObject implements DSpaceObjectLegacySupport {
     }
 
     /**
-     * Return Group members of a Group.
+     * Return Group members (i.e. direct subgroups) of a Group.
+     * <P>
+     * WARNING: This method may have bad performance for Groups with large numbers of Subgroups.
+     * Therefore, only use this when you need to access every Subgroup. Instead, consider using
+     * GroupService.findByParent() for a paginated list of Subgroups.
      *
-     * @return list of groups
+     * @return list of subgroups
      */
     public List<Group> getMemberGroups() {
         return groups;

--- a/dspace-api/src/main/java/org/dspace/eperson/GroupServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/GroupServiceImpl.java
@@ -382,6 +382,21 @@ public class GroupServiceImpl extends DSpaceObjectServiceImpl<Group> implements 
     }
 
     @Override
+    public int countAllMembers(Context context, Group group) throws SQLException {
+        // Get all groups which are a member of this group
+        List<Group2GroupCache> group2GroupCaches = group2GroupCacheDAO.findByParent(context, group);
+        Set<Group> groups = new HashSet<>();
+        for (Group2GroupCache group2GroupCache : group2GroupCaches) {
+            groups.add(group2GroupCache.getChild());
+        }
+        // Append current group as well
+        groups.add(group);
+
+        // Return total number of unique EPerson objects in any of these groups
+        return ePersonService.countByGroups(context, groups);
+    }
+
+    @Override
     public Group find(Context context, UUID id) throws SQLException {
         if (id == null) {
             return null;

--- a/dspace-api/src/main/java/org/dspace/eperson/GroupServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/GroupServiceImpl.java
@@ -382,7 +382,8 @@ public class GroupServiceImpl extends DSpaceObjectServiceImpl<Group> implements 
 
         // Get all groups which are a member of this group
         List<Group2GroupCache> group2GroupCaches = group2GroupCacheDAO.findByParent(c, g);
-        Set<Group> groups = new HashSet<>();
+        // Initialize HashSet based on List size to avoid Set resizing. See https://stackoverflow.com/a/21822273
+        Set<Group> groups = new HashSet<>((int) (group2GroupCaches.size() / 0.75 + 1));
         for (Group2GroupCache group2GroupCache : group2GroupCaches) {
             groups.add(group2GroupCache.getChild());
         }
@@ -399,7 +400,9 @@ public class GroupServiceImpl extends DSpaceObjectServiceImpl<Group> implements 
     public int countAllMembers(Context context, Group group) throws SQLException {
         // Get all groups which are a member of this group
         List<Group2GroupCache> group2GroupCaches = group2GroupCacheDAO.findByParent(context, group);
-        Set<Group> groups = new HashSet<>();
+        // Initialize HashSet based on List size + current 'group' to avoid Set resizing.
+        // See https://stackoverflow.com/a/21822273
+        Set<Group> groups = new HashSet<>((int) ((group2GroupCaches.size() + 1) / 0.75 + 1));
         for (Group2GroupCache group2GroupCache : group2GroupCaches) {
             groups.add(group2GroupCache.getChild());
         }

--- a/dspace-api/src/main/java/org/dspace/eperson/GroupServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/GroupServiceImpl.java
@@ -829,4 +829,20 @@ public class GroupServiceImpl extends DSpaceObjectServiceImpl<Group> implements 
     public String getName(Group dso) {
         return dso.getName();
     }
+
+    @Override
+    public List<Group> findByParent(Context context, Group parent, int pageSize, int offset) throws SQLException {
+        if (parent == null) {
+            return null;
+        }
+        return groupDAO.findByParent(context, parent, pageSize, offset);
+    }
+
+    @Override
+    public int countByParent(Context context, Group parent) throws SQLException {
+        if (parent == null) {
+            return 0;
+        }
+        return groupDAO.countByParent(context, parent);
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/eperson/GroupServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/GroupServiceImpl.java
@@ -179,8 +179,10 @@ public class GroupServiceImpl extends DSpaceObjectServiceImpl<Group> implements 
                 for (CollectionRole collectionRole : collectionRoles) {
                     if (StringUtils.equals(collectionRole.getRoleId(), role.getId())
                             && claimedTask.getWorkflowItem().getCollection() == collectionRole.getCollection()) {
-                        List<EPerson> ePeople = allMembers(context, group);
-                        if (ePeople.size() == 1 && ePeople.contains(ePerson)) {
+                        //  Get total number of unique EPerson objs who are a member of this group (or subgroup)
+                        int totalMembers = countAllMembers(context, group);
+                        // If only one EPerson is a member, then we cannot delete the last member of this group.
+                        if (totalMembers == 1) {
                             throw new IllegalStateException(
                                     "Refused to remove user " + ePerson
                                             .getID() + " from workflow group because the group " + group
@@ -191,8 +193,10 @@ public class GroupServiceImpl extends DSpaceObjectServiceImpl<Group> implements 
                 }
             }
             if (!poolTasks.isEmpty()) {
-                List<EPerson> ePeople = allMembers(context, group);
-                if (ePeople.size() == 1 && ePeople.contains(ePerson)) {
+                //  Get total number of unique EPerson objs who are a member of this group (or subgroup)
+                int totalMembers = countAllMembers(context, group);
+                // If only one EPerson is a member, then we cannot delete the last member of this group.
+                if (totalMembers == 1) {
                     throw new IllegalStateException(
                             "Refused to remove user " + ePerson
                                     .getID() + " from workflow group because the group " + group
@@ -212,9 +216,10 @@ public class GroupServiceImpl extends DSpaceObjectServiceImpl<Group> implements 
         if (!collectionRoles.isEmpty()) {
             List<PoolTask> poolTasks = poolTaskService.findByGroup(context, groupParent);
             if (!poolTasks.isEmpty()) {
-                List<EPerson> parentPeople = allMembers(context, groupParent);
-                List<EPerson> childPeople = allMembers(context, childGroup);
-                if (childPeople.containsAll(parentPeople)) {
+                // Count number of Groups which have this groupParent as a direct parent
+                int totalChildren = countByParent(context, groupParent);
+                // If only one group has this as a parent, we cannot delete the last child group
+                if (totalChildren == 1) {
                     throw new IllegalStateException(
                             "Refused to remove sub group " + childGroup
                                     .getID() + " from workflow group because the group " + groupParent

--- a/dspace-api/src/main/java/org/dspace/eperson/dao/EPersonDAO.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/dao/EPersonDAO.java
@@ -38,7 +38,29 @@ public interface EPersonDAO extends DSpaceObjectDAO<EPerson>, DSpaceObjectLegacy
 
     public int searchResultCount(Context context, String query, List<MetadataField> queryFields) throws SQLException;
 
-    public List<EPerson> findByGroups(Context context, Set<Group> groups) throws SQLException;
+    /**
+     * Find all EPersons who are a member of one or more of the listed groups in a paginated fashion. Order is
+     * indeterminate.
+     *
+     * @param context current Context
+     * @param groups Set of group(s) to check membership in
+     * @param pageSize number of EPerson objects to load at one time. Set to <=0 to disable pagination
+     * @param offset number of page to load (starting with 1). Set to <=0 to disable pagination
+     * @return List of all EPersons who are a member of one or more groups.
+     * @throws SQLException
+     */
+    List<EPerson> findByGroups(Context context, Set<Group> groups, int pageSize, int offset) throws SQLException;
+
+    /**
+     * Count total number of EPersons who are a member of one or more of the listed groups. This provides the total
+     * number of results to expect from corresponding findByGroups() for pagination purposes.
+     *
+     * @param context current Context
+     * @param groups Set of group(s) to check membership in
+     * @return total number of (unique) EPersons who are a member of one or more groups.
+     * @throws SQLException
+     */
+    int countByGroups(Context context, Set<Group> groups) throws SQLException;
 
     public List<EPerson> findWithPasswordWithoutDigestAlgorithm(Context context) throws SQLException;
 

--- a/dspace-api/src/main/java/org/dspace/eperson/dao/EPersonDAO.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/dao/EPersonDAO.java
@@ -39,8 +39,8 @@ public interface EPersonDAO extends DSpaceObjectDAO<EPerson>, DSpaceObjectLegacy
     public int searchResultCount(Context context, String query, List<MetadataField> queryFields) throws SQLException;
 
     /**
-     * Find all EPersons who are a member of one or more of the listed groups in a paginated fashion. Order is
-     * indeterminate.
+     * Find all EPersons who are a member of one or more of the listed groups in a paginated fashion. This returns
+     * EPersons ordered by UUID.
      *
      * @param context current Context
      * @param groups Set of group(s) to check membership in

--- a/dspace-api/src/main/java/org/dspace/eperson/dao/GroupDAO.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/dao/GroupDAO.java
@@ -146,4 +146,28 @@ public interface GroupDAO extends DSpaceObjectDAO<Group>, DSpaceObjectLegacySupp
      */
     Group findByIdAndMembership(Context context, UUID id, EPerson ePerson) throws SQLException;
 
+    /**
+     * Find all groups which are members of a given parent group.
+     * This provides the same behavior as group.getMemberGroups(), but in a paginated fashion.
+     *
+     * @param context   The DSpace context
+     * @param parent    Parent Group to search within
+     * @param pageSize how many results return
+     * @param offset   the position of the first result to return
+     * @return Groups matching the query
+     * @throws SQLException if database error
+     */
+    List<Group> findByParent(Context context, Group parent, int pageSize, int offset) throws SQLException;
+
+    /**
+     * Returns the number of groups which are members of a given parent group.
+     * This provides the same behavior as group.getMemberGroups().size(), but with better performance for large groups.
+     * This method may be used with findByParent() to perform pagination.
+     *
+     * @param context   The DSpace context
+     * @param parent    Parent Group to search within
+     * @return Number of Groups matching the query
+     * @throws SQLException if database error
+     */
+    int countByParent(Context context, Group parent) throws SQLException;
 }

--- a/dspace-api/src/main/java/org/dspace/eperson/dao/impl/EPersonDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/dao/impl/EPersonDAOImpl.java
@@ -112,7 +112,8 @@ public class EPersonDAOImpl extends AbstractHibernateDSODAO<EPerson> implements 
     }
 
     @Override
-    public List<EPerson> findByGroups(Context context, Set<Group> groups, int pageSize, int offset) throws SQLException {
+    public List<EPerson> findByGroups(Context context, Set<Group> groups, int pageSize, int offset)
+        throws SQLException {
         Query query = createQuery(context,
                                   "SELECT DISTINCT e FROM EPerson e " +
                                       "JOIN e.groups g " +
@@ -122,10 +123,16 @@ public class EPersonDAOImpl extends AbstractHibernateDSODAO<EPerson> implements 
         for (Group group : groups) {
             idList.add(group.getID());
         }
-
         query.setParameter("idList", idList);
 
-        return list(query, pageSize, offset);
+        if (pageSize > 0) {
+            query.setMaxResults(pageSize);
+        }
+        if (offset > 0) {
+            query.setFirstResult(offset);
+        }
+
+        return list(query);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/eperson/dao/impl/EPersonDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/dao/impl/EPersonDAOImpl.java
@@ -112,7 +112,7 @@ public class EPersonDAOImpl extends AbstractHibernateDSODAO<EPerson> implements 
     }
 
     @Override
-    public List<EPerson> findByGroups(Context context, Set<Group> groups) throws SQLException {
+    public List<EPerson> findByGroups(Context context, Set<Group> groups, int pageSize, int offset) throws SQLException {
         Query query = createQuery(context,
                                   "SELECT DISTINCT e FROM EPerson e " +
                                       "JOIN e.groups g " +
@@ -125,7 +125,24 @@ public class EPersonDAOImpl extends AbstractHibernateDSODAO<EPerson> implements 
 
         query.setParameter("idList", idList);
 
-        return list(query);
+        return list(query, pageSize, offset);
+    }
+
+    @Override
+    public int countByGroups(Context context, Set<Group> groups) throws SQLException {
+        Query query = createQuery(context,
+                                  "SELECT count(DISTINCT e) FROM EPerson e " +
+                                      "JOIN e.groups g " +
+                                      "WHERE g.id IN (:idList) ");
+
+        List<UUID> idList = new ArrayList<>(groups.size());
+        for (Group group : groups) {
+            idList.add(group.getID());
+        }
+
+        query.setParameter("idList", idList);
+
+        return count(query);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/eperson/dao/impl/GroupDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/dao/impl/GroupDAOImpl.java
@@ -199,7 +199,8 @@ public class GroupDAOImpl extends AbstractHibernateDSODAO<Group> implements Grou
     @Override
     public List<Group> findByParent(Context context, Group parent, int pageSize, int offset) throws SQLException {
         Query query = createQuery(context,
-                                  "from Group where (from Group g where g.id = :parent_id) in elements (parentGroups)");
+                                  "SELECT g FROM Group g JOIN g.parentGroups pg " +
+                                      "WHERE pg.id = :parent_id");
         query.setParameter("parent_id", parent.getID());
         if (pageSize > 0) {
             query.setMaxResults(pageSize);
@@ -213,8 +214,8 @@ public class GroupDAOImpl extends AbstractHibernateDSODAO<Group> implements Grou
     }
 
     public int countByParent(Context context, Group parent) throws SQLException {
-        Query query = createQuery(context, "SELECT count(*) from Group " +
-                                      "where (from Group g where g.id = :parent_id) in elements (parentGroups)");
+        Query query = createQuery(context, "SELECT count(g) FROM Group g JOIN g.parentGroups pg " +
+                                            "WHERE pg.id = :parent_id");
         query.setParameter("parent_id", parent.getID());
 
         return count(query);

--- a/dspace-api/src/main/java/org/dspace/eperson/dao/impl/GroupDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/dao/impl/GroupDAOImpl.java
@@ -196,4 +196,27 @@ public class GroupDAOImpl extends AbstractHibernateDSODAO<Group> implements Grou
         return count(createQuery(context, "SELECT count(*) FROM Group"));
     }
 
+    @Override
+    public List<Group> findByParent(Context context, Group parent, int pageSize, int offset) throws SQLException {
+        Query query = createQuery(context,
+                                  "from Group where (from Group g where g.id = :parent_id) in elements (parentGroups)");
+        query.setParameter("parent_id", parent.getID());
+        if (pageSize > 0) {
+            query.setMaxResults(pageSize);
+        }
+        if (offset > 0) {
+            query.setFirstResult(offset);
+        }
+        query.setHint("org.hibernate.cacheable", Boolean.TRUE);
+
+        return list(query);
+    }
+
+    public int countByParent(Context context, Group parent) throws SQLException {
+        Query query = createQuery(context, "SELECT count(*) from Group " +
+                                      "where (from Group g where g.id = :parent_id) in elements (parentGroups)");
+        query.setParameter("parent_id", parent.getID());
+
+        return count(query);
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/eperson/service/EPersonService.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/service/EPersonService.java
@@ -252,14 +252,43 @@ public interface EPersonService extends DSpaceObjectService<EPerson>, DSpaceObje
     public List<String> getDeleteConstraints(Context context, EPerson ePerson) throws SQLException;
 
     /**
-     * Retrieve all accounts which belong to at least one of the specified groups.
+     * Retrieve all EPerson accounts which belong to at least one of the specified groups.
+     * <P>
+     * WARNING: This method should be used sparingly, as it could have performance issues for Groups with very large
+     * lists of members. In that situation, a very large number of EPerson objects will be loaded into memory.
+     * See https://github.com/DSpace/DSpace/issues/9052
+     * <P>
+     * For better performance, use the paginated version of this method.
      *
      * @param c      The relevant DSpace Context.
      * @param groups set of eperson groups
      * @return a list of epeople
      * @throws SQLException An exception that provides information on a database access error or other errors.
      */
-    public List<EPerson> findByGroups(Context c, Set<Group> groups) throws SQLException;
+    List<EPerson> findByGroups(Context c, Set<Group> groups) throws SQLException;
+
+    /**
+     * Retrieve all EPerson accounts which belong to at least one of the specified groups, in a paginated fashion.
+     *
+     * @param c      The relevant DSpace Context.
+     * @param groups Set of group(s) to check membership in
+     * @param pageSize number of EPerson objects to load at one time. Set to <=0 to disable pagination
+     * @param offset number of page to load (starting with 1). Set to <=0 to disable pagination
+     * @return a list of epeople
+     * @throws SQLException An exception that provides information on a database access error or other errors.
+     */
+    List<EPerson> findByGroups(Context c, Set<Group> groups, int pageSize, int offset) throws SQLException;
+
+    /**
+     * Count all EPerson accounts which belong to at least one of the specified groups. This provides the total
+     * number of results to expect from corresponding findByGroups() for pagination purposes.
+     *
+     * @param c      The relevant DSpace Context.
+     * @param groups Set of group(s) to check membership in
+     * @return total number of (unique) EPersons who are a member of one or more groups.
+     * @throws SQLException An exception that provides information on a database access error or other errors.
+     */
+    int countByGroups(Context c, Set<Group> groups) throws SQLException;
 
     /**
      * Retrieve all accounts which are subscribed to receive information about new items.

--- a/dspace-api/src/main/java/org/dspace/eperson/service/EPersonService.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/service/EPersonService.java
@@ -254,9 +254,8 @@ public interface EPersonService extends DSpaceObjectService<EPerson>, DSpaceObje
     /**
      * Retrieve all EPerson accounts which belong to at least one of the specified groups.
      * <P>
-     * WARNING: This method should be used sparingly, as it could have performance issues for Groups with very large
-     * lists of members. In that situation, a very large number of EPerson objects will be loaded into memory.
-     * See https://github.com/DSpace/DSpace/issues/9052
+     * WARNING: This method may have bad performance issues for Groups with a very large number of members,
+     * as it will load all member EPerson objects into memory.
      * <P>
      * For better performance, use the paginated version of this method.
      *

--- a/dspace-api/src/main/java/org/dspace/eperson/service/GroupService.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/service/GroupService.java
@@ -327,4 +327,29 @@ public interface GroupService extends DSpaceObjectService<Group>, DSpaceObjectLe
      */
     List<Group> findByMetadataField(Context context, String searchValue, MetadataField metadataField)
         throws SQLException;
+
+    /**
+     * Find all groups which are a member of the given Parent group
+     *
+     * @param context The relevant DSpace Context.
+     * @param parent The parent Group to search on
+     * @param pageSize           how many results return
+     * @param offset             the position of the first result to return
+     * @return List of all groups which are members of the parent group
+     * @throws SQLException database exception if error
+     */
+    List<Group> findByParent(Context context, Group parent, int pageSize, int offset)
+        throws SQLException;
+
+    /**
+     * Return number of groups which are a member of the given Parent group.
+     * Can be used with findByParent() for pagination of all groups within a given Parent group.
+     *
+     * @param context The relevant DSpace Context.
+     * @param parent The parent Group to search on
+     * @return number of groups which are members of the parent group
+     * @throws SQLException database exception if error
+     */
+    int countByParent(Context context, Group parent)
+        throws SQLException;
 }

--- a/dspace-api/src/main/java/org/dspace/eperson/service/GroupService.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/service/GroupService.java
@@ -189,9 +189,11 @@ public interface GroupService extends DSpaceObjectService<Group>, DSpaceObjectLe
     Set<Group> allMemberGroupsSet(Context context, EPerson ePerson) throws SQLException;
 
     /**
-     * Get all of the epeople who are a member of the
-     * specified group, or a member of a sub-group of the
+     * Get all of the EPerson objects who are a member of the specified group, or a member of a subgroup of the
      * specified group, etc.
+     * <P>
+     * WARNING: This method may have bad performance for Groups with a very large number of members, as it will load
+     * all member EPerson objects into memory. Only use if you need access to *every* EPerson object at once.
      *
      * @param context The relevant DSpace Context.
      * @param group   Group object
@@ -199,6 +201,18 @@ public interface GroupService extends DSpaceObjectService<Group>, DSpaceObjectLe
      * @throws SQLException if error
      */
     public List<EPerson> allMembers(Context context, Group group) throws SQLException;
+
+    /**
+     * Count all of the EPerson objects who are a member of the specified group, or a member of a subgroup of the
+     * specified group, etc.
+     * In other words, this will return the size of "allMembers()" without having to load all EPerson objects into
+     * memory.
+     * @param context current DSpace context
+     * @param group Group object
+     * @return count of EPerson object members
+     * @throws SQLException if error
+     */
+    int countAllMembers(Context context, Group group) throws SQLException;
 
     /**
      * Find the group by its name - assumes name is unique

--- a/dspace-api/src/test/java/org/dspace/eperson/EPersonTest.java
+++ b/dspace-api/src/test/java/org/dspace/eperson/EPersonTest.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import javax.mail.MessagingException;
 
 import org.apache.commons.codec.DecoderException;
@@ -1029,6 +1030,42 @@ public class EPersonTest extends AbstractUnitTest {
                 wfi.getSubmitter());
     }
 
+    @Test
+    public void findAndCountByGroups() throws SQLException, AuthorizeException, IOException {
+        // Create a group with 3 EPerson members
+        Group group = createGroup("parentGroup");
+        EPerson eperson1 = createEPersonAndAddToGroup("test1@example.com", group);
+        EPerson eperson2 = createEPersonAndAddToGroup("test2@example.com", group);
+        EPerson eperson3 = createEPersonAndAddToGroup("test3@example.com", group);
+        groupService.update(context, group);
+
+        // Assert that findByGroup is the same list of EPersons as getMembers() when pagination is ignored
+        // (NOTE: Pagination is tested in GroupRestRepositoryIT)
+        assertEquals(group.getMembers(), ePersonService.findByGroups(context, Set.of(group), -1, -1));
+        // Assert countByGroups is the same as the size of members
+        assertEquals(group.getMembers().size(), ePersonService.countByGroups(context, Set.of(group)));
+
+        // Add another group with duplicate EPerson
+        Group group2 = createGroup("anotherGroup");
+        groupService.addMember(context, group2, eperson1);
+        groupService.update(context, group2);
+
+        // Verify countByGroups is still 3 (existing person should not be counted twice)
+        assertEquals(3, ePersonService.countByGroups(context, Set.of(group, group2)));
+
+        // Add a new EPerson to new group, verify count goes up by one
+        EPerson eperson4 = createEPersonAndAddToGroup("test4@example.com", group2);
+        assertEquals(4, ePersonService.countByGroups(context, Set.of(group, group2)));
+
+        // Clean up our data
+        groupService.delete(context, group);
+        groupService.delete(context, group2);
+        ePersonService.delete(context, eperson1);
+        ePersonService.delete(context, eperson2);
+        ePersonService.delete(context, eperson3);
+        ePersonService.delete(context, eperson4);
+    }
+
     /**
      * Creates an item, sets the specified submitter.
      *
@@ -1074,5 +1111,33 @@ public class EPersonTest extends AbstractUnitTest {
         workspaceItemService.update(context, wsi);
         context.restoreAuthSystemState();
         return wsi;
+    }
+
+    protected Group createGroup(String name) throws SQLException, AuthorizeException {
+        context.turnOffAuthorisationSystem();
+        Group group = groupService.create(context);
+        group.setName(name);
+        groupService.update(context, group);
+        context.restoreAuthSystemState();
+        return group;
+    }
+
+    protected EPerson createEPersonAndAddToGroup(String email, Group group) throws SQLException, AuthorizeException {
+        context.turnOffAuthorisationSystem();
+        EPerson ePerson = createEPerson(email);
+        groupService.addMember(context, group, ePerson);
+        groupService.update(context, group);
+        ePersonService.update(context, ePerson);
+        context.restoreAuthSystemState();
+        return ePerson;
+    }
+
+    protected EPerson createEPerson(String email) throws SQLException, AuthorizeException {
+        context.turnOffAuthorisationSystem();
+        EPerson ePerson = ePersonService.create(context);
+        ePerson.setEmail(email);
+        ePersonService.update(context, ePerson);
+        context.restoreAuthSystemState();
+        return ePerson;
     }
 }

--- a/dspace-api/src/test/java/org/dspace/eperson/EPersonTest.java
+++ b/dspace-api/src/test/java/org/dspace/eperson/EPersonTest.java
@@ -10,6 +10,7 @@ package org.dspace.eperson;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
@@ -20,6 +21,7 @@ import java.util.Set;
 import javax.mail.MessagingException;
 
 import org.apache.commons.codec.DecoderException;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.dspace.AbstractUnitTest;
@@ -1041,7 +1043,10 @@ public class EPersonTest extends AbstractUnitTest {
 
         // Assert that findByGroup is the same list of EPersons as getMembers() when pagination is ignored
         // (NOTE: Pagination is tested in GroupRestRepositoryIT)
-        assertEquals(group.getMembers(), ePersonService.findByGroups(context, Set.of(group), -1, -1));
+        // NOTE: isEqualCollection() must be used for comparison because Hibernate's "PersistentBag" cannot be compared
+        // directly to a List. See https://stackoverflow.com/a/57399383/3750035
+        assertTrue(CollectionUtils.isEqualCollection(group.getMembers(),
+                                                     ePersonService.findByGroups(context, Set.of(group), -1, -1)));
         // Assert countByGroups is the same as the size of members
         assertEquals(group.getMembers().size(), ePersonService.countByGroups(context, Set.of(group)));
 
@@ -1058,12 +1063,14 @@ public class EPersonTest extends AbstractUnitTest {
         assertEquals(4, ePersonService.countByGroups(context, Set.of(group, group2)));
 
         // Clean up our data
+        context.turnOffAuthorisationSystem();
         groupService.delete(context, group);
         groupService.delete(context, group2);
         ePersonService.delete(context, eperson1);
         ePersonService.delete(context, eperson2);
         ePersonService.delete(context, eperson3);
         ePersonService.delete(context, eperson4);
+        context.restoreAuthSystemState();
     }
 
     /**

--- a/dspace-api/src/test/java/org/dspace/eperson/GroupTest.java
+++ b/dspace-api/src/test/java/org/dspace/eperson/GroupTest.java
@@ -22,10 +22,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.Logger;
 import org.dspace.AbstractUnitTest;
 import org.dspace.authorize.AuthorizeException;
-import org.dspace.builder.GroupBuilder;
 import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.eperson.service.EPersonService;
 import org.dspace.eperson.service.GroupService;
@@ -636,15 +636,20 @@ public class GroupTest extends AbstractUnitTest {
 
         // Assert that findByParent is the same list of groups as getMemberGroups() when pagination is ignored
         // (NOTE: Pagination is tested in GroupRestRepositoryIT)
-        assertEquals(parentGroup.getMemberGroups(), groupService.findByParent(context, parentGroup, -1, -1));
+        // NOTE: isEqualCollection() must be used for comparison because Hibernate's "PersistentBag" cannot be compared
+        // directly to a List. See https://stackoverflow.com/a/57399383/3750035
+        assertTrue(CollectionUtils.isEqualCollection(parentGroup.getMemberGroups(),
+                                                     groupService.findByParent(context, parentGroup, -1, -1)));
         // Assert countBy parent is the same as the size of group members
         assertEquals(parentGroup.getMemberGroups().size(), groupService.countByParent(context, parentGroup));
 
         // Clean up our data
+        context.turnOffAuthorisationSystem();
         groupService.delete(context, parentGroup);
         groupService.delete(context, childGroup);
         groupService.delete(context, child2Group);
         groupService.delete(context, child3Group);
+        context.restoreAuthSystemState();
     }
 
 

--- a/dspace-api/src/test/java/org/dspace/eperson/GroupTest.java
+++ b/dspace-api/src/test/java/org/dspace/eperson/GroupTest.java
@@ -10,6 +10,7 @@ package org.dspace.eperson;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -24,6 +25,7 @@ import java.util.List;
 import org.apache.logging.log4j.Logger;
 import org.dspace.AbstractUnitTest;
 import org.dspace.authorize.AuthorizeException;
+import org.dspace.builder.GroupBuilder;
 import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.eperson.service.EPersonService;
 import org.dspace.eperson.service.GroupService;
@@ -618,6 +620,31 @@ public class GroupTest extends AbstractUnitTest {
         ePersonService.delete(context, person);
         context.restoreAuthSystemState();
         assertTrue(groupService.isEmpty(level2Group));
+    }
+
+    @Test
+    public void findAndCountByParent() throws SQLException, AuthorizeException, IOException {
+        // Create a parent group with 3 child groups
+        Group parentGroup = createGroup("parentGroup");
+        Group childGroup = createGroup("childGroup");
+        Group child2Group = createGroup("child2Group");
+        Group child3Group = createGroup("child3Group");
+        groupService.addMember(context, parentGroup, childGroup);
+        groupService.addMember(context, parentGroup, child2Group);
+        groupService.addMember(context, parentGroup, child3Group);
+        groupService.update(context, parentGroup);
+
+        // Assert that findByParent is the same list of groups as getMemberGroups() when pagination is ignored
+        // (NOTE: Pagination is tested in GroupRestRepositoryIT)
+        assertEquals(parentGroup.getMemberGroups(), groupService.findByParent(context, parentGroup, -1, -1));
+        // Assert countBy parent is the same as the size of group members
+        assertEquals(parentGroup.getMemberGroups().size(), groupService.countByParent(context, parentGroup));
+
+        // Clean up our data
+        groupService.delete(context, parentGroup);
+        groupService.delete(context, childGroup);
+        groupService.delete(context, child2Group);
+        groupService.delete(context, child3Group);
     }
 
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/GroupEPersonLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/GroupEPersonLinkRepository.java
@@ -8,6 +8,8 @@
 package org.dspace.app.rest.repository;
 
 import java.sql.SQLException;
+import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
@@ -15,7 +17,9 @@ import javax.servlet.http.HttpServletRequest;
 import org.dspace.app.rest.model.GroupRest;
 import org.dspace.app.rest.projection.Projection;
 import org.dspace.core.Context;
+import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
+import org.dspace.eperson.service.EPersonService;
 import org.dspace.eperson.service.GroupService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -32,6 +36,9 @@ public class GroupEPersonLinkRepository extends AbstractDSpaceRestRepository
         implements LinkRestRepository {
 
     @Autowired
+    EPersonService epersonService;
+
+    @Autowired
     GroupService groupService;
 
     @PreAuthorize("hasPermission(#groupId, 'GROUP', 'READ')")
@@ -45,7 +52,11 @@ public class GroupEPersonLinkRepository extends AbstractDSpaceRestRepository
             if (group == null) {
                 throw new ResourceNotFoundException("No such group: " + groupId);
             }
-            return converter.toRestPage(group.getMembers(), optionalPageable, projection);
+            int total = epersonService.countByGroups(context, Set.of(group));
+            Pageable pageable = utils.getPageable(optionalPageable);
+            List<EPerson> members = epersonService.findByGroups(context, Set.of(group), pageable.getPageSize(),
+                                                                Math.toIntExact(pageable.getOffset()));
+            return converter.toRestPage(members, pageable, total, projection);
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/GroupGroupLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/GroupGroupLinkRepository.java
@@ -8,6 +8,7 @@
 package org.dspace.app.rest.repository;
 
 import java.sql.SQLException;
+import java.util.List;
 import java.util.UUID;
 import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
@@ -45,7 +46,11 @@ public class GroupGroupLinkRepository extends AbstractDSpaceRestRepository
             if (group == null) {
                 throw new ResourceNotFoundException("No such group: " + groupId);
             }
-            return converter.toRestPage(group.getMemberGroups(), optionalPageable, projection);
+            int total = groupService.countByParent(context, group);
+            Pageable pageable = utils.getPageable(optionalPageable);
+            List<Group> memberGroups = groupService.findByParent(context, group, pageable.getPageSize(),
+                                                                Math.toIntExact(pageable.getOffset()));
+            return converter.toRestPage(memberGroups, pageable, total, projection);
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/GroupRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/GroupRestRepositoryIT.java
@@ -3169,6 +3169,79 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
                                  .andExpect(jsonPath("$.page.totalElements", is(5)));
     }
 
+    // Test of /groups/[uuid]/subgroups pagination
+    @Test
+    public void subgroupPaginationTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        Group group = GroupBuilder.createGroup(context)
+                                  .withName("Test group")
+                                  .build();
+
+        GroupBuilder.createGroup(context)
+                    .withParent(group)
+                    .withName("Test subgroup 1")
+                    .build();
+        GroupBuilder.createGroup(context)
+                    .withParent(group)
+                    .withName("Test subgroup 2")
+                    .build();
+        GroupBuilder.createGroup(context)
+                    .withParent(group)
+                    .withName("Test subgroup 3")
+                    .build();
+        GroupBuilder.createGroup(context)
+                    .withParent(group)
+                    .withName("Test subgroup 4")
+                    .build();
+        GroupBuilder.createGroup(context)
+                    .withParent(group)
+                    .withName("Test subgroup 5")
+                    .build();
+
+        context.restoreAuthSystemState();
+
+        String authTokenAdmin = getAuthToken(admin.getEmail(), password);
+        getClient(authTokenAdmin).perform(get("/api/eperson/groups/" + group.getID() + "/subgroups")
+                                              .param("page", "0")
+                                              .param("size", "2"))
+                                 .andExpect(status().isOk()).andExpect(content().contentType(contentType))
+                                 .andExpect(jsonPath("$._embedded.subgroups", Matchers.everyItem(
+                                     hasJsonPath("$.type", is("group")))
+                                 ))
+                                 .andExpect(jsonPath("$._embedded.subgroups").value(Matchers.hasSize(2)))
+                                 .andExpect(jsonPath("$.page.size", is(2)))
+                                 .andExpect(jsonPath("$.page.number", is(0)))
+                                 .andExpect(jsonPath("$.page.totalPages", is(3)))
+                                 .andExpect(jsonPath("$.page.totalElements", is(5)));
+
+        getClient(authTokenAdmin).perform(get("/api/eperson/groups/" + group.getID() + "/subgroups")
+                                              .param("page", "1")
+                                              .param("size", "2"))
+                                 .andExpect(status().isOk()).andExpect(content().contentType(contentType))
+                                 .andExpect(jsonPath("$._embedded.subgroups", Matchers.everyItem(
+                                     hasJsonPath("$.type", is("group")))
+                                 ))
+                                 .andExpect(jsonPath("$._embedded.subgroups").value(Matchers.hasSize(2)))
+                                 .andExpect(jsonPath("$.page.size", is(2)))
+                                 .andExpect(jsonPath("$.page.number", is(1)))
+                                 .andExpect(jsonPath("$.page.totalPages", is(3)))
+                                 .andExpect(jsonPath("$.page.totalElements", is(5)));
+
+        getClient(authTokenAdmin).perform(get("/api/eperson/groups/" + group.getID() + "/subgroups")
+                                              .param("page", "2")
+                                              .param("size", "2"))
+                                 .andExpect(status().isOk()).andExpect(content().contentType(contentType))
+                                 .andExpect(jsonPath("$._embedded.subgroups", Matchers.everyItem(
+                                     hasJsonPath("$.type", is("group")))
+                                 ))
+                                 .andExpect(jsonPath("$._embedded.subgroups").value(Matchers.hasSize(1)))
+                                 .andExpect(jsonPath("$.page.size", is(2)))
+                                 .andExpect(jsonPath("$.page.number", is(2)))
+                                 .andExpect(jsonPath("$.page.totalPages", is(3)))
+                                 .andExpect(jsonPath("$.page.totalElements", is(5)));
+    }
+
     @Test
     public void commAdminAndColAdminCannotExploitItemReadGroupTest() throws Exception {
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/GroupRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/GroupRestRepositoryIT.java
@@ -3091,6 +3091,84 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
 
     }
 
+    // Test of /groups/[uuid]/epersons pagination
+    @Test
+    public void epersonMemberPaginationTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        EPerson eperson1 = EPersonBuilder.createEPerson(context)
+                                         .withEmail("test1@example.com")
+                                         .withNameInMetadata("Test1", "User")
+                                         .build();
+        EPerson eperson2 = EPersonBuilder.createEPerson(context)
+                                         .withEmail("test2@example.com")
+                                         .withNameInMetadata("Test2", "User")
+                                         .build();
+        EPerson eperson3 = EPersonBuilder.createEPerson(context)
+                                         .withEmail("test3@example.com")
+                                         .withNameInMetadata("Test3", "User")
+                                         .build();
+        EPerson eperson4 = EPersonBuilder.createEPerson(context)
+                                         .withEmail("test4@example.com")
+                                         .withNameInMetadata("Test4", "User")
+                                         .build();
+        EPerson eperson5 = EPersonBuilder.createEPerson(context)
+                                         .withEmail("test5@example.com")
+                                         .withNameInMetadata("Test5", "User")
+                                         .build();
+
+        Group group = GroupBuilder.createGroup(context)
+                                  .withName("Test group")
+                                  .addMember(eperson1)
+                                  .addMember(eperson2)
+                                  .addMember(eperson3)
+                                  .addMember(eperson4)
+                                  .addMember(eperson5)
+                                  .build();
+
+        context.restoreAuthSystemState();
+
+        String authTokenAdmin = getAuthToken(admin.getEmail(), password);
+        getClient(authTokenAdmin).perform(get("/api/eperson/groups/" + group.getID() + "/epersons")
+                                              .param("page", "0")
+                                              .param("size", "2"))
+                                 .andExpect(status().isOk()).andExpect(content().contentType(contentType))
+                                 .andExpect(jsonPath("$._embedded.epersons", Matchers.everyItem(
+                                     hasJsonPath("$.type", is("eperson")))
+                                 ))
+                                 .andExpect(jsonPath("$._embedded.epersons").value(Matchers.hasSize(2)))
+                                 .andExpect(jsonPath("$.page.size", is(2)))
+                                 .andExpect(jsonPath("$.page.number", is(0)))
+                                 .andExpect(jsonPath("$.page.totalPages", is(3)))
+                                 .andExpect(jsonPath("$.page.totalElements", is(5)));
+
+        getClient(authTokenAdmin).perform(get("/api/eperson/groups/" + group.getID() + "/epersons")
+                                              .param("page", "1")
+                                              .param("size", "2"))
+                                 .andExpect(status().isOk()).andExpect(content().contentType(contentType))
+                                 .andExpect(jsonPath("$._embedded.epersons", Matchers.everyItem(
+                                     hasJsonPath("$.type", is("eperson")))
+                                 ))
+                                 .andExpect(jsonPath("$._embedded.epersons").value(Matchers.hasSize(2)))
+                                 .andExpect(jsonPath("$.page.size", is(2)))
+                                 .andExpect(jsonPath("$.page.number", is(1)))
+                                 .andExpect(jsonPath("$.page.totalPages", is(3)))
+                                 .andExpect(jsonPath("$.page.totalElements", is(5)));
+
+        getClient(authTokenAdmin).perform(get("/api/eperson/groups/" + group.getID() + "/epersons")
+                                              .param("page", "2")
+                                              .param("size", "2"))
+                                 .andExpect(status().isOk()).andExpect(content().contentType(contentType))
+                                 .andExpect(jsonPath("$._embedded.epersons", Matchers.everyItem(
+                                     hasJsonPath("$.type", is("eperson")))
+                                 ))
+                                 .andExpect(jsonPath("$._embedded.epersons").value(Matchers.hasSize(1)))
+                                 .andExpect(jsonPath("$.page.size", is(2)))
+                                 .andExpect(jsonPath("$.page.number", is(2)))
+                                 .andExpect(jsonPath("$.page.totalPages", is(3)))
+                                 .andExpect(jsonPath("$.page.totalElements", is(5)));
+    }
+
     @Test
     public void commAdminAndColAdminCannotExploitItemReadGroupTest() throws Exception {
 


### PR DESCRIPTION
## References
* Fixes #9052 by providing major speed improvements on backend & proper pagination of group members.
* _NOTE:_ This is not a complete fix, but will improve performance significantly.  Additional endpoints will be necessary to completely fix performance issues in Angular UI.  See https://github.com/DSpace/dspace-angular/issues/2512

## Description
This PR improves the performance of Groups which have many EPerson (or Group) members by adding proper pagination to these endpoints. (Previously all objects were always loaded into memory _before_ pagination was applied.)
* [`GET /api/eperson/groups/<:uuid>/epersons`](https://github.com/DSpace/RestContract/blob/main/epersongroups.md#get-epeople-for-a-single-eperson-group)
* [`GET /api/eperson/groups/<:uuid>/subgroups`](https://github.com/DSpace/RestContract/blob/main/epersongroups.md#get-sub-groups-in-a-single-parent-eperson-group)

This was implemented via new paginated methods in EPersonService/DAO and GroupService/DAO:
* EPersonService/DAO.findByGroups() -> Locates all EPersons who are a member of one or more groups in a paginated manner.
* EPersonService/DAO.countByGroups() -> Provides total count of those EPerson members (necessary for pagination)
* GroupService/DAO.findByParent() -> Locates all (Sub)Groups who are a member group of the given Parent group in a paginated manner.
* GroupService/DAO.countByParent() -> Provides total count of those (Sub)Groups members (necessary for pagination)
* Unit & Integration Tests were added for these new methods

Warnings were added to JavaDoc for the following methods. All of which will have very BAD performance for large groups:
* `Group.getMembers()`
* `Group.getMemberGroups()`
* `EPersonService.findByGroups()` (unpaginated version)
* `GroupService.allMembers()`
* NOTE: I did NOT remove all usages of these methods.  Attempting to remove all usages of these methods would require more discussion/thought. I just replaced the simple ones (i.e. some calls to `allMembers()`) as described below.

Finally, I discovered several usages of `GroupService.allMembers()` where the code only required the `size()` of that list.  These usages were replaced with new `countAllMembers()` or `countByParent()` methods. All these usages have existing detailed tests were still pass with the newly refactored code:
* `EPersonService.delete(Context, EPerson, cascade)`
* `GroupService.removeMember(Context, Group, EPerson)`
* `GroupService.removeMember(Context, Group, Group)`


## Instructions for Reviewers
* See #9052. 
* In UI, verify "Access Control" -> Groups is working properly for search/editing.
* In REST API, verify pagination still works properly for BOTH the `/epersons` and `/subgroups` endpoints (size = how many to return, page = which page of results to return).  With this PR in place, small pages (small values of `size`) will return a response quickly.  Without this PR (e.g. in 7.6), the `size` of page doesn't matter as every object is loaded into memory regardless of `size` before a response is returned.
    * e.g. `GET /api/eperson/groups/<:uuid>/epersons?page=0&size=1`  (Only return one result at a time per page)
    * e.g. `GET /api/eperson/groups/<:uuid>/subgroups?page=0&size=5` (Return first page of 5 results per page)
* Review code and new tests
* Verify all automated tests pass.
