### PR TITLE
Updated bitstream patch validation

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/BitstreamMetadataValueAddPatchOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/BitstreamMetadataValueAddPatchOperation.java
@@ -48,9 +48,10 @@ public class BitstreamMetadataValueAddPatchOperation extends MetadataValueAddPat
             throws Exception {
         //"path": "/sections/upload/files/0/metadata/dc.title/2"
         //"abspath": "/files/0/metadata/dc.title/2"
+        String stepId = getStepId(path);
         String absolutePath = getAbsolutePath(path);
         String[] split = absolutePath.split("/");
-        bitstreamMetadataValuePathUtils.validate(absolutePath);
+        bitstreamMetadataValuePathUtils.validate(stepId, absolutePath);
         Item item = source.getItem();
         List<Bundle> bundle = itemService.getBundles(item, Constants.CONTENT_BUNDLE_NAME);
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/BitstreamMetadataValueMovePatchOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/BitstreamMetadataValueMovePatchOperation.java
@@ -44,9 +44,10 @@ public class BitstreamMetadataValueMovePatchOperation extends MetadataValueMoveP
             throws Exception {
         //"path": "/sections/upload/files/0/metadata/dc.title/2"
         //"abspath": "/files/0/metadata/dc.title/2"
+        String stepId = getStepId(path);
         String absolutePath = getAbsolutePath(path);
         String[] splitTo = absolutePath.split("/");
-        bitstreamMetadataValuePathUtils.validate(absolutePath);
+        bitstreamMetadataValuePathUtils.validate(stepId, absolutePath);
         Item item = source.getItem();
         List<Bundle> bundle = itemService.getBundles(item, Constants.CONTENT_BUNDLE_NAME);
         for (Bundle bb : bundle) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/BitstreamMetadataValueRemovePatchOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/BitstreamMetadataValueRemovePatchOperation.java
@@ -44,9 +44,10 @@ public class BitstreamMetadataValueRemovePatchOperation extends MetadataValueRem
             Object value) throws Exception {
         //"path": "/sections/upload/files/0/metadata/dc.title/2"
         //"abspath": "/files/0/metadata/dc.title/2"
+        String stepId = getStepId(path);
         String absolutePath = getAbsolutePath(path);
         String[] split = absolutePath.split("/");
-        bitstreamMetadataValuePathUtils.validate(absolutePath);
+        bitstreamMetadataValuePathUtils.validate(stepId, absolutePath);
         Item item = source.getItem();
         List<Bundle> bundle = itemService.getBundles(item, Constants.CONTENT_BUNDLE_NAME);
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/BitstreamMetadataValueReplacePatchOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/BitstreamMetadataValueReplacePatchOperation.java
@@ -47,9 +47,10 @@ public class BitstreamMetadataValueReplacePatchOperation extends MetadataValueRe
             Object value) throws Exception {
         //"path": "/sections/upload/files/0/metadata/dc.title/2"
         //"abspath": "/files/0/metadata/dc.title/2"
+        String stepId = getStepId(path);
         String absolutePath = getAbsolutePath(path);
         String[] split = absolutePath.split("/");
-        bitstreamMetadataValuePathUtils.validate(absolutePath);
+        bitstreamMetadataValuePathUtils.validate(stepId, absolutePath);
         Item item = source.getItem();
         List<Bundle> bundle = itemService.getBundles(item, Constants.CONTENT_BUNDLE_NAME);
         for (Bundle bb : bundle) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/BitstreamResourcePolicyAddPatchOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/BitstreamResourcePolicyAddPatchOperation.java
@@ -54,7 +54,7 @@ public class BitstreamResourcePolicyAddPatchOperation extends AddPatchOperation<
         Item item = source.getItem();
 
         List<Bundle> bundle = itemService.getBundles(item, Constants.CONTENT_BUNDLE_NAME);
-        ;
+
         UploadConfiguration uploadConfig = uploadConfigurationService.getMap().get(splitPath[2]);
         for (Bundle bb : bundle) {
             int idx = 0;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/PatchOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/PatchOperation.java
@@ -60,6 +60,15 @@ public abstract class PatchOperation<T extends Object> {
         return absolutePath;
     }
 
+    public String getStepId(String fullpath) {
+        String[] path = fullpath.substring(1).split("/", 3);
+        String stepId = "";
+        if (path.length > 1) {
+            stepId = path[1];
+        }
+        return stepId;
+    }
+
     protected abstract Class<T[]> getArrayClassForEvaluation();
 
     protected abstract Class<T> getClassForEvaluation();

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/UploadStep.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/UploadStep.java
@@ -48,7 +48,7 @@ public class UploadStep extends AbstractProcessingStep
 
     private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(UploadStep.class);
 
-    public static final String UPLOAD_STEP_METADATA_SECTION = "bitstream-metadata";
+    public static String UPLOAD_STEP_ID;
 
     @Override
     public DataUpload getData(SubmissionService submissionService, InProgressSubmission obj,
@@ -94,6 +94,7 @@ public class UploadStep extends AbstractProcessingStep
             if (op.getPath().contains(UPLOAD_STEP_ACCESSCONDITIONS_OPERATION_ENTRY)) {
                 instance = stepConf.getType() + "." + UPLOAD_STEP_ACCESSCONDITIONS_OPERATION_ENTRY;
             } else if (op.getPath().contains(UPLOAD_STEP_METADATA_PATH)) {
+                UPLOAD_STEP_ID = stepConf.getId();
                 instance = UPLOAD_STEP_METADATA_OPERATION_ENTRY;
             } else if (op.getPath().contains(PRIMARY_FLAG_ENTRY)) {
                 instance = PRIMARY_FLAG_ENTRY;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/UploadStep.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/UploadStep.java
@@ -48,8 +48,6 @@ public class UploadStep extends AbstractProcessingStep
 
     private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(UploadStep.class);
 
-    public static String UPLOAD_STEP_ID;
-
     @Override
     public DataUpload getData(SubmissionService submissionService, InProgressSubmission obj,
                               SubmissionStepConfig config) throws Exception {
@@ -94,7 +92,6 @@ public class UploadStep extends AbstractProcessingStep
             if (op.getPath().contains(UPLOAD_STEP_ACCESSCONDITIONS_OPERATION_ENTRY)) {
                 instance = stepConf.getType() + "." + UPLOAD_STEP_ACCESSCONDITIONS_OPERATION_ENTRY;
             } else if (op.getPath().contains(UPLOAD_STEP_METADATA_PATH)) {
-                UPLOAD_STEP_ID = stepConf.getId();
                 instance = UPLOAD_STEP_METADATA_OPERATION_ENTRY;
             } else if (op.getPath().contains(PRIMARY_FLAG_ENTRY)) {
                 instance = PRIMARY_FLAG_ENTRY;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/BitstreamMetadataValuePathUtils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/BitstreamMetadataValuePathUtils.java
@@ -12,6 +12,9 @@ import org.dspace.app.rest.submit.step.UploadStep;
 import org.dspace.app.util.DCInputSet;
 import org.dspace.app.util.DCInputsReader;
 import org.dspace.app.util.DCInputsReaderException;
+import org.dspace.submit.model.UploadConfiguration;
+import org.dspace.submit.model.UploadConfigurationService;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * Utils class offering methods to validate patch operations for bitstream metadata in the submission
@@ -21,6 +24,9 @@ import org.dspace.app.util.DCInputsReaderException;
 public class BitstreamMetadataValuePathUtils {
 
     private DCInputsReader inputReader;
+
+    @Autowired
+    UploadConfigurationService uploadConfigurationService;
 
     BitstreamMetadataValuePathUtils() throws DCInputsReaderException {
         inputReader = new DCInputsReader();
@@ -36,13 +42,14 @@ public class BitstreamMetadataValuePathUtils {
      * @throws UnprocessableEntityException if the path is invalid
      */
     public void validate(String absolutePath) throws DCInputsReaderException {
+        UploadConfiguration uploadService = uploadConfigurationService.getMap().get(UploadStep.UPLOAD_STEP_ID);
+        DCInputSet inputConfig = inputReader.getInputsByFormName(uploadService.getMetadata());
         String[] split = absolutePath.split("/");
-        DCInputSet inputConfig = inputReader.getInputsByFormName(UploadStep.UPLOAD_STEP_METADATA_SECTION);
         // according to the rest contract the absolute path must be something like files/:idx/metadata/dc.title
         if (split.length >= 4) {
             if (!inputConfig.isFieldPresent(split[3])) {
                 throw new UnprocessableEntityException("The field " + split[3] + " is not present in section "
-                                                                    + UploadStep.UPLOAD_STEP_METADATA_SECTION);
+                                                                    + UploadStep.UPLOAD_STEP_ID);
             }
         } else {
             throw new UnprocessableEntityException("The path " + absolutePath + " cannot be patched ");

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/BitstreamMetadataValuePathUtils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/BitstreamMetadataValuePathUtils.java
@@ -34,7 +34,8 @@ public class BitstreamMetadataValuePathUtils {
     /**
      * Method to verify that the path included in the patch operation is supported
      * by the submission configuration of the upload section
-     * 
+     *
+     * @param stepId the name of the upload configuration
      * @param absolutePath the path in the json patch operation
      * @throws DCInputsReaderException      if an error occurs reading the
      *                                      submission configuration

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/BitstreamMetadataValuePathUtils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/BitstreamMetadataValuePathUtils.java
@@ -8,7 +8,6 @@
 package org.dspace.app.rest.utils;
 
 import org.dspace.app.rest.exception.UnprocessableEntityException;
-import org.dspace.app.rest.submit.step.UploadStep;
 import org.dspace.app.util.DCInputSet;
 import org.dspace.app.util.DCInputsReader;
 import org.dspace.app.util.DCInputsReaderException;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/BitstreamMetadataValuePathUtils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/BitstreamMetadataValuePathUtils.java
@@ -41,15 +41,15 @@ public class BitstreamMetadataValuePathUtils {
      *                                      submission configuration
      * @throws UnprocessableEntityException if the path is invalid
      */
-    public void validate(String absolutePath) throws DCInputsReaderException {
-        UploadConfiguration uploadService = uploadConfigurationService.getMap().get(UploadStep.UPLOAD_STEP_ID);
+    public void validate(String stepId, String absolutePath) throws DCInputsReaderException {
+        UploadConfiguration uploadService = uploadConfigurationService.getMap().get(stepId);
         DCInputSet inputConfig = inputReader.getInputsByFormName(uploadService.getMetadata());
         String[] split = absolutePath.split("/");
         // according to the rest contract the absolute path must be something like files/:idx/metadata/dc.title
         if (split.length >= 4) {
             if (!inputConfig.isFieldPresent(split[3])) {
                 throw new UnprocessableEntityException("The field " + split[3] + " is not present in section "
-                                                                    + UploadStep.UPLOAD_STEP_ID);
+                                                                    + stepId);
             }
         } else {
             throw new UnprocessableEntityException("The path " + absolutePath + " cannot be patched ");


### PR DESCRIPTION
## Description
Earlier this week I noticed that I could [modify UploadConfigurations](https://wiki.lyrasis.org/display/DSDOC7x/Submission+User+Interface#SubmissionUserInterface-ModifyingmetadataformpresentedforBitstreams) for the UI, but it's not possible to use a custom bitstream metadata submission form. You can create a new `UploadConfiguration` bean that references a custom bitstream metadata form and add this to the `UploadConfigurationService` bean in `access-conditions.xml` (as described in the documentation). This can be mapped to a submission process by handle and the metadata form appears in the UI. But when you submit the changes to the backend the PATCH operation fails.

This is because the backend is hard-coded to use the default "bitstream-metadata" form in `submission-forms.xml` for validation. In fairness, this seems consistent with the documentation. 

The changes in this PR allow for custom bitstream metadata forms in addition to the default "bitstream-metadata" form. 




## Instructions for Reviewers
List of changes in this PR:
* Patch validation changed to use the UploadConfigurationService to read the metadata used for validation.

I believe current IT's provide test coverage.

Testing requires a submission configuration that uses an alternative bitstream metadata form. I suppose it's possible to define the new form in `submission-forms.xml` and then just use this form
name in the  `uploadConfigurationDefault` "metadata" property. A more complete and realistic test is to create a new submission process, but that's probably not necessary for testing.

Question: The dc.title field is required so it seems like we could add a check for the required title field during validation. I wanted to see what others think first.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
