### PR TITLE
[Docker] Ensure 'dspace-solr' image redeploys the Solr instances for Demo/Sandbox

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -121,6 +121,10 @@ jobs:
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_ACCESS_TOKEN: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+      # Enable redeploy of sandbox & demo SOLR instance whenever dspace-solr image changes for deployed branch.
+      # These URLs MUST use different secrets than 'dspace/dspace' image build above as they are deployed separately.
+      REDEPLOY_SANDBOX_URL: ${{ secrets.REDEPLOY_SANDBOX_SOLR_URL }}
+      REDEPLOY_DEMO_URL: ${{ secrets.REDEPLOY_DEMO_SOLR_URL }}
 
   ###########################################################
   # Build/Push the 'dspace/dspace-postgres-pgcrypto' image


### PR DESCRIPTION
## References
* Minor follow-up to #9213

## Description
While #9213 works almost completely, I realized it doesn't trigger a redeploy of the Solr instance behind demo.dspace.org and/or sandbox.dspace.org when the `dspace-solr` image is updated.  This small PR fixes that, using a few new secrets I added to this repository

## Instructions for Reviewers
Not possible to test unfortunately until it is merged. This redeployment process is not triggered for PRs, and only triggers once a PR is merged.