### PR TITLE
Fix OAI indexing error & AuthorityConsumer error

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/DSpaceObjectServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/DSpaceObjectServiceImpl.java
@@ -629,6 +629,7 @@ public abstract class DSpaceObjectServiceImpl<T extends DSpaceObject> implements
                     // E.g. for an Author relationship,
                     //   the place should be updated using the same principle as dc.contributor.author.
                     StringUtils.startsWith(metadataValue.getAuthority(), Constants.VIRTUAL_AUTHORITY_PREFIX)
+                        && metadataValue instanceof RelationshipMetadataValue
                         && ((RelationshipMetadataValue) metadataValue).isUseForPlace()
                 ) {
                     int mvPlace = getMetadataValuePlace(fieldToLastPlace, metadataValue);

--- a/dspace-api/src/main/java/org/dspace/content/EntityServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/EntityServiceImpl.java
@@ -52,12 +52,7 @@ public class EntityServiceImpl implements EntityService {
     @Override
     public EntityType getType(Context context, Entity entity) throws SQLException {
         Item item = entity.getItem();
-        List<MetadataValue> list = itemService.getMetadata(item, "dspace", "entity", "type", Item.ANY, false);
-        if (!list.isEmpty()) {
-            return entityTypeService.findByEntityType(context, list.get(0).getValue());
-        } else {
-            return null;
-        }
+        return itemService.getEntityType(context, item);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/content/EntityServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/EntityServiceImpl.java
@@ -8,6 +8,7 @@
 package org.dspace.content;
 
 import java.sql.SQLException;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
@@ -103,7 +104,12 @@ public class EntityServiceImpl implements EntityService {
     @Override
     public List<RelationshipType> getAllRelationshipTypes(Context context, Entity entity, Integer limit, Integer offset)
             throws SQLException {
-        return relationshipTypeService.findByEntityType(context, this.getType(context, entity), limit, offset);
+        EntityType entityType = this.getType(context, entity);
+        if (entityType != null) {
+            return relationshipTypeService.findByEntityType(context, entityType, limit, offset);
+        } else {
+            return Collections.emptyList();
+        }
     }
 
     @Override
@@ -115,7 +121,12 @@ public class EntityServiceImpl implements EntityService {
     @Override
     public List<RelationshipType> getLeftRelationshipTypes(Context context, Entity entity, boolean isLeft,
                                                            Integer limit, Integer offset) throws SQLException {
-        return relationshipTypeService.findByEntityType(context, this.getType(context, entity), isLeft, limit, offset);
+        EntityType entityType = this.getType(context, entity);
+        if (entityType != null) {
+            return relationshipTypeService.findByEntityType(context, entityType, isLeft, limit, offset);
+        } else {
+            return Collections.emptyList();
+        }
     }
 
     @Override
@@ -128,7 +139,12 @@ public class EntityServiceImpl implements EntityService {
     public List<RelationshipType> getRightRelationshipTypes(Context context, Entity entity, boolean isLeft,
                                                             Integer limit, Integer offset) throws SQLException {
 
-        return relationshipTypeService.findByEntityType(context, this.getType(context, entity), isLeft, limit, offset);
+        EntityType entityType = this.getType(context, entity);
+        if (entityType != null) {
+            return relationshipTypeService.findByEntityType(context, entityType, isLeft, limit, offset);
+        } else {
+            return Collections.emptyList();
+        }
     }
 
     @Override

--- a/dspace-api/src/test/java/org/dspace/content/EntityServiceImplTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/EntityServiceImplTest.java
@@ -145,6 +145,7 @@ public class EntityServiceImplTest  {
         // Declare objects utilized for this test
         Item item = mock(Item.class);
         Entity entity = mock(Entity.class);
+        EntityType entityType = mock(EntityType.class);
         RelationshipType relationshipType = mock(RelationshipType.class);
         relationshipType.setLeftType(leftType);
         relationshipType.setLeftType(rightType);
@@ -156,7 +157,8 @@ public class EntityServiceImplTest  {
         // Mock the state of objects utilized in getAllRelationshipTypes()
         // to meet the success criteria of the invocation
         when(entity.getItem()).thenReturn(item);
-        when(relationshipTypeService.findByEntityType(context, entityService.getType(context, entity), -1, -1))
+        when(entityService.getType(context, entity)).thenReturn(entityType);
+        when(relationshipTypeService.findByEntityType(context, entityType, -1, -1))
                 .thenReturn(relationshipTypeList);
 
         // The relation(s) reported from our mocked Entity should match our relationshipList
@@ -181,10 +183,9 @@ public class EntityServiceImplTest  {
 
         // Mock the state of objects utilized in getLeftRelationshipTypes()
         // to meet the success criteria of the invocation
-        when(itemService.getMetadata(item, "dspace", "entity", "type", Item.ANY, false)).thenReturn(metsList);
         when(entity.getItem()).thenReturn(item);
         when(entityService.getType(context, entity)).thenReturn(entityType);
-        when(relationshipTypeService.findByEntityType(context, entityService.getType(context, entity), true, -1, -1))
+        when(relationshipTypeService.findByEntityType(context, entityType, true, -1, -1))
                 .thenReturn(relationshipTypeList);
 
         // The left relationshipType(s) reported from our mocked Entity should match our relationshipList
@@ -209,10 +210,9 @@ public class EntityServiceImplTest  {
 
         // Mock the state of objects utilized in getRightRelationshipTypes()
         // to meet the success criteria of the invocation
-        when(itemService.getMetadata(item, "dspace", "entity", "type", Item.ANY, false)).thenReturn(metsList);
         when(entity.getItem()).thenReturn(item);
         when(entityService.getType(context, entity)).thenReturn(entityType);
-        when(relationshipTypeService.findByEntityType(context, entityService.getType(context, entity), false, -1, -1))
+        when(relationshipTypeService.findByEntityType(context, entityType, false, -1, -1))
                 .thenReturn(relationshipTypeList);
 
         // The right relationshipType(s) reported from our mocked Entity should match our relationshipList


### PR DESCRIPTION
## References
* Fixes #9468 
* Fixes an issue discovered with AuthorityConsumer indexing while debugging other issue

## Description

This PR fixes #9468 by verifying an EntityType is non-null before querying for it in Hibernate.  Hibernate 6 does not accept null values in the same way as Hibernate 5 did, so we MUST ensure non-nulls are passed to Hibernate *or* explicitly search using `is null` or `is not null` if we want to use null values.

While not directly related to OAI indexing, I stumbled on an AuthorityConsumer indexing issue which was appearing for *all new submissions* (as long as the `authority` consumer is enabled:
```
2024-04-11 19:07:16,682 ERROR ec49885b-3617-4441-a022-20dcf8505f51 79dfdfcd-3611-4957-8e75-fa7cf21549e3 org.dspace.authority.indexer.AuthorityConsumer @ Error while consuming the authority consumer
 java.lang.ClassCastException: class org.dspace.content.MetadataValue cannot be cast to class org.dspace.content.RelationshipMetadataValue (org.dspace.content.MetadataValue and org.dspace.content.RelationshipMetadataValue are in unnamed module of loader org.apache.catalina.loader.ParallelWebappClassLoader @2796aeae)
   at org.dspace.content.DSpaceObjectServiceImpl.update(DSpaceObjectServiceImpl.java:631) ~[dspace-api-8.0-SNAPSHOT.jar:8.0-SNAPSHOT]
   at org.dspace.content.ItemServiceImpl.update(ItemServiceImpl.java:592) ~[dspace-api-8.0-SNAPSHOT.jar:8.0-SNAPSHOT]
   at org.dspace.content.ItemServiceImpl.updateLastModified(ItemServiceImpl.java:375) ~[dspace-api-8.0-SNAPSHOT.jar:8.0-SNAPSHOT]
   at org.dspace.content.ItemServiceImpl.updateLastModified(ItemServiceImpl.java:95) ~[dspace-api-8.0-SNAPSHOT.jar:8.0-SNAPSHOT]
   at org.dspace.content.MetadataValueServiceImpl.update(MetadataValueServiceImpl.java:99) ~[dspace-api-8.0-SNAPSHOT.jar:8.0-SNAPSHOT]
   at org.dspace.authority.AuthorityValue.updateItem(AuthorityValue.java:193) ~[dspace-api-8.0-SNAPSHOT.jar:8.0-SNAPSHOT]
   at org.dspace.authority.indexer.DSpaceAuthorityIndexer.getAuthorityValues(DSpaceAuthorityIndexer.java:110) ~[dspace-api-8.0-SNAPSHOT.jar:8.0-SNAPSHOT]
   at org.dspace.authority.indexer.DSpaceAuthorityIndexer.getAuthorityValues(DSpaceAuthorityIndexer.java:76) ~[dspace-api-8.0-SNAPSHOT.jar:8.0-SNAPSHOT]
   at org.dspace.authority.AuthorityServiceImpl.indexItem(AuthorityServiceImpl.java:49) ~[dspace-api-8.0-SNAPSHOT.jar:8.0-SNAPSHOT]
   at org.dspace.authority.indexer.AuthorityConsumer.end(AuthorityConsumer.java:97) ~[dspace-api-8.0-SNAPSHOT.jar:8.0-SNAPSHOT]
```
This ClassCastException was fixed by simply adding a safety check that the object is an `instanceof` RelationshipMetadataValue

## Instructions for Reviewers
* Ensure all tests pass.
* I've verified locally that both errors are gone with this PR in place. 