### PR TITLE
Improve sitemap performance and exclude restricted and undiscoverable content

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -1031,9 +1031,8 @@ public class SolrServiceImpl implements SearchService, IndexingService {
                         // Add information about our search fields
                         for (String field : searchFields) {
                             List<String> valuesAsString = new ArrayList<>();
-                            for (Object o : doc.getFieldValues(field)) {
-                                valuesAsString.add(String.valueOf(o));
-                            }
+                            Optional.ofNullable(doc.getFieldValues(field))
+                                    .ifPresent(l -> l.forEach(o -> valuesAsString.add(String.valueOf(o))));
                             resultDoc.addSearchField(field, valuesAsString.toArray(new String[valuesAsString.size()]));
                         }
                         result.addSearchDocument(indexableObject, resultDoc);

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SitemapRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SitemapRestControllerIT.java
@@ -236,8 +236,37 @@ public class SitemapRestControllerIT extends AbstractControllerIntegrationTest {
                                       .andReturn();
 
         String response = result.getResponse().getContentAsString();
+        // contains a link to communities: [dspace.ui.url]/communities/<uuid>
+        assertTrue(response
+                .contains(configurationService.getProperty("dspace.ui.url") + "/communities/" + community.getID()));
+        // contains a link to collections: [dspace.ui.url]/collections/<uuid>
+        assertTrue(response
+                .contains(configurationService.getProperty("dspace.ui.url") + "/collections/" + collection.getID()));
         // contains a link to items: [dspace.ui.url]/items/<uuid>
         assertTrue(response.contains(configurationService.getProperty("dspace.ui.url") + "/items/" + item1.getID()));
         assertTrue(response.contains(configurationService.getProperty("dspace.ui.url") + "/items/" + item2.getID()));
+        // contains proper link to entities items
+        assertTrue(response.contains(configurationService.getProperty("dspace.ui.url") + "/entities/publication/"
+                + entityPublication.getID()));
+        assertFalse(response
+                .contains(configurationService.getProperty("dspace.ui.url") + "/items/" + entityPublication.getID()));
+        // does not contain links to restricted content
+        assertFalse(response.contains(
+                configurationService.getProperty("dspace.ui.url") + "/communities/" + communityRestricted.getID()));
+        assertFalse(response.contains(
+                configurationService.getProperty("dspace.ui.url") + "/collections/" + collectionRestricted.getID()));
+        assertFalse(response
+                .contains(configurationService.getProperty("dspace.ui.url") + "/items/" + itemRestricted.getID()));
+        assertFalse(response.contains(configurationService.getProperty("dspace.ui.url") + "/entities/publication/"
+                + entityPublicationRestricted.getID()));
+        assertFalse(response.contains(
+                configurationService.getProperty("dspace.ui.url") + "/items/" + entityPublicationRestricted.getID()));
+        // does not contain links to undiscoverable content
+        assertFalse(response
+                .contains(configurationService.getProperty("dspace.ui.url") + "/items/" + itemUndiscoverable.getID()));
+        assertFalse(response.contains(configurationService.getProperty("dspace.ui.url") + "/entities/publication/"
+                + entityPublicationUndiscoverable.getID()));
+        assertFalse(response.contains(configurationService.getProperty("dspace.ui.url") + "/items/"
+                + entityPublicationUndiscoverable.getID()));
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SitemapRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SitemapRestControllerIT.java
@@ -8,6 +8,7 @@
 package org.dspace.app.rest;
 
 import static org.dspace.builder.ItemBuilder.createItem;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -16,6 +17,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import javax.servlet.ServletException;
 
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.authorize.service.ResourcePolicyService;
 import org.dspace.builder.CollectionBuilder;
 import org.dspace.builder.CommunityBuilder;
 import org.dspace.content.Collection;
@@ -38,10 +40,22 @@ public class SitemapRestControllerIT extends AbstractControllerIntegrationTest {
     @Autowired
     ConfigurationService configurationService;
 
+    @Autowired
+    ResourcePolicyService policyService;
+
     private final static String SITEMAPS_ENDPOINT = "sitemaps";
 
     private Item item1;
     private Item item2;
+    private Item itemRestricted;
+    private Item itemUndiscoverable;
+    private Item entityPublication;
+    private Item entityPublicationRestricted;
+    private Item entityPublicationUndiscoverable;
+    private Community community;
+    private Community communityRestricted;
+    private Collection collection;
+    private Collection collectionRestricted;
 
     @Before
     @Override
@@ -52,8 +66,16 @@ public class SitemapRestControllerIT extends AbstractControllerIntegrationTest {
 
         context.turnOffAuthorisationSystem();
 
-        Community community = CommunityBuilder.createCommunity(context).build();
-        Collection collection = CollectionBuilder.createCollection(context, community).build();
+        community = CommunityBuilder.createCommunity(context).build();
+        communityRestricted = CommunityBuilder.createCommunity(context).build();
+        policyService.removeAllPolicies(context, communityRestricted);
+        collection = CollectionBuilder.createCollection(context, community).build();
+        collectionRestricted = CollectionBuilder.createCollection(context, community).build();
+        Collection publicationCollection = CollectionBuilder.createCollection(context, community)
+                .withEntityType("Publication")
+                .withName("Publication Collection").build();
+        policyService.removeAllPolicies(context, collectionRestricted);
+
         this.item1 = createItem(context, collection)
             .withTitle("Test 1")
             .withIssueDate("2010-10-17")
@@ -62,6 +84,30 @@ public class SitemapRestControllerIT extends AbstractControllerIntegrationTest {
             .withTitle("Test 2")
             .withIssueDate("2015-8-3")
             .build();
+        this.itemRestricted = createItem(context, collection)
+                .withTitle("Test 3")
+                .withIssueDate("2015-8-3")
+                .build();
+        policyService.removeAllPolicies(context, itemRestricted);
+        this.itemUndiscoverable = createItem(context, collection)
+                .withTitle("Test 4")
+                .withIssueDate("2015-8-3")
+                .makeUnDiscoverable()
+                .build();
+        this.entityPublication = createItem(context, publicationCollection)
+                .withTitle("Item Publication")
+                .withIssueDate("2015-8-3")
+                .build();
+        this.entityPublicationRestricted = createItem(context, publicationCollection)
+                .withTitle("Item Publication Restricted")
+                .withIssueDate("2015-8-3")
+                .build();
+        policyService.removeAllPolicies(context, entityPublicationRestricted);
+        this.entityPublicationUndiscoverable = createItem(context, publicationCollection)
+                .withTitle("Item Publication")
+                .withIssueDate("2015-8-3")
+                .makeUnDiscoverable()
+                .build();
 
         runDSpaceScript("generate-sitemaps");
 
@@ -127,9 +173,39 @@ public class SitemapRestControllerIT extends AbstractControllerIntegrationTest {
                                       .andReturn();
 
         String response = result.getResponse().getContentAsString();
+        // contains a link to communities: [dspace.ui.url]/communities/<uuid>
+        assertTrue(response
+                .contains(configurationService.getProperty("dspace.ui.url") + "/communities/" + community.getID()));
+        // contains a link to collections: [dspace.ui.url]/collections/<uuid>
+        assertTrue(response
+                .contains(configurationService.getProperty("dspace.ui.url") + "/collections/" + collection.getID()));
         // contains a link to items: [dspace.ui.url]/items/<uuid>
         assertTrue(response.contains(configurationService.getProperty("dspace.ui.url") + "/items/" + item1.getID()));
         assertTrue(response.contains(configurationService.getProperty("dspace.ui.url") + "/items/" + item2.getID()));
+        // contains proper link to entities items
+        assertTrue(response.contains(configurationService.getProperty("dspace.ui.url") + "/entities/publication/"
+                + entityPublication.getID()));
+        assertFalse(response
+                .contains(configurationService.getProperty("dspace.ui.url") + "/items/" + entityPublication.getID()));
+        // does not contain links to restricted content
+        assertFalse(response.contains(
+                configurationService.getProperty("dspace.ui.url") + "/communities/" + communityRestricted.getID()));
+        assertFalse(response.contains(
+                configurationService.getProperty("dspace.ui.url") + "/collections/" + collectionRestricted.getID()));
+        assertFalse(response
+                .contains(configurationService.getProperty("dspace.ui.url") + "/items/" + itemRestricted.getID()));
+        assertFalse(response.contains(configurationService.getProperty("dspace.ui.url") + "/entities/publication/"
+                + entityPublicationRestricted.getID()));
+        assertFalse(response.contains(
+                configurationService.getProperty("dspace.ui.url") + "/items/" + entityPublicationRestricted.getID()));
+        // does not contain links to undiscoverable content
+        assertFalse(response
+                .contains(configurationService.getProperty("dspace.ui.url") + "/items/" + itemUndiscoverable.getID()));
+        assertFalse(response.contains(configurationService.getProperty("dspace.ui.url") + "/entities/publication/"
+                + entityPublicationUndiscoverable.getID()));
+        assertFalse(response.contains(configurationService.getProperty("dspace.ui.url") + "/items/"
+                + entityPublicationUndiscoverable.getID()));
+
     }
 
     @Test


### PR DESCRIPTION
## References
* Fixes #3182 
* Fixes #5394 
* Fixes #5343 
## Description
The sitemap generator logic has been reviewed to rely mostly on discovery to retrieve communities, collections and items in a paginated way. As we are now using discovery and there is no user in our context we automatically get only public visible item.

## Instructions for Reviewers
Review the improved ITs they show the scenarios that were reported to be buggy. This build show that the new IT tests with the current code fail
https://github.com/4Science/DSpace/actions/runs/6783139075/job/18436770293

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [n/a ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [n/a ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [n/a ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
