### PR TITLE
In workflow-attached curation, separate task-list building from execution.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/curate/XmlWorkflowCuratorServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/curate/XmlWorkflowCuratorServiceImpl.java
@@ -140,13 +140,14 @@ public class XmlWorkflowCuratorServiceImpl
             item.setOwningCollection(wfi.getCollection());
             for (Task task : step.tasks) {
                 curator.addTask(task.name);
-                // Check whether the task is configured to be queued rather than automatically run
-                if (StringUtils.isNotEmpty(step.queue)) {
-                    // queue attribute has been set in the FlowStep configuration: add task to configured queue
-                    curator.queue(c, item.getID().toString(), step.queue);
-                } else {
-                    // Task is configured to be run automatically
-                    curator.curate(c, item);
+            }
+
+            if (StringUtils.isNotEmpty(step.queue)) { // Step's tasks are to be queued.
+                curator.queue(c, item.getID().toString(), step.queue);
+            } else { // Step's tasks are to be run now.
+                curator.curate(c, item);
+
+                for (Task task : step.tasks) {
                     int status = curator.getStatus(task.name);
                     String result = curator.getResult(task.name);
                     String action = "none";
@@ -183,14 +184,14 @@ public class XmlWorkflowCuratorServiceImpl
                     }
                 }
                 curator.clear();
-            }
 
-            // Record any reporting done by the tasks.
-            if (reporter.length() > 0) {
-                LOG.info("Curation tasks over item {} for step {} report:%n{}",
-                    () -> wfi.getItem().getID(),
-                    () -> step.step,
-                    () -> reporter.toString());
+                // Record any reporting done by the tasks.
+                if (reporter.length() > 0) {
+                    LOG.info("Curation tasks over item {} for step {} report:\n{}",
+                        () -> wfi.getItem().getID(),
+                        () -> step.step,
+                        () -> reporter.toString());
+                }
             }
         }
         return true;

--- a/dspace-api/src/main/java/org/dspace/curate/package-info.java
+++ b/dspace-api/src/main/java/org/dspace/curate/package-info.java
@@ -20,6 +20,8 @@
  * </dl>
  *
  * <p>Curation requests may be run immediately or queued for batch processing.
+ * See {@link TaskQueue} and its relatives, {@link Curation} and its relatives
+ * for more on queued curation.
  *
  * <p>Tasks may also be attached to a workflow step, so that a set of tasks is
  * applied to each uninstalled Item which passes through that step.  See
@@ -27,5 +29,15 @@
  *
  * <p>A task may return to the Curator a status code, a final status message,
  * and an optional report character stream.
+ *
+ * <p>The {@link Reporter} classes absorb strings of text and preserve it in
+ * various ways.  A Reporter is a simple {@link Appendable} and makes no
+ * assumptions about e.g. whether a string represents a complete line.  If you
+ * want your report formatted, insert appropriate newlines and other whitespace
+ * as needed.  Your tasks can emit marked-up text if you wish, but the stock
+ * Reporter implementations make no attempt to render it.
+ *
+ * <p>Tasks may be annotated to inform the Curator of special properties.  See
+ * {@link Distributive}, {@link Mutative}, {@link Suspendable} etc.
  */
 package org.dspace.curate;


### PR DESCRIPTION
The old code would curate the object once for each task, meaning that all but one task would be executed N times up to the length of the list.  This patch first configures the Curator with tasks, and then runs it once (or queues it).

## References
* Fixes #9496

## Description
Completely configure the Curator before using it.

## Instructions for Reviewers
List of changes in this PR:
* Moved Curator.curate out of the loop that configures the Curator with tasks.
* Replaced literal `%n` with newline in report output
* Extended the internal documentation of the package

See comments for a good test procedure.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).