### PR TITLE
Fix deleting workspace items via SWORDv2 endpoint

### DIFF
--- a/dspace-swordv2/src/main/java/org/dspace/sword2/ContainerManagerDSpace.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/ContainerManagerDSpace.java
@@ -760,9 +760,6 @@ public class ContainerManagerDSpace extends DSpaceSwordAPI
                 WorkflowItem wfi = wft.getWorkflowItem(context, item);
                 workflowItemService.deleteWrapper(context, wfi);
             }
-
-            // then delete the item
-            itemService.delete(context, item);
         } catch (SQLException | IOException e) {
             throw new DSpaceSwordException(e);
         } catch (AuthorizeException e) {


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #9284 

## Description
There were unexpected database errors when attempting to delete a workspace item due to a duplicated item.delete call in the doContainerDelete method that causes hibernate errors as item is already deleted. A previous call to workspaceItemService.deleteAll(context, wsi) had already deleted the item.

## Instructions for Reviewers
Follow the steps described in the issue.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
