### PR TITLE
Refactor SubmissionConfigConsumer to avoid reload the submission config multiple times

### DIFF
--- a/dspace-api/src/main/java/org/dspace/submit/consumer/SubmissionConfigConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/submit/consumer/SubmissionConfigConsumer.java
@@ -8,15 +8,10 @@
 package org.dspace.submit.consumer;
 
 import org.apache.logging.log4j.Logger;
-import org.dspace.content.Collection;
-import org.dspace.content.DSpaceObject;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
-import org.dspace.discovery.IndexingService;
-import org.dspace.discovery.indexobject.IndexableCollection;
 import org.dspace.event.Consumer;
 import org.dspace.event.Event;
-import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.submit.factory.SubmissionServiceFactory;
 
 /**
@@ -28,11 +23,9 @@ public class SubmissionConfigConsumer implements Consumer {
     /**
      * log4j logger
      */
-    private static Logger log = org.apache.logging.log4j.LogManager.getLogger(SubmissionConfigConsumer.class);
+    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(SubmissionConfigConsumer.class);
 
-    IndexingService indexer = DSpaceServicesFactory.getInstance().getServiceManager()
-            .getServiceByName(IndexingService.class.getName(),
-                              IndexingService.class);
+    private boolean reloadNeeded = false;
 
     @Override
     public void initialize() throws Exception {
@@ -42,37 +35,27 @@ public class SubmissionConfigConsumer implements Consumer {
     @Override
     public void consume(Context ctx, Event event) throws Exception {
         int st = event.getSubjectType();
-        int et = event.getEventType();
 
+        if (st == Constants.COLLECTION) {
+            // NOTE: IndexEventConsumer ("discovery") should be declared before this consumer
+            // We don't reindex the collection because it will normally be reindexed by IndexEventConsumer
+            // before the submission configurations are reloaded
 
-        if ( st == Constants.COLLECTION ) {
-            switch (et) {
-                case Event.MODIFY_METADATA:
-                    // Submission configuration it's based on solr
-                    // for collection's entity type but, at this point
-                    // that info isn't indexed yet, we need to force it
-                    DSpaceObject subject = event.getSubject(ctx);
-                    Collection collectionFromDSOSubject = (Collection) subject;
-                    indexer.indexContent(ctx, new IndexableCollection (collectionFromDSOSubject), true, false, false);
-                    indexer.commit();
-
-                    log.debug("SubmissionConfigConsumer occured: " + event.toString());
-                    // reload submission configurations
-                    SubmissionServiceFactory.getInstance().getSubmissionConfigService().reload();
-                    break;
-
-                default:
-                    log.debug("SubmissionConfigConsumer occured: " + event.toString());
-                    // reload submission configurations
-                    SubmissionServiceFactory.getInstance().getSubmissionConfigService().reload();
-                    break;
-            }
+            log.debug("SubmissionConfigConsumer occurred: " + event);
+            // submission configurations should be reloaded
+            reloadNeeded = true;
         }
     }
 
     @Override
     public void end(Context ctx) throws Exception {
-        // No-op
+        if (reloadNeeded) {
+            // reload submission configurations
+            SubmissionServiceFactory.getInstance().getSubmissionConfigService().reload();
+
+            // Reset the boolean used
+            reloadNeeded = false;
+        }
     }
 
     @Override


### PR DESCRIPTION
## References
* Fixes DSpace/dspace-angular#2914

## Description
Refactoring `SubmissionConfigConsumer` to relocate the submission configuration reload process to the `end()` function ensures it is executed only once.

## Instructions for Reviewers

This refactor aligns the behavior of `SubmissionConfigConsumer` with that of `IndexEventConsumer`. The `consume()` function determines when a reload is necessary, and the reload process is executed in the `end()` function.

Additionally, this change eliminates the need for prior collection indexing, as this task is now handled by the previously declared `IndexEventConsumer`.

To test it, check that this change doesn't break the feature introduced by #8864 and if it mitigates the issue described in DSpace/dspace-angular#2914 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
