### PR TITLE
DS-9059: removes options to ping search engines when generating sitemaps

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1403,19 +1403,6 @@ sitemap.dir = ${dspace.dir}/sitemaps
 # Defaults to "sitemaps", which means they are available at ${dspace.server.url}/sitemaps/
 # sitemap.path = sitemaps
 
-#
-# Comma-separated list of search engine URLs to 'ping' when a new Sitemap has
-# been created.  Include everything except the Sitemap URL itself (which will
-# be URL-encoded and appended to form the actual URL 'pinged').
-#
-sitemap.engineurls = http://www.google.com/webmasters/sitemaps/ping?sitemap=
-
-# Add this to the above parameter if you have an application ID with Yahoo
-# (Replace REPLACE_ME with your application ID)
-# http://search.yahooapis.com/SiteExplorerService/V1/updateNotification?appid=REPLACE_ME&url=
-#
-# No known Sitemap 'ping' URL for MSN/Live search
-
 # Define cron for how frequently the sitemap should refresh.
 # Defaults to running daily at 1:15am
 # Cron syntax is defined at https://www.quartz-scheduler.org/api/2.3.0/org/quartz/CronTrigger.html


### PR DESCRIPTION
## References
* Fixes #9059 

## Description
This small PR removes the search engine pinging options from the sitemap generation process. NOTE: if this is merged then the ping options should be removed from the SEO documentation: https://wiki.lyrasis.org/display/DSDOC7x/Search+Engine+Optimization

## Instructions for Reviewers
1. Deploy the PR and check that the search engine ping options are no longer available with the sitemap generation process.

## Checklist
- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [X] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
