### PR TITLE
Remove unnecessary "exit" statements which stop running Postgres container

### DIFF
--- a/dspace/src/main/docker/dspace-postgres-pgcrypto-curl/install-pgcrypto.sh
+++ b/dspace/src/main/docker/dspace-postgres-pgcrypto-curl/install-pgcrypto.sh
@@ -23,7 +23,6 @@ then
   rm /tmp/dspace-db-init.sql
 
   touch $CHECKFILE
-  exit
 fi
 
 # If $LOCALSQL environment variable set, then simply run it in PostgreSQL
@@ -34,7 +33,6 @@ then
   psql -U $POSTGRES_USER < ${LOCALSQL}
 
   touch $CHECKFILE
-  exit
 fi
 
 # Then, setup pgcrypto on this database


### PR DESCRIPTION
## References
* Follow-up to #9490 

## Description
Fixes an additional bug with the `dspace-postgres-pgcrypto:latest-loadsql` image where it was exiting after loading the SQL file.  This `exit` caused the container to stop.  It had to be restarted in order to continue.
