### PR TITLE
Improvements customisation submission sections

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/DCInputsReader.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/DCInputsReader.java
@@ -166,7 +166,7 @@ public class DCInputsReader {
             List<DCInputSet> results = new ArrayList<DCInputSet>();
             for (int idx = 0; idx < config.getNumberOfSteps(); idx++) {
                 SubmissionStepConfig step = config.getStep(idx);
-                if (SubmissionStepConfig.INPUT_FORM_STEP_NAME.equals(step.getType())) {
+                if (step.supportsType(SubmissionStepConfig.INPUT_FORM_STEP_NAME)) {
                     results.add(getInputsByFormName(step.getId()));
                 }
             }
@@ -188,7 +188,7 @@ public class DCInputsReader {
             List<DCInputSet> results = new ArrayList<DCInputSet>();
             for (int idx = 0; idx < config.getNumberOfSteps(); idx++) {
                 SubmissionStepConfig step = config.getStep(idx);
-                if (SubmissionStepConfig.INPUT_FORM_STEP_NAME.equals(step.getType())) {
+                if (step.supportsType(SubmissionStepConfig.INPUT_FORM_STEP_NAME)) {
                     results.add(getInputsByFormName(step.getId()));
                 }
             }

--- a/dspace-api/src/main/java/org/dspace/app/util/SubmissionStepConfig.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/SubmissionStepConfig.java
@@ -11,6 +11,7 @@ import java.io.Serializable;
 import java.util.Map;
 
 import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.dspace.content.InProgressSubmission;
 import org.dspace.content.WorkspaceItem;
 import org.hibernate.proxy.HibernateProxyHelper;
@@ -68,6 +69,7 @@ public class SubmissionStepConfig implements Serializable {
      **/
     private String type = null;
 
+    private String extendsType = null;
 
     /**
      * The scope restriction for this step (submission or workflow).
@@ -112,6 +114,7 @@ public class SubmissionStepConfig implements Serializable {
         heading = stepMap.get("heading");
         processingClassName = stepMap.get("processing-class");
         type = stepMap.get("type");
+        extendsType = stepMap.get("type.extends");
         scope = stepMap.get("scope");
         visibility = stepMap.get("scope.visibility");
         visibilityOutside = stepMap.get("scope.visibilityOutside");
@@ -159,6 +162,10 @@ public class SubmissionStepConfig implements Serializable {
      */
     public String getType() {
         return type;
+    }
+
+    public String getExtendsType() {
+        return extendsType;
     }
 
     /**
@@ -242,5 +249,15 @@ public class SubmissionStepConfig implements Serializable {
 
     public boolean isMandatory() {
         return mandatory;
+    }
+
+    /**
+     * Check if this step supports the given type
+     *
+     * @param type  Type of step to check support for
+     * @return true if the type matches either this step's type, or the step it extends from
+     */
+    public boolean supportsType(String type) {
+        return StringUtils.equals(this.type, type) || StringUtils.equals(this.extendsType, type);
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionSectionConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionSectionConverter.java
@@ -37,6 +37,7 @@ public class SubmissionSectionConverter implements DSpaceConverter<SubmissionSte
         sp.setMandatory(step.isMandatory());
         sp.setHeader(step.getHeading());
         sp.setSectionType(step.getType());
+        sp.setExtendsSectionType(step.getExtendsType());
         sp.setId(step.getId());
         sp.setVisibility(new SubmissionVisibilityRest(VisibilityEnum.fromString(step.getVisibility()),
                                                       VisibilityEnum.fromString(step.getVisibilityOutside())));

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/SubmissionSectionRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/SubmissionSectionRest.java
@@ -10,6 +10,7 @@ package org.dspace.app.rest.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import org.apache.commons.lang3.StringUtils;
 import org.dspace.app.rest.RestResourceController;
 
 /**
@@ -28,6 +29,7 @@ public class SubmissionSectionRest extends BaseObjectRest<String> {
     private String header;
     private boolean mandatory;
     private String sectionType;
+    private String extendsSectionType;
     private ScopeEnum scope;
     private SubmissionVisibilityRest visibility;
 
@@ -87,4 +89,21 @@ public class SubmissionSectionRest extends BaseObjectRest<String> {
         this.sectionType = panelType;
     }
 
+    public String getExtendsSectionType() {
+        return extendsSectionType;
+    }
+
+    public void setExtendsSectionType(String extendsSectionType) {
+        this.extendsSectionType = extendsSectionType;
+    }
+
+    /**
+     * Check if this step supports the given type
+     *
+     * @param type  Type of step to check support for
+     * @return true if the type matches either this step's type, or the step it extends from
+     */
+    public boolean supportsType(String type) {
+        return StringUtils.equals(this.sectionType, type) || StringUtils.equals(this.extendsSectionType, type);
+    }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/DataProcessingStep.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/DataProcessingStep.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.dspace.app.rest.model.ErrorRest;
 import org.dspace.app.rest.model.patch.Operation;
 import org.dspace.app.rest.submit.step.validation.Validation;
@@ -61,7 +62,8 @@ public interface DataProcessingStep extends RestProcessingStep {
 
     /**
      * The method will expose the list of validation errors identified by the step. The default implementation will
-     * found a {@link Validation} spring bean in the context with the same name that the step id
+     * find a {@link Validation} spring bean in the context with the same name that the step id
+     * If no bean is found with the exact step id, it will look for beans matching the extended step id
      * 
      * @param submissionService
      * @param obj
@@ -76,8 +78,21 @@ public interface DataProcessingStep extends RestProcessingStep {
         List<Validation> validations = DSpaceServicesFactory.getInstance().getServiceManager()
                 .getServicesByType(Validation.class);
         if (validations != null) {
+            List<Validation> directValidations = new ArrayList<>();
+            List<Validation> extendedValidations = new ArrayList<>();
             for (Validation validation : validations) {
                 if (validation.getName().equals(config.getType())) {
+                    directValidations.add(validation);
+                } else if (validation.getName().equals(config.getExtendsType())) {
+                    extendedValidations.add(validation);
+                }
+            }
+            if (CollectionUtils.isNotEmpty(directValidations)) {
+                for (Validation validation : directValidations) {
+                    errors.addAll(validation.validate(submissionService, obj, config));
+                }
+            } else {
+                for (Validation validation : extendedValidations) {
                     errors.addAll(validation.validate(submissionService, obj, config));
                 }
             }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/validation/UploadValidation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/validation/UploadValidation.java
@@ -43,10 +43,14 @@ public class UploadValidation extends AbstractValidation {
         //TODO MANAGE METADATA
         List<ErrorRest> errors = new ArrayList<>();
         UploadConfiguration uploadConfig = uploadConfigurationService.getMap().get(config.getId());
-        if (uploadConfig.isRequired() && !itemService.hasUploadedFiles(obj.getItem())) {
-            addError(errors, ERROR_VALIDATION_FILEREQUIRED,
-                     "/" + WorkspaceItemRestRepository.OPERATION_PATH_SECTIONS + "/"
-                         + config.getId());
+        if (uploadConfig != null) {
+            if (uploadConfig.isRequired() && !itemService.hasUploadedFiles(obj.getItem())) {
+                addError(errors, ERROR_VALIDATION_FILEREQUIRED,
+                        "/" + WorkspaceItemRestRepository.OPERATION_PATH_SECTIONS + "/"
+                                + config.getId());
+            }
+        } else {
+            log.warn("No UploadConfiguration configured for submission step ID " + config.getId());
         }
         return errors;
     }

--- a/dspace/config/item-submission.dtd
+++ b/dspace/config/item-submission.dtd
@@ -27,6 +27,8 @@
  <!ELEMENT heading (#PCDATA) >
  <!ELEMENT processing-class (#PCDATA)>
  <!ELEMENT type (#PCDATA)>
+ <!ATTLIST type
+		   extends NMTOKEN #IMPLIED>
  <!ELEMENT scope (#PCDATA)>
  <!ATTLIST scope 
  		   visibility NMTOKEN #IMPLIED 


### PR DESCRIPTION
## References
* FIxes #9486 
* Angular PR [#2971](https://github.com/DSpace/dspace-angular/pull/2971)

## Description
This PR aims to add better customisability of additional submission steps, mainly adding steps that should inherit functionality from other existing steps.

## Instructions for Reviewers
We've added an attribute to the `type` tag of submission-steps in `item-submission.xml`. This tag is labeled "extends" and can contain a string value that refers to the existing type of a step the new step should inherit from.

From here-on out, it's up to the developer to decide which parts need extending or overwriting, but this approach avoids having to re-write entire sections when most of the functionality is the same as another existing step.

### Details on how to add and customise a step

On the REST side:
- Add a step-definition in `item-submission.xml` with `extends` attribute on `type` referring to an existing step to re-use functionality. e.g. `<type extends="upload">custom-upload</type>`
- Create a processing class for this step and configure it in the same step-definition. e.g. `<processing-class>org.dspace.app.rest.submit.step.CustomUploadStep</processing-class>`
- If extending from upload step: Add an entry to the map in `uploadConfigurationService` bean in `access-conditions.xml` with the key matching the ID of your new step. The value can refer to the `uploadConfigurationDefault` or a new one if desired. e.g. `<entry key="custom-upload" value-ref="uploadConfigurationDefault" />`
- Optionally, if custom validation is required, create a new class extending from `AbstractValidation` (or the validation of the step you're extending) and configure it as a bean in `spring-dspace-addon-validation-services.xml`. The name has to match your type. If no validation bean is configured for your step, but one exists for the step you're extending from, that one will be used instead.

On the Angular side:
- Add a new property to the `SectionsType` enum matching your custom step type
- Create a new component extending from `SectionModelComponent` and annotate it with `@renderSectionFor(SectionsType.{your-custom-step-type})`

#### Example

To make testing easier, I've created a separate branch starting from my PR, containing some custom code for a _very_ basic example of a custom upload step that inherits all of the functionality of the existing upload step, to give you an idea on how and where everything's configured. Also added several comments explaining into more detail, in case something isn't clear yet.

* Angular example branch [here](https://github.com/atmire/dspace-angular/commits/w2p-113996_Improvements-submission-sections-example-main)
* REST example branch [here](https://github.com/atmire/DSpace/commits/w2p-113996_Improvements-submission-sections-example-main)

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
