### PR TITLE
Expose 'creationTime' property on Process object and add it to '/search/byProperty' sort options

### DIFF
--- a/dspace-api/src/test/java/org/dspace/builder/ProcessBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/ProcessBuilder.java
@@ -68,8 +68,8 @@ public class ProcessBuilder extends AbstractBuilder<Process, ProcessService> {
 
     public ProcessBuilder withStartAndEndTime(String startTime, String endTime) throws ParseException {
         SimpleDateFormat simpleDateFormat = new SimpleDateFormat("dd/MM/yyyy");
-        process.setStartTime(simpleDateFormat.parse(startTime));
-        process.setFinishedTime(simpleDateFormat.parse(endTime));
+        process.setStartTime(startTime == null ? null : simpleDateFormat.parse(startTime));
+        process.setFinishedTime(endTime == null ? null : simpleDateFormat.parse(endTime));
         return this;
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ProcessConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ProcessConverter.java
@@ -43,6 +43,7 @@ public class ProcessConverter implements DSpaceConverter<Process, ProcessRest> {
         processRest.setProcessStatus(process.getProcessStatus());
         processRest.setStartTime(process.getStartTime());
         processRest.setEndTime(process.getFinishedTime());
+        processRest.setCreationTime(process.getCreationTime());
         processRest.setParameterRestList(processService.getParameters(process).stream()
                 .map(x -> (ParameterValueRest) converter.toRest(x, projection)).collect(Collectors.toList()));
         return processRest;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/ProcessRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/ProcessRest.java
@@ -60,6 +60,7 @@ public class ProcessRest extends BaseObjectRest<Integer> {
     private Integer processId;
     private Date startTime;
     private Date endTime;
+    private Date creationTime;
     private ProcessStatus processStatus;
     @JsonProperty(value = "parameters")
     private List<ParameterValueRest> parameterRestList;
@@ -102,6 +103,14 @@ public class ProcessRest extends BaseObjectRest<Integer> {
 
     public void setStartTime(Date startTime) {
         this.startTime = startTime;
+    }
+
+    public Date getCreationTime() {
+        return creationTime;
+    }
+
+    public void setCreationTime(Date creationTime) {
+        this.creationTime = creationTime;
     }
 
     public String getScriptName() {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ProcessRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ProcessRestRepository.java
@@ -230,6 +230,9 @@ public class ProcessRestRepository extends DSpaceRestRepository<ProcessRest, Int
                 } else if (StringUtils.equalsIgnoreCase(order.getProperty(), "endTime")) {
                     processQueryParameterContainer.setSortProperty(Process_.FINISHED_TIME);
                     processQueryParameterContainer.setSortOrder(order.getDirection().name());
+                } else if (StringUtils.equalsIgnoreCase(order.getProperty(), "creationTime")) {
+                    processQueryParameterContainer.setSortProperty(Process_.CREATION_TIME);
+                    processQueryParameterContainer.setSortOrder(order.getDirection().name());
                 } else {
                     throw new DSpaceBadRequestException("The given sort option was invalid: " + order.getProperty());
                 }


### PR DESCRIPTION
## References

* Related to DSpace/RestContract#253

## Description

This PR exposes the `creationTime` property on Process objects and adds it to the possible sort options for `/processes/search/byProperty`. As `startTime` and `endTime` are nullable, processes with these properties set to `null` can't be sorted properly. Every process does have a `creationTime` however, making for a more reliable sorting mechanism.

## Instructions for Reviewers

List of changes in this PR:
- Added `creationTime` to ProcessRest and ProcessConverter.
- Added `creationTime` to the possible sort options in ProcessRestRepository#handleSearchSort.
- Added 2 new ITs in ProcessRestRepository to test the new sort.

Steps to test: 

- Verify `/server/api/system/processes` returns processes which each have a `creationTime` property.
- Verify e.g. `/processes/search/byProperty?size=10&sort=creationTime,ASC&scriptName=metadata-import`, returns the processes, sorted ascendingly.
- Verify e.g. `/processes/search/byProperty?size=10&sort=creationTime,DESC&scriptName=metadata-import`, returns the processes, sorted descendingly.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

