### PR TITLE
7.x - CSRF bugfix

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/SecurityRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/SecurityRestController.java
@@ -31,12 +31,7 @@ public class SecurityRestController {
      */
     @RequestMapping(value = "/csrf", method = RequestMethod.POST)
     public ResponseEntity csrf(HttpServletRequest request, HttpServletResponse response) {
-        CsrfToken token = csrfTokenRepository.loadToken(request);
-        CsrfToken headerToken = csrfTokenRepository.loadTokenFromHeader(request);
-        if (token == null || headerToken == null || !token.getToken().equals(headerToken.getToken())) {
-            CsrfToken newToken = csrfTokenRepository.generateToken(request);
-            csrfTokenRepository.saveToken(newToken, request, response);
-        }
+        csrfTokenRepository.saveNewTokenIfCookieAndHeaderMatch(request, response);
         return ResponseEntity.ok().build();
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/SecurityRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/SecurityRestController.java
@@ -1,0 +1,36 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.dspace.app.rest.security.DSpaceCsrfTokenRepository;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping(value = "/api/security")
+@RestController
+public class SecurityRestController {
+    DSpaceCsrfTokenRepository csrfTokenRepository = new DSpaceCsrfTokenRepository();
+
+    @RequestMapping(value = "/csrf", method = RequestMethod.POST)
+    public ResponseEntity csrf(HttpServletRequest request, HttpServletResponse response) {
+        CsrfToken token = csrfTokenRepository.loadToken(request);
+        CsrfToken headerToken = csrfTokenRepository.loadTokenFromHeader(request);
+        if (token == null || headerToken == null || !token.getToken().equals(headerToken.getToken())) {
+            CsrfToken newToken = csrfTokenRepository.generateToken(request);
+            csrfTokenRepository.saveToken(newToken, request, response);
+        }
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/SecurityRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/SecurityRestController.java
@@ -17,11 +17,18 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * Rest controller handling security related requests
+ */
 @RequestMapping(value = "/api/security")
 @RestController
 public class SecurityRestController {
     DSpaceCsrfTokenRepository csrfTokenRepository = new DSpaceCsrfTokenRepository();
 
+    /**
+     * The csrf endpoint checks the current csrf cookie and header, resetting it if any of the two are missing, or
+     * they don't match anymore
+     */
     @RequestMapping(value = "/csrf", method = RequestMethod.POST)
     public ResponseEntity csrf(HttpServletRequest request, HttpServletResponse response) {
         CsrfToken token = csrfTokenRepository.loadToken(request);
@@ -30,7 +37,7 @@ public class SecurityRestController {
             CsrfToken newToken = csrfTokenRepository.generateToken(request);
             csrfTokenRepository.saveToken(newToken, request, response);
         }
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok().build();
     }
 
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/SecurityRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/SecurityRestController.java
@@ -12,7 +12,6 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.dspace.app.rest.security.DSpaceCsrfTokenRepository;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
@@ -31,7 +30,7 @@ public class SecurityRestController {
      */
     @RequestMapping(value = "/csrf", method = RequestMethod.POST)
     public ResponseEntity csrf(HttpServletRequest request, HttpServletResponse response) {
-        csrfTokenRepository.saveNewTokenIfCookieAndHeaderMatch(request, response);
+        csrfTokenRepository.saveNewTokenWhenCookieAndHeaderDontMatch(request, response);
         return ResponseEntity.ok().build();
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/StatisticsRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/StatisticsRestController.java
@@ -10,6 +10,9 @@ package org.dspace.app.rest;
 import java.util.Arrays;
 import java.util.UUID;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import org.dspace.app.rest.converter.ConverterService;
 import org.dspace.app.rest.exception.RepositoryMethodNotImplementedException;
 import org.dspace.app.rest.model.RestAddressableModel;
@@ -20,6 +23,7 @@ import org.dspace.app.rest.model.hateoas.ViewEventResource;
 import org.dspace.app.rest.repository.SearchEventRestRepository;
 import org.dspace.app.rest.repository.StatisticsRestRepository;
 import org.dspace.app.rest.repository.ViewEventRestRepository;
+import org.dspace.app.rest.security.DSpaceCsrfTokenRepository;
 import org.dspace.app.rest.utils.Utils;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,6 +42,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/" + RestAddressableModel.STATISTICS)
 public class StatisticsRestController implements InitializingBean {
+    DSpaceCsrfTokenRepository csrfTokenRepository = new DSpaceCsrfTokenRepository();
 
     @Autowired
     private Utils utils;
@@ -91,13 +96,21 @@ public class StatisticsRestController implements InitializingBean {
     }
 
     @RequestMapping(method = RequestMethod.POST, value = "/viewevents")
-    public ResponseEntity<RepresentationModel<?>> postViewEvent() throws Exception {
+    public ResponseEntity<RepresentationModel<?>> postViewEvent(HttpServletRequest request,
+                                                                HttpServletResponse response) throws Exception {
+        // WebSecurityConfiguration disabled CSRF for these endpoints, so they don't fail when the tokens are missing,
+        // but we should still add the proper response headers in these cases
+        csrfTokenRepository.saveNewTokenIfCookieAndHeaderMatch(request, response);
         ViewEventResource result = converter.toResource(viewEventRestRepository.createViewEvent());
         return ControllerUtils.toResponseEntity(HttpStatus.CREATED, new HttpHeaders(), result);
     }
 
     @RequestMapping(method = RequestMethod.POST, value = "/searchevents")
-    public ResponseEntity<RepresentationModel<?>> postSearchEvent() throws Exception {
+    public ResponseEntity<RepresentationModel<?>> postSearchEvent(HttpServletRequest request,
+                                                                  HttpServletResponse response) throws Exception {
+        // WebSecurityConfiguration disabled CSRF for these endpoints, so they don't fail when the tokens are missing,
+        // but we should still add the proper response headers in these cases
+        csrfTokenRepository.saveNewTokenIfCookieAndHeaderMatch(request, response);
         SearchEventResource result = converter.toResource(searchEventRestRepository.createSearchEvent());
         return ControllerUtils.toResponseEntity(HttpStatus.CREATED, new HttpHeaders(), result);
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/StatisticsRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/StatisticsRestController.java
@@ -9,7 +9,6 @@ package org.dspace.app.rest;
 
 import java.util.Arrays;
 import java.util.UUID;
-
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/StatisticsRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/StatisticsRestController.java
@@ -100,7 +100,7 @@ public class StatisticsRestController implements InitializingBean {
                                                                 HttpServletResponse response) throws Exception {
         // WebSecurityConfiguration disabled CSRF for these endpoints, so they don't fail when the tokens are missing,
         // but we should still add the proper response headers in these cases
-        csrfTokenRepository.saveNewTokenIfCookieAndHeaderMatch(request, response);
+        csrfTokenRepository.saveNewTokenWhenCookieAndHeaderDontMatch(request, response);
         ViewEventResource result = converter.toResource(viewEventRestRepository.createViewEvent());
         return ControllerUtils.toResponseEntity(HttpStatus.CREATED, new HttpHeaders(), result);
     }
@@ -110,7 +110,7 @@ public class StatisticsRestController implements InitializingBean {
                                                                   HttpServletResponse response) throws Exception {
         // WebSecurityConfiguration disabled CSRF for these endpoints, so they don't fail when the tokens are missing,
         // but we should still add the proper response headers in these cases
-        csrfTokenRepository.saveNewTokenIfCookieAndHeaderMatch(request, response);
+        csrfTokenRepository.saveNewTokenWhenCookieAndHeaderDontMatch(request, response);
         SearchEventResource result = converter.toResource(searchEventRestRepository.createSearchEvent());
         return ControllerUtils.toResponseEntity(HttpStatus.CREATED, new HttpHeaders(), result);
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/DSpaceCsrfTokenRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/DSpaceCsrfTokenRepository.java
@@ -83,6 +83,9 @@ public class DSpaceCsrfTokenRepository implements CsrfTokenRepository {
     /**
      * This method has been modified for DSpace.
      * <P>
+     * It filters out GET requests to avoid them refreshing the token when one is already being set by the csrf endpoint
+     * on SecurityRestController
+     * <P>
      * It now uses ResponseCookie to build the cookie, so that the "SameSite" attribute can be applied.
      * <P>
      * It also sends the token (if not empty) in both the cookie and the custom "DSPACE-XSRF-TOKEN" header
@@ -93,6 +96,9 @@ public class DSpaceCsrfTokenRepository implements CsrfTokenRepository {
     @Override
     public void saveToken(CsrfToken token, HttpServletRequest request,
                           HttpServletResponse response) {
+        if (request.getMethod().equals("GET")) {
+            return;
+        }
         String tokenValue = token == null ? "" : token.getToken();
         Cookie cookie = new Cookie(this.cookieName, tokenValue);
         cookie.setSecure(request.isSecure());

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/DSpaceCsrfTokenRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/DSpaceCsrfTokenRepository.java
@@ -150,6 +150,19 @@ public class DSpaceCsrfTokenRepository implements CsrfTokenRepository {
         return new DefaultCsrfToken(this.headerName, this.parameterName, token);
     }
 
+    /**
+     * Retrieve the csrf token from the header of the request, if present, otherwise return null
+     * As opposed to the regular loadToken method, which retrieves the token from the cookies instead
+     */
+    public CsrfToken loadTokenFromHeader(HttpServletRequest request) {
+        String token = request.getHeader(this.headerName);
+        if (!StringUtils.hasLength(token)) {
+            return null;
+        }
+
+        return new DefaultCsrfToken(this.headerName, this.parameterName, token);
+    }
+
 
     /**
      * Sets the name of the HTTP request parameter that should be used to provide a token.

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/DSpaceCsrfTokenRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/DSpaceCsrfTokenRepository.java
@@ -142,6 +142,19 @@ public class DSpaceCsrfTokenRepository implements CsrfTokenRepository {
         }
     }
 
+    /**
+     * Check the current CSRF token in the request's cookie and header and if any of them are missing, or they don't
+     * match, create a new token and save it on the response
+     */
+    public void saveNewTokenIfCookieAndHeaderMatch(HttpServletRequest request, HttpServletResponse response) {
+        CsrfToken token = loadToken(request);
+        CsrfToken headerToken = loadTokenFromHeader(request);
+        if (token == null || headerToken == null || !token.getToken().equals(headerToken.getToken())) {
+            CsrfToken newToken = generateToken(request);
+            saveToken(newToken, request, response);
+        }
+    }
+
     @Override
     public CsrfToken loadToken(HttpServletRequest request) {
         Cookie cookie = WebUtils.getCookie(request, this.cookieName);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/DSpaceCsrfTokenRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/DSpaceCsrfTokenRepository.java
@@ -146,7 +146,7 @@ public class DSpaceCsrfTokenRepository implements CsrfTokenRepository {
      * Check the current CSRF token in the request's cookie and header and if any of them are missing, or they don't
      * match, create a new token and save it on the response
      */
-    public void saveNewTokenIfCookieAndHeaderMatch(HttpServletRequest request, HttpServletResponse response) {
+    public void saveNewTokenWhenCookieAndHeaderDontMatch(HttpServletRequest request, HttpServletResponse response) {
         CsrfToken token = loadToken(request);
         CsrfToken headerToken = loadTokenFromHeader(request);
         if (token == null || headerToken == null || !token.getToken().equals(headerToken.getToken())) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/WebSecurityConfiguration.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/WebSecurityConfiguration.java
@@ -100,6 +100,7 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
             // (both are defined below as methods).
             // While we primarily use JWT in headers, CSRF protection is needed because we also support JWT via Cookies
             .csrf()
+                .ignoringAntMatchers("/api/statistics/**")
                 .csrfTokenRepository(this.getCsrfTokenRepository())
                 .sessionAuthenticationStrategy(this.sessionAuthenticationStrategy())
             .and()

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/WebSecurityConfiguration.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/WebSecurityConfiguration.java
@@ -100,6 +100,8 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
             // (both are defined below as methods).
             // While we primarily use JWT in headers, CSRF protection is needed because we also support JWT via Cookies
             .csrf()
+                // Allow statistics requests to go through without CSRF tokens
+                // (StatisticsRestController will still deal with setting the token in their responses, if invalid)
                 .ignoringAntMatchers("/api/statistics/**")
                 .csrfTokenRepository(this.getCsrfTokenRepository())
                 .sessionAuthenticationStrategy(this.sessionAuthenticationStrategy())

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SecurityRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SecurityRestControllerIT.java
@@ -1,0 +1,86 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import javax.servlet.http.Cookie;
+import javax.ws.rs.core.HttpHeaders;
+
+import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.hamcrest.core.StringContains;
+import org.junit.Test;
+
+public class SecurityRestControllerIT extends AbstractControllerIntegrationTest {
+
+    @Test
+    public void testCsrfEndpointWithoutCookieOrHeader() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+
+        getClient(token).perform(post("/api/security/csrf"))
+                .andExpect(status().isNoContent())
+                .andExpect(header().string(
+                        HttpHeaders.SET_COOKIE,
+                        StringContains.containsString("DSPACE-XSRF-COOKIE")
+                ));
+    }
+
+    @Test
+    public void testCsrfEndpointWithoutHeader() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+
+        getClient(token).perform(post("/api/security/csrf").cookie(
+                new Cookie("DSPACE-XSRF-COOKIE", "5f12f98b-5de3-4ee1-bd5f-95b784bd17cf")))
+                .andExpect(status().isNoContent())
+                .andExpect(header().string(
+                        HttpHeaders.SET_COOKIE,
+                        StringContains.containsString("DSPACE-XSRF-COOKIE")
+                ));
+    }
+
+    @Test
+    public void testCsrfEndpointWithoutCookie() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+
+        getClient(token).perform(post("/api/security/csrf").header("X-XSRF-TOKEN",
+                        "5f12f98b-5de3-4ee1-bd5f-95b784bd17cf"))
+                .andExpect(status().isNoContent())
+                .andExpect(header().string(
+                        HttpHeaders.SET_COOKIE,
+                        StringContains.containsString("DSPACE-XSRF-COOKIE")
+                ));
+    }
+
+    @Test
+    public void testCsrfEndpointMismatchingCookieAndHeader() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+
+        getClient(token).perform(post("/api/security/csrf").header("X-XSRF-TOKEN",
+                        "5f12f98b-5de3-4ee1-bd5f-95b784bd17cf").cookie(
+                        new Cookie("DSPACE-XSRF-COOKIE", "1427c36d-6d4c-423a-939d-8ddf0115b5c6")))
+                .andExpect(status().isNoContent())
+                .andExpect(header().string(
+                        HttpHeaders.SET_COOKIE,
+                        StringContains.containsString("DSPACE-XSRF-COOKIE")
+                ));
+    }
+
+    @Test
+    public void testCsrfEndpointMatchingCookieAndHeader() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+
+        getClient(token).perform(post("/api/security/csrf").header("X-XSRF-TOKEN",
+                        "5f12f98b-5de3-4ee1-bd5f-95b784bd17cf").cookie(
+                        new Cookie("DSPACE-XSRF-COOKIE", "5f12f98b-5de3-4ee1-bd5f-95b784bd17cf")))
+                .andExpect(status().isNoContent())
+                .andExpect(header().doesNotExist(HttpHeaders.SET_COOKIE));
+    }
+
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SecurityRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SecurityRestControllerIT.java
@@ -25,7 +25,7 @@ public class SecurityRestControllerIT extends AbstractControllerIntegrationTest 
         String token = getAuthToken(admin.getEmail(), password);
 
         getClient(token).perform(post("/api/security/csrf"))
-                .andExpect(status().isNoContent())
+                .andExpect(status().isOk())
                 .andExpect(header().string(
                         HttpHeaders.SET_COOKIE,
                         StringContains.containsString("DSPACE-XSRF-COOKIE")
@@ -38,7 +38,7 @@ public class SecurityRestControllerIT extends AbstractControllerIntegrationTest 
 
         getClient(token).perform(post("/api/security/csrf").cookie(
                 new Cookie("DSPACE-XSRF-COOKIE", "5f12f98b-5de3-4ee1-bd5f-95b784bd17cf")))
-                .andExpect(status().isNoContent())
+                .andExpect(status().isOk())
                 .andExpect(header().string(
                         HttpHeaders.SET_COOKIE,
                         StringContains.containsString("DSPACE-XSRF-COOKIE")
@@ -51,7 +51,7 @@ public class SecurityRestControllerIT extends AbstractControllerIntegrationTest 
 
         getClient(token).perform(post("/api/security/csrf").header("X-XSRF-TOKEN",
                         "5f12f98b-5de3-4ee1-bd5f-95b784bd17cf"))
-                .andExpect(status().isNoContent())
+                .andExpect(status().isOk())
                 .andExpect(header().string(
                         HttpHeaders.SET_COOKIE,
                         StringContains.containsString("DSPACE-XSRF-COOKIE")
@@ -65,7 +65,7 @@ public class SecurityRestControllerIT extends AbstractControllerIntegrationTest 
         getClient(token).perform(post("/api/security/csrf").header("X-XSRF-TOKEN",
                         "5f12f98b-5de3-4ee1-bd5f-95b784bd17cf").cookie(
                         new Cookie("DSPACE-XSRF-COOKIE", "1427c36d-6d4c-423a-939d-8ddf0115b5c6")))
-                .andExpect(status().isNoContent())
+                .andExpect(status().isOk())
                 .andExpect(header().string(
                         HttpHeaders.SET_COOKIE,
                         StringContains.containsString("DSPACE-XSRF-COOKIE")
@@ -79,7 +79,7 @@ public class SecurityRestControllerIT extends AbstractControllerIntegrationTest 
         getClient(token).perform(post("/api/security/csrf").header("X-XSRF-TOKEN",
                         "5f12f98b-5de3-4ee1-bd5f-95b784bd17cf").cookie(
                         new Cookie("DSPACE-XSRF-COOKIE", "5f12f98b-5de3-4ee1-bd5f-95b784bd17cf")))
-                .andExpect(status().isNoContent())
+                .andExpect(status().isOk())
                 .andExpect(header().doesNotExist(HttpHeaders.SET_COOKIE));
     }
 


### PR DESCRIPTION
## References
* Fixes #9236 
* Angular side of this PR: [#2839](https://github.com/DSpace/dspace-angular/pull/2839)
* "main" REST side of this PR: [#9368](https://github.com/DSpace/DSpace/pull/9368)
* "main" Angular side of this PR: [#2838](https://github.com/DSpace/dspace-angular/pull/2838)

## Description
This PR adds a `/api/security/csrf` endpoint to send POST requests to, which returns the appropriate CSRF headers/cookies, avoiding any subsequent POST request from failing before CSRF headers are set.

## Instructions for Reviewers
Changes made:
* A new `SecurityRestController` with `/api/security/csrf` POST endpoint
* Disabled CSRF for statistics endpoints
* Modified `DSpaceCsrfTokenRepository` to create and return CSRF tokens as header and cookie when either one of them is missing from a POST request

For testing, I'd advise setting up both Angular and REST side of this PR (note, when referring to csrf cookie, I'm talking about "DSPACE-XSRF-COOKIE"):
* Load the homepage as anonymous and confirm a csrf POST request is sent to the new endpoint
* Confirm the first "statistics" POST request (should be "viewevents") contains the correct CSRF cookie and header and succeeds
* Confirm the same happens when logged in
* Using curl or any other method (e.g. Postman), copy the statistics request from your browser (containing equal valid CSRF header and cookie) and confirm the response DOES NOT contain the header and cookie
* Modify the request by removing the header, leaving only the cookie and confirm the response DOES contain the new cookie
* Modify the request by removing the cookie, leaving only the header and confirm the response contains the new cookie
* Modify the request by removing both cookie and header and once again, confirm it contains the new cookie
* Modify the request by changing the header/cookie to be different from each other and confirm it contains the new cookie

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
