### PR TITLE
Fix bug in Docker `amd64` build in GitHub Actions

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -154,7 +154,7 @@ jobs:
         if: ${{ ! matrix.isPr }}
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ inputs.build_id }}
+          name: digests-${{ inputs.build_id }}-${{ matrix.arch }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -172,7 +172,7 @@ jobs:
 
       # If this build is NOT a PR and passed in a REDEPLOY_DEMO_URL secret,
       # Then redeploy https://demo.dspace.org if this build is for our deployment architecture and demo branch.
-      - name: Redeploy demo.dspace.org (based on maintenace branch)
+      - name: Redeploy demo.dspace.org (based on maintenance branch)
         if: |
           !matrix.isPR &&
           env.REDEPLOY_DEMO_URL != '' &&
@@ -194,8 +194,10 @@ jobs:
       - name: Download Docker build digests
         uses: actions/download-artifact@v4
         with:
-          name: digests-${{ inputs.build_id }}
           path: /tmp/digests
+          # Download digests for both AMD64 and ARM64 into same directory
+          pattern: digests-${{ inputs.build_id }}-*
+          merge-multiple: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
This is a small, follow-up PR  to #9454 

In #9454, we updated to the latest version of the upload/download artifacts GitHub Actions.  This upgrade resulted in a bug in our Docker build where some Docker images are not being built properly (arm64 is successful, but amd64 is failing)

This PR fixes Docker build by ensuring all artifacts are named with architecture (amd64 vs arm64).  The new version of these artifact actions require a *unique* name at all times.

This PR does NOT touch any DSpace code. It just fixes our GitHub actions.  Therefore it will be merged immediately if it succeeds.