### PR TITLE
Fix #9383: Set email subject for request copy form

### DIFF
--- a/dspace-api/src/main/java/org/dspace/core/Email.java
+++ b/dspace-api/src/main/java/org/dspace/core/Email.java
@@ -395,7 +395,7 @@ public class Email {
         for (String headerName : templateHeaders) {
             String headerValue = (String) vctx.get(headerName);
             if ("subject".equalsIgnoreCase(headerName)) {
-                if (null != headerValue) {
+                if ((subject == null || subject.isEmpty()) && null != headerValue) {
                     subject = headerValue;
                 }
             } else if ("charset".equalsIgnoreCase(headerName)) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RequestItemRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RequestItemRepository.java
@@ -247,11 +247,15 @@ public class RequestItemRepository
             message = responseMessageNode.asText();
         }
 
+        JsonNode responseSubjectNode = requestBody.findValue("subject");
+        String subject = null;
+        if (responseSubjectNode != null && !responseSubjectNode.isNull()) {
+            subject = responseSubjectNode.asText();
+        }
         ri.setDecision_date(new Date());
         requestItemService.update(context, ri);
 
         // Send the response email
-        String subject = requestBody.findValue("subject").asText();
         try {
             requestItemEmailNotifier.sendResponse(context, ri, subject, message);
         } catch (IOException ex) {


### PR DESCRIPTION
## References
Fixes #9383

## Description
1. Make sure, the email subject does not get overwritten with the subject from the email template if the subject is set explicitly via `Email>>setSubject()` as described in the comment of `Email>>send()` but not implemented:

> <p>"subject" is treated specially:  if {@link setSubject()} has not been    
> called, the value of any "subject" property will be used as if setSubject    
> had been called with that value.  Thus a template may define its subject,    
> but the caller may override it.    

2. Test for empty subject in `RequestItemRepository>>put()`.

## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

1. Request a copy of a bitstream under embargo
2. Click the link to grant or deny the request
3. Enter a custom subject line
4. Verify the email sent: the subject you entered in the form should now be the subject of the email sent.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR passes all tests ~~and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).~~
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
