### PR TITLE
Fix Codecov token in GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,13 +99,14 @@ jobs:
       # Retry action: https://github.com/marketplace/actions/retry-action
       # Codecov action: https://github.com/codecov/codecov-action
       - name: Upload coverage to Codecov.io
-        uses: Wandalen/wretry.action@v1.3.0
+        uses: Wandalen/wretry.action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           action: codecov/codecov-action@v4
           # Ensure codecov-action throws an error when it fails to upload
           with: |
             fail_ci_if_error: true
-            token: ${{ secrets.CODECOV_TOKEN }}
           # Try re-running action 5 times max
           attempt_limit: 5
           # Run again in 30 seconds


### PR DESCRIPTION
## Description
This small PR fixes our usage of `CODECOV_TOKEN`.  We were mistakenly passing it as a parameter, but it MUST be sent as an environment variable.  See https://docs.codecov.com/docs/adding-the-codecov-token#github-actions

Currently, on `main` (and `dspace-7_x`), while we have a token, it is being _ignored_. This means we sometimes get these errors from Codecov about how Tokenless uploads have hit their rate limit: 
```
error - 2024-04-26 14:12:02,881 -- Commit creating failed: {"detail":"Tokenless has reached GitHub rate limit. Please upload using a token: https://docs.codecov.com/docs/adding-the-codecov-token. Expected available in 441 seconds."}
```

Assuming this works, it will need to be ported to `dspace-7_x` and also ported to the `dspace-angular` project.

## Instructions for Reviewers
* We simply need to see how this runs in GitHub CI and make sure the Codecov step in our build process is now *seeing* the token we've set.