### PR TITLE
Restore batch templates mail

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
@@ -2233,7 +2233,7 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
                                     String fileName) throws MessagingException {
         try {
             Locale supportedLocale = I18nUtil.getEPersonLocale(eperson);
-            Email email = Email.getEmail(I18nUtil.getEmailFilename(supportedLocale, "bte_batch_import_success"));
+            Email email = Email.getEmail(I18nUtil.getEmailFilename(supportedLocale, "batch_import_success"));
             email.addRecipient(eperson.getEmail());
             email.addArgument(fileName);
 
@@ -2249,7 +2249,7 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
         logError("An error occurred during item import, the user will be notified. " + error);
         try {
             Locale supportedLocale = I18nUtil.getEPersonLocale(eperson);
-            Email email = Email.getEmail(I18nUtil.getEmailFilename(supportedLocale, "bte_batch_import_error"));
+            Email email = Email.getEmail(I18nUtil.getEmailFilename(supportedLocale, "batch_import_error"));
             email.addRecipient(eperson.getEmail());
             email.addArgument(error);
             email.addArgument(configurationService.getProperty("dspace.ui.url") + "/feedback");

--- a/dspace/config/emails/batch_import_error
+++ b/dspace/config/emails/batch_import_error
@@ -1,0 +1,19 @@
+## Email sent to DSpace users when they batch import fails.
+##
+## Parameters: {0} the export error
+##             {1} the URL to the feedback page
+##
+##
+## See org.dspace.core.Email for information on the format of this file.
+##
+#set($subject = 'DSpace - The batch import was not completed.')
+The batch import you initiated from the DSpace UI was not completed, due to the following reason:
+ ${params[0]}
+
+For more information you may contact your system administrator:
+ ${params[1]}
+
+
+
+The DSpace Team
+

--- a/dspace/config/emails/batch_import_error
+++ b/dspace/config/emails/batch_import_error
@@ -1,4 +1,4 @@
-## Email sent to DSpace users when they batch import fails.
+## Email sent to DSpace users when their batch import fails.
 ##
 ## Parameters: {0} the export error
 ##             {1} the URL to the feedback page

--- a/dspace/config/emails/batch_import_success
+++ b/dspace/config/emails/batch_import_success
@@ -1,0 +1,16 @@
+
+## Email sent to DSpace users when they successfully batch import items.
+##
+## Parameters: {0} the filepath to the mapfile created by the batch import
+##
+##
+## See org.dspace.core.Email for information on the format of this file.
+##
+#set($subject = 'DSpace - Batch import successfully completed')
+The batch item import you initiated from the DSpace UI has completed successfully.
+
+You may find the mapfile for the import in the following path: ${params[0]}
+
+
+The DSpace Team
+


### PR DESCRIPTION
## References

Fixes #9416

## Description
Restored and renamed template mails for batch import status

List of changes in this PR:
As above

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
