### PR TITLE
Add new date format pattern to DCDate

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/DCDate.java
+++ b/dspace-api/src/main/java/org/dspace/content/DCDate.java
@@ -80,6 +80,9 @@ public class DCDate {
     // just year, "2009"
     private final SimpleDateFormat yearIso = new SimpleDateFormat("yyyy");
 
+    // Additional iso-like format which contains milliseconds
+    private final SimpleDateFormat fullIsoWithMs = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'.000'");
+
     private static Map<Locale, DateFormatSymbols> dfsLocaleMap = new HashMap<Locale, DateFormatSymbols>();
 
     /**
@@ -194,6 +197,9 @@ public class DCDate {
             date = tryParse(fullIso4, fromDC);
         }
         if (date == null) {
+            date = tryParse(fullIsoWithMs, fromDC);
+        }
+        if (date == null) {
             // Seems there is no time component to the date.
             date = tryParse(dateIso, fromDC);
             if (date != null) {
@@ -244,6 +250,7 @@ public class DCDate {
         dateIso.setTimeZone(utcZone);
         yearMonthIso.setTimeZone(utcZone);
         yearIso.setTimeZone(utcZone);
+        fullIsoWithMs.setTimeZone(utcZone);
     }
 
     // Attempt to parse, swallowing errors; return null for failure.

--- a/dspace-api/src/test/java/org/dspace/content/DCDateTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/DCDateTest.java
@@ -281,6 +281,23 @@ public class DCDateTest {
         assertThat("testDCDateString 10", dc.getHourUTC(), equalTo(0));
         assertThat("testDCDateString 11", dc.getMinuteUTC(), equalTo(0));
         assertThat("testDCDateString 12", dc.getSecondUTC(), equalTo(1));
+
+        // test additional ISO format
+        dc = new DCDate("2010-04-14T00:00:01.000");
+        assertThat("testDCDateString 1", dc.getYear(), equalTo(2010));
+        assertThat("testDCDateString 2", dc.getMonth(), equalTo(04));
+        assertThat("testDCDateString 3", dc.getDay(), equalTo(13));
+        assertThat("testDCDateString 4", dc.getHour(), equalTo(16));
+        assertThat("testDCDateString 5", dc.getMinute(), equalTo(0));
+        assertThat("testDCDateIntBits 6", dc.getSecond(), equalTo(1));
+
+        assertThat("testDCDateString 7", dc.getYearUTC(), equalTo(2010));
+        assertThat("testDCDateString 8", dc.getMonthUTC(), equalTo(04));
+        assertThat("testDCDateString 9", dc.getDayUTC(), equalTo(14));
+        assertThat("testDCDateString 10", dc.getHourUTC(), equalTo(0));
+        assertThat("testDCDateString 11", dc.getMinuteUTC(), equalTo(0));
+        assertThat("testDCDateString 12", dc.getSecondUTC(), equalTo(1));
+
     }
 
 
@@ -381,6 +398,11 @@ public class DCDateTest {
         assertThat("testDisplayDate 7 ", dc.displayDate(false, false,
                                                         new Locale("en_GB")),
                    equalTo("14-Apr-2010"));
+
+        dc = new DCDate("2010-04-14T00:00:01.000");
+        assertThat("testDisplayDate 8 ", dc.displayDate(false, false,
+                        new Locale("en_GB")),
+                equalTo("14-Apr-2010"));
     }
 
     /**


### PR DESCRIPTION
## Description
This small change adds an additional date format to DCDate for parsing purposes: `yyyy-MM-dd'T'HH:mm:ss'.000'`
This date format is used by some APIs and is useful to have in our list of formats to support when parsing date strings.

## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* New pattern added to DCDate, and included in this class's methods where all patterns are tried or added in succession
* New tests added to DCDateTest to ensure date parsing is successful for the new format

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
