### PR TITLE
Fix email dependency issues which were causing Submission failures

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -458,7 +458,12 @@
             <artifactId>commons-validator</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.sun.mail</groupId>
+            <groupId>jakarta.mail</groupId>
+            <artifactId>jakarta.mail-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.angus</groupId>
             <artifactId>jakarta.mail</artifactId>
         </dependency>
         <dependency>

--- a/dspace-services/pom.xml
+++ b/dspace-services/pom.xml
@@ -102,7 +102,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.sun.mail</groupId>
+            <groupId>jakarta.mail</groupId>
+            <artifactId>jakarta.mail-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.angus</groupId>
             <artifactId>jakarta.mail</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,8 @@
         <jackson.version>2.16.0</jackson.version>
         <jackson-databind.version>2.16.0</jackson-databind.version>
         <jakarta-annotation.version>2.1.1</jakarta-annotation.version>
-        <jaxb-api.version>4.0.0</jaxb-api.version>
-        <jaxb-runtime.version>4.0.1</jaxb-runtime.version>
+        <jaxb-api.version>4.0.2</jaxb-api.version>
+        <jaxb-runtime.version>4.0.5</jaxb-runtime.version>
         <jcache-version>1.1.1</jcache-version>
         <!-- NOTE: Jetty needed for Solr, Handle Server & tests -->
         <jetty.version>9.4.54.v20240208</jetty.version>
@@ -1522,9 +1522,22 @@
                 <version>2.12.5</version>
             </dependency>
             <dependency>
-                <groupId>com.sun.mail</groupId>
+                <groupId>jakarta.activation</groupId>
+                <artifactId>jakarta.activation-api</artifactId>
+                <version>2.1.3</version>
+            </dependency>
+            <!-- Jakarta mail API definition -->
+            <dependency>
+                <groupId>jakarta.mail</groupId>
+                <artifactId>jakarta.mail-api</artifactId>
+                <version>2.1.3</version>
+                <scope>provided</scope>
+            </dependency>
+            <!-- Jakarta mail default implementation/provider -->
+            <dependency>
+                <groupId>org.eclipse.angus</groupId>
                 <artifactId>jakarta.mail</artifactId>
-                <version>2.0.1</version>
+                <version>2.0.3</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.servlet</groupId>


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/dspace-angular/issues/2920

## Description

Migrate to using `org.eclipse.angus:jakarta.mail`. Some additional minor dependency cleanup to avoid convergence errors.

This dependency issue appears to cause the submission failures.  See https://github.com/DSpace/dspace-angular/issues/2920#issuecomment-2050088989

## Instructions for Reviewers
* Verify all tests pass with new dependency 
* I've tested this locally with an external email server.  It appears to fix the problem locally.