### PR TITLE
Fix an issue where the `closed` attribute of vocabularies in the submission forms would be neglected

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionFormConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionFormConverter.java
@@ -125,7 +125,7 @@ public class SubmissionFormConverter implements DSpaceConverter<DCInputSet, Subm
                                                         dcinput.getVocabulary()));
                     selMd.setClosed(
                             isClosed(dcinput.getSchema(), dcinput.getElement(), dcinput.getQualifier(),
-                                    dcinput.getPairsType(), dcinput.getVocabulary()));
+                                    dcinput.getPairsType(), dcinput.getVocabulary(), dcinput.isClosedVocabulary()));
                 } else {
                     inputRest.setType(inputType);
                 }
@@ -145,7 +145,7 @@ public class SubmissionFormConverter implements DSpaceConverter<DCInputSet, Subm
                         selMd.setControlledVocabulary(getAuthorityName(dcinput.getSchema(), dcinput.getElement(),
                                 pairs.get(idx + 1), dcinput.getPairsType(), dcinput.getVocabulary()));
                         selMd.setClosed(isClosed(dcinput.getSchema(), dcinput.getElement(),
-                                dcinput.getQualifier(), null, dcinput.getVocabulary()));
+                                dcinput.getQualifier(), null, dcinput.getVocabulary(), dcinput.isClosedVocabulary()));
                     }
                     selectableMetadata.add(selMd);
                 }
@@ -212,9 +212,11 @@ public class SubmissionFormConverter implements DSpaceConverter<DCInputSet, Subm
     }
 
     private boolean isClosed(String schema, String element, String qualifier, String valuePairsName,
-            String vocabularyName) {
-        if (StringUtils.isNotBlank(valuePairsName) || StringUtils.isNotBlank(vocabularyName)) {
+            String vocabularyName, boolean isClosedVocabulary) {
+        if (StringUtils.isNotBlank(valuePairsName)) {
             return true;
+        } else if (StringUtils.isNotBlank(vocabularyName)) {
+            return isClosedVocabulary;
         }
         return authorityUtils.isClosed(schema, element, qualifier);
     }


### PR DESCRIPTION
## References
* Fixes DSpace/dspace-angular#2435 (**combined with the PR below**)
* Related to DSpace/dspace-angular#2602
## Description
Fixes the faulty `isClosed()` method which would not keep the 'closed' atrribute in mind from the submission form

## Instructions for Reviewers

You can test this PR by:
- Setting up the relevant back and front end locally
- Create a submission form with both closed and non-closed vocabulary controlled fields, for the tag and onebox types
   - Use the following rows in your "traditionalpageone" for example 
```
            <row>
                <field>
                    <dc-schema>dc</dc-schema>
                    <dc-element>subject</dc-element>
                    <dc-qualifier></dc-qualifier>
                    <!-- An input-type of tag MUST be marked as repeatable -->
                    <repeatable>true</repeatable>
                    <label>Subject Keywords (default)</label>
                    <input-type>tag</input-type>
                    <hint>Enter appropriate subject keywords or phrases.</hint>
                    <required></required>
                    <vocabulary>srsc</vocabulary>
                </field>
            </row>
            <row>
                <field>
                    <dc-schema>dc</dc-schema>
                    <dc-element>subject</dc-element>
                    <dc-qualifier></dc-qualifier>
                    <!-- An input-type of tag MUST be marked as repeatable -->
                    <repeatable>true</repeatable>
                    <label>Subject Keywords (closed false)</label>
                    <input-type>tag</input-type>
                    <hint>Enter appropriate subject keywords or phrases.</hint>
                    <required></required>
                    <vocabulary closed="false">srsc</vocabulary>
                </field>
            </row>
            <row>
                <field>
                    <dc-schema>dc</dc-schema>
                    <dc-element>subject</dc-element>
                    <dc-qualifier></dc-qualifier>
                    <!-- An input-type of tag MUST be marked as repeatable -->
                    <repeatable>true</repeatable>
                    <label>Subject Keywords (closed true)</label>
                    <input-type>tag</input-type>
                    <hint>Enter appropriate subject keywords or phrases.</hint>
                    <required></required>
                    <vocabulary closed="true">srsc</vocabulary>
                </field>
            </row>
            <row>
                <field>
                    <dc-schema>dc</dc-schema>
                    <dc-element>subject</dc-element>
                    <dc-qualifier></dc-qualifier>
                    <!-- An input-type of tag MUST be marked as repeatable -->
                    <repeatable>true</repeatable>
                    <label>Subject Keywords (default)</label>
                    <input-type>onebox</input-type>
                    <hint>Enter appropriate subject keywords or phrases.</hint>
                    <required></required>
                    <vocabulary>srsc</vocabulary>
                </field>
            </row>
            <row>
                <field>
                    <dc-schema>dc</dc-schema>
                    <dc-element>subject</dc-element>
                    <dc-qualifier></dc-qualifier>
                    <!-- An input-type of tag MUST be marked as repeatable -->
                    <repeatable>true</repeatable>
                    <label>Subject Keywords (closed false)</label>
                    <input-type>onebox</input-type>
                    <hint>Enter appropriate subject keywords or phrases.</hint>
                    <required></required>
                    <vocabulary closed="false">srsc</vocabulary>
                </field>
            </row>
            <row>
                <field>
                    <dc-schema>dc</dc-schema>
                    <dc-element>subject</dc-element>
                    <dc-qualifier></dc-qualifier>
                    <!-- An input-type of tag MUST be marked as repeatable -->
                    <repeatable>true</repeatable>
                    <label>Subject Keywords (closed true)</label>
                    <input-type>onebox</input-type>
                    <hint>Enter appropriate subject keywords or phrases.</hint>
                    <required></required>
                    <vocabulary closed="true">srsc</vocabulary>
                </field>
            </row>
``` 
- Verify that you can now input custom values for vocabulary controlled fields that are **not** closed
   - For the `onebox` input type this is done by using the new "Add" button
   - For `tag` input type this is done by simply typing your value, if values from the vocabulary would match these should be displayed **first** and your custom value should be added to the bottom of the list. If no values from the vocabulary match, simply entering your value does the job
- Verify that you can **not** enter custom values for vocabulary controlled fields that are closed 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
