### PR TITLE
Small improvs to External Services and Providers (search hint, metadata mapping, typing)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/external/provider/AbstractExternalDataProvider.java
+++ b/dspace-api/src/main/java/org/dspace/external/provider/AbstractExternalDataProvider.java
@@ -80,8 +80,8 @@ public abstract class AbstractExternalDataProvider implements ExternalDataProvid
     public abstract List<ExternalDataObject> searchExternalDataObjects(String query, String hint, int start, int limit);
 
     /**
-     *
-     * @return
+     * Get metadata maps by 'type', if present. See spring configuration for examples.
+     * @return map of metadata types
      */
     @Override
     public Map<String, Map<String, MetadataFieldConfig>> getMetadataMapsByType() {

--- a/dspace-api/src/main/java/org/dspace/external/provider/AbstractExternalDataProvider.java
+++ b/dspace-api/src/main/java/org/dspace/external/provider/AbstractExternalDataProvider.java
@@ -7,7 +7,11 @@
  */
 package org.dspace.external.provider;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+
+import org.dspace.external.model.ExternalDataObject;
+import org.dspace.importer.external.metadatamapping.MetadataFieldConfig;
 
 /**
  * This abstract class allows to configure the list of supported entity types
@@ -19,6 +23,12 @@ import java.util.Objects;
 public abstract class AbstractExternalDataProvider implements ExternalDataProvider {
 
     private List<String> supportedEntityTypes;
+
+    /**
+     * Map of metadata fields, by "type" (this classification is up to the implementer)
+     * set in spring configuration
+     */
+    protected Map<String, Map<String, MetadataFieldConfig>> metadataMapsByType;
 
     public void setSupportedEntityTypes(List<String> supportedEntityTypes) {
         this.supportedEntityTypes = supportedEntityTypes;
@@ -40,4 +50,50 @@ public abstract class AbstractExternalDataProvider implements ExternalDataProvid
         return Objects.isNull(supportedEntityTypes) || supportedEntityTypes.contains(entityType);
     }
 
+    /**
+     * Get entity type for a given ExternalDataObject. We leave it to the provider to determine this
+     * but the idea is to allow it to inspect the object itself rather than relying only on configuration
+     * or the hardcoded nature of the provider itself.
+     *
+     * @param externalDataObject the external data object
+     * @return a supported entity label or null to indicate no entities are supported, or this
+     *         feature is not implemented
+     */
+    @Override
+    public String getEntityTypeForExternalDataObject(ExternalDataObject externalDataObject) {
+        return null;
+    }
+
+    /**
+     * Search external data objects with an optional 'hint' String, which the provider will use to
+     * help determine which filters or other URL parameters to apply to the query. This is a simple
+     * way to give some additional context about what and why we are searching something, and could
+     * be provided by the user, or a frontend component, etc.
+     *
+     * @param query the query text
+     * @param hint a string which the provider will use to determine additional parameters
+     * @param start start record / row
+     * @param limit page size
+     * @return
+     */
+    @Override
+    public abstract List<ExternalDataObject> searchExternalDataObjects(String query, String hint, int start, int limit);
+
+    /**
+     *
+     * @return
+     */
+    @Override
+    public Map<String, Map<String, MetadataFieldConfig>> getMetadataMapsByType() {
+        return metadataMapsByType;
+    }
+
+    /**
+     * Set metadata field maps (see external data spring configuration)
+     * @param metadataFieldMapsByType
+     */
+    @Override
+    public void setMetadataMapsByType(Map<String, Map<String, MetadataFieldConfig>> metadataFieldMapsByType) {
+        this.metadataMapsByType = metadataFieldMapsByType;
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/external/provider/ExternalDataProvider.java
+++ b/dspace-api/src/main/java/org/dspace/external/provider/ExternalDataProvider.java
@@ -8,9 +8,11 @@
 package org.dspace.external.provider;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.dspace.external.model.ExternalDataObject;
+import org.dspace.importer.external.metadatamapping.MetadataFieldConfig;
 
 /**
  * This interface should be implemented by all providers that will deal with external data
@@ -43,6 +45,20 @@ public interface ExternalDataProvider {
     List<ExternalDataObject> searchExternalDataObjects(String query, int start, int limit);
 
     /**
+     * Search external data objects with an optional 'hint' String, which the provider will use to
+     * help determine which filters or other URL parameters to apply to the query. This is a simple
+     * way to give some additional context about what and why we are searching something, and could
+     * be provided by the user, or a frontend component, etc.
+     *
+     * @param query the query text
+     * @param hint a string which the provider will use to determine additional parameters
+     * @param start start record / row
+     * @param limit page size
+     * @return list of external data objects as returned by the external data source
+     */
+    public List<ExternalDataObject> searchExternalDataObjects(String query, String hint, int start, int limit);
+
+    /**
      * This method will return a boolean indicating whether this ExternalDataProvider can deal with the given source
      * or not
      * @param source The source on which the check needs to be done
@@ -68,5 +84,29 @@ public interface ExternalDataProvider {
     public default boolean supportsEntityType(String entityType) {
         return true;
     }
+
+    /**
+     * Get entity type for a given ExternalDataObject. We leave it to the provider to determine this
+     * but the idea is to allow it to inspect the object itself rather than relying only on configuration
+     * or the hardcoded nature of the provider itself.
+     *
+     * @param externalDataObject the external data object
+     * @return a supported entity label
+     */
+    public String getEntityTypeForExternalDataObject(ExternalDataObject externalDataObject);
+
+    /**
+     * Set metadata map by external data record type (a map of maps, see external-gnd.xml)
+     *
+     * @param metadataMapsByType map of metadata maps (set in spring)
+     */
+    public void setMetadataMapsByType(Map<String, Map<String, MetadataFieldConfig>> metadataMapsByType);
+
+    /**
+     * Get metadata map by external data record type (a map of maps, see external-gnd.xml)
+     *
+     * @return metadataMapsByType map of metadata maps (set in spring)
+     */
+    public Map<String, Map<String, MetadataFieldConfig>> getMetadataMapsByType();
 
 }

--- a/dspace-api/src/main/java/org/dspace/external/provider/impl/LiveImportDataProvider.java
+++ b/dspace-api/src/main/java/org/dspace/external/provider/impl/LiveImportDataProvider.java
@@ -90,8 +90,31 @@ public class LiveImportDataProvider extends AbstractExternalDataProvider {
         }
     }
 
+    /**
+     * To comply with new interface and abstract, the 'hint' is now implemented if not actually
+     * supported in this provider.
+     *
+     * @param query The query for the search
+     * @param start The start of the search
+     * @param limit The max amount of records to be returned by the search
+     * @return
+     */
     @Override
     public List<ExternalDataObject> searchExternalDataObjects(String query, int start, int limit) {
+        return searchExternalDataObjects(query, null, start, limit);
+    }
+
+    /**
+     * Search live import source and return a list of external data objects
+     *
+     * @param query The query for the search
+     * @param hint A hint string to help with parameters or additional filters / logic
+     * @param start The start of the search
+     * @param limit The max amount of records to be returned by the search
+     * @return a list of external data objects
+     */
+    @Override
+    public List<ExternalDataObject> searchExternalDataObjects(String query, String hint, int start, int limit) {
         Collection<ImportRecord> records;
         try {
             records = querySource.getRecords(query, start, limit);

--- a/dspace-api/src/main/java/org/dspace/external/provider/impl/OpenaireFundingDataProvider.java
+++ b/dspace-api/src/main/java/org/dspace/external/provider/impl/OpenaireFundingDataProvider.java
@@ -115,8 +115,34 @@ public class OpenaireFundingDataProvider extends AbstractExternalDataProvider {
         return Optional.empty();
     }
 
+    /**
+     * To comply with new interface and abstract, the 'hint' is now implemented if not actually
+     * supported in this provider.
+     *
+     * @param query The query for the search
+     * @param start The start of the search
+     * @param limit The max amount of records to be returned by the search
+     * @return
+     */
     @Override
     public List<ExternalDataObject> searchExternalDataObjects(String query, int start, int limit) {
+        return searchExternalDataObjects(query, null, start, limit);
+    }
+
+    /**
+     * Search the external source for objects based on a query and hint.
+     *
+     * To comply with new interface and abstract, the 'hint' is now implemented if not actually
+     * supported in this provider.
+     *
+     * @param query The query for the search
+     * @param hint The hint to help construct additional filters or business logic
+     * @param start The start of the search
+     * @param limit The max amount of records to be returned by the search
+     * @return
+     */
+    @Override
+    public List<ExternalDataObject> searchExternalDataObjects(String query, String hint, int start, int limit) {
 
         // ensure we have a positive > 0 limit
         if (limit < 1) {

--- a/dspace-api/src/main/java/org/dspace/external/provider/impl/OrcidPublicationDataProvider.java
+++ b/dspace-api/src/main/java/org/dspace/external/provider/impl/OrcidPublicationDataProvider.java
@@ -133,8 +133,34 @@ public class OrcidPublicationDataProvider extends AbstractExternalDataProvider {
             .map(work -> convertToExternalDataObject(orcid, work));
     }
 
+    /**
+     * To comply with new interface and abstract, the 'hint' is now implemented if not actually
+     * supported in this provider.
+     *
+     * @param orcid The query for the search (ORCID ID)
+     * @param start The start of the search
+     * @param limit The max amount of records to be returned by the search
+     * @return
+     */
     @Override
     public List<ExternalDataObject> searchExternalDataObjects(String orcid, int start, int limit) {
+        return searchExternalDataObjects(orcid, null, start, limit);
+    }
+
+    /**
+     * Search the ORCIDv3 external source for objects based on a query and hint.
+     *
+     * To comply with new interface and abstract, the 'hint' is now implemented if not actually
+     * supported in this provider.
+     *
+     * @param orcid The query for the search (ORCID ID)
+     * @param hint The hint to help construct additional filters or business logic
+     * @param start The start of the search
+     * @param limit The max amount of records to be returned by the search
+     * @return
+     */
+    @Override
+    public List<ExternalDataObject> searchExternalDataObjects(String orcid, String hint, int start, int limit) {
 
         validateOrcidId(orcid);
 

--- a/dspace-api/src/main/java/org/dspace/external/provider/impl/OrcidV3AuthorDataProvider.java
+++ b/dspace-api/src/main/java/org/dspace/external/provider/impl/OrcidV3AuthorDataProvider.java
@@ -186,8 +186,34 @@ public class OrcidV3AuthorDataProvider extends AbstractExternalDataProvider {
         return StringUtils.isNotBlank(text) && text.matches(ORCID_ID_SYNTAX);
     }
 
+    /**
+     * To comply with new interface and abstract, the 'hint' is now implemented if not actually
+     * supported in this provider.
+     *
+     * @param query The query for the search
+     * @param start The start of the search
+     * @param limit The max amount of records to be returned by the search
+     * @return
+     */
     @Override
     public List<ExternalDataObject> searchExternalDataObjects(String query, int start, int limit) {
+        return searchExternalDataObjects(query, null, start, limit);
+    }
+
+    /**
+     * Search the ORCIDv3 external source for objects based on a query and hint.
+     *
+     * To comply with new interface and abstract, the 'hint' is now implemented if not actually
+     * supported in this provider.
+     *
+     * @param query The query for the search
+     * @param hint The hint to help construct additional filters or business logic
+     * @param start The start of the search
+     * @param limit The max amount of records to be returned by the search
+     * @return
+     */
+    @Override
+    public List<ExternalDataObject> searchExternalDataObjects(String query, String hint, int start, int limit) {
         if (limit > 100) {
             throw new IllegalArgumentException("The maximum number of results to retrieve cannot exceed 100.");
         }

--- a/dspace-api/src/main/java/org/dspace/external/provider/impl/SHERPAv2JournalDataProvider.java
+++ b/dspace-api/src/main/java/org/dspace/external/provider/impl/SHERPAv2JournalDataProvider.java
@@ -105,14 +105,29 @@ public class SHERPAv2JournalDataProvider extends AbstractExternalDataProvider {
     }
 
     /**
+     * To comply with new interface and abstract, the 'hint' is now implemented if not actually
+     * supported in this provider.
+     *
+     * @param query The query for the search
+     * @param start The start of the search
+     * @param limit The max amount of records to be returned by the search
+     * @return
+     */
+    @Override
+    public List<ExternalDataObject> searchExternalDataObjects(String query, int start, int limit) {
+       return searchExternalDataObjects(query, null, start, limit);
+    }
+
+    /**
      * Search SHERPA v2 API for journal results based on a 'contains word' query
      * @param query The query for the search
+     * @param hint A hint string to help with parameters or additional filters / logic
      * @param start The start of the search
      * @param limit The max amount of records to be returned by the search
      * @return a list of external data objects
      */
     @Override
-    public List<ExternalDataObject> searchExternalDataObjects(String query, int start, int limit) {
+    public List<ExternalDataObject> searchExternalDataObjects(String query, String hint, int start, int limit) {
         // Search SHERPA for journals with the query term in the title
         SHERPAResponse sherpaResponse = sherpaService.performRequest("publication", "title",
             "contains word", query, start, limit);

--- a/dspace-api/src/main/java/org/dspace/external/provider/impl/SHERPAv2JournalISSNDataProvider.java
+++ b/dspace-api/src/main/java/org/dspace/external/provider/impl/SHERPAv2JournalISSNDataProvider.java
@@ -117,14 +117,29 @@ public class SHERPAv2JournalISSNDataProvider extends AbstractExternalDataProvide
     }
 
     /**
+     * To comply with new interface and abstract, the 'hint' is now implemented if not actually
+     * supported in this provider.
+     *
+     * @param query The query for the search
+     * @param start The start of the search
+     * @param limit The max amount of records to be returned by the search
+     * @return
+     */
+    @Override
+    public List<ExternalDataObject> searchExternalDataObjects(String query, int start, int limit) {
+        return searchExternalDataObjects(query, null, start, limit);
+    }
+
+    /**
      * Search SHERPA v2 API for journal results based on a 'contains word' query
      * @param query The term to query for the search
+     * @param hint A hint string to help with parameters or additional filters / logic
      * @param start The start of the search
      * @param limit The max amount of records to be returned by the search
      * @return a list of external data objects
      */
     @Override
-    public List<ExternalDataObject> searchExternalDataObjects(String query, int start, int limit) {
+    public List<ExternalDataObject> searchExternalDataObjects(String query, String hint, int start, int limit) {
 
         // Get SHERPA response from the API for all objects matching this ISSN
         SHERPAResponse sherpaResponse = sherpaService.performRequest(

--- a/dspace-api/src/main/java/org/dspace/external/provider/impl/SHERPAv2PublisherDataProvider.java
+++ b/dspace-api/src/main/java/org/dspace/external/provider/impl/SHERPAv2PublisherDataProvider.java
@@ -75,14 +75,29 @@ public class SHERPAv2PublisherDataProvider extends AbstractExternalDataProvider 
     }
 
     /**
+     * To comply with new interface and abstract, the 'hint' is now implemented if not actually
+     * supported in this provider.
+     *
+     * @param query The query for the search
+     * @param start The start of the search
+     * @param limit The max amount of records to be returned by the search
+     * @return
+     */
+    @Override
+    public List<ExternalDataObject> searchExternalDataObjects(String query, int start, int limit) {
+        return searchExternalDataObjects(query, null, start, limit);
+    }
+
+    /**
      * Search SHERPA v2 API for publisher results based on a 'contains word' query for publisher name
      * @param query The query for the search
+     * @param hint A hint string to help with parameters or additional filters / logic
      * @param start The start of the search
      * @param limit The max amount of records to be returned by the search
      * @return a list of external data objects
      */
     @Override
-    public List<ExternalDataObject> searchExternalDataObjects(String query, int start, int limit) {
+    public List<ExternalDataObject> searchExternalDataObjects(String query, String hint, int start, int limit) {
         // Search SHERPA for publishers with the query term in the title (name)
         SHERPAPublisherResponse sherpaResponse = sherpaService.performPublisherRequest(
             "publisher", "name", "contains word", query, start, limit);

--- a/dspace-api/src/main/java/org/dspace/external/service/ExternalDataService.java
+++ b/dspace-api/src/main/java/org/dspace/external/service/ExternalDataService.java
@@ -58,6 +58,19 @@ public interface ExternalDataService {
     public List<ExternalDataObject> searchExternalDataObjects(String source, String query, int start, int limit);
 
     /**
+     * This method will return a list of ExternalDataObjects as defined through the source in which they will be
+     * searched for, the given query start and limit parameters
+     * @param source    The source that defines which ExternalDataProvider is to be used
+     * @param query     The query for which the search will be done
+     * @param hint      A hint to help the provider with additional filtering or query construction (e.g. field)
+     * @param start     The start of the search
+     * @param limit     The maximum amount of records to be returned by the search
+     * @return          A list of ExternalDataObjects that obey the rules in the parameters
+     */
+    public List<ExternalDataObject> searchExternalDataObjects(String source, String query, String hint,
+                                                              int start, int limit);
+
+    /**
      * This method wil return the total amount of results that will be found for the given query in the given source
      * @param source    The source in which the query will happen to return the number of results
      * @param query     The query to be ran in this source to retrieve the total amount of results

--- a/dspace-api/src/main/java/org/dspace/external/service/impl/ExternalDataServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/external/service/impl/ExternalDataServiceImpl.java
@@ -55,11 +55,17 @@ public class ExternalDataServiceImpl implements ExternalDataService {
 
     @Override
     public List<ExternalDataObject> searchExternalDataObjects(String source, String query, int start, int limit) {
+        return searchExternalDataObjects(source, query, null, start, limit);
+    }
+
+    @Override
+    public List<ExternalDataObject> searchExternalDataObjects(String source, String query, String hint,
+                                                              int start, int limit) {
         ExternalDataProvider provider = getExternalDataProvider(source);
         if (provider == null) {
             throw new IllegalArgumentException("Provider for: " + source + " couldn't be found");
         }
-        return provider.searchExternalDataObjects(query, start, limit);
+        return provider.searchExternalDataObjects(query, hint, start, limit);
     }
 
 

--- a/dspace-api/src/test/java/org/dspace/external/provider/impl/MockDataProvider.java
+++ b/dspace-api/src/test/java/org/dspace/external/provider/impl/MockDataProvider.java
@@ -43,8 +43,22 @@ public class MockDataProvider extends AbstractExternalDataProvider {
         }
     }
 
+    /**
+     * To comply with new interface and abstract, the 'hint' is now implemented if not actually
+     * supported in this provider.
+     *
+     * @param query The query for the search
+     * @param start The start of the search
+     * @param limit The max amount of records to be returned by the search
+     * @return
+     */
     @Override
     public List<ExternalDataObject> searchExternalDataObjects(String query, int start, int limit) {
+        return searchExternalDataObjects(query, null, start, limit);
+    }
+
+    @Override
+    public List<ExternalDataObject> searchExternalDataObjects(String query, String hint, int start, int limit) {
         List<ExternalDataObject> listToReturn = new ArrayList<>();
         for (Map.Entry<String, ExternalDataObject> entry : mockLookupMap.entrySet()) {
             if (StringUtils.containsIgnoreCase(entry.getKey(), query)) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/ExternalSourcesRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/ExternalSourcesRestController.java
@@ -17,11 +17,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.hateoas.PagedModel;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 /**
  * This RestController takes care of the retrieval of External data from various endpoints and providers depending
@@ -57,11 +53,12 @@ public class ExternalSourcesRestController {
     public PagedModel<ExternalSourceEntryResource> getExternalSourceEntries(
         @PathVariable("externalSourceName") String externalSourceName,
         @RequestParam(name = "query") String query,
+        @RequestParam(name = "hint") String hint,
         @RequestParam(name = "parent", required = false) String parent,
         Pageable pageable, PagedResourcesAssembler assembler) {
 
         Page<ExternalSourceEntryRest> externalSourceEntryRestPage = externalSourceRestRepository
-            .getExternalSourceEntries(externalSourceName, query, parent, pageable);
+            .getExternalSourceEntries(externalSourceName, query, parent, hint, pageable);
         Page<ExternalSourceEntryResource> externalSourceEntryResources = externalSourceEntryRestPage
             .map(externalSourceEntryRest -> new ExternalSourceEntryResource(externalSourceEntryRest));
         externalSourceEntryResources.forEach(linkService::addLinks);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ExternalSourceRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ExternalSourceRestRepository.java
@@ -63,22 +63,22 @@ public class ExternalSourceRestRepository extends DSpaceRestRepository<ExternalS
      * param
      * @param externalSourceName The externalSourceName that defines which ExternalDataProvider is used
      * @param query         The query used in the lookup
-     * @param parent        The parent used in the lookup
+     * @param hint          An additional hint to be used for further filtering / query construction (eg. field)
      * @param pageable      The pagination object
      * @return              A paginated list of ExternalSourceEntryResource objects that comply with the params
      */
-    public Page<ExternalSourceEntryRest> getExternalSourceEntries(String externalSourceName, String query,
-                                                                  String parent, Pageable pageable) {
+    public Page<ExternalSourceEntryRest> getExternalSourceEntries(String externalSourceName, String query, String parent,
+                                                                  String hint, Pageable pageable) {
         if (externalDataService.getExternalDataProvider(externalSourceName) == null) {
             throw new ResourceNotFoundException("The externalSource for: " + externalSourceName + " couldn't be found");
         }
         List<ExternalDataObject> externalDataObjects = externalDataService
-            .searchExternalDataObjects(externalSourceName, query, Math.toIntExact(pageable.getOffset()),
+            .searchExternalDataObjects(externalSourceName, query, hint, Math.toIntExact(pageable.getOffset()),
                     pageable.getPageSize());
         int numberOfResults = externalDataService.getNumberOfResults(externalSourceName, query);
 
         return converter.toRestPage(externalDataObjects, pageable, numberOfResults,
-                                    utils.obtainProjection());
+                utils.obtainProjection());
     }
 
     @Override
@@ -112,9 +112,9 @@ public class ExternalSourceRestRepository extends DSpaceRestRepository<ExternalS
     public Page<ExternalSourceRest> findByEntityType(Context context, Pageable pageable,
           @Parameter(required = true, value = "entityType") String entityType) {
         List<ExternalDataProvider> externalSources = externalDataService.getExternalDataProviders()
-                                                                        .stream()
-                                                                        .filter(ep -> ep.supportsEntityType(entityType))
-                                                                        .collect(Collectors.toList());
+                .stream()
+                .filter(ep -> ep.supportsEntityType(entityType))
+                .collect(Collectors.toList());
 
         return converter.toRestPage(externalSources, pageable, utils.obtainProjection());
     }

--- a/dspace-server-webapp/src/test/java/org/dspace/external/provider/impl/MockDataProvider.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/external/provider/impl/MockDataProvider.java
@@ -8,6 +8,7 @@
 package org.dspace.external.provider.impl;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -41,8 +42,23 @@ public class MockDataProvider extends AbstractExternalDataProvider {
         }
     }
 
+    /**
+     * To comply with new interface and abstract, the 'hint' is now implemented if not actually
+     * supported in this provider.
+     *
+     * @param query The query for the search
+     * @param start The start of the search
+     * @param limit The max amount of records to be returned by the search
+     * @return
+     */
+    @Override
     public List<ExternalDataObject> searchExternalDataObjects(String query, int start, int limit) {
-        List<ExternalDataObject> listToReturn = new LinkedList<>();
+        return searchExternalDataObjects(query, null, start, limit);
+    }
+
+    @Override
+    public List<ExternalDataObject> searchExternalDataObjects(String query, String hint, int start, int limit) {
+        List<ExternalDataObject> listToReturn = new ArrayList<>();
         for (Map.Entry<String, ExternalDataObject> entry : mockLookupMap.entrySet()) {
             if (StringUtils.containsIgnoreCase(entry.getKey(), query)) {
                 listToReturn.add(entry.getValue());


### PR DESCRIPTION
## Description
This is a set of small improvements to the interfaces, abstracts and implementations of External Data Providers and Services. They originate from a separate piece of work which I plan to submit, but I think they are best reviewed and merged (with changes as per feedback) as core improvements.

Fundamentally, the idea is to extend external data services and provider interfaces/abstract classes without affecting any existing implementations.

1. New `searchExternalDataObjects` method in provider and service interfaces accepts a new 'hint' String argument. This argument 

WIP - DRAFT PULL REQUEST