### PR TITLE
Allow users with write permission to see hidden metadata

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ItemConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ItemConverter.java
@@ -67,7 +67,7 @@ public class ItemConverter
      * Overrides the parent method to include virtual metadata
      * @param context The context
      * @param obj     The object of which the filtered metadata will be retrieved
-     * @return A list of object metadata (including virtual metadata) filtered based on the the hidden metadata
+     * @return A list of object metadata (including virtual metadata) filtered based on the hidden metadata
      * configuration
      */
     @Override
@@ -79,7 +79,7 @@ public class ItemConverter
                                       Objects.isNull(context.getCurrentUser()) || !authorizeService.isAdmin(context))) {
                 return new MetadataValueList(new ArrayList<MetadataValue>());
             }
-            if (context != null && authorizeService.isAdmin(context)) {
+            if (context != null && (authorizeService.isAdmin(context) || itemService.canEdit(context, obj))) {
                 return new MetadataValueList(fullList);
             }
             for (MetadataValue mv : fullList) {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
@@ -3021,10 +3021,10 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         String token = getAuthToken(eperson.getEmail(), password);
 
         getClient(token).perform(get("/api/core/items/" + item.getID()))
-                        .andExpect(status().isOk())
-                        .andExpect(jsonPath("$", ItemMatcher.matchItemProperties(item)))
-                        .andExpect(jsonPath("$.metadata", matchMetadata("dc.title", "Public item 1")))
-                        .andExpect(jsonPath("$.metadata", matchMetadataDoesNotExist("dc.description.provenance")));
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", ItemMatcher.matchItemProperties(item)))
+            .andExpect(jsonPath("$.metadata", matchMetadata("dc.title", "Public item 1")))
+            .andExpect(jsonPath("$.metadata", matchMetadata("dc.description.provenance", "Provenance data")));
 
     }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
@@ -14,6 +14,7 @@ import static org.dspace.app.rest.matcher.MetadataMatcher.matchMetadata;
 import static org.dspace.app.rest.matcher.MetadataMatcher.matchMetadataDoesNotExist;
 import static org.dspace.builder.OrcidHistoryBuilder.createOrcidHistory;
 import static org.dspace.builder.OrcidQueueBuilder.createOrcidQueue;
+import static org.dspace.core.Constants.READ;
 import static org.dspace.core.Constants.WRITE;
 import static org.dspace.orcid.OrcidOperation.DELETE;
 import static org.dspace.profile.OrcidEntitySyncPreference.ALL;
@@ -3025,6 +3026,39 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
             .andExpect(jsonPath("$", ItemMatcher.matchItemProperties(item)))
             .andExpect(jsonPath("$.metadata", matchMetadata("dc.title", "Public item 1")))
             .andExpect(jsonPath("$.metadata", matchMetadata("dc.description.provenance", "Provenance data")));
+
+    }
+
+    @Test
+    public void testHiddenMetadataForUserWithReadRights() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .build();
+        Collection col1 = CollectionBuilder.createCollection(context, parentCommunity).withName("Collection 1").build();
+
+        Item item = ItemBuilder.createItem(context, col1)
+            .withTitle("Public item 1")
+            .withProvenanceData("Provenance data")
+            .build();
+
+        context.restoreAuthSystemState();
+
+
+        ResourcePolicyBuilder.createResourcePolicy(context)
+            .withUser(eperson)
+            .withAction(READ)
+            .withDspaceObject(item)
+            .build();
+
+        String token = getAuthToken(eperson.getEmail(), password);
+
+        getClient(token).perform(get("/api/core/items/" + item.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", ItemMatcher.matchItemProperties(item)))
+            .andExpect(jsonPath("$.metadata", matchMetadata("dc.title", "Public item 1")))
+            .andExpect(jsonPath("$.metadata", matchMetadataDoesNotExist("dc.description.provenance")));
 
     }
 


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/dspace-angular/issues/1997

## Description
This PR shows the hidden metadata to users with item write permissions in order to edit this metadata correctly during submission/revision and edition of archived items.

A test have been modified to allow this new behavior.

## Instructions for Reviewers
Define a hidden metadata and try to reproduce the issue with a normal submitter or local admin. After applying this change, the submitters and local admins should be able to see this hidden metadada during submission/revision.

Also, logged in as a local admin, try adding new values to hidden metadata. This should work properly.

NOTE: this PR changes the behavior of hidden metadata a bit compared to previous versions. In previous versions, a local administrator was not shown the hidden metadata in the item view, although he could see it when editing it. With this change the hidden metadata is also shown in the item view.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
