### PR TITLE
Fix OAIHarvester#extractHandle not handling config properly

### DIFF
--- a/dspace-api/src/main/java/org/dspace/harvest/OAIHarvester.java
+++ b/dspace-api/src/main/java/org/dspace/harvest/OAIHarvester.java
@@ -16,6 +16,7 @@ import java.net.ConnectException;
 import java.sql.SQLException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
@@ -683,15 +684,11 @@ public class OAIHarvester {
      * @return null or the handle to be used.
      */
     protected String extractHandle(Item item) {
-        String[] acceptedHandleServers = configurationService.getArrayProperty("oai.harvester.acceptedHandleServer");
-        if (acceptedHandleServers == null) {
-            acceptedHandleServers = new String[] {"hdl.handle.net"};
-        }
+        String[] acceptedHandleServers = configurationService
+            .getArrayProperty("oai.harvester.acceptedHandleServer", new String[] {"hdl.handle.net"});
 
-        String[] rejectedHandlePrefixes = configurationService.getArrayProperty("oai.harvester.rejectedHandlePrefix");
-        if (rejectedHandlePrefixes == null) {
-            rejectedHandlePrefixes = new String[] {"123456789"};
-        }
+        String[] rejectedHandlePrefixes = configurationService
+            .getArrayProperty("oai.harvester.rejectedHandlePrefix", new String[] {"123456789"});
 
         List<MetadataValue> values = itemService.getMetadata(item, "dc", "identifier", Item.ANY, Item.ANY);
 
@@ -706,12 +703,9 @@ public class OAIHarvester {
 
                 for (String server : acceptedHandleServers) {
                     if (urlPieces[2].equals(server)) {
-                        for (String prefix : rejectedHandlePrefixes) {
-                            if (!urlPieces[3].equals(prefix)) {
-                                return urlPieces[3] + "/" + urlPieces[4];
-                            }
+                        if (Arrays.stream(rejectedHandlePrefixes).noneMatch(prefix -> prefix.equals(urlPieces[3]))) {
+                            return urlPieces[3] + "/" + urlPieces[4];
                         }
-
                     }
                 }
             }


### PR DESCRIPTION
## References
* Fixes #9408 

## Description
This PR fixes the way `OAIHarvester#extractHandle` handles the config properties `oai.harvester.acceptedHandleServer` and `oai.harvester.rejectedHandlePrefix`.

## Instructions for Reviewers

List of changes:
-  If multiple `rejectedHandlePrefixes` were configured, the `for (String prefix : rejectedHandlePrefixes)` [loop](https://github.com/DSpace/DSpace/blob/eee0bfd2b1ec5995f582b98b92c40b903eed9746/dspace-api/src/main/java/org/dspace/harvest/OAIHarvester.java#L709) made it so `extractHandle` would _always_ return a handle (since the current handle would always differ from at least 1 rejected prefix). Replaced this with a `noneMatch`.
- While debugging I also noticed that the way of setting default values for `oai.harvester.acceptedHandleServer` and `oai.harvester.rejectedHandlePrefix` didn't work. `ConfigurationService#getArrayProperty` returns an empty array when nothing is configured, which means the `if's` [below](https://github.com/DSpace/DSpace/blob/eee0bfd2b1ec5995f582b98b92c40b903eed9746/dspace-api/src/main/java/org/dspace/harvest/OAIHarvester.java#L687) always failed and the default was never set. Since it's a small change I also adjusted these.

When repeating the steps of #9408, the import should no longer fail when multiple prefixes are configured.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
