### PR TITLE
Improve equality comparison for ExternalDataObject and MetadataValueDTO

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/dto/MetadataValueDTO.java
+++ b/dspace-api/src/main/java/org/dspace/content/dto/MetadataValueDTO.java
@@ -7,6 +7,9 @@
  */
 package org.dspace.content.dto;
 
+import java.util.Comparator;
+import java.util.Objects;
+
 import org.dspace.content.MetadataField;
 import org.dspace.content.MetadataSchema;
 import org.dspace.content.MetadataValue;
@@ -136,4 +139,62 @@ public class MetadataValueDTO {
     public void setConfidence(int confidence) {
         this.confidence = confidence;
     }
+
+    @Override
+    public String toString() {
+        return "MetadataValueDTO{" +
+                "schema='" + schema + '\'' +
+                ", element='" + element + '\'' +
+                ", qualifier='" + qualifier + '\'' +
+                ", language='" + language + '\'' +
+                ", value='" + value + '\'' +
+                ", authority='" + authority + '\'' +
+                ", confidence=" + confidence +
+                "}\n";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        MetadataValueDTO that = (MetadataValueDTO) o;
+        return confidence == that.confidence &&
+                Objects.equals(schema, that.schema) && Objects.equals(element, that.element) &&
+                Objects.equals(qualifier, that.qualifier) && Objects.equals(language, that.language) &&
+                Objects.equals(value, that.value) && Objects.equals(authority, that.authority);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(schema, element, qualifier, language, value, authority, confidence);
+    }
+
+    /**
+     * Build a comparator to support proper sorting of MetadataValueDTO objects.
+     * Order of sorting is based on how these things are normally sorted in human-readable formats, with
+     * field name -> value -> lang/auth/etc being the usual order we use. In all these individual tests, nulls are
+     * sorted first (eg. dc.title before dc.title.alternative)
+     * @see org.dspace.external.model.ExternalDataObject#equals(Object)
+     * 1. Qualifier
+     * 2. Element
+     * 3. Schema
+     * 4. Value
+     * 5. Language
+     * 6. Authority
+     * @return comparator
+     */
+    public static Comparator<MetadataValueDTO> comparator() {
+        return Comparator.comparing(MetadataValueDTO::getQualifier, Comparator.nullsFirst(Comparator.naturalOrder()))
+                .thenComparing(MetadataValueDTO::getElement, Comparator.nullsFirst(Comparator.naturalOrder()))
+                .thenComparing(MetadataValueDTO::getSchema, Comparator.nullsFirst(Comparator.naturalOrder()))
+                .thenComparing(MetadataValueDTO::getValue, Comparator.nullsFirst(Comparator.naturalOrder()))
+                .thenComparing(MetadataValueDTO::getLanguage, Comparator.nullsFirst(Comparator.naturalOrder()))
+                .thenComparing(MetadataValueDTO::getAuthority, Comparator.nullsFirst(Comparator.naturalOrder()));
+    }
+
+
 }

--- a/dspace-api/src/main/java/org/dspace/external/model/ExternalDataObject.java
+++ b/dspace-api/src/main/java/org/dspace/external/model/ExternalDataObject.java
@@ -9,7 +9,10 @@ package org.dspace.external.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.dspace.content.dto.MetadataValueDTO;
 
 /**
@@ -37,6 +40,8 @@ public class ExternalDataObject {
      * The display value of the ExternalDataObject
      */
     private String displayValue;
+
+    private Logger log = LogManager.getLogger(ExternalDataObject.class);
 
     /**
      * Default constructor
@@ -143,4 +148,63 @@ public class ExternalDataObject {
     public void setValue(String value) {
         this.value = value;
     }
+
+    /**
+     * Sort metadata before printing, to help with comparison by eye
+     * @return
+     */
+    @Override
+    public String toString() {
+        List<MetadataValueDTO> thisMetadata = new ArrayList<>(this.metadata);
+        thisMetadata.sort(MetadataValueDTO.comparator());
+        return "ExternalDataObject{" +
+                "id='" + id + '\'' +
+                ", value='" + value + '\'' +
+                ", source='" + source + '\'' +
+                ", displayValue='" + displayValue + '\'' +
+                ", metadata=" + thisMetadata +
+                '}';
+    }
+
+    /**
+     * Equality test for ExternalDataObject takes into account the fact that we might have
+     * lists of metadata values which are identical except for sort order, so we sort and compare these
+     * using a custom comparator.
+     * @param o The other object ("that") with which to compare this object ("this")
+     * @return  true if objects are identical, false if not
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ExternalDataObject that = (ExternalDataObject) o;
+        // Compare *sorted* lists
+        List<MetadataValueDTO> thisMetadata = new ArrayList<>(this.metadata);
+        List<MetadataValueDTO> thatMetadata = new ArrayList<>(that.metadata);
+        // Sort both lists using our custom comparator
+        thisMetadata.sort(MetadataValueDTO.comparator());
+        thatMetadata.sort(MetadataValueDTO.comparator());
+
+        // Return straight comparisons of basic member variables
+        return Objects.equals(id, that.id) &&
+                Objects.equals(value, that.value) &&
+                Objects.equals(source, that.source) &&
+                Objects.equals(displayValue, that.displayValue) &&
+                // Compare the sorted lists rather than the raw stored metadata
+                Objects.equals(thisMetadata, thatMetadata);
+    }
+
+    /**
+     * Explicit override of Object hashCode()
+     * @return
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, value, source, metadata, displayValue);
+    }
+
 }


### PR DESCRIPTION
## Description
This is a small improvement to the `toString`, `equals`, `hashcode` methods of `ExternalDataObject` (the data model for external data before it is reused elsewhere in DSpace) and `MetadataValueDTO` (the more primitive version of MetadataValue specifically used in object conversion, including ExternalDataObject).

The main purpose of this is to ensure that comparing two ExternalDataObjects ignores the precise order of unique DTO metadata values.

I introduced a new comparator to MetadataValueDTO, and this is used whenever we want to sort these values, either for printing output, or for equality comparison of the parent objects like ExternalDataObject

(it also gives more user-friendly output of external data objects and metadata value DTOs through the new `toString` methods)

New tests are written in the `SHERPADataProviderTest` integration test class, to demonstrate comparison of:
* Identical EDOs (one created by hand, the other returned by the mock provider)
* EDOs identical except for order of metadata values (which I expect to be found 'equal')
* EDOs that differ by actual value content, which we expect to be evaluated as non-equal

I hope that review by code inspection and integration test inspection / run should be sufficient.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
