### PR TITLE
Fix Runnable JAR issues & use it in all Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,9 @@ ENV MAVEN_FLAGS="-P-test-environment -Denforcer.skip=true -Dcheckstyle.skip=true
 RUN mvn --no-transfer-progress package ${MAVEN_FLAGS} && \
   mv /app/dspace/target/${TARGET_DIR}/* /install && \
   mvn clean
+# Remove the server webapp to keep image small. Rename runnable JAR to server-boot.jar.
+RUN rm -rf /install/webapps/server/ && \
+  mv /install/webapps/server-boot-*.jar /install/webapps/server-boot.jar
 
 # Step 2 - Run Ant Deploy
 FROM eclipse-temurin:${JDK_VERSION} as ant_build
@@ -49,23 +52,16 @@ RUN mkdir $ANT_HOME && \
 # Run necessary 'ant' deploy scripts
 RUN ant init_installation update_configs update_code update_webapps
 
-# Step 3 - Run tomcat
-# Create a new tomcat image that does not retain the the build directory contents
-FROM tomcat:10-jdk${JDK_VERSION}
+# Step 3 - Start up DSpace via Runnable JAR
+FROM eclipse-temurin:${JDK_VERSION}
 # NOTE: DSPACE_INSTALL must align with the "dspace.dir" default configuration.
 ENV DSPACE_INSTALL=/dspace
 # Copy the /dspace directory from 'ant_build' container to /dspace in this container
 COPY --from=ant_build /dspace $DSPACE_INSTALL
-# Expose Tomcat port and AJP port
-EXPOSE 8080 8009
+WORKDIR $DSPACE_INSTALL
+# Expose Tomcat port
+EXPOSE 8080
 # Give java extra memory (2GB)
 ENV JAVA_OPTS=-Xmx2000m
-
-# Link the DSpace 'server' webapp into Tomcat's webapps directory.
-# This ensures that when we start Tomcat, it runs from /server path (e.g. http://localhost:8080/server/)
-RUN ln -s $DSPACE_INSTALL/webapps/server   /usr/local/tomcat/webapps/server
-# If you wish to run "server" webapp off the ROOT path, then comment out the above RUN, and uncomment the below RUN.
-# You also MUST update the 'dspace.server.url' configuration to match.
-# Please note that server webapp should only run on one path at a time.
-#RUN mv /usr/local/tomcat/webapps/ROOT /usr/local/tomcat/webapps/ROOT.bk && \
-#    ln -s $DSPACE_INSTALL/webapps/server   /usr/local/tomcat/webapps/ROOT
+# On startup, run DSpace Runnable JAR
+ENTRYPOINT ["java", "-jar", "webapps/server-boot.jar", "--dspace.dir=$DSPACE_INSTALL"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,8 @@ ENV MAVEN_FLAGS="-P-test-environment -Denforcer.skip=true -Dcheckstyle.skip=true
 RUN mvn --no-transfer-progress package ${MAVEN_FLAGS} && \
   mv /app/dspace/target/${TARGET_DIR}/* /install && \
   mvn clean
-# Remove the server webapp to keep image small. Rename runnable JAR to server-boot.jar.
-RUN rm -rf /install/webapps/server/ && \
-  mv /install/webapps/server-boot-*.jar /install/webapps/server-boot.jar
+# Remove the server webapp to keep image small.
+RUN rm -rf /install/webapps/server/
 
 # Step 2 - Run Ant Deploy
 FROM eclipse-temurin:${JDK_VERSION} as ant_build

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -26,6 +26,9 @@ ADD --chown=dspace . /app/
 RUN mvn --no-transfer-progress package && \
   mv /app/dspace/target/${TARGET_DIR}/* /install && \
   mvn clean
+# Remove the server webapp to keep image small. Rename runnable JAR to server-boot.jar.
+RUN rm -rf /install/webapps/server/ && \
+  mv /install/webapps/server-boot-*.jar /install/webapps/server-boot.jar
 
 # Step 2 - Run Ant Deploy
 FROM eclipse-temurin:${JDK_VERSION} as ant_build
@@ -48,29 +51,18 @@ RUN mkdir $ANT_HOME && \
 # Run necessary 'ant' deploy scripts
 RUN ant init_installation update_configs update_code update_webapps
 
-# Step 3 - Run tomcat
-# Create a new tomcat image that does not retain the the build directory contents
-FROM tomcat:10-jdk${JDK_VERSION}
+# Step 3 - Start up DSpace via Runnable JAR
+FROM eclipse-temurin:${JDK_VERSION}
+# NOTE: DSPACE_INSTALL must align with the "dspace.dir" default configuration.
 ENV DSPACE_INSTALL=/dspace
-ENV TOMCAT_INSTALL=/usr/local/tomcat
-# Copy the /dspace directory from 'ant_build' containger to /dspace in this container
+# Copy the /dspace directory from 'ant_build' container to /dspace in this container
 COPY --from=ant_build /dspace $DSPACE_INSTALL
-# Enable the AJP connector in Tomcat's server.xml
-# NOTE: secretRequired="false" should only be used when AJP is NOT accessible from an external network. But, secretRequired="true" isn't supported by mod_proxy_ajp until Apache 2.5
-RUN sed -i '/Service name="Catalina".*/a \\n    <Connector protocol="AJP/1.3" port="8009" address="0.0.0.0" redirectPort="8443" URIEncoding="UTF-8" secretRequired="false" />' $TOMCAT_INSTALL/conf/server.xml
-# Expose Tomcat port and AJP port
-EXPOSE 8080 8009 8000
+WORKDIR $DSPACE_INSTALL
+# Expose Tomcat port and debugging port
+EXPOSE 8080 8000
 # Give java extra memory (2GB)
 ENV JAVA_OPTS=-Xmx2000m
 # Set up debugging
 ENV CATALINA_OPTS=-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=*:8000
-
-# Link the DSpace 'server' webapp into Tomcat's webapps directory.
-# This ensures that when we start Tomcat, it runs from /server path (e.g. http://localhost:8080/server/)
-RUN ln -s $DSPACE_INSTALL/webapps/server   /usr/local/tomcat/webapps/server
-# If you wish to run "server" webapp off the ROOT path, then comment out the above RUN, and uncomment the below RUN.
-# You also MUST update the 'dspace.server.url' configuration to match.
-# Please note that server webapp should only run on one path at a time.
-#RUN mv /usr/local/tomcat/webapps/ROOT /usr/local/tomcat/webapps/ROOT.bk && \
-#    ln -s $DSPACE_INSTALL/webapps/server   /usr/local/tomcat/webapps/ROOT
-
+# On startup, run DSpace Runnable JAR
+ENTRYPOINT ["java", "-jar", "webapps/server-boot.jar", "--dspace.dir=$DSPACE_INSTALL"]

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -27,8 +27,7 @@ RUN mvn --no-transfer-progress package && \
   mv /app/dspace/target/${TARGET_DIR}/* /install && \
   mvn clean
 # Remove the server webapp to keep image small. Rename runnable JAR to server-boot.jar.
-RUN rm -rf /install/webapps/server/ && \
-  mv /install/webapps/server-boot-*.jar /install/webapps/server-boot.jar
+RUN rm -rf /install/webapps/server/
 
 # Step 2 - Run Ant Deploy
 FROM eclipse-temurin:${JDK_VERSION} as ant_build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,8 +39,6 @@ services:
     ports:
     - published: 8080
       target: 8080
-    - published: 8009
-      target: 8009
     - published: 8000
       target: 8000
     stdin_open: true
@@ -54,14 +52,14 @@ services:
     # Ensure that the database is ready BEFORE starting tomcat
     # 1. While a TCP connection to dspacedb port 5432 is not available, continue to sleep
     # 2. Then, run database migration to init database tables
-    # 3. Finally, start Tomcat
+    # 3. Finally, start DSpace
     entrypoint:
     - /bin/bash
     - '-c'
     - |
       while (!</dev/tcp/dspacedb/5432) > /dev/null 2>&1; do sleep 1; done;
       /dspace/bin/dspace database migrate
-      catalina.sh run
+      java -jar /dspace/webapps/server-boot.jar --dspace.dir=/dspace
   # DSpace PostgreSQL database container
   dspacedb:
     container_name: dspacedb

--- a/dspace/src/main/assembly/assembly.xml
+++ b/dspace/src/main/assembly/assembly.xml
@@ -63,10 +63,6 @@
          <outputDirectory>bin</outputDirectory>
       </fileSet>
       <fileSet>
-         <directory>etc</directory>
-         <outputDirectory>etc</outputDirectory>
-      </fileSet>
-      <fileSet>
          <directory>solr</directory>
          <outputDirectory>solr</outputDirectory>
       </fileSet>
@@ -95,7 +91,7 @@
          <includes>
             <include>org.dspace.modules:*:jar:*</include>
          </includes>
-        <binaries>
+         <binaries>
             <includeDependencies>true</includeDependencies>
             <outputDirectory>lib</outputDirectory>
             <unpack>false</unpack>
@@ -107,6 +103,20 @@
                   </includes>
                </dependencySet>
             </dependencySets>
+         </binaries>
+      </moduleSet>
+
+      <!--
+      Add server-boot.jar to the 'webapps' directory
+      -->
+      <moduleSet>
+         <includes>
+            <include>org.dspace:server-boot</include>
+         </includes>
+         <binaries>
+            <includeDependencies>false</includeDependencies>
+            <outputDirectory>webapps</outputDirectory>
+            <unpack>false</unpack>
          </binaries>
       </moduleSet>
 

--- a/dspace/src/main/assembly/assembly.xml
+++ b/dspace/src/main/assembly/assembly.xml
@@ -117,6 +117,7 @@
             <includeDependencies>false</includeDependencies>
             <outputDirectory>webapps</outputDirectory>
             <unpack>false</unpack>
+            <outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>
          </binaries>
       </moduleSet>
 

--- a/dspace/src/main/docker-compose/db.entities.yml
+++ b/dspace/src/main/docker-compose/db.entities.yml
@@ -17,11 +17,11 @@ services:
     # Ensure that the database is ready BEFORE starting tomcat
     # 1. While a TCP connection to dspacedb port 5432 is not available, continue to sleep
     # 2. Then, run migration latest version of database tables (run with "ignored" in case this SQL data is outdated)
-    # 3. Finally, start Tomcat
+    # 3. Finally, start DSpace
     entrypoint:
       - /bin/bash
       - '-c'
       - |
         while (!</dev/tcp/dspacedb/5432) > /dev/null 2>&1; do sleep 1; done;
         /dspace/bin/dspace database migrate ignored
-        catalina.sh run
+        java -jar /dspace/webapps/server-boot.jar --dspace.dir=/dspace

--- a/pom.xml
+++ b/pom.xml
@@ -1091,13 +1091,6 @@
                 <groupId>org.hibernate.orm</groupId>
                 <artifactId>hibernate-jpamodelgen</artifactId>
                 <version>${hibernate.version}</version>
-                <exclusions>
-                    <!-- Later version provided by Hibernate Core -->
-                    <exclusion>
-                        <groupId>org.antlr</groupId>
-                        <artifactId>antlr4-runtime</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
 
             <dependency>
@@ -1124,6 +1117,13 @@
                 <groupId>org.jboss.logging</groupId>
                 <artifactId>jboss-logging</artifactId>
                 <version>3.4.3.Final</version>
+            </dependency>
+
+            <!-- Hibernate & Solr disagree on the version of antlr. So, specify the latest version -->
+            <dependency>
+                <groupId>org.antlr</groupId>
+                <artifactId>antlr4-runtime</artifactId>
+                <version>4.13.0</version>
             </dependency>
 
             <!-- Rome is used for RSS / ATOM syndication feeds -->

--- a/pom.xml
+++ b/pom.xml
@@ -1123,7 +1123,7 @@
             <dependency>
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr4-runtime</artifactId>
-                <version>4.13.0</version>
+                <version>4.13.1</version>
             </dependency>
 
             <!-- Rome is used for RSS / ATOM syndication feeds -->


### PR DESCRIPTION
## References
* Fixes #9476 

## Description
This PR fixes the current bug with Embedded Tomcat not starting in our Runnable JAR and updates our Docker scripts to use the Runnable JAR by default (instead of using a Tomcat image).

Specific changes in this PR:
1. Fix #9476 bug with multiple Antlr versions which was causing Embedded Tomcat to fail.  See https://github.com/DSpace/DSpace/pull/9505/commits/75a2ee2eaa2b2a0bf5b39f8428c82d90bc427aa9
2. Update our Maven Assembly to ensure `server-boot.jar` is copied into `[src]/dspace/target/dspace-installer/webapps` alongside the "server" webapp. This make it easier to find & use.  (Currently you must manually copy it from the src folders)  See https://github.com/DSpace/DSpace/pull/9505/commits/c89c6265047f7b8124ba9e143d6678988e9c8a56
3. Update all Dockerfiles and docker-compose scripts to use the Runnable JAR *instead of* a Tomcat image.  See https://github.com/DSpace/DSpace/pull/9505/commits/6a012c8fc195eb545e8b2cc085a8d38f1429385b

If anyone disagrees with one of these 3 commits, I can break this PR into smaller pieces.  But, combined, these make it easier to find issues with the Runnable JAR if it's used in our Dockerfiles  (as these Dockerfiles are also used in e2e tests on `dspace-angular`)

## Instructions for Reviewers
* Rebuild/Redeploy DSpace (mvn clean package; ant update) and verify the Runnable JAR is working.  You can now run it from the DSpace installation folder, e.g.
```
java -jar [dspace]/webapps/server-boot.jar --dspace.dir=[dspace]
```
* Optionally test the Docker scripts.  However I've tested these locally thoroughly and they are working. They use the Runnable JAR in the same way as that command above.


**NOTE TO SELF:** Once this is merged, there will be minor updates necessary to the docker-compose scripts in `dspace-angular`!!