### PR TITLE
Delete sync settings when disconnect from orcid

### DIFF
--- a/dspace-api/src/main/java/org/dspace/orcid/service/impl/OrcidSynchronizationServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/orcid/service/impl/OrcidSynchronizationServiceImpl.java
@@ -118,6 +118,14 @@ public class OrcidSynchronizationServiceImpl implements OrcidSynchronizationServ
         itemService.clearMetadata(context, profile, "dspace", "orcid", "scope", Item.ANY);
         itemService.clearMetadata(context, profile, "dspace", "orcid", "authenticated", Item.ANY);
 
+        itemService.clearMetadata(context, profile, "dspace", "orcid", "sync-mode", Item.ANY);
+        itemService.clearMetadata(context, profile, "dspace", "orcid", "sync-profile", Item.ANY);
+
+        for (OrcidEntityType entityType : OrcidEntityType.values()) {
+            itemService.clearMetadata(context, profile, "dspace", "orcid",
+                "sync-" + entityType.name().toLowerCase() + "s", Item.ANY);
+        }
+
         orcidTokenService.deleteByProfileItem(context, profile);
 
         updateItem(context, profile);

--- a/dspace-api/src/main/java/org/dspace/orcid/service/impl/OrcidSynchronizationServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/orcid/service/impl/OrcidSynchronizationServiceImpl.java
@@ -118,12 +118,8 @@ public class OrcidSynchronizationServiceImpl implements OrcidSynchronizationServ
         itemService.clearMetadata(context, profile, "dspace", "orcid", "scope", Item.ANY);
         itemService.clearMetadata(context, profile, "dspace", "orcid", "authenticated", Item.ANY);
 
-        itemService.clearMetadata(context, profile, "dspace", "orcid", "sync-mode", Item.ANY);
-        itemService.clearMetadata(context, profile, "dspace", "orcid", "sync-profile", Item.ANY);
-
-        for (OrcidEntityType entityType : OrcidEntityType.values()) {
-            itemService.clearMetadata(context, profile, "dspace", "orcid",
-                "sync-" + entityType.name().toLowerCase() + "s", Item.ANY);
+        if (!configurationService.getBooleanProperty("orcid.disconnection.remain-sync", false)) {
+            clearSynchronizationSettings(context, profile);
         }
 
         orcidTokenService.deleteByProfileItem(context, profile);
@@ -273,6 +269,17 @@ public class OrcidSynchronizationServiceImpl implements OrcidSynchronizationServ
 
         return true;
 
+    }
+
+    private void clearSynchronizationSettings(Context context, Item profile)
+        throws SQLException {
+        itemService.clearMetadata(context, profile, "dspace", "orcid", "sync-mode", Item.ANY);
+        itemService.clearMetadata(context, profile, "dspace", "orcid", "sync-profile", Item.ANY);
+
+        for (OrcidEntityType entityType : OrcidEntityType.values()) {
+            itemService.clearMetadata(context, profile, "dspace", "orcid",
+                "sync-" + entityType.name().toLowerCase() + "s", Item.ANY);
+        }
     }
 
     private boolean containsSameValues(List<String> firstList, List<String> secondList) {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResearcherProfileRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResearcherProfileRestRepositoryIT.java
@@ -20,6 +20,7 @@ import static org.dspace.app.rest.matcher.MetadataMatcher.matchMetadataNotEmpty;
 import static org.dspace.app.rest.matcher.ResourcePolicyMatcher.matchResourcePolicyProperties;
 import static org.dspace.builder.RelationshipTypeBuilder.createRelationshipTypeBuilder;
 import static org.dspace.profile.OrcidEntitySyncPreference.ALL;
+import static org.dspace.profile.OrcidEntitySyncPreference.DISABLED;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
@@ -2230,6 +2231,81 @@ public class ResearcherProfileRestRepositoryIT extends AbstractControllerIntegra
         assertThat(getMetadataValues(profile, "dspace.orcid.authenticated"), not(empty()));
         assertThat(getOrcidAccessToken(profile), is("3de2e370-8aa9-4bbe-8d7e-f5b1577bdad4"));
     }
+
+    @Test
+    public void testOwnerPatchToDisconnectProfileFromOrcidWithSyncSettings() throws Exception {
+
+        configurationService.setProperty("orcid.disconnection.allowed-users", "only_owner");
+
+        context.turnOffAuthorisationSystem();
+
+        EPerson ePerson = EPersonBuilder.createEPerson(context)
+            .withCanLogin(true)
+            .withOrcid("0000-1111-2222-3333")
+            .withOrcidScope("/read")
+            .withOrcidScope("/write")
+            .withEmail("test@email.it")
+            .withPassword(password)
+            .withNameInMetadata("Test", "User")
+            .build();
+
+        OrcidTokenBuilder.create(context, ePerson, "3de2e370-8aa9-4bbe-8d7e-f5b1577bdad4").build();
+
+        Item profile = createProfile(ePerson);
+
+        assertThat(getMetadataValues(profile, "person.identifier.orcid"), not(empty()));
+        assertThat(getMetadataValues(profile, "dspace.orcid.scope"), not(empty()));
+        assertThat(getMetadataValues(profile, "dspace.orcid.authenticated"), not(empty()));
+        assertThat(getOrcidAccessToken(profile), is("3de2e370-8aa9-4bbe-8d7e-f5b1577bdad4"));
+
+        context.restoreAuthSystemState();
+
+        String authToken = getAuthToken(ePerson.getEmail(), password);
+        String ePersonId = ePerson.getID().toString();
+        List<Operation> operations = asList(new ReplaceOperation("/orcid/mode", "BATCH"),
+            new ReplaceOperation("/orcid/publications", "DISABLED"),
+            new ReplaceOperation("/orcid/fundings", "ALL"),
+            new ReplaceOperation("/orcid/profile", "BIOGRAPHICAL,IDENTIFIERS"));
+
+        getClient(authToken).perform(patch("/api/eperson/profiles/{id}", ePersonId)
+                .content(getPatchContent(operations))
+                .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.orcidSynchronization.mode", is("BATCH")))
+            .andExpect(jsonPath("$.orcidSynchronization.profilePreferences",
+                containsInAnyOrder("IDENTIFIERS", "BIOGRAPHICAL")))
+            .andExpect(jsonPath("$.orcidSynchronization.fundingsPreference", is(ALL.name())))
+            .andExpect(jsonPath("$.orcidSynchronization.publicationsPreference", is(DISABLED.name())));
+
+        profile = context.reloadEntity(profile);
+        List<MetadataValue> metadata = profile.getMetadata();
+        assertThat(metadata, hasItem(with("dspace.orcid.sync-mode","BATCH")));
+        assertThat(metadata, hasItem(with("dspace.orcid.sync-publications",DISABLED.name())));
+        assertThat(metadata, hasItem(with("dspace.orcid.sync-fundings",ALL.name())));
+        assertThat(getMetadataValues(profile, "dspace.orcid.sync-profile"), hasSize(2));
+
+        getClient(authToken).perform(patch("/api/eperson/profiles/{id}", ePersonId)
+                .content(getPatchContent(asList(new RemoveOperation("/orcid"))))
+                .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id", is(ePersonId)))
+            .andExpect(jsonPath("$.visible", is(false)))
+            .andExpect(jsonPath("$.type", is("profile")))
+            .andExpect(jsonPath("$.orcid").doesNotExist())
+            .andExpect(jsonPath("$.orcidSynchronization").doesNotExist());
+
+        profile = context.reloadEntity(profile);
+
+        assertThat(getMetadataValues(profile, "person.identifier.orcid"), empty());
+        assertThat(getMetadataValues(profile, "dspace.orcid.scope"), empty());
+        assertThat(getMetadataValues(profile, "dspace.orcid.authenticated"), empty());
+        assertThat(getMetadataValues(profile, "dspace.orcid.sync-profile"), empty());
+        assertThat(getMetadataValues(profile, "dspace.orcid.sync-mode"), empty());
+        assertThat(getMetadataValues(profile, "dspace.orcid.sync-fundings"), empty());
+        assertThat(getMetadataValues(profile, "dspace.orcid.sync-publications"), empty());
+        assertThat(getOrcidAccessToken(profile), nullValue());
+    }
+
 
     @Test
     public void testCloneFromExternalProfileAlreadyAssociated() throws Exception {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResearcherProfileRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResearcherProfileRestRepositoryIT.java
@@ -2233,9 +2233,10 @@ public class ResearcherProfileRestRepositoryIT extends AbstractControllerIntegra
     }
 
     @Test
-    public void testOwnerPatchToDisconnectProfileFromOrcidWithSyncSettings() throws Exception {
+    public void testOwnerPatchToDisconnectProfileFromOrcidWithSyncSettingsRemoved() throws Exception {
 
         configurationService.setProperty("orcid.disconnection.allowed-users", "only_owner");
+        configurationService.setProperty("orcid.disconnection.remain-sync", "false");
 
         context.turnOffAuthorisationSystem();
 
@@ -2303,6 +2304,80 @@ public class ResearcherProfileRestRepositoryIT extends AbstractControllerIntegra
         assertThat(getMetadataValues(profile, "dspace.orcid.sync-mode"), empty());
         assertThat(getMetadataValues(profile, "dspace.orcid.sync-fundings"), empty());
         assertThat(getMetadataValues(profile, "dspace.orcid.sync-publications"), empty());
+        assertThat(getOrcidAccessToken(profile), nullValue());
+    }
+
+    @Test
+    public void testOwnerPatchToDisconnectProfileFromOrcidWithSyncSettingsRemain() throws Exception {
+
+        configurationService.setProperty("orcid.disconnection.allowed-users", "only_owner");
+
+        context.turnOffAuthorisationSystem();
+
+        EPerson ePerson = EPersonBuilder.createEPerson(context)
+            .withCanLogin(true)
+            .withOrcid("0000-1111-2222-3333")
+            .withOrcidScope("/read")
+            .withOrcidScope("/write")
+            .withEmail("test@email.it")
+            .withPassword(password)
+            .withNameInMetadata("Test", "User")
+            .build();
+
+        OrcidTokenBuilder.create(context, ePerson, "3de2e370-8aa9-4bbe-8d7e-f5b1577bdad4").build();
+
+        Item profile = createProfile(ePerson);
+
+        assertThat(getMetadataValues(profile, "person.identifier.orcid"), not(empty()));
+        assertThat(getMetadataValues(profile, "dspace.orcid.scope"), not(empty()));
+        assertThat(getMetadataValues(profile, "dspace.orcid.authenticated"), not(empty()));
+        assertThat(getOrcidAccessToken(profile), is("3de2e370-8aa9-4bbe-8d7e-f5b1577bdad4"));
+
+        context.restoreAuthSystemState();
+
+        String authToken = getAuthToken(ePerson.getEmail(), password);
+        String ePersonId = ePerson.getID().toString();
+        List<Operation> operations = asList(new ReplaceOperation("/orcid/mode", "BATCH"),
+            new ReplaceOperation("/orcid/publications", "DISABLED"),
+            new ReplaceOperation("/orcid/fundings", "ALL"),
+            new ReplaceOperation("/orcid/profile", "BIOGRAPHICAL,IDENTIFIERS"));
+
+        getClient(authToken).perform(patch("/api/eperson/profiles/{id}", ePersonId)
+                .content(getPatchContent(operations))
+                .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.orcidSynchronization.mode", is("BATCH")))
+            .andExpect(jsonPath("$.orcidSynchronization.profilePreferences",
+                containsInAnyOrder("IDENTIFIERS", "BIOGRAPHICAL")))
+            .andExpect(jsonPath("$.orcidSynchronization.fundingsPreference", is(ALL.name())))
+            .andExpect(jsonPath("$.orcidSynchronization.publicationsPreference", is(DISABLED.name())));
+
+        profile = context.reloadEntity(profile);
+        List<MetadataValue> metadata = profile.getMetadata();
+        assertThat(metadata, hasItem(with("dspace.orcid.sync-mode","BATCH")));
+        assertThat(metadata, hasItem(with("dspace.orcid.sync-publications",DISABLED.name())));
+        assertThat(metadata, hasItem(with("dspace.orcid.sync-fundings",ALL.name())));
+        assertThat(getMetadataValues(profile, "dspace.orcid.sync-profile"), hasSize(2));
+
+        getClient(authToken).perform(patch("/api/eperson/profiles/{id}", ePersonId)
+                .content(getPatchContent(asList(new RemoveOperation("/orcid"))))
+                .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id", is(ePersonId)))
+            .andExpect(jsonPath("$.visible", is(false)))
+            .andExpect(jsonPath("$.type", is("profile")))
+            .andExpect(jsonPath("$.orcid").doesNotExist())
+            .andExpect(jsonPath("$.orcidSynchronization").doesNotExist());
+
+        profile = context.reloadEntity(profile);
+
+        assertThat(getMetadataValues(profile, "person.identifier.orcid"), empty());
+        assertThat(getMetadataValues(profile, "dspace.orcid.scope"), empty());
+        assertThat(getMetadataValues(profile, "dspace.orcid.authenticated"), empty());
+        assertThat(metadata, hasItem(with("dspace.orcid.sync-mode","BATCH")));
+        assertThat(metadata, hasItem(with("dspace.orcid.sync-publications",DISABLED.name())));
+        assertThat(metadata, hasItem(with("dspace.orcid.sync-fundings",ALL.name())));
+        assertThat(getMetadataValues(profile, "dspace.orcid.sync-profile"), hasSize(2));
         assertThat(getOrcidAccessToken(profile), nullValue());
     }
 

--- a/dspace/config/modules/orcid.cfg
+++ b/dspace/config/modules/orcid.cfg
@@ -7,6 +7,9 @@
 # Allowed values are disabled, only_admin, only_owner or admin_and_owner
 orcid.disconnection.allowed-users = admin_and_owner
 
+# Configuration if the orcid sync settings should be remain on he profile when it is disconnected from orcid or not
+orcid.disconnection.remain-sync = true
+
 #------------------------------------------------------------------#
 #--------------------ORCID CLIENT CONFIGURATIONS-------------------#
 #------------------------------------------------------------------#


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #9390

## Description
This PR introduces a new functionality to delete some profile orcid synchronization settings when the corresponding profile is unlinked from orcid.

## Instructions for Reviewers

List of changes in this PR:
* boolean configuration `orcid.disconnection.remain-sync = true` whether the orcid synchronization metadata should remain in the profile when it is unlinked from orcid or whether they should by deleted. By default the synchronization settings remain in the profile
* additional check in the unlink method for this configuration which deletes in the `clearSynchronizationSettings` method the `dspace.orcid.sync-mode` , `dspace.orcid.sync-profile` and all `dspace.orcid.sync-<entityType>+s`, e.g. `dspace.orcid.sync-publications` metadatavalues

**Include guidance for how to test or review your PR.**
- Provided two integration tests checking if the sync options are deleted or not depending on the configuration setting.
- For testing: link some profile with orcid -> set orcid sync settings -> unlink profile from orcid -> depending on the configuration check if the profile still has the synchronization settings or if they have been deleted.
- Configurable option has been set true (or remain) by default. https://github.com/DSpace/DSpace/issues/9390#issuecomment-1981041046

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
