### PR TITLE
[Port dspace-7_x] Fix Docker image build issues for new versions of Docker (25.0.2) and Docker Compose (2.24.3) 

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -102,6 +102,8 @@ jobs:
       build_id: dspace-solr
       image_name: dspace/dspace-solr
       dockerfile_path: ./dspace/src/main/docker/dspace-solr/Dockerfile
+      # Must pass solrconfigs to the Dockerfile so that it can find the required Solr config files
+      dockerfile_additional_contexts: 'solrconfigs=./dspace/solr/'
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_ACCESS_TOKEN: ${{ secrets.DOCKER_ACCESS_TOKEN }}

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -24,6 +24,12 @@ on:
       dockerfile_context:
         required: false
         type: string
+        default: '.'
+      # Optionally a list of "additional_contexts" to pass to Dockerfile. Defaults to empty
+      dockerfile_additional_contexts:
+        required: false
+        type: string
+        default: ''
       # If Docker image should have additional tag flavor details (e.g. a suffix), it may be passed in.
       tags_flavor:
         required: false
@@ -123,7 +129,9 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v5
         with:
-          context: ${{ inputs.dockerfile_context || '.' }}
+          build-contexts: |
+            ${{ inputs.dockerfile_additional_contexts }}
+          context: ${{ inputs.dockerfile_context }}
           file: ${{ inputs.dockerfile_path }}
           platforms: ${{ matrix.arch }}
           # For pull requests, we run the Docker build (to ensure no PR changes break the build),

--- a/docker-compose-cli.yml
+++ b/docker-compose-cli.yml
@@ -1,5 +1,10 @@
 version: "3.7"
-
+networks:
+  # Default to using network named 'dspacenet' from docker-compose.yml.
+  # Its full name will be prepended with the project name (e.g. "-p d7" means it will be named "d7_dspacenet")
+  default:
+    name: ${COMPOSE_PROJECT_NAME}_dspacenet
+    external: true
 services:
   dspace-cli:
     image: "${DOCKER_OWNER:-dspace}/dspace-cli:${DSPACE_VER:-dspace-7_x}"
@@ -26,13 +31,8 @@ services:
     - ./dspace/config:/dspace/config
     entrypoint: /dspace/bin/dspace
     command: help
-    networks:
-      - dspacenet
     tty: true
     stdin_open: true
 
 volumes:
   assetstore:
-
-networks:
-  dspacenet:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     depends_on:
     - dspacedb
     networks:
-      dspacenet:
+      - dspacenet
     ports:
     - published: 8080
       target: 8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,8 +89,10 @@ services:
     container_name: dspacesolr
     image: "${DOCKER_OWNER:-dspace}/dspace-solr:${DSPACE_VER:-dspace-7_x}"
     build:
-      context: .
-      dockerfile: ./dspace/src/main/docker/dspace-solr/Dockerfile
+      context: ./dspace/src/main/docker/dspace-solr/
+      # Provide path to Solr configs necessary to build Docker image
+      additional_contexts:
+        solrconfigs: ./dspace/solr/
       args:
         SOLR_VERSION: "${SOLR_VER:-8.11}"
     networks:

--- a/dspace/src/main/docker-compose/README.md
+++ b/dspace/src/main/docker-compose/README.md
@@ -78,6 +78,7 @@ docker-compose -p d7 up -d
 ```
 docker-compose -p d7 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-angular.yml up -d
 ```
+NOTE: This starts the UI in development mode. It will take a few minutes to see the UI as the Angular code needs to be compiled.
 
 ## Run DSpace REST and DSpace Angular from local branches
 

--- a/dspace/src/main/docker-compose/docker-compose-angular.yml
+++ b/dspace/src/main/docker-compose/docker-compose-angular.yml
@@ -8,7 +8,11 @@
 
 version: '3.7'
 networks:
-  dspacenet:
+  # Default to using network named 'dspacenet' from docker-compose.yml.
+  # Its full name will be prepended with the project name (e.g. "-p d7" means it will be named "d7_dspacenet")
+  default:
+    name: ${COMPOSE_PROJECT_NAME}_dspacenet
+    external: true
 services:
   dspace-angular:
     container_name: dspace-angular
@@ -24,8 +28,6 @@ services:
       DSPACE_REST_PORT: 8080
       DSPACE_REST_NAMESPACE: /server
     image: dspace/dspace-angular:dspace-7_x
-    networks:
-      dspacenet:
     ports:
     - published: 4000
       target: 4000

--- a/dspace/src/main/docker-compose/docker-compose-iiif.yml
+++ b/dspace/src/main/docker-compose/docker-compose-iiif.yml
@@ -12,7 +12,11 @@
 #
 version: '3.7'
 networks:
-  dspacenet:
+  # Default to using network named 'dspacenet' from docker-compose.yml.
+  # Its full name will be prepended with the project name (e.g. "-p d7" means it will be named "d7_dspacenet")
+  default:
+    name: ${COMPOSE_PROJECT_NAME}_dspacenet
+    external: true
 services:
   dspace-iiif:
     container_name: dspace-iiif
@@ -21,8 +25,6 @@ services:
     # Using UCLA Library image as it seems to be most maintained at this time. There is no official image.
     # https://hub.docker.com/r/uclalibrary/cantaloupe
     image: uclalibrary/cantaloupe:5.0.4-0
-    networks:
-      dspacenet:
     ports:
       - '8182:8182'
     # For a guide of environment variables that can be used, see

--- a/dspace/src/main/docker-compose/docker-compose-shibboleth.yml
+++ b/dspace/src/main/docker-compose/docker-compose-shibboleth.yml
@@ -12,7 +12,11 @@
 #
 version: '3.7'
 networks:
-  dspacenet:
+  # Default to using network named 'dspacenet' from docker-compose.yml.
+  # Its full name will be prepended with the project name (e.g. "-p d7" means it will be named "d7_dspacenet")
+  default:
+    name: ${COMPOSE_PROJECT_NAME}_dspacenet
+    external: true
 services:
   dspace-shibboleth:
     container_name: dspace-shibboleth
@@ -22,8 +26,6 @@ services:
     build:
       # Must be relative to root, so that it can be built alongside [src]/docker-compose.yml
       context: ./dspace/src/main/docker/dspace-shibboleth
-    networks:
-      dspacenet:
     ports:
       - published: 80
         target: 80

--- a/dspace/src/main/docker/dspace-solr/Dockerfile
+++ b/dspace/src/main/docker/dspace-solr/Dockerfile
@@ -26,10 +26,12 @@ RUN mkdir -p $AUTHORITY_CONFIGSET_PATH && \
     mkdir -p $SEARCH_CONFIGSET_PATH && \
     mkdir -p $STATISTICS_CONFIGSET_PATH
 
-COPY dspace/solr/authority/conf/* $AUTHORITY_CONFIGSET_PATH/
-COPY dspace/solr/oai/conf/* $OAI_CONFIGSET_PATH/
-COPY dspace/solr/search/conf/* $SEARCH_CONFIGSET_PATH/
-COPY dspace/solr/statistics/conf/* $STATISTICS_CONFIGSET_PATH/
+# NOTE: "solrconfigs" MUST be passed in by docker-compose via "additional_contexts"
+# OR via "docker build --build-context solrconfigs=[path-to-dspace/solr]"
+COPY --from=solrconfigs authority/conf/* $AUTHORITY_CONFIGSET_PATH/
+COPY --from=solrconfigs oai/conf/* $OAI_CONFIGSET_PATH/
+COPY --from=solrconfigs search/conf/* $SEARCH_CONFIGSET_PATH/
+COPY --from=solrconfigs statistics/conf/* $STATISTICS_CONFIGSET_PATH/
 
 RUN chown -R solr:solr /opt/solr/server/solr/configsets
 


### PR DESCRIPTION
(Manual) Port of #9303 by @tdonohue to `dspace-7_x`.   Because these Docker scripts are slightly different, an automated port failed cause of minor code conflicts.