### PR TITLE
Attempt to fix failing NotifyServiceRestRepositoryIT

### DIFF
--- a/dspace-api/src/test/java/org/dspace/builder/NotifyServiceBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/NotifyServiceBuilder.java
@@ -47,7 +47,7 @@ public class NotifyServiceBuilder extends AbstractBuilder<NotifyServiceEntity, N
             // Ensure object and any related objects are reloaded before checking to see what needs cleanup
             notifyServiceEntity = c.reloadEntity(notifyServiceEntity);
             if (notifyServiceEntity != null) {
-                delete(notifyServiceEntity);
+                delete(c, notifyServiceEntity);
             }
             c.complete();
             indexingService.commit();
@@ -73,19 +73,6 @@ public class NotifyServiceBuilder extends AbstractBuilder<NotifyServiceEntity, N
             log.error(e);
         }
         return notifyServiceEntity;
-    }
-
-    public void delete(NotifyServiceEntity notifyServiceEntity) throws Exception {
-        try (Context c = new Context()) {
-            c.turnOffAuthorisationSystem();
-            NotifyServiceEntity nsEntity = c.reloadEntity(notifyServiceEntity);
-            if (nsEntity != null) {
-                getService().delete(c, nsEntity);
-            }
-            c.complete();
-        }
-
-        indexingService.commit();
     }
 
     public static NotifyServiceBuilder createNotifyServiceBuilder(Context context, String name) {

--- a/dspace-api/src/test/java/org/dspace/builder/util/AbstractBuilderCleanupUtil.java
+++ b/dspace-api/src/test/java/org/dspace/builder/util/AbstractBuilderCleanupUtil.java
@@ -26,6 +26,7 @@ import org.dspace.builder.ItemBuilder;
 import org.dspace.builder.MetadataFieldBuilder;
 import org.dspace.builder.MetadataSchemaBuilder;
 import org.dspace.builder.NotifyServiceBuilder;
+import org.dspace.builder.NotifyServiceInboundPatternBuilder;
 import org.dspace.builder.OrcidHistoryBuilder;
 import org.dspace.builder.OrcidQueueBuilder;
 import org.dspace.builder.OrcidTokenBuilder;
@@ -84,6 +85,7 @@ public class AbstractBuilderCleanupUtil {
         map.put(MetadataSchemaBuilder.class.getName(), new ArrayList<>());
         map.put(SiteBuilder.class.getName(), new ArrayList<>());
         map.put(ProcessBuilder.class.getName(), new ArrayList<>());
+        map.put(NotifyServiceInboundPatternBuilder.class.getName(), new ArrayList<>());
         map.put(NotifyServiceBuilder.class.getName(), new ArrayList<>());
     }
 

--- a/dspace-api/src/test/java/org/dspace/builder/util/AbstractBuilderCleanupUtil.java
+++ b/dspace-api/src/test/java/org/dspace/builder/util/AbstractBuilderCleanupUtil.java
@@ -25,6 +25,7 @@ import org.dspace.builder.GroupBuilder;
 import org.dspace.builder.ItemBuilder;
 import org.dspace.builder.MetadataFieldBuilder;
 import org.dspace.builder.MetadataSchemaBuilder;
+import org.dspace.builder.NotifyServiceBuilder;
 import org.dspace.builder.OrcidHistoryBuilder;
 import org.dspace.builder.OrcidQueueBuilder;
 import org.dspace.builder.OrcidTokenBuilder;
@@ -83,6 +84,7 @@ public class AbstractBuilderCleanupUtil {
         map.put(MetadataSchemaBuilder.class.getName(), new ArrayList<>());
         map.put(SiteBuilder.class.getName(), new ArrayList<>());
         map.put(ProcessBuilder.class.getName(), new ArrayList<>());
+        map.put(NotifyServiceBuilder.class.getName(), new ArrayList<>());
     }
 
     /**

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/NotifyServiceRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/NotifyServiceRestRepositoryIT.java
@@ -2246,23 +2246,6 @@ public class NotifyServiceRestRepositoryIT extends AbstractControllerIntegration
         ;
     }
 
-    @Override
-    @After
-    public void destroy() throws Exception {
-        List<NotifyServiceEntity> notifyServiceEntities = notifyService.findAll(context);
-        if (CollectionUtils.isNotEmpty(notifyServiceEntities)) {
-            notifyServiceEntities.forEach(notifyServiceEntity -> {
-                try {
-                    notifyService.delete(context, notifyServiceEntity);
-                } catch (SQLException e) {
-                    throw new RuntimeException(e);
-                }
-            });
-        }
-
-        super.destroy();
-    }
-
     @Test
     public void notifyServiceLowerIpReplaceOperationBadRequestTest() throws Exception {
 


### PR DESCRIPTION
Currently on `main`, `NotifyServiceRestRepositoryIT` is failing **again** in GitHub CI. It does **not** fail when run locally, so it's unclear to me why it's consistently failing in GitHub CI.   

My best guess is that some data is not being cleaned up between tests, and that's causing unexpected behaviors.  

Previously, I *thought* I had fixed it in #9444 , but that fix doesn't appear to have solved the issues.

This PR is a draft to attempt to solve the failures.