### PR TITLE
CrossRefImport: ignore empty responses rather than generating empty phantom ImportRecords

### DIFF
--- a/dspace-api/src/main/java/org/dspace/importer/external/crossref/CrossRefImportMetadataSourceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/crossref/CrossRefImportMetadataSourceServiceImpl.java
@@ -162,7 +162,9 @@ public class CrossRefImportMetadataSourceServiceImpl extends AbstractImportMetad
             Iterator<JsonNode> nodes = jsonNode.at("/message/items").iterator();
             while (nodes.hasNext()) {
                 JsonNode node = nodes.next();
-                results.add(transformSourceRecords(node.toString()));
+                if (!node.isMissingNode()) {
+                    results.add(transformSourceRecords(node.toString()));
+                }
             }
             return results;
         }
@@ -196,7 +198,9 @@ public class CrossRefImportMetadataSourceServiceImpl extends AbstractImportMetad
             String responseString = liveImportClient.executeHttpGetRequest(1000, uriBuilder.toString(), params);
             JsonNode jsonNode = convertStringJsonToJsonNode(responseString);
             JsonNode messageNode = jsonNode.at("/message");
-            results.add(transformSourceRecords(messageNode.toString()));
+            if (!messageNode.isMissingNode()) {
+                results.add(transformSourceRecords(messageNode.toString()));
+            }
             return results;
         }
     }
@@ -250,7 +254,9 @@ public class CrossRefImportMetadataSourceServiceImpl extends AbstractImportMetad
             Iterator<JsonNode> nodes = jsonNode.at("/message/items").iterator();
             while (nodes.hasNext()) {
                 JsonNode node = nodes.next();
-                results.add(transformSourceRecords(node.toString()));
+                if (!node.isMissingNode()) {
+                    results.add(transformSourceRecords(node.toString()));
+                }
             }
             return results;
         }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CrossRefImportMetadataSourceServiceIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CrossRefImportMetadataSourceServiceIT.java
@@ -49,6 +49,24 @@ public class CrossRefImportMetadataSourceServiceIT extends AbstractLiveImportInt
     private CrossRefImportMetadataSourceServiceImpl crossRefServiceImpl;
 
     @Test
+    public void crossRefImportMetadataGetNoRecordsTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        CloseableHttpClient originalHttpClient = liveImportClientImpl.getHttpClient();
+        CloseableHttpClient httpClient = Mockito.mock(CloseableHttpClient.class);
+        try {
+            liveImportClientImpl.setHttpClient(httpClient);
+            CloseableHttpResponse response = mockResponse("" , 404, "Not Found");
+            when(httpClient.execute(ArgumentMatchers.any())).thenReturn(response);
+
+            context.restoreAuthSystemState();
+            Collection<ImportRecord> recordsImported = crossRefServiceImpl.getRecords("test query", 0, 2);
+            assertEquals(0, recordsImported.size());
+        } finally {
+            liveImportClientImpl.setHttpClient(originalHttpClient);
+        }
+    }
+
+    @Test
     public void crossRefImportMetadataGetRecordsTest() throws Exception {
         context.turnOffAuthorisationSystem();
         CloseableHttpClient originalHttpClient = liveImportClientImpl.getHttpClient();


### PR DESCRIPTION
Crossref searches for invalid or non-Crossref DOIs result in ImportRecords, visible to the user, without any metadata. Don't create those.

## References
* Fixes #9202
* Related to #9132

## Description
Verify that we have a valid JSON response from Crossref before creating an ImportRecord. The empty string is invalid as JSON and returned for failed matches.

## Instructions for Reviewers

List of changes in this PR:
* Avoid issue #9202 by verifying the JSON node we transform into an ImportRecord isn't a MissingNode.

**Include guidance for how to test or review your PR.** See issue #9202 : attempt to import a DataCite DOI before and after the PR's changes.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
