### PR TITLE
added switcher to writing personal data to of submitter in dc.description.provenance metadata

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/InstallItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/InstallItemServiceImpl.java
@@ -28,6 +28,7 @@ import org.dspace.event.Event;
 import org.dspace.identifier.Identifier;
 import org.dspace.identifier.IdentifierException;
 import org.dspace.identifier.service.IdentifierService;
+import org.dspace.services.ConfigurationService;
 import org.dspace.supervision.SupervisionOrder;
 import org.dspace.supervision.service.SupervisionOrderService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -55,6 +56,9 @@ public class InstallItemServiceImpl implements InstallItemService {
     @Autowired(required = false)
 
     Logger log = LogManager.getLogger(InstallItemServiceImpl.class);
+
+    @Autowired
+    protected ConfigurationService configurationService;
 
     protected InstallItemServiceImpl() {
     }
@@ -270,14 +274,20 @@ public class InstallItemServiceImpl implements InstallItemService {
         // Create provenance description
         StringBuffer provmessage = new StringBuffer();
 
-        if (item.getSubmitter() != null) {
+        //behavior to generate provenance message, if set true, personal data (e.g. email) of submitter will be hidden
+        //default value false, personal data of submitter will be shown in provenance message
+        String isProvenancePrivacyActiveProperty =
+                configurationService.getProperty("dc.description.provenance.privacy", "false");
+        boolean isProvenancePrivacyActive = Boolean.parseBoolean(isProvenancePrivacyActiveProperty);
+
+        if (item.getSubmitter() != null && !isProvenancePrivacyActive) {
             provmessage.append("Submitted by ").append(item.getSubmitter().getFullName())
-                .append(" (").append(item.getSubmitter().getEmail()).append(") on ")
-                .append(now.toString());
+                    .append(" (").append(item.getSubmitter().getEmail()).append(") on ")
+                    .append(now.toString());
         } else {
             // else, null submitter
-            provmessage.append("Submitted by unknown (probably automated) on")
-                .append(now.toString());
+            provmessage.append("Submitted by unknown (probably automated or submitter hidden) on ")
+                    .append(now.toString());
         }
         provmessage.append("\n");
 

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowServiceImpl.java
@@ -1191,14 +1191,20 @@ public class XmlWorkflowServiceImpl implements XmlWorkflowService {
         // Create provenance description
         StringBuffer provmessage = new StringBuffer();
 
-        if (myitem.getSubmitter() != null) {
+        //behavior to generate provenance message, if set true, personal data (e.g. email) of submitter will be hidden
+        //default value false, personal data of submitter will be shown in provenance message
+        String isProvenancePrivacyActiveProperty =
+                configurationService.getProperty("dc.description.provenance.privacy", "false");
+        boolean isProvenancePrivacyActive = Boolean.parseBoolean(isProvenancePrivacyActiveProperty);
+
+        if (myitem.getSubmitter() != null && !isProvenancePrivacyActive) {
             provmessage.append("Submitted by ").append(myitem.getSubmitter().getFullName())
-                .append(" (").append(myitem.getSubmitter().getEmail()).append(") on ")
-                .append(now.toString());
+                    .append(" (").append(myitem.getSubmitter().getEmail()).append(") on ")
+                    .append(now.toString());
         } else {
             // else, null submitter
-            provmessage.append("Submitted by unknown (probably automated) on")
-                .append(now.toString());
+            provmessage.append("Submitted by unknown (probably automated or submitter hidden) on ")
+                    .append(now.toString());
         }
         if (action != null) {
             provmessage.append(" workflow start=").append(action.getProvenanceStartId()).append("\n");

--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -243,4 +243,4 @@ ldn.enabled = true
 # Behavior to generate provenance message, if set true,
 # personal data (e.g. email) of submitter will be hidden in dc.description.provenance
 # true - personal
-#dc.description.provenance.privacy=true
+#dc.description.provenance.privacy = true

--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -236,3 +236,11 @@ db.password = dspace
 #  LDN INBOX SETTINGS  #
 ########################
 ldn.enabled = true
+
+#---------------------------------------------------------------#
+#---------------PERSONAL DATA STORED IN PROVENANCE--------------#
+#---------------------------------------------------------------#
+# Behavior to generate provenance message, if set true,
+# personal data (e.g. email) of submitter will be hidden in dc.description.provenance
+# true - personal
+#dc.description.provenance.privacy=true


### PR DESCRIPTION
## References
* Fixes #2889

## Description
Added property and functionality to two classes that register personal data (e.g., email) of the submitter in the dc.description.provenance metadata.  

## Instructions for Reviewers
This fix includes changes in two classes and adds one property in local.cfg.

List of changes in this PR:
* First, added a boolean value (dc.description.provenance) to local.cfg.EXAMPLE that regulates whether the personal data of the submitter is registered in the provenance.  
* Second, made changes in the InstallItemServiceImpl class that include refactoring of text about the submitter in case of hidden personal data.  
* Thirdly, applied the same changes in the XmlWorkflowServiceImpl class that regulate whether the personal data of the submitter are saved in the provenance.

To test these changes, you need to create dc.description.provenance.privacy in local.cfg and set it to true. After that, create a publication, and in the case of a hidden submitter in dc.description.provenance, you will see the text 'Submitted by unknown (probably automated or submitter hidden) on ...'.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).