### PR TITLE
fix not resolved thumbnail due to filename issues

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
@@ -403,7 +403,7 @@ public class BitstreamServiceImpl extends DSpaceObjectServiceImpl<Bitstream> imp
 
     @Override
     public Bitstream getThumbnail(Context context, Bitstream bitstream) throws SQLException {
-        Pattern pattern = Pattern.compile("^" + bitstream.getName() + ".([^.]+)$");
+        Pattern pattern = Pattern.compile("^" + Pattern.quote(bitstream.getName()) + ".([^.]+)$");
 
         for (Bundle bundle : bitstream.getBundles()) {
             for (Item item : bundle.getItems()) {

--- a/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
@@ -403,9 +403,7 @@ public class BitstreamServiceImpl extends DSpaceObjectServiceImpl<Bitstream> imp
 
     @Override
     public Bitstream getThumbnail(Context context, Bitstream bitstream) throws SQLException {
-        Pattern pattern = Pattern.compile("^" +
-            (bitstream.getName() != null ? Pattern.quote(bitstream.getName()) : bitstream.getName())
-            + ".([^.]+)$");
+        Pattern pattern = getBitstreamNamePattern(bitstream);
 
         for (Bundle bundle : bitstream.getBundles()) {
             for (Item item : bundle.getItems()) {
@@ -420,6 +418,13 @@ public class BitstreamServiceImpl extends DSpaceObjectServiceImpl<Bitstream> imp
         }
 
         return null;
+    }
+
+    protected Pattern getBitstreamNamePattern(Bitstream bitstream) {
+        if (bitstream.getName() != null) {
+            return Pattern.compile("^" + Pattern.quote(bitstream.getName()) + ".([^.]+)$");
+        }
+        return Pattern.compile("^" + bitstream.getName() + ".([^.]+)$");
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
@@ -403,7 +403,9 @@ public class BitstreamServiceImpl extends DSpaceObjectServiceImpl<Bitstream> imp
 
     @Override
     public Bitstream getThumbnail(Context context, Bitstream bitstream) throws SQLException {
-        Pattern pattern = Pattern.compile("^" + Pattern.quote(bitstream.getName()) + ".([^.]+)$");
+        Pattern pattern = Pattern.compile("^" +
+            (bitstream.getName() != null ? Pattern.quote(bitstream.getName()) : bitstream.getName())
+            + ".([^.]+)$");
 
         for (Bundle bundle : bitstream.getBundles()) {
             for (Item item : bundle.getItems()) {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestRepositoryIT.java
@@ -1696,6 +1696,53 @@ public class BitstreamRestRepositoryIT extends AbstractControllerIntegrationTest
     }
 
     @Test
+    public void thumbnailEndpointTestWithSpecialCharactersInFileName() throws Exception {
+        // Given an Item
+        context.turnOffAuthorisationSystem();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .build();
+
+        Collection col1 = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Collection 1").build();
+
+        Item item = ItemBuilder.createItem(context, col1)
+            .withTitle("Test item -- thumbnail")
+            .withIssueDate("2017-10-17")
+            .withAuthor("Smith, Donald").withAuthor("Doe, John")
+            .build();
+
+        Bundle originalBundle = BundleBuilder.createBundle(context, item)
+            .withName(Constants.DEFAULT_BUNDLE_NAME)
+            .build();
+        Bundle thumbnailBundle = BundleBuilder.createBundle(context, item)
+            .withName("THUMBNAIL")
+            .build();
+
+        InputStream is = IOUtils.toInputStream("dummy", "utf-8");
+
+        // With an ORIGINAL Bitstream & matching THUMBNAIL Bitstream containing special characters in filenames
+        Bitstream bitstream = BitstreamBuilder.createBitstream(context, originalBundle, is)
+            .withName("test (2023) file.pdf")
+            .withMimeType("application/pdf")
+            .build();
+        Bitstream thumbnail = BitstreamBuilder.createBitstream(context, thumbnailBundle, is)
+            .withName("test (2023) file.pdf.jpg")
+            .withMimeType("image/jpeg")
+            .build();
+
+        context.restoreAuthSystemState();
+
+        String tokenAdmin = getAuthToken(admin.getEmail(), password);
+
+        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream.getID() + "/thumbnail"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.uuid", Matchers.is(thumbnail.getID().toString())))
+            .andExpect(jsonPath("$.type", is("bitstream")));
+    }
+
+    @Test
     public void thumbnailEndpointMultipleThumbnailsWithPrimaryBitstreamTest() throws Exception {
         // Given an Item
         context.turnOffAuthorisationSystem();


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/DSpace/issues/9112

## Description
Modify the construction of the regular expression pattern. Use the literal form of the filename for retrieving the thumbnail ignoring special characters in the filename which affect the regex.

## Instructions for Reviewers
List of changes in this PR:
* quote regex pattern where the bitstream file name is being used.
* Adopted Test. Without the change mentioned above this test should fail.

**Include guidance for how to test or review your PR.**
- upload a file with special characters in the name, e.g. ` John Doe (Test) 2021 01.jpg`
- the belonging thumbnail should be correctly generated and shown in the bundle/bitstream administration. In addition the thumbnail should be resolved correctly in the REST API.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
