### PR TITLE
Update to latest Spring 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <!--=== GENERAL / DSPACE-API DEPENDENCIES ===-->
         <java.version>11</java.version>
-        <spring.version>5.3.31</spring.version>
+        <spring.version>5.3.32</spring.version>
         <spring-boot.version>2.7.18</spring-boot.version>
         <spring-security.version>5.7.11</spring-security.version> <!-- sync with version used by spring-boot-->
         <hibernate.version>5.6.15.Final</hibernate.version>
@@ -1155,6 +1155,12 @@
             <dependency>
                 <artifactId>spring-context</artifactId>
                 <groupId>org.springframework</groupId>
+                <version>${spring.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-context-support</artifactId>
                 <version>${spring.version}</version>
             </dependency>
 


### PR DESCRIPTION
## Description
Minor Spring update to version 5.3.32 which includes several security fixes https://spring.io/blog/2024/02/15/spring-framework-6-1-4-6-0-17-and-5-3-32-available-now

(This is being built against `main` even though we'll be upgrading to Spring 6 soon in #9321.  It's primarily a fix for `dspace-7_x`, but is safe to add to both branches.)