### PR TITLE
adding Unicode filtering for sorts

### DIFF
--- a/dspace/solr/search/conf/schema.xml
+++ b/dspace/solr/search/conf/schema.xml
@@ -162,6 +162,7 @@
       <analyzer>
         <tokenizer class="solr.KeywordTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory" />
+        <filter class="solr.ICUFoldingFilterFactory"/>
         <filter class="solr.TrimFilterFactory" />
       </analyzer>
     </fieldType>


### PR DESCRIPTION
## References
* Fixes #9425
* https://solr.apache.org/guide/8_0/filter-descriptions.html#icu-folding-filter

## Description
This PR adds a new solr filter for lowerCaseSort that applies Unicode normalization

## Instructions for Reviewers
To test it, you need to add a new community with diacritics like `ÂBC - Test` and do a full index:
`/dspace/bin/dspace index-discovery -b`
Your repository should have some communities, starting with different letters.
The community `ÂBC - Test` should appear on the top, or near the other AA 