### PR TITLE
Fix randomly failing IT in NotifyServiceRestRepositoryIT

### DIFF
--- a/dspace-api/src/test/java/org/dspace/builder/NotifyServiceBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/NotifyServiceBuilder.java
@@ -141,4 +141,20 @@ public class NotifyServiceBuilder extends AbstractBuilder<NotifyServiceEntity, N
         return this;
     }
 
+    /**
+     * Delete the Test NotifyServiceEntity referred to by the given ID
+     * @param id ID of NotifyServiceEntity to delete
+     * @throws SQLException if error occurs
+     */
+    public static void deleteNotifyService(Integer id) throws SQLException {
+        try (Context c = new Context()) {
+            c.turnOffAuthorisationSystem();
+            NotifyServiceEntity notifyServiceEntity = notifyService.find(c, id);
+            if (notifyServiceEntity != null) {
+                notifyService.delete(c, notifyServiceEntity);
+            }
+            c.complete();
+        }
+    }
+
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/NotifyServiceRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/NotifyServiceRestRepositoryIT.java
@@ -234,6 +234,9 @@ public class NotifyServiceRestRepositoryIT extends AbstractControllerIntegration
                     matchNotifyServicePattern("patternB", null, false)
                 )))
             ));
+
+        // Delete the created service
+        NotifyServiceBuilder.deleteNotifyService(idRef.get());
     }
 
     @Test


### PR DESCRIPTION
## Description

In GitHub CI, a few tests in `NotifyServiceRestRepositoryIT` are randomly failing.  This is visible in #9443 (created by dependabot). 

I've tracked down what seems to be the problem.  This `NotifyServiceRestRepositoryIT` class isn't cleaning up its data at all times.  This PR attempts to fix that bug.

Assuming this passes tests, I'm going to merge this immediately as this is minor cleanup after #9321 was merged.  It does NOT modify DSpace behavior, just the behavior of the ITs