### PR TITLE
[Port dspace-7_x] Refactor SubmissionConfigReader to use a map for the item process configurations based on entityType

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/DCInputsReader.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/DCInputsReader.java
@@ -14,7 +14,6 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import javax.servlet.ServletException;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.FactoryConfigurationError;
@@ -150,17 +149,16 @@ public class DCInputsReader {
      * Returns the set of DC inputs used for a particular collection, or the
      * default set if no inputs defined for the collection
      *
-     * @param collectionHandle collection's unique Handle
+     * @param collection collection for which search the set of DC inputs
      * @return DC input set
      * @throws DCInputsReaderException if no default set defined
-     * @throws ServletException
      */
-    public List<DCInputSet> getInputsByCollectionHandle(String collectionHandle)
+    public List<DCInputSet> getInputsByCollection(Collection collection)
         throws DCInputsReaderException {
         SubmissionConfig config;
         try {
             config = SubmissionServiceFactory.getInstance().getSubmissionConfigService()
-                        .getSubmissionConfigByCollection(collectionHandle);
+                        .getSubmissionConfigByCollection(collection);
             String formName = config.getSubmissionName();
             if (formName == null) {
                 throw new DCInputsReaderException("No form designated as default");
@@ -691,7 +689,7 @@ public class DCInputsReader {
 
     public String getInputFormNameByCollectionAndField(Collection collection, String field)
         throws DCInputsReaderException {
-        List<DCInputSet> inputSets = getInputsByCollectionHandle(collection.getHandle());
+        List<DCInputSet> inputSets = getInputsByCollection(collection);
         for (DCInputSet inputSet : inputSets) {
             String[] tokenized = Utils.tokenize(field);
             String schema = tokenized[0];

--- a/dspace-api/src/main/java/org/dspace/app/util/SubmissionConfigReader.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/SubmissionConfigReader.java
@@ -11,6 +11,7 @@ import java.io.File;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -154,7 +155,7 @@ public class SubmissionConfigReader {
     private void buildInputs(String fileName) throws SubmissionConfigReaderException {
         collectionToSubmissionConfig = new HashMap<String, String>();
         entityTypeToSubmissionConfig = new HashMap<String, String>();
-        submitDefns = new HashMap<String, List<Map<String, String>>>();
+        submitDefns = new LinkedHashMap<String, List<Map<String, String>>>();
 
         String uri = "file:" + new File(fileName).getAbsolutePath();
 

--- a/dspace-api/src/main/java/org/dspace/app/util/SubmissionConfigReader.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/SubmissionConfigReader.java
@@ -210,18 +210,26 @@ public class SubmissionConfigReader {
      * Returns the Item Submission process config used for a particular
      * collection, or the default if none is defined for the collection
      *
-     * @param collectionHandle collection's unique Handle
+     * @param col collection for which search Submission process config
      * @return the SubmissionConfig representing the item submission config
-     * @throws SubmissionConfigReaderException if no default submission process configuration defined
+     * @throws IllegalStateException if no default submission process configuration defined
      */
-    public SubmissionConfig getSubmissionConfigByCollection(String collectionHandle) {
-        // get the name of the submission process config for this collection
-        String submitName = collectionToSubmissionConfig
-            .get(collectionHandle);
-        if (submitName == null) {
+    public SubmissionConfig getSubmissionConfigByCollection(Collection col) {
+
+        String submitName;
+
+        if (col != null) {
+
+            // get the name of the submission process config for this collection
             submitName = collectionToSubmissionConfig
-                .get(DEFAULT_COLLECTION);
+                .get(col.getHandle());
+            if (submitName != null) {
+                return getSubmissionConfigByName(submitName);
+            }
         }
+
+        submitName = collectionToSubmissionConfig.get(DEFAULT_COLLECTION);
+
         if (submitName == null) {
             throw new IllegalStateException(
                 "No item submission process configuration designated as 'default' in 'submission-map' section of " +

--- a/dspace-api/src/main/java/org/dspace/app/util/Util.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/Util.java
@@ -405,21 +405,13 @@ public class Util {
         DCInput myInputs = null;
         boolean myInputsFound = false;
         String formFileName = I18nUtil.getInputFormsFileName(locale);
-        String col_handle = "";
 
         Collection collection = item.getOwningCollection();
-
-        if (collection == null) {
-            // set an empty handle so to get the default input set
-            col_handle = "";
-        } else {
-            col_handle = collection.getHandle();
-        }
 
         // Read the input form file for the specific collection
         DCInputsReader inputsReader = new DCInputsReader(formFileName);
 
-        List<DCInputSet> inputSets = inputsReader.getInputsByCollectionHandle(col_handle);
+        List<DCInputSet> inputSets = inputsReader.getInputsByCollection(collection);
 
         // Replace the values of Metadatum[] with the correct ones in case
         // of
@@ -500,8 +492,8 @@ public class Util {
     public static List<String> differenceInSubmissionFields(Collection fromCollection, Collection toCollection)
         throws DCInputsReaderException {
         DCInputsReader reader = new DCInputsReader();
-        List<DCInputSet> from = reader.getInputsByCollectionHandle(fromCollection.getHandle());
-        List<DCInputSet> to = reader.getInputsByCollectionHandle(toCollection.getHandle());
+        List<DCInputSet> from = reader.getInputsByCollection(fromCollection);
+        List<DCInputSet> to = reader.getInputsByCollection(toCollection);
 
         Set<String> fromFieldName = new HashSet<>();
         Set<String> toFieldName = new HashSet<>();

--- a/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
@@ -1054,26 +1054,6 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
         return (int) resp.getTotalSearchResults();
     }
 
-    @Override
-    @SuppressWarnings("rawtypes")
-    public List<Collection> findAllCollectionsByEntityType(Context context, String entityType)
-            throws SearchServiceException {
-        List<Collection> collectionList = new ArrayList<>();
-
-        DiscoverQuery discoverQuery = new DiscoverQuery();
-        discoverQuery.setDSpaceObjectFilter(IndexableCollection.TYPE);
-        discoverQuery.addFilterQueries("dspace.entity.type:" + entityType);
-
-        DiscoverResult discoverResult = searchService.search(context, discoverQuery);
-        List<IndexableObject> solrIndexableObjects = discoverResult.getIndexableObjects();
-
-        for (IndexableObject solrCollection : solrIndexableObjects) {
-            Collection c = ((IndexableCollection) solrCollection).getIndexedObject();
-            collectionList.add(c);
-        }
-        return collectionList;
-    }
-
     /**
      * Returns total collection archived items
      *

--- a/dspace-api/src/main/java/org/dspace/content/authority/ChoiceAuthorityServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/ChoiceAuthorityServiceImpl.java
@@ -242,7 +242,7 @@ public final class ChoiceAuthorityServiceImpl implements ChoiceAuthorityService 
             // check if it is the requested collection
             Map<String, ChoiceAuthority> controllerFormDef = controllerFormDefinitions.get(fieldKey);
             SubmissionConfig submissionConfig = submissionConfigService
-                    .getSubmissionConfigByCollection(collection.getHandle());
+                    .getSubmissionConfigByCollection(collection);
             String submissionName = submissionConfig.getSubmissionName();
             // check if the requested collection has a submission definition that use an authority for the metadata
             if (controllerFormDef.containsKey(submissionName)) {
@@ -495,7 +495,7 @@ public final class ChoiceAuthorityServiceImpl implements ChoiceAuthorityService 
             try {
                 configReaderService = SubmissionServiceFactory.getInstance().getSubmissionConfigService();
                 SubmissionConfig submissionName = configReaderService
-                        .getSubmissionConfigByCollection(collection.getHandle());
+                        .getSubmissionConfigByCollection(collection);
                 ma = controllerFormDefinitions.get(fieldKey).get(submissionName.getSubmissionName());
             } catch (SubmissionConfigReaderException e) {
                 // the system is in an illegal state as the submission definition is not valid

--- a/dspace-api/src/main/java/org/dspace/content/service/CollectionService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/CollectionService.java
@@ -457,21 +457,6 @@ public interface CollectionService
         throws SQLException, SearchServiceException;
 
     /**
-     * Returns a list of all collections for a specific entity type.
-     * NOTE: for better performance, this method retrieves its results from an index (cache)
-     *       and does not query the database directly.
-     *       This means that results may be stale or outdated until
-     *       https://github.com/DSpace/DSpace/issues/2853 is resolved."
-     *
-     * @param context          DSpace Context
-     * @param entityType       limit the returned collection to those related to given entity type
-     * @return                 list of collections found
-     * @throws SearchServiceException    if search error
-     */
-    public List<Collection> findAllCollectionsByEntityType(Context context, String entityType)
-        throws SearchServiceException;
-
-    /**
      * Returns total collection archived items
      *
      * @param collection       Collection

--- a/dspace-api/src/main/java/org/dspace/ctask/general/RequiredMetadata.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/RequiredMetadata.java
@@ -17,6 +17,7 @@ import org.dspace.app.util.DCInput;
 import org.dspace.app.util.DCInputSet;
 import org.dspace.app.util.DCInputsReader;
 import org.dspace.app.util.DCInputsReaderException;
+import org.dspace.content.Collection;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataValue;
@@ -69,7 +70,7 @@ public class RequiredMetadata extends AbstractCurationTask {
                     handle = "in workflow";
                 }
                 sb.append("Item: ").append(handle);
-                for (String req : getReqList(item.getOwningCollection().getHandle())) {
+                for (String req : getReqList(item.getOwningCollection())) {
                     List<MetadataValue> vals = itemService.getMetadataByMetadataString(item, req);
                     if (vals.size() == 0) {
                         sb.append(" missing required field: ").append(req);
@@ -91,14 +92,14 @@ public class RequiredMetadata extends AbstractCurationTask {
         }
     }
 
-    protected List<String> getReqList(String handle) throws DCInputsReaderException {
-        List<String> reqList = reqMap.get(handle);
+    protected List<String> getReqList(Collection collection) throws DCInputsReaderException {
+        List<String> reqList = reqMap.get(collection.getHandle());
         if (reqList == null) {
             reqList = reqMap.get("default");
         }
         if (reqList == null) {
             reqList = new ArrayList<String>();
-            List<DCInputSet> inputSet = reader.getInputsByCollectionHandle(handle);
+            List<DCInputSet> inputSet = reader.getInputsByCollection(collection);
             for (DCInputSet inputs : inputSet) {
                 for (DCInput[] row : inputs.getFields()) {
                     for (DCInput input : row) {

--- a/dspace-api/src/main/java/org/dspace/submit/service/SubmissionConfigService.java
+++ b/dspace-api/src/main/java/org/dspace/submit/service/SubmissionConfigService.java
@@ -34,7 +34,7 @@ public interface SubmissionConfigService {
 
     public int countSubmissionConfigs();
 
-    public SubmissionConfig getSubmissionConfigByCollection(String collectionHandle);
+    public SubmissionConfig getSubmissionConfigByCollection(Collection collection);
 
     public SubmissionConfig getSubmissionConfigByName(String submitName);
 

--- a/dspace-api/src/main/java/org/dspace/submit/service/SubmissionConfigServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/submit/service/SubmissionConfigServiceImpl.java
@@ -57,8 +57,8 @@ public class SubmissionConfigServiceImpl implements SubmissionConfigService, Ini
     }
 
     @Override
-    public SubmissionConfig getSubmissionConfigByCollection(String collectionHandle) {
-        return submissionConfigReader.getSubmissionConfigByCollection(collectionHandle);
+    public SubmissionConfig getSubmissionConfigByCollection(Collection collection) {
+        return submissionConfigReader.getSubmissionConfigByCollection(collection);
     }
 
     @Override

--- a/dspace-api/src/test/data/dspaceFolder/config/item-submission.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/item-submission.xml
@@ -24,6 +24,8 @@
         <name-map collection-handle="123456789/typebind-test" submission-name="typebindtest"/>
         <name-map collection-handle="123456789/accessCondition-not-discoverable" submission-name="accessConditionNotDiscoverable"/>
         <name-map collection-handle="123456789/test-hidden" submission-name="test-hidden"/>
+        <name-map collection-handle="123456789/collection-test" submission-name="collectiontest"/>
+        <name-map collection-entity-type="CustomEntityType" submission-name="entitytypetest"/>
     </submission-map>
 
 
@@ -255,6 +257,14 @@
             <step id="test-outside-submission-hidden"/>
             <step id="test-never-hidden"/>
             <step id="test-always-hidden"/>
+        </submission-process>
+
+        <submission-process name="collectiontest">
+            <step id="collection"/>
+        </submission-process>
+
+        <submission-process name="entitytypetest">
+            <step id="collection"/>
         </submission-process>
 
     </submission-definitions>

--- a/dspace-api/src/test/java/org/dspace/app/util/SubmissionConfigIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/util/SubmissionConfigIT.java
@@ -1,0 +1,60 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.util;
+
+import static org.junit.Assert.assertEquals;
+
+import org.dspace.AbstractIntegrationTestWithDatabase;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.submit.factory.SubmissionServiceFactory;
+import org.dspace.submit.service.SubmissionConfigService;
+import org.junit.Test;
+
+/**
+ * Integration Tests for parsing and utilities on submission config forms / readers
+ *
+ * @author Toni Prieto
+ */
+public class SubmissionConfigIT extends AbstractIntegrationTestWithDatabase {
+
+    @Test
+    public void testSubmissionConfigMapByCollectionOrEntityType()
+        throws SubmissionConfigReaderException {
+
+        context.turnOffAuthorisationSystem();
+        // Sep up a structure with one top community and two collections
+        Community topcom = CommunityBuilder.createCommunity(context, "123456789/topcommunity-test")
+            .withName("Parent Community")
+            .build();
+        // col1 should use the item submission form directly mapped for this collection
+        Collection col1 = CollectionBuilder.createCollection(context, topcom, "123456789/collection-test")
+            .withName("Collection 1")
+            .withEntityType("CustomEntityType")
+            .build();
+        // col2 should use the item submission form mapped for the entity type CustomEntityType
+        Collection col2 = CollectionBuilder.createCollection(context, topcom, "123456789/not-mapped1")
+            .withName("Collection 2")
+            .withEntityType("CustomEntityType")
+            .build();
+        context.restoreAuthSystemState();
+
+        SubmissionConfigService submissionConfigService = SubmissionServiceFactory.getInstance()
+            .getSubmissionConfigService();
+
+        // for col1, it should return the item submission form defined directly for the collection
+        SubmissionConfig submissionConfig1 = submissionConfigService.getSubmissionConfigByCollection(col1);
+        assertEquals("collectiontest", submissionConfig1.getSubmissionName());
+
+        // for col2, it should return the item submission form defined for the entitytype CustomEntityType
+        SubmissionConfig submissionConfig2 = submissionConfigService.getSubmissionConfigByCollection(col2);
+        assertEquals("entitytypetest", submissionConfig2.getSubmissionName());
+    }
+}

--- a/dspace-api/src/test/java/org/dspace/app/util/SubmissionConfigTest.java
+++ b/dspace-api/src/test/java/org/dspace/app/util/SubmissionConfigTest.java
@@ -9,17 +9,20 @@ package org.dspace.app.util;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import org.dspace.AbstractUnitTest;
+import org.dspace.content.Collection;
 import org.dspace.submit.factory.SubmissionServiceFactory;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.Mock;
 
 /**
  * Tests for parsing and utilities on submission config forms / readers
@@ -29,6 +32,9 @@ import org.junit.Test;
 public class SubmissionConfigTest extends AbstractUnitTest {
 
     DCInputsReader inputReader;
+
+    @Mock
+    private Collection col1;
 
     @BeforeClass
     public static void setUpClass() {
@@ -56,6 +62,8 @@ public class SubmissionConfigTest extends AbstractUnitTest {
         String typeBindSubmissionName = "typebindtest";
         String typeBindSubmissionStepName = "typebindtest";
 
+        when(col1.getHandle()).thenReturn(typeBindHandle);
+
         // Expected field lists from typebindtest form
         List<String> allConfiguredFields = new ArrayList<>();
         allConfiguredFields.add("dc.title");
@@ -67,7 +75,7 @@ public class SubmissionConfigTest extends AbstractUnitTest {
         // Get submission configuration
         SubmissionConfig submissionConfig =
                 SubmissionServiceFactory.getInstance().getSubmissionConfigService()
-                    .getSubmissionConfigByCollection(typeBindHandle);
+                    .getSubmissionConfigByCollection(col1);
         // Submission name should match name defined in item-submission.xml
         assertEquals(typeBindSubmissionName, submissionConfig.getSubmissionName());
         // Step 0 - our process only has one step. It should not be null and have the ID typebindtest

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/AInprogressItemConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/AInprogressItemConverter.java
@@ -82,7 +82,7 @@ public abstract class AInprogressItemConverter<T extends InProgressSubmission,
 
         if (collection != null) {
             SubmissionDefinitionRest def = converter.toRest(
-                    submissionConfigService.getSubmissionConfigByCollection(collection.getHandle()), projection);
+                    submissionConfigService.getSubmissionConfigByCollection(collection), projection);
             witem.setSubmissionDefinition(def);
             for (SubmissionSectionRest sections : def.getPanels()) {
                 SubmissionStepConfig stepConfig = submissionSectionConverter.toModel(sections);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/SubmissionDefinitionRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/SubmissionDefinitionRestRepository.java
@@ -70,7 +70,7 @@ public class SubmissionDefinitionRestRepository extends DSpaceRestRepository<Sub
             return null;
         }
         SubmissionDefinitionRest def = converter
-            .toRest(submissionConfigService.getSubmissionConfigByCollection(col.getHandle()),
+            .toRest(submissionConfigService.getSubmissionConfigByCollection(col),
                     utils.obtainProjection());
         return def;
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkspaceItemRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkspaceItemRestRepository.java
@@ -251,7 +251,7 @@ public class WorkspaceItemRestRepository extends DSpaceRestRepository<WorkspaceI
         }
 
         SubmissionConfig submissionConfig =
-            submissionConfigService.getSubmissionConfigByCollection(collection.getHandle());
+            submissionConfigService.getSubmissionConfigByCollection(collection);
         List<WorkspaceItem> result = null;
         List<ImportRecord> records = new ArrayList<>();
         try {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionDefinitionsControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionDefinitionsControllerIT.java
@@ -32,6 +32,11 @@ import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
  */
 public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegrationTest {
 
+    // The total number of expected submission definitions is referred to in multiple tests and assertions as
+    // is the last page (totalDefinitions - 1)
+    // This integer should be maintained along with any changes to item-submissions.xml
+    private static final int totalDefinitions = 9;
+
     @Test
     public void findAll() throws Exception {
         //When we call the root endpoint as anonymous user
@@ -243,110 +248,110 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
         getClient(tokenAdmin).perform(get("/api/config/submissiondefinitions")
                 .param("size", "1")
                 .param("page", "0"))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(contentType))
-                .andExpect(jsonPath("$._embedded.submissiondefinitions[0].id", is("traditional")))
-                .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
-                        Matchers.containsString("/api/config/submissiondefinitions?"),
-                        Matchers.containsString("page=0"), Matchers.containsString("size=1"))))
-                .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
-                        Matchers.containsString("/api/config/submissiondefinitions?"),
-                        Matchers.containsString("page=0"), Matchers.containsString("size=1"))))
-                .andExpect(jsonPath("$._links.next.href", Matchers.allOf(
-                        Matchers.containsString("/api/config/submissiondefinitions?"),
-                        Matchers.containsString("page=1"), Matchers.containsString("size=1"))))
-                .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
-                        Matchers.containsString("/api/config/submissiondefinitions?"),
-                        Matchers.containsString("page=6"), Matchers.containsString("size=1"))))
-                .andExpect(jsonPath("$.page.size", is(1)))
-                .andExpect(jsonPath("$.page.totalElements", is(7)))
-                .andExpect(jsonPath("$.page.totalPages", is(7)))
-                .andExpect(jsonPath("$.page.number", is(0)));
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._embedded.submissiondefinitions[0].id", is("traditional")))
+            .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=0"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=0"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.next.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=1"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=" + (totalDefinitions - 1)), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$.page.size", is(1)))
+            .andExpect(jsonPath("$.page.totalElements", is(totalDefinitions)))
+            .andExpect(jsonPath("$.page.totalPages", is(totalDefinitions)))
+            .andExpect(jsonPath("$.page.number", is(0)));
 
         getClient(tokenAdmin).perform(get("/api/config/submissiondefinitions")
                 .param("size", "1")
                 .param("page", "1"))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(contentType))
-                .andExpect(jsonPath("$._embedded.submissiondefinitions[0].id", is("test-hidden")))
-                .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
-                        Matchers.containsString("/api/config/submissiondefinitions?"),
-                        Matchers.containsString("page=0"), Matchers.containsString("size=1"))))
-                .andExpect(jsonPath("$._links.prev.href", Matchers.allOf(
-                        Matchers.containsString("/api/config/submissiondefinitions?"),
-                        Matchers.containsString("page=0"), Matchers.containsString("size=1"))))
-                .andExpect(jsonPath("$._links.next.href", Matchers.allOf(
-                        Matchers.containsString("/api/config/submissiondefinitions?"),
-                        Matchers.containsString("page=2"), Matchers.containsString("size=1"))))
-                .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
-                        Matchers.containsString("/api/config/submissiondefinitions?"),
-                        Matchers.containsString("page=1"), Matchers.containsString("size=1"))))
-                .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
-                        Matchers.containsString("/api/config/submissiondefinitions?"),
-                        Matchers.containsString("page="), Matchers.containsString("size=1"))))
-                .andExpect(jsonPath("$.page.size", is(1)))
-                .andExpect(jsonPath("$.page.totalElements", is(7)))
-                .andExpect(jsonPath("$.page.totalPages", is(7)))
-                .andExpect(jsonPath("$.page.number", is(1)));
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._embedded.submissiondefinitions[0].id", is("languagetestprocess")))
+            .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=0"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.prev.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=0"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.next.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=2"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=1"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=" + (totalDefinitions - 1)), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$.page.size", is(1)))
+            .andExpect(jsonPath("$.page.totalElements", is(totalDefinitions)))
+            .andExpect(jsonPath("$.page.totalPages", is(totalDefinitions)))
+            .andExpect(jsonPath("$.page.number", is(1)));
 
         getClient(tokenAdmin).perform(get("/api/config/submissiondefinitions")
                 .param("size", "1")
                 .param("page", "2"))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(contentType))
-                .andExpect(jsonPath("$._embedded.submissiondefinitions[0].id", is("accessConditionNotDiscoverable")))
-                .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
-                    Matchers.containsString("/api/config/submissiondefinitions?"),
-                    Matchers.containsString("page=0"), Matchers.containsString("size=1"))))
-                .andExpect(jsonPath("$._links.prev.href", Matchers.allOf(
-                    Matchers.containsString("/api/config/submissiondefinitions?"),
-                    Matchers.containsString("page=1"), Matchers.containsString("size=1"))))
-                .andExpect(jsonPath("$._links.next.href", Matchers.allOf(
-                    Matchers.containsString("/api/config/submissiondefinitions?"),
-                    Matchers.containsString("page=3"), Matchers.containsString("size=1"))))
-                .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
-                    Matchers.containsString("/api/config/submissiondefinitions?"),
-                    Matchers.containsString("page=2"), Matchers.containsString("size=1"))))
-                .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
-                    Matchers.containsString("/api/config/submissiondefinitions?"),
-                    Matchers.containsString("page=6"), Matchers.containsString("size=1"))))
-                .andExpect(jsonPath("$.page.size", is(1)))
-                .andExpect(jsonPath("$.page.totalElements", is(7)))
-                .andExpect(jsonPath("$.page.totalPages", is(7)))
-                .andExpect(jsonPath("$.page.number", is(2)));
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._embedded.submissiondefinitions[0].id", is("extractiontestprocess")))
+            .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=0"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.prev.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=1"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.next.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=3"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=2"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=" + (totalDefinitions - 1)), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$.page.size", is(1)))
+            .andExpect(jsonPath("$.page.totalElements", is(totalDefinitions)))
+            .andExpect(jsonPath("$.page.totalPages", is(totalDefinitions)))
+            .andExpect(jsonPath("$.page.number", is(2)));
 
         getClient(tokenAdmin).perform(get("/api/config/submissiondefinitions")
                 .param("size", "1")
                 .param("page", "3"))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(contentType))
-                .andExpect(jsonPath("$._embedded.submissiondefinitions[0].id", is("languagetestprocess")))
-                .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
-                    Matchers.containsString("/api/config/submissiondefinitions?"),
-                    Matchers.containsString("page=0"), Matchers.containsString("size=1"))))
-                .andExpect(jsonPath("$._links.prev.href", Matchers.allOf(
-                    Matchers.containsString("/api/config/submissiondefinitions?"),
-                    Matchers.containsString("page=2"), Matchers.containsString("size=1"))))
-                .andExpect(jsonPath("$._links.next.href", Matchers.allOf(
-                    Matchers.containsString("/api/config/submissiondefinitions?"),
-                    Matchers.containsString("page=4"), Matchers.containsString("size=1"))))
-                .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
-                    Matchers.containsString("/api/config/submissiondefinitions?"),
-                    Matchers.containsString("page=3"), Matchers.containsString("size=1"))))
-                .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
-                    Matchers.containsString("/api/config/submissiondefinitions?"),
-                    Matchers.containsString("page=6"), Matchers.containsString("size=1"))))
-                .andExpect(jsonPath("$.page.size", is(1)))
-                .andExpect(jsonPath("$.page.totalElements", is(7)))
-                .andExpect(jsonPath("$.page.totalPages", is(7)))
-                .andExpect(jsonPath("$.page.number", is(3)));
-
-        getClient(tokenAdmin).perform(get("/api/config/submissiondefinitions")
-            .param("size", "1")
-            .param("page", "4"))
             .andExpect(status().isOk())
             .andExpect(content().contentType(contentType))
             .andExpect(jsonPath("$._embedded.submissiondefinitions[0].id", is("qualdroptest")))
+            .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=0"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.prev.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=2"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.next.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=4"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=3"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=" + (totalDefinitions - 1)), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$.page.size", is(1)))
+            .andExpect(jsonPath("$.page.totalElements", is(totalDefinitions)))
+            .andExpect(jsonPath("$.page.totalPages", is(totalDefinitions)))
+            .andExpect(jsonPath("$.page.number", is(3)));
+
+        getClient(tokenAdmin).perform(get("/api/config/submissiondefinitions")
+                .param("size", "1")
+                .param("page", "4"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._embedded.submissiondefinitions[0].id", is("typebindtest")))
             .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
                 Matchers.containsString("/api/config/submissiondefinitions?"),
                 Matchers.containsString("page=0"), Matchers.containsString("size=1"))))
@@ -361,18 +366,18 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
                 Matchers.containsString("page=4"), Matchers.containsString("size=1"))))
             .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
                 Matchers.containsString("/api/config/submissiondefinitions?"),
-                Matchers.containsString("page=6"), Matchers.containsString("size=1"))))
+                Matchers.containsString("page=" + (totalDefinitions - 1)), Matchers.containsString("size=1"))))
             .andExpect(jsonPath("$.page.size", is(1)))
-            .andExpect(jsonPath("$.page.totalElements", is(7)))
-            .andExpect(jsonPath("$.page.totalPages", is(7)))
+            .andExpect(jsonPath("$.page.totalElements", is(totalDefinitions)))
+            .andExpect(jsonPath("$.page.totalPages", is(totalDefinitions)))
             .andExpect(jsonPath("$.page.number", is(4)));
 
         getClient(tokenAdmin).perform(get("/api/config/submissiondefinitions")
-            .param("size", "1")
-            .param("page", "5"))
+                .param("size", "1")
+                .param("page", "5"))
             .andExpect(status().isOk())
             .andExpect(content().contentType(contentType))
-            .andExpect(jsonPath("$._embedded.submissiondefinitions[0].id", is("extractiontestprocess")))
+            .andExpect(jsonPath("$._embedded.submissiondefinitions[0].id", is("accessConditionNotDiscoverable")))
             .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
                 Matchers.containsString("/api/config/submissiondefinitions?"),
                 Matchers.containsString("page=0"), Matchers.containsString("size=1"))))
@@ -387,11 +392,113 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
                 Matchers.containsString("page=5"), Matchers.containsString("size=1"))))
             .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
                 Matchers.containsString("/api/config/submissiondefinitions?"),
-                Matchers.containsString("page=6"), Matchers.containsString("size=1"))))
+                Matchers.containsString("page=" + (totalDefinitions - 1)), Matchers.containsString("size=1"))))
             .andExpect(jsonPath("$.page.size", is(1)))
-            .andExpect(jsonPath("$.page.totalElements", is(7)))
-            .andExpect(jsonPath("$.page.totalPages", is(7)))
+            .andExpect(jsonPath("$.page.totalElements", is(totalDefinitions)))
+            .andExpect(jsonPath("$.page.totalPages", is(totalDefinitions)))
             .andExpect(jsonPath("$.page.number", is(5)));
+
+        getClient(tokenAdmin).perform(get("/api/config/submissiondefinitions")
+                .param("size", "1")
+                .param("page", "5"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._embedded.submissiondefinitions[0].id", is("accessConditionNotDiscoverable")))
+            .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=0"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.prev.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=4"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.next.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=6"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=5"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=" + (totalDefinitions - 1)), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$.page.size", is(1)))
+            .andExpect(jsonPath("$.page.totalElements", is(totalDefinitions)))
+            .andExpect(jsonPath("$.page.totalPages", is(totalDefinitions)))
+            .andExpect(jsonPath("$.page.number", is(5)));
+
+        getClient(tokenAdmin).perform(get("/api/config/submissiondefinitions")
+                .param("size", "1")
+                .param("page", "6"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._embedded.submissiondefinitions[0].id", is("test-hidden")))
+            .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=0"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.prev.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=5"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.next.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=7"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=6"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=" + (totalDefinitions - 1)), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$.page.size", is(1)))
+            .andExpect(jsonPath("$.page.totalElements", is(totalDefinitions)))
+            .andExpect(jsonPath("$.page.totalPages", is(totalDefinitions)))
+            .andExpect(jsonPath("$.page.number", is(6)));
+
+        getClient(tokenAdmin).perform(get("/api/config/submissiondefinitions")
+                .param("size", "1")
+                .param("page", "7"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._embedded.submissiondefinitions[0].id", is("collectiontest")))
+            .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=0"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.prev.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=6"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.next.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=8"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=7"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=" + (totalDefinitions - 1)), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$.page.size", is(1)))
+            .andExpect(jsonPath("$.page.totalElements", is(totalDefinitions)))
+            .andExpect(jsonPath("$.page.totalPages", is(totalDefinitions)))
+            .andExpect(jsonPath("$.page.number", is(7)));
+
+        getClient(tokenAdmin).perform(get("/api/config/submissiondefinitions")
+                .param("size", "1")
+                .param("page", "8"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._embedded.submissiondefinitions[0].id", is("entitytypetest")))
+            .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=0"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.prev.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=7"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=8"), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissiondefinitions?"),
+                Matchers.containsString("page=" + (totalDefinitions - 1)), Matchers.containsString("size=1"))))
+            .andExpect(jsonPath("$.page.size", is(1)))
+            .andExpect(jsonPath("$.page.totalElements", is(totalDefinitions)))
+            .andExpect(jsonPath("$.page.totalPages", is(totalDefinitions)))
+            .andExpect(jsonPath("$.page.number", is(8)));
+
     }
 
 }

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -780,7 +780,7 @@ event.dispatcher.default.class = org.dspace.event.BasicDispatcher
 # Add rdf here, if you are using dspace-rdf to export your repository content as RDF.
 # Add iiif here, if you are using dspace-iiif.
 # Add orcidqueue here, if the integration with ORCID is configured and wish to enable the synchronization queue functionality
-event.dispatcher.default.consumers = versioning, discovery, eperson, submissionconfig
+event.dispatcher.default.consumers = versioning, discovery, eperson
 
 # The noindex dispatcher will not create search or browse indexes (useful for batch item imports)
 event.dispatcher.noindex.class = org.dspace.event.BasicDispatcher

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -823,6 +823,11 @@ event.consumer.orcidqueue.class = org.dspace.orcid.consumer.OrcidQueueConsumer
 event.consumer.orcidqueue.filters = Item+Install|Modify|Modify_Metadata|Delete|Remove
 
 # item submission config reload consumer
+# This consumer can be useful for reloading changes made in the item-submission.xml config file,
+# without restarting Tomcat, primarily for adding new collection mappings.
+# With this consumer, configuration reloading is triggered after a collection is updated.
+# It is disabled by default. To enable it, add 'submissionconfig' to the list of
+# activated consumers (event.dispatcher.default.consumers).
 event.consumer.submissionconfig.class = org.dspace.submit.consumer.SubmissionConfigConsumer
 event.consumer.submissionconfig.filters = Collection+Modify_Metadata
 


### PR DESCRIPTION
Manual port to `dspace-7_x` of #9478 with some changes of #9259 (to use a collection object instead of a handle to return the form configured in `DCInputReader.getInputsByCollection`)