### PR TITLE
Return both user and operational LDAP attributes

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
@@ -494,6 +494,8 @@ public class LDAPAuthentication
                 try {
                     SearchControls ctrls = new SearchControls();
                     ctrls.setSearchScope(ldap_search_scope_value);
+                    // Fetch both user attributes '*' (eg. uid, cn) and operational attributes '+' (eg. memberOf)
+                    ctrls.setReturningAttributes(new String[] {"*", "+"});
 
                     String searchName;
                     if (useTLS) {
@@ -700,13 +702,13 @@ public class LDAPAuthentication
     /*
      * Add authenticated users to the group defined in dspace.cfg by
      * the authentication-ldap.login.groupmap.* key.
-     * 
+     *
      * @param dn
      *  The string containing distinguished name of the user
-     * 
+     *
      * @param group
      *  List of strings with LDAP dn of groups
-     * 
+     *
      * @param context
      *  DSpace context
      */


### PR DESCRIPTION
## References
Fixes #9151 

## Description
Explicitly request both user and operation attributes for LDAP group search as the default searching does not include operational attributes.

This is required to fetch the `memberOf` attribute when checking LDAP group membership.


## Instructions for Reviewers
This change is relevant for LDAP environments that utilise the memberOf overlay to assign group membership within the LDAP schema.

https://man7.org/linux/man-pages/man5/slapo-memberof.5.html

References for the change:
https://stackoverflow.com/questions/38013340/retrieving-operational-internal-ldap-attributes-via-jndi-in-one-batch
https://www.zytrax.com/books/ldap/ch3/#operational


## Testing the changes
Testing would require a working LDAP environment that uses the memberOf overlay.

Example `local.cfg`:
```
authentication-ldap.login.groupmap.attribute = memberOf
authentication-ldap.login.groupmap.1 = cn=dspace-administrators\,ou=DSpace\,ou=Groups\,dc=example\,dc=com:Administrator
```
I have verified the change on my local LDAP server environment that uses memberOf overlay.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
