### PR TITLE
Update Docker build process to do native `macos-latest` builds for ARM64

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -86,9 +86,9 @@ jobs:
         exclude:
           # If this is a PR, we ONLY build for AMD64. For PRs, we only do a sanity check to ensure Docker builds work.
           # The below exclude therefore ensures we do NOT build ARM64 for PRs.
-          - isPr: true
-            arch: linux/arm64
-            os: macos-latest
+          #- isPr: true
+          #  arch: linux/arm64
+          #  os: macos-latest
           # Exclude invalid arch & OS combinations. Only build on native OS to avoid emulation.
           - arch: linux/amd64
             os: macos-latest

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -110,6 +110,20 @@ jobs:
       - name: Checkout codebase
         uses: actions/checkout@v4
 
+      # MacOS runners don't have Docker by default because of a licensing issue
+      # See https://github.com/actions/runner-images/issues/2150
+      # This code borrowed from https://github.com/actions/runner/issues/1456#issuecomment-1676495453
+      - name: Setup docker and docker-compose (missing on MacOS)
+        if: runner.os == 'macos'
+        run: |
+          brew install docker docker-compose
+
+          # Link the Docker Compose v2 plugin so it's understood by the docker CLI
+          mkdir -p ~/.docker/cli-plugins
+          ln -sfn /usr/local/opt/docker-compose/bin/docker-compose ~/.docker/cli-plugins/docker-compose
+
+          colima start
+
       # https://github.com/docker/setup-buildx-action
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -80,15 +80,20 @@ jobs:
       matrix:
         # Architectures / Platforms for which we will build Docker images
         arch: [ 'linux/amd64', 'linux/arm64' ]
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-latest, macos-latest ]
         isPr:
           - ${{ github.event_name == 'pull_request' }}
-        # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
-        # The below exclude therefore ensures we do NOT build ARM64 for PRs.
         exclude:
+          # If this is a PR, we ONLY build for AMD64. For PRs, we only do a sanity check to ensure Docker builds work.
+          # The below exclude therefore ensures we do NOT build ARM64 for PRs.
           - isPr: true
-            os: ubuntu-latest
             arch: linux/arm64
+            os: macos-latest
+          # Exclude invalid arch & OS combinations. Only build on native OS to avoid emulation.
+          - arch: linux/amd64
+            os: macos-latest
+          - arch: linux/arm64
+            os: ubuntu-latest
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
## References
* Fixes #9475 

## Description
Minor updates to our `reusable-docker-build.yml` script (which is used by both DSpace/DSpace and DSpace/dspace-angular) to use `macos-latest` for ARM64 builds.  Currently, we are using `ubuntu-latest` for both AMD64 and ARM64.  Because the ARM64 builds use emulation, they take 8-12 times longer to complete.  Building ARM64 on `macos-latest` should therefore be a major speed boost.