### PR TITLE
Avoid index virtual metadata in Solr Authority core

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authority/indexer/DSpaceAuthorityIndexer.java
+++ b/dspace-api/src/main/java/org/dspace/authority/indexer/DSpaceAuthorityIndexer.java
@@ -80,7 +80,15 @@ public class DSpaceAuthorityIndexer implements AuthorityIndexerInterface, Initia
             throws SQLException, AuthorizeException {
         List<AuthorityValue> values = new ArrayList<>();
         for (String metadataField : metadataFields) {
-            List<MetadataValue> metadataValues = itemService.getMetadataByMetadataString(item, metadataField);
+
+            String[] fieldParts = metadataField.split("\\.");
+            String schema = (fieldParts.length > 0 ? fieldParts[0] : null);
+            String element = (fieldParts.length > 1 ? fieldParts[1] : null);
+            String qualifier = (fieldParts.length > 2 ? fieldParts[2] : null);
+
+            // Get metadata values without virtual metadata
+            List<MetadataValue> metadataValues = itemService.getMetadata(item, schema, element, qualifier, Item.ANY,
+                false);
             for (MetadataValue metadataValue : metadataValues) {
                 String content = metadataValue.getValue();
                 String authorityKey = metadataValue.getAuthority();


### PR DESCRIPTION
## References
* Related to DSpace/dspace-angular#2653

## Description
The Solr Authority core should not index virtual metadata because they are not valid authority values. The authority key that they use is to map the related entity. 

## Instructions for Reviewers

This error could happen if the same metadada field is used to save authorities and map configurable entities with virtual metadada. By example, using ORCID SolrAuthorities and Person entities.

This query could be used to check if virtual metadada is currently indexed in authority solr core ( search query => `id:virtual\:\:*` ) :

http://localhost:8983/solr/authority/select?indent=true&q.op=OR&q=id%3Avirtual\%3A\%3A*

After applying the PR and reindexing the authority core with:

```
 [dspace]/bin/dspace index-authority
```

The virtual metadata should have been removed from the index.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
