### PR TITLE
Fix resource policy type not set for bitstreams when importing items

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
@@ -1743,7 +1743,8 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
                     } else {
                         logInfo("\tSetting special permissions for "
                             + bitstreamName);
-                        setPermission(c, myGroup, actionID, bs);
+                        String rpType = useWorkflow ? ResourcePolicy.TYPE_SUBMISSION : ResourcePolicy.TYPE_INHERITED;
+                        setPermission(c, myGroup, rpType, actionID, bs);
                     }
                 }
 
@@ -1801,13 +1802,14 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
      *
      * @param c        DSpace Context
      * @param g        Dspace Group
+     * @param rpType   resource policy type string
      * @param actionID action identifier
      * @param bs       Bitstream
      * @throws SQLException       if database error
      * @throws AuthorizeException if authorization error
      * @see org.dspace.core.Constants
      */
-    protected void setPermission(Context c, Group g, int actionID, Bitstream bs)
+    protected void setPermission(Context c, Group g, String rpType, int actionID, Bitstream bs)
         throws SQLException, AuthorizeException {
         if (!isTest) {
             // remove the default policy
@@ -1819,6 +1821,7 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
             rp.setdSpaceObject(bs);
             rp.setAction(actionID);
             rp.setGroup(g);
+            rp.setRpType(rpType);
 
             resourcePolicyService.update(c, rp);
         } else {


### PR DESCRIPTION
Fix resource policy type not set for bitstreams when importing items as reported in #9290 - which causes conflicts if later on  policies are set via the Access control functionality.

## References
* Fixes #9290 

## Description
Simple fix to set rptype to TYPE_SUBMISSION if workflow is enabled; TYPE_INHERITED otherwise if items are archived upon import directly.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [X] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
