### PR TITLE
Fixes to Docker scripts for DSpace 8

### DIFF
--- a/dspace/src/main/docker-compose/README.md
+++ b/dspace/src/main/docker-compose/README.md
@@ -33,7 +33,7 @@ Documentation for all Dockerfiles used by these compose scripts can be found in 
   - Docker compose file that will download and install a default assetstore.
   - The default assetstore is the configurable entities test dataset. Useful for [testing/demos of Entities](#Ingest Option 2 Ingest Entities Test Data).
 - cli.ingest.yml
-  - Docker compose file that will run an AIP ingest into DSpace 7. Useful for testing/demos with basic Items.
+  - Docker compose file that will run an AIP ingest into DSpace. Useful for testing/demos with basic Items.
 - db.entities.yml
   - Docker compose file that pre-populate a database instance using a downloaded SQL dump.
   - The default dataset is the configurable entities test dataset. Useful for [testing/demos of Entities](#Ingest Option 2 Ingest Entities Test Data).
@@ -68,15 +68,15 @@ docker-compose -f docker-compose.yml -f docker-compose-cli.yml build --build-arg
 ```
 Default is Java 11, but other LTS releases (e.g. 17) are also supported.
 
-## Run DSpace 7 REST from your current branch
+## Run DSpace 8 REST from your current branch
 ```
-docker-compose -p d7 up -d
+docker-compose -p d8 up -d
 ```
 
-## Run DSpace 7 REST and Angular from your branch
+## Run DSpace 8 REST and Angular from your branch
 
 ```
-docker-compose -p d7 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-angular.yml up -d
+docker-compose -p d8 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-angular.yml up -d
 ```
 NOTE: This starts the UI in development mode. It will take a few minutes to see the UI as the Angular code needs to be compiled.
 
@@ -86,7 +86,7 @@ NOTE: This starts the UI in development mode. It will take a few minutes to see 
 
 See documentation in [DSpace User Interface Docker instructions](https://github.com/DSpace/dspace-angular/blob/main/docker/README.md#run-dspace-rest-and-dspace-angular-from-local-branches).
 
-## Run DSpace 7 REST with a IIIF Image Server from your branch
+## Run DSpace 8 REST with a IIIF Image Server from your branch
 *Only useful for testing IIIF support in a development environment*
 
 This command starts our `dspace-iiif` container alongside the REST API.
@@ -94,10 +94,10 @@ That container provides a [Cantaloupe image server](https://cantaloupe-project.g
 which can be used when IIIF support is enabled in DSpace (`iiif.enabled=true`).
 
 ```
-docker-compose -p d7 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-iiif.yml up -d
+docker-compose -p d8 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-iiif.yml up -d
 ```
 
-## Run DSpace 7 REST and Shibboleth SP (in Apache) from your branch
+## Run DSpace 8 REST and Shibboleth SP (in Apache) from your branch
 *Only useful for testing Shibboleth in a development environment*
 
 This Shibboleth container uses https://samltest.id/ as an IdP (see `../docker/dspace-shibboleth/`).
@@ -132,17 +132,17 @@ The remainder of these instructions assume you are using ngrok (though other pro
 3. Build the Shibboleth container (if you haven't built or pulled it before):
    ```
    cd [dspace-src]
-   docker-compose -p d7 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-shibboleth.yml build
+   docker-compose -p d8 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-shibboleth.yml build
    ```
 
 4. Start all containers, passing your public hostname as the `DSPACE_HOSTNAME` environment variable:
    ```
-   DSPACE_HOSTNAME=[subdomain].ngrok.io docker-compose -p d7 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-shibboleth.yml up -d
+   DSPACE_HOSTNAME=[subdomain].ngrok.io docker-compose -p d8 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-shibboleth.yml up -d
    ```
    NOTE: For Windows you MUST either set the environment variable separately, or use the 'env' command provided with Git/Cygwin
    (you may already have this command if you are running Git for Windows). See https://superuser.com/a/1079563
    ```
-   env DSPACE_HOSTNAME=[subdomain].ngrok.io docker-compose -p d7 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-shibboleth.yml up -d
+   env DSPACE_HOSTNAME=[subdomain].ngrok.io docker-compose -p d8 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-shibboleth.yml up -d
    ```
 
 5. Finally, for https://samltest.id/, you need to upload your Shibboleth Metadata for the site to "trust" you.
@@ -170,7 +170,7 @@ The remainder of these instructions assume you are using ngrok (though other pro
         ```
       * Spin up the `dspace-angular` container alongside the others, e.g.
         ```
-        DSPACE_HOSTNAME=[subdomain].ngrok.io docker-compose -p d7 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-angular.yml -f dspace/src/main/docker-compose/docker-compose-shibboleth.yml up -d
+        DSPACE_HOSTNAME=[subdomain].ngrok.io docker-compose -p d8 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-angular.yml -f dspace/src/main/docker-compose/docker-compose-shibboleth.yml up -d
         ```
 
 ## Sample Test Data
@@ -180,17 +180,17 @@ The remainder of these instructions assume you are using ngrok (though other pro
 *Allows you to ingest a set of AIPs into your DSpace instance for testing/demo purposes.* These AIPs represent basic Communities, Collections and Items.
 
 Prerequisites
-- Start DSpace 7 using one of the options listed above
+- Start DSpace using one of the options listed above
 - Build the DSpace CLI image if needed.  See the instructions above.
 
 Create an admin account.  By default, the dspace-cli container runs the dspace command.
 ```
-docker-compose -p d7 -f docker-compose-cli.yml run --rm dspace-cli create-administrator -e test@test.edu -f admin -l user -p admin -c en
+docker-compose -p d8 -f docker-compose-cli.yml run --rm dspace-cli create-administrator -e test@test.edu -f admin -l user -p admin -c en
 ```
 
 Download a Zip file of AIP content and ingest test data
 ```
-docker-compose -p d7 -f docker-compose-cli.yml -f dspace/src/main/docker-compose/cli.ingest.yml run --rm dspace-cli
+docker-compose -p d8 -f docker-compose-cli.yml -f dspace/src/main/docker-compose/cli.ingest.yml run --rm dspace-cli
 ```
 
 ### Ingest Entities Test Data
@@ -198,18 +198,18 @@ docker-compose -p d7 -f docker-compose-cli.yml -f dspace/src/main/docker-compose
 *Allows you to load Configurable Entities test data for testing/demo purposes.*
 
 Prerequisites
-- Start DSpace 7 using one of the options listed above
+- Start DSpace using one of the options listed above
 - Build the DSpace CLI image if needed.  See the instructions above.
-- _Remove your d7 volumes if you already ingested content into your docker volumes_
+- _Remove your volumes if you already ingested content into your docker volumes_
 
 Start DSpace REST with a postgres database dump downloaded from the internet.
 ```
-docker-compose -p d7 -f docker-compose.yml -f dspace/src/main/docker-compose/db.entities.yml up -d
+docker-compose -p d8 -f docker-compose.yml -f dspace/src/main/docker-compose/db.entities.yml up -d
 ```
 
 Download an assetstore from a tar file on the internet.
 ```
-docker-compose -p d7 -f docker-compose-cli.yml -f dspace/src/main/docker-compose/cli.assetstore.yml run dspace-cli
+docker-compose -p d8 -f docker-compose-cli.yml -f dspace/src/main/docker-compose/cli.assetstore.yml run dspace-cli
 ```
 
 ## Modify DSpace Configuration in Docker
@@ -223,20 +223,20 @@ Many DSpace configuration settings will reload automatically (after a few second
 While the Docker containers are running, you can use the DSpace CLI image to run any DSpace commandline script (i.e. any command that normally can be run by `[dspace]/bin/dspace`).  The general format is:
 
 ```
-docker-compose -p d7 -f docker-compose-cli.yml run --rm dspace-cli [command] [parameters]
+docker-compose -p d8 -f docker-compose-cli.yml run --rm dspace-cli [command] [parameters]
 ```
 
 So, for example, to reindex all content in Discovery, normally you'd run `./dspace index-discovery -b` from commandline.  Using our DSpace CLI image, that command becomes:
 
 ```
-docker-compose -p d7 -f docker-compose-cli.yml run --rm dspace-cli index-discovery -b
+docker-compose -p d8 -f docker-compose-cli.yml run --rm dspace-cli index-discovery -b
 ```
 
 Similarly, you can see the value of any DSpace configuration (in local.cfg or dspace.cfg) by running:
 
 ```
 # Output the value of `dspace.ui.url` from running Docker instance
-docker-compose -p d7 -f docker-compose-cli.yml run --rm dspace-cli dsprop -p dspace.ui.url
+docker-compose -p d8 -f docker-compose-cli.yml run --rm dspace-cli dsprop -p dspace.ui.url
 ```
 
 NOTE: It is also possible to run CLI scripts directly on the "dspace" container (where the backend runs)
@@ -245,7 +245,7 @@ This can be useful if you want to pass environment variables which override DSpa
 # Run the "./dspace database clean" command from the "dspace" container
 # Before doing so, it sets "db.cleanDisabled=false".
 # WARNING: This will delete all your data. It's just an example of how to do so.
-docker-compose -p d7 exec -e "db__P__cleanDisabled=false" dspace /dspace/bin/dspace database clean
+docker-compose -p d8 exec -e "db__P__cleanDisabled=false" dspace /dspace/bin/dspace database clean
 ```
 
 ## Upgrading PostgreSQL in Docker
@@ -263,7 +263,7 @@ Here's how to fix those issues by migrating your old Postgres data to the new ve
 1. First, you must start up the older PostgreSQL image (to dump your existing data to a `*.sql` file)
     ```
     # This command assumes you are using the process described above to start all your containers
-    docker-compose -p d7 up -d
+    docker-compose -p d8 up -d
     ```
     * If you've already accidentally updated to the new PostgreSQL image, you have a few options:
         * Pull down an older version of the image from Dockerhub (using a tag)
@@ -272,7 +272,7 @@ Here's how to fix those issues by migrating your old Postgres data to the new ve
           # This command will rebuild using PostgreSQL v11 & tag it locally as "latest"
           docker build --build-arg POSTGRES_VERSION=11 -t dspace/dspace-postgres-pgcrypto:latest ./dspace/src/main/docker/dspace-postgres-pgcrypto/
           # Then restart container with that image
-          docker-compose -p d7 up -d
+          docker-compose -p d8 up -d
           ```
 2. Dump your entire "dspace" database out of the old "dspacedb" container to a local file named `pgdump.sql`
     ```
@@ -295,12 +295,12 @@ Here's how to fix those issues by migrating your old Postgres data to the new ve
 3. Now, stop all existing containers. This shuts down the old version of PostgreSQL
     ```
     # This command assumes you are using the process described above to start/stop all your containers
-    docker-compose -p d7 down
+    docker-compose -p d8 down
     ```
 4. Delete the `pgdata` volume. WARNING: This deletes all your old PostgreSQL data. Make sure you have that `pgdump.sql` file FIRST!
     ```
-    # Assumes you are using `-p d7` which prefixes all volumes with `d7_`
-    docker volume rm d7_pgdata
+    # Assumes you are using `-p d8` which prefixes all volumes with `d8_`
+    docker volume rm d8_pgdata
     ```
 5. Now, pull down the latest PostgreSQL image with the NEW version of PostgreSQL.
     ```
@@ -311,12 +311,12 @@ using the local `./pgdump.sql` file. IMPORTANT: If you renamed that "pgdump.sql"
 then you MUST change the name/directory in the `db.restore.yml` script.
     ```
     # Restore database from "./pgdump.sql" (this path is hardcoded in db.restore.yml)
-    docker-compose -p d7 -f docker-compose.yml -f dspace/src/main/docker-compose/db.restore.yml up -d
+    docker-compose -p d8 -f docker-compose.yml -f dspace/src/main/docker-compose/db.restore.yml up -d
     ```
 7. Finally, reindex all database contents into Solr (just to be sure Solr indexes are current).
     ```
     # Run "./dspace index-discovery -b" using our CLI image
-    docker-compose -p d7 -f docker-compose-cli.yml run --rm dspace-cli index-discovery -b
+    docker-compose -p d8 -f docker-compose-cli.yml run --rm dspace-cli index-discovery -b
     ```
 At this point in time, all your old database data should be migrated to the new Postgres
 and running at http://localhost:8080/server/

--- a/dspace/src/main/docker-compose/db.entities.yml
+++ b/dspace/src/main/docker-compose/db.entities.yml
@@ -18,27 +18,12 @@ services:
     ### OVERRIDE default 'entrypoint' in 'docker-compose.yml ####
     # Ensure that the database is ready BEFORE starting tomcat
     # 1. While a TCP connection to dspacedb port 5432 is not available, continue to sleep
-    # 2. Then, run database migration to init database tables
-    # 3. (Custom for Entities) enable Entity-specific collection submission mappings in item-submission.xml
-    #    This 'sed' command inserts the sample configurations specific to the Entities data set, see:
-    #    https://github.com/DSpace/DSpace/blob/main/dspace/config/item-submission.xml#L36-L49
-    # 4. Finally, start Tomcat
+    # 2. Then, run migration latest version of database tables (run with "ignored" in case this SQL data is outdated)
+    # 3. Finally, start Tomcat
     entrypoint:
       - /bin/bash
       - '-c'
       - |
         while (!</dev/tcp/dspacedb/5432) > /dev/null 2>&1; do sleep 1; done;
-        /dspace/bin/dspace database migrate
-        sed -i '/name-map collection-handle="default".*/a \\n <name-map collection-handle="123456789/3" submission-name="Publication"/> \
-          <name-map collection-handle="123456789/4" submission-name="Publication"/> \
-          <name-map collection-handle="123456789/281" submission-name="Publication"/> \
-          <name-map collection-handle="123456789/5" submission-name="Publication"/> \
-          <name-map collection-handle="123456789/8" submission-name="OrgUnit"/> \
-          <name-map collection-handle="123456789/6" submission-name="Person"/> \
-          <name-map collection-handle="123456789/279" submission-name="Person"/> \
-          <name-map collection-handle="123456789/7" submission-name="Project"/> \
-          <name-map collection-handle="123456789/280" submission-name="Project"/> \
-          <name-map collection-handle="123456789/28" submission-name="Journal"/> \
-          <name-map collection-handle="123456789/29" submission-name="JournalVolume"/> \
-          <name-map collection-handle="123456789/30" submission-name="JournalIssue"/>' /dspace/config/item-submission.xml
+        /dspace/bin/dspace database migrate ignored
         catalina.sh run

--- a/dspace/src/main/docker/README.md
+++ b/dspace/src/main/docker/README.md
@@ -21,8 +21,6 @@ docker build -t dspace/dspace-dependencies:latest -f Dockerfile.dependencies .
 
 This image is built *automatically* after each commit is made to the `main` branch.
 
-A corresponding image exists for DSpace 4-6.
-
 Admins to our DockerHub repo can manually publish with the following command.
 ```
 docker push dspace/dspace-dependencies:latest
@@ -30,9 +28,9 @@ docker push dspace/dspace-dependencies:latest
 
 ## Dockerfile.test (in root folder)
 
-This Dockerfile builds a DSpace 7 backend image (for testing/development).
+This Dockerfile builds a DSpace REST API backend image (for testing/development).
 This image deploys one webapp to Tomcat running in Docker:
-1. The DSpace 7 REST API (at `http://localhost:8080/server`)
+1. The DSpace REST API (at `http://localhost:8080/server`)
 This image also sets up debugging in Tomcat for development.
 
 ```
@@ -41,8 +39,6 @@ docker build -t dspace/dspace:latest-test -f Dockerfile.test .
 
 This image is built *automatically* after each commit is made to the `main` branch.
 
-A corresponding image exists for DSpace 4-6.
-
 Admins to our DockerHub repo can manually publish with the following command.
 ```
 docker push dspace/dspace:latest-test
@@ -50,17 +46,15 @@ docker push dspace/dspace:latest-test
 
 ## Dockerfile (in root folder)
 
-This Dockerfile builds a DSpace 7 backend image.
+This Dockerfile builds a DSpace REST API backend image.
 This image deploys one DSpace webapp to Tomcat running in Docker:
-1. The DSpace 7 REST API (at `http://localhost:8080/server`)
+1. The DSpace REST API (at `http://localhost:8080/server`)
 
 ```
 docker build -t dspace/dspace:latest -f Dockerfile .
 ```
 
 This image is built *automatically* after each commit is made to the `main` branch.
-
-A corresponding image exists for DSpace 4-6.
 
 Admins to our DockerHub repo can publish with the following command.
 ```
@@ -69,14 +63,12 @@ docker push dspace/dspace:latest
 
 ## Dockerfile.cli (in root folder)
 
-This Dockerfile builds a DSpace 7 CLI (command line interface) image, which can be used to run DSpace's commandline tools via Docker.
+This Dockerfile builds a DSpace CLI (command line interface) image, which can be used to run DSpace's commandline tools via Docker.
 ```
 docker build -t dspace/dspace-cli:latest -f Dockerfile.cli .
 ```
 
 This image is built *automatically* after each commit is made to the `main` branch.
-
-A corresponding image exists for DSpace 6.
 
 Admins to our DockerHub repo can publish with the following command.
 ```
@@ -100,8 +92,6 @@ cd dspace/src/main/docker/dspace-postgres-pgcrypto
 docker build -t dspace/dspace-postgres-pgcrypto:latest --build-arg POSTGRES_VERSION=11 --build-arg POSTGRES_PASSWORD=mypass .
 ```
 
-A copy of this file exists in the DSpace 6 branch.  A specialized version of this file exists for DSpace 4 in DSpace-Docker-Images.
-
 Admins to our DockerHub repo can (manually) publish with the following command.
 ```
 docker push dspace/dspace-postgres-pgcrypto:latest
@@ -122,8 +112,6 @@ docker build -t dspace/dspace-postgres-pgcrypto:latest-loadsql .
 
 Similar to `dspace-postgres-pgcrypto` above, you can also modify the version of PostgreSQL or the PostgreSQL user's password.
 See examples above.
-
-A copy of this file exists in the DSpace 6 branch.
 
 Admins to our DockerHub repo can (manually) publish with the following command.
 ```
@@ -158,14 +146,14 @@ documentation. Or, to just build and/or run Solr:
 
 ```bash
 docker-compose build dspacesolr
-docker-compose -p d7 up -d dspacesolr
+docker-compose -p d8 up -d dspacesolr
 ```
 
 If you're making iterative changes to the DSpace Solr configsets you'll need to rebuild /
 restart the `dspacesolr` container for the changes to be deployed. From DSpace root:
 
 ```bash
-docker-compose -p d7 up --detach --build dspacesolr
+docker-compose -p d8 up --detach --build dspacesolr
 ```
 
 ## ./test/ folder

--- a/dspace/src/main/docker/dspace-postgres-pgcrypto-curl/Dockerfile
+++ b/dspace/src/main/docker/dspace-postgres-pgcrypto-curl/Dockerfile
@@ -10,7 +10,7 @@
 # docker build --build-arg POSTGRES_VERSION=13 --build-arg POSTGRES_PASSWORD=mypass ./dspace/src/main/docker/dspace-postgres-pgcrypto-curl/
 # This will be published as dspace/dspace-postgres-pgcrypto:$DSPACE_VERSION-loadsql
 
-ARG POSTGRES_VERSION=13
+ARG POSTGRES_VERSION=15
 ARG POSTGRES_PASSWORD=dspace
 
 FROM postgres:${POSTGRES_VERSION}

--- a/dspace/src/main/docker/dspace-postgres-pgcrypto-curl/install-pgcrypto.sh
+++ b/dspace/src/main/docker/dspace-postgres-pgcrypto-curl/install-pgcrypto.sh
@@ -40,9 +40,9 @@ fi
 # Then, setup pgcrypto on this database
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
   -- Create a new schema in this database named "extensions" (or whatever you want to name it)
-  CREATE SCHEMA extensions;
+  CREATE SCHEMA IF NOT EXISTS extensions;
   -- Enable this extension in this new schema
-  CREATE EXTENSION pgcrypto SCHEMA extensions;
+  CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA extensions;
   -- Update your database's "search_path" to also search the new "extensions" schema.
   -- You are just appending it on the end of the existing comma-separated list.
   ALTER DATABASE dspace SET search_path TO "\$user",public,extensions;

--- a/dspace/src/main/docker/dspace-postgres-pgcrypto/Dockerfile
+++ b/dspace/src/main/docker/dspace-postgres-pgcrypto/Dockerfile
@@ -10,7 +10,7 @@
 # docker build --build-arg POSTGRES_VERSION=13 --build-arg POSTGRES_PASSWORD=mypass ./dspace/src/main/docker/dspace-postgres-pgcrypto/
 # This will be published as dspace/dspace-postgres-pgcrypto:$DSPACE_VERSION
 
-ARG POSTGRES_VERSION=13
+ARG POSTGRES_VERSION=15
 ARG POSTGRES_PASSWORD=dspace
 
 FROM postgres:${POSTGRES_VERSION}

--- a/dspace/src/main/docker/dspace-postgres-pgcrypto/install-pgcrypto.sh
+++ b/dspace/src/main/docker/dspace-postgres-pgcrypto/install-pgcrypto.sh
@@ -11,9 +11,9 @@ set -e
 
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
   -- Create a new schema in this database named "extensions" (or whatever you want to name it)
-  CREATE SCHEMA extensions;
+  CREATE SCHEMA IF NOT EXISTS extensions;
   -- Enable this extension in this new schema
-  CREATE EXTENSION pgcrypto SCHEMA extensions;
+  CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA extensions;
   -- Update your database's "search_path" to also search the new "extensions" schema.
   -- You are just appending it on the end of the existing comma-separated list.
   ALTER DATABASE dspace SET search_path TO "\$user",public,extensions;


### PR DESCRIPTION
## References
Backend Fixes related to https://github.com/DSpace/dspace-angular/pull/2966

## Description
This PR includes some important bug fixes to the DSpace 8 Docker scripts.  Namely:
* Fixes bug where if `pgcrypto` is already installed, an error was thrown
* Fixes bug where using Entities test data resulted in startup failure because `ignored` migrations were not run.
* Minor updates Docker READMEs for DSpace 8.

## Instructions for Reviewers
Assuming this build succeeds in GitHub CI, I plan to merge this immediately as this PR is **required** for https://github.com/DSpace/dspace-angular/pull/2966