### PR TITLE
Improve implementation of `getBestMatch()` of SHERPARoMEO authorities

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/authority/SHERPARoMEOPublisher.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/SHERPARoMEOPublisher.java
@@ -60,7 +60,38 @@ public class SHERPARoMEOPublisher implements ChoiceAuthority {
 
     @Override
     public Choices getBestMatch(String text, String locale) {
-        return getMatches(text, 0, 1, locale);
+        // punt if there is no query text
+        if (text == null || text.trim().length() == 0) {
+            return new Choices(true);
+        }
+        int limit = 10;
+        SHERPAService sherpaService = new DSpace().getSingletonService(SHERPAService.class);
+        SHERPAPublisherResponse sherpaResponse = sherpaService.performPublisherRequest("publisher", "name",
+                "equals", text, 0, limit);
+        Choices result;
+        if (CollectionUtils.isNotEmpty(sherpaResponse.getPublishers())) {
+            List<Choice> list = sherpaResponse
+                    .getPublishers().stream()
+                    .map(sherpaPublisher ->
+                            new Choice(sherpaPublisher.getIdentifier(),
+                                    sherpaPublisher.getName(), sherpaPublisher.getName()))
+                    .collect(Collectors.toList());
+            int total = sherpaResponse.getPublishers().size();
+
+            int confidence;
+            if (list.isEmpty()) {
+                confidence = Choices.CF_NOTFOUND;
+            } else if (list.size() == 1) {
+                confidence = Choices.CF_UNCERTAIN;
+            } else {
+                confidence = Choices.CF_AMBIGUOUS;
+            }
+            result = new Choices(list.toArray(new Choice[list.size()]), 0, total, confidence,
+                    total > limit);
+        } else {
+            result = new Choices(false);
+        }
+        return result;
     }
 
     @Override


### PR DESCRIPTION
## References
* Related to DSpace/dspace-angular#2653

## Description
The `getBestMatch()` method of a `ChoiceAuthority` implementation should return values ​​that exactly match the searched value, but the current implementation in Sherpa Romeo authorities is returning the first value returned by the "contains word" search. This PR modifies the methods to request the exact value from the Sherpa Romeo API.

See javadocs for more info:

https://github.com/DSpace/DSpace/blob/main/dspace-api/src/main/java/org/dspace/content/authority/ChoiceAuthority.java#L46-L58

## Instructions for Reviewers

To test it activate the Sherpa Romeo authorities:

```
plugin.named.org.dspace.content.authority.ChoiceAuthority = \
 org.dspace.content.authority.SHERPARoMEOPublisher = SRPublisher, \
 org.dspace.content.authority.SHERPARoMEOJournalTitle = SRJournalTitle, \
 org.dspace.content.authority.SolrAuthority = SolrAuthorAuthority

choices.plugin.dc.publisher = SRPublisher
choices.presentation.dc.publisher = suggest
authority.controlled.dc.publisher = true

choices.plugin.dc.relation.ispartof = SRJournalTitle
choices.presentation.dc.relation.ispartof = lookup
authority.controlled.dc.relation.ispartof = true

sherpa.romeo.apikey = <sherpa-api-key>
```

It could be tested doing request to the `entries` endpoint of the vocabulary `SRPublisher` and `SRJournalTitle` with the `exact` param equals to `true`: 

```
http://localhost/server/api/submission/vocabularies/SRPublisher/entries?filter=<Publisher-name>&exact=true

http://localhost/server/api/submission/vocabularies/SRJournalTitle/entries?filter=<Journal-Title>&exact=true
```
It should return results only when the filter parameter is exactly the same as one of the publisher names or journal titles included in the Sherpa Romeo API. It is case-sensitive because the Sherpa Romeo API's equal search is also case-sensitive.

You could find examples here: https://www.sherpa.ac.uk/romeo/

Another way to test it is to import a SAF zip file with `dc.publisher` and `dc.relation.ispartof` values. When a new Item is imported, the system use the method `getBestMatch()` to try to assign an authority key to metadada values of a metadata field that is authority controlled.  In addition to the authority key, it will also assign a confidence value:

I have used this zip to test it: https://github.com/toniprieto/test-import-metadata-dspace/raw/main/sherpa-romeo-example.zip

This example should assign :
- A authority key and a confidence value of 500 (UNCERTAIN, that means that is a valid authority but has not been accepted by an interactive user) to the next values: Nature Research, Alanya Üniversitesi, Springer, Human Nature, Aufklärung: Revista de Filosofia, Open Medicine
- A authority key and a confidence value of 400 (AMBIGUOUS, that means that more than one result has been found for this value) to value Al-Nahrain University (this publisher name has two entries in Sherpa Romeo API)
- And no-authority for School, non-existent, Journal, non-existent

These values ​​can be checked in the database.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
