### PR TITLE
Add parallel builds for Docker Images in GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
       # https://github.com/actions/checkout
       - name: Checkout codebase
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # https://github.com/actions/setup-java
       - name: Install JDK ${{ matrix.java }}
@@ -53,16 +53,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
-
-      # https://github.com/actions/cache
-      - name: Cache Maven dependencies
-        uses: actions/cache@v3
-        with:
-          # Cache entire ~/.m2/repository
-          path: ~/.m2/repository
-          # Cache key is hash of all pom.xml files. Therefore any changes to POMs will invalidate cache
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-maven-
+          cache: 'maven'
 
       # Run parallel Maven builds based on the above 'strategy.matrix'
       - name: Run Maven ${{ matrix.type }}
@@ -96,7 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Download artifacts from previous 'tests' job
       - name: Download coverage artifacts
@@ -108,10 +99,13 @@ jobs:
       # Retry action: https://github.com/marketplace/actions/retry-action
       # Codecov action: https://github.com/codecov/codecov-action
       - name: Upload coverage to Codecov.io
-        uses: Wandalen/wretry.action@v1.0.36
+        uses: Wandalen/wretry.action@v1.3.0
         with:
           action: codecov/codecov-action@v3
-          # Try upload 5 times max
+          # Ensure codecov-action throws an error when it fails to upload
+          with: |
+            fail_ci_if_error: true
+          # Try re-running action 5 times max
           attempt_limit: 5
           # Run again in 30 seconds
           attempt_delay: 30000

--- a/.github/workflows/codescan.yml
+++ b/.github/workflows/codescan.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       # https://github.com/actions/checkout
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # https://github.com/actions/setup-java
       - name: Install JDK

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,7 +39,7 @@ env:
 jobs:
   ####################################################
   # Build/Push the 'dspace/dspace-dependencies' image.
-  # This image is used by all other jobs.
+  # This image is used by all other DSpace build jobs.
   ####################################################
   dspace-dependencies:
     # Ensure this job never runs on forked repos. It's only executed for 'dspace/dspace'
@@ -49,21 +49,21 @@ jobs:
     steps:
       # https://github.com/actions/checkout
       - name: Checkout codebase
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # https://github.com/docker/setup-buildx-action
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU emulation to build for multiple architectures
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       # https://github.com/docker/login-action
       - name: Login to DockerHub
         # Only login if not a PR, as PRs only trigger a Docker build and not a push
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
@@ -72,7 +72,7 @@ jobs:
       # Get Metadata for docker_build_deps step below
       - name: Sync metadata (tags, labels) from GitHub to Docker for 'dspace-dependencies' image
         id: meta_build_deps
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: dspace/dspace-dependencies
           tags: ${{ env.IMAGE_TAGS }}
@@ -81,7 +81,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push 'dspace-dependencies' image
         id: docker_build_deps
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./Dockerfile.dependencies
@@ -106,21 +106,21 @@ jobs:
     steps:
       # https://github.com/actions/checkout
       - name: Checkout codebase
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # https://github.com/docker/setup-buildx-action
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU emulation to build for multiple architectures
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       # https://github.com/docker/login-action
       - name: Login to DockerHub
         # Only login if not a PR, as PRs only trigger a Docker build and not a push
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
@@ -128,7 +128,7 @@ jobs:
       # Get Metadata for docker_build step below
       - name: Sync metadata (tags, labels) from GitHub to Docker for 'dspace' image
         id: meta_build
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: dspace/dspace
           tags: ${{ env.IMAGE_TAGS }}
@@ -136,7 +136,7 @@ jobs:
 
       - name: Build and push 'dspace' image
         id: docker_build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./Dockerfile
@@ -161,21 +161,21 @@ jobs:
     steps:
       # https://github.com/actions/checkout
       - name: Checkout codebase
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # https://github.com/docker/setup-buildx-action
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU emulation to build for multiple architectures
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       # https://github.com/docker/login-action
       - name: Login to DockerHub
         # Only login if not a PR, as PRs only trigger a Docker build and not a push
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
@@ -183,7 +183,7 @@ jobs:
       # Get Metadata for docker_build_test step below
       - name: Sync metadata (tags, labels) from GitHub to Docker for 'dspace-test' image
         id: meta_build_test
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@5
         with:
           images: dspace/dspace
           tags: ${{ env.IMAGE_TAGS }}
@@ -194,7 +194,7 @@ jobs:
 
       - name: Build and push 'dspace-test' image
         id: docker_build_test
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./Dockerfile.test
@@ -219,21 +219,21 @@ jobs:
     steps:
       # https://github.com/actions/checkout
       - name: Checkout codebase
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # https://github.com/docker/setup-buildx-action
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU emulation to build for multiple architectures
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       # https://github.com/docker/login-action
       - name: Login to DockerHub
         # Only login if not a PR, as PRs only trigger a Docker build and not a push
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
@@ -241,7 +241,7 @@ jobs:
       # Get Metadata for docker_build_test step below
       - name: Sync metadata (tags, labels) from GitHub to Docker for 'dspace-cli' image
         id: meta_build_cli
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: dspace/dspace-cli
           tags: ${{ env.IMAGE_TAGS }}
@@ -249,7 +249,7 @@ jobs:
 
       - name: Build and push 'dspace-cli' image
         id: docker_build_cli
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./Dockerfile.cli
@@ -276,17 +276,17 @@ jobs:
 
       # https://github.com/docker/setup-buildx-action
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU emulation to build for multiple architectures
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       # https://github.com/docker/login-action
       - name: Login to DockerHub
         # Only login if not a PR, as PRs only trigger a Docker build and not a push
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
@@ -294,7 +294,7 @@ jobs:
       # Get Metadata for docker_build_solr step below
       - name: Sync metadata (tags, labels) from GitHub to Docker for 'dspace-solr' image
         id: meta_build_solr
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: dspace/dspace-solr
           tags: ${{ env.IMAGE_TAGS }}
@@ -302,7 +302,7 @@ jobs:
 
       - name: Build and push 'dspace-solr' image
         id: docker_build_solr
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./dspace/src/main/docker/dspace-solr/Dockerfile
@@ -325,21 +325,21 @@ jobs:
     steps:
       # https://github.com/actions/checkout
       - name: Checkout codebase
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # https://github.com/docker/setup-buildx-action
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU emulation to build for multiple architectures
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       # https://github.com/docker/login-action
       - name: Login to DockerHub
         # Only login if not a PR, as PRs only trigger a Docker build and not a push
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
@@ -347,7 +347,7 @@ jobs:
       # Get Metadata for docker_build_postgres step below
       - name: Sync metadata (tags, labels) from GitHub to Docker for 'dspace-postgres-pgcrypto' image
         id: meta_build_postgres
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: dspace/dspace-postgres-pgcrypto
           tags: ${{ env.IMAGE_TAGS }}
@@ -355,7 +355,7 @@ jobs:
 
       - name: Build and push 'dspace-postgres-pgcrypto' image
         id: docker_build_postgres
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           # Must build out of subdirectory to have access to install script for pgcrypto
           context: ./dspace/src/main/docker/dspace-postgres-pgcrypto/
@@ -379,21 +379,21 @@ jobs:
     steps:
       # https://github.com/actions/checkout
       - name: Checkout codebase
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # https://github.com/docker/setup-buildx-action
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU emulation to build for multiple architectures
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       # https://github.com/docker/login-action
       - name: Login to DockerHub
         # Only login if not a PR, as PRs only trigger a Docker build and not a push
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
@@ -401,7 +401,7 @@ jobs:
       # Get Metadata for docker_build_postgres_loadsql step below
       - name: Sync metadata (tags, labels) from GitHub to Docker for 'dspace-postgres-pgcrypto-loadsql' image
         id: meta_build_postgres_loadsql
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: dspace/dspace-postgres-pgcrypto
           tags: ${{ env.IMAGE_TAGS }}
@@ -412,7 +412,7 @@ jobs:
 
       - name: Build and push 'dspace-postgres-pgcrypto-loadsql' image
         id: docker_build_postgres_loadsql
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           # Must build out of subdirectory to have access to install script for pgcrypto
           context: ./dspace/src/main/docker/dspace-postgres-pgcrypto-curl/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -183,7 +183,7 @@ jobs:
       # Get Metadata for docker_build_test step below
       - name: Sync metadata (tags, labels) from GitHub to Docker for 'dspace-test' image
         id: meta_build_test
-        uses: docker/metadata-action@5
+        uses: docker/metadata-action@v5
         with:
           images: dspace/dspace
           tags: ${{ env.IMAGE_TAGS }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,7 @@ name: Docker images
 
 # Run this Build for all pushes to 'main' or maintenance branches, or tagged releases.
 # Also run for PRs to ensure PR doesn't break Docker build process
+# NOTE: uses "reusable-docker-build.yml" to actually build each of the Docker images.
 on:
   push:
     branches:
@@ -30,11 +31,6 @@ env:
   # We manage the 'latest' tag ourselves to the 'main' branch (see settings above)
   TAGS_FLAVOR: |
     latest=false
-  # Architectures / Platforms for which we will build Docker images
-  # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
-  # If this is NOT a PR (e.g. a tag or merge commit), also build for ARM64. NOTE: The ARM64 build takes MUCH
-  # longer (around 45mins or so) which is why we only run it when pushing a new Docker image.
-  PLATFORMS: linux/amd64${{ github.event_name != 'pull_request' && ', linux/arm64' || '' }}
 
 jobs:
   ####################################################
@@ -44,54 +40,14 @@ jobs:
   dspace-dependencies:
     # Ensure this job never runs on forked repos. It's only executed for 'dspace/dspace'
     if: github.repository == 'dspace/dspace'
-    runs-on: ubuntu-latest
-
-    steps:
-      # https://github.com/actions/checkout
-      - name: Checkout codebase
-        uses: actions/checkout@v4
-
-      # https://github.com/docker/setup-buildx-action
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      # https://github.com/docker/setup-qemu-action
-      - name: Set up QEMU emulation to build for multiple architectures
-        uses: docker/setup-qemu-action@v3
-
-      # https://github.com/docker/login-action
-      - name: Login to DockerHub
-        # Only login if not a PR, as PRs only trigger a Docker build and not a push
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
-
-      # https://github.com/docker/metadata-action
-      # Get Metadata for docker_build_deps step below
-      - name: Sync metadata (tags, labels) from GitHub to Docker for 'dspace-dependencies' image
-        id: meta_build_deps
-        uses: docker/metadata-action@v5
-        with:
-          images: dspace/dspace-dependencies
-          tags: ${{ env.IMAGE_TAGS }}
-          flavor: ${{ env.TAGS_FLAVOR }}
-
-      # https://github.com/docker/build-push-action
-      - name: Build and push 'dspace-dependencies' image
-        id: docker_build_deps
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./Dockerfile.dependencies
-          platforms: ${{ env.PLATFORMS }}
-          # For pull requests, we run the Docker build (to ensure no PR changes break the build),
-          # but we ONLY do an image push to DockerHub if it's NOT a PR
-          push: ${{ github.event_name != 'pull_request' }}
-          # Use tags / labels provided by 'docker/metadata-action' above
-          tags: ${{ steps.meta_build_deps.outputs.tags }}
-          labels: ${{ steps.meta_build_deps.outputs.labels }}
+    uses: ./.github/workflows/reusable-docker-build.yml
+    with:
+      build_id: dspace-dependencies
+      image_name: dspace/dspace-dependencies
+      dockerfile_path: ./Dockerfile.dependencies
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_ACCESS_TOKEN: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
   #######################################
   # Build/Push the 'dspace/dspace' image
@@ -101,52 +57,18 @@ jobs:
     if: github.repository == 'dspace/dspace'
     # Must run after 'dspace-dependencies' job above
     needs: dspace-dependencies
-    runs-on: ubuntu-latest
-
-    steps:
-      # https://github.com/actions/checkout
-      - name: Checkout codebase
-        uses: actions/checkout@v4
-
-      # https://github.com/docker/setup-buildx-action
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      # https://github.com/docker/setup-qemu-action
-      - name: Set up QEMU emulation to build for multiple architectures
-        uses: docker/setup-qemu-action@v3
-
-      # https://github.com/docker/login-action
-      - name: Login to DockerHub
-        # Only login if not a PR, as PRs only trigger a Docker build and not a push
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
-
-      # Get Metadata for docker_build step below
-      - name: Sync metadata (tags, labels) from GitHub to Docker for 'dspace' image
-        id: meta_build
-        uses: docker/metadata-action@v5
-        with:
-          images: dspace/dspace
-          tags: ${{ env.IMAGE_TAGS }}
-          flavor: ${{ env.TAGS_FLAVOR }}
-
-      - name: Build and push 'dspace' image
-        id: docker_build
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./Dockerfile
-          platforms: ${{ env.PLATFORMS }}
-          # For pull requests, we run the Docker build (to ensure no PR changes break the build),
-          # but we ONLY do an image push to DockerHub if it's NOT a PR
-          push: ${{ github.event_name != 'pull_request' }}
-          # Use tags / labels provided by 'docker/metadata-action' above
-          tags: ${{ steps.meta_build.outputs.tags }}
-          labels: ${{ steps.meta_build.outputs.labels }}
+    uses: ./.github/workflows/reusable-docker-build.yml
+    with:
+      build_id: dspace
+      image_name: dspace/dspace
+      dockerfile_path: ./Dockerfile
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_ACCESS_TOKEN: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+      # Enable redeploy of sandbox & demo if the branch for this image matches the deployment branch of
+      # these sites as specified in reusable-docker-build.xml
+      REDEPLOY_SANDBOX_URL: ${{ secrets.REDEPLOY_SANDBOX_URL }}
+      REDEPLOY_DEMO_URL: ${{ secrets.REDEPLOY_DEMO_URL }}
 
   #############################################################
   # Build/Push the 'dspace/dspace' image ('-test' tag)
@@ -156,55 +78,17 @@ jobs:
     if: github.repository == 'dspace/dspace'
     # Must run after 'dspace-dependencies' job above
     needs: dspace-dependencies
-    runs-on: ubuntu-latest
-
-    steps:
-      # https://github.com/actions/checkout
-      - name: Checkout codebase
-        uses: actions/checkout@v4
-
-      # https://github.com/docker/setup-buildx-action
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      # https://github.com/docker/setup-qemu-action
-      - name: Set up QEMU emulation to build for multiple architectures
-        uses: docker/setup-qemu-action@v3
-
-      # https://github.com/docker/login-action
-      - name: Login to DockerHub
-        # Only login if not a PR, as PRs only trigger a Docker build and not a push
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
-
-      # Get Metadata for docker_build_test step below
-      - name: Sync metadata (tags, labels) from GitHub to Docker for 'dspace-test' image
-        id: meta_build_test
-        uses: docker/metadata-action@v5
-        with:
-          images: dspace/dspace
-          tags: ${{ env.IMAGE_TAGS }}
-          # As this is a test/development image, its tags are all suffixed with "-test". Otherwise, it uses the same
-          # tagging logic as the primary 'dspace/dspace' image above.
-          flavor: ${{ env.TAGS_FLAVOR }}
-            suffix=-test
-
-      - name: Build and push 'dspace-test' image
-        id: docker_build_test
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./Dockerfile.test
-          platforms: ${{ env.PLATFORMS }}
-          # For pull requests, we run the Docker build (to ensure no PR changes break the build),
-          # but we ONLY do an image push to DockerHub if it's NOT a PR
-          push: ${{ github.event_name != 'pull_request' }}
-          # Use tags / labels provided by 'docker/metadata-action' above
-          tags: ${{ steps.meta_build_test.outputs.tags }}
-          labels: ${{ steps.meta_build_test.outputs.labels }}
+    uses: ./.github/workflows/reusable-docker-build.yml
+    with:
+      build_id: dspace-test
+      image_name: dspace/dspace
+      dockerfile_path: ./Dockerfile.test
+      # As this is a test/development image, its tags are all suffixed with "-test". Otherwise, it uses the same
+      # tagging logic as the primary 'dspace/dspace' image above.
+      tags_flavor: suffix=-test
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_ACCESS_TOKEN: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
   ###########################################
   # Build/Push the 'dspace/dspace-cli' image
@@ -214,52 +98,14 @@ jobs:
     if: github.repository == 'dspace/dspace'
     # Must run after 'dspace-dependencies' job above
     needs: dspace-dependencies
-    runs-on: ubuntu-latest
-
-    steps:
-      # https://github.com/actions/checkout
-      - name: Checkout codebase
-        uses: actions/checkout@v4
-
-      # https://github.com/docker/setup-buildx-action
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      # https://github.com/docker/setup-qemu-action
-      - name: Set up QEMU emulation to build for multiple architectures
-        uses: docker/setup-qemu-action@v3
-
-      # https://github.com/docker/login-action
-      - name: Login to DockerHub
-        # Only login if not a PR, as PRs only trigger a Docker build and not a push
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
-
-      # Get Metadata for docker_build_test step below
-      - name: Sync metadata (tags, labels) from GitHub to Docker for 'dspace-cli' image
-        id: meta_build_cli
-        uses: docker/metadata-action@v5
-        with:
-          images: dspace/dspace-cli
-          tags: ${{ env.IMAGE_TAGS }}
-          flavor: ${{ env.TAGS_FLAVOR }}
-
-      - name: Build and push 'dspace-cli' image
-        id: docker_build_cli
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./Dockerfile.cli
-          platforms: ${{ env.PLATFORMS }}
-          # For pull requests, we run the Docker build (to ensure no PR changes break the build),
-          # but we ONLY do an image push to DockerHub if it's NOT a PR
-          push: ${{ github.event_name != 'pull_request' }}
-          # Use tags / labels provided by 'docker/metadata-action' above
-          tags: ${{ steps.meta_build_cli.outputs.tags }}
-          labels: ${{ steps.meta_build_cli.outputs.labels }}
+    uses: ./.github/workflows/reusable-docker-build.yml
+    with:
+      build_id: dspace-cli
+      image_name: dspace/dspace-cli
+      dockerfile_path: ./Dockerfile.cli
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_ACCESS_TOKEN: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
   ###########################################
   # Build/Push the 'dspace/dspace-solr' image
@@ -267,52 +113,14 @@ jobs:
   dspace-solr:
     # Ensure this job never runs on forked repos. It's only executed for 'dspace/dspace'
     if: github.repository == 'dspace/dspace'
-    runs-on: ubuntu-latest
-
-    steps:
-      # https://github.com/actions/checkout
-      - name: Checkout codebase
-        uses: actions/checkout@v3
-
-      # https://github.com/docker/setup-buildx-action
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      # https://github.com/docker/setup-qemu-action
-      - name: Set up QEMU emulation to build for multiple architectures
-        uses: docker/setup-qemu-action@v3
-
-      # https://github.com/docker/login-action
-      - name: Login to DockerHub
-        # Only login if not a PR, as PRs only trigger a Docker build and not a push
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
-
-      # Get Metadata for docker_build_solr step below
-      - name: Sync metadata (tags, labels) from GitHub to Docker for 'dspace-solr' image
-        id: meta_build_solr
-        uses: docker/metadata-action@v5
-        with:
-          images: dspace/dspace-solr
-          tags: ${{ env.IMAGE_TAGS }}
-          flavor: ${{ env.TAGS_FLAVOR }}
-
-      - name: Build and push 'dspace-solr' image
-        id: docker_build_solr
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./dspace/src/main/docker/dspace-solr/Dockerfile
-          platforms: ${{ env.PLATFORMS }}
-          # For pull requests, we run the Docker build (to ensure no PR changes break the build),
-          # but we ONLY do an image push to DockerHub if it's NOT a PR
-          push: ${{ github.event_name != 'pull_request' }}
-          # Use tags / labels provided by 'docker/metadata-action' above
-          tags: ${{ steps.meta_build_solr.outputs.tags }}
-          labels: ${{ steps.meta_build_solr.outputs.labels }}
+    uses: ./.github/workflows/reusable-docker-build.yml
+    with:
+      build_id: dspace-solr
+      image_name: dspace/dspace-solr
+      dockerfile_path: ./dspace/src/main/docker/dspace-solr/Dockerfile
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_ACCESS_TOKEN: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
   ###########################################################
   # Build/Push the 'dspace/dspace-postgres-pgcrypto' image
@@ -320,53 +128,16 @@ jobs:
   dspace-postgres-pgcrypto:
     # Ensure this job never runs on forked repos. It's only executed for 'dspace/dspace'
     if: github.repository == 'dspace/dspace'
-    runs-on: ubuntu-latest
-
-    steps:
-      # https://github.com/actions/checkout
-      - name: Checkout codebase
-        uses: actions/checkout@v4
-
-      # https://github.com/docker/setup-buildx-action
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      # https://github.com/docker/setup-qemu-action
-      - name: Set up QEMU emulation to build for multiple architectures
-        uses: docker/setup-qemu-action@v3
-
-      # https://github.com/docker/login-action
-      - name: Login to DockerHub
-        # Only login if not a PR, as PRs only trigger a Docker build and not a push
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
-
-      # Get Metadata for docker_build_postgres step below
-      - name: Sync metadata (tags, labels) from GitHub to Docker for 'dspace-postgres-pgcrypto' image
-        id: meta_build_postgres
-        uses: docker/metadata-action@v5
-        with:
-          images: dspace/dspace-postgres-pgcrypto
-          tags: ${{ env.IMAGE_TAGS }}
-          flavor: ${{ env.TAGS_FLAVOR }}
-
-      - name: Build and push 'dspace-postgres-pgcrypto' image
-        id: docker_build_postgres
-        uses: docker/build-push-action@v5
-        with:
-          # Must build out of subdirectory to have access to install script for pgcrypto
-          context: ./dspace/src/main/docker/dspace-postgres-pgcrypto/
-          dockerfile: Dockerfile
-          platforms: ${{ env.PLATFORMS }}
-          # For pull requests, we run the Docker build (to ensure no PR changes break the build),
-          # but we ONLY do an image push to DockerHub if it's NOT a PR
-          push: ${{ github.event_name != 'pull_request' }}
-          # Use tags / labels provided by 'docker/metadata-action' above
-          tags: ${{ steps.meta_build_postgres.outputs.tags }}
-          labels: ${{ steps.meta_build_postgres.outputs.labels }}
+    uses: ./.github/workflows/reusable-docker-build.yml
+    with:
+      build_id: dspace-postgres-pgcrypto
+      image_name: dspace/dspace-postgres-pgcrypto
+      # Must build out of subdirectory to have access to install script for pgcrypto.
+      # NOTE: this context will build the image based on the Dockerfile in the specified directory
+      dockerfile_context: ./dspace/src/main/docker/dspace-postgres-pgcrypto/
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_ACCESS_TOKEN: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
   ########################################################################
   # Build/Push the 'dspace/dspace-postgres-pgcrypto' image (-loadsql tag)
@@ -374,53 +145,16 @@ jobs:
   dspace-postgres-pgcrypto-loadsql:
     # Ensure this job never runs on forked repos. It's only executed for 'dspace/dspace'
     if: github.repository == 'dspace/dspace'
-    runs-on: ubuntu-latest
-
-    steps:
-      # https://github.com/actions/checkout
-      - name: Checkout codebase
-        uses: actions/checkout@v4
-
-      # https://github.com/docker/setup-buildx-action
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      # https://github.com/docker/setup-qemu-action
-      - name: Set up QEMU emulation to build for multiple architectures
-        uses: docker/setup-qemu-action@v3
-
-      # https://github.com/docker/login-action
-      - name: Login to DockerHub
-        # Only login if not a PR, as PRs only trigger a Docker build and not a push
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
-
-      # Get Metadata for docker_build_postgres_loadsql step below
-      - name: Sync metadata (tags, labels) from GitHub to Docker for 'dspace-postgres-pgcrypto-loadsql' image
-        id: meta_build_postgres_loadsql
-        uses: docker/metadata-action@v5
-        with:
-          images: dspace/dspace-postgres-pgcrypto
-          tags: ${{ env.IMAGE_TAGS }}
-          # Suffix all tags with "-loadsql". Otherwise, it uses the same
-          # tagging logic as the primary 'dspace/dspace-postgres-pgcrypto' image above.
-          flavor: ${{ env.TAGS_FLAVOR }}
-            suffix=-loadsql
-
-      - name: Build and push 'dspace-postgres-pgcrypto-loadsql' image
-        id: docker_build_postgres_loadsql
-        uses: docker/build-push-action@v5
-        with:
-          # Must build out of subdirectory to have access to install script for pgcrypto
-          context: ./dspace/src/main/docker/dspace-postgres-pgcrypto-curl/
-          dockerfile: Dockerfile
-          platforms: ${{ env.PLATFORMS }}
-          # For pull requests, we run the Docker build (to ensure no PR changes break the build),
-          # but we ONLY do an image push to DockerHub if it's NOT a PR
-          push: ${{ github.event_name != 'pull_request' }}
-          # Use tags / labels provided by 'docker/metadata-action' above
-          tags: ${{ steps.meta_build_postgres_loadsql.outputs.tags }}
-          labels: ${{ steps.meta_build_postgres_loadsql.outputs.labels }}
+    uses: ./.github/workflows/reusable-docker-build.yml
+    with:
+      build_id: dspace-postgres-pgcrypto-loadsql
+      image_name: dspace/dspace-postgres-pgcrypto
+      # Must build out of subdirectory to have access to install script for pgcrypto.
+      # NOTE: this context will build the image based on the Dockerfile in the specified directory
+      dockerfile_context: ./dspace/src/main/docker/dspace-postgres-pgcrypto-curl/
+      # Suffix all tags with "-loadsql". Otherwise, it uses the same
+      # tagging logic as the primary 'dspace/dspace-postgres-pgcrypto' image above.
+      tags_flavor: suffix=-loadsql
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_ACCESS_TOKEN: ${{ secrets.DOCKER_ACCESS_TOKEN }}

--- a/.github/workflows/port_merged_pull_request.yml
+++ b/.github/workflows/port_merged_pull_request.yml
@@ -23,11 +23,11 @@ jobs:
     if: github.event.pull_request.merged
     steps:
       # Checkout code
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # Port PR to other branch (ONLY if labeled with "port to")
       # See https://github.com/korthout/backport-action
       - name: Create backport pull requests
-        uses: korthout/backport-action@v1
+        uses: korthout/backport-action@v2
         with:
           # Trigger based on a "port to [branch]" label on PR
           # (This label must specify the branch name to port to)

--- a/.github/workflows/pull_request_opened.yml
+++ b/.github/workflows/pull_request_opened.yml
@@ -21,4 +21,4 @@ jobs:
     # Assign the PR to whomever created it. This is useful for visualizing assignments on project boards
     # See https://github.com/toshimaru/auto-author-assign
     - name: Assign PR to creator
-      uses: toshimaru/auto-author-assign@v1.6.2
+      uses: toshimaru/auto-author-assign@v2.0.1

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -1,0 +1,217 @@
+#
+# DSpace's reusable Docker build/push workflow.
+#
+# This is used by docker.yml for all Docker image builds
+name: Reusable DSpace Docker Build
+
+on:
+  workflow_call:
+    # Possible Inputs to this reusable job
+    inputs:
+      # Build name/id for this Docker build. Used for digest storage to avoid digest overlap between builds.
+      build_id:
+        required: true
+        type: string
+      # Requires the image name to build (e.g dspace/dspace-test)
+      image_name:
+        required: true
+        type: string
+      # Optionally the path to the Dockerfile to use for the build. (Default is [dockerfile_context]/Dockerfile)
+      dockerfile_path:
+        required: false
+        type: string
+      # Optionally the context directory to build the Dockerfile within. Defaults to "." (current directory)
+      dockerfile_context:
+        required: false
+        type: string
+      # If Docker image should have additional tag flavor details (e.g. a suffix), it may be passed in.
+      tags_flavor:
+        required: false
+        type: string
+    secrets:
+      # Requires that Docker login info be passed in as secrets.
+      DOCKER_USERNAME:
+        required: true
+      DOCKER_ACCESS_TOKEN:
+        required: true
+      # These URL secrets are optional. When specified & branch checks match, the redeployment code below will trigger.
+      # Therefore builds which need to trigger redeployment MUST specify these URLs. All others should leave them empty.
+      REDEPLOY_SANDBOX_URL:
+        required: false
+      REDEPLOY_DEMO_URL:
+        required: false
+
+# Define shared default settings as environment variables
+env:
+  IMAGE_NAME: ${{ inputs.image_name }}
+  # Define tags to use for Docker images based on Git tags/branches (for docker/metadata-action)
+  # For a new commit on default branch (main), use the literal tag 'latest' on Docker image.
+  # For a new commit on other branches, use the branch name as the tag for Docker image.
+  # For a new tag, copy that tag name as the tag for Docker image.
+  IMAGE_TAGS: |
+    type=raw,value=latest,enable=${{ github.ref_name == github.event.repository.default_branch }}
+    type=ref,event=branch,enable=${{ github.ref_name != github.event.repository.default_branch }}
+    type=ref,event=tag
+  # Define default tag "flavor" for docker/metadata-action per
+  # https://github.com/docker/metadata-action#flavor-input
+  # We manage the 'latest' tag ourselves to the 'main' branch (see settings above)
+  TAGS_FLAVOR: |
+    latest=false
+    ${{ inputs.tags_flavor }}
+  # When these URL variables are specified & required branch matches, then the sandbox or demo site will be redeployed.
+  # See "Redeploy" steps below for more details.
+  REDEPLOY_SANDBOX_URL: ${{ secrets.REDEPLOY_SANDBOX_URL }}
+  REDEPLOY_DEMO_URL: ${{ secrets.REDEPLOY_DEMO_URL }}
+  # Current DSpace maintenance branch (and architecture) which is deployed to demo.dspace.org / sandbox.dspace.org
+  # (NOTE: No deployment branch specified for sandbox.dspace.org as it uses the default_branch)
+  DEPLOY_DEMO_BRANCH: 'dspace-7_x'
+  DEPLOY_ARCH: 'linux/amd64'
+
+jobs:
+  docker-build:
+
+    strategy:
+      matrix:
+        # Architectures / Platforms for which we will build Docker images
+        arch: [ 'linux/amd64', 'linux/arm64' ]
+        os: [ ubuntu-latest ]
+        isPr:
+          - ${{ github.event_name == 'pull_request' }}
+        # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
+        # The below exclude therefore ensures we do NOT build ARM64 for PRs.
+        exclude:
+          - isPr: true
+            os: ubuntu-latest
+            arch: linux/arm64
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      # https://github.com/actions/checkout
+      - name: Checkout codebase
+        uses: actions/checkout@v4
+
+      # https://github.com/docker/setup-buildx-action
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # https://github.com/docker/setup-qemu-action
+      - name: Set up QEMU emulation to build for multiple architectures
+        uses: docker/setup-qemu-action@v3
+
+      # https://github.com/docker/login-action
+      - name: Login to DockerHub
+        # Only login if not a PR, as PRs only trigger a Docker build and not a push
+        if: ${{ ! matrix.isPr }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+
+      # https://github.com/docker/metadata-action
+      # Get Metadata for docker_build_deps step below
+      - name: Sync metadata (tags, labels) from GitHub to Docker for image
+        id: meta_build
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: ${{ env.IMAGE_TAGS }}
+          flavor: ${{ env.TAGS_FLAVOR }}
+
+      # https://github.com/docker/build-push-action
+      - name: Build and push image
+        id: docker_build
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ inputs.dockerfile_context || '.' }}
+          file: ${{ inputs.dockerfile_path }}
+          platforms: ${{ matrix.arch }}
+          # For pull requests, we run the Docker build (to ensure no PR changes break the build),
+          # but we ONLY do an image push to DockerHub if it's NOT a PR
+          push: ${{ ! matrix.isPr }}
+          # Use tags / labels provided by 'docker/metadata-action' above
+          tags: ${{ steps.meta_build.outputs.tags }}
+          labels: ${{ steps.meta_build.outputs.labels }}
+
+      # Export the digest of Docker build locally (for non PRs only)
+      - name: Export Docker build digest
+        if: ${{ ! matrix.isPr }}
+        run: |
+            mkdir -p /tmp/digests
+            digest="${{ steps.docker_build.outputs.digest }}"
+            touch "/tmp/digests/${digest#sha256:}"
+
+      # Upload digest to an artifact, so that it can be used in manifest below
+      - name: Upload Docker build digest to artifact
+        if: ${{ ! matrix.isPr }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: digests-${{ inputs.build_id }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+      # If this build is NOT a PR and passed in a REDEPLOY_SANDBOX_URL secret,
+      # Then redeploy https://sandbox.dspace.org if this build is for our deployment architecture and 'main' branch.
+      - name: Redeploy sandbox.dspace.org (based on main branch)
+        if: |
+          !matrix.isPR &&
+          env.REDEPLOY_SANDBOX_URL != '' &&
+          matrix.arch == env.DEPLOY_ARCH &&
+          github.ref_name == github.event.repository.default_branch
+        run: |
+          curl -X POST $REDEPLOY_SANDBOX_URL
+
+      # If this build is NOT a PR and passed in a REDEPLOY_DEMO_URL secret,
+      # Then redeploy https://demo.dspace.org if this build is for our deployment architecture and demo branch.
+      - name: Redeploy demo.dspace.org (based on maintenace branch)
+        if: |
+          !matrix.isPR &&
+          env.REDEPLOY_DEMO_URL != '' &&
+          matrix.arch == env.DEPLOY_ARCH &&
+          github.ref_name == env.DEPLOY_DEMO_BRANCH
+        run: |
+          curl -X POST $REDEPLOY_DEMO_URL
+
+  # Merge Docker digests (from various architectures) into a manifest.
+  # This runs after all Docker builds complete above, and it tells hub.docker.com
+  # that these builds should be all included in the manifest for this tag.
+  # (e.g. AMD64 and ARM64 should be listed as options under the same tagged Docker image)
+  docker-build_manifest:
+    if: ${{ github.event_name != 'pull_request' }}
+    runs-on: ubuntu-latest
+    needs:
+      - docker-build
+    steps:
+      - name: Download Docker build digests
+        uses: actions/download-artifact@v3
+        with:
+          name: digests-${{ inputs.build_id }}
+          path: /tmp/digests
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Add Docker metadata for image
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: ${{ env.IMAGE_TAGS }}
+          flavor: ${{ env.TAGS_FLAVOR }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+
+      - name: Create manifest list from digests and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+          $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,10 @@ USER dspace
 ADD --chown=dspace . /app/
 # Build DSpace (note: this build doesn't include the optional, deprecated "dspace-rest" webapp)
 # Copy the dspace-installer directory to /install.  Clean up the build to keep the docker image small
-RUN mvn --no-transfer-progress package && \
+# Maven flags here ensure that we skip building test environment and skip all code verification checks.
+# These flags speed up this compilation as much as reasonably possible.
+ENV MAVEN_FLAGS="-P-test-environment -Denforcer.skip=true -Dcheckstyle.skip=true -Dlicense.skip=true -Dxml.skip=true"
+RUN mvn --no-transfer-progress package ${MAVEN_FLAGS} && \
   mv /app/dspace/target/${TARGET_DIR}/* /install && \
   mvn clean
 

--- a/Dockerfile.dependencies
+++ b/Dockerfile.dependencies
@@ -15,11 +15,6 @@ RUN useradd dspace \
     && mkdir -p /home/dspace \
     && chown -Rv dspace: /home/dspace
 RUN chown -Rv dspace: /app
-# Need git to support buildnumber-maven-plugin, which lets us know what version of DSpace is being run.
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends git \
-    && apt-get purge -y --auto-remove \
-    && rm -rf /var/lib/apt/lists/*
 
 # Switch to dspace user & run below commands as that user
 USER dspace
@@ -28,7 +23,10 @@ USER dspace
 ADD --chown=dspace . /app/
 
 # Trigger the installation of all maven dependencies (hide download progress messages)
-RUN mvn --no-transfer-progress package
+# Maven flags here ensure that we skip final assembly, skip building test environment and skip all code verification checks.
+# These flags speed up this installation as much as reasonably possible.
+ENV MAVEN_FLAGS="-P-assembly -P-test-environment -Denforcer.skip=true -Dcheckstyle.skip=true -Dlicense.skip=true -Dxml.skip=true"
+RUN mvn --no-transfer-progress install ${MAVEN_FLAGS}
 
 # Clear the contents of the /app directory (including all maven builds), so no artifacts remain.
 # This ensures when dspace:dspace is built, it will use the Maven local cache (~/.m2) for dependencies


### PR DESCRIPTION
## References
* Based on the changes made for `dspace-angular` in https://github.com/DSpace/dspace-angular/pull/2644 (and follow-up PRs). 
* Borrows ideas from https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners

## Description
This PR allows for parallel builds of our Docker images, specifically allowing the amd64 and arm64 images to build simultaneously.  Previously all these builds were sequential, which meant a full build of all images could take 1-2 hours of real time.

With simultaneous builds, the amd64 images can be pushed to DockerHub immediately after they complete.  The arm64 builds (which take much longer because of emulation) will be pushed later as soon as they finally finish.

Finally, this PR also adds redeployment of https://demo.dspace.org and https://sandbox.dspace.org into these Docker scripts.  This provides more control over _when_ these sites redeploy, similar to what was done for `dspace-angular` in https://github.com/DSpace/dspace-angular/pull/2649

Additional minor changes of note:
* Minor speed improvements to Maven builds for Docker images (only).  Passes in many new flags to avoid steps/checks which are unnecessary for Docker image builds.
* Remove `git` from Docker images as it's no longer needed in 7.6.1. See #9016
* Updates version of all Docker action plugins
* Minor fix to Codecov plugin settings to ensure it retries when an error occurs.

## Instructions for Reviewers
I've tested this in my own forked GitHub repo and DockerHub account.  It appears to be working (at least as far as I can test).  

This PR itself also uses the new GitHub Actions...so you can see the result in the Checks run by this PR.  (However, not all Docker builds will occur in a PR as we specifically only run an amd64 build for PRs.)

The only way for a complete test is to merge this and see if it works for `DSpace/DSpace`.