### PR TITLE
Switch to using `org.dspace:orcid-model-jakarta` in Maven Central

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -738,26 +738,15 @@
 
         <!-- TODO: This may need to be replaced with the "orcid-model" artifact once this ticket is resolved:
              https://github.com/ORCID/orcid-model/issues/50 -->
+        <!-- Maintained at https://github.com/DSpace/orcid-model -->
         <dependency>
-            <groupId>org.orcid</groupId>
+            <groupId>org.dspace</groupId>
             <artifactId>orcid-model-jakarta</artifactId>
-            <version>3.3.0</version>
+            <version>3.3.0-SNAPSHOT</version>
             <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.jarkarta.rs</groupId>
-                    <artifactId>jackson-jakarta-rs-json-provider</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.yaml</groupId>
-                    <artifactId>snakeyaml</artifactId>
-                </exclusion>
                 <exclusion>
                     <groupId>org.javassist</groupId>
                     <artifactId>javassist</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.swagger.core.v3</groupId>
-                    <artifactId>swagger-jaxrs2-jakarta</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -742,7 +742,7 @@
         <dependency>
             <groupId>org.dspace</groupId>
             <artifactId>orcid-model-jakarta</artifactId>
-            <version>3.3.0-SNAPSHOT</version>
+            <version>3.3.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.javassist</groupId>

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/CollectionAdminFeatureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/CollectionAdminFeatureIT.java
@@ -175,8 +175,10 @@ public class CollectionAdminFeatureIT extends AbstractControllerIntegrationTest 
         String token = getAuthToken(eperson.getEmail(), password);
 
         // Verify an ePerson in a subgroup of the site administrators has this feature
+        // Filter by "feature" ID because Admins may have >20 features enabled & cause this endpoint to paginate.
         getClient(token).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
-            + "http://localhost/api/core/sites/" + siteService.findSite(context).getID()))
+            + "http://localhost/api/core/sites/" + siteService.findSite(context).getID()
+            + "&feature=isCollectionAdmin"))
             .andExpect(status().isOk())
             .andExpect(
                 jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='isCollectionAdmin')]")
@@ -284,8 +286,10 @@ public class CollectionAdminFeatureIT extends AbstractControllerIntegrationTest 
         String token = getAuthToken(eperson.getEmail(), password);
 
         // Verify an ePerson in a sub-subgroup of the site administrators has this feature
+        // Filter by "feature" ID because Admins may have >20 features enabled & cause this endpoint to paginate.
         getClient(token).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
-            + "http://localhost/api/core/sites/" + siteService.findSite(context).getID()))
+            + "http://localhost/api/core/sites/" + siteService.findSite(context).getID()
+            + "&feature=isCollectionAdmin"))
             .andExpect(status().isOk())
             .andExpect(
                 jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='isCollectionAdmin')]")

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
                                         <version>${java.version}</version>
                                     </requireJavaVersion>
                                     <requireMavenVersion>
-                                        <version>[3.0.5,)</version>
+                                        <version>[3.8,)</version>
                                     </requireMavenVersion>
                                 </rules>
                             </configuration>
@@ -1990,15 +1990,6 @@
         <repository>
             <id>handle.net</id>
             <url>https://handle.net/maven</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-        <!-- For Jakarta EE version of "orcid-model". REMOVE once official "orcid-model" is updated to Jakarta,
-             see https://github.com/ORCID/orcid-model/issues/50-->
-        <repository>
-            <id>oicr.on.ca</id>
-            <url>https://artifacts.oicr.on.ca/artifactory/collab-release/</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>


### PR DESCRIPTION
## References
* Fixes #9480 
* Requires https://github.com/DSpace/orcid-model/pull/1
    * The `orcid-model` PR has been released as a temporary `3.3.0-SNAPSHOT` release. Assuming all tests succeed, then we'll need to do an official `3.3.0` release and update this PR.

## Description
Fixes #9480 by using our forked copy of the `orcid-model-jakarta` library in  https://github.com/DSpace/orcid-model

This forked copy of the library is a temporary solution until https://github.com/ORCID/orcid-model/issues/50 is solved.

**NOTE: Also includes a minor bug fix to `CollectionAdminFeatureIT` to fix some tests that are causing random failures.**

## Instructions for Reviewers
* Review changes
* Ensure no ORCID tests fail