### PR TITLE
Fix incorrect coar_version value for 'vor' type

### DIFF
--- a/dspace/config/crosswalks/oai/metadataFormats/rioxx.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/rioxx.xsl
@@ -785,7 +785,7 @@
                 <xsl:text>http://purl.org/coar/version/c_ab4af688f83e57aa</xsl:text>
             </xsl:when>
             <xsl:when test="$lc_description = 'published version' or $lc_version='vor'">
-                <xsl:text>http://purl.org/coar/resource_type/c_1162</xsl:text>
+                <xsl:text>http://purl.org/coar/version/c_970fb48d4fbd8a85</xsl:text>
             </xsl:when>
             <xsl:when test="$lc_description = 'submitted version' or $lc_version='ao'">
                 <xsl:text>http://purl.org/coar/version/c_b1a7d7d4d402bcce</xsl:text>


### PR DESCRIPTION
rioxx.xsl: update incorrect COAR version url for 'vor'

## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #9373 

## Description
Corrected the coar version url: https://vocabularies.coar-repositories.org/version_types/c_970fb48d4fbd8a85/

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
