### PR TITLE
Fixes to Docker scripts for DSpace 7.x

### DIFF
--- a/dspace/src/main/docker-compose/db.entities.yml
+++ b/dspace/src/main/docker-compose/db.entities.yml
@@ -18,27 +18,12 @@ services:
     ### OVERRIDE default 'entrypoint' in 'docker-compose.yml ####
     # Ensure that the database is ready BEFORE starting tomcat
     # 1. While a TCP connection to dspacedb port 5432 is not available, continue to sleep
-    # 2. Then, run database migration to init database tables
-    # 3. (Custom for Entities) enable Entity-specific collection submission mappings in item-submission.xml
-    #    This 'sed' command inserts the sample configurations specific to the Entities data set, see:
-    #    https://github.com/DSpace/DSpace/blob/main/dspace/config/item-submission.xml#L36-L49
-    # 4. Finally, start Tomcat
+    # 2. Then, run migration latest version of database tables (run with "ignored" in case this SQL data is outdated)
+    # 3. Finally, start Tomcat
     entrypoint:
       - /bin/bash
       - '-c'
       - |
         while (!</dev/tcp/dspacedb/5432) > /dev/null 2>&1; do sleep 1; done;
-        /dspace/bin/dspace database migrate
-        sed -i '/name-map collection-handle="default".*/a \\n <name-map collection-handle="123456789/3" submission-name="Publication"/> \
-          <name-map collection-handle="123456789/4" submission-name="Publication"/> \
-          <name-map collection-handle="123456789/281" submission-name="Publication"/> \
-          <name-map collection-handle="123456789/5" submission-name="Publication"/> \
-          <name-map collection-handle="123456789/8" submission-name="OrgUnit"/> \
-          <name-map collection-handle="123456789/6" submission-name="Person"/> \
-          <name-map collection-handle="123456789/279" submission-name="Person"/> \
-          <name-map collection-handle="123456789/7" submission-name="Project"/> \
-          <name-map collection-handle="123456789/280" submission-name="Project"/> \
-          <name-map collection-handle="123456789/28" submission-name="Journal"/> \
-          <name-map collection-handle="123456789/29" submission-name="JournalVolume"/> \
-          <name-map collection-handle="123456789/30" submission-name="JournalIssue"/>' /dspace/config/item-submission.xml
+        /dspace/bin/dspace database migrate ignored
         catalina.sh run

--- a/dspace/src/main/docker/dspace-postgres-pgcrypto-curl/Dockerfile
+++ b/dspace/src/main/docker/dspace-postgres-pgcrypto-curl/Dockerfile
@@ -10,7 +10,7 @@
 # docker build --build-arg POSTGRES_VERSION=13 --build-arg POSTGRES_PASSWORD=mypass ./dspace/src/main/docker/dspace-postgres-pgcrypto-curl/
 # This will be published as dspace/dspace-postgres-pgcrypto:$DSPACE_VERSION-loadsql
 
-ARG POSTGRES_VERSION=13
+ARG POSTGRES_VERSION=15
 ARG POSTGRES_PASSWORD=dspace
 
 FROM postgres:${POSTGRES_VERSION}

--- a/dspace/src/main/docker/dspace-postgres-pgcrypto-curl/install-pgcrypto.sh
+++ b/dspace/src/main/docker/dspace-postgres-pgcrypto-curl/install-pgcrypto.sh
@@ -40,9 +40,9 @@ fi
 # Then, setup pgcrypto on this database
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
   -- Create a new schema in this database named "extensions" (or whatever you want to name it)
-  CREATE SCHEMA extensions;
+  CREATE SCHEMA IF NOT EXISTS extensions;
   -- Enable this extension in this new schema
-  CREATE EXTENSION pgcrypto SCHEMA extensions;
+  CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA extensions;
   -- Update your database's "search_path" to also search the new "extensions" schema.
   -- You are just appending it on the end of the existing comma-separated list.
   ALTER DATABASE dspace SET search_path TO "\$user",public,extensions;

--- a/dspace/src/main/docker/dspace-postgres-pgcrypto/Dockerfile
+++ b/dspace/src/main/docker/dspace-postgres-pgcrypto/Dockerfile
@@ -10,7 +10,7 @@
 # docker build --build-arg POSTGRES_VERSION=13 --build-arg POSTGRES_PASSWORD=mypass ./dspace/src/main/docker/dspace-postgres-pgcrypto/
 # This will be published as dspace/dspace-postgres-pgcrypto:$DSPACE_VERSION
 
-ARG POSTGRES_VERSION=13
+ARG POSTGRES_VERSION=15
 ARG POSTGRES_PASSWORD=dspace
 
 FROM postgres:${POSTGRES_VERSION}

--- a/dspace/src/main/docker/dspace-postgres-pgcrypto/install-pgcrypto.sh
+++ b/dspace/src/main/docker/dspace-postgres-pgcrypto/install-pgcrypto.sh
@@ -11,9 +11,9 @@ set -e
 
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
   -- Create a new schema in this database named "extensions" (or whatever you want to name it)
-  CREATE SCHEMA extensions;
+  CREATE SCHEMA IF NOT EXISTS extensions;
   -- Enable this extension in this new schema
-  CREATE EXTENSION pgcrypto SCHEMA extensions;
+  CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA extensions;
   -- Update your database's "search_path" to also search the new "extensions" schema.
   -- You are just appending it on the end of the existing comma-separated list.
   ALTER DATABASE dspace SET search_path TO "\$user",public,extensions;


### PR DESCRIPTION
## References

* Required for https://github.com/DSpace/dspace-angular/pull/2967

## Description
Manual port of #9490 to `dspace-7_x`.  (Includes all commits except for README updates)
* Fixes bug where if `pgcrypto` is already installed, an error was thrown
* Fixes bug where using Entities test data resulted in startup failure because `ignored` migrations were not run.

## Instructions for Reviewers
Assuming this build succeeds in GitHub CI, I plan to merge this immediately as this PR is required for https://github.com/DSpace/dspace-angular/pull/2967