### PR TITLE
DS-7936: remove optimize option (-o) from oai import

### DIFF
--- a/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
@@ -85,7 +85,6 @@ public class XOAI {
 
     // needed because the solr query only returns 10 rows by default
     private final Context context;
-    private boolean optimize;
     private final boolean verbose;
     private boolean clean;
 
@@ -122,9 +121,8 @@ public class XOAI {
         return formats;
     }
 
-    public XOAI(Context context, boolean optimize, boolean clean, boolean verbose) {
+    public XOAI(Context context, boolean clean, boolean verbose) {
         this.context = context;
-        this.optimize = optimize;
         this.clean = clean;
         this.verbose = verbose;
 
@@ -172,12 +170,6 @@ public class XOAI {
 
             }
             solrServerResolver.getServer().commit();
-
-            if (optimize) {
-                println("Optimizing Index");
-                solrServerResolver.getServer().optimize();
-                println("Index optimized");
-            }
 
             // Set last compilation date
             xoaiLastCompilationCacheService.put(new Date());
@@ -586,7 +578,6 @@ public class XOAI {
             CommandLineParser parser = new DefaultParser();
             Options options = new Options();
             options.addOption("c", "clear", false, "Clear index before indexing");
-            options.addOption("o", "optimize", false, "Optimize index at the end");
             options.addOption("v", "verbose", false, "Verbose output");
             options.addOption("h", "help", false, "Shows some help");
             options.addOption("n", "number", true, "FOR DEVELOPMENT MUST DELETE");
@@ -620,7 +611,7 @@ public class XOAI {
 
                 if (COMMAND_IMPORT.equals(command)) {
                     ctx = new Context(Context.Mode.READ_ONLY);
-                    XOAI indexer = new XOAI(ctx, line.hasOption('o'), line.hasOption('c'), line.hasOption('v'));
+                    XOAI indexer = new XOAI(ctx, line.hasOption('c'), line.hasOption('v'));
 
                     applicationContext.getAutowireCapableBeanFactory().autowireBean(indexer);
 
@@ -706,7 +697,6 @@ public class XOAI {
             System.out.println("     " + COMMAND_IMPORT + " - To import DSpace items into OAI index and cache system");
             System.out.println("     " + COMMAND_CLEAN_CACHE + " - Cleans the OAI cached responses");
             System.out.println("> Parameters:");
-            System.out.println("     -o Optimize index after indexing (" + COMMAND_IMPORT + " only)");
             System.out.println("     -c Clear index (" + COMMAND_IMPORT + " only)");
             System.out.println("     -v Verbose output");
             System.out.println("     -h Shows this text");


### PR DESCRIPTION
## References
* Fixes #7936 

## Description
This small PR removes the optimize option from the OAI import process. NOTE: if this is merged then the optimize option should be removed from the OAI indexing documentation: https://wiki.lyrasis.org/display/DSDOC7x/OAI+2.0+Server#OAI2.0Server-IndexingOAIcontent. 

## Instructions for Reviewers
1. Deploy the PR and observe that optimize is no longer an option with the OAI import command.

## Checklist
- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [X] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
