### PR TITLE
Bump dependencies

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -620,7 +620,7 @@
         <dependency>
             <groupId>com.maxmind.geoip2</groupId>
             <artifactId>geoip2</artifactId>
-            <version>2.11.0</version>
+            <version>2.17.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.ant</groupId>

--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -528,7 +528,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -902,7 +902,7 @@
           <dependency>
               <groupId>org.xmlunit</groupId>
               <artifactId>xmlunit-core</artifactId>
-              <version>2.8.0</version>
+              <version>2.9.1</version>
               <scope>test</scope>
           </dependency>
           <dependency>

--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -867,32 +867,32 @@
           <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-buffer</artifactId>
-            <version>4.1.94.Final</version>
+            <version>4.1.106.Final</version>
           </dependency>
           <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport</artifactId>
-            <version>4.1.94.Final</version>
+            <version>4.1.106.Final</version>
           </dependency>
           <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-unix-common</artifactId>
-            <version>4.1.94.Final</version>
+            <version>4.1.106.Final</version>
            </dependency>
           <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-common</artifactId>
-            <version>4.1.94.Final</version>
+            <version>4.1.106.Final</version>
           </dependency>
           <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
-            <version>4.1.94.Final</version>
+            <version>4.1.106.Final</version>
           </dependency>
           <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec</artifactId>
-            <version>4.1.94.Final</version>
+            <version>4.1.106.Final</version>
           </dependency>
           <dependency>
             <groupId>org.apache.velocity</groupId>

--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -784,7 +784,7 @@
         <dependency>
             <groupId>com.opencsv</groupId>
             <artifactId>opencsv</artifactId>
-            <version>5.7.1</version>
+            <version>5.9</version>
         </dependency>
 
         <!-- Email templating -->

--- a/dspace-oai/pom.xml
+++ b/dspace-oai/pom.xml
@@ -156,7 +156,7 @@
         <!-- As our Parent POM sets this to 'test' scope, we must override it -->
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
+            <artifactId>hamcrest</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/dspace-server-webapp/pom.xml
+++ b/dspace-server-webapp/pom.xml
@@ -360,7 +360,7 @@
         <dependency>
             <groupId>org.webjars.bowergithub.jquery</groupId>
             <artifactId>jquery-dist</artifactId>
-            <version>3.7.0</version>
+            <version>3.7.1</version>
         </dependency>
         <!-- Pull in current version of Toastr (toastrjs.com) via WebJars
              Made available at: webjars/toastr/build/toastr.min.js -->

--- a/dspace-server-webapp/pom.xml
+++ b/dspace-server-webapp/pom.xml
@@ -340,7 +340,7 @@
         <dependency>
             <groupId>com.flipkart.zjsonpatch</groupId>
             <artifactId>zjsonpatch</artifactId>
-            <version>0.4.14</version>
+            <version>0.4.16</version>
         </dependency>
 
         <!-- HAL Browser (via WebJars) : https://github.com/mikekelly/hal-browser -->

--- a/dspace-server-webapp/pom.xml
+++ b/dspace-server-webapp/pom.xml
@@ -548,7 +548,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/dspace-server-webapp/pom.xml
+++ b/dspace-server-webapp/pom.xml
@@ -406,7 +406,7 @@
         <dependency>
             <groupId>org.webjars.bowergithub.twbs</groupId>
             <artifactId>bootstrap</artifactId>
-            <version>4.6.1</version>
+            <version>4.6.2</version>
         </dependency>
 
         <!-- Add in Spring Security for AuthN and AuthZ -->

--- a/dspace/modules/additions/pom.xml
+++ b/dspace/modules/additions/pom.xml
@@ -273,7 +273,7 @@
       </dependency>
       <dependency>
          <groupId>org.hamcrest</groupId>
-         <artifactId>hamcrest-core</artifactId>
+         <artifactId>hamcrest</artifactId>
          <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <!-- NOTE: Jetty needed for Solr, Handle Server & tests -->
         <jetty.version>9.4.53.v20231009</jetty.version>
         <log4j.version>2.20.0</log4j.version>
-        <pdfbox-version>2.0.29</pdfbox-version>
+        <pdfbox-version>2.0.30</pdfbox-version>
         <rome.version>1.19.0</rome.version>
         <slf4j.version>1.7.36</slf4j.version>
         <tika.version>2.5.0</tika.version>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <jcache-version>1.1.1</jcache-version>
         <!-- NOTE: Jetty needed for Solr, Handle Server & tests -->
         <jetty.version>9.4.53.v20231009</jetty.version>
-        <log4j.version>2.20.0</log4j.version>
+        <log4j.version>2.22.1</log4j.version>
         <pdfbox-version>2.0.30</pdfbox-version>
         <rome.version>1.19.0</rome.version>
         <slf4j.version>1.7.36</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,8 @@
         <ehcache.version>3.10.8</ehcache.version>
         <errorprone.version>2.10.0</errorprone.version>
         <!-- NOTE: when updating jackson.version, also sync jackson-databind.version below -->
-        <jackson.version>2.13.4</jackson.version>
-        <jackson-databind.version>2.13.4.2</jackson-databind.version>
+        <jackson.version>2.16.0</jackson.version>
+        <jackson-databind.version>2.16.0</jackson-databind.version>
         <javax-annotation.version>1.3.2</javax-annotation.version>
         <jaxb-api.version>2.3.1</jaxb-api.version>
         <jaxb-runtime.version>2.3.9</jaxb-runtime.version>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <jackson-databind.version>2.13.4.2</jackson-databind.version>
         <javax-annotation.version>1.3.2</javax-annotation.version>
         <jaxb-api.version>2.3.1</jaxb-api.version>
-        <jaxb-runtime.version>2.3.8</jaxb-runtime.version>
+        <jaxb-runtime.version>2.3.9</jaxb-runtime.version>
         <jcache-version>1.1.1</jcache-version>
         <!-- NOTE: Jetty needed for Solr, Handle Server & tests -->
         <jetty.version>9.4.53.v20231009</jetty.version>

--- a/pom.xml
+++ b/pom.xml
@@ -334,7 +334,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.6.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -294,7 +294,7 @@
                 <plugin>
                     <groupId>com.github.spotbugs</groupId>
                     <artifactId>spotbugs-maven-plugin</artifactId>
-                    <version>4.0.4</version>
+                    <version>4.8.2.0</version>
                     <configuration>
                         <effort>Max</effort>
                         <threshold>Low</threshold>
@@ -304,7 +304,7 @@
                         <dependency>
                             <groupId>com.github.spotbugs</groupId>
                             <artifactId>spotbugs</artifactId>
-                            <version>4.1.2</version>
+                            <version>4.8.2</version>
                         </dependency>
                     </dependencies>
                     <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 
         <!--=== SERVER WEBAPP DEPENDENCIES ===-->
         <!-- Library for reading JSON documents: https://github.com/json-path/JsonPath (used by Server webapp) -->
-        <json-path.version>2.6.0</json-path.version>
+        <json-path.version>2.8.0</json-path.version>
         <!-- Library for managing JSON Web Tokens (JWT): https://bitbucket.org/connect2id/nimbus-jose-jwt/wiki/Home
              (used by Server webapp) -->
         <nimbus-jose-jwt.version>7.9</nimbus-jose-jwt.version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,9 @@
     <properties>
         <!--=== GENERAL / DSPACE-API DEPENDENCIES ===-->
         <java.version>11</java.version>
-        <spring.version>5.3.28</spring.version>
-        <spring-boot.version>2.7.13</spring-boot.version>
-        <spring-security.version>5.7.9</spring-security.version> <!-- sync with version used by spring-boot-->
+        <spring.version>5.3.31</spring.version>
+        <spring-boot.version>2.7.18</spring-boot.version>
+        <spring-security.version>5.7.11</spring-security.version> <!-- sync with version used by spring-boot-->
         <hibernate.version>5.6.15.Final</hibernate.version>
         <hibernate-validator.version>6.2.5.Final</hibernate-validator.version>
         <postgresql.driver.version>42.6.0</postgresql.driver.version>

--- a/pom.xml
+++ b/pom.xml
@@ -257,7 +257,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.3.1</version>
                     <executions>
                         <execution>
                             <id>verify-style</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1646,7 +1646,7 @@
             <dependency>
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
-                <version>2.2.220</version>
+                <version>2.2.224</version>
                 <scope>test</scope>
             </dependency>
             <!-- Google Analytics -->

--- a/pom.xml
+++ b/pom.xml
@@ -1704,7 +1704,7 @@
             <dependency>
                 <groupId>com.fasterxml</groupId>
                 <artifactId>classmate</artifactId>
-                <version>1.5.1</version>
+                <version>1.6.0</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1419,7 +1419,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-collections4</artifactId>
-                <version>4.1</version>
+                <version>4.4</version>
             </dependency>
             <!-- commons-collections v3 is still required by commons-beanutils,
                  which is required by commons-configuration. Once those are

--- a/pom.xml
+++ b/pom.xml
@@ -1452,7 +1452,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.12.0</version>
+                <version>3.14.0</version>
             </dependency>
             <!-- NOTE: We don't use commons-logging directly, but many dependencies rely on it.
                  So, we specify the version to use to avoid dependency convergence issues. -->

--- a/pom.xml
+++ b/pom.xml
@@ -1294,7 +1294,7 @@
             <dependency>
                 <groupId>org.apache.ant</groupId>
                 <artifactId>ant</artifactId>
-                <version>1.10.13</version>
+                <version>1.10.14</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.jena</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1409,7 +1409,7 @@
             <dependency>
                 <groupId>commons-cli</groupId>
                 <artifactId>commons-cli</artifactId>
-                <version>1.5.0</version>
+                <version>1.6.0</version>
             </dependency>
             <dependency>
                 <groupId>commons-codec</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1447,7 +1447,7 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.13.0</version>
+                <version>2.15.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1437,7 +1437,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-dbcp2</artifactId>
-                <version>2.9.0</version>
+                <version>2.11.0</version>
             </dependency>
             <dependency>
                 <groupId>commons-fileupload</groupId>
@@ -1464,7 +1464,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-pool2</artifactId>
-                <version>2.11.1</version>
+                <version>2.12.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1619,21 +1619,21 @@
             </dependency>
             <!-- JUnit, Mockito and Hamcrest are used for Unit/Integration tests -->
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>4.13.2</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-all</artifactId>
-                <version>1.3</version>
+                <artifactId>hamcrest</artifactId>
+                <version>2.2</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-core</artifactId>
-                <version>1.3</version>
+                <version>2.2</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>4.13.2</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1432,7 +1432,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-configuration2</artifactId>
-                <version>2.8.0</version>
+                <version>2.9.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1459,7 +1459,7 @@
             <dependency>
                 <groupId>commons-logging</groupId>
                 <artifactId>commons-logging</artifactId>
-                <version>1.2</version>
+                <version>1.3.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
## Description
Bump a handful of dependencies in various `pom.xml` files. I used the [renovate bot](https://docs.renovatebot.com/) in a fork of the DSpace repository to unearth viable dependency updates. In most cases these are _minor_ and _patch_ level updates (ie 2.x.x) , as I specifically excluded major ones. In many cases they updates fix bugs, improve performance, improve compatibility with newer Java versions, and update transitive dependencies.

I have tested browsing, searching, editing items, submitting new ones, and Discovery indexing. All working as expected.

## Instructions for Reviewers

List of changes in this PR:
* Try building DSpace with `mvn -U clean package` to make sure you don't use any old packages
* Try running DSpace
* Try various normal actions in the web interface, command line, HAL browser, and various APIs.