### PR TITLE
[Port dspace-7_x] Bump org.eclipse.jetty:jetty-http

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <jaxb-runtime.version>2.3.1</jaxb-runtime.version>
         <jcache-version>1.1.0</jcache-version>
         <!-- NOTE: Jetty needed for Solr, Handle Server & tests -->
-        <jetty.version>9.4.52.v20230823</jetty.version>
+        <jetty.version>9.4.53.v20231009</jetty.version>
         <log4j.version>2.20.0</log4j.version>
         <pdfbox-version>2.0.28</pdfbox-version>
         <rome.version>1.19.0</rome.version>


### PR DESCRIPTION
Manual port of #9117 to `dspace-7_x`. 

Bumps [org.eclipse.jetty:jetty-http](https://github.com/eclipse/jetty.project) from 9.4.52.v20230823 to 9.4.53.v20231009.
- [Release notes](https://github.com/eclipse/jetty.project/releases)
- [Commits](https://github.com/eclipse/jetty.project/compare/jetty-9.4.52.v20230823...jetty-9.4.53.v20231009)

---
updated-dependencies:
- dependency-name: org.eclipse.jetty:jetty-http dependency-type: direct:production ...
