### PR TITLE
Correct response of get controlled vocabulary by metadata and collection when NO controlled vocabulary is available for the specified metadata and collection

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/VocabularyRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/VocabularyRestRepository.java
@@ -100,6 +100,9 @@ public class VocabularyRestRepository extends DSpaceRestRepository<VocabularyRes
         }
 
         String authorityName = cas.getChoiceAuthorityName(tokens[0], tokens[1], tokens[2], collection);
+        if (authorityName == null) {
+            return null;
+        }
         ChoiceAuthority source = cas.getChoiceAuthorityByAuthorityName(authorityName);
         return authorityUtils.convertAuthority(source, authorityName, utils.obtainProjection());
     }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/VocabularyRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/VocabularyRestRepositoryIT.java
@@ -395,6 +395,20 @@ public class VocabularyRestRepositoryIT extends AbstractControllerIntegrationTes
     }
 
     @Test
+    public void findByMetadataAndCollectionWithMetadataWithoutVocabularyTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Collection collection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Test collection")
+            .build();
+        context.restoreAuthSystemState();
+        String token = getAuthToken(admin.getEmail(), password);
+        getClient(token).perform(get("/api/submission/vocabularies/search/byMetadataAndCollection")
+                .param("metadata", "dc.title")
+                .param("collection", collection.getID().toString()))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
     public void findByMetadataAndCollectionUnprocessableEntityTest() throws Exception {
         context.turnOffAuthorisationSystem();
         Collection collection = CollectionBuilder.createCollection(context, parentCommunity)


### PR DESCRIPTION
## References
* Related to DSpace/dspace-angular#2653

## Description
According to [the RESTContract the operation to get controlled vocabulary by metadata and collection](https://github.com/DSpace/RestContract/blob/main/vocabularies.md#get-controlled-vocabulary-by-metadata-and-collection) should return a 204 HTTP Code if the operation succeed but NO controlled vocabulary is available for the specified metadata and collection, but it returns a 400 HTTP code because of a NullPointerException. This PR corrects it avoiding this NPE.

## Instructions for Reviewers

List of changes in this PR:
* Avoids a NPE 
* Add a related missing test

This operation is not used by the current UI, I have seen it using DSpace/dspace-angular#2653, but it could be tested in HAL Browser:

* Login into HAL Browser
* Go to endpoint vocabularies
* Perform a GET operation using dc.title as metadata and a valid uuid collection against `/api/submission/vocabularies/search/byMetadataAndCollection?metadata=dc.title&collection=[valid-uuid-collection]`

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
