### PR TITLE
Exclude old Apache Geronimo dependencies from SWORDv2

### DIFF
--- a/dspace-swordv2/pom.xml
+++ b/dspace-swordv2/pom.xml
@@ -45,6 +45,20 @@
                     <groupId>org.glassfish.jersey.core</groupId>
                     <artifactId>jersey-common</artifactId>
                 </exclusion>
+                <!-- Exclude older Apache Geronimo dependencies as these are not Jakarta EE compatible
+                     and can cause runtime errors with newer Jakarta EE compatible dependencies -->
+                <exclusion>
+                    <groupId>org.apache.geronimo.specs</groupId>
+                    <artifactId>geronimo-activation_1.1_spec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.geronimo.specs</groupId>
+                    <artifactId>geronimo-javamail_1.4_spec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.geronimo.specs</groupId>
+                    <artifactId>geronimo-stax-api_1.0_spec</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 


### PR DESCRIPTION


## References

* Fixes https://github.com/DSpace/dspace-angular/issues/2920

## Description
Exclude old Apache Geronimo dependencies as they seem to cause runtime errors with sending mail from DSpace

Current error on sandbox.dspace.org when emails are sent via Amazon SES is:
```
2024-04-12 09:55:48,819 ERROR 541bfbc1-43a4-425c-9eda-66f76bfa7d05 9695e190-55ec-45e4-aede-d6188b01e8e4 org.dspace.app.rest.RestResourceController @ Something went wrong whilst creating the object for apiCategory: workflow and model: workflowitems
 java.lang.ClassCastException: class org.apache.geronimo.mail.handlers.TextHandler cannot be cast to class jakarta.activation.DataContentHandler (org.apache.geronimo.mail.handlers.TextHandler and jakarta.activation.DataContentHandler are in unnamed module of loader org.apache.catalina.loader.ParallelWebappClassLoader @413f69cc)
        at jakarta.activation.MailcapCommandMap.getDataContentHandler(MailcapCommandMap.java:620) ~[jakarta.activation-api-2.1.3.jar:?]
        at jakarta.activation.MailcapCommandMap.createDataContentHandler(MailcapCommandMap.java:573) ~[jakarta.activation-api-2.1.3.jar:?]
        at jakarta.activation.DataHandler.getDataContentHandler(DataHandler.java:591) ~[jakarta.activation-api-2.1.3.jar:?]
        at jakarta.activation.DataHandler.writeTo(DataHandler.java:290) ~[jakarta.activation-api-2.1.3.jar:?]
        at jakarta.mail.internet.MimeUtility.getEncoding(MimeUtility.java:318) ~[jakarta.mail-2.0.3.jar:?]
        at jakarta.mail.internet.MimeBodyPart.updateHeaders(MimeBodyPart.java:1562) ~[jakarta.mail-2.0.3.jar:?]
        at jakarta.mail.internet.MimeMessage.updateHeaders(MimeMessage.java:2272) ~[jakarta.mail-2.0.3.jar:?]
        at jakarta.mail.internet.MimeMessage.saveChanges(MimeMessage.java:2232) ~[jakarta.mail-2.0.3.jar:?]
        at jakarta.mail.Transport.send(Transport.java:101) ~[jakarta.mail-2.0.3.jar:?]
        at org.dspace.core.Email.send(Email.java:482) ~[dspace-api-8.0-SNAPSHOT.jar:8.0-SNAPSHOT]
        at org.dspace.xmlworkflow.XmlWorkflowServiceImpl.notifyOfArchive(XmlWorkflowServiceImpl.java:682) ~[dspace-api-8.0-SNAPSHOT.jar:8.0-SNAPSHOT]
        at org.dspace.xmlworkflow.XmlWorkflowServiceImpl.archive(XmlWorkflowServiceImpl.java:627) ~[dspace-api-8.0-SNAPSHOT.jar:8.0-SNAPSHOT]
        at org.dspace.xmlworkflow.XmlWorkflowServiceImpl.start(XmlWorkflowServiceImpl.java:226) ~[dspace-api-8.0-SNAPSHOT.jar:8.0-SNAPSHOT]
        at org.dspace.xmlworkflow.XmlWorkflowServiceImpl.start(XmlWorkflowServiceImpl.java:88) ~[dspace-api-8.0-SNAPSHOT.jar:8.0-SNAPSHOT]
```

