### PR TITLE
Configure Item submission process at community level

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/DCInputsReader.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/DCInputsReader.java
@@ -14,7 +14,6 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import javax.servlet.ServletException;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.FactoryConfigurationError;
@@ -150,17 +149,16 @@ public class DCInputsReader {
      * Returns the set of DC inputs used for a particular collection, or the
      * default set if no inputs defined for the collection
      *
-     * @param collectionHandle collection's unique Handle
+     * @param collection collection for which search the set of DC inputs
      * @return DC input set
      * @throws DCInputsReaderException if no default set defined
-     * @throws ServletException
      */
-    public List<DCInputSet> getInputsByCollectionHandle(String collectionHandle)
+    public List<DCInputSet> getInputsByCollection(Collection collection)
         throws DCInputsReaderException {
         SubmissionConfig config;
         try {
             config = SubmissionServiceFactory.getInstance().getSubmissionConfigService()
-                        .getSubmissionConfigByCollection(collectionHandle);
+                        .getSubmissionConfigByCollection(collection);
             String formName = config.getSubmissionName();
             if (formName == null) {
                 throw new DCInputsReaderException("No form designated as default");
@@ -691,7 +689,7 @@ public class DCInputsReader {
 
     public String getInputFormNameByCollectionAndField(Collection collection, String field)
         throws DCInputsReaderException {
-        List<DCInputSet> inputSets = getInputsByCollectionHandle(collection.getHandle());
+        List<DCInputSet> inputSets = getInputsByCollection(collection);
         for (DCInputSet inputSet : inputSets) {
             String[] tokenized = Utils.tokenize(field);
             String schema = tokenized[0];

--- a/dspace-api/src/main/java/org/dspace/app/util/SubmissionConfigReader.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/SubmissionConfigReader.java
@@ -11,6 +11,7 @@ import java.io.File;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -21,6 +22,7 @@ import javax.xml.parsers.FactoryConfigurationError;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.dspace.content.Collection;
+import org.dspace.content.Community;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.CollectionService;
@@ -91,6 +93,13 @@ public class SubmissionConfigReader {
     private Map<String, String> collectionToSubmissionConfig = null;
 
     /**
+     * Hashmap which stores which submission process configuration is used by
+     * which community, computed from the item submission config file
+     * (specifically, the 'submission-map' tag)
+     */
+    private Map<String, String> communityToSubmissionConfig = null;
+
+    /**
      * Reference to the global submission step definitions defined in the
      * "step-definitions" section
      */
@@ -127,6 +136,7 @@ public class SubmissionConfigReader {
 
     public void reload() throws SubmissionConfigReaderException {
         collectionToSubmissionConfig = null;
+        communityToSubmissionConfig = null;
         stepDefns = null;
         submitDefns = null;
         buildInputs(configDir + SUBMIT_DEF_FILE_PREFIX + SUBMIT_DEF_FILE_SUFFIX);
@@ -145,7 +155,8 @@ public class SubmissionConfigReader {
      */
     private void buildInputs(String fileName) throws SubmissionConfigReaderException {
         collectionToSubmissionConfig = new HashMap<String, String>();
-        submitDefns = new HashMap<String, List<Map<String, String>>>();
+        communityToSubmissionConfig = new HashMap<String, String>();
+        submitDefns = new LinkedHashMap<String, List<Map<String, String>>>();
 
         String uri = "file:" + new File(fileName).getAbsolutePath();
 
@@ -210,24 +221,69 @@ public class SubmissionConfigReader {
      * Returns the Item Submission process config used for a particular
      * collection, or the default if none is defined for the collection
      *
-     * @param collectionHandle collection's unique Handle
+     * @param col collection for which search Submission process config
      * @return the SubmissionConfig representing the item submission config
-     * @throws SubmissionConfigReaderException if no default submission process configuration defined
+     * @throws IllegalStateException if no default submission process configuration defined
      */
-    public SubmissionConfig getSubmissionConfigByCollection(String collectionHandle) {
-        // get the name of the submission process config for this collection
-        String submitName = collectionToSubmissionConfig
-            .get(collectionHandle);
-        if (submitName == null) {
+    public SubmissionConfig getSubmissionConfigByCollection(Collection col) {
+
+        String submitName;
+
+        if (col != null) {
+
+            // get the name of the submission process config for this collection
             submitName = collectionToSubmissionConfig
-                .get(DEFAULT_COLLECTION);
+                .get(col.getHandle());
+            if (submitName != null) {
+                return getSubmissionConfigByName(submitName);
+            }
+
+            try {
+                List<Community> communities = col.getCommunities();
+                for (Community com : communities) {
+                    submitName = getSubmissionConfigByCommunity(com);
+                    if (submitName != null) {
+                        return getSubmissionConfigByName(submitName);
+                    }
+                }
+            } catch (SQLException sqle) {
+                throw new IllegalStateException("Error occurred while getting item submission configured " +
+                                                "by community", sqle);
+            }
         }
+
+        submitName = collectionToSubmissionConfig.get(DEFAULT_COLLECTION);
+
         if (submitName == null) {
             throw new IllegalStateException(
                 "No item submission process configuration designated as 'default' in 'submission-map' section of " +
                     "'item-submission.xml'.");
         }
         return getSubmissionConfigByName(submitName);
+    }
+
+    /**
+     * Recursive function to return the Item Submission process config
+     * used for a community or the closest community parent, or null
+     * if none is defined
+     *
+     * @param com community for which search Submission process config
+     * @return the SubmissionConfig representing the item submission config
+     */
+    private String getSubmissionConfigByCommunity(Community com) {
+        String submitName = communityToSubmissionConfig
+                .get(com.getHandle());
+        if (submitName != null) {
+            return submitName;
+        }
+        List<Community> communities = com.getParentCommunities();
+        for (Community parentCom : communities) {
+            submitName = getSubmissionConfigByCommunity(parentCom);
+            if (submitName != null) {
+                return submitName;
+            }
+        }
+        return null;
     }
 
     /**
@@ -357,13 +413,14 @@ public class SubmissionConfigReader {
             Node nd = nl.item(i);
             if (nd.getNodeName().equals("name-map")) {
                 String id = getAttribute(nd, "collection-handle");
+                String communityId = getAttribute(nd, "community-handle");
                 String entityType = getAttribute(nd, "collection-entity-type");
                 String value = getAttribute(nd, "submission-name");
                 String content = getValue(nd);
-                if (id == null && entityType == null) {
+                if (id == null && communityId == null && entityType == null) {
                     throw new SAXException(
-                        "name-map element is missing collection-handle or collection-entity-type attribute " +
-                            "in 'item-submission.xml'");
+                        "name-map element is missing collection-handle or community-handle or collection-entity-type " +
+                            "attribute in 'item-submission.xml'");
                 }
                 if (value == null) {
                     throw new SAXException(
@@ -375,7 +432,8 @@ public class SubmissionConfigReader {
                 }
                 if (id != null) {
                     collectionToSubmissionConfig.put(id, value);
-
+                } else if (communityId != null) {
+                    communityToSubmissionConfig.put(communityId, value);
                 } else {
                     // get all collections for this entity-type
                     List<Collection> collections = collectionService.findAllCollectionsByEntityType( context,

--- a/dspace-api/src/main/java/org/dspace/app/util/SubmissionConfigReader.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/SubmissionConfigReader.java
@@ -238,17 +238,19 @@ public class SubmissionConfigReader {
                 return getSubmissionConfigByName(submitName);
             }
 
-            try {
-                List<Community> communities = col.getCommunities();
-                for (Community com : communities) {
-                    submitName = getSubmissionConfigByCommunity(com);
-                    if (submitName != null) {
-                        return getSubmissionConfigByName(submitName);
+            if (!communityToSubmissionConfig.isEmpty()) {
+                try {
+                    List<Community> communities = col.getCommunities();
+                    for (Community com : communities) {
+                        submitName = getSubmissionConfigByCommunity(com);
+                        if (submitName != null) {
+                            return getSubmissionConfigByName(submitName);
+                        }
                     }
+                } catch (SQLException sqle) {
+                    throw new IllegalStateException("Error occurred while getting item submission configured " +
+                                                    "by community", sqle);
                 }
-            } catch (SQLException sqle) {
-                throw new IllegalStateException("Error occurred while getting item submission configured " +
-                                                "by community", sqle);
             }
         }
 

--- a/dspace-api/src/main/java/org/dspace/app/util/Util.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/Util.java
@@ -405,21 +405,13 @@ public class Util {
         DCInput myInputs = null;
         boolean myInputsFound = false;
         String formFileName = I18nUtil.getInputFormsFileName(locale);
-        String col_handle = "";
 
         Collection collection = item.getOwningCollection();
-
-        if (collection == null) {
-            // set an empty handle so to get the default input set
-            col_handle = "";
-        } else {
-            col_handle = collection.getHandle();
-        }
 
         // Read the input form file for the specific collection
         DCInputsReader inputsReader = new DCInputsReader(formFileName);
 
-        List<DCInputSet> inputSets = inputsReader.getInputsByCollectionHandle(col_handle);
+        List<DCInputSet> inputSets = inputsReader.getInputsByCollection(collection);
 
         // Replace the values of Metadatum[] with the correct ones in case
         // of
@@ -500,8 +492,8 @@ public class Util {
     public static List<String> differenceInSubmissionFields(Collection fromCollection, Collection toCollection)
         throws DCInputsReaderException {
         DCInputsReader reader = new DCInputsReader();
-        List<DCInputSet> from = reader.getInputsByCollectionHandle(fromCollection.getHandle());
-        List<DCInputSet> to = reader.getInputsByCollectionHandle(toCollection.getHandle());
+        List<DCInputSet> from = reader.getInputsByCollection(fromCollection);
+        List<DCInputSet> to = reader.getInputsByCollection(toCollection);
 
         Set<String> fromFieldName = new HashSet<>();
         Set<String> toFieldName = new HashSet<>();

--- a/dspace-api/src/main/java/org/dspace/content/authority/ChoiceAuthorityServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/ChoiceAuthorityServiceImpl.java
@@ -242,7 +242,7 @@ public final class ChoiceAuthorityServiceImpl implements ChoiceAuthorityService 
             // check if it is the requested collection
             Map<String, ChoiceAuthority> controllerFormDef = controllerFormDefinitions.get(fieldKey);
             SubmissionConfig submissionConfig = submissionConfigService
-                    .getSubmissionConfigByCollection(collection.getHandle());
+                    .getSubmissionConfigByCollection(collection);
             String submissionName = submissionConfig.getSubmissionName();
             // check if the requested collection has a submission definition that use an authority for the metadata
             if (controllerFormDef.containsKey(submissionName)) {
@@ -495,7 +495,7 @@ public final class ChoiceAuthorityServiceImpl implements ChoiceAuthorityService 
             try {
                 configReaderService = SubmissionServiceFactory.getInstance().getSubmissionConfigService();
                 SubmissionConfig submissionName = configReaderService
-                        .getSubmissionConfigByCollection(collection.getHandle());
+                        .getSubmissionConfigByCollection(collection);
                 ma = controllerFormDefinitions.get(fieldKey).get(submissionName.getSubmissionName());
             } catch (SubmissionConfigReaderException e) {
                 // the system is in an illegal state as the submission definition is not valid

--- a/dspace-api/src/main/java/org/dspace/ctask/general/RequiredMetadata.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/RequiredMetadata.java
@@ -17,6 +17,7 @@ import org.dspace.app.util.DCInput;
 import org.dspace.app.util.DCInputSet;
 import org.dspace.app.util.DCInputsReader;
 import org.dspace.app.util.DCInputsReaderException;
+import org.dspace.content.Collection;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataValue;
@@ -69,7 +70,7 @@ public class RequiredMetadata extends AbstractCurationTask {
                     handle = "in workflow";
                 }
                 sb.append("Item: ").append(handle);
-                for (String req : getReqList(item.getOwningCollection().getHandle())) {
+                for (String req : getReqList(item.getOwningCollection())) {
                     List<MetadataValue> vals = itemService.getMetadataByMetadataString(item, req);
                     if (vals.size() == 0) {
                         sb.append(" missing required field: ").append(req);
@@ -91,14 +92,14 @@ public class RequiredMetadata extends AbstractCurationTask {
         }
     }
 
-    protected List<String> getReqList(String handle) throws DCInputsReaderException {
-        List<String> reqList = reqMap.get(handle);
+    protected List<String> getReqList(Collection collection) throws DCInputsReaderException {
+        List<String> reqList = reqMap.get(collection.getHandle());
         if (reqList == null) {
             reqList = reqMap.get("default");
         }
         if (reqList == null) {
             reqList = new ArrayList<String>();
-            List<DCInputSet> inputSet = reader.getInputsByCollectionHandle(handle);
+            List<DCInputSet> inputSet = reader.getInputsByCollection(collection);
             for (DCInputSet inputs : inputSet) {
                 for (DCInput[] row : inputs.getFields()) {
                     for (DCInput input : row) {

--- a/dspace-api/src/main/java/org/dspace/submit/service/SubmissionConfigService.java
+++ b/dspace-api/src/main/java/org/dspace/submit/service/SubmissionConfigService.java
@@ -34,7 +34,7 @@ public interface SubmissionConfigService {
 
     public int countSubmissionConfigs();
 
-    public SubmissionConfig getSubmissionConfigByCollection(String collectionHandle);
+    public SubmissionConfig getSubmissionConfigByCollection(Collection collection);
 
     public SubmissionConfig getSubmissionConfigByName(String submitName);
 

--- a/dspace-api/src/main/java/org/dspace/submit/service/SubmissionConfigServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/submit/service/SubmissionConfigServiceImpl.java
@@ -57,8 +57,8 @@ public class SubmissionConfigServiceImpl implements SubmissionConfigService, Ini
     }
 
     @Override
-    public SubmissionConfig getSubmissionConfigByCollection(String collectionHandle) {
-        return submissionConfigReader.getSubmissionConfigByCollection(collectionHandle);
+    public SubmissionConfig getSubmissionConfigByCollection(Collection collection) {
+        return submissionConfigReader.getSubmissionConfigByCollection(collection);
     }
 
     @Override

--- a/dspace-api/src/test/data/dspaceFolder/config/item-submission.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/item-submission.xml
@@ -24,6 +24,8 @@
         <name-map collection-handle="123456789/typebind-test" submission-name="typebindtest"/>
         <name-map collection-handle="123456789/accessCondition-not-discoverable" submission-name="accessConditionNotDiscoverable"/>
         <name-map collection-handle="123456789/test-hidden" submission-name="test-hidden"/>
+        <name-map community-handle="123456789/topcommunity-test" submission-name="topcommunitytest"/>
+        <name-map community-handle="123456789/subcommunity-test" submission-name="subcommunitytest"/>
     </submission-map>
 
 
@@ -255,6 +257,14 @@
             <step id="test-outside-submission-hidden"/>
             <step id="test-never-hidden"/>
             <step id="test-always-hidden"/>
+        </submission-process>
+
+        <submission-process name="topcommunitytest">
+            <step id="collection"/>
+        </submission-process>
+
+        <submission-process name="subcommunitytest">
+            <step id="collection"/>
         </submission-process>
 
     </submission-definitions>

--- a/dspace-api/src/test/data/dspaceFolder/config/item-submission.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/item-submission.xml
@@ -26,6 +26,7 @@
         <name-map collection-handle="123456789/test-hidden" submission-name="test-hidden"/>
         <name-map community-handle="123456789/topcommunity-test" submission-name="topcommunitytest"/>
         <name-map community-handle="123456789/subcommunity-test" submission-name="subcommunitytest"/>
+        <name-map collection-handle="123456789/collection-test" submission-name="collectiontest"/>
     </submission-map>
 
 
@@ -264,6 +265,10 @@
         </submission-process>
 
         <submission-process name="subcommunitytest">
+            <step id="collection"/>
+        </submission-process>
+
+        <submission-process name="collectiontest">
             <step id="collection"/>
         </submission-process>
 

--- a/dspace-api/src/test/java/org/dspace/app/util/SubmissionConfigIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/util/SubmissionConfigIT.java
@@ -1,0 +1,73 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.util;
+
+import static org.junit.Assert.assertEquals;
+
+import org.dspace.AbstractIntegrationTestWithDatabase;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.submit.factory.SubmissionServiceFactory;
+import org.dspace.submit.service.SubmissionConfigService;
+import org.junit.Test;
+
+/**
+ * Integration Tests for parsing and utilities on submission config forms / readers
+ *
+ * @author Toni Prieto
+ */
+public class SubmissionConfigIT extends AbstractIntegrationTestWithDatabase {
+
+    @Test
+    public void testSubmissionMapByCommunityHandleSubmissionConfig()
+        throws SubmissionConfigReaderException {
+
+        context.turnOffAuthorisationSystem();
+        // Sep up a structure with one top community and two subcommunities with collections
+        Community topcom = CommunityBuilder.createCommunity(context, "123456789/topcommunity-test")
+            .withName("Parent Community")
+            .build();
+        Community subcom1 = CommunityBuilder.createSubCommunity(context, topcom, "123456789/subcommunity-test")
+            .withName("Subcommunity 1")
+            .build();
+        Community subcom2 = CommunityBuilder.createSubCommunity(context, topcom, "123456789/not-mapped3")
+            .withName("Subcommunity 2")
+            .build();
+        // col1 should use the form item submission form mapped for subcom1
+        Collection col1 = CollectionBuilder.createCollection(context, subcom1, "123456789/not-mapped1")
+            .withName("Collection 1")
+            .build();
+        // col2 should use the item submission form mapped for the top community
+        Collection col2 = CollectionBuilder.createCollection(context, subcom2, "123456789/not-mapped2")
+            .withName("Collection 2")
+            .build();
+        // col3 should use the item submission form directly mapped for this collection
+        Collection col3 = CollectionBuilder.createCollection(context, subcom1, "123456789/collection-test")
+            .withName("Collection 3")
+            .build();
+        context.restoreAuthSystemState();
+
+        SubmissionConfigService submissionConfigService = SubmissionServiceFactory.getInstance()
+            .getSubmissionConfigService();
+
+        // for col1, it should return the item submission form defined for their parent subcom1
+        SubmissionConfig submissionConfig1 = submissionConfigService.getSubmissionConfigByCollection(col1);
+        assertEquals("subcommunitytest", submissionConfig1.getSubmissionName());
+
+        // for col2, it should return the item submission form defined for topcom
+        SubmissionConfig submissionConfig2 = submissionConfigService.getSubmissionConfigByCollection(col2);
+        assertEquals("topcommunitytest", submissionConfig2.getSubmissionName());
+
+        // for col3, it should return the item submission form defined directly for the collection
+        SubmissionConfig submissionConfig3 = submissionConfigService.getSubmissionConfigByCollection(col3);
+        assertEquals("collectiontest", submissionConfig3.getSubmissionName());
+
+    }
+}

--- a/dspace-api/src/test/java/org/dspace/app/util/SubmissionConfigTest.java
+++ b/dspace-api/src/test/java/org/dspace/app/util/SubmissionConfigTest.java
@@ -11,13 +11,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.when;
 
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.dspace.AbstractUnitTest;
 import org.dspace.content.Collection;
-import org.dspace.content.Community;
 import org.dspace.submit.factory.SubmissionServiceFactory;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -36,19 +34,7 @@ public class SubmissionConfigTest extends AbstractUnitTest {
     DCInputsReader inputReader;
 
     @Mock
-    Community topcom;
-
-    @Mock
-    Community subcom1;
-
-    @Mock
-    Community subcom2;
-
-    @Mock
     private Collection col1;
-
-    @Mock
-    private Collection col2;
 
     @BeforeClass
     public static void setUpClass() {
@@ -108,36 +94,5 @@ public class SubmissionConfigTest extends AbstractUnitTest {
         // Article and type should match a subset of the fields without ISBN
         assertEquals(unboundFields, allowedFieldsForArticle);
         assertEquals(unboundFields, allowedFieldsForNoType);
-    }
-
-    @Test
-    public void testSubmissionMapByCommunityHandleSubmissionConfig()
-        throws SubmissionConfigReaderException, DCInputsReaderException, SQLException {
-
-        // Sep up a structure with one top community and two subcommunities
-        // with one collection
-        when(col1.getHandle()).thenReturn("123456789/not-mapped1");
-        when(col1.getCommunities()).thenReturn(List.of(subcom1));
-
-        when(col2.getHandle()).thenReturn("123456789/not-mapped2");
-        when(col2.getCommunities()).thenReturn(List.of(subcom2));
-
-        when(subcom1.getHandle()).thenReturn("123456789/subcommunity-test");
-
-        when(subcom2.getParentCommunities()).thenReturn(List.of(topcom));
-        when(subcom2.getHandle()).thenReturn("123456789/not-mapped3");
-
-        when(topcom.getHandle()).thenReturn("123456789/topcommunity-test");
-
-        // for col1, it should return the item submission form defined for their parent subcom1
-        SubmissionConfig submissionConfig1 =
-            new SubmissionConfigReader().getSubmissionConfigByCollection(col1);
-        assertEquals("subcommunitytest", submissionConfig1.getSubmissionName());
-
-        // for col2, it should return the item submission form defined for topcom
-        SubmissionConfig submissionConfig2 =
-            new SubmissionConfigReader().getSubmissionConfigByCollection(col2);
-        assertEquals("topcommunitytest", submissionConfig2.getSubmissionName());
-
     }
 }

--- a/dspace-api/src/test/java/org/dspace/app/util/SubmissionConfigTest.java
+++ b/dspace-api/src/test/java/org/dspace/app/util/SubmissionConfigTest.java
@@ -9,17 +9,22 @@ package org.dspace.app.util;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.when;
 
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.dspace.AbstractUnitTest;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
 import org.dspace.submit.factory.SubmissionServiceFactory;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.Mock;
 
 /**
  * Tests for parsing and utilities on submission config forms / readers
@@ -29,6 +34,21 @@ import org.junit.Test;
 public class SubmissionConfigTest extends AbstractUnitTest {
 
     DCInputsReader inputReader;
+
+    @Mock
+    Community topcom;
+
+    @Mock
+    Community subcom1;
+
+    @Mock
+    Community subcom2;
+
+    @Mock
+    private Collection col1;
+
+    @Mock
+    private Collection col2;
 
     @BeforeClass
     public static void setUpClass() {
@@ -56,6 +76,8 @@ public class SubmissionConfigTest extends AbstractUnitTest {
         String typeBindSubmissionName = "typebindtest";
         String typeBindSubmissionStepName = "typebindtest";
 
+        when(col1.getHandle()).thenReturn(typeBindHandle);
+
         // Expected field lists from typebindtest form
         List<String> allConfiguredFields = new ArrayList<>();
         allConfiguredFields.add("dc.title");
@@ -67,7 +89,7 @@ public class SubmissionConfigTest extends AbstractUnitTest {
         // Get submission configuration
         SubmissionConfig submissionConfig =
                 SubmissionServiceFactory.getInstance().getSubmissionConfigService()
-                    .getSubmissionConfigByCollection(typeBindHandle);
+                    .getSubmissionConfigByCollection(col1);
         // Submission name should match name defined in item-submission.xml
         assertEquals(typeBindSubmissionName, submissionConfig.getSubmissionName());
         // Step 0 - our process only has one step. It should not be null and have the ID typebindtest
@@ -86,5 +108,36 @@ public class SubmissionConfigTest extends AbstractUnitTest {
         // Article and type should match a subset of the fields without ISBN
         assertEquals(unboundFields, allowedFieldsForArticle);
         assertEquals(unboundFields, allowedFieldsForNoType);
+    }
+
+    @Test
+    public void testSubmissionMapByCommunityHandleSubmissionConfig()
+        throws SubmissionConfigReaderException, DCInputsReaderException, SQLException {
+
+        // Sep up a structure with one top community and two subcommunities
+        // with one collection
+        when(col1.getHandle()).thenReturn("123456789/not-mapped1");
+        when(col1.getCommunities()).thenReturn(List.of(subcom1));
+
+        when(col2.getHandle()).thenReturn("123456789/not-mapped2");
+        when(col2.getCommunities()).thenReturn(List.of(subcom2));
+
+        when(subcom1.getHandle()).thenReturn("123456789/subcommunity-test");
+
+        when(subcom2.getParentCommunities()).thenReturn(List.of(topcom));
+        when(subcom2.getHandle()).thenReturn("123456789/not-mapped3");
+
+        when(topcom.getHandle()).thenReturn("123456789/topcommunity-test");
+
+        // for col1, it should return the item submission form defined for their parent subcom1
+        SubmissionConfig submissionConfig1 =
+            new SubmissionConfigReader().getSubmissionConfigByCollection(col1);
+        assertEquals("subcommunitytest", submissionConfig1.getSubmissionName());
+
+        // for col2, it should return the item submission form defined for topcom
+        SubmissionConfig submissionConfig2 =
+            new SubmissionConfigReader().getSubmissionConfigByCollection(col2);
+        assertEquals("topcommunitytest", submissionConfig2.getSubmissionName());
+
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/AInprogressItemConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/AInprogressItemConverter.java
@@ -82,7 +82,7 @@ public abstract class AInprogressItemConverter<T extends InProgressSubmission,
 
         if (collection != null) {
             SubmissionDefinitionRest def = converter.toRest(
-                    submissionConfigService.getSubmissionConfigByCollection(collection.getHandle()), projection);
+                    submissionConfigService.getSubmissionConfigByCollection(collection), projection);
             witem.setSubmissionDefinition(def);
             for (SubmissionSectionRest sections : def.getPanels()) {
                 SubmissionStepConfig stepConfig = submissionSectionConverter.toModel(sections);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/SubmissionDefinitionRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/SubmissionDefinitionRestRepository.java
@@ -70,7 +70,7 @@ public class SubmissionDefinitionRestRepository extends DSpaceRestRepository<Sub
             return null;
         }
         SubmissionDefinitionRest def = converter
-            .toRest(submissionConfigService.getSubmissionConfigByCollection(col.getHandle()),
+            .toRest(submissionConfigService.getSubmissionConfigByCollection(col),
                     utils.obtainProjection());
         return def;
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkspaceItemRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkspaceItemRestRepository.java
@@ -251,7 +251,7 @@ public class WorkspaceItemRestRepository extends DSpaceRestRepository<WorkspaceI
         }
 
         SubmissionConfig submissionConfig =
-            submissionConfigService.getSubmissionConfigByCollection(collection.getHandle());
+            submissionConfigService.getSubmissionConfigByCollection(collection);
         List<WorkspaceItem> result = null;
         List<ImportRecord> records = new ArrayList<>();
         try {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionDefinitionsControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionDefinitionsControllerIT.java
@@ -91,6 +91,7 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
                    //The status has to be 200 OK
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$", SubmissionDefinitionsMatcher.matchFullEmbeds()))
+                   .andExpect(jsonPath("$", SubmissionDefinitionsMatcher.matchLinks()))
                    //We expect the content type to be "application/hal+json;charset=UTF-8"
                    .andExpect(content().contentType(contentType))
 
@@ -257,10 +258,10 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
                         Matchers.containsString("page=1"), Matchers.containsString("size=1"))))
                 .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
                         Matchers.containsString("/api/config/submissiondefinitions?"),
-                        Matchers.containsString("page=6"), Matchers.containsString("size=1"))))
+                        Matchers.containsString("page=8"), Matchers.containsString("size=1"))))
                 .andExpect(jsonPath("$.page.size", is(1)))
-                .andExpect(jsonPath("$.page.totalElements", is(7)))
-                .andExpect(jsonPath("$.page.totalPages", is(7)))
+                .andExpect(jsonPath("$.page.totalElements", is(9)))
+                .andExpect(jsonPath("$.page.totalPages", is(9)))
                 .andExpect(jsonPath("$.page.number", is(0)));
 
         getClient(tokenAdmin).perform(get("/api/config/submissiondefinitions")
@@ -268,7 +269,7 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
                 .param("page", "1"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(contentType))
-                .andExpect(jsonPath("$._embedded.submissiondefinitions[0].id", is("test-hidden")))
+                .andExpect(jsonPath("$._embedded.submissiondefinitions[0].id", is("languagetestprocess")))
                 .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
                         Matchers.containsString("/api/config/submissiondefinitions?"),
                         Matchers.containsString("page=0"), Matchers.containsString("size=1"))))
@@ -283,10 +284,10 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
                         Matchers.containsString("page=1"), Matchers.containsString("size=1"))))
                 .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
                         Matchers.containsString("/api/config/submissiondefinitions?"),
-                        Matchers.containsString("page="), Matchers.containsString("size=1"))))
+                        Matchers.containsString("page=8"), Matchers.containsString("size=1"))))
                 .andExpect(jsonPath("$.page.size", is(1)))
-                .andExpect(jsonPath("$.page.totalElements", is(7)))
-                .andExpect(jsonPath("$.page.totalPages", is(7)))
+                .andExpect(jsonPath("$.page.totalElements", is(9)))
+                .andExpect(jsonPath("$.page.totalPages", is(9)))
                 .andExpect(jsonPath("$.page.number", is(1)));
 
         getClient(tokenAdmin).perform(get("/api/config/submissiondefinitions")
@@ -294,7 +295,7 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
                 .param("page", "2"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(contentType))
-                .andExpect(jsonPath("$._embedded.submissiondefinitions[0].id", is("accessConditionNotDiscoverable")))
+                .andExpect(jsonPath("$._embedded.submissiondefinitions[0].id", is("extractiontestprocess")))
                 .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
                     Matchers.containsString("/api/config/submissiondefinitions?"),
                     Matchers.containsString("page=0"), Matchers.containsString("size=1"))))
@@ -309,10 +310,10 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
                     Matchers.containsString("page=2"), Matchers.containsString("size=1"))))
                 .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
                     Matchers.containsString("/api/config/submissiondefinitions?"),
-                    Matchers.containsString("page=6"), Matchers.containsString("size=1"))))
+                    Matchers.containsString("page=8"), Matchers.containsString("size=1"))))
                 .andExpect(jsonPath("$.page.size", is(1)))
-                .andExpect(jsonPath("$.page.totalElements", is(7)))
-                .andExpect(jsonPath("$.page.totalPages", is(7)))
+                .andExpect(jsonPath("$.page.totalElements", is(9)))
+                .andExpect(jsonPath("$.page.totalPages", is(9)))
                 .andExpect(jsonPath("$.page.number", is(2)));
 
         getClient(tokenAdmin).perform(get("/api/config/submissiondefinitions")
@@ -320,7 +321,7 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
                 .param("page", "3"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(contentType))
-                .andExpect(jsonPath("$._embedded.submissiondefinitions[0].id", is("languagetestprocess")))
+                .andExpect(jsonPath("$._embedded.submissiondefinitions[0].id", is("qualdroptest")))
                 .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
                     Matchers.containsString("/api/config/submissiondefinitions?"),
                     Matchers.containsString("page=0"), Matchers.containsString("size=1"))))
@@ -335,10 +336,10 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
                     Matchers.containsString("page=3"), Matchers.containsString("size=1"))))
                 .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
                     Matchers.containsString("/api/config/submissiondefinitions?"),
-                    Matchers.containsString("page=6"), Matchers.containsString("size=1"))))
+                    Matchers.containsString("page=8"), Matchers.containsString("size=1"))))
                 .andExpect(jsonPath("$.page.size", is(1)))
-                .andExpect(jsonPath("$.page.totalElements", is(7)))
-                .andExpect(jsonPath("$.page.totalPages", is(7)))
+                .andExpect(jsonPath("$.page.totalElements", is(9)))
+                .andExpect(jsonPath("$.page.totalPages", is(9)))
                 .andExpect(jsonPath("$.page.number", is(3)));
 
         getClient(tokenAdmin).perform(get("/api/config/submissiondefinitions")
@@ -346,7 +347,7 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
             .param("page", "4"))
             .andExpect(status().isOk())
             .andExpect(content().contentType(contentType))
-            .andExpect(jsonPath("$._embedded.submissiondefinitions[0].id", is("qualdroptest")))
+            .andExpect(jsonPath("$._embedded.submissiondefinitions[0].id", is("typebindtest")))
             .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
                 Matchers.containsString("/api/config/submissiondefinitions?"),
                 Matchers.containsString("page=0"), Matchers.containsString("size=1"))))
@@ -361,10 +362,10 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
                 Matchers.containsString("page=4"), Matchers.containsString("size=1"))))
             .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
                 Matchers.containsString("/api/config/submissiondefinitions?"),
-                Matchers.containsString("page=6"), Matchers.containsString("size=1"))))
+                Matchers.containsString("page=8"), Matchers.containsString("size=1"))))
             .andExpect(jsonPath("$.page.size", is(1)))
-            .andExpect(jsonPath("$.page.totalElements", is(7)))
-            .andExpect(jsonPath("$.page.totalPages", is(7)))
+            .andExpect(jsonPath("$.page.totalElements", is(9)))
+            .andExpect(jsonPath("$.page.totalPages", is(9)))
             .andExpect(jsonPath("$.page.number", is(4)));
 
         getClient(tokenAdmin).perform(get("/api/config/submissiondefinitions")
@@ -372,7 +373,7 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
             .param("page", "5"))
             .andExpect(status().isOk())
             .andExpect(content().contentType(contentType))
-            .andExpect(jsonPath("$._embedded.submissiondefinitions[0].id", is("extractiontestprocess")))
+            .andExpect(jsonPath("$._embedded.submissiondefinitions[0].id", is("accessConditionNotDiscoverable")))
             .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
                 Matchers.containsString("/api/config/submissiondefinitions?"),
                 Matchers.containsString("page=0"), Matchers.containsString("size=1"))))
@@ -387,11 +388,112 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
                 Matchers.containsString("page=5"), Matchers.containsString("size=1"))))
             .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
                 Matchers.containsString("/api/config/submissiondefinitions?"),
-                Matchers.containsString("page=6"), Matchers.containsString("size=1"))))
+                Matchers.containsString("page=8"), Matchers.containsString("size=1"))))
             .andExpect(jsonPath("$.page.size", is(1)))
-            .andExpect(jsonPath("$.page.totalElements", is(7)))
-            .andExpect(jsonPath("$.page.totalPages", is(7)))
+            .andExpect(jsonPath("$.page.totalElements", is(9)))
+            .andExpect(jsonPath("$.page.totalPages", is(9)))
             .andExpect(jsonPath("$.page.number", is(5)));
+
+        getClient(tokenAdmin).perform(get("/api/config/submissiondefinitions")
+                .param("size", "1")
+                .param("page", "5"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._embedded.submissiondefinitions[0].id", is("accessConditionNotDiscoverable")))
+            .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=0"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.prev.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=4"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.next.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=6"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=5"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=8"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$.page.size", is(1)))
+            .andExpect(jsonPath("$.page.totalElements", is(9)))
+            .andExpect(jsonPath("$.page.totalPages", is(9)))
+            .andExpect(jsonPath("$.page.number", is(5)));
+
+        getClient(tokenAdmin).perform(get("/api/config/submissiondefinitions")
+                .param("size", "1")
+                .param("page", "6"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._embedded.submissiondefinitions[0].id", is("test-hidden")))
+            .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=0"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.prev.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=5"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.next.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=7"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=6"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=8"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$.page.size", is(1)))
+            .andExpect(jsonPath("$.page.totalElements", is(9)))
+            .andExpect(jsonPath("$.page.totalPages", is(9)))
+            .andExpect(jsonPath("$.page.number", is(6)));
+
+        getClient(tokenAdmin).perform(get("/api/config/submissiondefinitions")
+                .param("size", "1")
+                .param("page", "7"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._embedded.submissiondefinitions[0].id", is("topcommunitytest")))
+            .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=0"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.prev.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=6"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.next.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=8"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=7"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=8"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$.page.size", is(1)))
+            .andExpect(jsonPath("$.page.totalElements", is(9)))
+            .andExpect(jsonPath("$.page.totalPages", is(9)))
+            .andExpect(jsonPath("$.page.number", is(7)));
+
+        getClient(tokenAdmin).perform(get("/api/config/submissiondefinitions")
+                .param("size", "1")
+                .param("page", "8"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._embedded.submissiondefinitions[0].id", is("subcommunitytest")))
+            .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=0"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.prev.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=7"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=8"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=8"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$.page.size", is(1)))
+            .andExpect(jsonPath("$.page.totalElements", is(9)))
+            .andExpect(jsonPath("$.page.totalPages", is(9)))
+            .andExpect(jsonPath("$.page.number", is(8)));
     }
 
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionDefinitionsControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionDefinitionsControllerIT.java
@@ -258,10 +258,10 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
                         Matchers.containsString("page=1"), Matchers.containsString("size=1"))))
                 .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
                         Matchers.containsString("/api/config/submissiondefinitions?"),
-                        Matchers.containsString("page=8"), Matchers.containsString("size=1"))))
+                        Matchers.containsString("page=9"), Matchers.containsString("size=1"))))
                 .andExpect(jsonPath("$.page.size", is(1)))
-                .andExpect(jsonPath("$.page.totalElements", is(9)))
-                .andExpect(jsonPath("$.page.totalPages", is(9)))
+                .andExpect(jsonPath("$.page.totalElements", is(10)))
+                .andExpect(jsonPath("$.page.totalPages", is(10)))
                 .andExpect(jsonPath("$.page.number", is(0)));
 
         getClient(tokenAdmin).perform(get("/api/config/submissiondefinitions")
@@ -284,10 +284,10 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
                         Matchers.containsString("page=1"), Matchers.containsString("size=1"))))
                 .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
                         Matchers.containsString("/api/config/submissiondefinitions?"),
-                        Matchers.containsString("page=8"), Matchers.containsString("size=1"))))
+                        Matchers.containsString("page=9"), Matchers.containsString("size=1"))))
                 .andExpect(jsonPath("$.page.size", is(1)))
-                .andExpect(jsonPath("$.page.totalElements", is(9)))
-                .andExpect(jsonPath("$.page.totalPages", is(9)))
+                .andExpect(jsonPath("$.page.totalElements", is(10)))
+                .andExpect(jsonPath("$.page.totalPages", is(10)))
                 .andExpect(jsonPath("$.page.number", is(1)));
 
         getClient(tokenAdmin).perform(get("/api/config/submissiondefinitions")
@@ -310,10 +310,10 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
                     Matchers.containsString("page=2"), Matchers.containsString("size=1"))))
                 .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
                     Matchers.containsString("/api/config/submissiondefinitions?"),
-                    Matchers.containsString("page=8"), Matchers.containsString("size=1"))))
+                    Matchers.containsString("page=9"), Matchers.containsString("size=1"))))
                 .andExpect(jsonPath("$.page.size", is(1)))
-                .andExpect(jsonPath("$.page.totalElements", is(9)))
-                .andExpect(jsonPath("$.page.totalPages", is(9)))
+                .andExpect(jsonPath("$.page.totalElements", is(10)))
+                .andExpect(jsonPath("$.page.totalPages", is(10)))
                 .andExpect(jsonPath("$.page.number", is(2)));
 
         getClient(tokenAdmin).perform(get("/api/config/submissiondefinitions")
@@ -336,10 +336,10 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
                     Matchers.containsString("page=3"), Matchers.containsString("size=1"))))
                 .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
                     Matchers.containsString("/api/config/submissiondefinitions?"),
-                    Matchers.containsString("page=8"), Matchers.containsString("size=1"))))
+                    Matchers.containsString("page=9"), Matchers.containsString("size=1"))))
                 .andExpect(jsonPath("$.page.size", is(1)))
-                .andExpect(jsonPath("$.page.totalElements", is(9)))
-                .andExpect(jsonPath("$.page.totalPages", is(9)))
+                .andExpect(jsonPath("$.page.totalElements", is(10)))
+                .andExpect(jsonPath("$.page.totalPages", is(10)))
                 .andExpect(jsonPath("$.page.number", is(3)));
 
         getClient(tokenAdmin).perform(get("/api/config/submissiondefinitions")
@@ -362,10 +362,10 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
                 Matchers.containsString("page=4"), Matchers.containsString("size=1"))))
             .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
                 Matchers.containsString("/api/config/submissiondefinitions?"),
-                Matchers.containsString("page=8"), Matchers.containsString("size=1"))))
+                Matchers.containsString("page=9"), Matchers.containsString("size=1"))))
             .andExpect(jsonPath("$.page.size", is(1)))
-            .andExpect(jsonPath("$.page.totalElements", is(9)))
-            .andExpect(jsonPath("$.page.totalPages", is(9)))
+            .andExpect(jsonPath("$.page.totalElements", is(10)))
+            .andExpect(jsonPath("$.page.totalPages", is(10)))
             .andExpect(jsonPath("$.page.number", is(4)));
 
         getClient(tokenAdmin).perform(get("/api/config/submissiondefinitions")
@@ -388,10 +388,10 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
                 Matchers.containsString("page=5"), Matchers.containsString("size=1"))))
             .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
                 Matchers.containsString("/api/config/submissiondefinitions?"),
-                Matchers.containsString("page=8"), Matchers.containsString("size=1"))))
+                Matchers.containsString("page=9"), Matchers.containsString("size=1"))))
             .andExpect(jsonPath("$.page.size", is(1)))
-            .andExpect(jsonPath("$.page.totalElements", is(9)))
-            .andExpect(jsonPath("$.page.totalPages", is(9)))
+            .andExpect(jsonPath("$.page.totalElements", is(10)))
+            .andExpect(jsonPath("$.page.totalPages", is(10)))
             .andExpect(jsonPath("$.page.number", is(5)));
 
         getClient(tokenAdmin).perform(get("/api/config/submissiondefinitions")
@@ -414,10 +414,10 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
                 Matchers.containsString("page=5"), Matchers.containsString("size=1"))))
             .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
                 Matchers.containsString("/api/config/submissiondefinitions?"),
-                Matchers.containsString("page=8"), Matchers.containsString("size=1"))))
+                Matchers.containsString("page=9"), Matchers.containsString("size=1"))))
             .andExpect(jsonPath("$.page.size", is(1)))
-            .andExpect(jsonPath("$.page.totalElements", is(9)))
-            .andExpect(jsonPath("$.page.totalPages", is(9)))
+            .andExpect(jsonPath("$.page.totalElements", is(10)))
+            .andExpect(jsonPath("$.page.totalPages", is(10)))
             .andExpect(jsonPath("$.page.number", is(5)));
 
         getClient(tokenAdmin).perform(get("/api/config/submissiondefinitions")
@@ -440,10 +440,10 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
                 Matchers.containsString("page=6"), Matchers.containsString("size=1"))))
             .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
                 Matchers.containsString("/api/config/submissiondefinitions?"),
-                Matchers.containsString("page=8"), Matchers.containsString("size=1"))))
+                Matchers.containsString("page=9"), Matchers.containsString("size=1"))))
             .andExpect(jsonPath("$.page.size", is(1)))
-            .andExpect(jsonPath("$.page.totalElements", is(9)))
-            .andExpect(jsonPath("$.page.totalPages", is(9)))
+            .andExpect(jsonPath("$.page.totalElements", is(10)))
+            .andExpect(jsonPath("$.page.totalPages", is(10)))
             .andExpect(jsonPath("$.page.number", is(6)));
 
         getClient(tokenAdmin).perform(get("/api/config/submissiondefinitions")
@@ -466,10 +466,10 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
                 Matchers.containsString("page=7"), Matchers.containsString("size=1"))))
             .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
                 Matchers.containsString("/api/config/submissiondefinitions?"),
-                Matchers.containsString("page=8"), Matchers.containsString("size=1"))))
+                Matchers.containsString("page=9"), Matchers.containsString("size=1"))))
             .andExpect(jsonPath("$.page.size", is(1)))
-            .andExpect(jsonPath("$.page.totalElements", is(9)))
-            .andExpect(jsonPath("$.page.totalPages", is(9)))
+            .andExpect(jsonPath("$.page.totalElements", is(10)))
+            .andExpect(jsonPath("$.page.totalPages", is(10)))
             .andExpect(jsonPath("$.page.number", is(7)));
 
         getClient(tokenAdmin).perform(get("/api/config/submissiondefinitions")
@@ -484,16 +484,42 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
             .andExpect(jsonPath("$._links.prev.href", Matchers.allOf(
                 Matchers.containsString("/api/config/submissiondefinitions?"),
                 Matchers.containsString("page=7"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.next.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=9"), Matchers.containsString("size=1"))))
             .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
                 Matchers.containsString("/api/config/submissiondefinitions?"),
                 Matchers.containsString("page=8"), Matchers.containsString("size=1"))))
             .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
                 Matchers.containsString("/api/config/submissiondefinitions?"),
-                Matchers.containsString("page=8"), Matchers.containsString("size=1"))))
+                Matchers.containsString("page=9"), Matchers.containsString("size=1"))))
             .andExpect(jsonPath("$.page.size", is(1)))
-            .andExpect(jsonPath("$.page.totalElements", is(9)))
-            .andExpect(jsonPath("$.page.totalPages", is(9)))
+            .andExpect(jsonPath("$.page.totalElements", is(10)))
+            .andExpect(jsonPath("$.page.totalPages", is(10)))
             .andExpect(jsonPath("$.page.number", is(8)));
+
+        getClient(tokenAdmin).perform(get("/api/config/submissiondefinitions")
+                .param("size", "1")
+                .param("page", "9"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._embedded.submissiondefinitions[0].id", is("collectiontest")))
+            .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=0"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.prev.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=8"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=9"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=9"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$.page.size", is(1)))
+            .andExpect(jsonPath("$.page.totalElements", is(10)))
+            .andExpect(jsonPath("$.page.totalPages", is(10)))
+            .andExpect(jsonPath("$.page.number", is(9)));
     }
 
 }

--- a/dspace/config/item-submission.dtd
+++ b/dspace/config/item-submission.dtd
@@ -12,6 +12,7 @@
  <!ELEMENT name-map EMPTY >
  <!ATTLIST name-map 
            collection-handle CDATA #IMPLIED
+           community-handle CDATA #IMPLIED
            collection-entity-type CDATA #IMPLIED
            submission-name NMTOKEN #REQUIRED>
 

--- a/dspace/config/item-submission.xml
+++ b/dspace/config/item-submission.xml
@@ -63,6 +63,15 @@
         <name-map collection-entity-type="Journal" submission-name="Journal"/>
         <name-map collection-entity-type="JournalVolume" submission-name="JournalVolume"/>
         <name-map collection-entity-type="JournalIssue" submission-name="JournalIssue"/>
+
+        <!-- Example of configuration using a community handle to map an Item Submission Process.
+
+            This configuration maps the submission process to the community's descendant
+            collections that do not have a mapping defined by collection-handle or entity-type
+
+        <name-map community-handle="123456789/1234" submission-name="xxxx"/>
+        -->
+
     </submission-map>
 
 


### PR DESCRIPTION
## Description
This PR allows to use a community handle to map the descendant collections to an item submission process.  This can be useful for repositories where top-level communities represent different document types or scopes and descendant collections should share the same submission process.

## Instructions for Reviewers

To test it, create two top-level communities with collections without a entity-type assigned and map the first community handle to a new item submission process in `item-submission.xml` (for example, one with the cclicense). 

```
  <name-map community-handle="<community-handle>" submission-name="test"/>

    <submission-process name="test">
        <step id="collection"/>
        <step id="traditionalpageone"/>
        <step id="upload"/>
        <step id="cclicense"/>
        <step id="license"/>
    </submission-process>
```
This new item submission process should be used for collections descendant of the community configured.

Additional info:
- It should also work with sub-communities handles.
- Mappings assigned by collection-handle or entity-type have a higher priority than this new mapping by community.
- A new test has been added to check this new configuration

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
