### PR TITLE
Issue-9435

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
@@ -1957,58 +1957,57 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
         try {
             while (entries.hasMoreElements()) {
                 entry = entries.nextElement();
+                String entryName = entry.getName();
+                File outFile = new File(zipDir + entryName);
+                // Verify that this file/directory will be extracted into our zipDir (and not somewhere else!)
+                if (!outFile.toPath().normalize().startsWith(zipDir)) {
+                    throw new IOException("Bad zip entry: '" + entryName
+                                              + "' in file '" + zipfile.getAbsolutePath() + "'!"
+                                              + " Cannot process this file or directory.");
+                }
                 if (entry.isDirectory()) {
-                    if (!new File(zipDir + entry.getName()).mkdirs()) {
+                    if (!outFile.mkdirs()) {
                         logError("Unable to create contents directory: " + zipDir + entry.getName());
                     }
                 } else {
-                    String entryName = entry.getName();
-                    File outFile = new File(zipDir + entryName);
-                    // Verify that this file will be extracted into our zipDir (and not somewhere else!)
-                    if (!outFile.toPath().normalize().startsWith(zipDir)) {
-                        throw new IOException("Bad zip entry: '" + entryName
-                                                  + "' in file '" + zipfile.getAbsolutePath() + "'!"
-                                                  + " Cannot process this file.");
-                    } else {
-                        logInfo("Extracting file: " + entryName);
+                    logInfo("Extracting file: " + entryName);
 
-                        int index = entryName.lastIndexOf('/');
-                        if (index == -1) {
-                            // Was it created on Windows instead?
-                            index = entryName.lastIndexOf('\\');
-                        }
-                        if (index > 0) {
-                            File dir = new File(zipDir + entryName.substring(0, index));
-                            if (!dir.exists() && !dir.mkdirs()) {
-                                logError("Unable to create directory: " + dir.getAbsolutePath());
-                            }
-
-                            //Entries could have too many directories, and we need to adjust the sourcedir
-                            // file1.zip (SimpleArchiveFormat / item1 / contents|dublin_core|...
-                            //            SimpleArchiveFormat / item2 / contents|dublin_core|...
-                            // or
-                            // file2.zip (item1 / contents|dublin_core|...
-                            //            item2 / contents|dublin_core|...
-
-                            //regex supports either windows or *nix file paths
-                            String[] entryChunks = entryName.split("/|\\\\");
-                            if (entryChunks.length > 2) {
-                                if (StringUtils.equals(sourceDirForZip, sourcedir)) {
-                                    sourceDirForZip = sourcedir + "/" + entryChunks[0];
-                                }
-                            }
-                        }
-                        byte[] buffer = new byte[1024];
-                        int len;
-                        InputStream in = zf.getInputStream(entry);
-                        BufferedOutputStream out = new BufferedOutputStream(
-                            new FileOutputStream(outFile));
-                        while ((len = in.read(buffer)) >= 0) {
-                            out.write(buffer, 0, len);
-                        }
-                        in.close();
-                        out.close();
+                    int index = entryName.lastIndexOf('/');
+                    if (index == -1) {
+                        // Was it created on Windows instead?
+                        index = entryName.lastIndexOf('\\');
                     }
+                    if (index > 0) {
+                        File dir = new File(zipDir + entryName.substring(0, index));
+                        if (!dir.exists() && !dir.mkdirs()) {
+                            logError("Unable to create directory: " + dir.getAbsolutePath());
+                        }
+
+                        //Entries could have too many directories, and we need to adjust the sourcedir
+                        // file1.zip (SimpleArchiveFormat / item1 / contents|dublin_core|...
+                        //            SimpleArchiveFormat / item2 / contents|dublin_core|...
+                        // or
+                        // file2.zip (item1 / contents|dublin_core|...
+                        //            item2 / contents|dublin_core|...
+
+                        //regex supports either windows or *nix file paths
+                        String[] entryChunks = entryName.split("/|\\\\");
+                        if (entryChunks.length > 2) {
+                            if (StringUtils.equals(sourceDirForZip, sourcedir)) {
+                                sourceDirForZip = sourcedir + "/" + entryChunks[0];
+                            }
+                        }
+                    }
+                    byte[] buffer = new byte[1024];
+                    int len;
+                    InputStream in = zf.getInputStream(entry);
+                    BufferedOutputStream out = new BufferedOutputStream(
+                        new FileOutputStream(outFile));
+                    while ((len = in.read(buffer)) >= 0) {
+                        out.write(buffer, 0, len);
+                    }
+                    in.close();
+                    out.close();
                 }
             }
         } finally {

--- a/dspace-api/src/main/java/org/dspace/app/itemupdate/DeleteBitstreamsAction.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemupdate/DeleteBitstreamsAction.java
@@ -70,16 +70,19 @@ public class DeleteBitstreamsAction extends UpdateBitstreamsAction {
                                 }
                             }
 
-                            if (alterProvenance) {
+                            if (alterProvenance && !bundles.isEmpty()) {
                                 DtoMetadata dtom = DtoMetadata.create("dc.description.provenance", "en", "");
 
                                 String append = "Bitstream " + bs.getName() + " deleted on " + DCDate
                                     .getCurrent() + "; ";
-                                Item item = bundles.iterator().next().getItems().iterator().next();
-                                ItemUpdate.pr("Append provenance with: " + append);
+                                List<Item> items = bundles.iterator().next().getItems();
+                                if (!items.isEmpty()) {
+                                    Item item = items.iterator().next();
+                                    ItemUpdate.pr("Append provenance with: " + append);
 
-                                if (!isTest) {
-                                    MetadataUtilities.appendMetadata(context, item, dtom, false, append);
+                                    if (!isTest) {
+                                        MetadataUtilities.appendMetadata(context, item, dtom, false, append);
+                                    }
                                 }
                             }
                         }

--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/CreativeCommonsRDFStreamDisseminationCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/CreativeCommonsRDFStreamDisseminationCrosswalk.java
@@ -59,7 +59,6 @@ public class CreativeCommonsRDFStreamDisseminationCrosswalk
             Bitstream cc = creativeCommonsService.getLicenseRdfBitstream((Item) dso);
             if (cc != null) {
                 Utils.copy(bitstreamService.retrieve(context, cc), out);
-                out.close();
             }
         }
     }

--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/CreativeCommonsTextStreamDisseminationCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/CreativeCommonsTextStreamDisseminationCrosswalk.java
@@ -65,7 +65,6 @@ public class CreativeCommonsTextStreamDisseminationCrosswalk
             Bitstream cc = creativeCommonsService.getLicenseTextBitstream((Item) dso);
             if (cc != null) {
                 Utils.copy(bitstreamService.retrieve(context, cc), out);
-                out.close();
             }
         }
     }

--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/LicenseStreamDisseminationCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/LicenseStreamDisseminationCrosswalk.java
@@ -57,7 +57,6 @@ public class LicenseStreamDisseminationCrosswalk
 
             if (licenseBs != null) {
                 Utils.copy(bitstreamService.retrieve(context, licenseBs), out);
-                out.close();
             }
         }
     }

--- a/dspace-api/src/main/java/org/dspace/content/packager/AbstractMETSDisseminator.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/AbstractMETSDisseminator.java
@@ -628,6 +628,7 @@ public abstract class AbstractMETSDisseminator
                         // Disseminate crosswalk output to an outputstream
                         ByteArrayOutputStream disseminateOutput = new ByteArrayOutputStream();
                         sxwalk.disseminate(context, dso, disseminateOutput);
+                        disseminateOutput.close();
                         // Convert output to an inputstream, so we can write to manifest or Zip file
                         ByteArrayInputStream crosswalkedStream = new ByteArrayInputStream(
                             disseminateOutput.toByteArray());

--- a/dspace-api/src/main/java/org/dspace/subscriptions/ContentGenerator.java
+++ b/dspace-api/src/main/java/org/dspace/subscriptions/ContentGenerator.java
@@ -89,6 +89,7 @@ public class ContentGenerator implements SubscriptionGenerator<IndexableObject> 
                         .orElseGet(() -> entityType2Disseminator.get("Item"))
                         .disseminate(context, item, out);
             }
+            out.close();
             return out.toString();
         } catch (Exception e) {
             log.error(e.getMessage(), e);


### PR DESCRIPTION
## References
* Fixes #9435 

## Description
* add path check before mkdirs.
* add collection empty check before call 'iterator().next()'
* move 'outputStream.close()' from callee method 'disseminate' to caller, avoid write after close in for loop.

## Instructions for Reviewers
* check path before mkdirs
    * Move the path validation statement from line 1968 to before line 1960. 

* Add empty check before call iterator().next()
Before call "Item item = bundles.iterator().next().getItems().iterator().next();",
    * check "bundles" is not empty. 
    * Then, check "bundles.iterator().next().getItems()" is not empty.

* avoid outputStream write after close
 Because "generateBodyMail" has a for loop, it calls "out.close()" in callee "disseminate", then may call "out.write()".
    * remove "out.close()" in callee method "disseminate". 
    * add "out.close()" in caller method "makeMdSec" and "generateBodyMail".
