### PR TITLE
Call cas.init() method in the VocabularyRestRepositoryIT#setup method

### DIFF
--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/VocabularyRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/VocabularyRestRepositoryIT.java
@@ -92,6 +92,11 @@ public class VocabularyRestRepositoryIT extends AbstractControllerIntegrationTes
         // the properties that we're altering above and this is only used within the tests
         DCInputAuthority.reset();
         pluginService.clearNamedPluginClasses();
+
+        // The following line is needed to call init() method in the ChoiceAuthorityServiceImpl class, without it
+        // the `submissionConfigService` will be null what will cause a NPE in the clearCache() method
+        // https://github.com/DSpace/DSpace/issues/9292
+        cas.getChoiceAuthoritiesNames();
         cas.clearCache();
 
         context.turnOffAuthorisationSystem();


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes https://github.com/DSpace/DSpace/issues/9292

## Description
The `VocabularyRestRepositoryIT` test failed when executed as a single test

## Instructions for Reviewers
Just run that single `VocabularyRestRepositoryIT.java` test by this command: `mvn install -Dit.test=org.dspace.app.rest.VocabularyRestRepositoryIT -DskipIntegrationTests=false`

List of changes in this PR:
* First: I called the `cas.getChoiceAuthoritiesNames()` method which, in turn, invokes the `init()` method in the `VocabularyRestRepositoryIT.java` setup. I know this is not the best solution. The real question is whether the `ChoiceAuthorityServiceImpl` should be refactored so that the `init()` method is not explicitly called from certain `get*` methods.
Right now, I'm not confident enough to make such refactoring because of possible side effects that I may not know.

**Include guidance for how to test or review your PR.**
Just run that single `VocabularyRestRepositoryIT.java` test by this command: `mvn install -Dit.test=org.dspace.app.rest.VocabularyRestRepositoryIT -DskipIntegrationTests=false`

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
