### PR TITLE
COAR Notify Protocol refactor: url to ietf:item

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/ldn/model/Citation.java
+++ b/dspace-api/src/main/java/org/dspace/app/ldn/model/Citation.java
@@ -18,7 +18,7 @@ public class Citation extends Base {
     @JsonProperty("ietf:cite-as")
     private String ietfCiteAs;
 
-    @JsonProperty("url")
+    @JsonProperty("ietf:item")
     private Url url;
 
     /**

--- a/dspace-server-webapp/src/test/resources/org/dspace/app/rest/ldn_announce_endorsement.json
+++ b/dspace-server-webapp/src/test/resources/org/dspace/app/rest/ldn_announce_endorsement.json
@@ -12,7 +12,7 @@
 		"id": "<<object>>",
 	   "ietf:cite-as": "https://doi.org/10.5555/12345680",
 	   "type": ["sorg:AboutPage"],
-	   "url": {
+	   "ietf:item": {
 	     "id": "https://research-organisation.org/repository/preprint/201203/421/content.pdf",
 	     "mediaType": "application/pdf",
 	     "type": [

--- a/dspace-server-webapp/src/test/resources/org/dspace/app/rest/ldn_announce_release.json
+++ b/dspace-server-webapp/src/test/resources/org/dspace/app/rest/ldn_announce_release.json
@@ -13,7 +13,7 @@
     "id_handle": "http://localhost:4000/handle/123456789/1119",
     "ietf:cite-as": "https://doi.org/10.5555/12345680",
     "type": "sorg:AboutPage",
-    "url": {
+    "ietf:item": {
       "id": "https://another-research-organisation.org/repository/datasets/item/201203421/data_archive.zip",
       "mediaType": "application/zip",
       "type": [

--- a/dspace-server-webapp/src/test/resources/org/dspace/app/rest/ldn_announce_review.json
+++ b/dspace-server-webapp/src/test/resources/org/dspace/app/rest/ldn_announce_review.json
@@ -12,7 +12,7 @@
 	"id": "<<object>>",
 	"ietf:cite-as": "https://doi.org/10.5555/12345680",
     "type": "sorg:AboutPage",
-    "url": {
+    "ietf:item": {
       "id": "https://research-organisation.org/repository/preprint/201203/421/content.pdf",
       "mediaType": "application/pdf",
       "type": [

--- a/dspace-server-webapp/src/test/resources/org/dspace/app/rest/ldn_offer_endorsement.json
+++ b/dspace-server-webapp/src/test/resources/org/dspace/app/rest/ldn_offer_endorsement.json
@@ -13,7 +13,7 @@
     "id": "https://overlay-journal.com/articles/00001/",
     "ietf:cite-as": "https://doi.org/10.5555/12345680",
     "type": "sorg:AboutPage",
-    "url": {
+    "ietf:item": {
         "id": "https://research-organisation.org/repository/preprint/201203/421/content.pdf",
         "mediaType": "application/pdf",
         "type": [

--- a/dspace-server-webapp/src/test/resources/org/dspace/app/rest/ldn_offer_endorsement_badrequest.json
+++ b/dspace-server-webapp/src/test/resources/org/dspace/app/rest/ldn_offer_endorsement_badrequest.json
@@ -13,7 +13,7 @@
 	    "id": "https://overlay-journal.com/articles/00001/",
 	    "ietf:cite-as": "https://doi.org/10.5555/12345680",
 	    "type": ["sorg:AboutPage"],
-	    "url": {
+	    "ietf:item": {
 	        "id": "https://research-organisation.org/repository/preprint/201203/421/content.pdf",
 	        "mediaType": "application/pdf",
 	        "type": [

--- a/dspace-server-webapp/src/test/resources/org/dspace/app/rest/ldn_offer_endorsement_object.json
+++ b/dspace-server-webapp/src/test/resources/org/dspace/app/rest/ldn_offer_endorsement_object.json
@@ -12,7 +12,7 @@
         "id": "<<object>>",
         "ietf:cite-as": "https://doi.org/10.5555/12345680",
         "type": ["sorg:AboutPage"],
-        "url": {
+        "ietf:item": {
             "id": "https://research-organisation.org/repository/preprint/201203/421/content.pdf",
             "mediaType": "application/pdf",
             "type": [

--- a/dspace-server-webapp/src/test/resources/org/dspace/app/rest/ldn_offer_review.json
+++ b/dspace-server-webapp/src/test/resources/org/dspace/app/rest/ldn_offer_review.json
@@ -13,7 +13,7 @@
     "id": "<<object_handle>>",
     "ietf:cite-as": "https://doi.org/10.5555/12345680",
     "type": "sorg:AboutPage",
-    "url": {
+    "ietf:item": {
       "id": "url.pdf",
       "mediaType": "applicationpdf",
       "type": [

--- a/dspace-server-webapp/src/test/resources/org/dspace/app/rest/ldn_offer_review2.json
+++ b/dspace-server-webapp/src/test/resources/org/dspace/app/rest/ldn_offer_review2.json
@@ -13,7 +13,7 @@
     "id": "<<object_handle>>",
     "ietf:cite-as": "https://doi.org/10.5555/12345680",
     "type": "sorg:AboutPage",
-    "url": {
+    "ietf:item": {
       "id": "url.pdf",
       "mediaType": "applicationpdf",
       "type": [

--- a/dspace-server-webapp/src/test/resources/org/dspace/app/rest/ldn_origin_inbox_unregistered.json
+++ b/dspace-server-webapp/src/test/resources/org/dspace/app/rest/ldn_origin_inbox_unregistered.json
@@ -12,7 +12,7 @@
 		"id": "<<object>>",
 	   "ietf:cite-as": "https://doi.org/10.5555/12345680",
 	   "type": ["sorg:AboutPage"],
-	   "url": {
+	   "ietf:item": {
 	     "id": "https://research-organisation.org/repository/preprint/201203/421/content.pdf",
 	     "mediaType": "application/pdf",
 	     "type": [

--- a/dspace/config/ldn/request-endorsement
+++ b/dspace/config/ldn/request-endorsement
@@ -26,7 +26,7 @@
     "id": "${params[5]}",
     "ietf:cite-as": "${params[6]}",
     "type": "sorg:AboutPage",
-    "url": {
+    "ietf:item": {
       "id": "${params[7]}",
       "mediaType": "${params[8]}",
       "type": [

--- a/dspace/config/ldn/request-ingest
+++ b/dspace/config/ldn/request-ingest
@@ -26,7 +26,7 @@
     "id": "${params[5]}",
     "ietf:cite-as": "${params[6]}",
     "type": "sorg:AboutPage",
-    "url": {
+    "ietf:item": {
       "id": "${params[7]}",
       "mediaType": "${params[8]}",
       "type": [

--- a/dspace/config/ldn/request-review
+++ b/dspace/config/ldn/request-review
@@ -26,7 +26,7 @@
     "id": "${params[5]}",
     "ietf:cite-as": "${params[6]}",
     "type": "sorg:AboutPage",
-    "url": {
+    "ietf:item": {
       "id": "${params[7]}",
       "mediaType": "${params[8]}",
       "type": [


### PR DESCRIPTION
## Description
**COAR Notify Protocol** [patterns](https://notify.coar-repositories.org/specification/patterns/) have changed. A refactor is needed for _object_ and _context_ properties on its old url attribute, that became _ietf:item_

## Instructions for Reviewers
LDN json has been changed according to the refactor needed. DSpace COAR integration documentation has been changed accordingly at [lyrasis](https://wiki.lyrasis.org/display/DSPACE/COAR+Notify+Documentation)

List of changes in this PR:
* changed the parent DTO java class _org.dspace.app.ldn.model.Citation_ on the @JsonProperty of the url attribute
* changed the LDN templates json for message consumer
* changed the LDN .json test files
