### PR TITLE
Fix packager NPE if using the passwords=true option

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/packager/RoleDisseminator.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/RoleDisseminator.java
@@ -431,7 +431,7 @@ public class RoleDisseminator implements PackageDisseminator {
 
         if (emitPassword) {
             PasswordHash password = ePersonService.getPasswordHash(eperson);
-            if (null != password) {
+            if (null != password && password.getHashString() != null) {
                 writer.writeStartElement(PASSWORD_HASH);
 
                 String algorithm = password.getAlgorithm();


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #9428 

## Description
Very simple fix to include a check for empty password hash string before generating the password mets element

## Instructions for Reviewers
To verify fix:

1. An eperson without a password must exist in the DB (this is a common scenario in cases where shibboleth login is used)
2. Run package command to generate a site package with the passwords=true option, e.g. [dspace]/bin/dspace -d -t AIP -o passwords=true -e [admin email] -i [handle_prefix]/0 [full-path-to-aip-package]

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
