### PR TITLE
Refactor SubmissionConfigReader to use a map for the item process configurations based on entityType

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/SubmissionConfigReader.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/SubmissionConfigReader.java
@@ -24,10 +24,10 @@ import org.apache.logging.log4j.Logger;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.DSpaceObject;
+import org.dspace.content.Item;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.CollectionService;
 import org.dspace.core.Context;
-import org.dspace.discovery.SearchServiceException;
 import org.dspace.handle.factory.HandleServiceFactory;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.w3c.dom.Document;
@@ -100,6 +100,13 @@ public class SubmissionConfigReader {
     private Map<String, String> communityToSubmissionConfig = null;
 
     /**
+     * Hashmap which stores which submission process configuration is used by
+     * which entityType, computed from the item submission config file
+     * (specifically, the 'submission-map' tag)
+     */
+    private Map<String, String> entityTypeToSubmissionConfig = null;
+
+    /**
      * Reference to the global submission step definitions defined in the
      * "step-definitions" section
      */
@@ -137,6 +144,7 @@ public class SubmissionConfigReader {
     public void reload() throws SubmissionConfigReaderException {
         collectionToSubmissionConfig = null;
         communityToSubmissionConfig = null;
+        entityTypeToSubmissionConfig = null;
         stepDefns = null;
         submitDefns = null;
         buildInputs(configDir + SUBMIT_DEF_FILE_PREFIX + SUBMIT_DEF_FILE_SUFFIX);
@@ -156,6 +164,7 @@ public class SubmissionConfigReader {
     private void buildInputs(String fileName) throws SubmissionConfigReaderException {
         collectionToSubmissionConfig = new HashMap<String, String>();
         communityToSubmissionConfig = new HashMap<String, String>();
+        entityTypeToSubmissionConfig = new HashMap<String, String>();
         submitDefns = new LinkedHashMap<String, List<Map<String, String>>>();
 
         String uri = "file:" + new File(fileName).getAbsolutePath();
@@ -173,9 +182,6 @@ public class SubmissionConfigReader {
         } catch (FactoryConfigurationError fe) {
             throw new SubmissionConfigReaderException(
                 "Cannot create Item Submission Configuration parser", fe);
-        } catch (SearchServiceException se) {
-            throw new SubmissionConfigReaderException(
-                "Cannot perform a discovery search for Item Submission Configuration", se);
         } catch (Exception e) {
             throw new SubmissionConfigReaderException(
                 "Error creating Item Submission Configuration: " + e);
@@ -236,6 +242,16 @@ public class SubmissionConfigReader {
                 .get(col.getHandle());
             if (submitName != null) {
                 return getSubmissionConfigByName(submitName);
+            }
+
+            // get the name of the submission process based on the entity type of this collections
+            if (!entityTypeToSubmissionConfig.isEmpty()) {
+                String entityType = collectionService.getMetadataFirstValue(col, "dspace", "entity", "type", Item.ANY);
+                submitName = entityTypeToSubmissionConfig
+                    .get(entityType);
+                if (submitName != null) {
+                    return getSubmissionConfigByName(submitName);
+                }
             }
 
             if (!communityToSubmissionConfig.isEmpty()) {
@@ -358,7 +374,7 @@ public class SubmissionConfigReader {
      * should correspond to the collection-form maps, the form definitions, and
      * the display/storage word pairs.
      */
-    private void doNodes(Node n) throws SAXException, SearchServiceException, SubmissionConfigReaderException {
+    private void doNodes(Node n) throws SAXException, SubmissionConfigReaderException {
         if (n == null) {
             return;
         }
@@ -405,9 +421,7 @@ public class SubmissionConfigReader {
      * the collection handle and item submission name, put name in hashmap keyed
      * by the collection handle.
      */
-    private void processMap(Node e) throws SAXException, SearchServiceException {
-        // create a context
-        Context context = new Context();
+    private void processMap(Node e) throws SAXException {
 
         NodeList nl = e.getChildNodes();
         int len = nl.getLength();
@@ -428,7 +442,7 @@ public class SubmissionConfigReader {
                     throw new SAXException(
                         "name-map element is missing submission-name attribute in 'item-submission.xml'");
                 }
-                if (content != null && content.length() > 0) {
+                if (content != null && !content.isEmpty()) {
                     throw new SAXException(
                         "name-map element has content in 'item-submission.xml', it should be empty.");
                 }
@@ -437,12 +451,7 @@ public class SubmissionConfigReader {
                 } else if (communityId != null) {
                     communityToSubmissionConfig.put(communityId, value);
                 } else {
-                    // get all collections for this entity-type
-                    List<Collection> collections = collectionService.findAllCollectionsByEntityType( context,
-                                    entityType);
-                    for (Collection collection : collections) {
-                        collectionToSubmissionConfig.putIfAbsent(collection.getHandle(), value);
-                    }
+                    entityTypeToSubmissionConfig.put(entityType, value);
                 }
             } // ignore any child node that isn't a "name-map"
         }

--- a/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
@@ -1109,26 +1109,6 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
         return (int) resp.getTotalSearchResults();
     }
 
-    @Override
-    @SuppressWarnings("rawtypes")
-    public List<Collection> findAllCollectionsByEntityType(Context context, String entityType)
-            throws SearchServiceException {
-        List<Collection> collectionList = new ArrayList<>();
-
-        DiscoverQuery discoverQuery = new DiscoverQuery();
-        discoverQuery.setDSpaceObjectFilter(IndexableCollection.TYPE);
-        discoverQuery.addFilterQueries("dspace.entity.type:" + entityType);
-
-        DiscoverResult discoverResult = searchService.search(context, discoverQuery);
-        List<IndexableObject> solrIndexableObjects = discoverResult.getIndexableObjects();
-
-        for (IndexableObject solrCollection : solrIndexableObjects) {
-            Collection c = ((IndexableCollection) solrCollection).getIndexedObject();
-            collectionList.add(c);
-        }
-        return collectionList;
-    }
-
     /**
      * Returns total collection archived items
      *

--- a/dspace-api/src/main/java/org/dspace/content/service/CollectionService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/CollectionService.java
@@ -485,21 +485,6 @@ public interface CollectionService
         throws SQLException, SearchServiceException;
 
     /**
-     * Returns a list of all collections for a specific entity type.
-     * NOTE: for better performance, this method retrieves its results from an index (cache)
-     *       and does not query the database directly.
-     *       This means that results may be stale or outdated until
-     *       https://github.com/DSpace/DSpace/issues/2853 is resolved."
-     *
-     * @param context          DSpace Context
-     * @param entityType       limit the returned collection to those related to given entity type
-     * @return                 list of collections found
-     * @throws SearchServiceException    if search error
-     */
-    public List<Collection> findAllCollectionsByEntityType(Context context, String entityType)
-        throws SearchServiceException;
-
-    /**
      * Returns total collection archived items
      *
      * @param collection       Collection

--- a/dspace-api/src/test/data/dspaceFolder/config/item-submission.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/item-submission.xml
@@ -27,6 +27,7 @@
         <name-map community-handle="123456789/topcommunity-test" submission-name="topcommunitytest"/>
         <name-map community-handle="123456789/subcommunity-test" submission-name="subcommunitytest"/>
         <name-map collection-handle="123456789/collection-test" submission-name="collectiontest"/>
+        <name-map collection-entity-type="Publication" submission-name="entitytypetest"/>
         <name-map collection-handle="123456789/test-duplicate-detection" submission-name="test-duplicate-detection"/>
     </submission-map>
 
@@ -286,6 +287,10 @@
         </submission-process>
 
         <submission-process name="collectiontest">
+            <step id="collection"/>
+        </submission-process>
+
+        <submission-process name="entitytypetest">
             <step id="collection"/>
         </submission-process>
 

--- a/dspace-api/src/test/data/dspaceFolder/config/item-submission.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/item-submission.xml
@@ -27,7 +27,7 @@
         <name-map community-handle="123456789/topcommunity-test" submission-name="topcommunitytest"/>
         <name-map community-handle="123456789/subcommunity-test" submission-name="subcommunitytest"/>
         <name-map collection-handle="123456789/collection-test" submission-name="collectiontest"/>
-        <name-map collection-entity-type="Publication" submission-name="entitytypetest"/>
+        <name-map collection-entity-type="CustomEntityType" submission-name="entitytypetest"/>
         <name-map collection-handle="123456789/test-duplicate-detection" submission-name="test-duplicate-detection"/>
     </submission-map>
 

--- a/dspace-api/src/test/java/org/dspace/app/util/SubmissionConfigIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/util/SubmissionConfigIT.java
@@ -51,12 +51,12 @@ public class SubmissionConfigIT extends AbstractIntegrationTestWithDatabase {
         // col3 should use the item submission form directly mapped for this collection
         Collection col3 = CollectionBuilder.createCollection(context, subcom1, "123456789/collection-test")
             .withName("Collection 3")
-            .withEntityType("Publication")
+            .withEntityType("CustomEntityType")
             .build();
         // col4 should use the item submission form mapped for the entity type Publication
         Collection col4 = CollectionBuilder.createCollection(context, subcom1, "123456789/not-mapped4")
             .withName("Collection 4")
-            .withEntityType("Publication")
+            .withEntityType("CustomEntityType")
             .build();
         context.restoreAuthSystemState();
 

--- a/dspace-api/src/test/java/org/dspace/app/util/SubmissionConfigIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/util/SubmissionConfigIT.java
@@ -53,7 +53,7 @@ public class SubmissionConfigIT extends AbstractIntegrationTestWithDatabase {
             .withName("Collection 3")
             .withEntityType("CustomEntityType")
             .build();
-        // col4 should use the item submission form mapped for the entity type Publication
+        // col4 should use the item submission form mapped for the entity type CustomEntityType
         Collection col4 = CollectionBuilder.createCollection(context, subcom1, "123456789/not-mapped4")
             .withName("Collection 4")
             .withEntityType("CustomEntityType")
@@ -75,7 +75,7 @@ public class SubmissionConfigIT extends AbstractIntegrationTestWithDatabase {
         SubmissionConfig submissionConfig3 = submissionConfigService.getSubmissionConfigByCollection(col3);
         assertEquals("collectiontest", submissionConfig3.getSubmissionName());
 
-        // for col4, it should return the item submission form defined for the entitytype Publication
+        // for col4, it should return the item submission form defined for the entitytype CustomEntityType
         SubmissionConfig submissionConfig4 = submissionConfigService.getSubmissionConfigByCollection(col4);
         assertEquals("entitytypetest", submissionConfig4.getSubmissionName());
     }

--- a/dspace-api/src/test/java/org/dspace/app/util/SubmissionConfigIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/util/SubmissionConfigIT.java
@@ -51,6 +51,12 @@ public class SubmissionConfigIT extends AbstractIntegrationTestWithDatabase {
         // col3 should use the item submission form directly mapped for this collection
         Collection col3 = CollectionBuilder.createCollection(context, subcom1, "123456789/collection-test")
             .withName("Collection 3")
+            .withEntityType("Publication")
+            .build();
+        // col4 should use the item submission form mapped for the entity type Publication
+        Collection col4 = CollectionBuilder.createCollection(context, subcom1, "123456789/not-mapped4")
+            .withName("Collection 4")
+            .withEntityType("Publication")
             .build();
         context.restoreAuthSystemState();
 
@@ -69,5 +75,8 @@ public class SubmissionConfigIT extends AbstractIntegrationTestWithDatabase {
         SubmissionConfig submissionConfig3 = submissionConfigService.getSubmissionConfigByCollection(col3);
         assertEquals("collectiontest", submissionConfig3.getSubmissionName());
 
+        // for col4, it should return the item submission form defined for the entitytype Publication
+        SubmissionConfig submissionConfig4 = submissionConfigService.getSubmissionConfigByCollection(col4);
+        assertEquals("entitytypetest", submissionConfig4.getSubmissionName());
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionDefinitionsControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionDefinitionsControllerIT.java
@@ -35,7 +35,7 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
     // The total number of expected submission definitions is referred to in multiple tests and assertions as
     // is the last page (totalDefinitions - 1)
     // This integer should be maintained along with any changes to item-submissions.xml
-    private static final int totalDefinitions = 11;
+    private static final int totalDefinitions = 12;
 
     @Test
     public void findAll() throws Exception {
@@ -419,7 +419,7 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
                 Matchers.containsString("page=5"), Matchers.containsString("size=1"))))
             .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
                 Matchers.containsString("/api/config/submissiondefinitions?"),
-                Matchers.containsString("page=10"), Matchers.containsString("size=1"))))
+                Matchers.containsString("page=" + (totalDefinitions - 1)), Matchers.containsString("size=1"))))
             .andExpect(jsonPath("$.page.size", is(1)))
             .andExpect(jsonPath("$.page.totalElements", is(totalDefinitions)))
             .andExpect(jsonPath("$.page.totalPages", is(totalDefinitions)))
@@ -445,7 +445,7 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
                 Matchers.containsString("page=6"), Matchers.containsString("size=1"))))
             .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
                 Matchers.containsString("/api/config/submissiondefinitions?"),
-                Matchers.containsString("page=10"), Matchers.containsString("size=1"))))
+                Matchers.containsString("page=" + (totalDefinitions - 1)), Matchers.containsString("size=1"))))
             .andExpect(jsonPath("$.page.size", is(1)))
             .andExpect(jsonPath("$.page.totalElements", is(totalDefinitions)))
             .andExpect(jsonPath("$.page.totalPages", is(totalDefinitions)))
@@ -471,7 +471,7 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
                 Matchers.containsString("page=7"), Matchers.containsString("size=1"))))
             .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
                 Matchers.containsString("/api/config/submissiondefinitions?"),
-                Matchers.containsString("page=10"), Matchers.containsString("size=1"))))
+                Matchers.containsString("page=" + (totalDefinitions - 1)), Matchers.containsString("size=1"))))
             .andExpect(jsonPath("$.page.size", is(1)))
             .andExpect(jsonPath("$.page.totalElements", is(totalDefinitions)))
             .andExpect(jsonPath("$.page.totalPages", is(totalDefinitions)))
@@ -497,7 +497,7 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
                 Matchers.containsString("page=8"), Matchers.containsString("size=1"))))
             .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
                 Matchers.containsString("/api/config/submissiondefinitions?"),
-                Matchers.containsString("page=10"), Matchers.containsString("size=1"))))
+                Matchers.containsString("page=" + (totalDefinitions - 1)), Matchers.containsString("size=1"))))
             .andExpect(jsonPath("$.page.size", is(1)))
             .andExpect(jsonPath("$.page.totalElements", is(totalDefinitions)))
             .andExpect(jsonPath("$.page.totalPages", is(totalDefinitions)))
@@ -515,16 +515,68 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
             .andExpect(jsonPath("$._links.prev.href", Matchers.allOf(
                 Matchers.containsString("/api/config/submissiondefinitions?"),
                 Matchers.containsString("page=8"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.next.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=10"), Matchers.containsString("size=1"))))
             .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
                 Matchers.containsString("/api/config/submissiondefinitions?"),
                 Matchers.containsString("page=9"), Matchers.containsString("size=1"))))
             .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
                 Matchers.containsString("/api/config/submissiondefinitions?"),
-                Matchers.containsString("page=10"), Matchers.containsString("size=1"))))
+                Matchers.containsString("page=" + (totalDefinitions - 1)), Matchers.containsString("size=1"))))
             .andExpect(jsonPath("$.page.size", is(1)))
             .andExpect(jsonPath("$.page.totalElements", is(totalDefinitions)))
             .andExpect(jsonPath("$.page.totalPages", is(totalDefinitions)))
             .andExpect(jsonPath("$.page.number", is(9)));
+
+        getClient(tokenAdmin).perform(get("/api/config/submissiondefinitions")
+                .param("size", "1")
+                .param("page", "10"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._embedded.submissiondefinitions[0].id", is("entitytypetest")))
+            .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=0"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.prev.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=9"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.next.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=11"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=10"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=" + (totalDefinitions - 1)), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$.page.size", is(1)))
+            .andExpect(jsonPath("$.page.totalElements", is(totalDefinitions)))
+            .andExpect(jsonPath("$.page.totalPages", is(totalDefinitions)))
+            .andExpect(jsonPath("$.page.number", is(10)));
+
+        getClient(tokenAdmin).perform(get("/api/config/submissiondefinitions")
+                .param("size", "1")
+                .param("page", "11"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._embedded.submissiondefinitions[0].id", is("test-duplicate-detection")))
+            .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=0"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.prev.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=10"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=11"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=" + (totalDefinitions - 1)), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$.page.size", is(1)))
+            .andExpect(jsonPath("$.page.totalElements", is(totalDefinitions)))
+            .andExpect(jsonPath("$.page.totalPages", is(totalDefinitions)))
+            .andExpect(jsonPath("$.page.number", is(11)));
     }
 
 }

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -831,6 +831,11 @@ event.consumer.ldnmessage.class = org.dspace.app.ldn.LDNMessageConsumer
 event.consumer.ldnmessage.filters = Item+Install
 
 # item submission config reload consumer
+# This consumer can be useful for reloading changes made in the item-submission.xml config file,
+# without restarting Tomcat, primarily for adding new collection mappings.
+# With this consumer, configuration reloading is triggered after a collection is updated.
+# It is disabled by default. To enable it, add 'submissionconfig' to the list of
+# activated consumers (event.dispatcher.default.consumers).
 event.consumer.submissionconfig.class = org.dspace.submit.consumer.SubmissionConfigConsumer
 event.consumer.submissionconfig.filters = Collection+Modify_Metadata
 

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -780,7 +780,7 @@ event.dispatcher.default.class = org.dspace.event.BasicDispatcher
 # Add rdf here, if you are using dspace-rdf to export your repository content as RDF.
 # Add iiif here, if you are using dspace-iiif.
 # Add orcidqueue here, if the integration with ORCID is configured and wish to enable the synchronization queue functionality
-event.dispatcher.default.consumers = versioning, discovery, eperson, submissionconfig, qaeventsdelete, ldnmessage
+event.dispatcher.default.consumers = versioning, discovery, eperson, qaeventsdelete, ldnmessage
 
 # The noindex dispatcher will not create search or browse indexes (useful for batch item imports)
 event.dispatcher.noindex.class = org.dspace.event.BasicDispatcher


### PR DESCRIPTION
## References
* Fixes #9402
* Fixes #9217 (The strange NullPointerException will no longer occur. Now you get a clear error message that Solr is unavailable, e.g. `Failed to contact Solr at http://dspacesolr:8983/solr/search :  IOException occurred when talking to server at: http://dspacesolr:8983/solr/search`)
* Related to DSpace/dspace-angular#2914
* Port to 7x: #9487

## Description
This PR implements the changes described in [this comment](https://github.com/DSpace/dspace-angular/issues/2914#issuecomment-2050041593) to utilize a map for returning the item process submission form configured for collections with a specific entityType. The implementation follows a similar approach to #9259

## Instructions for Reviewers

List of changes in this PR:
* Refactor `SubmissionConfigReader` to use a new map for entityType-configured submission forms
* Add a new test to ensure that entityType-configured submission forms work correctly and take precedence over community-based configurations.
* Remove from default configuration the submissionconfig consumer used to reload the submission configuration after creating/modifying a collection. With the proposed changes, this reload should not be necessary. This change could be undone if it is useful for other use cases.

Test that the entityType configurations are working properly after creating o editing the entityType of a collection and that the issue #9402 is also resolved.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.