### PR TITLE
Clear primary bistream when it's deleted- Fix issue #9099

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
@@ -276,6 +276,10 @@ public class BitstreamServiceImpl extends DSpaceObjectServiceImpl<Bitstream> imp
         //Remove our bitstream from all our bundles
         final List<Bundle> bundles = bitstream.getBundles();
         for (Bundle bundle : bundles) {
+            //We also need to remove the bitstream id when it's set as bundle's primary bitstream
+            if(bitstream.equals(bundle.getPrimaryBitstream())) {
+                bundle.unsetPrimaryBitstreamID();
+            }
             bundle.removeBitstream(bitstream);
         }
 

--- a/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
@@ -276,6 +276,7 @@ public class BitstreamServiceImpl extends DSpaceObjectServiceImpl<Bitstream> imp
         //Remove our bitstream from all our bundles
         final List<Bundle> bundles = bitstream.getBundles();
         for (Bundle bundle : bundles) {
+            authorizeService.authorizeAction(context, bundle, Constants.REMOVE);
             //We also need to remove the bitstream id when it's set as bundle's primary bitstream
             if(bitstream.equals(bundle.getPrimaryBitstream())) {
                 bundle.unsetPrimaryBitstreamID();

--- a/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
@@ -278,7 +278,7 @@ public class BitstreamServiceImpl extends DSpaceObjectServiceImpl<Bitstream> imp
         for (Bundle bundle : bundles) {
             authorizeService.authorizeAction(context, bundle, Constants.REMOVE);
             //We also need to remove the bitstream id when it's set as bundle's primary bitstream
-            if(bitstream.equals(bundle.getPrimaryBitstream())) {
+            if (bitstream.equals(bundle.getPrimaryBitstream())) {
                 bundle.unsetPrimaryBitstreamID();
             }
             bundle.removeBitstream(bitstream);

--- a/dspace-api/src/main/java/org/dspace/content/Bundle.java
+++ b/dspace-api/src/main/java/org/dspace/content/Bundle.java
@@ -126,7 +126,7 @@ public class Bundle extends DSpaceObject implements DSpaceObjectLegacySupport {
      * Unset the primary bitstream ID of the bundle
      */
     public void unsetPrimaryBitstreamID() {
-        primaryBitstream = null;
+        setPrimaryBitstreamID(null);
     }
 
     /**

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.6_2023.10.12__Fix-deleted-primary-bitstreams.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.6_2023.10.12__Fix-deleted-primary-bitstreams.sql
@@ -8,7 +8,7 @@
 
 BEGIN;
 
--- Remove all primary bitstreams that are marked as deleted
+-- Unset any primary bitstream that is marked as deleted
 UPDATE bundle
 SET primary_bitstream_id = NULL
 WHERE primary_bitstream_id IN
@@ -17,7 +17,7 @@ WHERE primary_bitstream_id IN
            INNER JOIN bundle as bl ON bs.uuid = bl.primary_bitstream_id
            WHERE bs.deleted IS TRUE );
 
--- Remove all primary bitstreams that don't make part on bundle's bitstreams
+-- Unset any primary bitstream that don't belong to bundle's bitstreams list
 UPDATE bundle
 SET primary_bitstream_id = NULL
 WHERE primary_bitstream_id IN

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.6_2023.10.12__Fix-deleted-primary-bitstreams.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.6_2023.10.12__Fix-deleted-primary-bitstreams.sql
@@ -17,7 +17,7 @@ WHERE primary_bitstream_id IN
            INNER JOIN bundle as bl ON bs.uuid = bl.primary_bitstream_id
            WHERE bs.deleted IS TRUE );
 
--- Unset any primary bitstream that don't belong to bundle's bitstreams list
+-- Unset any primary bitstream that don't belong to bundle's bitstream list
 UPDATE bundle
 SET primary_bitstream_id = NULL
 WHERE primary_bitstream_id IN

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.6_2023.10.12__Fix-deleted-primary-bitstreams.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.6_2023.10.12__Fix-deleted-primary-bitstreams.sql
@@ -1,3 +1,11 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
 BEGIN;
 
 -- Remove all primary bitstreams that are marked as deleted

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.6_2023.10.12__Fix-deleted-primary-bitstreams.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.6_2023.10.12__Fix-deleted-primary-bitstreams.sql
@@ -1,0 +1,26 @@
+BEGIN;
+
+-- Remove all primary bitstreams that are marked as deleted
+UPDATE bundle
+SET primary_bitstream_id = NULL
+WHERE primary_bitstream_id IN
+    ( SELECT bs.uuid
+           FROM bitstream AS bs
+           INNER JOIN bundle as bl ON bs.uuid = bl.primary_bitstream_id
+           WHERE bs.deleted IS TRUE );
+
+-- Remove all primary bitstreams that don't make part on bundle's bitstreams
+UPDATE bundle
+SET primary_bitstream_id = NULL
+WHERE primary_bitstream_id IN
+    ( SELECT bl.primary_bitstream_id
+           FROM bundle as bl
+           WHERE bl.primary_bitstream_id IS NOT NULL
+               AND bl.primary_bitstream_id NOT IN
+                   ( SELECT bitstream_id
+                          FROM bundle2bitstream AS b2b
+                          WHERE b2b.bundle_id = bl.uuid
+                   )
+    );
+
+COMMIT;

--- a/dspace-api/src/test/java/org/dspace/content/BitstreamTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/BitstreamTest.java
@@ -447,10 +447,6 @@ public class BitstreamTest extends AbstractDSpaceObjectTest {
         Item item = installItemService.installItem(context, workspaceItem);
         Bundle b = bundleService.create(context, item, "TESTBUNDLE");
 
-        // Allow Item WRITE permissions
-        doNothing().when(authorizeServiceSpy).authorizeAction(context, item, Constants.WRITE);
-        // Allow Bundle ADD permissions
-        doNothing().when(authorizeServiceSpy).authorizeAction(context, b, Constants.ADD);
         // Allow Bundle REMOVE permissions
         doNothing().when(authorizeServiceSpy).authorizeAction(context, b, Constants.REMOVE);
         // Allow Bitstream WRITE permissions

--- a/dspace-api/src/test/java/org/dspace/content/BitstreamTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/BitstreamTest.java
@@ -464,18 +464,18 @@ public class BitstreamTest extends AbstractDSpaceObjectTest {
         File f = new File(testProps.get("test.bitstream").toString());
 
         // Create a new bitstream, which we can delete.
-        Bitstream bs = bitstreamService.create(context, new FileInputStream(f));
-        bundleService.addBitstream(context, b, bs);
+        Bitstream delBS = bitstreamService.create(context, new FileInputStream(f));
+        bundleService.addBitstream(context, b, delBS);
         // set primary bitstream
-        b.setPrimaryBitstreamID(bs);
+        b.setPrimaryBitstreamID(delBS);
         context.restoreAuthSystemState();
 
         // Test that delete will flag the bitstream as deleted
-        assertFalse("testDeleteBitstreamAndUnsetPrimaryBitstreamID 0", bs.isDeleted());
-        assertThat("testDeleteBitstreamAndUnsetPrimaryBitstreamID 1", b.getPrimaryBitstream(), equalTo(bs));
+        assertFalse("testDeleteBitstreamAndUnsetPrimaryBitstreamID 0", delBS.isDeleted());
+        assertThat("testDeleteBitstreamAndUnsetPrimaryBitstreamID 1", b.getPrimaryBitstream(), equalTo(delBS));
         // Delete bitstream
-        bitstreamService.delete(context, bs);
-        assertTrue("testDeleteBitstreamAndUnsetPrimaryBitstreamID 2", bs.isDeleted());
+        bitstreamService.delete(context, delBS);
+        assertTrue("testDeleteBitstreamAndUnsetPrimaryBitstreamID 2", delBS.isDeleted());
 
         // Now test if the primary bitstream was unset from bundle
         assertThat("testDeleteBitstreamAndUnsetPrimaryBitstreamID 3", b.getPrimaryBitstream(), equalTo(null));

--- a/dspace-api/src/test/java/org/dspace/content/BundleTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/BundleTest.java
@@ -514,6 +514,38 @@ public class BundleTest extends AbstractDSpaceObjectTest {
 
 
     /**
+     * Test removeBitstream method and also the unsetPrimaryBitstreamID method, of class Bundle.
+     */
+    @Test
+    public void testRemoveBitstreamAuthAndUnsetPrimaryBitstreamID() throws IOException, SQLException, AuthorizeException {
+        // Allow Item WRITE permissions
+        doNothing().when(authorizeServiceSpy).authorizeAction(context, item, Constants.WRITE);
+        // Allow Bundle ADD permissions
+        doNothing().when(authorizeServiceSpy).authorizeAction(context, b, Constants.ADD);
+        // Allow Bitstream WRITE permissions
+        doNothing().when(authorizeServiceSpy)
+                   .authorizeAction(any(Context.class), any(Bitstream.class), eq(Constants.WRITE));
+        // Allow Bitstream DELETE permissions
+        doNothing().when(authorizeServiceSpy)
+                   .authorizeAction(any(Context.class), any(Bitstream.class), eq(Constants.DELETE));
+
+
+        context.turnOffAuthorisationSystem();
+        //set a value different than default
+        File f = new File(testProps.get("test.bitstream").toString());
+        Bitstream bs = bitstreamService.create(context, new FileInputStream(f));
+        bundleService.addBitstream(context, b, bs);
+        b.setPrimaryBitstreamID(bs);
+        context.restoreAuthSystemState();
+
+        assertThat("testRemoveBitstreamAuthAndUnsetPrimaryBitstreamID 0", b.getPrimaryBitstream(), equalTo(bs));
+        //remove bitstream
+        bundleService.removeBitstream(context, b, bs);
+        //is -1 when not set
+        assertThat("testRemoveBitstreamAuthAndUnsetPrimaryBitstreamID 1", b.getPrimaryBitstream(), equalTo(null));
+    }
+
+    /**
      * Test of update method, of class Bundle.
      */
     @Test

--- a/dspace-api/src/test/java/org/dspace/content/BundleTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/BundleTest.java
@@ -522,6 +522,8 @@ public class BundleTest extends AbstractDSpaceObjectTest {
         doNothing().when(authorizeServiceSpy).authorizeAction(context, item, Constants.WRITE);
         // Allow Bundle ADD permissions
         doNothing().when(authorizeServiceSpy).authorizeAction(context, b, Constants.ADD);
+        // Allow Bundle REMOVE permissions
+        doNothing().when(authorizeServiceSpy).authorizeAction(context, b, Constants.REMOVE);
         // Allow Bitstream WRITE permissions
         doNothing().when(authorizeServiceSpy)
                    .authorizeAction(any(Context.class), any(Bitstream.class), eq(Constants.WRITE));

--- a/dspace-api/src/test/java/org/dspace/content/BundleTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/BundleTest.java
@@ -517,7 +517,8 @@ public class BundleTest extends AbstractDSpaceObjectTest {
      * Test removeBitstream method and also the unsetPrimaryBitstreamID method, of class Bundle.
      */
     @Test
-    public void testRemoveBitstreamAuthAndUnsetPrimaryBitstreamID() throws IOException, SQLException, AuthorizeException {
+    public void testRemoveBitstreamAuthAndUnsetPrimaryBitstreamID()
+            throws IOException, SQLException, AuthorizeException {
         // Allow Item WRITE permissions
         doNothing().when(authorizeServiceSpy).authorizeAction(context, item, Constants.WRITE);
         // Allow Bundle ADD permissions


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #9099

## Description
This PR fixes issue #9099.

## Instructions for Reviewers
The description for reviewing and testing it's on the issue #9099

**To Reproduce**
Steps to reproduce the behavior:
1. Create a new item
2. Upload several files into the item and fill the required data
3. Deposit the item
4. As an admin, Edit that Item and promote one bitstream to be Primary Bitstream (this will reference that bitstream at the bundle level)
5. Please take note of that bitstream's UUID 
6. Delete that bitstream that we promote to primary
7. Check the database (please consider your UUID here):
``` sql
SELECT * FROM bundle WHERE primary_bitstream_id='814aefff-4874-4a97-a7aa-b654172e7a40'
```
8. You should expect to see the `primary_bitstream_id` as `null`

List of changes in this PR:
* I've changed the bundle to force a setModified()
* I've created a new test to address the issue
* I've created a migration sql script to fix existing deleted primary bitstreams