### PR TITLE
Verify optional request-a-copy message is not missing or a literal "null" value

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RequestItemRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RequestItemRepository.java
@@ -242,7 +242,10 @@ public class RequestItemRepository
         }
 
         JsonNode responseMessageNode = requestBody.findValue("responseMessage");
-        String message = responseMessageNode.asText();
+        String message = null;
+        if (responseMessageNode != null && !responseMessageNode.isNull()) {
+            message = responseMessageNode.asText();
+        }
 
         ri.setDecision_date(new Date());
         requestItemService.update(context, ri);


### PR DESCRIPTION
## References
* Fixes very minor issue found in review of https://github.com/DSpace/dspace-angular/pull/2439#issuecomment-1773330888

## Description
On `main` or `dspace-7_x` (since https://github.com/DSpace/dspace-angular/pull/2439 was merged), if you submit a "request-a-copy" **approval** message, then the user will see literal "null" text in the email like this:

```
Date: Fri, 20 Oct 2023 19:25:56 +0000 (UTC)
From: dspace-noreply@myu.edu
To: testuser@test.com
Subject: Request for Copy of Restricted Document is Granted

Dear Tim Donohue:

Your request for a copy of the file(s) from the below document has been approved by Demo Site Administrator.  You may find the requested file(s) attached.

Automatic Generation of Headlines for Online Math Questions
http://localhost:4000/handle/123456789/1151

An additional message from Demo Site Administrator follows:

null

Best regards,
The DSpace Started with Docker Compose Team
```

## Instructions for Reviewers
Can be verified by testing via Request-a-Copy
1. As anonymous user submit a request-a-copy request
2. Click on link in the request to approve/reject it.
3. Click approve and do NOT fill in the optional message
4. Verify that the email response no longer says "null" (and also is missing "An additional message from..." section).