### PR TITLE
[Port dspace-7_x] DS-4414: adds authorization check for license bitstream in OAI import

### DIFF
--- a/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
@@ -21,6 +21,8 @@ import org.apache.logging.log4j.Logger;
 import org.dspace.app.util.factory.UtilServiceFactory;
 import org.dspace.app.util.service.MetadataExposureService;
 import org.dspace.authorize.AuthorizeException;
+import org.dspace.authorize.factory.AuthorizeServiceFactory;
+import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Bundle;
 import org.dspace.content.Item;
@@ -59,6 +61,10 @@ public class ItemUtils {
 
     private static final ConfigurationService configurationService
             = DSpaceServicesFactory.getInstance().getConfigurationService();
+
+    private static final AuthorizeService authorizeService
+        = AuthorizeServiceFactory.getInstance().getAuthorizeService();
+
     /**
      * Default constructor
      */
@@ -163,13 +169,17 @@ public class ItemUtils {
             List<Bitstream> licBits = licBundle.getBitstreams();
             if (!licBits.isEmpty()) {
                 Bitstream licBit = licBits.get(0);
-                InputStream in;
+                if (authorizeService.authorizeActionBoolean(context, licBit, Constants.READ)) {
+                    InputStream in;
 
-                in = bitstreamService.retrieve(context, licBit);
-                ByteArrayOutputStream out = new ByteArrayOutputStream();
-                Utils.bufferedCopy(in, out);
-                license.getField().add(createValue("bin", Base64Utils.encode(out.toString())));
-
+                    in = bitstreamService.retrieve(context, licBit);
+                    ByteArrayOutputStream out = new ByteArrayOutputStream();
+                    Utils.bufferedCopy(in, out);
+                    license.getField().add(createValue("bin", Base64Utils.encode(out.toString())));
+                } else {
+                    log.info("Missing READ rights for license bitstream. Did not include license bitstream for item: "
+                             + item.getID() + ".");
+                }
             }
         }
         return license;


### PR DESCRIPTION
## References
* Backport of https://github.com/DSpace/DSpace/pull/9080
* Fixes #2633 

## Checklist
- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [X] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
