### PR TITLE
Alteration to index-discovery script to only (re-)index specific type of IndexableObject

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/IndexClient.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexClient.java
@@ -7,6 +7,8 @@
  */
 package org.dspace.discovery;
 
+import static org.dspace.discovery.IndexClientOptions.TYPE_OPTION;
+
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.Iterator;
@@ -15,6 +17,7 @@ import java.util.UUID;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.ParseException;
+import org.apache.commons.lang3.StringUtils;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.DSpaceObject;
@@ -49,6 +52,11 @@ public class IndexClient extends DSpaceRunnable<IndexDiscoveryScriptConfiguratio
         if (indexClientOptions == IndexClientOptions.HELP) {
             printHelp();
             return;
+        }
+
+        String type = null;
+        if (commandLine.hasOption(TYPE_OPTION)) {
+            type = commandLine.getOptionValue(TYPE_OPTION);
         }
 
         /** Acquire from dspace-services in future */
@@ -113,6 +121,10 @@ public class IndexClient extends DSpaceRunnable<IndexDiscoveryScriptConfiguratio
         } else if (indexClientOptions == IndexClientOptions.BUILD ||
             indexClientOptions == IndexClientOptions.BUILDANDSPELLCHECK) {
             handler.logInfo("(Re)building index from scratch.");
+            if (StringUtils.isNotBlank(type)) {
+                handler.logWarning(String.format("Type option, %s, not applicable for entire index rebuild option, b" +
+                        ", type will be ignored", TYPE_OPTION));
+            }
             indexer.deleteIndex();
             indexer.createIndex(context);
             if (indexClientOptions == IndexClientOptions.BUILDANDSPELLCHECK) {
@@ -133,14 +145,14 @@ public class IndexClient extends DSpaceRunnable<IndexDiscoveryScriptConfiguratio
         } else if (indexClientOptions == IndexClientOptions.UPDATE ||
             indexClientOptions == IndexClientOptions.UPDATEANDSPELLCHECK) {
             handler.logInfo("Updating Index");
-            indexer.updateIndex(context, false);
+            indexer.updateIndex(context, false, type);
             if (indexClientOptions == IndexClientOptions.UPDATEANDSPELLCHECK) {
                 checkRebuildSpellCheck(commandLine, indexer);
             }
         } else if (indexClientOptions == IndexClientOptions.FORCEUPDATE ||
             indexClientOptions == IndexClientOptions.FORCEUPDATEANDSPELLCHECK) {
             handler.logInfo("Updating Index");
-            indexer.updateIndex(context, true);
+            indexer.updateIndex(context, true, type);
             if (indexClientOptions == IndexClientOptions.FORCEUPDATEANDSPELLCHECK) {
                 checkRebuildSpellCheck(commandLine, indexer);
             }

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexClient.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexClient.java
@@ -11,9 +11,12 @@ import static org.dspace.discovery.IndexClientOptions.TYPE_OPTION;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.ParseException;
@@ -56,7 +59,13 @@ public class IndexClient extends DSpaceRunnable<IndexDiscoveryScriptConfiguratio
 
         String type = null;
         if (commandLine.hasOption(TYPE_OPTION)) {
+            List<String> indexableObjectTypes = IndexObjectFactoryFactory.getInstance().getIndexFactories().stream()
+                    .map((indexFactory -> indexFactory.getType())).collect(Collectors.toList());
             type = commandLine.getOptionValue(TYPE_OPTION);
+            if (!indexableObjectTypes.contains(type)) {
+                handler.handleException(String.format("%s is not a valid indexable object type, options: %s",
+                        type, Arrays.toString(indexableObjectTypes.toArray())));
+            }
         }
 
         /** Acquire from dspace-services in future */

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexClientOptions.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexClientOptions.java
@@ -8,8 +8,13 @@
 
 package org.dspace.discovery;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
+import org.dspace.discovery.indexobject.factory.IndexObjectFactoryFactory;
 
 /**
  * This Enum holds all the possible options and combinations for the Index discovery script
@@ -28,6 +33,8 @@ public enum IndexClientOptions {
     UPDATEANDSPELLCHECK,
     FORCEUPDATEANDSPELLCHECK,
     HELP;
+
+    public static final String TYPE_OPTION = "t";
 
     /**
      * This method resolves the CommandLine parameters to figure out which action the index-discovery script should
@@ -71,11 +78,15 @@ public enum IndexClientOptions {
 
     protected static Options constructOptions() {
         Options options = new Options();
+        List<String> indexableObjectTypes = IndexObjectFactoryFactory.getInstance().getIndexFactories().stream()
+                .map((indexFactory -> indexFactory.getType())).collect(Collectors.toList());
 
         options
             .addOption("r", "remove", true, "remove an Item, Collection or Community from index based on its handle");
         options.addOption("i", "index", true,
                           "add or update an Item, Collection or Community based on its handle or uuid");
+        options.addOption(TYPE_OPTION, "type", true, "reindex only specific type of " +
+                "(re)indexable objects; options: " + Arrays.toString(indexableObjectTypes.toArray()));
         options.addOption("c", "clean", false,
                           "clean existing index removing any documents that no longer exist in the db");
         options.addOption("d", "delete", false,


### PR DESCRIPTION
## Description
Alteration to index-discovery script to only (re-)index specific type of IndexableObject

## Instructions for Reviewers
- With `-t` option, help output logs options of types of `IndexableObject` with indexing factory
- Not compatible with `-b` option since this clears entire index first (& expect to rebuild it in its entirety) 
- Compatible with `-f` to force reindex specific type of `IndexableObject`

Test option `-t`
- Clear solr search core
- Run `ds index-discovery -t MetadataField` => Verify all metadata fields are indexed
- Also testable with: `ClaimedTask, Collection, Community, Item, PoolTask, XmlWorkflowItem, WorkspaceItem`

With `-f` option:
- Alter config so more things are indexed on an Item, eg virtual metadata for an item with relationship
- Run `ds index-discovery -f -t Item` => Verify the changes are indexed & only the Item docs are reindexed

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
