### PR TITLE
Improve default identifiers.cfg properties

### DIFF
--- a/dspace/config/modules/identifiers.cfg
+++ b/dspace/config/modules/identifiers.cfg
@@ -41,9 +41,7 @@
 
 # Show Register DOI button in item status page?
 # Default: false
-# This configuration property is exposed over rest. For dspace-angular to work,
-# this property must always have a true or false value. Do not comment it out!
-identifiers.item-status.register-doi = false
+#identifiers.item-status.register-doi = true
 
 # Which identifier types to show in submission step?
 # Default: handle, doi (currently the only supported identifier 'types')


### PR DESCRIPTION
* Related to [dspace-angular#2766](https://github.com/DSpace/dspace-angular/pull/2766)

This small PR takes advantage of the improved configuration handling for enabling the register DOI button in dspace-angular#2765 -- since the behaviour of the item status page is now to hide the button by default or on 'false' property, we no longer need an uncommented default of 'false' in identifiers.cfg or the warning about never commenting it out.