### PR TITLE
Enforce resource policies to have group or eperson (DSpace 8)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
@@ -1820,7 +1820,6 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
 
             rp.setdSpaceObject(bs);
             rp.setAction(actionID);
-            rp.setGroup(g);
             rp.setRpType(rpType);
 
             resourcePolicyService.update(c, rp);

--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
@@ -1816,7 +1816,7 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
             authorizeService.removeAllPolicies(c, bs);
 
             // add the policy
-            ResourcePolicy rp = resourcePolicyService.create(c);
+            ResourcePolicy rp = resourcePolicyService.create(c, null, g);
 
             rp.setdSpaceObject(bs);
             rp.setAction(actionID);

--- a/dspace-api/src/main/java/org/dspace/authorize/AuthorizeServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/AuthorizeServiceImpl.java
@@ -550,13 +550,11 @@ public class AuthorizeServiceImpl implements AuthorizeService {
         List<ResourcePolicy> newPolicies = new ArrayList<>(policies.size());
 
         for (ResourcePolicy srp : policies) {
-            ResourcePolicy rp = resourcePolicyService.create(c);
+            ResourcePolicy rp = resourcePolicyService.create(c, srp.getEPerson(), srp.getGroup());
 
             // copy over values
             rp.setdSpaceObject(dest);
             rp.setAction(srp.getAction());
-            rp.setEPerson(srp.getEPerson());
-            rp.setGroup(srp.getGroup());
             rp.setStartDate(srp.getStartDate());
             rp.setEndDate(srp.getEndDate());
             rp.setRpName(srp.getRpName());
@@ -670,11 +668,9 @@ public class AuthorizeServiceImpl implements AuthorizeService {
                 "We need at least an eperson or a group in order to create a resource policy.");
         }
 
-        ResourcePolicy myPolicy = resourcePolicyService.create(context);
+        ResourcePolicy myPolicy = resourcePolicyService.create(context, eperson, group);
         myPolicy.setdSpaceObject(dso);
         myPolicy.setAction(type);
-        myPolicy.setGroup(group);
-        myPolicy.setEPerson(eperson);
         myPolicy.setRpType(rpType);
         myPolicy.setRpName(rpName);
         myPolicy.setRpDescription(rpDescription);

--- a/dspace-api/src/main/java/org/dspace/authorize/FixDefaultPolicies.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/FixDefaultPolicies.java
@@ -126,10 +126,9 @@ public class FixDefaultPolicies {
 
         // now create the default policies for submitted items
         ResourcePolicyService resourcePolicyService = AuthorizeServiceFactory.getInstance().getResourcePolicyService();
-        ResourcePolicy myPolicy = resourcePolicyService.create(c);
+        ResourcePolicy myPolicy = resourcePolicyService.create(c, null, anonymousGroup);
         myPolicy.setdSpaceObject(t);
         myPolicy.setAction(myaction);
-        myPolicy.setGroup(anonymousGroup);
         resourcePolicyService.update(c, myPolicy);
     }
 }

--- a/dspace-api/src/main/java/org/dspace/authorize/PolicySet.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/PolicySet.java
@@ -229,11 +229,10 @@ public class PolicySet {
                         // before create a new policy check if an identical policy is already in place
                         if (!authorizeService.isAnIdenticalPolicyAlreadyInPlace(c, myitem, group, actionID, -1)) {
                             // now add the policy
-                            ResourcePolicy rp = resourcePolicyService.create(c);
+                            ResourcePolicy rp = resourcePolicyService.create(c, null, group);
 
                             rp.setdSpaceObject(myitem);
                             rp.setAction(actionID);
-                            rp.setGroup(group);
 
                             rp.setRpName(name);
                             rp.setRpDescription(description);
@@ -262,11 +261,10 @@ public class PolicySet {
                             // before create a new policy check if an identical policy is already in place
                             if (!authorizeService.isAnIdenticalPolicyAlreadyInPlace(c, bundle, group, actionID, -1)) {
                                 // now add the policy
-                                ResourcePolicy rp = resourcePolicyService.create(c);
+                                ResourcePolicy rp = resourcePolicyService.create(c, null, group);
 
                                 rp.setdSpaceObject(bundle);
                                 rp.setAction(actionID);
-                                rp.setGroup(group);
 
                                 rp.setRpName(name);
                                 rp.setRpDescription(description);
@@ -305,11 +303,10 @@ public class PolicySet {
                                     if (!authorizeService
                                         .isAnIdenticalPolicyAlreadyInPlace(c, bitstream, group, actionID, -1)) {
                                         // now add the policy
-                                        ResourcePolicy rp = resourcePolicyService.create(c);
+                                        ResourcePolicy rp = resourcePolicyService.create(c, null, group);
 
                                         rp.setdSpaceObject(bitstream);
                                         rp.setAction(actionID);
-                                        rp.setGroup(group);
 
                                         rp.setRpName(name);
                                         rp.setRpDescription(description);

--- a/dspace-api/src/main/java/org/dspace/authorize/ResourcePolicyServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/ResourcePolicyServiceImpl.java
@@ -71,14 +71,22 @@ public class ResourcePolicyServiceImpl implements ResourcePolicyService {
      * Create a new ResourcePolicy
      *
      * @param context DSpace context object
+     * @param ePerson
+     * @param group
      * @return ResourcePolicy
      * @throws SQLException if database error
      */
     @Override
-    public ResourcePolicy create(Context context) throws SQLException {
+    public ResourcePolicy create(Context context, EPerson ePerson, Group group) throws SQLException {
         // FIXME: Check authorisation
         // Create a table row
-        ResourcePolicy resourcePolicy = resourcePolicyDAO.create(context, new ResourcePolicy());
+        ResourcePolicy policyToBeCreated = new ResourcePolicy();
+        if (ePerson == null && group == null) {
+            throw new IllegalArgumentException("A resource policy must contain a valid eperson or group");
+        }
+        policyToBeCreated.setEPerson(ePerson);
+        policyToBeCreated.setGroup(group);
+        ResourcePolicy resourcePolicy = resourcePolicyDAO.create(context, policyToBeCreated);
         return resourcePolicy;
     }
 
@@ -205,9 +213,7 @@ public class ResourcePolicyServiceImpl implements ResourcePolicyService {
     @Override
     public ResourcePolicy clone(Context context, ResourcePolicy resourcePolicy)
         throws SQLException, AuthorizeException {
-        ResourcePolicy clone = create(context);
-        clone.setGroup(resourcePolicy.getGroup());
-        clone.setEPerson(resourcePolicy.getEPerson());
+        ResourcePolicy clone = create(context, resourcePolicy.getEPerson(), resourcePolicy.getGroup());
         clone.setStartDate((Date) ObjectUtils.clone(resourcePolicy.getStartDate()));
         clone.setEndDate((Date) ObjectUtils.clone(resourcePolicy.getEndDate()));
         clone.setRpType((String) ObjectUtils.clone(resourcePolicy.getRpType()));

--- a/dspace-api/src/main/java/org/dspace/authorize/service/ResourcePolicyService.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/service/ResourcePolicyService.java
@@ -17,7 +17,6 @@ import org.dspace.content.DSpaceObject;
 import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
-import org.dspace.service.DSpaceCRUDService;
 
 /**
  * Service interface class for the ResourcePolicy object.
@@ -26,7 +25,34 @@ import org.dspace.service.DSpaceCRUDService;
  *
  * @author kevinvandevelde at atmire.com
  */
-public interface ResourcePolicyService extends DSpaceCRUDService<ResourcePolicy> {
+public interface ResourcePolicyService {
+
+    public ResourcePolicy create(Context context, EPerson eperson, Group group) throws SQLException, AuthorizeException;
+
+    public ResourcePolicy find(Context context, int id) throws SQLException;
+
+    /**
+     * Persist a model object.
+     *
+     * @param context
+     * @param resourcePolicy object to be persisted.
+     * @throws SQLException passed through.
+     * @throws AuthorizeException passed through.
+     */
+    public void update(Context context, ResourcePolicy resourcePolicy) throws SQLException, AuthorizeException;
+
+
+    /**
+     * Persist a collection of model objects.
+     *
+     * @param context
+     * @param resourcePolicies object to be persisted.
+     * @throws SQLException passed through.
+     * @throws AuthorizeException passed through.
+     */
+    public void update(Context context, List<ResourcePolicy> resourcePolicies) throws SQLException, AuthorizeException;
+
+    public void delete(Context context, ResourcePolicy resourcePolicy) throws SQLException, AuthorizeException;
 
 
     public List<ResourcePolicy> find(Context c, DSpaceObject o) throws SQLException;

--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/METSRightsCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/METSRightsCrosswalk.java
@@ -432,31 +432,7 @@ public class METSRightsCrosswalk
                     //get what class of context this is
                     String contextClass = element.getAttributeValue("CONTEXTCLASS");
 
-                    ResourcePolicy rp = resourcePolicyService.create(context);
-                    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
-
-                    // get reference to the <Permissions> element
-                    // Note: we are assuming here that there will only ever be ONE <Permissions>
-                    //  element. Currently there are no known use cases for multiple.
-                    Element permsElement = element.getChild("Permissions", METSRights_NS);
-                    if (permsElement == null) {
-                        log.error("No <Permissions> element was found. Skipping this <Context> element.");
-                        continue;
-                    }
-
-                    if (element.getAttributeValue("rpName") != null) {
-                        rp.setRpName(element.getAttributeValue("rpName"));
-                    }
-                    try {
-                        if (element.getAttributeValue("start-date") != null) {
-                            rp.setStartDate(sdf.parse(element.getAttributeValue("start-date")));
-                        }
-                        if (element.getAttributeValue("end-date") != null) {
-                            rp.setEndDate(sdf.parse(element.getAttributeValue("end-date")));
-                        }
-                    } catch (ParseException ex) {
-                        log.error("Failed to parse embargo date. The date needs to be in the format 'yyyy-MM-dd'.", ex);
-                    }
+                    ResourcePolicy rp = null;
 
                     //Check if this permission pertains to Anonymous users
                     if (ANONYMOUS_CONTEXTCLASS.equals(contextClass)) {
@@ -464,22 +440,23 @@ public class METSRightsCrosswalk
                         Group anonGroup = groupService.findByName(context, Group.ANONYMOUS);
                         if (anonGroup == null) {
                             throw new CrosswalkInternalException(
-                                "The DSpace database has not been properly initialized.  The Anonymous Group is " +
-                                    "missing from the database.");
+                                    "The DSpace database has not been properly initialized.  The Anonymous Group is " +
+                                            "missing from the database.");
                         }
 
-                        rp.setGroup(anonGroup);
+                        rp = resourcePolicyService.create(context, null, anonGroup);
                     } else if (ADMIN_CONTEXTCLASS.equals(contextClass)) {
                         // else if this permission declaration pertains to Administrators
                         // get DSpace Administrator group
                         Group adminGroup = groupService.findByName(context, Group.ADMIN);
                         if (adminGroup == null) {
                             throw new CrosswalkInternalException(
-                                "The DSpace database has not been properly initialized.  The Administrator Group is " +
-                                    "missing from the database.");
+                                    "The DSpace database has not been properly initialized.  " +
+                                            "The Administrator Group is " +
+                                            "missing from the database.");
                         }
 
-                        rp.setGroup(adminGroup);
+                        rp = resourcePolicyService.create(context, null, adminGroup);
                     } else if (GROUP_CONTEXTCLASS.equals(contextClass)) {
                         // else if this permission pertains to another DSpace group
                         try {
@@ -498,18 +475,17 @@ public class METSRightsCrosswalk
                             //if not found, throw an error -- user should restore group from the SITE AIP
                             if (group == null) {
                                 throw new CrosswalkInternalException("Cannot restore Group permissions on object ("
-                                                                         + "type=" + Constants.typeText[dso
-                                    .getType()] + ", "
-                                                                         + "handle=" + dso.getHandle() + ", "
-                                                                         + "ID=" + dso.getID()
-                                                                         + "). The Group named '" + groupName + "' is" +
-                                                                         " missing from DSpace. "
-                                                                         + "Please restore this group using the SITE " +
-                                                                         "AIP, or recreate it.");
+                                                                 + "type=" + Constants.typeText[dso.getType()] + ", "
+                                                                 + "handle=" + dso.getHandle() + ", "
+                                                                 + "ID=" + dso.getID()
+                                                                 + "). The Group named '" + groupName + "' is" +
+                                                                 " missing from DSpace. "
+                                                                 + "Please restore this group using the SITE " +
+                                                                 "AIP, or recreate it.");
                             }
 
                             //assign group to policy
-                            rp.setGroup(group);
+                            rp = resourcePolicyService.create(context, null, group);
                         } catch (PackageException pe) {
                             //A PackageException will only be thrown if translateDefaultGroupName() fails
                             //We'll just wrap it as a CrosswalkException and throw it upwards
@@ -535,25 +511,51 @@ public class METSRightsCrosswalk
                         //if not found, throw an error -- user should restore person from the SITE AIP
                         if (person == null) {
                             throw new CrosswalkInternalException("Cannot restore Person permissions on object ("
-                                                                     + "type=" + Constants.typeText[dso
-                                .getType()] + ", "
-                                                                     + "handle=" + dso.getHandle() + ", "
-                                                                     + "ID=" + dso.getID()
-                                                                     + "). The Person with email/netid '" +
-                                                                     personEmail + "' is missing from DSpace. "
-                                                                     + "Please restore this Person object using the " +
-                                                                     "SITE AIP, or recreate it.");
+                                                                 + "type=" + Constants.typeText[dso.getType()] + ", "
+                                                                 + "handle=" + dso.getHandle() + ", "
+                                                                 + "ID=" + dso.getID()
+                                                                 + "). The Person with email/netid '" +
+                                                                 personEmail + "' is missing from DSpace. "
+                                                                 + "Please restore this Person object using the " +
+                                                                 "SITE AIP, or recreate it.");
                         }
 
-                        //assign person to the policy
-                        rp.setEPerson(person);
+                        //create rp with the person
+                        rp = resourcePolicyService.create(context, person, null);
                     } else {
                         log.error("Unrecognized CONTEXTCLASS:  " + contextClass);
                     }
+                    if (rp != null) {
+                        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
 
-                    //set permissions on policy add to list of policies
-                    rp.setAction(parsePermissions(permsElement));
-                    policies.add(rp);
+                        // get reference to the <Permissions> element
+                        // Note: we are assuming here that there will only ever be ONE <Permissions>
+                        //  element. Currently there are no known use cases for multiple.
+                        Element permsElement = element.getChild("Permissions", METSRights_NS);
+                        if (permsElement == null) {
+                            log.error("No <Permissions> element was found. Skipping this <Context> element.");
+                            continue;
+                        }
+
+                        if (element.getAttributeValue("rpName") != null) {
+                            rp.setRpName(element.getAttributeValue("rpName"));
+                        }
+                        try {
+                            if (element.getAttributeValue("start-date") != null) {
+                                rp.setStartDate(sdf.parse(element.getAttributeValue("start-date")));
+                            }
+                            if (element.getAttributeValue("end-date") != null) {
+                                rp.setEndDate(sdf.parse(element.getAttributeValue("end-date")));
+                            }
+                        } catch (ParseException ex) {
+                            log.error("Failed to parse embargo date. The date needs to be in the format 'yyyy-MM-dd'.",
+                                      ex);
+                        }
+
+                        //set permissions on policy add to list of policies
+                        rp.setAction(parsePermissions(permsElement));
+                        policies.add(rp);
+                    }
                 } //end if "Context" element
             } //end for loop
 

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V7.6_2023.09.28__enforce_group_or_eperson_for_resourcepolicy.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V7.6_2023.09.28__enforce_group_or_eperson_for_resourcepolicy.sql
@@ -8,3 +8,5 @@
 
 ALTER TABLE ResourcePolicy ADD CONSTRAINT resourcepolicy_eperson_and_epersongroup_not_nullobject_chk
     CHECK (eperson_id is not null or epersongroup_id is not null) ;
+
+DELETE FROM ResourcePolicy WHERE eperson_id is null and epersongroup_id is null;

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V7.6_2023.09.28__enforce_group_or_eperson_for_resourcepolicy.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V7.6_2023.09.28__enforce_group_or_eperson_for_resourcepolicy.sql
@@ -1,0 +1,10 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+ALTER TABLE ResourcePolicy ADD CONSTRAINT resourcepolicy_eperson_and_epersongroup_not_nullobject_chk
+    CHECK (eperson_id is not null or epersongroup_id is not null) ;

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V7.6_2023.09.28__enforce_group_or_eperson_for_resourcepolicy.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V7.6_2023.09.28__enforce_group_or_eperson_for_resourcepolicy.sql
@@ -6,7 +6,7 @@
 -- http://www.dspace.org/license/
 --
 
+DELETE FROM ResourcePolicy WHERE eperson_id is null and epersongroup_id is null;
+
 ALTER TABLE ResourcePolicy ADD CONSTRAINT resourcepolicy_eperson_and_epersongroup_not_nullobject_chk
     CHECK (eperson_id is not null or epersongroup_id is not null) ;
-
-DELETE FROM ResourcePolicy WHERE eperson_id is null and epersongroup_id is null;

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.6_2023.09.28__enforce_group_or_eperson_for_resourcepolicy.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.6_2023.09.28__enforce_group_or_eperson_for_resourcepolicy.sql
@@ -8,3 +8,5 @@
 
 ALTER TABLE ResourcePolicy ADD CONSTRAINT resourcepolicy_eperson_and_epersongroup_not_nullobject_chk
     CHECK (eperson_id is not null or epersongroup_id is not null) ;
+
+DELETE FROM ResourcePolicy WHERE eperson_id is null and epersongroup_id is null;

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.6_2023.09.28__enforce_group_or_eperson_for_resourcepolicy.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.6_2023.09.28__enforce_group_or_eperson_for_resourcepolicy.sql
@@ -1,0 +1,10 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+ALTER TABLE ResourcePolicy ADD CONSTRAINT resourcepolicy_eperson_and_epersongroup_not_nullobject_chk
+    CHECK (eperson_id is not null or epersongroup_id is not null) ;

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.6_2023.09.28__enforce_group_or_eperson_for_resourcepolicy.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.6_2023.09.28__enforce_group_or_eperson_for_resourcepolicy.sql
@@ -6,7 +6,7 @@
 -- http://www.dspace.org/license/
 --
 
+DELETE FROM ResourcePolicy WHERE eperson_id is null and epersongroup_id is null;
+
 ALTER TABLE ResourcePolicy ADD CONSTRAINT resourcepolicy_eperson_and_epersongroup_not_nullobject_chk
     CHECK (eperson_id is not null or epersongroup_id is not null) ;
-
-DELETE FROM ResourcePolicy WHERE eperson_id is null and epersongroup_id is null;

--- a/dspace-api/src/test/java/org/dspace/access/status/DefaultAccessStatusHelperTest.java
+++ b/dspace-api/src/test/java/org/dspace/access/status/DefaultAccessStatusHelperTest.java
@@ -262,10 +262,9 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         bitstream.setName(context, "primary");
         bundle.setPrimaryBitstreamID(bitstream);
         List<ResourcePolicy> policies = new ArrayList<>();
-        ResourcePolicy policy = resourcePolicyService.create(context);
-        policy.setRpName("Embargo");
         Group group = groupService.findByName(context, Group.ANONYMOUS);
-        policy.setGroup(group);
+        ResourcePolicy policy = resourcePolicyService.create(context, null, group);
+        policy.setRpName("Embargo");
         policy.setAction(Constants.READ);
         policy.setStartDate(dateFrom(9999, 12, 31));
         policies.add(policy);
@@ -291,10 +290,9 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         bitstream.setName(context, "primary");
         bundle.setPrimaryBitstreamID(bitstream);
         List<ResourcePolicy> policies = new ArrayList<>();
-        ResourcePolicy policy = resourcePolicyService.create(context);
-        policy.setRpName("Restriction");
         Group group = groupService.findByName(context, Group.ANONYMOUS);
-        policy.setGroup(group);
+        ResourcePolicy policy = resourcePolicyService.create(context, null, group);
+        policy.setRpName("Restriction");
         policy.setAction(Constants.READ);
         policy.setStartDate(dateFrom(10000, 1, 1));
         policies.add(policy);
@@ -318,10 +316,9 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         bitstream.setName(context, "primary");
         bundle.setPrimaryBitstreamID(bitstream);
         List<ResourcePolicy> policies = new ArrayList<>();
-        ResourcePolicy policy = resourcePolicyService.create(context);
-        policy.setRpName("Restriction");
         Group group = groupService.findByName(context, Group.ADMIN);
-        policy.setGroup(group);
+        ResourcePolicy policy = resourcePolicyService.create(context, null, group);
+        policy.setRpName("Restriction");
         policy.setAction(Constants.READ);
         policies.add(policy);
         authorizeService.removeAllPolicies(context, bitstream);
@@ -381,10 +378,9 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
                 new ByteArrayInputStream("1".getBytes(StandardCharsets.UTF_8)));
         bundle.setPrimaryBitstreamID(primaryBitstream);
         List<ResourcePolicy> policies = new ArrayList<>();
-        ResourcePolicy policy = resourcePolicyService.create(context);
-        policy.setRpName("Embargo");
         Group group = groupService.findByName(context, Group.ANONYMOUS);
-        policy.setGroup(group);
+        ResourcePolicy policy = resourcePolicyService.create(context, null, group);
+        policy.setRpName("Embargo");
         policy.setAction(Constants.READ);
         policy.setStartDate(dateFrom(9999, 12, 31));
         policies.add(policy);
@@ -412,10 +408,9 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         Bitstream anotherBitstream = bitstreamService.create(context, bundle,
                 new ByteArrayInputStream("1".getBytes(StandardCharsets.UTF_8)));
         List<ResourcePolicy> policies = new ArrayList<>();
-        ResourcePolicy policy = resourcePolicyService.create(context);
-        policy.setRpName("Embargo");
         Group group = groupService.findByName(context, Group.ANONYMOUS);
-        policy.setGroup(group);
+        ResourcePolicy policy = resourcePolicyService.create(context, null, group);
+        policy.setRpName("Embargo");
         policy.setAction(Constants.READ);
         policy.setStartDate(dateFrom(9999, 12, 31));
         policies.add(policy);

--- a/dspace-api/src/test/java/org/dspace/builder/CollectionBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/CollectionBuilder.java
@@ -253,8 +253,7 @@ public class CollectionBuilder extends AbstractDSpaceObjectBuilder<Collection> {
     public CollectionBuilder withDefaultItemRead(Group group) throws SQLException, AuthorizeException {
         resourcePolicyService.removePolicies(context, collection, DEFAULT_ITEM_READ);
 
-        ResourcePolicy resourcePolicy = resourcePolicyService.create(context);
-        resourcePolicy.setGroup(group);
+        ResourcePolicy resourcePolicy = resourcePolicyService.create(context, null, group);
         resourcePolicy.setAction(DEFAULT_ITEM_READ);
         resourcePolicy.setdSpaceObject(collection);
         resourcePolicyService.update(context, resourcePolicy);

--- a/dspace-api/src/test/java/org/dspace/builder/ResourcePolicyBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/ResourcePolicyBuilder.java
@@ -110,28 +110,20 @@ public class ResourcePolicyBuilder extends AbstractBuilder<ResourcePolicy, Resou
         indexingService.commit();
     }
 
-    public static ResourcePolicyBuilder createResourcePolicy(Context context)
+    public static ResourcePolicyBuilder createResourcePolicy(Context context, EPerson ePerson,
+                                                             Group group)
             throws SQLException, AuthorizeException {
         ResourcePolicyBuilder resourcePolicyBuilder = new ResourcePolicyBuilder(context);
-        return resourcePolicyBuilder.create(context);
+        return resourcePolicyBuilder.create(context, ePerson, group);
     }
 
-    private ResourcePolicyBuilder create(Context context)
+    private ResourcePolicyBuilder create(Context context, final EPerson ePerson,
+                                         final Group epersonGroup)
             throws SQLException, AuthorizeException {
         this.context = context;
 
-        resourcePolicy = resourcePolicyService.create(context);
+        resourcePolicy = resourcePolicyService.create(context, ePerson, epersonGroup);
 
-        return this;
-    }
-
-    public ResourcePolicyBuilder withUser(EPerson ePerson) throws SQLException {
-        resourcePolicy.setEPerson(ePerson);
-        return this;
-    }
-
-    public ResourcePolicyBuilder withGroup(Group epersonGroup) throws SQLException {
-        resourcePolicy.setGroup(epersonGroup);
         return this;
     }
 

--- a/dspace-api/src/test/java/org/dspace/content/BundleTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/BundleTest.java
@@ -633,9 +633,9 @@ public class BundleTest extends AbstractDSpaceObjectTest {
     @Test
     public void testReplaceAllBitstreamPolicies() throws SQLException, AuthorizeException {
         List<ResourcePolicy> newpolicies = new ArrayList<ResourcePolicy>();
-        newpolicies.add(resourcePolicyService.create(context));
-        newpolicies.add(resourcePolicyService.create(context));
-        newpolicies.add(resourcePolicyService.create(context));
+        newpolicies.add(resourcePolicyService.create(context, eperson, null));
+        newpolicies.add(resourcePolicyService.create(context, eperson, null));
+        newpolicies.add(resourcePolicyService.create(context, eperson, null));
         bundleService.replaceAllBitstreamPolicies(context, b, newpolicies);
 
         List<ResourcePolicy> bspolicies = bundleService.getBundlePolicies(context, b);

--- a/dspace-api/src/test/java/org/dspace/content/ItemTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/ItemTest.java
@@ -1257,7 +1257,7 @@ public class ItemTest extends AbstractDSpaceObjectTest {
     @Test
     public void testReplaceAllItemPolicies() throws Exception {
         List<ResourcePolicy> newpolicies = new ArrayList<ResourcePolicy>();
-        ResourcePolicy pol1 = resourcePolicyService.create(context);
+        ResourcePolicy pol1 = resourcePolicyService.create(context, eperson, null);
         newpolicies.add(pol1);
         itemService.replaceAllItemPolicies(context, it, newpolicies);
 
@@ -1284,9 +1284,9 @@ public class ItemTest extends AbstractDSpaceObjectTest {
         bundleService.addBitstream(context, created, result);
 
         List<ResourcePolicy> newpolicies = new ArrayList<ResourcePolicy>();
-        newpolicies.add(resourcePolicyService.create(context));
-        newpolicies.add(resourcePolicyService.create(context));
-        newpolicies.add(resourcePolicyService.create(context));
+        newpolicies.add(resourcePolicyService.create(context, eperson, null));
+        newpolicies.add(resourcePolicyService.create(context, eperson, null));
+        newpolicies.add(resourcePolicyService.create(context, eperson, null));
         context.restoreAuthSystemState();
 
         itemService.replaceAllBitstreamPolicies(context, it, newpolicies);
@@ -1316,9 +1316,8 @@ public class ItemTest extends AbstractDSpaceObjectTest {
         context.turnOffAuthorisationSystem();
         List<ResourcePolicy> newpolicies = new ArrayList<ResourcePolicy>();
         Group g = groupService.create(context);
-        ResourcePolicy pol1 = resourcePolicyService.create(context);
+        ResourcePolicy pol1 = resourcePolicyService.create(context, null, g);
         newpolicies.add(pol1);
-        pol1.setGroup(g);
         itemService.replaceAllItemPolicies(context, it, newpolicies);
 
         itemService.removeGroupPolicies(context, it, g);

--- a/dspace-api/src/test/java/org/dspace/content/packager/ITDSpaceAIP.java
+++ b/dspace-api/src/test/java/org/dspace/content/packager/ITDSpaceAIP.java
@@ -386,9 +386,8 @@ public class ITDSpaceAIP extends AbstractIntegrationTest {
 
         // Create a custom resource policy for this community
         List<ResourcePolicy> policies = new ArrayList<>();
-        ResourcePolicy policy = resourcePolicyService.create(context);
+        ResourcePolicy policy = resourcePolicyService.create(context, null, group);
         policy.setRpName("Special Read Only");
-        policy.setGroup(group);
         policy.setAction(Constants.READ);
         policies.add(policy);
 
@@ -600,9 +599,8 @@ public class ITDSpaceAIP extends AbstractIntegrationTest {
 
         // Create a custom resource policy for this Collection
         List<ResourcePolicy> policies = new ArrayList<>();
-        ResourcePolicy policy = resourcePolicyService.create(context);
+        ResourcePolicy policy = resourcePolicyService.create(context, null, group);
         policy.setRpName("Special Read Only");
-        policy.setGroup(group);
         policy.setAction(Constants.READ);
         policies.add(policy);
 
@@ -822,10 +820,9 @@ public class ITDSpaceAIP extends AbstractIntegrationTest {
 
         // Create a custom resource policy for this Item
         List<ResourcePolicy> policies = new ArrayList<>();
-        ResourcePolicy admin_policy = resourcePolicyService.create(context);
-        admin_policy.setRpName("Admin Read-Only");
         Group adminGroup = groupService.findByName(context, Group.ADMIN);
-        admin_policy.setGroup(adminGroup);
+        ResourcePolicy admin_policy = resourcePolicyService.create(context, null, adminGroup);
+        admin_policy.setRpName("Admin Read-Only");
         admin_policy.setAction(Constants.READ);
         policies.add(admin_policy);
         itemService.replaceAllItemPolicies(context, item, policies);

--- a/dspace-api/src/test/java/org/dspace/content/service/ItemServiceIT.java
+++ b/dspace-api/src/test/java/org/dspace/content/service/ItemServiceIT.java
@@ -692,8 +692,7 @@ public class ItemServiceIT extends AbstractIntegrationTestWithDatabase {
 
     @Test
     public void testFindAndCountItemsWithEditEPerson() throws Exception {
-        ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context)
-            .withUser(eperson)
+        ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
             .withDspaceObject(item)
             .withAction(Constants.WRITE)
             .build();
@@ -706,8 +705,7 @@ public class ItemServiceIT extends AbstractIntegrationTestWithDatabase {
 
     @Test
     public void testFindAndCountItemsWithAdminEPerson() throws Exception {
-         ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context)
-            .withUser(eperson)
+         ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
             .withDspaceObject(item)
             .withAction(Constants.ADMIN)
             .build();
@@ -726,8 +724,7 @@ public class ItemServiceIT extends AbstractIntegrationTestWithDatabase {
             .build();
         context.restoreAuthSystemState();
 
-        ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context)
-            .withGroup(group)
+        ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context, null, group)
             .withDspaceObject(item)
             .withAction(Constants.WRITE)
             .build();
@@ -746,8 +743,7 @@ public class ItemServiceIT extends AbstractIntegrationTestWithDatabase {
             .build();
         context.restoreAuthSystemState();
 
-        ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context)
-            .withGroup(group)
+        ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context, null, group)
             .withDspaceObject(item)
             .withAction(Constants.ADMIN)
             .build();

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamControllerIT.java
@@ -302,25 +302,25 @@ public class BitstreamControllerIT extends AbstractControllerIntegrationTest {
                                                 .withPassword("test")
                                                 .withNameInMetadata("Bundle", "Put").build();
 
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.REMOVE)
                              .withDspaceObject(bundle1).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(bundle1).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(targetBundle).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.ADD)
                              .withDspaceObject(targetBundle).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(bitstream).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(publicItem1).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(targetItem).build();
 
@@ -471,31 +471,31 @@ public class BitstreamControllerIT extends AbstractControllerIntegrationTest {
                                                 .withPassword("test")
                                                 .withNameInMetadata("Bundle", "Put").build();
 
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.REMOVE)
                              .withDspaceObject(bundle1).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(bundle1).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.REMOVE)
                              .withDspaceObject(bundle2).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(bundle2).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(targetBundle).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.ADD)
                              .withDspaceObject(targetBundle).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(bitstream).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(publicItem1).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(targetItem).build();
 
@@ -592,25 +592,25 @@ public class BitstreamControllerIT extends AbstractControllerIntegrationTest {
                                                 .withPassword("test")
                                                 .withNameInMetadata("Bundle", "Put").build();
 
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.REMOVE)
                              .withDspaceObject(bundle1).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(bundle1).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(targetBundle).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.ADD)
                              .withDspaceObject(targetBundle).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(bitstream).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(publicItem1).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(targetItem).build();
 
@@ -708,22 +708,22 @@ public class BitstreamControllerIT extends AbstractControllerIntegrationTest {
                                                 .withPassword("test")
                                                 .withNameInMetadata("Bundle", "Put").build();
 
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(bundle1).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(targetBundle).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.ADD)
                              .withDspaceObject(targetBundle).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(bitstream).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(publicItem1).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(targetItem).build();
 
@@ -810,22 +810,22 @@ public class BitstreamControllerIT extends AbstractControllerIntegrationTest {
                                                 .withPassword("test")
                                                 .withNameInMetadata("Bundle", "Put").build();
 
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.REMOVE)
                              .withDspaceObject(bundle1).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(targetBundle).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.ADD)
                              .withDspaceObject(targetBundle).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(bitstream).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(publicItem1).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(targetItem).build();
 
@@ -913,22 +913,22 @@ public class BitstreamControllerIT extends AbstractControllerIntegrationTest {
                                                 .withPassword("test")
                                                 .withNameInMetadata("Bundle", "Put").build();
 
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.REMOVE)
                              .withDspaceObject(bundle1).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(bundle1).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.ADD)
                              .withDspaceObject(targetBundle).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(bitstream).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(publicItem1).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(targetItem).build();
 
@@ -1015,22 +1015,22 @@ public class BitstreamControllerIT extends AbstractControllerIntegrationTest {
                                                 .withPassword("test")
                                                 .withNameInMetadata("Bundle", "Put").build();
 
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.REMOVE)
                              .withDspaceObject(bundle1).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(bundle1).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(targetBundle).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(bitstream).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(publicItem1).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(targetItem).build();
 
@@ -1117,22 +1117,22 @@ public class BitstreamControllerIT extends AbstractControllerIntegrationTest {
                                                 .withPassword("test")
                                                 .withNameInMetadata("Bundle", "Put").build();
 
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.REMOVE)
                              .withDspaceObject(bundle1).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(bundle1).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(targetBundle).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.ADD)
                              .withDspaceObject(targetBundle).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(publicItem1).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(targetItem).build();
 
@@ -1220,22 +1220,22 @@ public class BitstreamControllerIT extends AbstractControllerIntegrationTest {
                                                 .withPassword("test")
                                                 .withNameInMetadata("Bundle", "Put").build();
 
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.REMOVE)
                              .withDspaceObject(bundle1).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(bundle1).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(targetBundle).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.ADD)
                              .withDspaceObject(targetBundle).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(bitstream).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(targetItem).build();
 
@@ -1322,22 +1322,22 @@ public class BitstreamControllerIT extends AbstractControllerIntegrationTest {
                                                 .withPassword("test")
                                                 .withNameInMetadata("Bundle", "Put").build();
 
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.REMOVE)
                              .withDspaceObject(bundle1).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(bundle1).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(targetBundle).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.ADD)
                              .withDspaceObject(targetBundle).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(bitstream).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(putBundlePerson)
+        ResourcePolicyBuilder.createResourcePolicy(context, putBundlePerson, null)
                              .withAction(Constants.WRITE)
                              .withDspaceObject(publicItem1).build();
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
@@ -1099,8 +1099,7 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
 
         context.turnOffAuthorisationSystem();
 
-        createResourcePolicy(context)
-                .withUser(eperson)
+        createResourcePolicy(context, eperson, null)
                 .withAction(WRITE)
                 .withDspaceObject(bitstream)
                 .build();

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestRepositoryIT.java
@@ -645,7 +645,7 @@ public class BitstreamRestRepositoryIT extends AbstractControllerIntegrationTest
 
         // Replace anon read policy on bundle of bitstream with ePerson READ policy
         resourcePolicyService.removePolicies(context, bitstream.getBundles().get(0), Constants.READ);
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(eperson)
+        ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
                              .withAction(Constants.READ)
                              .withDspaceObject(bitstream.getBundles().get(0)).build();
 
@@ -708,9 +708,9 @@ public class BitstreamRestRepositoryIT extends AbstractControllerIntegrationTest
 
         // Replace anon read policy on bundle of bitstream with ePerson READ policy
         resourcePolicyService.removePolicies(context, bitstream.getBundles().get(0), Constants.READ);
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(eperson)
-            .withAction(Constants.READ)
-            .withDspaceObject(bitstream.getBundles().get(0)).build();
+        ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
+                             .withAction(Constants.READ)
+                             .withDspaceObject(bitstream.getBundles().get(0)).build();
 
         context.restoreAuthSystemState();
 
@@ -833,7 +833,7 @@ public class BitstreamRestRepositoryIT extends AbstractControllerIntegrationTest
 
         // Replace anon read policy on item of bitstream with ePerson READ policy
         resourcePolicyService.removePolicies(context, publicItem1, Constants.READ);
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(eperson)
+        ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
                              .withAction(Constants.READ)
                              .withDspaceObject(publicItem1).build();
 
@@ -1481,8 +1481,7 @@ public class BitstreamRestRepositoryIT extends AbstractControllerIntegrationTest
                                         .build();
         }
 
-        ResourcePolicyBuilder.createResourcePolicy(context)
-                             .withUser(eperson)
+        ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
                              .withAction(WRITE)
                              .withDspaceObject(col1)
                              .build();

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BundleRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BundleRestRepositoryIT.java
@@ -347,7 +347,7 @@ public class BundleRestRepositoryIT extends AbstractControllerIntegrationTest {
                                                     .withPassword("test")
                                                     .withNameInMetadata("Create", "Bundle").build();
 
-        ResourcePolicy rp1 = ResourcePolicyBuilder.createResourcePolicy(context).withUser(createBundleEperson)
+        ResourcePolicy rp1 = ResourcePolicyBuilder.createResourcePolicy(context, createBundleEperson, null)
                                                   .withAction(Constants.ADD)
                                                   .withDspaceObject(item).build();
         context.restoreAuthSystemState();

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CollectionRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CollectionRestRepositoryIT.java
@@ -1811,8 +1811,7 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
 
 
 
-        ResourcePolicyBuilder.createResourcePolicy(context)
-                             .withUser(eperson)
+        ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
                              .withAction(WRITE)
                              .withDspaceObject(col1)
                              .build();
@@ -2894,11 +2893,10 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
         communityC = CommunityBuilder.createCommunity(context)
             .withName("the last community is topLevelCommunityC")
             .build();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, null, groupService.findByName(context, "COMMUNITY_" +
+                                     topLevelCommunityA.getID() + "_ADMIN"))
             .withDspaceObject(communityB)
-            .withAction(Constants.ADMIN)
-            .withGroup(groupService.findByName(context, "COMMUNITY_" + topLevelCommunityA.getID() + "_ADMIN"))
-            .build();
+            .withAction(Constants.ADMIN).build();
         collectionB = CollectionBuilder.createCollection(context, subCommunityA)
             .withName("collectionB is a very original name")
             .build();
@@ -2950,11 +2948,10 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
             .withName("the last community is topLevelCommunityC")
             .addParentCommunity(context, topLevelCommunityA)
             .build();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, null, groupService.findByName(context, "COMMUNITY_"
+                                     + subCommunityA.getID() + "_ADMIN"))
             .withDspaceObject(communityB)
-            .withAction(Constants.ADMIN)
-            .withGroup(groupService.findByName(context, "COMMUNITY_" + subCommunityA.getID() + "_ADMIN"))
-            .build();
+            .withAction(Constants.ADMIN).build();
         collectionB = CollectionBuilder.createCollection(context, subCommunityA)
             .withName("collectionB is a very original name")
             .build();
@@ -3012,11 +3009,10 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
         collectionC = CollectionBuilder.createCollection(context, communityC)
             .withName("the last collection is collectionC")
             .build();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, null, groupService.findByName(context, "COLLECTION_"
+                                     + collectionA.getID() + "_ADMIN"))
             .withDspaceObject(collectionB)
-            .withAction(Constants.ADMIN)
-            .withGroup(groupService.findByName(context, "COLLECTION_" + collectionA.getID() + "_ADMIN"))
-            .build();
+            .withAction(Constants.ADMIN).build();
         context.restoreAuthSystemState();
 
         String token = getAuthToken(eperson.getEmail(), password);
@@ -3065,11 +3061,10 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
         collectionB = CollectionBuilder.createCollection(context, communityB)
             .withName("collectionB is a very original name")
             .build();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, null, groupService.findByName(context, "COLLECTION_"
+                                     + collectionA.getID() + "_SUBMIT"))
             .withDspaceObject(collectionB)
-            .withAction(Constants.ADD)
-            .withGroup(groupService.findByName(context, "COLLECTION_" + collectionA.getID() + "_SUBMIT"))
-            .build();
+            .withAction(Constants.ADD).build();
         collectionC = CollectionBuilder.createCollection(context, communityC)
             .withName("the last collection is collectionC")
             .build();

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
@@ -2376,10 +2376,10 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
         communityC = CommunityBuilder.createCommunity(context)
             .withName("the last community is topLevelCommunityC")
             .build();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, null, groupService.findByName(context, "COMMUNITY_"
+                                     + topLevelCommunityA.getID() + "_ADMIN"))
             .withDspaceObject(communityB)
             .withAction(Constants.ADMIN)
-            .withGroup(groupService.findByName(context, "COMMUNITY_" + topLevelCommunityA.getID() + "_ADMIN"))
             .build();
         context.restoreAuthSystemState();
 
@@ -2429,10 +2429,10 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
             .withName("the last community is topLevelCommunityC")
             .addParentCommunity(context, topLevelCommunityA)
             .build();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, null, groupService.findByName(context, "COMMUNITY_"
+                                     + subCommunityA.getID() + "_ADMIN"))
             .withDspaceObject(communityB)
             .withAction(Constants.ADMIN)
-            .withGroup(groupService.findByName(context, "COMMUNITY_" + subCommunityA.getID() + "_ADMIN"))
             .build();
         context.restoreAuthSystemState();
 
@@ -2479,10 +2479,10 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
         Collection collectionB = CollectionBuilder.createCollection(context, communityB)
             .withName("collectionB")
             .build();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, null, groupService.findByName(context, "COLLECTION_"
+                                     + collectionA.getID() + "_ADMIN"))
             .withDspaceObject(collectionB)
             .withAction(Constants.ADMIN)
-            .withGroup(groupService.findByName(context, "COLLECTION_" + collectionA.getID() + "_ADMIN"))
             .build();
         communityC = CommunityBuilder.createCommunity(context)
             .withName("the last community is topLevelCommunityC")
@@ -2527,10 +2527,10 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
         Collection collectionB = CollectionBuilder.createCollection(context, communityB)
             .withName("collectionB")
             .build();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, null, groupService.findByName(context, "COLLECTION_"
+                                     + collectionA.getID() + "_SUBMIT"))
             .withDspaceObject(collectionB)
             .withAction(Constants.ADD)
-            .withGroup(groupService.findByName(context, "COLLECTION_" + collectionA.getID() + "_SUBMIT"))
             .build();
         communityC = CommunityBuilder.createCommunity(context)
             .withName("the last community is topLevelCommunityC")

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/GroupRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/GroupRestRepositoryIT.java
@@ -3461,10 +3461,10 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
                                            .build();
 
         Group adminGroup = groupService.findByName(context, Group.ADMIN);
-        ResourcePolicyBuilder.createResourcePolicy(context).withAction(Constants.DEFAULT_ITEM_READ)
-                .withGroup(adminGroup).withDspaceObject(child1).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withAction(Constants.DEFAULT_ITEM_READ)
-                .withGroup(adminGroup).withDspaceObject(col1).build();
+        ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup).withAction(Constants.DEFAULT_ITEM_READ)
+                             .withDspaceObject(child1).build();
+        ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup).withAction(Constants.DEFAULT_ITEM_READ)
+                             .withDspaceObject(col1).build();
         context.restoreAuthSystemState();
 
         String tokenAdminComm = getAuthToken(adminChild1.getEmail(), password);
@@ -3524,10 +3524,12 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
                                            .build();
 
         Group adminGroup = groupService.findByName(context, Group.ADMIN);
-        ResourcePolicyBuilder.createResourcePolicy(context).withAction(Constants.DEFAULT_BITSTREAM_READ)
-                .withGroup(adminGroup).withDspaceObject(child1).build();
-        ResourcePolicyBuilder.createResourcePolicy(context).withAction(Constants.DEFAULT_BITSTREAM_READ)
-                .withGroup(adminGroup).withDspaceObject(col1).build();
+        ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup)
+                             .withAction(Constants.DEFAULT_BITSTREAM_READ)
+                             .withDspaceObject(child1).build();
+        ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup)
+                             .withAction(Constants.DEFAULT_BITSTREAM_READ)
+                             .withDspaceObject(col1).build();
         context.restoreAuthSystemState();
 
         String tokenAdminComm = getAuthToken(adminChild1.getEmail(), password);

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemOwningCollectionUpdateRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemOwningCollectionUpdateRestControllerIT.java
@@ -131,13 +131,13 @@ public class ItemOwningCollectionUpdateRestControllerIT extends AbstractControll
         EPerson itemMoveEperson = EPersonBuilder.createEPerson(context).withEmail("item@move.org").withPassword("test")
                                                 .withNameInMetadata("Item", "Move").build();
 
-        ResourcePolicy rp1 = ResourcePolicyBuilder.createResourcePolicy(context).withUser(itemMoveEperson)
+        ResourcePolicy rp1 = ResourcePolicyBuilder.createResourcePolicy(context, itemMoveEperson, null)
                                                   .withAction(Constants.ADMIN)
                                                   .withDspaceObject(col1).build();
-        ResourcePolicy rp2 = ResourcePolicyBuilder.createResourcePolicy(context).withUser(itemMoveEperson)
+        ResourcePolicy rp2 = ResourcePolicyBuilder.createResourcePolicy(context, itemMoveEperson, null)
                                                   .withAction(Constants.WRITE)
                                                   .withDspaceObject(publicItem1).build();
-        ResourcePolicy rp3 = ResourcePolicyBuilder.createResourcePolicy(context).withUser(itemMoveEperson)
+        ResourcePolicy rp3 = ResourcePolicyBuilder.createResourcePolicy(context, itemMoveEperson, null)
                                                   .withAction(Constants.ADD)
                                                   .withDspaceObject(col2).build();
 
@@ -181,10 +181,10 @@ public class ItemOwningCollectionUpdateRestControllerIT extends AbstractControll
         EPerson itemMoveEperson = EPersonBuilder.createEPerson(context).withEmail("item@move.org").withPassword("test")
                                                 .withNameInMetadata("Item", "Move").build();
 
-        ResourcePolicy rp1 = ResourcePolicyBuilder.createResourcePolicy(context).withUser(itemMoveEperson)
+        ResourcePolicy rp1 = ResourcePolicyBuilder.createResourcePolicy(context, itemMoveEperson, null)
                                                   .withAction(Constants.ADMIN)
                                                   .withDspaceObject(col1).build();
-        ResourcePolicy rp2 = ResourcePolicyBuilder.createResourcePolicy(context).withUser(itemMoveEperson)
+        ResourcePolicy rp2 = ResourcePolicyBuilder.createResourcePolicy(context, itemMoveEperson, null)
                                                   .withAction(Constants.WRITE)
                                                   .withDspaceObject(publicItem1).build();
 
@@ -222,10 +222,10 @@ public class ItemOwningCollectionUpdateRestControllerIT extends AbstractControll
         EPerson itemMoveEperson = EPersonBuilder.createEPerson(context).withEmail("item@move.org").withPassword("test")
                                                 .withNameInMetadata("Item", "Move").build();
 
-        ResourcePolicy rp2 = ResourcePolicyBuilder.createResourcePolicy(context).withUser(itemMoveEperson)
+        ResourcePolicy rp2 = ResourcePolicyBuilder.createResourcePolicy(context, itemMoveEperson, null)
                                                   .withAction(Constants.WRITE)
                                                   .withDspaceObject(publicItem1).build();
-        ResourcePolicy rp3 = ResourcePolicyBuilder.createResourcePolicy(context).withUser(itemMoveEperson)
+        ResourcePolicy rp3 = ResourcePolicyBuilder.createResourcePolicy(context, itemMoveEperson, null)
                                                   .withAction(Constants.ADD)
                                                   .withDspaceObject(col2).build();
 
@@ -263,10 +263,10 @@ public class ItemOwningCollectionUpdateRestControllerIT extends AbstractControll
         EPerson itemMoveEperson = EPersonBuilder.createEPerson(context).withEmail("item@move.org").withPassword("test")
                                                 .withNameInMetadata("Item", "Move").build();
 
-        ResourcePolicy rp1 = ResourcePolicyBuilder.createResourcePolicy(context).withUser(itemMoveEperson)
+        ResourcePolicy rp1 = ResourcePolicyBuilder.createResourcePolicy(context, itemMoveEperson, null)
                                                   .withAction(Constants.ADMIN)
                                                   .withDspaceObject(col1).build();
-        ResourcePolicy rp3 = ResourcePolicyBuilder.createResourcePolicy(context).withUser(itemMoveEperson)
+        ResourcePolicy rp3 = ResourcePolicyBuilder.createResourcePolicy(context, itemMoveEperson, null)
                                                   .withAction(Constants.ADD)
                                                   .withDspaceObject(col2).build();
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
@@ -2936,7 +2936,7 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
                        BitstreamMatcher.matchBitstreamEntryWithoutEmbed(bitstream2.getID(), bitstream2.getSizeBytes())
                    )))
                    .andExpect(jsonPath("$._embedded.owningCollection._embedded.mappedItems." +
-                                           "_embedded.mappedItems[0]_embedded.relationships").doesNotExist())
+                                           "_embedded.mappedItems[0]._embedded.relationships").doesNotExist())
                    .andExpect(jsonPath("$._embedded.owningCollection._embedded.mappedItems" +
                                            "._embedded.mappedItems[0]._embedded.bundles._embedded.bundles[0]." +
                                            "_embedded.primaryBitstream").doesNotExist())
@@ -3045,8 +3045,7 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.restoreAuthSystemState();
 
 
-        ResourcePolicyBuilder.createResourcePolicy(context)
-            .withUser(eperson)
+        ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
             .withAction(READ)
             .withDspaceObject(item)
             .build();

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
@@ -3013,8 +3013,7 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.restoreAuthSystemState();
 
 
-        ResourcePolicyBuilder.createResourcePolicy(context)
-                             .withUser(eperson)
+        ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
                              .withAction(WRITE)
                              .withDspaceObject(item)
                              .build();

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemTemplateRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemTemplateRestControllerIT.java
@@ -253,9 +253,9 @@ public class ItemTemplateRestControllerIT extends AbstractControllerIntegrationT
 
         String itemId = installTestTemplate();
 
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(eperson)
-                .withAction(Constants.ADMIN)
-                .withDspaceObject(childCollection).build();
+        ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
+                             .withAction(Constants.ADMIN)
+                             .withDspaceObject(childCollection).build();
         String collAdminToken = getAuthToken(eperson.getEmail(), password);
 
         getClient(collAdminToken).perform(patch(getTemplateItemUrlTemplate(itemId))
@@ -374,9 +374,9 @@ public class ItemTemplateRestControllerIT extends AbstractControllerIntegrationT
         setupTestTemplate();
         String itemId = installTestTemplate();
 
-        ResourcePolicyBuilder.createResourcePolicy(context).withUser(eperson)
-                .withAction(Constants.ADMIN)
-                .withDspaceObject(childCollection).build();
+        ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
+                             .withAction(Constants.ADMIN)
+                             .withDspaceObject(childCollection).build();
         String collAdminToken = getAuthToken(eperson.getEmail(), password);
 
         getClient(collAdminToken).perform(delete(getTemplateItemUrlTemplate(itemId)))

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
@@ -80,8 +80,10 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
         context.turnOffAuthorisationSystem();
         Community community = CommunityBuilder.createCommunity(context).withName("My community").build();
 
-        ResourcePolicyBuilder.createResourcePolicy(context).withDspaceObject(community).withAction(Constants.READ)
-            .withUser(admin).build();
+        ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
+                             .withDspaceObject(community)
+                             .withAction(Constants.READ)
+                             .build();
         context.restoreAuthSystemState();
 
         String authToken = getAuthToken(admin.getEmail(), password);
@@ -94,8 +96,10 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
         context.turnOffAuthorisationSystem();
         Community community = CommunityBuilder.createCommunity(context).withName("My community").build();
 
-        ResourcePolicyBuilder.createResourcePolicy(context).withDspaceObject(community).withAction(Constants.READ)
-            .withUser(admin).build();
+        ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
+                             .withDspaceObject(community)
+                             .withAction(Constants.READ)
+                             .build();
         context.restoreAuthSystemState();
 
         getClient().perform(get("/api/authz/resourcepolicies")).andExpect(status().isUnauthorized());
@@ -112,10 +116,9 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         Community community = CommunityBuilder.createCommunity(context).withName("My community").build();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, eperson1, null)
             .withDspaceObject(community)
             .withAction(Constants.READ)
-            .withUser(eperson1)
             .build();
 
         context.restoreAuthSystemState();
@@ -144,10 +147,9 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         Community community = CommunityBuilder.createCommunity(context).withName("My community").build();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, null, groupAnonymous)
             .withDspaceObject(community)
             .withAction(Constants.READ)
-            .withGroup(groupAnonymous)
             .build();
 
         context.restoreAuthSystemState();
@@ -165,8 +167,10 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
         context.turnOffAuthorisationSystem();
         Community community = CommunityBuilder.createCommunity(context).withName("My community").build();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context).withDspaceObject(community)
-            .withAction(Constants.READ).withUser(eperson).build();
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
+                                                             .withDspaceObject(community)
+                                                             .withAction(Constants.READ)
+                                                             .build();
 
         context.restoreAuthSystemState();
 
@@ -201,10 +205,9 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
         Collection collection = CollectionBuilder.createCollection(context, community)
             .withName("My collection").build();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, eperson1, null)
             .withDspaceObject(collection)
-            .withAction(Constants.WRITE)
-            .withUser(eperson1).build();
+            .withAction(Constants.WRITE).build();
 
         context.restoreAuthSystemState();
 
@@ -228,10 +231,9 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         Community community = CommunityBuilder.createCommunity(context).withName("My community").build();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, eperson1, null)
             .withDspaceObject(community)
-            .withAction(Constants.WRITE)
-            .withUser(eperson1).build();
+            .withAction(Constants.WRITE).build();
 
         context.restoreAuthSystemState();
 
@@ -262,10 +264,9 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
         Collection collection = CollectionBuilder.createCollection(context, community)
             .withName("My collection").build();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, null, group1)
             .withDspaceObject(collection)
             .withAction(Constants.ADD)
-            .withGroup(group1)
             .build();
 
         context.restoreAuthSystemState();
@@ -297,15 +298,13 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
         Community community = CommunityBuilder.createCommunity(context).withName("My community").build();
         Community community2 = CommunityBuilder.createCommunity(context).withName("My community_2").build();
 
-        ResourcePolicy resourcePolicyOfEPerson1 = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicyOfEPerson1 = ResourcePolicyBuilder.createResourcePolicy(context, eperson1, null)
             .withDspaceObject(community)
-            .withAction(Constants.ADD)
-            .withUser(eperson1).build();
+            .withAction(Constants.ADD).build();
 
-        ResourcePolicy resourcePolicyOfEPerson2 = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicyOfEPerson2 = ResourcePolicyBuilder.createResourcePolicy(context, eperson2, null)
             .withDspaceObject(community2)
-            .withAction(Constants.REMOVE)
-            .withUser(eperson2).build();
+            .withAction(Constants.REMOVE).build();
 
         context.restoreAuthSystemState();
 
@@ -336,20 +335,18 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
         Collection collection = CollectionBuilder.createCollection(context, community).withName("My collection")
             .build();
 
-        ResourcePolicy resourcePolicyOfCommunity = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicyOfCommunity = ResourcePolicyBuilder.createResourcePolicy(context, eperson1, null)
             .withDspaceObject(community)
-            .withAction(Constants.READ)
-            .withUser(eperson1).build();
+            .withAction(Constants.READ).build();
 
-        ResourcePolicy secondResourcePolicyOfCommunity = ResourcePolicyBuilder.createResourcePolicy(context)
-            .withDspaceObject(community)
-            .withAction(Constants.REMOVE)
-            .withUser(eperson1).build();
+        ResourcePolicy secondResourcePolicyOfCommunity = ResourcePolicyBuilder
+                .createResourcePolicy(context, eperson1, null)
+                .withDspaceObject(community)
+                .withAction(Constants.REMOVE).build();
 
-        ResourcePolicy resourcePolicyOfCollection = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicyOfCollection = ResourcePolicyBuilder.createResourcePolicy(context, eperson1, null)
             .withDspaceObject(collection)
-            .withAction(Constants.REMOVE)
-            .withUser(eperson1).build();
+            .withAction(Constants.REMOVE).build();
 
         context.restoreAuthSystemState();
 
@@ -395,10 +392,9 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         Community community = CommunityBuilder.createCommunity(context).withName("My community").build();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, eperson1, null)
             .withDspaceObject(community)
-            .withAction(Constants.READ)
-            .withUser(eperson1).build();
+            .withAction(Constants.READ).build();
 
         context.restoreAuthSystemState();
 
@@ -437,15 +433,13 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         Community community2 = CommunityBuilder.createCommunity(context).withName("My 2 community").build();
 
-        ResourcePolicy resourcePolicyOfEPerson1 = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicyOfEPerson1 = ResourcePolicyBuilder.createResourcePolicy(context, eperson1, null)
             .withDspaceObject(community).withAction(Constants.WRITE)
-            .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
-            .withUser(eperson1).build();
+            .withPolicyType(ResourcePolicy.TYPE_CUSTOM).build();
 
-        ResourcePolicy resourcePolicyOfEPerson2 = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicyOfEPerson2 = ResourcePolicyBuilder.createResourcePolicy(context, eperson2, null)
             .withDspaceObject(community2).withAction(Constants.ADD)
-            .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
-            .withUser(eperson2).build();
+            .withPolicyType(ResourcePolicy.TYPE_CUSTOM).build();
 
         context.restoreAuthSystemState();
 
@@ -474,16 +468,18 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         Community community2 = CommunityBuilder.createCommunity(context).withName("My second community").build();
 
-        ResourcePolicy firstResourcePolicyOfEPerson1 = ResourcePolicyBuilder.createResourcePolicy(context)
-            .withDspaceObject(community)
-            .withAction(Constants.ADMIN)
-            .withUser(eperson1).build();
+        ResourcePolicy firstResourcePolicyOfEPerson1 = ResourcePolicyBuilder
+                .createResourcePolicy(context, eperson1, null)
+                .withDspaceObject(community)
+                .withAction(Constants.ADMIN)
+                .build();
 
-        ResourcePolicy firstResourcePolicyOfEPerson2 = ResourcePolicyBuilder.createResourcePolicy(context)
-            .withDspaceObject(community2)
-            .withAction(Constants.ADD)
-            .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
-            .withUser(eperson2).build();
+        ResourcePolicy firstResourcePolicyOfEPerson2 = ResourcePolicyBuilder
+                .createResourcePolicy(context, eperson2, null)
+                .withDspaceObject(community2)
+                .withAction(Constants.ADD)
+                .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
+                .build();
 
         ResourcePolicy resourcePolicyAnonymous = authorizeService
             .findByTypeGroupAction(context, community, EPersonServiceFactory.getInstance()
@@ -528,20 +524,23 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         Community community2 = CommunityBuilder.createCommunity(context).withName("My 2 community").build();
 
-        ResourcePolicy firstResourcePolicyOfEPerson1 = ResourcePolicyBuilder.createResourcePolicy(context)
-            .withDspaceObject(community)
-            .withAction(Constants.ADMIN)
-            .withUser(eperson1).build();
+        ResourcePolicy firstResourcePolicyOfEPerson1 = ResourcePolicyBuilder
+                .createResourcePolicy(context, eperson1, null)
+                .withDspaceObject(community)
+                .withAction(Constants.ADMIN)
+                .build();
 
-        ResourcePolicy firstResourcePolicyOfEPerson2 = ResourcePolicyBuilder.createResourcePolicy(context)
-            .withDspaceObject(community)
-            .withAction(Constants.ADD)
-            .withUser(eperson2).build();
+        ResourcePolicy firstResourcePolicyOfEPerson2 = ResourcePolicyBuilder
+                .createResourcePolicy(context, eperson2, null)
+                .withDspaceObject(community)
+                .withAction(Constants.ADD)
+                .build();
 
-        ResourcePolicy secondResourcePolicyOfEPerson2 = ResourcePolicyBuilder.createResourcePolicy(context)
-            .withDspaceObject(community2)
-            .withAction(Constants.ADD)
-            .withUser(eperson2).build();
+        ResourcePolicy secondResourcePolicyOfEPerson2 = ResourcePolicyBuilder
+                .createResourcePolicy(context, eperson2, null)
+                .withDspaceObject(community2)
+                .withAction(Constants.ADD)
+                .build();
 
         context.restoreAuthSystemState();
 
@@ -592,28 +591,32 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
         Community community = CommunityBuilder.createCommunity(context).withName("My community").build();
 
 
-        ResourcePolicy firstResourcePolicyOfEPerson1 = ResourcePolicyBuilder.createResourcePolicy(context)
-            .withDspaceObject(community)
-            .withAction(Constants.ADMIN)
-            .withUser(eperson1).build();
+        ResourcePolicy firstResourcePolicyOfEPerson1 = ResourcePolicyBuilder
+                .createResourcePolicy(context, eperson1, null)
+                .withDspaceObject(community)
+                .withAction(Constants.ADMIN)
+                .build();
 
-        ResourcePolicy firstResourcePolicyOfEPerson2 = ResourcePolicyBuilder.createResourcePolicy(context)
-            .withDspaceObject(community)
-            .withAction(Constants.ADD)
-            .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
-            .withUser(eperson2).build();
+        ResourcePolicy firstResourcePolicyOfEPerson2 = ResourcePolicyBuilder
+                .createResourcePolicy(context, eperson2, null)
+                .withDspaceObject(community)
+                .withAction(Constants.ADD)
+                .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
+                .build();
 
-        ResourcePolicy firstResourcePolicyOfEPerson3 = ResourcePolicyBuilder.createResourcePolicy(context)
-            .withDspaceObject(community)
-            .withAction(Constants.DELETE)
-            .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
-            .withUser(eperson3).build();
+        ResourcePolicy firstResourcePolicyOfEPerson3 = ResourcePolicyBuilder
+                .createResourcePolicy(context, eperson3, null)
+                .withDspaceObject(community)
+                .withAction(Constants.DELETE)
+                .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
+                .build();
 
-        ResourcePolicy firstResourcePolicyOfEPerson4 = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy firstResourcePolicyOfEPerson4 = ResourcePolicyBuilder
+                .createResourcePolicy(context, eperson4, null)
                 .withDspaceObject(community)
                 .withAction(Constants.WRITE)
                 .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
-                .withUser(eperson4).build();
+                .build();
 
         ResourcePolicy resourcePolicyAnonymous = authorizeService
             .findByTypeGroupAction(context, community, EPersonServiceFactory.getInstance()
@@ -701,10 +704,9 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         Community community = CommunityBuilder.createCommunity(context).withName("My community").build();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, eperson1, null)
             .withDspaceObject(community)
-            .withAction(Constants.READ)
-            .withUser(eperson1).build();
+            .withAction(Constants.READ).build();
 
         context.restoreAuthSystemState();
 
@@ -742,17 +744,15 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         Community community2 = CommunityBuilder.createCommunity(context).withName("My 2 community").build();
 
-        ResourcePolicy resourcePolicyOfEPerson1 = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicyOfEPerson1 = ResourcePolicyBuilder.createResourcePolicy(context, eperson1, null)
             .withDspaceObject(community)
             .withAction(Constants.REMOVE)
-            .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
-            .withUser(eperson1).build();
+            .withPolicyType(ResourcePolicy.TYPE_CUSTOM).build();
 
-        ResourcePolicy resourcePolicyOfEPerson2 = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicyOfEPerson2 = ResourcePolicyBuilder.createResourcePolicy(context, eperson2, null)
             .withDspaceObject(community2)
             .withAction(Constants.ADD)
-            .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
-            .withUser(eperson2).build();
+            .withPolicyType(ResourcePolicy.TYPE_CUSTOM).build();
 
         context.restoreAuthSystemState();
 
@@ -791,25 +791,22 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
             .withName("My collection")
             .build();
 
-        ResourcePolicy firstResourcePolicyOfGroup1 = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy firstResourcePolicyOfGroup1 = ResourcePolicyBuilder.createResourcePolicy(context, null, group1)
             .withDspaceObject(community)
-            .withAction(Constants.ADD)
-            .withGroup(group1).build();
+            .withAction(Constants.ADD).build();
 
-        ResourcePolicy secondResourcePolicyOfGroup1 = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy secondResourcePolicyOfGroup1 = ResourcePolicyBuilder.createResourcePolicy(context, null, group1)
             .withDspaceObject(community)
-            .withAction(Constants.READ)
-            .withGroup(group1).build();
+            .withAction(Constants.READ).build();
 
-        ResourcePolicy collectionResourcePolicyOfGroup1 = ResourcePolicyBuilder.createResourcePolicy(context)
-            .withDspaceObject(collection)
-            .withAction(Constants.WRITE)
-            .withGroup(group1).build();
+        ResourcePolicy collectionResourcePolicyOfGroup1 = ResourcePolicyBuilder
+                .createResourcePolicy(context, null, group1)
+                .withDspaceObject(collection)
+                .withAction(Constants.WRITE).build();
 
-        ResourcePolicy firstResourcePolicyOfGroup2 = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy firstResourcePolicyOfGroup2 = ResourcePolicyBuilder.createResourcePolicy(context, null, group2)
             .withDspaceObject(community2)
-            .withAction(Constants.ADD)
-            .withGroup(group2).build();
+            .withAction(Constants.ADD).build();
 
         context.restoreAuthSystemState();
 
@@ -857,15 +854,13 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
         Community community = CommunityBuilder.createCommunity(context).withName("My community").build();
         Community community2 = CommunityBuilder.createCommunity(context).withName("My second community").build();
 
-        ResourcePolicy firstResourcePolicyOfGroup1 = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy firstResourcePolicyOfGroup1 = ResourcePolicyBuilder.createResourcePolicy(context, null, group1)
             .withDspaceObject(community)
-            .withAction(Constants.ADD)
-            .withGroup(group1).build();
+            .withAction(Constants.ADD).build();
 
-        ResourcePolicy secondResourcePolicyOfGroup1 = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy secondResourcePolicyOfGroup1 = ResourcePolicyBuilder.createResourcePolicy(context, null, group1)
             .withDspaceObject(community2)
-            .withAction(Constants.WRITE)
-            .withGroup(group1).build();
+            .withAction(Constants.WRITE).build();
 
         context.restoreAuthSystemState();
 
@@ -913,10 +908,9 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         Community community = CommunityBuilder.createCommunity(context).withName("My community").build();
 
-        ResourcePolicy firstResourcePolicyOfGroup1 = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy firstResourcePolicyOfGroup1 = ResourcePolicyBuilder.createResourcePolicy(context, null, group1)
             .withDspaceObject(community)
-            .withAction(Constants.ADD)
-            .withGroup(group1).build();
+            .withAction(Constants.ADD).build();
 
         context.restoreAuthSystemState();
 
@@ -953,10 +947,9 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         Community community = CommunityBuilder.createCommunity(context).withName("My community").build();
 
-        ResourcePolicy resourcePolicyOfGroup1 = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicyOfGroup1 = ResourcePolicyBuilder.createResourcePolicy(context, null, group1)
             .withDspaceObject(community).withAction(Constants.WRITE)
-            .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
-            .withGroup(group1).build();
+            .withPolicyType(ResourcePolicy.TYPE_CUSTOM).build();
 
         context.restoreAuthSystemState();
 
@@ -981,10 +974,10 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         Community community = CommunityBuilder.createCommunity(context).withName("My community").build();
 
-        ResourcePolicy resourcePolicyOfGroup1 = ResourcePolicyBuilder.createResourcePolicy(context)
-            .withDspaceObject(community).withAction(Constants.WRITE)
-            .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
-            .withGroup(groupAnonymous).build();
+        ResourcePolicy resourcePolicyOfGroup1 = ResourcePolicyBuilder
+                .createResourcePolicy(context, null, groupAnonymous)
+                .withDspaceObject(community).withAction(Constants.WRITE)
+                .withPolicyType(ResourcePolicy.TYPE_CUSTOM).build();
 
         context.restoreAuthSystemState();
 
@@ -1143,9 +1136,8 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
             .withName("My community")
             .build();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, eperson1, null)
             .withDspaceObject(community)
-            .withUser(eperson1)
             .withAction(Constants.ADMIN)
             .build();
 
@@ -1170,11 +1162,10 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
             .withPassword("qwerty01")
             .build();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, eperson1, null)
             .withDspaceObject(community)
             .withAction(Constants.DELETE)
             .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
-            .withUser(eperson1)
             .build();
 
         context.restoreAuthSystemState();
@@ -1200,10 +1191,9 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
         Collection collection = CollectionBuilder.createCollection(context, community)
             .withName("My collection").build();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, eperson1, null)
             .withDspaceObject(collection)
-            .withAction(Constants.ADD)
-            .withUser(eperson1).build();
+            .withAction(Constants.ADD).build();
 
         context.restoreAuthSystemState();
 
@@ -1253,10 +1243,10 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         Date data = calendar.getTime();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, null,
+                   EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
             .withAction(Constants.READ)
             .withDspaceObject(publicItem1)
-            .withGroup(EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
             .withStartDate(data)
             .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
             .build();
@@ -1323,10 +1313,10 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         Date date = calendar.getTime();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, null,
+                           EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
             .withAction(Constants.READ)
             .withDspaceObject(publicItem1)
-            .withGroup(EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
             .withEndDate(date)
             .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
             .build();
@@ -1385,10 +1375,10 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
             .withTitle("Public item")
             .build();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, null,
+                       EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
             .withAction(Constants.READ)
             .withDspaceObject(publicItem1)
-            .withGroup(EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
             .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
             .build();
 
@@ -1446,13 +1436,12 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
                                       .withTitle("Public item")
                                       .build();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context,null,
+                                                           EPersonServiceFactory.getInstance().getGroupService()
+                                                                                 .findByName(context, Group.ANONYMOUS)
+                                                                                   )
                                                              .withAction(Constants.READ)
                                                              .withDspaceObject(publicItem1)
-                                                             .withGroup(
-                                                                 EPersonServiceFactory.getInstance().getGroupService()
-                                                                                      .findByName(context,
-                                                                                          Group.ANONYMOUS))
                                                              .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
                                                              .build();
 
@@ -1513,10 +1502,10 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         Date data = calendar.getTime();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, null,
+                       EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
             .withAction(Constants.READ)
             .withDspaceObject(publicItem1)
-            .withGroup(EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
             .withStartDate(data)
             .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
             .build();
@@ -1574,10 +1563,10 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         Date date = calendar.getTime();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, null,
+                           EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
             .withAction(Constants.READ)
             .withDspaceObject(publicItem1)
-            .withGroup(EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
             .withStartDate(date)
             .withDescription("my description")
             .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
@@ -1625,7 +1614,7 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         Date date = calendar.getTime();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
             .withAction(Constants.WRITE)
             .withDspaceObject(item)
             .withStartDate(date)
@@ -1687,10 +1676,10 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         Date date = calendar.getTime();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, null,
+                       EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
             .withAction(Constants.READ)
             .withDspaceObject(item)
-            .withGroup(EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
             .withStartDate(date)
             .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
             .build();
@@ -1793,10 +1782,9 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         Date endDate = calendarEndDate.getTime();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, eperson1, null)
             .withAction(Constants.READ)
             .withDspaceObject(publicItem1)
-            .withUser(eperson1)
             .withStartDate(startDate)
             .withEndDate(endDate)
             .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
@@ -1851,10 +1839,10 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
             .withTitle("Public item")
             .build();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, null,
+                       EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
             .withAction(Constants.READ)
             .withDspaceObject(publicItem1)
-            .withGroup(EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
             .withDescription("my description")
             .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
             .build();
@@ -1903,10 +1891,10 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
             .withTitle("Public item")
             .build();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, null,
+                       EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
             .withAction(Constants.READ)
             .withDspaceObject(item)
-            .withGroup(EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
             .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
             .build();
 
@@ -1954,11 +1942,11 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
             .withTitle("Public item")
             .build();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, null,
+                           EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
             .withAction(Constants.READ)
             .withDspaceObject(item)
             .withDescription("my description")
-            .withGroup(EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
             .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
             .build();
 
@@ -1996,7 +1984,7 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         Item item = ItemBuilder.createItem(context, collection).build();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
             .withAction(Constants.WRITE)
             .withDspaceObject(item)
             .withDescription("My Description")
@@ -2042,10 +2030,10 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
             .withTitle("Public item")
             .build();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, null,
+                       EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
             .withAction(Constants.READ)
             .withDspaceObject(item)
-            .withGroup(EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
             .withDescription("My Description")
             .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
             .build();
@@ -2098,10 +2086,10 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
             .withTitle("Public item")
             .build();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, null,
+                           EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
             .withAction(Constants.READ)
             .withDspaceObject(publicItem1)
-            .withGroup(EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
             .withDescription("my description")
             .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
             .build();
@@ -2146,10 +2134,10 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
             .withTitle("Public item")
             .build();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, null,
+                       EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
             .withAction(Constants.READ)
             .withDspaceObject(myItem)
-            .withGroup(EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
             .withName("My name")
             .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
             .build();
@@ -2197,10 +2185,10 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
             .withTitle("Public item")
             .build();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, null,
+                       EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
             .withAction(Constants.READ)
             .withDspaceObject(myItem)
-            .withGroup(EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
             .withName("My name")
             .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
             .build();
@@ -2245,10 +2233,10 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
             .withTitle("Public item")
             .build();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, null,
+                       EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
             .withAction(Constants.READ)
             .withDspaceObject(myItem)
-            .withGroup(EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
             .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
             .build();
 
@@ -2290,10 +2278,9 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
             .withTitle("Public item")
             .build();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
             .withAction(Constants.READ)
             .withDspaceObject(myItem)
-            .withUser(eperson)
             .withName("My Name")
             .build();
 
@@ -2334,10 +2321,9 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
             .withTitle("Public item")
             .build();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
             .withAction(Constants.READ)
             .withDspaceObject(myItem)
-            .withUser(eperson)
             .withName("My name")
             .withPolicyType(ResourcePolicy.TYPE_SUBMISSION)
             .build();
@@ -2374,7 +2360,7 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         Item item = ItemBuilder.createItem(context, collection).build();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
             .withAction(Constants.WRITE)
             .withDspaceObject(item)
             .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
@@ -2413,10 +2399,9 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
             .withTitle("Public item")
             .build();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
             .withAction(Constants.READ)
             .withDspaceObject(item)
-            .withUser(eperson)
             .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
             .build();
 
@@ -2464,10 +2449,9 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
             .withTitle("Public item")
             .build();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
             .withAction(Constants.READ)
             .withDspaceObject(publicItem1)
-            .withUser(eperson)
             .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
             .build();
 
@@ -2500,10 +2484,9 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
             .withTitle("Public item")
             .build();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
             .withAction(Constants.READ)
             .withDspaceObject(myItem)
-            .withUser(eperson)
             .withName("My Name")
             .build();
 
@@ -2545,10 +2528,9 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
             .withTitle("Public item")
             .build();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
             .withAction(Constants.READ)
             .withDspaceObject(myItem)
-            .withUser(eperson)
             .withName("My Name")
             .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
             .build();
@@ -2590,10 +2572,9 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
             .withTitle("Public item")
             .build();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
             .withAction(Constants.READ)
             .withDspaceObject(myItem)
-            .withUser(eperson)
             .withName("My name")
             .withPolicyType(ResourcePolicy.TYPE_SUBMISSION)
             .build();
@@ -2632,7 +2613,7 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         Item item = ItemBuilder.createItem(context, collection).build();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
             .withAction(Constants.WRITE)
             .withDspaceObject(item)
             .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
@@ -2672,10 +2653,9 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
             .withTitle("Public item")
             .build();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
             .withAction(Constants.READ)
             .withDspaceObject(item)
-            .withUser(eperson)
             .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
             .build();
 
@@ -2722,10 +2702,9 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
             .withTitle("Public item")
             .build();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
             .withAction(Constants.READ)
             .withDspaceObject(publicItem1)
-            .withUser(eperson)
             .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
             .build();
 
@@ -2763,11 +2742,11 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
             .withTitle("Public item")
             .build();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, null,
+                       EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
             .withAction(Constants.READ)
             .withDspaceObject(myItem)
             .withName("My name")
-            .withGroup(EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
             .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
             .build();
 
@@ -2811,10 +2790,10 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
             .withTitle("Public item")
             .build();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, null,
+                       EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
             .withAction(Constants.READ)
             .withDspaceObject(myItem)
-            .withGroup(EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
             .withName("My Name")
             .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
             .build();
@@ -2860,10 +2839,10 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
             .withTitle("Public item")
             .build();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, null,
+                       EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
             .withAction(Constants.READ)
             .withDspaceObject(myItem)
-            .withGroup(EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
             .withName("My Name")
             .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
             .build();
@@ -2923,12 +2902,12 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         Date endDate = calendarEndDate.getTime();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, null,
+                       EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
             .withAction(Constants.READ)
             .withDspaceObject(publicItem1)
             .withStartDate(startDate)
             .withEndDate(endDate)
-            .withGroup(EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
             .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
             .build();
 
@@ -3013,12 +2992,12 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         Date endDate = calendarEndDate.getTime();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, null,
+                       EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
             .withAction(Constants.READ)
             .withDspaceObject(publicItem1)
             .withName("My Name")
             .withEndDate(endDate)
-            .withGroup(EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
             .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
             .build();
 
@@ -3092,25 +3071,21 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
             .withName("My collection")
             .build();
 
-        ResourcePolicy rpCommunityADD = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy rpCommunityADD = ResourcePolicyBuilder.createResourcePolicy(context, null, group1)
             .withDspaceObject(community)
-            .withAction(Constants.ADD)
-            .withGroup(group1).build();
+            .withAction(Constants.ADD).build();
 
-        ResourcePolicy rpCommunityREAD = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy rpCommunityREAD = ResourcePolicyBuilder.createResourcePolicy(context, null, group1)
             .withDspaceObject(community)
-            .withAction(Constants.READ)
-            .withGroup(group1).build();
+            .withAction(Constants.READ).build();
 
-        ResourcePolicy rpCommunity2READ = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy rpCommunity2READ = ResourcePolicyBuilder.createResourcePolicy(context, null, group1)
             .withDspaceObject(community2)
-            .withAction(Constants.READ)
-            .withGroup(group1).build();
+            .withAction(Constants.READ).build();
 
-        ResourcePolicy rpCollectionWRITE = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy rpCollectionWRITE = ResourcePolicyBuilder.createResourcePolicy(context, null, group1)
             .withDspaceObject(collection)
-            .withAction(Constants.WRITE)
-            .withGroup(group1).build();
+            .withAction(Constants.WRITE).build();
 
         context.restoreAuthSystemState();
 
@@ -3213,10 +3188,9 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
                                           .withName("Collection 1")
                                           .build();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
                                             .withAction(Constants.ADD)
                                             .withDspaceObject(col)
-                                            .withUser(eperson)
                                             .withDescription("My Description")
                                             .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
                                             .build();
@@ -3260,10 +3234,9 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
                                           .withName("Collection 1")
                                           .build();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
                                             .withAction(Constants.ADD)
                                             .withDspaceObject(col)
-                                            .withUser(eperson)
                                             .withDescription("My Description")
                                             .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
                                             .build();
@@ -3308,10 +3281,9 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
                                           .withName("Collection 1")
                                           .build();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
                                             .withAction(Constants.ADD)
                                             .withDspaceObject(col)
-                                            .withUser(eperson)
                                             .withDescription("My Description")
                                             .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
                                             .build();
@@ -3358,10 +3330,9 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
                                           .withName("Collection 1")
                                           .build();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, null, originGroup)
                                             .withAction(Constants.ADD)
                                             .withDspaceObject(col)
-                                            .withGroup(originGroup)
                                             .withDescription("My Description")
                                             .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
                                             .build();
@@ -3408,10 +3379,9 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
                                           .withName("Collection 1")
                                           .build();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, null, originGroup)
                                             .withAction(Constants.ADD)
                                             .withDspaceObject(col)
-                                            .withGroup(originGroup)
                                             .withDescription("My Description")
                                             .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
                                             .build();
@@ -3459,10 +3429,9 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
                                           .withName("Collection 1")
                                           .build();
 
-        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, null, originGroup)
                                             .withAction(Constants.ADD)
                                             .withDspaceObject(col)
-                                            .withGroup(originGroup)
                                             .withDescription("My Description")
                                             .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
                                             .build();
@@ -3501,10 +3470,9 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
                                               .withName("My community")
                                               .build();
 
-        ResourcePolicy resourcePolicyOfEPerson = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicyOfEPerson = ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
                                                              .withDspaceObject(community)
                                                              .withAction(Constants.READ)
-                                                             .withUser(eperson)
                                                              .build();
         context.restoreAuthSystemState();
 
@@ -3534,10 +3502,9 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
                                               .withName("My community")
                                               .build();
 
-        ResourcePolicy resourcePolicyOfGroup = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicyOfGroup = ResourcePolicyBuilder.createResourcePolicy(context, null, group)
                                                                     .withDspaceObject(community)
-                                                                    .withAction(Constants.ADD)
-                                                                    .withGroup(group).build();
+                                                                    .withAction(Constants.ADD).build();
 
         context.restoreAuthSystemState();
 
@@ -3597,10 +3564,9 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
                                               .build();
 
 
-        ResourcePolicy resourcePolicyOfGroup = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicyOfGroup = ResourcePolicyBuilder.createResourcePolicy(context, null, group)
                                                                     .withDspaceObject(community)
-                                                                    .withAction(Constants.ADD)
-                                                                    .withGroup(group).build();
+                                                                    .withAction(Constants.ADD).build();
         context.restoreAuthSystemState();
 
         String tokenAdmin = getAuthToken(admin.getEmail(), password);
@@ -3622,10 +3588,9 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
                                               .withName("My community")
                                               .build();
 
-        ResourcePolicy resourcePolicyOfGroup = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy resourcePolicyOfGroup = ResourcePolicyBuilder.createResourcePolicy(context, null, group1)
                                                                     .withDspaceObject(community)
-                                                                    .withAction(Constants.ADD)
-                                                                    .withGroup(group1).build();
+                                                                    .withAction(Constants.ADD).build();
         context.restoreAuthSystemState();
 
         String tokenAdmin = getAuthToken(admin.getEmail(), password);
@@ -3642,10 +3607,9 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         Community community = CommunityBuilder.createCommunity(context).withName("My community").build();
 
-        ResourcePolicy rpOfEPerson = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy rpOfEPerson = ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
                                                           .withDspaceObject(community)
                                                           .withAction(Constants.READ)
-                                                          .withUser(eperson)
                                                           .build();
         context.restoreAuthSystemState();
 
@@ -3671,10 +3635,9 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         Community community = CommunityBuilder.createCommunity(context).withName("My community").build();
 
-        ResourcePolicy rpOfEPerson = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy rpOfEPerson = ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
                                                           .withDspaceObject(community)
                                                           .withAction(Constants.READ)
-                                                          .withUser(eperson)
                                                           .build();
         context.restoreAuthSystemState();
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/StatisticsRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/StatisticsRestRepositoryIT.java
@@ -205,10 +205,9 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         // ** WHEN **
         context.turnOffAuthorisationSystem();
         authorizeService.removeAllPolicies(context, itemNotVisitedWithBitstreams);
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
                              .withDspaceObject(itemNotVisitedWithBitstreams)
-                             .withAction(Constants.READ)
-                             .withUser(eperson).build();
+                             .withAction(Constants.READ).build();
 
         EPerson eperson1 = EPersonBuilder.createEPerson(context)
                                          .withEmail("eperson1@mail.com")
@@ -239,10 +238,9 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         configurationService.setProperty("usage-statistics.authorization.admin.usage", false);
         context.turnOffAuthorisationSystem();
         authorizeService.removeAllPolicies(context, itemNotVisitedWithBitstreams);
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
                              .withDspaceObject(itemNotVisitedWithBitstreams)
-                             .withAction(Constants.READ)
-                             .withUser(eperson).build();
+                             .withAction(Constants.READ).build();
 
         EPerson eperson1 = EPersonBuilder.createEPerson(context)
                                          .withEmail("eperson1@mail.com")
@@ -1150,10 +1148,9 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         // ** WHEN **
         context.turnOffAuthorisationSystem();
         authorizeService.removeAllPolicies(context, itemNotVisitedWithBitstreams);
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
                              .withDspaceObject(itemNotVisitedWithBitstreams)
-                             .withAction(Constants.READ)
-                             .withUser(eperson).build();
+                             .withAction(Constants.READ).build();
 
         EPerson eperson1 = EPersonBuilder.createEPerson(context)
                                          .withEmail("eperson1@mail.com")

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkspaceItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkspaceItemRestRepositoryIT.java
@@ -6722,7 +6722,9 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
                                                   .build();
         witem.getItem().setDiscoverable(false);
 
-ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup)
+        ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup).withDspaceObject(witem.getItem())
+                             .withPolicyType(TYPE_CUSTOM)
+                             .withName("administrator")
                              .build();
 
         ResourcePolicyBuilder.createResourcePolicy(context, null, anonymousGroup)
@@ -7119,7 +7121,10 @@ ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup)
                              .build();
 
 ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup)
-                             .build();
+                     .withDspaceObject(witem.getItem())
+                     .withPolicyType(TYPE_CUSTOM)
+                     .withName("administrator")
+                     .build();
 
         Calendar calendar = Calendar.getInstance();
 
@@ -7198,7 +7203,10 @@ ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup)
                              .build();
 
 ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup)
-                             .build();
+                     .withDspaceObject(witem.getItem())
+                     .withPolicyType(TYPE_CUSTOM)
+                     .withName("administrator")
+                     .build();
 
         context.restoreAuthSystemState();
 
@@ -7258,7 +7266,10 @@ ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup)
                              .build();
 
 ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup)
-                             .build();
+                     .withDspaceObject(witem.getItem())
+                     .withPolicyType(TYPE_CUSTOM)
+                     .withName("administrator")
+                     .build();
 
         context.restoreAuthSystemState();
 
@@ -7320,7 +7331,10 @@ ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup)
                              .build();
 
 ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup)
-                             .build();
+                     .withDspaceObject(witem.getItem())
+                     .withPolicyType(TYPE_CUSTOM)
+                     .withName("administrator")
+                     .build();
 
         context.restoreAuthSystemState();
 
@@ -7382,7 +7396,10 @@ ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup)
                              .build();
 
 ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup)
-                             .build();
+                     .withDspaceObject(witem.getItem())
+                     .withPolicyType(TYPE_CUSTOM)
+                     .withName("administrator")
+                     .build();
 
         context.restoreAuthSystemState();
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkspaceItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkspaceItemRestRepositoryIT.java
@@ -124,6 +124,7 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
     private Group embargoedGroup1;
     private Group embargoedGroup2;
     private Group anonymousGroup;
+    private Group adminGroup;
 
     @Before
     @Override
@@ -147,6 +148,7 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
                 .build();
 
         anonymousGroup = EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS);
+        adminGroup = EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ADMIN);
 
         context.restoreAuthSystemState();
     }
@@ -6720,13 +6722,10 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
                                                   .build();
         witem.getItem().setDiscoverable(false);
 
-        ResourcePolicyBuilder.createResourcePolicy(context)
-                             .withDspaceObject(witem.getItem())
-                             .withPolicyType(TYPE_CUSTOM)
-                             .withName("administrator")
+ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup)
                              .build();
 
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, null, anonymousGroup)
                              .withDspaceObject(witem.getItem())
                              .withPolicyType(TYPE_CUSTOM)
                              .withName("openaccess")
@@ -6780,7 +6779,7 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
                                                   .withSubject("ExtraEntry")
                                                   .build();
 
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, null, anonymousGroup)
                              .withDspaceObject(witem.getItem())
                              .withPolicyType(TYPE_CUSTOM)
                              .withName("openaccess")
@@ -6827,7 +6826,7 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
                                                   .withSubject("ExtraEntry")
                                                   .build();
 
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, null, anonymousGroup)
                              .withDspaceObject(witem.getItem())
                              .withPolicyType(TYPE_CUSTOM)
                              .withName("openaccess")
@@ -6880,7 +6879,7 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
                                                   .withSubject("ExtraEntry")
                                                   .build();
 
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, null, anonymousGroup)
                              .withDspaceObject(witem.getItem())
                              .withPolicyType(TYPE_CUSTOM)
                              .withName("openaccess")
@@ -6938,7 +6937,7 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
                                                   .withSubject("ExtraEntry")
                                                   .build();
 
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, null, anonymousGroup)
                              .withDspaceObject(witem.getItem())
                              .withPolicyType(TYPE_CUSTOM)
                              .withName("openaccess")
@@ -7053,13 +7052,13 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
                                                   .withSubject("ExtraEntry")
                                                   .build();
 
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, null, anonymousGroup)
                              .withDspaceObject(witem.getItem())
                              .withPolicyType(TYPE_CUSTOM)
                              .withName("openaccess")
                              .build();
 
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup)
                              .withDspaceObject(witem.getItem())
                              .withPolicyType(TYPE_CUSTOM)
                              .withName("administrator")
@@ -7113,16 +7112,13 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
                                                   .withSubject("ExtraEntry")
                                                   .build();
 
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, null, anonymousGroup)
                              .withDspaceObject(witem.getItem())
                              .withPolicyType(TYPE_CUSTOM)
                              .withName("openaccess")
                              .build();
 
-        ResourcePolicyBuilder.createResourcePolicy(context)
-                             .withDspaceObject(witem.getItem())
-                             .withPolicyType(TYPE_CUSTOM)
-                             .withName("administrator")
+ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup)
                              .build();
 
         Calendar calendar = Calendar.getInstance();
@@ -7133,7 +7129,7 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
 
         Date data = calendar.getTime();
 
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, null, embargoedGroup1)
                              .withDspaceObject(witem.getItem())
                              .withPolicyType(TYPE_CUSTOM)
                              .withName("embargoed")
@@ -7195,16 +7191,13 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
                                                   .withSubject("ExtraEntry")
                                                   .build();
 
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, null, anonymousGroup)
                              .withDspaceObject(witem.getItem())
                              .withPolicyType(TYPE_CUSTOM)
                              .withName("openaccess")
                              .build();
 
-        ResourcePolicyBuilder.createResourcePolicy(context)
-                             .withDspaceObject(witem.getItem())
-                             .withPolicyType(TYPE_CUSTOM)
-                             .withName("administrator")
+ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup)
                              .build();
 
         context.restoreAuthSystemState();
@@ -7258,16 +7251,13 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
                                                   .withSubject("ExtraEntry")
                                                   .build();
 
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, null, anonymousGroup)
                              .withDspaceObject(witem.getItem())
                              .withPolicyType(TYPE_CUSTOM)
                              .withName("openaccess")
                              .build();
 
-        ResourcePolicyBuilder.createResourcePolicy(context)
-                             .withDspaceObject(witem.getItem())
-                             .withPolicyType(TYPE_CUSTOM)
-                             .withName("administrator")
+ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup)
                              .build();
 
         context.restoreAuthSystemState();
@@ -7323,16 +7313,13 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
                                                   .withSubject("ExtraEntry")
                                                   .build();
 
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, null, anonymousGroup)
                              .withDspaceObject(witem.getItem())
                              .withPolicyType(TYPE_CUSTOM)
                              .withName("openaccess")
                              .build();
 
-        ResourcePolicyBuilder.createResourcePolicy(context)
-                             .withDspaceObject(witem.getItem())
-                             .withPolicyType(TYPE_CUSTOM)
-                             .withName("administrator")
+ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup)
                              .build();
 
         context.restoreAuthSystemState();
@@ -7388,16 +7375,13 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
                                                   .withSubject("ExtraEntry")
                                                   .build();
 
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, null, anonymousGroup)
                              .withDspaceObject(witem.getItem())
                              .withPolicyType(TYPE_CUSTOM)
                              .withName("openaccess")
                              .build();
 
-        ResourcePolicyBuilder.createResourcePolicy(context)
-                             .withDspaceObject(witem.getItem())
-                             .withPolicyType(TYPE_CUSTOM)
-                             .withName("administrator")
+ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup)
                              .build();
 
         context.restoreAuthSystemState();
@@ -7458,7 +7442,7 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
                                                   .withSubject("ExtraEntry")
                                                   .build();
 
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, null, anonymousGroup)
                              .withDspaceObject(witem.getItem())
                              .withPolicyType(TYPE_CUSTOM)
                              .withName("openaccess")
@@ -7472,7 +7456,7 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
 
         Date data = calendar.getTime();
 
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, null, embargoedGroup1)
                              .withDspaceObject(witem.getItem())
                              .withPolicyType(TYPE_CUSTOM)
                              .withName("embargo")
@@ -7538,7 +7522,7 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
                                                   .withSubject("ExtraEntry")
                                                   .build();
 
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, null, anonymousGroup)
                              .withDspaceObject(witem.getItem())
                              .withPolicyType(TYPE_CUSTOM)
                              .withName("openaccess")

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/CCLicenseFeatureRestIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/CCLicenseFeatureRestIT.java
@@ -202,8 +202,10 @@ public class CCLicenseFeatureRestIT extends AbstractControllerIntegrationTest {
         Community com = CommunityBuilder.createCommunity(context).withName("A community").build();
         Collection col = CollectionBuilder.createCollection(context, com).withName("A collection").build();
         Item item = ItemBuilder.createItem(context, col).withTitle("Item to withdraw").build();
-        ResourcePolicy resource = ResourcePolicyBuilder.createResourcePolicy(context).withAction(Constants.ADMIN)
-                .withUser(eperson).withDspaceObject(item).build();
+        ResourcePolicy resource = ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
+                                                       .withAction(Constants.ADMIN)
+                                                       .withDspaceObject(item)
+                                                       .build();
         context.restoreAuthSystemState();
 
         ItemRest itemRest = itemConverter.convert(item, Projection.DEFAULT);

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/CanManageBitstreamBundlesFeatureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/CanManageBitstreamBundlesFeatureIT.java
@@ -216,9 +216,8 @@ public class CanManageBitstreamBundlesFeatureIT extends AbstractControllerIntegr
     @SuppressWarnings("unchecked")
     public void itemAdminSetPropertyCreateBitstreamToFalseTest() throws Exception {
         context.turnOffAuthorisationSystem();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, userA, null)
                              .withAction(Constants.ADMIN)
-                             .withUser(userA)
                              .withDspaceObject(itemA).build();
 
         configurationService.setProperty("core.authorization.item-admin.create-bitstream", false);
@@ -260,9 +259,8 @@ public class CanManageBitstreamBundlesFeatureIT extends AbstractControllerIntegr
     @SuppressWarnings("unchecked")
     public void itemAdminSetPropertyDeleteBitstreamToFalseTest() throws Exception {
         context.turnOffAuthorisationSystem();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, userA, null)
                              .withAction(Constants.ADMIN)
-                             .withUser(userA)
                              .withDspaceObject(itemA).build();
 
         configurationService.setProperty("core.authorization.item-admin.delete-bitstream", false);
@@ -304,9 +302,8 @@ public class CanManageBitstreamBundlesFeatureIT extends AbstractControllerIntegr
     @SuppressWarnings("unchecked")
     public void itemAdminSetPropertyCollectionAdminCreateBitstreamToFalseTest() throws Exception {
         context.turnOffAuthorisationSystem();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, userA, null)
                              .withAction(Constants.ADMIN)
-                             .withUser(userA)
                              .withDspaceObject(itemA).build();
 
         configurationService.setProperty("core.authorization.collection-admin.item.create-bitstream", false);
@@ -365,9 +362,8 @@ public class CanManageBitstreamBundlesFeatureIT extends AbstractControllerIntegr
     @SuppressWarnings("unchecked")
     public void itemAdminSetPropertyCollectionAdminDeleteBitstreamToFalseTest() throws Exception {
         context.turnOffAuthorisationSystem();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, userA, null)
                              .withAction(Constants.ADMIN)
-                             .withUser(userA)
                              .withDspaceObject(itemA).build();
 
         configurationService.setProperty("core.authorization.collection-admin.item.delete-bitstream", false);
@@ -426,9 +422,8 @@ public class CanManageBitstreamBundlesFeatureIT extends AbstractControllerIntegr
     @SuppressWarnings("unchecked")
     public void itemAdminSetPropertyCommunityAdminCreateBitstreamToFalseTest() throws Exception {
         context.turnOffAuthorisationSystem();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, userA, null)
                              .withAction(Constants.ADMIN)
-                             .withUser(userA)
                              .withDspaceObject(itemA).build();
 
         configurationService.setProperty("core.authorization.community-admin.item.create-bitstream", false);
@@ -487,9 +482,8 @@ public class CanManageBitstreamBundlesFeatureIT extends AbstractControllerIntegr
     @SuppressWarnings("unchecked")
     public void itemAdminSetPropertyCommunityAdminDeleteBitstreamToFalseTest() throws Exception {
         context.turnOffAuthorisationSystem();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, userA, null)
                              .withAction(Constants.ADMIN)
-                             .withUser(userA)
                              .withDspaceObject(itemA).build();
 
         configurationService.setProperty("core.authorization.community-admin.item.delete-bitstream", false);

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/CanManageMappingsFeatureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/CanManageMappingsFeatureIT.java
@@ -151,15 +151,13 @@ public class CanManageMappingsFeatureIT extends AbstractControllerIntegrationTes
 
     @Test
     public void addWriteEpersonCollectionSuccess() throws Exception {
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
             .withDspaceObject(collectionA)
             .withAction(Constants.ADD)
-            .withUser(eperson)
             .build();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
             .withDspaceObject(collectionA)
             .withAction(Constants.WRITE)
-            .withUser(eperson)
             .build();
 
         String epersonToken = getAuthToken(eperson.getEmail(), password);
@@ -175,10 +173,9 @@ public class CanManageMappingsFeatureIT extends AbstractControllerIntegrationTes
 
     @Test
     public void adminEpersonCollectionSuccess() throws Exception {
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
             .withDspaceObject(collectionA)
             .withAction(Constants.ADMIN)
-            .withUser(eperson)
             .build();
 
         String epersonToken = getAuthToken(eperson.getEmail(), password);

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/CanSubscribeFeatureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/CanSubscribeFeatureIT.java
@@ -287,10 +287,9 @@ public class CanSubscribeFeatureIT extends AbstractControllerIntegrationTest {
 
     private void setPermissions(DSpaceObject dSpaceObject, Group group, Integer permissions) {
         try {
-            ResourcePolicyBuilder.createResourcePolicy(context)
+            ResourcePolicyBuilder.createResourcePolicy(context, null, group)
                                  .withDspaceObject(dSpaceObject)
                                  .withAction(permissions)
-                                 .withGroup(group)
                                  .build();
         } catch (SQLException | AuthorizeException sqlException) {
             log.error(sqlException.getMessage());

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/EditItemFeatureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/EditItemFeatureIT.java
@@ -96,8 +96,7 @@ public class EditItemFeatureIT extends AbstractControllerIntegrationTest {
 
     @Test
     public void testDirectEPersonWritePolicy() throws Exception {
-        ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context)
-            .withUser(eperson)
+        ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
             .withDspaceObject(itemA1X)
             .withAction(Constants.WRITE)
             .build();
@@ -108,8 +107,7 @@ public class EditItemFeatureIT extends AbstractControllerIntegrationTest {
 
     @Test
     public void testDirectGroupWritePolicy() throws Exception {
-        ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context)
-            .withGroup(group)
+        ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context, null, group)
             .withDspaceObject(itemA1X)
             .withAction(Constants.WRITE)
             .build();
@@ -120,8 +118,7 @@ public class EditItemFeatureIT extends AbstractControllerIntegrationTest {
 
     @Test
     public void testDirectEPersonAdminPolicy() throws Exception {
-        ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context)
-            .withUser(eperson)
+        ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
             .withDspaceObject(itemA1X)
             .withAction(Constants.ADMIN)
             .build();
@@ -132,8 +129,7 @@ public class EditItemFeatureIT extends AbstractControllerIntegrationTest {
 
     @Test
     public void testDirectGroupAdminPolicy() throws Exception {
-        ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context)
-            .withGroup(group)
+        ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context, null, group)
             .withDspaceObject(itemA1X)
             .withAction(Constants.ADMIN)
             .build();

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/GenericAuthorizationFeatureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/GenericAuthorizationFeatureIT.java
@@ -151,25 +151,21 @@ public class GenericAuthorizationFeatureIT extends AbstractControllerIntegration
             .withName("item1AdminGroup")
             .addMember(item1Admin)
             .build();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, null, item1AdminGroup)
             .withDspaceObject(item1)
             .withAction(Constants.ADMIN)
-            .withGroup(item1AdminGroup)
             .build();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, communityAWriter, null)
             .withDspaceObject(communityA)
             .withAction(Constants.WRITE)
-            .withUser(communityAWriter)
             .build();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, collectionXWriter, null)
             .withDspaceObject(collectionX)
             .withAction(Constants.WRITE)
-            .withUser(collectionXWriter)
             .build();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, item1Writer, null)
             .withDspaceObject(item1)
             .withAction(Constants.WRITE)
-            .withUser(item1Writer)
             .build();
 
         communityB = CommunityBuilder.createCommunity(context)
@@ -671,10 +667,9 @@ public class GenericAuthorizationFeatureIT extends AbstractControllerIntegration
         // grant item 1 admin REMOVE permissions on the item’s owning collection
         // verify item 1 admin has this feature on item 1
         context.turnOffAuthorisationSystem();
-        ResourcePolicy removePermission = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy removePermission = ResourcePolicyBuilder.createResourcePolicy(context, item1Writer, null)
             .withDspaceObject(collectionX)
             .withAction(Constants.REMOVE)
-            .withUser(item1Writer)
             .build();
         context.restoreAuthSystemState();
 
@@ -691,10 +686,9 @@ public class GenericAuthorizationFeatureIT extends AbstractControllerIntegration
 
         // grant item 1 write REMOVE permissions on the item’s owning collection
         context.turnOffAuthorisationSystem();
-        ResourcePolicy removePermission = ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicy removePermission = ResourcePolicyBuilder.createResourcePolicy(context, item1Writer, null)
             .withDspaceObject(collectionX)
             .withAction(Constants.REMOVE)
-            .withUser(item1Writer)
             .build();
         context.restoreAuthSystemState();
 
@@ -766,10 +760,9 @@ public class GenericAuthorizationFeatureIT extends AbstractControllerIntegration
             .withEmail("communityAAAdmin@my.edu")
             .withPassword(password)
             .build();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, communityAAAdmin, null)
             .withDspaceObject(communityAA)
             .withAction(Constants.ADMIN)
-            .withUser(communityAAAdmin)
             .build();
         context.restoreAuthSystemState();
         String communityAAAdminToken = getAuthToken(communityAAAdmin.getEmail(), password);
@@ -924,10 +917,9 @@ public class GenericAuthorizationFeatureIT extends AbstractControllerIntegration
             .withEmail("communityAAAdmin@my.edu")
             .withPassword(password)
             .build();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, communityAAAdmin, null)
             .withDspaceObject(communityA)
             .withAction(Constants.REMOVE)
-            .withUser(communityAAAdmin)
             .build();
         context.restoreAuthSystemState();
         String communityAAAdminToken = getAuthToken(communityAAAdmin.getEmail(), password);
@@ -939,10 +931,9 @@ public class GenericAuthorizationFeatureIT extends AbstractControllerIntegration
 
         // Grant REMOVE permissions on community AA for collection X admin
         context.turnOffAuthorisationSystem();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, collectionXAdmin, null)
             .withDspaceObject(communityAA)
             .withAction(Constants.REMOVE)
-            .withUser(collectionXAdmin)
             .build();
         context.restoreAuthSystemState();
         // verify collection X admin has this feature on collection X
@@ -953,10 +944,9 @@ public class GenericAuthorizationFeatureIT extends AbstractControllerIntegration
 
         // Grant REMOVE permissions on collection X for item 1 admin
         context.turnOffAuthorisationSystem();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, item1Admin, null)
             .withDspaceObject(collectionX)
             .withAction(Constants.REMOVE)
-            .withUser(item1Admin)
             .build();
         context.restoreAuthSystemState();
         // verify item 1 admin has this feature on item 1
@@ -982,10 +972,9 @@ public class GenericAuthorizationFeatureIT extends AbstractControllerIntegration
             .withEmail("communityADeleter@my.edu")
             .withPassword(password)
             .build();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, communityADeleter, null)
             .withDspaceObject(communityA)
             .withAction(Constants.DELETE)
-            .withUser(communityADeleter)
             .build();
         context.restoreAuthSystemState();
         String communityADeleterToken = getAuthToken(communityADeleter.getEmail(), password);
@@ -1008,10 +997,9 @@ public class GenericAuthorizationFeatureIT extends AbstractControllerIntegration
             .withEmail("communityARemover@my.edu")
             .withPassword(password)
             .build();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, communityARemover, null)
             .withDspaceObject(communityA)
             .withAction(Constants.REMOVE)
-            .withUser(communityARemover)
             .build();
         context.restoreAuthSystemState();
         String communityARemoverToken = getAuthToken(communityARemover.getEmail(), password);
@@ -1038,10 +1026,9 @@ public class GenericAuthorizationFeatureIT extends AbstractControllerIntegration
             .withEmail("communityAARemover@my.edu")
             .withPassword(password)
             .build();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, communityAARemover, null)
             .withDspaceObject(communityAA)
             .withAction(Constants.REMOVE)
-            .withUser(communityAARemover)
             .build();
         context.restoreAuthSystemState();
         String communityAARemoverToken = getAuthToken(communityAARemover.getEmail(), password);
@@ -1068,10 +1055,9 @@ public class GenericAuthorizationFeatureIT extends AbstractControllerIntegration
             .withEmail("communityXRemover@my.edu")
             .withPassword(password)
             .build();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, collectionXRemover, null)
             .withDspaceObject(collectionX)
             .withAction(Constants.REMOVE)
-            .withUser(collectionXRemover)
             .build();
         context.restoreAuthSystemState();
         String collectionXRemoverToken = getAuthToken(collectionXRemover.getEmail(), password);
@@ -1088,10 +1074,9 @@ public class GenericAuthorizationFeatureIT extends AbstractControllerIntegration
             .withEmail("item1Deleter@my.edu")
             .withPassword(password)
             .build();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, item1Deleter, null)
             .withDspaceObject(item1)
             .withAction(Constants.DELETE)
-            .withUser(item1Deleter)
             .build();
         context.restoreAuthSystemState();
         String item1DeleterToken = getAuthToken(item1Deleter.getEmail(), password);
@@ -1108,15 +1093,13 @@ public class GenericAuthorizationFeatureIT extends AbstractControllerIntegration
             .withEmail("collectionXDeleter@my.edu")
             .withPassword(password)
             .build();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, collectionXRemoverItem1Deleter, null)
             .withDspaceObject(collectionX)
             .withAction(Constants.REMOVE)
-            .withUser(collectionXRemoverItem1Deleter)
             .build();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, collectionXRemoverItem1Deleter, null)
             .withDspaceObject(item1)
             .withAction(Constants.DELETE)
-            .withUser(collectionXRemoverItem1Deleter)
             .build();
         context.restoreAuthSystemState();
         String collectionXRemoverItem1DeleterToken = getAuthToken(collectionXRemoverItem1Deleter.getEmail(), password);
@@ -1143,10 +1126,9 @@ public class GenericAuthorizationFeatureIT extends AbstractControllerIntegration
             .withEmail("item1Remover@my.edu")
             .withPassword(password)
             .build();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, item1Remover, null)
             .withDspaceObject(item1)
             .withAction(Constants.REMOVE)
-            .withUser(item1Remover)
             .build();
         context.restoreAuthSystemState();
         String item1RemoverToken = getAuthToken(item1Remover.getEmail(), password);
@@ -1173,10 +1155,9 @@ public class GenericAuthorizationFeatureIT extends AbstractControllerIntegration
             .withEmail("bundle1Remover@my.edu")
             .withPassword(password)
             .build();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, bundle1Remover, null)
             .withDspaceObject(bundle1)
             .withAction(Constants.REMOVE)
-            .withUser(bundle1Remover)
             .build();
         context.restoreAuthSystemState();
         String bundle1RemoverToken = getAuthToken(bundle1Remover.getEmail(), password);
@@ -1194,15 +1175,13 @@ public class GenericAuthorizationFeatureIT extends AbstractControllerIntegration
             .withEmail("bundle1item1Remover@my.edu")
             .withPassword(password)
             .build();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, bundle1item1Remover, null)
             .withDspaceObject(bundle1)
             .withAction(Constants.REMOVE)
-            .withUser(bundle1item1Remover)
             .build();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, bundle1item1Remover, null)
             .withDspaceObject(item1)
             .withAction(Constants.REMOVE)
-            .withUser(bundle1item1Remover)
             .build();
         context.restoreAuthSystemState();
         String bundle1item1RemoverToken = getAuthToken(bundle1item1Remover.getEmail(), password);
@@ -1354,10 +1333,9 @@ public class GenericAuthorizationFeatureIT extends AbstractControllerIntegration
             .withEmail("bundle1Writer@my.edu")
             .withPassword(password)
             .build();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, bundle1Writer, null)
             .withDspaceObject(bundle1)
             .withAction(Constants.WRITE)
-            .withUser(bundle1Writer)
             .build();
         context.restoreAuthSystemState();
         String bundle1WriterToken = getAuthToken(bundle1Writer.getEmail(), password);
@@ -1374,10 +1352,9 @@ public class GenericAuthorizationFeatureIT extends AbstractControllerIntegration
             .withEmail("bundle1Adder@my.edu")
             .withPassword(password)
             .build();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, bundle1Adder, null)
             .withDspaceObject(bundle1)
             .withAction(Constants.ADD)
-            .withUser(bundle1Adder)
             .build();
         context.restoreAuthSystemState();
         String bundle1AdderToken = getAuthToken(bundle1Adder.getEmail(), password);
@@ -1395,25 +1372,21 @@ public class GenericAuthorizationFeatureIT extends AbstractControllerIntegration
             .withEmail("bundle1WriterAdder@my.edu")
             .withPassword(password)
             .build();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, bundle1WriterAdder, null)
             .withDspaceObject(bundle1)
             .withAction(Constants.ADD)
-            .withUser(bundle1WriterAdder)
             .build();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, bundle1WriterAdder, null)
             .withDspaceObject(bundle1)
             .withAction(Constants.WRITE)
-            .withUser(bundle1WriterAdder)
             .build();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, bundle1WriterAdder, null)
             .withDspaceObject(item1)
             .withAction(Constants.ADD)
-            .withUser(bundle1WriterAdder)
             .build();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, bundle1WriterAdder, null)
             .withDspaceObject(item1)
             .withAction(Constants.WRITE)
-            .withUser(bundle1WriterAdder)
             .build();
         context.restoreAuthSystemState();
         String bundle1WriterAdderToken = getAuthToken(bundle1WriterAdder.getEmail(), password);
@@ -1461,15 +1434,13 @@ public class GenericAuthorizationFeatureIT extends AbstractControllerIntegration
             .withEmail("item1AdderWriter@my.edu")
             .withPassword(password)
             .build();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, item1AdderWriter, null)
             .withDspaceObject(item1)
             .withAction(Constants.ADD)
-            .withUser(item1AdderWriter)
             .build();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, item1AdderWriter, null)
             .withDspaceObject(item1)
             .withAction(Constants.WRITE)
-            .withUser(item1AdderWriter)
             .build();
         context.restoreAuthSystemState();
         String item1AdderWriterToken = getAuthToken(item1AdderWriter.getEmail(), password);
@@ -1493,3 +1464,4 @@ public class GenericAuthorizationFeatureIT extends AbstractControllerIntegration
             );
     }
 }
+

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/ManageAdminGroupFeatureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/ManageAdminGroupFeatureIT.java
@@ -123,10 +123,9 @@ public class ManageAdminGroupFeatureIT extends AbstractControllerIntegrationTest
     @Test
     public void collectionAdminCollectionTestSuccess() throws Exception {
         context.turnOffAuthorisationSystem();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
             .withDspaceObject(collectionA)
             .withAction(Constants.ADMIN)
-            .withUser(eperson)
             .build();
         context.restoreAuthSystemState();
 
@@ -144,10 +143,9 @@ public class ManageAdminGroupFeatureIT extends AbstractControllerIntegrationTest
     @Test
     public void collectionAdminCommunityTestNotFound() throws Exception {
         context.turnOffAuthorisationSystem();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
             .withDspaceObject(collectionA)
             .withAction(Constants.ADMIN)
-            .withUser(eperson)
             .build();
         context.restoreAuthSystemState();
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/ManageSubmitterGroupFeatureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/ManageSubmitterGroupFeatureIT.java
@@ -123,10 +123,9 @@ public class ManageSubmitterGroupFeatureIT extends AbstractControllerIntegration
     @Test
     public void collectionAdminCollectionTestSuccess() throws Exception {
         context.turnOffAuthorisationSystem();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
             .withDspaceObject(collectionA)
             .withAction(Constants.ADMIN)
-            .withUser(eperson)
             .build();
         context.restoreAuthSystemState();
 
@@ -144,10 +143,9 @@ public class ManageSubmitterGroupFeatureIT extends AbstractControllerIntegration
     @Test
     public void collectionAdminCommunityTestNotFound() throws Exception {
         context.turnOffAuthorisationSystem();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
             .withDspaceObject(collectionA)
             .withAction(Constants.ADMIN)
-            .withUser(eperson)
             .build();
         context.restoreAuthSystemState();
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/ManageTemplateItemFeatureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/ManageTemplateItemFeatureIT.java
@@ -123,10 +123,9 @@ public class ManageTemplateItemFeatureIT extends AbstractControllerIntegrationTe
     @Test
     public void collectionAdminCollectionTestSuccess() throws Exception {
         context.turnOffAuthorisationSystem();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
             .withDspaceObject(collectionA)
             .withAction(Constants.ADMIN)
-            .withUser(eperson)
             .build();
         context.restoreAuthSystemState();
 
@@ -144,10 +143,9 @@ public class ManageTemplateItemFeatureIT extends AbstractControllerIntegrationTe
     @Test
     public void collectionAdminCommunityTestNotFound() throws Exception {
         context.turnOffAuthorisationSystem();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
             .withDspaceObject(collectionA)
             .withAction(Constants.ADMIN)
-            .withUser(eperson)
             .build();
         context.restoreAuthSystemState();
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/ManageWorkflowGroupFeatureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/ManageWorkflowGroupFeatureIT.java
@@ -123,10 +123,9 @@ public class ManageWorkflowGroupFeatureIT extends AbstractControllerIntegrationT
     @Test
     public void collectionAdminCollectionTestSuccess() throws Exception {
         context.turnOffAuthorisationSystem();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
             .withDspaceObject(collectionA)
             .withAction(Constants.ADMIN)
-            .withUser(eperson)
             .build();
         context.restoreAuthSystemState();
 
@@ -144,10 +143,9 @@ public class ManageWorkflowGroupFeatureIT extends AbstractControllerIntegrationT
     @Test
     public void collectionAdminCommunityTestNotFound() throws Exception {
         context.turnOffAuthorisationSystem();
-        ResourcePolicyBuilder.createResourcePolicy(context)
+        ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
             .withDspaceObject(collectionA)
             .withAction(Constants.ADMIN)
-            .withUser(eperson)
             .build();
         context.restoreAuthSystemState();
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/SubmitFeatureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/SubmitFeatureIT.java
@@ -89,8 +89,7 @@ public class SubmitFeatureIT extends AbstractControllerIntegrationTest {
 
     @Test
     public void testDirectEPersonAddPolicy() throws Exception {
-        ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context)
-                .withUser(eperson)
+        ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
                 .withDspaceObject(collectionA1)
                 .withAction(Constants.ADD)
                 .build();
@@ -99,8 +98,7 @@ public class SubmitFeatureIT extends AbstractControllerIntegrationTest {
 
     @Test
     public void testDirectGroupAddPolicy() throws Exception {
-        ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context)
-            .withGroup(group)
+        ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context, null, group)
             .withDspaceObject(collectionA1)
             .withAction(Constants.ADD)
             .build();
@@ -109,8 +107,7 @@ public class SubmitFeatureIT extends AbstractControllerIntegrationTest {
 
     @Test
     public void testDirectEPersonAdminPolicy() throws Exception {
-        ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context)
-            .withUser(eperson)
+        ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
             .withDspaceObject(collectionA1)
             .withAction(Constants.ADMIN)
             .build();
@@ -119,8 +116,7 @@ public class SubmitFeatureIT extends AbstractControllerIntegrationTest {
 
     @Test
     public void testDirectGroupAdminPolicy() throws Exception {
-        ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context)
-            .withGroup(group)
+        ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context, null, group)
             .withDspaceObject(collectionA1)
             .withAction(Constants.ADMIN)
             .build();
@@ -199,8 +195,7 @@ public class SubmitFeatureIT extends AbstractControllerIntegrationTest {
 
     @Test
     public void testDirectEPersonAddPolicyOnCollection() throws Exception {
-        ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context)
-                .withUser(eperson)
+        ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
                 .withDspaceObject(collectionA1)
                 .withAction(Constants.ADD)
                 .build();
@@ -210,8 +205,7 @@ public class SubmitFeatureIT extends AbstractControllerIntegrationTest {
 
     @Test
     public void testDirectGroupAddPolicyOnCollection() throws Exception {
-        ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context)
-            .withGroup(group)
+        ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context, null, group)
             .withDspaceObject(collectionA1)
             .withAction(Constants.ADD)
             .build();
@@ -221,8 +215,7 @@ public class SubmitFeatureIT extends AbstractControllerIntegrationTest {
 
     @Test
     public void testDirectEPersonAdminPolicyOnCollection() throws Exception {
-        ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context)
-            .withUser(eperson)
+        ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
             .withDspaceObject(collectionA1)
             .withAction(Constants.ADMIN)
             .build();
@@ -232,8 +225,7 @@ public class SubmitFeatureIT extends AbstractControllerIntegrationTest {
 
     @Test
     public void testDirectGroupAdminPolicyOnCollection() throws Exception {
-        ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context)
-            .withGroup(group)
+        ResourcePolicy rp = ResourcePolicyBuilder.createResourcePolicy(context, null, group)
             .withDspaceObject(collectionA1)
             .withAction(Constants.ADMIN)
             .build();


### PR DESCRIPTION
## References
* Fixes #9190 
* DSpace 8 version of #9191

## Description
The DSpace code currently does not enforce that a created resource policy has either a connected group or eperson.
As a consequence, it can happen that a resource policy is created with neither.

This will then cause issues down the line where DSpace assumes that all resource policies have either a group or eperson connected to it.

## Instructions for Reviewers
Verify that it is no longer possible to create a resource policy without a group or eperson. 

## Checklist
- [ ] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
