### PR TITLE
Additional Item class cast fixes in handle providers

### DIFF
--- a/dspace-api/src/main/java/org/dspace/identifier/HandleIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/HandleIdentifierProvider.java
@@ -68,10 +68,9 @@ public class HandleIdentifierProvider extends IdentifierProvider {
         try {
             String id = mint(context, dso);
 
-            // move canonical to point the latest version
+            // Populate metadata
             if (dso instanceof Item || dso instanceof Collection || dso instanceof Community) {
-                Item item = (Item) dso;
-                populateHandleMetadata(context, item, id);
+                populateHandleMetadata(context, dso, id);
             }
 
             return id;

--- a/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProviderWithCanonicalHandles.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProviderWithCanonicalHandles.java
@@ -95,11 +95,11 @@ public class VersionedHandleIdentifierProviderWithCanonicalHandles extends Ident
         String id = mint(context, dso);
 
         // move canonical to point the latest version
-        if (dso != null && dso.getType() == Constants.ITEM) {
+        if (dso.getType() == Constants.ITEM && dso instanceof Item) {
             Item item = (Item) dso;
-            VersionHistory history = null;
+            VersionHistory history;
             try {
-                history = versionHistoryService.findByItem(context, (Item) dso);
+                history = versionHistoryService.findByItem(context, item);
             } catch (SQLException ex) {
                 throw new RuntimeException("A problem with the database connection occured.", ex);
             }


### PR DESCRIPTION
BACKPORT OF #9097 to dspace-7_x

DSOs were not properly checked if they were instanceof Item before attempting the cast in HandleIdentifierProvider and VersionedHandleIdentifierProviderWithCanonicalHandles

This small PR fixes further problems as identified in PR #9068 

It seems our ITs do not cover these cases. This is actually a showstopping bug for instances that do not use versioning as no Community or Collection objects can be created! (from my understanding, and in walking through the issue with an affected developer)

## To test

**Before applying this fix**

1. DISABLE versioning explicitly, and enable the plain handle identifier provider (no longer the default in DSpace)
2. Create a collection or community and observe errors
3. Apply this PR and repeat the above test

These same steps should be repeated with versioning enabled, and with the less common `VersionedHandleProviderWithCanonicalHandles` provider enabled instead of the default versioned handle provider.

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).