### PR TITLE
Fix generating versioned identifiers if pre-registration is enabled

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/WorkspaceItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/WorkspaceItemServiceImpl.java
@@ -96,11 +96,18 @@ public class WorkspaceItemServiceImpl implements WorkspaceItemService {
     @Override
     public WorkspaceItem create(Context context, Collection collection, boolean template)
             throws AuthorizeException, SQLException {
-        return create(context, collection, null, template);
+        return create(context, collection, null, template, false);
     }
 
     @Override
-    public WorkspaceItem create(Context context, Collection collection, UUID uuid, boolean template)
+    public WorkspaceItem create(Context context, Collection collection, boolean template, boolean isNewVersion)
+            throws AuthorizeException, SQLException {
+        return create(context, collection, null, template, isNewVersion);
+    }
+
+    @Override
+    public WorkspaceItem create(Context context, Collection collection, UUID uuid, boolean template,
+                                boolean isNewVersion)
         throws AuthorizeException, SQLException {
         // Check the user has permission to ADD to the collection
         authorizeService.authorizeAction(context, collection, Constants.ADD);
@@ -174,8 +181,10 @@ public class WorkspaceItemServiceImpl implements WorkspaceItemService {
 
         // If configured, register identifiers (eg handle, DOI) now. This is typically used with the Show Identifiers
         // submission step which previews minted handles and DOIs during the submission process. Default: false
+        // Additional check needed: if we are creating a new version of an existing item we skip the identifier
+        // generation here, as this will be performed when the new version is created in VersioningServiceImpl
         if (DSpaceServicesFactory.getInstance().getConfigurationService()
-                .getBooleanProperty("identifiers.submission.register", false)) {
+                .getBooleanProperty("identifiers.submission.register", false) && !isNewVersion) {
             try {
                 // Get map of filters to use for identifier types, while the item is in progress
                 Map<Class<? extends Identifier>, Filter> filters = FilterUtils.getIdentifierFilters(true);

--- a/dspace-api/src/main/java/org/dspace/content/packager/PackageUtils.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/PackageUtils.java
@@ -503,7 +503,7 @@ public class PackageUtils {
                     wsi = workspaceItemService.create(context, (Collection)parent, params.useCollectionTemplate());
                 } else {
                     wsi = workspaceItemService.create(context, (Collection)parent,
-                            uuid, params.useCollectionTemplate());
+                            uuid, params.useCollectionTemplate(), false);
                 }
 
                 // Please note that we are returning an Item which is *NOT* yet in the Archive,

--- a/dspace-api/src/main/java/org/dspace/content/service/WorkspaceItemService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/WorkspaceItemService.java
@@ -56,6 +56,23 @@ public interface WorkspaceItemService extends InProgressSubmissionService<Worksp
     public WorkspaceItem create(Context context, Collection collection, boolean template)
         throws AuthorizeException, SQLException;
 
+
+    /**
+     * Create a new workspace item, with a new ID. An Item is also created. The
+     * submitter is the current user in the context.
+     *
+     * @param context    DSpace context object
+     * @param collection Collection being submitted to
+     * @param template   if <code>true</code>, the workspace item starts as a copy
+     *                   of the collection's template item
+     * @param isNewVersion whether we are creating a new workspace item version of an existing item
+     * @return the newly created workspace item
+     * @throws SQLException       if database error
+     * @throws AuthorizeException if authorization error
+     */
+    public WorkspaceItem create(Context context, Collection collection, boolean template, boolean isNewVersion)
+            throws AuthorizeException, SQLException;
+
     /**
      * Create a new workspace item, with a new ID. An Item is also created. The
      * submitter is the current user in the context.
@@ -65,11 +82,13 @@ public interface WorkspaceItemService extends InProgressSubmissionService<Worksp
      * @param uuid       the preferred uuid of the new item (used if restoring an item and retaining old uuid)
      * @param template   if <code>true</code>, the workspace item starts as a copy
      *                   of the collection's template item
+     * @param isNewVersion whether we are creating a new workspace item version of an existing item
      * @return the newly created workspace item
      * @throws SQLException       if database error
      * @throws AuthorizeException if authorization error
      */
-    public WorkspaceItem create(Context context, Collection collection, UUID uuid, boolean template)
+    public WorkspaceItem create(Context context, Collection collection, UUID uuid, boolean template,
+                                boolean isNewVersion)
             throws AuthorizeException, SQLException;
 
     public WorkspaceItem create(Context c, WorkflowItem wfi) throws SQLException, AuthorizeException;

--- a/dspace-api/src/main/java/org/dspace/versioning/DefaultItemVersionProvider.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/DefaultItemVersionProvider.java
@@ -52,7 +52,9 @@ public class DefaultItemVersionProvider extends AbstractVersionProvider implemen
     @Override
     public Item createNewItemAndAddItInWorkspace(Context context, Item nativeItem) {
         try {
-            WorkspaceItem workspaceItem = workspaceItemService.create(context, nativeItem.getOwningCollection(), false);
+            WorkspaceItem workspaceItem = workspaceItemService.create(context, nativeItem.getOwningCollection(),
+                    false,
+                    true);
             Item itemNew = workspaceItem.getItem();
             itemService.update(context, itemNew);
             return itemNew;

--- a/dspace-api/src/test/java/org/dspace/app/packager/PackagerIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/packager/PackagerIT.java
@@ -159,7 +159,7 @@ public class PackagerIT extends AbstractIntegrationTestWithDatabase {
         performExportScript(article.getHandle(), tempFile);
         UUID id = article.getID();
         itemService.delete(context, article);
-        WorkspaceItem workspaceItem = workspaceItemService.create(context, col1, id, false);
+        WorkspaceItem workspaceItem = workspaceItemService.create(context, col1, id, false, false);
         installItemService.installItem(context, workspaceItem, "123456789/0100");
         performImportNoForceScript(tempFile);
         Iterator<Item> items = itemService.findByCollection(context, col1);


### PR DESCRIPTION
## References
* Fixes #8675 

## Description
This PR fixes the creation of versioned identifiers if the submission pre-registration is enabled.

## Instructions for Reviewers
To test:

1. Turn on identifier pre-registration in identifiers.cfg
2. Use VersionedDOIIdentifierProvider in identifier-service.xml
3. Create an item
4. Create a new version of this item
5. You get an versioned  DOI with the pattern olddoi.versionnumber

List of changes in this PR:
* WorkspaceItemServiceImpl: modify the create method to take a boolean flag (isNewVersion) to allow to skip identifiers minting for versioned items as this process is done after the version is created and the versionhistory is updated
* DefaultItemVersionProvider: modify createNewItemAndAddItInWorkspace to call the create method with the isNewVersion flag set to true

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
