### PR TITLE
Cache 'Administrator' group to improve performance of Workflow Tasks Page.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authorize/AuthorizeServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/AuthorizeServiceImpl.java
@@ -451,7 +451,7 @@ public class AuthorizeServiceImpl implements AuthorizeService {
         if (e == null) {
             return false; // anonymous users can't be admins....
         } else {
-            return groupService.isMember(c, e, Group.ADMIN);
+            return groupService.isMember(c, e, c.getAdminGroup());
         }
     }
 

--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -128,6 +128,11 @@ public class Context implements AutoCloseable {
 
     private DBConnection dbConnection;
 
+    /**
+     * The default administrator group
+     */
+    private Group adminGroup;
+
     public enum Mode {
         READ_ONLY,
         READ_WRITE,
@@ -950,5 +955,16 @@ public class Context implements AutoCloseable {
      */
     public boolean isContextUserSwitched() {
         return currentUserPreviousState != null;
+    }
+
+    /**
+     * Returns the default "Administrator" group for DSpace administrators.
+     * The result is cached in the 'adminGroup' field, so it is only looked up once.
+     * This is done to improve performance, as this method is called quite often.
+     */
+    public Group getAdminGroup() throws SQLException {
+        return (adminGroup == null) ? EPersonServiceFactory.getInstance()
+                                                           .getGroupService()
+                                                           .findByName(this, Group.ADMIN) : adminGroup;
     }
 }


### PR DESCRIPTION
## References
* Fixes #9053 (although more improvements are suggested there)

## Description
Based on performance testing, with large amounts of Groups, the retrieval from the admin group from the database slows down

## Instructions for Reviewers
The only change it to cache the Administrator Group, but only within the scope of one context.
This ensures the Group only is retrieved once in a request

This improved processing time from 14.5 seconds to 10.5 seconds on a database with many databases for the `server/api/discover/search/objects?sort=score,DESC&page=0&size=10&configuration=workflow&embed=thumbnail&embed=item%2Fthumbnail` call

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
