### PR TITLE
Remove Oracle script that accidentally made it in via #8800

### DIFF
--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/V7.6_2023.04.19__process_parameters_to_text_type.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/oracle/V7.6_2023.04.19__process_parameters_to_text_type.sql
@@ -1,9 +1,0 @@
---
--- The contents of this file are subject to the license and copyright
--- detailed in the LICENSE and NOTICE files at the root of the source
--- tree and available online at
---
--- http://www.dspace.org/license/
---
-
-ALTER TABLE process MODIFY (parameters CLOB);


### PR DESCRIPTION
## Description
Removes a new Oracle DB script that was accidentally committed as part of #8800

This PR 8800 was merged just a little after Oracle Support was removed in #8822 

This is a tiny code cleanup which I will just merge one tests pass.  The Oracle script in question is unused.