### PR TITLE
S3store is always enabled

### DIFF
--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/S3BitStoreService.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/S3BitStoreService.java
@@ -169,7 +169,7 @@ public class S3BitStoreService extends BaseBitStoreService {
     @Override
     public void init() throws IOException {
 
-        if (this.isInitialized()) {
+        if (this.isInitialized() || !this.isEnabled()) {
             return;
         }
 

--- a/dspace-api/src/test/java/org/dspace/storage/bitstore/S3BitStoreServiceIT.java
+++ b/dspace-api/src/test/java/org/dspace/storage/bitstore/S3BitStoreServiceIT.java
@@ -43,6 +43,7 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import io.findify.s3mock.S3Mock;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.BooleanUtils;
 import org.dspace.AbstractIntegrationTestWithDatabase;
 import org.dspace.app.matcher.LambdaMatcher;
 import org.dspace.authorize.AuthorizeException;
@@ -61,6 +62,7 @@ import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 
 
 /**
@@ -86,6 +88,7 @@ public class S3BitStoreServiceIT extends AbstractIntegrationTestWithDatabase {
     @Before
     public void setup() throws Exception {
 
+        configurationService.setProperty("assetstore.s3.enabled", "true");
         s3Directory = new File(System.getProperty("java.io.tmpdir"), "s3");
 
         s3Mock = S3Mock.create(8001, s3Directory.getAbsolutePath());
@@ -94,7 +97,8 @@ public class S3BitStoreServiceIT extends AbstractIntegrationTestWithDatabase {
         amazonS3Client = createAmazonS3Client();
 
         s3BitStoreService = new S3BitStoreService(amazonS3Client);
-
+        s3BitStoreService.setEnabled(BooleanUtils.toBoolean(
+                configurationService.getProperty("assetstore.s3.enabled")));
         context.turnOffAuthorisationSystem();
 
         parentCommunity = CommunityBuilder.createCommunity(context)
@@ -391,7 +395,7 @@ public class S3BitStoreServiceIT extends AbstractIntegrationTestWithDatabase {
     @Test
     public void testDoNotInitializeConfigured() throws Exception {
         String assetstores3enabledOldValue = configurationService.getProperty("assetstore.s3.enabled");
-        configurationService.setProperty("assetstore.s3.enabled", false);
+        configurationService.setProperty("assetstore.s3.enabled", "false");
         s3BitStoreService = new S3BitStoreService(amazonS3Client);
         s3BitStoreService.init();
         assertFalse(s3BitStoreService.isInitialized());

--- a/dspace-api/src/test/java/org/dspace/storage/bitstore/S3BitStoreServiceIT.java
+++ b/dspace-api/src/test/java/org/dspace/storage/bitstore/S3BitStoreServiceIT.java
@@ -19,6 +19,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
@@ -53,6 +54,8 @@ import org.dspace.content.Bitstream;
 import org.dspace.content.Collection;
 import org.dspace.content.Item;
 import org.dspace.core.Utils;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.junit.After;
@@ -76,6 +79,9 @@ public class S3BitStoreServiceIT extends AbstractIntegrationTestWithDatabase {
     private Collection collection;
 
     private File s3Directory;
+    
+    private ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
+
 
     @Before
     public void setup() throws Exception {
@@ -380,6 +386,17 @@ public class S3BitStoreServiceIT extends AbstractIntegrationTestWithDatabase {
         assertThat(computedPath, Matchers.not(Matchers.startsWith(File.separator)));
         assertThat(computedPath, Matchers.not(Matchers.endsWith(File.separator)));
         assertThat(computedPath, Matchers.not(Matchers.containsString(File.separator)));
+    }
+
+    @Test
+    public void testDoNotInitializeConfigured() throws Exception {
+        String assetstores3enabledOldValue = configurationService.getProperty("assetstore.s3.enabled");
+        configurationService.setProperty("assetstore.s3.enabled", false);
+        s3BitStoreService = new S3BitStoreService(amazonS3Client);
+        s3BitStoreService.init();
+        assertFalse(s3BitStoreService.isInitialized());
+        assertFalse(s3BitStoreService.isEnabled());
+        configurationService.setProperty("assetstore.s3.enabled", assetstores3enabledOldValue);
     }
 
     private byte[] generateChecksum(String content) {

--- a/dspace-api/src/test/java/org/dspace/storage/bitstore/S3BitStoreServiceIT.java
+++ b/dspace-api/src/test/java/org/dspace/storage/bitstore/S3BitStoreServiceIT.java
@@ -79,7 +79,7 @@ public class S3BitStoreServiceIT extends AbstractIntegrationTestWithDatabase {
     private Collection collection;
 
     private File s3Directory;
-    
+
     private ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
 
 


### PR DESCRIPTION
## Description
S3 Store is always enabled regardless the value of the configuration **_assetstore.s3.enabled_** - but it should. This pull request contains the code to consider the configuration value in S3 store enabling. 

## Instructions for Reviewers
Java classes involved are just S3BitStoreService and S3BitStoreServiceIT - testing the correct initialization and enabling of the S3 Store feature.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
