### PR TITLE
[Port dspace-7-x] CrossRefImport: ignore empty responses rather than generating empty phantom ImportRecords

### DIFF
--- a/dspace-api/src/main/java/org/dspace/importer/external/crossref/CrossRefImportMetadataSourceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/crossref/CrossRefImportMetadataSourceServiceImpl.java
@@ -162,7 +162,9 @@ public class CrossRefImportMetadataSourceServiceImpl extends AbstractImportMetad
             Iterator<JsonNode> nodes = jsonNode.at("/message/items").iterator();
             while (nodes.hasNext()) {
                 JsonNode node = nodes.next();
-                results.add(transformSourceRecords(node.toString()));
+                if (!node.isMissingNode()) {
+                    results.add(transformSourceRecords(node.toString()));
+                }
             }
             return results;
         }
@@ -196,7 +198,9 @@ public class CrossRefImportMetadataSourceServiceImpl extends AbstractImportMetad
             String responseString = liveImportClient.executeHttpGetRequest(1000, uriBuilder.toString(), params);
             JsonNode jsonNode = convertStringJsonToJsonNode(responseString);
             JsonNode messageNode = jsonNode.at("/message");
-            results.add(transformSourceRecords(messageNode.toString()));
+            if (!messageNode.isMissingNode()) {
+                results.add(transformSourceRecords(messageNode.toString()));
+            }
             return results;
         }
     }
@@ -250,7 +254,9 @@ public class CrossRefImportMetadataSourceServiceImpl extends AbstractImportMetad
             Iterator<JsonNode> nodes = jsonNode.at("/message/items").iterator();
             while (nodes.hasNext()) {
                 JsonNode node = nodes.next();
-                results.add(transformSourceRecords(node.toString()));
+                if (!node.isMissingNode()) {
+                    results.add(transformSourceRecords(node.toString()));
+                }
             }
             return results;
         }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CrossRefImportMetadataSourceServiceIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CrossRefImportMetadataSourceServiceIT.java
@@ -49,6 +49,24 @@ public class CrossRefImportMetadataSourceServiceIT extends AbstractLiveImportInt
     private CrossRefImportMetadataSourceServiceImpl crossRefServiceImpl;
 
     @Test
+    public void crossRefImportMetadataGetNoRecordsTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        CloseableHttpClient originalHttpClient = liveImportClientImpl.getHttpClient();
+        CloseableHttpClient httpClient = Mockito.mock(CloseableHttpClient.class);
+        try {
+            liveImportClientImpl.setHttpClient(httpClient);
+            CloseableHttpResponse response = mockResponse("" , 404, "Not Found");
+            when(httpClient.execute(ArgumentMatchers.any())).thenReturn(response);
+
+            context.restoreAuthSystemState();
+            Collection<ImportRecord> recordsImported = crossRefServiceImpl.getRecords("test query", 0, 2);
+            assertEquals(0, recordsImported.size());
+        } finally {
+            liveImportClientImpl.setHttpClient(originalHttpClient);
+        }
+    }
+
+    @Test
     public void crossRefImportMetadataGetRecordsTest() throws Exception {
         context.turnOffAuthorisationSystem();
         CloseableHttpClient originalHttpClient = liveImportClientImpl.getHttpClient();


### PR DESCRIPTION
Manual port of #9203 by @philipprumpf to `dspace-7_x`.