### PR TITLE
[#9192] Makes forgot-password link removable

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/AuthorizeUtil.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/AuthorizeUtil.java
@@ -628,10 +628,21 @@ public class AuthorizeUtil {
             // actually expected to be returning true.
             // For example the LDAP canSelfRegister will return true due to auto-register, while that
             // does not imply a new user can register explicitly
-            return AuthenticateServiceFactory.getInstance().getAuthenticationService()
-                                             .allowSetPassword(context, request, null);
+            return authorizePasswordChange(context, request);
         }
         return false;
+    }
+
+    /**
+     * This method will return a boolean indicating whether the current user is allowed to reset the password
+     * or not
+     *
+     * @return          A boolean indicating whether the current user can reset its password or not
+     * @throws SQLException If something goes wrong
+     */
+    public static boolean authorizeForgotPassword() {
+        return DSpaceServicesFactory.getInstance().getConfigurationService()
+                             .getBooleanProperty("user.forgot-password", true);
     }
 
     /**
@@ -647,13 +658,25 @@ public class AuthorizeUtil {
             if (eperson != null && eperson.canLogIn()) {
                 HttpServletRequest request = new DSpace().getRequestService().getCurrentRequest()
                                                          .getHttpServletRequest();
-                return AuthenticateServiceFactory.getInstance().getAuthenticationService()
-                                                 .allowSetPassword(context, request, null);
+                return authorizePasswordChange(context, request);
             }
         } catch (SQLException e) {
             log.error("Something went wrong trying to retrieve EPerson for email: " + email, e);
         }
         return false;
+    }
+
+    /**
+     * Checks if the current configuration has at least one password based authentication method
+     *
+     * @param context Dspace Context
+     * @param request Current Request
+     * @return True if the password change is enabled
+     * @throws SQLException
+     */
+    protected static boolean authorizePasswordChange(Context context, HttpServletRequest request) throws SQLException {
+        return AuthenticateServiceFactory.getInstance().getAuthenticationService()
+                                         .allowSetPassword(context, request, null);
     }
 
     /**

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/EPersonForgotPasswordFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/EPersonForgotPasswordFeature.java
@@ -1,0 +1,58 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.authorization.impl;
+
+import java.sql.SQLException;
+
+import org.dspace.app.rest.authorization.AuthorizationFeature;
+import org.dspace.app.rest.authorization.AuthorizationFeatureDocumentation;
+import org.dspace.app.rest.model.BaseObjectRest;
+import org.dspace.app.rest.model.EPersonRest;
+import org.dspace.app.rest.model.SiteRest;
+import org.dspace.app.util.AuthorizeUtil;
+import org.dspace.core.Context;
+import org.springframework.stereotype.Component;
+
+/**
+ * Checks if the user provided is allowed to request a password reset.
+ * If none user specified, checks if the current context is allowed to set the password.
+ *
+ * @author Vincenzo Mecca (vins01-4science - vincenzo.mecca at 4science.com)
+ **/
+@Component
+@AuthorizationFeatureDocumentation(name = EPersonForgotPasswordFeature.NAME,
+    description = "It can be used to check password reset for an eperson")
+public class EPersonForgotPasswordFeature implements AuthorizationFeature {
+
+    public static final String NAME = "epersonForgotPassword";
+
+    @Override
+    public boolean isAuthorized(Context context, BaseObjectRest object) throws SQLException {
+        boolean isEperson = object instanceof EPersonRest;
+        boolean isSite = object instanceof SiteRest;
+        if (!isEperson && !isSite) {
+            return false;
+        }
+        if (!AuthorizeUtil.authorizeForgotPassword()) {
+            return false;
+        }
+        if (isEperson) {
+            return AuthorizeUtil.authorizeUpdatePassword(context, ((EPersonRest) object).getEmail());
+        }
+        return true;
+    }
+
+    @Override
+    public String[] getSupportedTypes() {
+        return new String[] {
+            SiteRest.CATEGORY + "." + SiteRest.NAME,
+            EPersonRest.CATEGORY + "." + EPersonRest.NAME
+        };
+    }
+
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RegistrationRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RegistrationRestRepository.java
@@ -127,6 +127,9 @@ public class RegistrationRestRepository extends DSpaceRestRepository<Registratio
         }
         if (eperson != null && accountType.equalsIgnoreCase(TYPE_FORGOT)) {
             try {
+                if (!AuthorizeUtil.authorizeForgotPassword()) {
+                    throw new AccessDeniedException("Password reset is not allowed!");
+                }
                 if (!AuthorizeUtil.authorizeUpdatePassword(context, eperson.getEmail())) {
                     throw new DSpaceBadRequestException("Password cannot be updated for the given EPerson with email: "
                                                             + eperson.getEmail());

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/EPersonForgotPasswordFeatureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/EPersonForgotPasswordFeatureIT.java
@@ -67,7 +67,6 @@ public class EPersonForgotPasswordFeatureIT extends AbstractControllerIntegratio
 
     @Test
     public void userForgotPasswordSuccessTest() throws Exception {
-        String property = configurationService.getProperty("user.forgot-password");
 
         context.turnOffAuthorisationSystem();
         EPerson epersonPassLogin = EPersonBuilder.createEPerson(context)
@@ -78,41 +77,31 @@ public class EPersonForgotPasswordFeatureIT extends AbstractControllerIntegratio
                                               .build();
         context.restoreAuthSystemState();
 
-        try {
-            configurationService.setProperty("user.forgot-password", true);
-            EPersonRest personRest = personConverter.convert(epersonPassLogin, Projection.DEFAULT);
-            String personUri = utils.linkToSingleResource(personRest, "self").getHref();
+        configurationService.setProperty("user.forgot-password", true);
+        EPersonRest personRest = personConverter.convert(epersonPassLogin, Projection.DEFAULT);
+        String personUri = utils.linkToSingleResource(personRest, "self").getHref();
 
         getClient().perform(get("/api/authz/authorizations/search/object")
                                 .param("uri", personUri)
                                 .param("feature", epersonForgotPasswordFeature.getName()))
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$.page.totalElements", greaterThan(0)));
-        } finally {
-            configurationService.setProperty("user.forgot-password", property);
-        }
     }
 
     @Test
     public void userForgotPasswordFeatureUnauthorizedTest() throws Exception {
-        String property = configurationService.getProperty("user.forgot-password");
 
         Site site = siteService.findSite(context);
         SiteRest SiteRest = siteConverter.convert(site, Projection.DEFAULT);
         String siteUri = utils.linkToSingleResource(SiteRest, "self").getHref();
 
-        try {
-            configurationService.setProperty("user.forgot-password", false);
+        configurationService.setProperty("user.forgot-password", false);
 
-            getClient().perform(get("/api/authz/authorizations/search/object")
-                                    .param("uri", siteUri)
-                                    .param("feature", epersonForgotPasswordFeature.getName()))
-                       .andExpect(status().isOk())
-                       .andExpect(jsonPath("$.page.totalElements", is(0)));
-
-        } finally {
-            configurationService.setProperty("user.forgot-password", property);
-        }
+        getClient().perform(get("/api/authz/authorizations/search/object")
+                                .param("uri", siteUri)
+                                .param("feature", epersonForgotPasswordFeature.getName()))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.page.totalElements", is(0)));
     }
 
 
@@ -129,38 +118,26 @@ public class EPersonForgotPasswordFeatureIT extends AbstractControllerIntegratio
 
         EPersonRest personRest = personConverter.convert(noLoginPerson, Projection.DEFAULT);
         String personUri = utils.linkToSingleResource(personRest, "self").getHref();
-        String property = configurationService.getProperty("user.forgot-password");
-        try {
-            configurationService.setProperty("user.forgot-password", true);
+        configurationService.setProperty("user.forgot-password", true);
         getClient().perform(get("/api/authz/authorizations/search/object")
                                 .param("uri", personUri)
                                 .param("feature", epersonForgotPasswordFeature.getName()))
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$.page.totalElements", is(0)));
-        } finally {
-            configurationService.setProperty("user.forgot-password", property);
-        }
     }
 
     @Test
     public void userForgotPasswordUnauthorizedNoPasswordAuthMethodTest() throws Exception {
         //Enable Shibboleth and password login
-        String property =
-            configurationService.getProperty("plugin.sequence.org.dspace.authenticate.AuthenticationMethod");
+        configurationService.setProperty("plugin.sequence.org.dspace.authenticate.AuthenticationMethod", SHIB_ONLY);
 
-        try {
-            configurationService.setProperty("plugin.sequence.org.dspace.authenticate.AuthenticationMethod", SHIB_ONLY);
+        EPersonRest personRest = personConverter.convert(eperson, Projection.DEFAULT);
+        String personUri = utils.linkToSingleResource(personRest, "self").getHref();
 
-            EPersonRest personRest = personConverter.convert(eperson, Projection.DEFAULT);
-            String personUri = utils.linkToSingleResource(personRest, "self").getHref();
-
-            getClient().perform(get("/api/authz/authorizations/search/object")
-                                    .param("uri", personUri)
-                                    .param("feature", epersonForgotPasswordFeature.getName()))
-                       .andExpect(status().isOk())
-                       .andExpect(jsonPath("$.page.totalElements", is(0)));
-        } finally {
-            configurationService.setProperty("plugin.sequence.org.dspace.authenticate.AuthenticationMethod", property);
-        }
+        getClient().perform(get("/api/authz/authorizations/search/object")
+                                .param("uri", personUri)
+                                .param("feature", epersonForgotPasswordFeature.getName()))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.page.totalElements", is(0)));
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/EPersonForgotPasswordFeatureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/EPersonForgotPasswordFeatureIT.java
@@ -14,7 +14,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.dspace.app.rest.authorization.impl.EPersonForgotPasswordFeature;
-import org.dspace.app.rest.authorization.impl.EPersonRegistrationFeature;
 import org.dspace.app.rest.converter.EPersonConverter;
 import org.dspace.app.rest.converter.SiteConverter;
 import org.dspace.app.rest.model.EPersonRest;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/EPersonForgotPasswordFeatureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/EPersonForgotPasswordFeatureIT.java
@@ -1,0 +1,167 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.authorization;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.dspace.app.rest.authorization.impl.EPersonForgotPasswordFeature;
+import org.dspace.app.rest.authorization.impl.EPersonRegistrationFeature;
+import org.dspace.app.rest.converter.EPersonConverter;
+import org.dspace.app.rest.converter.SiteConverter;
+import org.dspace.app.rest.model.EPersonRest;
+import org.dspace.app.rest.model.SiteRest;
+import org.dspace.app.rest.projection.Projection;
+import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.app.rest.utils.Utils;
+import org.dspace.builder.EPersonBuilder;
+import org.dspace.content.Site;
+import org.dspace.content.service.SiteService;
+import org.dspace.eperson.EPerson;
+import org.dspace.services.ConfigurationService;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * @author Vincenzo Mecca (vins01-4science - vincenzo.mecca at 4science.com)
+ **/
+public class EPersonForgotPasswordFeatureIT extends AbstractControllerIntegrationTest {
+    @Autowired
+    private AuthorizationFeatureService authorizationFeatureService;
+
+    @Autowired
+    private ConfigurationService configurationService;
+
+    @Autowired
+    private SiteService siteService;
+
+    @Autowired
+    private SiteConverter siteConverter;
+
+
+    @Autowired
+    private EPersonConverter personConverter;
+
+    @Autowired
+    private Utils utils;
+
+    private AuthorizationFeature epersonForgotPasswordFeature;
+
+    public static final String[] SHIB_ONLY = {"org.dspace.authenticate.ShibAuthentication"};
+
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        epersonForgotPasswordFeature = authorizationFeatureService.find(EPersonForgotPasswordFeature.NAME);
+    }
+
+    @Test
+    public void userForgotPasswordSuccessTest() throws Exception {
+        String property = configurationService.getProperty("user.forgot-password");
+
+        context.turnOffAuthorisationSystem();
+        EPerson epersonPassLogin = EPersonBuilder.createEPerson(context)
+                                              .withNameInMetadata("Vincenzo", "Mecca")
+                                              .withCanLogin(true)
+                                              .withPassword("Strong-Password")
+                                              .withEmail("vincenzo.mecca@4science.it")
+                                              .build();
+        context.restoreAuthSystemState();
+
+        try {
+            configurationService.setProperty("user.forgot-password", true);
+            EPersonRest personRest = personConverter.convert(epersonPassLogin, Projection.DEFAULT);
+            String personUri = utils.linkToSingleResource(personRest, "self").getHref();
+
+        getClient().perform(get("/api/authz/authorizations/search/object")
+                                .param("uri", personUri)
+                                .param("feature", epersonForgotPasswordFeature.getName()))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.page.totalElements", greaterThan(0)));
+        } finally {
+            configurationService.setProperty("user.forgot-password", property);
+        }
+    }
+
+    @Test
+    public void userForgotPasswordFeatureUnauthorizedTest() throws Exception {
+        String property = configurationService.getProperty("user.forgot-password");
+
+        Site site = siteService.findSite(context);
+        SiteRest SiteRest = siteConverter.convert(site, Projection.DEFAULT);
+        String siteUri = utils.linkToSingleResource(SiteRest, "self").getHref();
+
+        try {
+            configurationService.setProperty("user.forgot-password", false);
+
+            getClient().perform(get("/api/authz/authorizations/search/object")
+                                    .param("uri", siteUri)
+                                    .param("feature", epersonForgotPasswordFeature.getName()))
+                       .andExpect(status().isOk())
+                       .andExpect(jsonPath("$.page.totalElements", is(0)));
+
+        } finally {
+            configurationService.setProperty("user.forgot-password", property);
+        }
+    }
+
+
+    @Test
+    public void userForgotPasswordNoLoginTest() throws Exception {
+
+        context.turnOffAuthorisationSystem();
+        EPerson noLoginPerson = EPersonBuilder.createEPerson(context)
+                                      .withNameInMetadata("User", "NoLogin")
+                                      .withCanLogin(false)
+                                      .withPassword("Strong-Password")
+                                      .build();
+        context.restoreAuthSystemState();
+
+        EPersonRest personRest = personConverter.convert(noLoginPerson, Projection.DEFAULT);
+        String personUri = utils.linkToSingleResource(personRest, "self").getHref();
+        String property = configurationService.getProperty("user.forgot-password");
+        try {
+            configurationService.setProperty("user.forgot-password", true);
+        getClient().perform(get("/api/authz/authorizations/search/object")
+                                .param("uri", personUri)
+                                .param("feature", epersonForgotPasswordFeature.getName()))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.page.totalElements", is(0)));
+        } finally {
+            configurationService.setProperty("user.forgot-password", property);
+        }
+    }
+
+    @Test
+    public void userForgotPasswordUnauthorizedNoPasswordAuthMethodTest() throws Exception {
+        //Enable Shibboleth and password login
+        String property =
+            configurationService.getProperty("plugin.sequence.org.dspace.authenticate.AuthenticationMethod");
+
+        try {
+            configurationService.setProperty("plugin.sequence.org.dspace.authenticate.AuthenticationMethod", SHIB_ONLY);
+
+            EPersonRest personRest = personConverter.convert(eperson, Projection.DEFAULT);
+            String personUri = utils.linkToSingleResource(personRest, "self").getHref();
+
+            getClient().perform(get("/api/authz/authorizations/search/object")
+                                    .param("uri", personUri)
+                                    .param("feature", epersonForgotPasswordFeature.getName()))
+                       .andExpect(status().isOk())
+                       .andExpect(jsonPath("$.page.totalElements", is(0)));
+        } finally {
+            configurationService.setProperty("plugin.sequence.org.dspace.authenticate.AuthenticationMethod", property);
+        }
+    }
+}

--- a/dspace/config/modules/authentication-password.cfg
+++ b/dspace/config/modules/authentication-password.cfg
@@ -7,7 +7,10 @@
 #
 
 # self-registration can be disabled completely by setting the user.registration property to false
-# user.registration = false
+#user.registration = false
+
+# forgot-password can be disabled completely by setting the user.forgot-password property to false
+#user.forgot-password = false
 
 # Only emails ending in the following domains are allowed to self-register
 # Example - example.com domain : @example.com


### PR DESCRIPTION
## References
* Fixes #9192 
* Requires DSpace/dspace-angular#2624

## Description
This PR introduces a new `AuthorizationFeature` that checks for the forgot-password feature.
The same feature can also check, whenever is provided, that the user is able to update its password.

## Instructions for Reviewers
Try to enable the additional configuration:
```cfg
user.forgot-password = false
```
inside the `authentication-password.cfg` and check that it is not shown inside the login-component, in both:
- dropdown login menu
- login page

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
