### PR TITLE
Create general iiif server

### DIFF
--- a/dspace-iiif/src/main/java/org/dspace/app/iiif/service/AbstractResourceService.java
+++ b/dspace-iiif/src/main/java/org/dspace/app/iiif/service/AbstractResourceService.java
@@ -74,14 +74,19 @@ public abstract class AbstractResourceService {
         IIIF_LOGO_IMAGE = configurationService.getProperty("iiif.logo.image");
         BITSTREAM_PATH_SUFFIX = configurationService.getProperty("iiif.http.suffix");
         SLASH_SUBSTITUTE = configurationService.getProperty("iiif.server.slash_substitute");
+
+        // Set BITSTREAM_PATH_SUFFIX to default empty string, if not set.
+        BITSTREAM_PATH_SUFFIX = BITSTREAM_PATH_SUFFIX != null ? BITSTREAM_PATH_SUFFIX : "";
         /*
            If the variable SLASH_SUBSTITUTE is not empty, replace all occurrences of "/" in BITSTREAM_PATH_PREFIX and
            add it to the IMAGE_SERVICE url.
          */
-        BITSTREAM_PATH_SUFFIX = BITSTREAM_PATH_SUFFIX != null ? BITSTREAM_PATH_SUFFIX : "";
         if (SLASH_SUBSTITUTE != null) {
             IMAGE_SERVICE = IMAGE_SERVICE.concat(BITSTREAM_PATH_PREFIX.replace("/",
                     SLASH_SUBSTITUTE)).concat(SLASH_SUBSTITUTE);
+            /*
+                If BITSTREAM_PATH_SUFFIX is not null, replace slashes there as well.
+             */
             if (BITSTREAM_PATH_SUFFIX != null) {
                 BITSTREAM_PATH_SUFFIX = BITSTREAM_PATH_SUFFIX.replace("/", SLASH_SUBSTITUTE);
             }

--- a/dspace-iiif/src/main/java/org/dspace/app/iiif/service/AbstractResourceService.java
+++ b/dspace-iiif/src/main/java/org/dspace/app/iiif/service/AbstractResourceService.java
@@ -78,7 +78,8 @@ public abstract class AbstractResourceService {
            If the variable SLASH_SUBSTITUTE is not empty, replace all occurrences of "/" in BITSTREAM_PATH_PREFIX and
            add it to the IMAGE_SERVICE url.
          */
-        if (SLASH_SUBSTITUTE != null){
+        BITSTREAM_PATH_SUFFIX = BITSTREAM_PATH_SUFFIX != null ? BITSTREAM_PATH_SUFFIX : "";
+        if (SLASH_SUBSTITUTE != null) {
             IMAGE_SERVICE = IMAGE_SERVICE.concat(BITSTREAM_PATH_PREFIX.replace("/",
                     SLASH_SUBSTITUTE)).concat(SLASH_SUBSTITUTE);
             if (BITSTREAM_PATH_SUFFIX != null) {

--- a/dspace-iiif/src/main/java/org/dspace/app/iiif/service/AbstractResourceService.java
+++ b/dspace-iiif/src/main/java/org/dspace/app/iiif/service/AbstractResourceService.java
@@ -2,6 +2,7 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
+ *
  * http://www.dspace.org/license/
  */
 package org.dspace.app.iiif.service;

--- a/dspace-iiif/src/main/java/org/dspace/app/iiif/service/AbstractResourceService.java
+++ b/dspace-iiif/src/main/java/org/dspace/app/iiif/service/AbstractResourceService.java
@@ -2,7 +2,6 @@
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
- *
  * http://www.dspace.org/license/
  */
 package org.dspace.app.iiif.service;
@@ -28,9 +27,11 @@ public abstract class AbstractResourceService {
     protected String IIIF_ENDPOINT;
     protected String IMAGE_SERVICE;
     protected String SEARCH_URL;
+    protected String SLASH_SUBSTITUTE;
     protected String CLIENT_URL;
     protected String IIIF_LOGO_IMAGE;
     protected String BITSTREAM_PATH_PREFIX;
+    protected String BITSTREAM_PATH_SUFFIX;
     protected int DEFAULT_CANVAS_WIDTH;
     protected int DEFAULT_CANVAS_HEIGHT;
     /**
@@ -71,6 +72,20 @@ public abstract class AbstractResourceService {
         DOCUMENT_VIEWING_HINT = configurationService.getProperty("iiif.document.viewing.hint");
         CLIENT_URL = configurationService.getProperty("dspace.ui.url");
         IIIF_LOGO_IMAGE = configurationService.getProperty("iiif.logo.image");
+        BITSTREAM_PATH_SUFFIX = configurationService.getProperty("iiif.http.suffix");
+        SLASH_SUBSTITUTE = configurationService.getProperty("iiif.server.slash_substitute");
+        /*
+           If the variable SLASH_SUBSTITUTE is not empty, replace all occurrences of "/" in BITSTREAM_PATH_PREFIX and
+           add it to the IMAGE_SERVICE url.
+         */
+        if (SLASH_SUBSTITUTE != null){
+            IMAGE_SERVICE = IMAGE_SERVICE.concat(BITSTREAM_PATH_PREFIX.replace("/",
+                    SLASH_SUBSTITUTE)).concat(SLASH_SUBSTITUTE);
+            if (BITSTREAM_PATH_SUFFIX != null) {
+                BITSTREAM_PATH_SUFFIX = BITSTREAM_PATH_SUFFIX.replace("/", SLASH_SUBSTITUTE);
+            }
+        }
+
     }
 
     protected void setDefaultCanvasDimensions() {

--- a/dspace-iiif/src/main/java/org/dspace/app/iiif/service/ImageContentService.java
+++ b/dspace-iiif/src/main/java/org/dspace/app/iiif/service/ImageContentService.java
@@ -44,7 +44,7 @@ public class ImageContentService extends AbstractResourceService {
      * @return
      */
     protected ImageContentGenerator getImageContent(UUID uuid, String mimetype, ProfileGenerator profile, String path) {
-        return new ImageContentGenerator(IMAGE_SERVICE + uuid + path)
+        return new ImageContentGenerator(IMAGE_SERVICE + uuid + BITSTREAM_PATH_SUFFIX + path)
                 .setFormat(mimetype)
                 .addService(getImageService(profile, uuid.toString()));
     }
@@ -62,7 +62,7 @@ public class ImageContentService extends AbstractResourceService {
      * @return object representing the Image Service
      */
     private ImageServiceGenerator getImageService(ProfileGenerator profile, String uuid) {
-        return new ImageServiceGenerator(IMAGE_SERVICE + uuid).setProfile(profile);
+        return new ImageServiceGenerator(IMAGE_SERVICE + uuid + BITSTREAM_PATH_SUFFIX).setProfile(profile);
     }
 
 }

--- a/dspace/config/modules/iiif.cfg
+++ b/dspace/config/modules/iiif.cfg
@@ -7,6 +7,15 @@ iiif.enabled = false
 # uuid is appended to this URL
 iiif.image.server = http://localhost:8182/iiif/2/
 
+# The slash substitute, which is used in the IIIF-Server settings. Allows you to use one central IIIF-Server for more
+# than one DSpace-instance. If not set, prefix and suffix must be set on the iiif-server. This value must be exactly the
+# same as the setting on iiif-server.
+# iiif.server.slash_substitute = __
+
+# The suffix which must be added to the uri to retrieve the bitstream. Can be added here, to avoid special settings on
+# the IIIF-Server. The standard suffix in DSpace-settings is "/content". If not set, no suffix will be added.
+# iiif.http.suffix = /content
+
 # Base URL of the search service used to support the (experimental) IIIF Search
 # capability. The actual path will depend on how search is being supported.
 # This example uses the solr plugin https://dbmdz.github.io/solr-ocrhighlighting/


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #9030 

## Description
This PR aims to enable DSpace with one IIIF-Server. In the moment every single DSpace-instance needs a dedicated IIIF-Server to work with. Using two new configuration parameters to give institutions the possibility to use one general IIIF-Server for all there services (including one or more DSpace instances).  

## Instructions for Reviewers
This PR comes with only a few changes to Java classes AbstractResourceService and ImageContentService and two new parameters to the IIIF-module.

List of changes in this PR:
* Added Parameters `iiif.server.slash_substitute` and `iiif.http.suffix` to dspace/config/modules/iiif.cfg
* Use parameters to adjust creation of manifest files.

**Include guidance for how to test or review your PR.**
* Run a new DSpace-Instance including IIIF so set `iiif.enabled = true` and uncomment `iiif.server.slash_substitute = __` and `iiif.http.suffix = /content`. Don't put a path prefix and suffix on the iiif-server side.
* Check the manifest of a image bitsream: [dspace.server.url]/iiif/<uuid>/manifest
* The links to the iiif-server must look like this: `[iiif.server.url]/https:____<[dspace.server.url] + __api__core__bitstreams>__<uuid>__content/full/90,/0/default.jpg`
 * install the frontend including the mirador viewer
 * Set `dspace.iiif.enabled=true` for an item and check, if the Viewer displays the bitstreams


## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
