### PR TITLE
Whitespace normalization

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/AbstractItemEnhancer.java
+++ b/dspace-api/src/main/java/org/dspace/app/AbstractItemEnhancer.java
@@ -1,0 +1,19 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app;
+
+/**
+ * Abstract implementation of {@link ItemEnhancer} that provide common structure
+ * for all the item enhancers.
+ *
+ * @author Luca Giamminonni (luca.giamminonni at 4science.it)
+ *
+ */
+public abstract class AbstractItemEnhancer implements ItemEnhancer {
+
+}

--- a/dspace-api/src/main/java/org/dspace/app/ItemEnhancer.java
+++ b/dspace-api/src/main/java/org/dspace/app/ItemEnhancer.java
@@ -1,0 +1,46 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app;
+
+import org.dspace.content.Item;
+import org.dspace.core.Context;
+
+/**
+ * The enhancers allow to add metadata to the item so that additional
+ * information can be associated with it.
+ *
+ * @author Luca Giamminonni (luca.giamminonni at 4science.it)
+ *
+ */
+public interface ItemEnhancer {
+
+    /**
+     * Check if the given item can be enhanced.
+     *
+     * @param  context the DSpace Context
+     * @param  item    the item to check
+     * @return         true if the given item can be enhanced, false otherwise
+     */
+    boolean canEnhance(Context context, Item item);
+
+    /**
+     * Enhances the metadata of the given item according to a specific logic. The
+     * added metadata have the form cris.virtual.<qualifier>, where <qualifier> is
+     * set arbitrarily based on the strategy used. In addition, metadata of the type
+     * cris.virtualsource.<qualifier> can be added to specify the source of the
+     * enhancement. Multiple metadata values can be added on the given item. This
+     * method returns true if the given item's metadata values are changed. The
+     * enhancement is idempotent: multiple invocations on the same item must not
+     * produce metadata different from those that would be obtained with a single
+     * invocation.
+     *
+     * @param  context the DSpace Context
+     * @param  item    the item to enhance
+     */
+    void enhance(Context context, Item item);
+}

--- a/dspace-api/src/main/java/org/dspace/app/ItemEnhancerByDateScript.java
+++ b/dspace-api/src/main/java/org/dspace/app/ItemEnhancerByDateScript.java
@@ -1,0 +1,391 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ * <p>
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.apache.commons.cli.ParseException;
+import org.apache.commons.text.StringEscapeUtils;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.client.solrj.response.SolrPingResponse;
+import org.apache.solr.common.SolrDocument;
+import org.apache.solr.common.SolrDocumentList;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.content.DSpaceObject;
+import org.dspace.content.Item;
+import org.dspace.content.dto.MetadataValueDTO;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.CollectionService;
+import org.dspace.content.service.EntityTypeService;
+import org.dspace.content.service.ItemService;
+import org.dspace.core.Context;
+import org.dspace.discovery.SearchUtils;
+import org.dspace.discovery.SolrSearchCore;
+import org.dspace.eperson.EPerson;
+import org.dspace.eperson.factory.EPersonServiceFactory;
+import org.dspace.scripts.DSpaceRunnable;
+import org.dspace.util.UUIDUtils;
+import org.dspace.utils.DSpace;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Script that allows to enhance items, also forcing the updating of the
+ * calculated metadata with the enhancement.
+ *
+ * @author Luca Giamminonni (luca.giamminonni at 4science.it)
+ * <p>
+ * Extended to solr search to discover not-enhanced entities.
+ * Some Query can be delivered,
+ * additional some daterange filterquery on the lastModified field
+ * and additional collection/entitytype queries as filterfacets.
+ * @author florian.gantner@uni-bamberg.de
+ */
+public class ItemEnhancerByDateScript
+        extends DSpaceRunnable<ItemEnhancerByDateScriptConfiguration<ItemEnhancerByDateScript>> {
+
+    private ItemService itemService;
+    private CollectionService collectionService;
+
+    protected SolrSearchCore solrSearchCore;
+    private boolean dryrun;
+    private Map<UUID, List<MetadataValueDTO>> dryrunMetadata;
+    private UUID collection;
+    private String entitytype;
+
+    private String query;
+
+    private String dateupper;
+
+    private String datelower;
+
+    private Context context;
+
+    private int max;
+
+    private int limit;
+
+    private EntityTypeService entityTypeService;
+
+    private static final Logger log = LoggerFactory.getLogger(ItemEnhancerByDateScript.class);
+
+    private List<ItemEnhancer> itemEnhancers;
+
+    @Override
+    public void setup() throws ParseException {
+        this.itemService = ContentServiceFactory.getInstance().getItemService();
+        this.collectionService = ContentServiceFactory.getInstance().getCollectionService();
+        this.entityTypeService = ContentServiceFactory.getInstance().getEntityTypeService();
+        this.solrSearchCore = new DSpace().getSingletonService(SolrSearchCore.class);
+        this.itemEnhancers = new DSpace().getServiceManager().getApplicationContext()
+                .getBeansOfType(ItemEnhancer.class).values().stream().collect(Collectors.toList());
+        if (commandLine.hasOption('c')) {
+            this.collection = UUIDUtils.fromString(commandLine.getOptionValue('c'));
+        }
+        if (commandLine.hasOption('n')) {
+            dryrun = true;
+            dryrunMetadata = new HashMap<>();
+        }
+        if (commandLine.hasOption('e')) {
+            this.entitytype = commandLine.getOptionValue('e');
+        }
+        if (commandLine.hasOption('q')) {
+            this.query = commandLine.getOptionValue('q');
+        }
+        if (commandLine.hasOption('d')) {
+            this.dateupper = commandLine.getOptionValue('d');
+        }
+        if (commandLine.hasOption('s')) {
+            this.datelower = commandLine.getOptionValue('s');
+        }
+        if (commandLine.hasOption('m')) {
+            try {
+                this.max = Integer.parseInt(commandLine.getOptionValue('m'));
+            } catch (Exception e) {
+                //
+            }
+        }
+        if (commandLine.hasOption('l')) {
+            try {
+                this.limit = Integer.parseInt(commandLine.getOptionValue('l'));
+            } catch (Exception e) {
+                //
+            }
+        }
+    }
+
+    @Override
+    public void internalRun() throws Exception {
+        context = new Context();
+        assignCurrentUserInContext();
+        assignSpecialGroupsInContext();
+        if (commandLine.hasOption('e') && Objects.isNull(entityTypeService.findByEntityType(context, entitytype))) {
+            throw new Exception("unknown entity " + entitytype);
+        }
+        if (commandLine.hasOption('c') && (Objects.isNull(collection) ||
+                Objects.isNull(this.collectionService.find(context, collection)))) {
+            throw new Exception("specified collection does not exist");
+        }
+        SolrPingResponse ping = solrSearchCore.getSolr().ping();
+        if (ping.getStatus() > 299) {
+            throw new Exception("Solr seems not to be available. Status" + ping.getStatus());
+        }
+
+        context.turnOffAuthorisationSystem();
+        try {
+            searchItems();
+            commitOrRollback();
+            context.complete();
+            handler.logInfo("Enhancement completed with success");
+        } catch (Exception e) {
+            handler.handleException("An error occurs during enhancement. The process is aborted", e);
+            context.abort();
+        } finally {
+            context.restoreAuthSystemState();
+        }
+    }
+
+    private boolean removeMetadata(List<MetadataValueDTO> mvs, MetadataValueDTO mv) {
+        for (MetadataValueDTO other : mvs) {
+            boolean match = (Objects.equals(mv.getSchema(), other.getSchema()) &&
+                    Objects.equals(mv.getElement(), other.getElement()) &&
+                    Objects.equals(mv.getQualifier(), other.getQualifier()) &&
+                    Objects.equals(mv.getValue(), other.getValue()) &&
+                    Objects.equals(mv.getAuthority(), other.getAuthority()) &&
+                    Objects.equals(mv.getLanguage(), other.getLanguage()));
+
+            if (match) {
+                mvs.remove(other);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private String describeMetadata(MetadataValueDTO mv) {
+        return StringEscapeUtils.escapeCsv(mv.getValue());
+    }
+
+    private static class Stats {
+        long totalItemsChanged = 0;
+        long totalFieldsAdded = 0;
+        long totalFieldsRemoved = 0;
+    }
+
+    Stats stats = new Stats();
+
+    private void commitOrRollback() throws SQLException {
+        if (dryrun) {
+            for (UUID uuid : dryrunMetadata.keySet()) {
+                DSpaceObject dso = itemService.find(context, uuid);
+                if (dso != null) {
+                    dryrunMetadata.put(uuid, dso.getMetadata().stream().map(mv -> new MetadataValueDTO(mv)).collect(Collectors.toList()));
+                } else {
+                    dryrunMetadata.put(uuid, Collections.emptyList());
+                }
+            }
+            context.rollback();
+            for (UUID uuid : dryrunMetadata.keySet()) {
+                boolean counted = false;
+                List<MetadataValueDTO> newMetadata = dryrunMetadata.get(uuid);
+                DSpaceObject dso = itemService.find(context, uuid);
+                List<MetadataValueDTO> oldMetadata = dso.getMetadata().stream().map(mv -> new MetadataValueDTO(mv))
+                        .collect(Collectors.toList());
+                for (MetadataValueDTO mv : oldMetadata) {
+                    if (removeMetadata(newMetadata, mv)) {
+                        continue;
+                    }
+
+                    if (!counted) {
+                        stats.totalItemsChanged++;
+                    }
+
+                    counted = true;
+
+                    log.warn(describeMetadata(mv) + " disappeared");
+                    handler.logInfo(describeMetadata(mv) + " disappeared");
+
+                    stats.totalFieldsRemoved++;
+                }
+
+                for (MetadataValueDTO mv : newMetadata) {
+                    log.warn(describeMetadata(mv) + " was added");
+                    handler.logInfo(describeMetadata(mv) + " was added");
+
+                    if (!counted) {
+                        stats.totalItemsChanged++;
+                    }
+
+                    counted = true;
+
+                    stats.totalFieldsAdded++;
+                }
+            }
+        } else {
+            context.commit();
+        }
+    }
+
+    private void searchItems() {
+        List<Item> items = new ArrayList<>();
+        try {
+            SolrDocumentList results = searchItemsInSolr(this.query, this.dateupper, this.datelower);
+            for (SolrDocument doc : results) {
+                String resourceid = (String) doc.getFieldValue(SearchUtils.RESOURCE_ID_FIELD);
+                if (Objects.nonNull(resourceid) && Objects.nonNull(UUIDUtils.fromString(resourceid))) {
+                    Item item = itemService.findByIdOrLegacyId(context, resourceid);
+                    if (item != null)
+                        items.add(item);
+                }
+            }
+        } catch (SQLException | SolrServerException | IOException e) {
+            handler.logError(e.getMessage(), e);
+            log.error(e.getMessage());
+        }
+        int total = items.size();
+        if (total == 0) {
+            handler.logInfo("No results in solr-Query");
+            log.info("No results in solr-Query");
+            return;
+        }
+
+        if (this.limit > 0) {
+            // Split through every list
+            int counter = 0;
+            int start;
+            int end;
+            while (counter < total) {
+                start = counter;
+                end = counter + limit;
+                if (end > total) {
+                    end = total;
+                }
+                try {
+                    items.subList(start, end).forEach(this::enhanceItem);
+                    commitOrRollback();
+                    counter += limit;
+                } catch (SQLException e) {
+                    handler.logError(e.getMessage());
+                    counter += limit;
+                }
+
+            }
+            handler.logInfo("enhanced " + total + " items");
+            log.info("enhanced " + total + " items");
+
+            if (dryrun) {
+                handler.logInfo("stats: " + stats.totalItemsChanged + " items changed (" + stats.totalFieldsAdded + " fields added, " + stats.totalFieldsRemoved + " fields removed)");
+                log.info("stats: " + stats.totalItemsChanged + " items changed (" + stats.totalFieldsAdded + " fields added, " + stats.totalFieldsRemoved + " fields removed)");
+            }
+        } else {
+            items.forEach(this::enhanceItem);
+            handler.logInfo("enhanced " + total + " items");
+            log.info("enhanced " + total + " items");
+        }
+    }
+
+    private SolrDocumentList searchItemsInSolr(String query, String datequeryupper, String datequerylower)
+            throws SolrServerException, IOException {
+        SolrQuery sQuery;
+        if (Objects.nonNull(query)) {
+            sQuery = new SolrQuery(query);
+        } else {
+            sQuery = new SolrQuery("*");
+        }
+        if (Objects.nonNull(datequeryupper) && Objects.nonNull(datequerylower)) {
+            sQuery.addFilterQuery("lastModified:[" + datequerylower + " TO " + datequeryupper + "]");
+        } else if (Objects.nonNull(datequeryupper)) {
+            sQuery.addFilterQuery("lastModified:[* TO " + datequeryupper + "]");
+        } else if (Objects.nonNull(datequerylower)) {
+            sQuery.addFilterQuery("lastModified:[" + datequerylower + " TO *]");
+        }
+        if (Objects.nonNull(entitytype)) {
+            sQuery.addFilterQuery("search.entitytype:" + entitytype);
+        }
+        sQuery.addFilterQuery(SearchUtils.RESOURCE_TYPE_FIELD + ":Item");
+        if (Objects.nonNull(collection)) {
+            sQuery.addFilterQuery("location.coll:" + UUIDUtils.toString(collection));
+        }
+        sQuery.addField(SearchUtils.RESOURCE_ID_FIELD);
+        if (max > 0) {
+            sQuery.setRows(this.max);
+        } else {
+            sQuery.setRows(Integer.MAX_VALUE);
+        }
+        sQuery.setSort("lastModified_dt", SolrQuery.ORDER.asc);
+        handler.logInfo("Query Params:" + sQuery);
+        QueryResponse qResp = solrSearchCore.getSolr().query(sQuery);
+        return qResp.getResults();
+    }
+
+    private void enhanceItem(Item item) {
+        if (dryrun) {
+            dryrunMetadata.put(item.getID(), null);
+        }
+        try {
+            enhance(context, item);
+            uncacheItem(item);
+        } catch (SQLException e) {
+            // deliberately empty
+        }
+    }
+
+    private void uncacheItem(Item item) throws SQLException {
+        context.uncacheEntity(item);
+    }
+
+    private void assignCurrentUserInContext() throws SQLException {
+        UUID uuid = getEpersonIdentifier();
+        if (uuid != null) {
+            EPerson ePerson = EPersonServiceFactory.getInstance().getEPersonService().find(context, uuid);
+            context.setCurrentUser(ePerson);
+        }
+    }
+
+    private void enhance(Context context, Item item) {
+        itemEnhancers.stream()
+                .filter(itemEnhancer -> itemEnhancer.canEnhance(context, item))
+                .forEach(itemEnhancer -> itemEnhancer.enhance(context, item));
+
+        updateItem(context, item);
+    }
+
+    private void updateItem(Context context, Item item) {
+        try {
+            itemService.update(context, item);
+        } catch (SQLException | AuthorizeException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
+    private void assignSpecialGroupsInContext() {
+        for (UUID uuid : handler.getSpecialGroups()) {
+            context.setSpecialGroup(uuid);
+        }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public ItemEnhancerByDateScriptConfiguration<ItemEnhancerByDateScript> getScriptConfiguration() {
+        return new DSpace().getServiceManager().getServiceByName("item-enhancer",
+                ItemEnhancerByDateScriptConfiguration.class);
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/app/ItemEnhancerByDateScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/app/ItemEnhancerByDateScriptConfiguration.java
@@ -1,0 +1,56 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app;
+
+import org.apache.commons.cli.Options;
+import org.dspace.scripts.configuration.ScriptConfiguration;
+
+/**
+ * Script configuration of {@link ItemEnhancerByDateScript}.
+ *
+ * @author Luca Giamminonni (luca.giamminonni at 4science.it)
+ * @author Florian Gantner (florian.gantner@uni-bamberg.de)
+ */
+public class ItemEnhancerByDateScriptConfiguration<T extends ItemEnhancerByDateScript> extends ScriptConfiguration<T> {
+
+    private Class<T> dspaceRunnableClass;
+
+    @Override
+    public Options getOptions() {
+        if (options == null) {
+            Options options = new Options();
+
+            options.addOption("c", "collection", true,
+                "uuid of the collection. If the collection does not exist the script aborts.");
+            options.addOption("e", "entity", true, "Entity type of the items.");
+            options.addOption("d", "dateupper", true,
+                "iso date as upper range of  date query. e.g. 2022-10-27T12:12:17.369Z ");
+            options.addOption("s", "datelower", true, "iso date as lower range of  date query ");
+            options.addOption("m", "max", true, "--max results/rows from solr");
+            options.addOption("l", "limit", true, "commit after --limit entities processed");
+            options.addOption("q", "query", true,
+                "additional filterquery for the entities. this can for example be the exclusion " +
+                    " of some already enhanced metadata.");
+            options.addOption("n", "dryrun", false, "do not commit changes");
+
+            super.options = options;
+        }
+        return options;
+    }
+
+    @Override
+    public Class<T> getDspaceRunnableClass() {
+        return dspaceRunnableClass;
+    }
+
+    @Override
+    public void setDspaceRunnableClass(Class<T> dspaceRunnableClass) {
+        this.dspaceRunnableClass = dspaceRunnableClass;
+    }
+
+}

--- a/dspace-api/src/main/java/org/dspace/app/RewriteEnhancer.java
+++ b/dspace-api/src/main/java/org/dspace/app/RewriteEnhancer.java
@@ -1,0 +1,97 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app;
+
+import org.dspace.content.Item;
+import org.dspace.content.MetadataValue;
+import org.dspace.content.service.ItemService;
+import org.dspace.content.service.MetadataFieldService;
+import org.dspace.core.Context;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public abstract class RewriteEnhancer extends AbstractItemEnhancer {
+    @Autowired
+    private ItemService itemService;
+
+    @Autowired
+    private MetadataFieldService metadatafieldService;
+
+    /**
+     * Update item, replacing metadata field values with those in newValues. A field is replaced if its field name is
+     * contained as a key in newValues, even if the corresponding list is empty.
+     *
+     * @param context   DSpace Context
+     * @param item      Item
+     * @param newValues keys: field names; values: List of new values of this field.
+     */
+    protected void updateItem(Context context, Item item, HashMap<String, List<String>> newValues) {
+        HashMap<String, HashSet<String>> oldValues = new HashMap<>();
+        try {
+            for (String tf : newValues.keySet()) {
+                List<MetadataValue> fields = itemService.getMetadataByMetadataString(item, tf);
+
+                if (!fields.isEmpty()) {
+                    oldValues.put(tf, new HashSet<>());
+                    oldValues.get(tf).addAll(fields.stream().map(MetadataValue::getValue).collect(Collectors.toList()));
+                }
+            }
+        } catch (Exception e) {
+            return;
+        }
+
+        reloop:
+        while (true) {
+            for (String field : oldValues.keySet()) {
+                if (newValues.containsKey(field)) {
+                    for (String oldValue : oldValues.get(field)) {
+                        if (newValues.get(field).contains(oldValue)) {
+                            newValues.get(field).remove(oldValue);
+                            oldValues.get(field).remove(oldValue);
+                            continue reloop;
+                        }
+                    }
+                }
+            }
+            break;
+        }
+
+        List<MetadataValue> mvs = item.getMetadata();
+        List<MetadataValue> mvsToDelete = new ArrayList<>();
+        mv:
+        for (MetadataValue mv : mvs) {
+            String f = mv.getMetadataField().toString('.');
+            if (oldValues.containsKey(f)) {
+                for (String oldValue : oldValues.get(f)) {
+                    if (oldValue.equals(mv.getValue())) {
+                        mvsToDelete.add(mv);
+                        continue mv;
+                    }
+                }
+            }
+        }
+
+        try {
+            for (String f : newValues.keySet()) {
+                for (String value : newValues.get(f)) {
+                    itemService.addMetadata(context, item, metadatafieldService.findByString(context, f, '.'),
+                            null, value);
+                }
+            }
+            itemService.removeMetadataValues(context, item, mvsToDelete);
+        } catch (SQLException e) {
+            // deliberately left empty. Order ensures we do as little harm as possible.
+        }
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/app/WhitespaceNormalizeEnhancer.java
+++ b/dspace-api/src/main/java/org/dspace/app/WhitespaceNormalizeEnhancer.java
@@ -1,0 +1,129 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app;
+
+import org.dspace.content.Item;
+import org.dspace.content.MetadataValue;
+import org.dspace.content.service.ItemService;
+import org.dspace.content.service.MetadataFieldService;
+import org.dspace.core.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.sql.SQLException;
+import java.text.Normalizer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+@Component
+public class WhitespaceNormalizeEnhancer extends RewriteEnhancer {
+    protected static final Logger LOGGER = LoggerFactory.getLogger(WhitespaceNormalizeEnhancer.class);
+    private List<String> metaDataFields;
+
+    @Autowired
+    protected ItemService itemService;
+
+    @Autowired
+    protected MetadataFieldService metadatafieldService;
+
+    protected String sourceEntityType;
+
+    public void setSourceEntityType(String sourceEntityType) {
+        this.sourceEntityType = sourceEntityType;
+    }
+
+    @Override
+    public boolean canEnhance(Context context, Item item) {
+        try {
+            return sourceEntityType == null || sourceEntityType.equals(itemService.getEntityType(context, item).toString());
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void enhance(Context context, Item item) {
+        HashMap<String, List<String>> newValues = new HashMap<>();
+        boolean modified = false;
+        for (String metaDataField : metaDataFields) {
+            List<MetadataValue> values = itemService.getMetadataByMetadataString(item, metaDataField);
+            if (values == null) {
+                continue;
+            }
+            for (MetadataValue mv : values) {
+                String text = mv.getValue();
+                String textCopy = text;
+                text = replaceSpecialSpaces(text);
+                text = replaceSpecialNewline(text);
+                text = replaceNewlineToReturnNewline(text);
+                text = removeWhitespacesBeforeReturnNewline(text);
+                text = removeZeroWidthSpaces(text);
+                text = normalizeToNFC(text);
+                if (!newValues.containsKey(metaDataField)) {
+                    newValues.put(metaDataField, new ArrayList<>());
+                }
+                if (text.equals(textCopy)) {
+                    newValues.get(metaDataField).add(textCopy);
+                } else {
+                    newValues.get(metaDataField).add(text);
+                    modified = true;
+                }
+            }
+        }
+        if (modified) {
+            updateItem(context, item, newValues);
+        }
+    }
+
+    private static String doWhileReplaceAll(String original, String regex, String replacement) {
+        String temp;
+        do {
+            temp = original;
+            original = temp.replaceAll(regex, replacement);
+        }
+        while (!temp.equals(original));
+        return original;
+    }
+
+    private static String replaceSpecialSpaces(String original) {
+        String regex = "(\\u0009|\\u00A0|\\u1680|\\u2000|\\u2001|\\u2002|\\u2003|\\u2004|\\u2005|" +
+            "\\u2006|\\u2007|\\u2008|\\u2009|\\u200A|\\u202F|\\u205F|\\u3000)+|(\\u0020){2,}";
+        return doWhileReplaceAll(original, regex, " ");
+    }
+
+    private static String replaceSpecialNewline(String original) {
+        String regex = "(\\u000B|\\u000C|\\u0085|\\u2028|\\u2029)";
+        return doWhileReplaceAll(original, regex, "\n");
+    }
+
+    private static String replaceNewlineToReturnNewline(String original) {
+        String regex = "(?<!\\u000D)\\u000A";
+        return doWhileReplaceAll(original, regex, "\r\n");
+    }
+
+    private static String removeWhitespacesBeforeReturnNewline(String original) {
+        String regex = "(\\u0020)+(?=\\u000D\\u000A)";
+        return doWhileReplaceAll(original, regex, "");
+    }
+
+    private static String removeZeroWidthSpaces(String original) {
+        String regex = "(\\u180E|\\u200B|\\u200C|\\u200D|\\u2060|\\uFEFF)+";
+        return doWhileReplaceAll(original, regex, "");
+    }
+
+    private static String normalizeToNFC(String original) {
+        return Normalizer.normalize(original, Normalizer.Form.NFC);
+    }
+
+    public void setMetaDataFields(List<String> metaDataFields) {
+        this.metaDataFields = metaDataFields;
+    }
+}

--- a/dspace/config/spring/api/core-services.xml
+++ b/dspace/config/spring/api/core-services.xml
@@ -162,6 +162,5 @@
     <bean class="org.dspace.submit.service.SubmissionConfigServiceImpl"/>
 
     <bean class="org.dspace.correctiontype.service.impl.CorrectionTypeServiceImpl"/>
-
 </beans>
 

--- a/dspace/config/spring/api/metadata-enhancers.xml
+++ b/dspace/config/spring/api/metadata-enhancers.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <bean class="org.dspace.app.WhitespaceNormalizeEnhancer">
+        <property name="metaDataFields">
+            <list>
+                <value>dc.title</value>
+            </list>
+        </property>
+    </bean>
+</beans>

--- a/dspace/config/spring/api/scripts.xml
+++ b/dspace/config/spring/api/scripts.xml
@@ -102,4 +102,8 @@
        <property name="dspaceRunnableClass" value="org.dspace.app.suggestion.openaire.PublicationLoaderRunnableCli"/>
     </bean>
 
+    <bean id="item-enhancer" class="org.dspace.app.ItemEnhancerByDateScriptConfiguration">
+        <property name="description" value="Run enhancers"/>
+        <property name="dspaceRunnableClass" value="org.dspace.app.ItemEnhancerByDateScript"/>
+    </bean>
 </beans>


### PR DESCRIPTION
This is currently a draft PR/PoC for enabling archived publications' metadata to be modified. The University of Bamberg uses such modifications for a variety of purposes, for general-purpose normalization and processing of item metadata. An example by @viktorholzwert normalizing whitespace and character encodings is included, but functionality goes beyond this.

The script can be run with the `-n` switch so it doesn't modify the database, but generates a report describing the changes that would be performed. That way, changes can be checked before being written to the database, or a list of changes can be generated and applied manually.

There was a talk about this (in German) at the DSpace Praxistreffen 2024 in Mainz. Video and slides will be available soon: https://wiki.lyrasis.org/display/DSPACE/DSpace+Praxistreffen+2024 (Nicht immer ist der SOLR schuld!)