### PR TITLE
Authentication Method related special groups are put in claim set even if a different authentication method is used

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authenticate/AuthenticationMethod.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/AuthenticationMethod.java
@@ -154,6 +154,22 @@ public interface AuthenticationMethod {
         throws SQLException;
 
     /**
+     * Returns true if the special groups returned by
+     * {@link org.dspace.authenticate.AuthenticationMethod#getSpecialGroups(Context, HttpServletRequest)}
+     * should be implicitly be added to the groups related to the current user. By
+     * default this is true if the authentication method is the actual
+     * authentication mechanism used by the user.
+     * @param  context A valid DSpace context.
+     * @param  request The request that started this operation, or null if not
+     *                 applicable.
+     * @return         true is the special groups must be considered, false
+     *                 otherwise
+     */
+    public default boolean areSpecialGroupsApplicable(Context context, HttpServletRequest request) {
+        return getName().equals(context.getAuthenticationMethod());
+    }
+
+    /**
      * Authenticate the given or implicit credentials.
      * This is the heart of the authentication method: test the
      * credentials for authenticity, and if accepted, attempt to match

--- a/dspace-api/src/main/java/org/dspace/authenticate/AuthenticationServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/AuthenticationServiceImpl.java
@@ -179,10 +179,15 @@ public class AuthenticationServiceImpl implements AuthenticationService {
         int totalLen = 0;
 
         for (AuthenticationMethod method : getAuthenticationMethodStack()) {
-            List<Group> gl = method.getSpecialGroups(context, request);
-            if (gl.size() > 0) {
-                result.addAll(gl);
-                totalLen += gl.size();
+
+            if (method.areSpecialGroupsApplicable(context, request)) {
+
+                List<Group> gl = method.getSpecialGroups(context, request);
+                if (gl.size() > 0) {
+                    result.addAll(gl);
+                    totalLen += gl.size();
+                }
+
             }
         }
 

--- a/dspace-api/src/main/java/org/dspace/authenticate/IPAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/IPAuthentication.java
@@ -253,6 +253,11 @@ public class IPAuthentication implements AuthenticationMethod {
     }
 
     @Override
+    public boolean areSpecialGroupsApplicable(Context context, HttpServletRequest request) {
+        return true;
+    }
+
+    @Override
     public int authenticate(Context context, String username, String password,
                             String realm, HttpServletRequest request) throws SQLException {
         return BAD_ARGS;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/AuthenticationRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/AuthenticationRestControllerIT.java
@@ -8,6 +8,7 @@
 package org.dspace.app.rest;
 
 import static java.lang.Thread.sleep;
+import static org.dspace.app.rest.matcher.GroupMatcher.matchGroupWithName;
 import static org.dspace.app.rest.utils.RegexUtils.REGEX_UUID;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
@@ -1639,6 +1640,71 @@ public class AuthenticationRestControllerIT extends AbstractControllerIntegratio
         } finally {
             orcidConfiguration.setClientId(originalClientId);
         }
+    }
+
+    @Test
+    public void testAreSpecialGroupsApplicable() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        GroupBuilder.createGroup(context)
+            .withName("specialGroupPwd")
+            .build();
+        GroupBuilder.createGroup(context)
+            .withName("specialGroupShib")
+            .build();
+
+        configurationService.setProperty("plugin.sequence.org.dspace.authenticate.AuthenticationMethod", SHIB_AND_PASS);
+        configurationService.setProperty("authentication-password.login.specialgroup", "specialGroupPwd");
+        configurationService.setProperty("authentication-shibboleth.role.faculty", "specialGroupShib");
+        configurationService.setProperty("authentication-shibboleth.default-roles", "faculty");
+
+        context.restoreAuthSystemState();
+
+        String passwordToken = getAuthToken(eperson.getEmail(), password);
+
+        getClient(passwordToken).perform(get("/api/authn/status").param("projection", "full"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", AuthenticationStatusMatcher.matchFullEmbeds()))
+            .andExpect(jsonPath("$", AuthenticationStatusMatcher.matchLinks()))
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$.okay", is(true)))
+            .andExpect(jsonPath("$.authenticated", is(true)))
+            .andExpect(jsonPath("$.authenticationMethod", is("password")))
+            .andExpect(jsonPath("$.type", is("status")))
+            .andExpect(jsonPath("$._links.specialGroups.href", startsWith(REST_SERVER_URL)))
+            .andExpect(jsonPath("$._embedded.specialGroups._embedded.specialGroups",
+                Matchers.containsInAnyOrder(matchGroupWithName("specialGroupPwd"))));
+
+        getClient(passwordToken).perform(get("/api/authn/status/specialGroups").param("projection", "full"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._embedded.specialGroups",
+                Matchers.containsInAnyOrder(matchGroupWithName("specialGroupPwd"))));
+
+        String shibToken = getClient().perform(post("/api/authn/login")
+            .requestAttr("SHIB-MAIL", eperson.getEmail())
+            .requestAttr("SHIB-SCOPED-AFFILIATION", "faculty;staff"))
+            .andExpect(status().isOk())
+            .andReturn().getResponse().getHeader(AUTHORIZATION_HEADER).replace(AUTHORIZATION_TYPE, "");
+
+        getClient(shibToken).perform(get("/api/authn/status").param("projection", "full"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", AuthenticationStatusMatcher.matchFullEmbeds()))
+            .andExpect(jsonPath("$", AuthenticationStatusMatcher.matchLinks()))
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$.okay", is(true)))
+            .andExpect(jsonPath("$.authenticated", is(true)))
+            .andExpect(jsonPath("$.authenticationMethod", is("shibboleth")))
+            .andExpect(jsonPath("$.type", is("status")))
+            .andExpect(jsonPath("$._links.specialGroups.href", startsWith(REST_SERVER_URL)))
+            .andExpect(jsonPath("$._embedded.specialGroups._embedded.specialGroups",
+                Matchers.containsInAnyOrder(matchGroupWithName("specialGroupShib"))));
+
+        getClient(shibToken).perform(get("/api/authn/status/specialGroups").param("projection", "full"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._embedded.specialGroups",
+                Matchers.containsInAnyOrder(matchGroupWithName("specialGroupShib"))));
     }
 
     // Get a short-lived token based on an active login token


### PR DESCRIPTION
## References
* Fixes #9127
* Fixes #9074

## Description
With these changes the system is able to distinguish when special groups are to be put in context, for example only when a specific authentication method is used.

## Instructions for Reviewers

Steps to reproduce the behavior:
- Enable Shibboleth authentication
- Configure a special group to be put in context during Shibboleth Authentication flow
- Login via Password Authentication and go to "Profile" Page
- Authorization special groups you belong to will not list the special group set at point 2

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [X] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
