### PR TITLE
Fix bug where empty metadata List can result in "Index 0 out of bounds for length 0" exceptions in several scenarios

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
@@ -825,8 +825,10 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
                 addRelationships(c, item, element, values);
             } else {
                 itemService.clearMetadata(c, item, schema, element, qualifier, language);
-                itemService.addMetadata(c, item, schema, element, qualifier,
-                                        language, values, authorities, confidences);
+                if (!values.isEmpty()) {
+                    itemService.addMetadata(c, item, schema, element, qualifier,
+                                            language, values, authorities, confidences);
+                }
                 itemService.update(c, item);
             }
         }
@@ -1121,8 +1123,8 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
                     .getAuthoritySeparator() + dcv.getConfidence();
             }
 
-            // Add it
-            if ((value != null) && (!"".equals(value))) {
+            // Add it, if value is not blank
+            if (value != null && StringUtils.isNotBlank(value)) {
                 changes.registerAdd(dcv);
             }
         }

--- a/dspace-api/src/main/java/org/dspace/content/DSpaceObjectServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/DSpaceObjectServiceImpl.java
@@ -314,20 +314,26 @@ public abstract class DSpaceObjectServiceImpl<T extends DSpaceObject> implements
     @Override
     public MetadataValue addMetadata(Context context, T dso, MetadataField metadataField, String language,
                             String value, String authority, int confidence) throws SQLException {
-        return addMetadata(context, dso, metadataField, language, Arrays.asList(value), Arrays.asList(authority),
-                    Arrays.asList(confidence)).get(0);
+        List<MetadataValue> metadataValues =
+            addMetadata(context, dso, metadataField, language, Arrays.asList(value), Arrays.asList(authority),
+                        Arrays.asList(confidence));
+        return CollectionUtils.isNotEmpty(metadataValues) ? metadataValues.get(0) : null;
     }
 
     @Override
     public MetadataValue addMetadata(Context context, T dso, String schema, String element, String qualifier,
                              String lang, String value) throws SQLException {
-        return addMetadata(context, dso, schema, element, qualifier, lang, Arrays.asList(value)).get(0);
+        List<MetadataValue> metadataValues =
+            addMetadata(context, dso, schema, element, qualifier, lang, Arrays.asList(value));
+        return CollectionUtils.isNotEmpty(metadataValues) ? metadataValues.get(0) : null;
     }
 
     @Override
     public MetadataValue addMetadata(Context context, T dso, MetadataField metadataField, String language, String value)
         throws SQLException {
-        return addMetadata(context, dso, metadataField, language, Arrays.asList(value)).get(0);
+        List<MetadataValue> metadataValues =
+            addMetadata(context, dso, metadataField, language, Arrays.asList(value));
+        return CollectionUtils.isNotEmpty(metadataValues) ? metadataValues.get(0) : null;
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/content/DSpaceObjectServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/DSpaceObjectServiceImpl.java
@@ -242,9 +242,30 @@ public abstract class DSpaceObjectServiceImpl<T extends DSpaceObject> implements
 
     }
 
+    /**
+     * Add metadata value(s) to a MetadataField of a DSpace Object
+     * @param context current DSpace context
+     * @param dso DSpaceObject to modify
+     * @param metadataField MetadataField to add values to
+     * @param lang Language code to add
+     * @param values One or more metadata values to add
+     * @param authorities One or more authorities to add
+     * @param confidences One or more confidences to add (for authorities)
+     * @param placeSupplier Supplier of "place" for new metadata values
+     * @return List of newly added metadata values
+     * @throws SQLException if database error occurs
+     * @throws IllegalArgumentException for an empty list of values
+     */
     public List<MetadataValue> addMetadata(Context context, T dso, MetadataField metadataField, String lang,
             List<String> values, List<String> authorities, List<Integer> confidences, Supplier<Integer> placeSupplier)
                     throws SQLException {
+
+        // Throw an error if we are attempting to add empty values
+        if (values == null || values.isEmpty()) {
+            throw new IllegalArgumentException("Cannot add empty values to a new metadata field " +
+                                                   metadataField.toString() + " on object with uuid = " +
+                                                   dso.getID().toString() + " and type = " + getTypeText(dso));
+        }
 
         boolean authorityControlled = metadataAuthorityService.isAuthorityControlled(metadataField);
         boolean authorityRequired = metadataAuthorityService.isAuthorityRequired(metadataField);

--- a/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataImportIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataImportIT.java
@@ -9,12 +9,12 @@ package org.dspace.app.bulkedit;
 
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertTrue;
+import static junit.framework.TestCase.fail;
 
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStreamWriter;
-import java.sql.SQLException;
 import java.util.List;
 
 import org.apache.commons.cli.ParseException;
@@ -218,9 +218,10 @@ public class MetadataImportIT extends AbstractIntegrationTestWithDatabase {
 
     @Test
     public void metadataImportRemovingValueTest() throws Exception {
-
         context.turnOffAuthorisationSystem();
-        Item item = ItemBuilder.createItem(context,personCollection).withAuthor("TestAuthorToRemove").withTitle("title")
+        String itemTitle = "Testing removing author";
+        Item item = ItemBuilder.createItem(context,personCollection).withAuthor("TestAuthorToRemove")
+                               .withTitle(itemTitle)
                                .build();
         context.restoreAuthSystemState();
 
@@ -232,19 +233,21 @@ public class MetadataImportIT extends AbstractIntegrationTestWithDatabase {
         String[] csv = {"id,collection,dc.title,dc.contributor.author[*]",
             item.getID().toString() + "," + personCollection.getHandle() + "," + item.getName() + ","};
         performImportScript(csv);
-        item = findItemByName("title");
+        item = findItemByName(itemTitle);
         assertEquals(0, itemService.getMetadata(item, "dc", "contributor", "author", Item.ANY).size());
     }
 
-    private Item findItemByName(String name) throws SQLException {
-        Item importedItem = null;
-        List<Item> allItems = IteratorUtils.toList(itemService.findAll(context));
-        for (Item item : allItems) {
-            if (item.getName().equals(name)) {
-                importedItem = item;
-            }
+    private Item findItemByName(String name) throws Exception {
+        List<Item> items =
+            IteratorUtils.toList(itemService.findByMetadataField(context, "dc", "title", null, name));
+
+        if (items != null && !items.isEmpty()) {
+            // Just return first matching Item. Tests should ensure name/title is unique.
+            return items.get(0);
+        } else {
+            fail("Could not find expected Item with dc.title = '" + name + "'");
+            return null;
         }
-        return importedItem;
     }
 
     public void performImportScript(String[] csv) throws Exception {

--- a/dspace-api/src/test/java/org/dspace/content/ItemTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/ItemTest.java
@@ -639,7 +639,7 @@ public class ItemTest extends AbstractDSpaceObjectTest {
     }
 
     /**
-     * Test of addMetadata method, of class Item.
+     * This is the same as testAddMetadata_5args_1 except it is adding a *single* value as a String, not a List.
      */
     @Test
     public void testAddMetadata_5args_2() throws SQLException {
@@ -647,24 +647,18 @@ public class ItemTest extends AbstractDSpaceObjectTest {
         String element = "contributor";
         String qualifier = "author";
         String lang = Item.ANY;
-        List<String> values = Arrays.asList("value0", "value1");
-        itemService.addMetadata(context, it, schema, element, qualifier, lang, values);
+        String value = "value0";
+        itemService.addMetadata(context, it, schema, element, qualifier, lang, value);
 
         List<MetadataValue> dc = itemService.getMetadata(it, schema, element, qualifier, lang);
         assertThat("testAddMetadata_5args_2 0", dc, notNullValue());
-        assertTrue("testAddMetadata_5args_2 1", dc.size() == 2);
+        assertTrue("testAddMetadata_5args_2 1", dc.size() == 1);
         assertThat("testAddMetadata_5args_2 2", dc.get(0).getMetadataField().getMetadataSchema().getName(),
                    equalTo(schema));
         assertThat("testAddMetadata_5args_2 3", dc.get(0).getMetadataField().getElement(), equalTo(element));
         assertThat("testAddMetadata_5args_2 4", dc.get(0).getMetadataField().getQualifier(), equalTo(qualifier));
         assertThat("testAddMetadata_5args_2 5", dc.get(0).getLanguage(), equalTo(lang));
-        assertThat("testAddMetadata_5args_2 6", dc.get(0).getValue(), equalTo(values.get(0)));
-        assertThat("testAddMetadata_5args_2 7", dc.get(1).getMetadataField().getMetadataSchema().getName(),
-                   equalTo(schema));
-        assertThat("testAddMetadata_5args_2 8", dc.get(1).getMetadataField().getElement(), equalTo(element));
-        assertThat("testAddMetadata_5args_2 9", dc.get(1).getMetadataField().getQualifier(), equalTo(qualifier));
-        assertThat("testAddMetadata_5args_2 10", dc.get(1).getLanguage(), equalTo(lang));
-        assertThat("testAddMetadata_5args_2 11", dc.get(1).getValue(), equalTo(values.get(1)));
+        assertThat("testAddMetadata_5args_2 6", dc.get(0).getValue(), equalTo(value));
     }
 
     /**

--- a/dspace-api/src/test/java/org/dspace/content/ItemTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/ItemTest.java
@@ -537,6 +537,17 @@ public class ItemTest extends AbstractDSpaceObjectTest {
         assertThat("testAddMetadata_5args_1 11", dc.get(1).getValue(), equalTo(values[1]));
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddMetadata_5args_no_values() throws Exception {
+        String schema = "dc";
+        String element = "contributor";
+        String qualifier = "author";
+        String lang = Item.ANY;
+        String[] values = {};
+        itemService.addMetadata(context, it, schema, element, qualifier, lang, Arrays.asList(values));
+        fail("IllegalArgumentException expected");
+    }
+
     /**
      * Test of addMetadata method, of class Item.
      */
@@ -612,6 +623,19 @@ public class ItemTest extends AbstractDSpaceObjectTest {
         assertThat("testAddMetadata_7args_1 13", dc.get(1).getValue(), equalTo(values.get(1)));
         assertThat("testAddMetadata_7args_1 14", dc.get(1).getAuthority(), nullValue());
         assertThat("testAddMetadata_7args_1 15", dc.get(1).getConfidence(), equalTo(-1));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddMetadata_7args_no_values() throws Exception {
+        String schema = "dc";
+        String element = "contributor";
+        String qualifier = "author";
+        String lang = Item.ANY;
+        List<String> values = new ArrayList();
+        List<String> authorities = new ArrayList();
+        List<Integer> confidences = new ArrayList();
+        itemService.addMetadata(context, it, schema, element, qualifier, lang, values, authorities, confidences);
+        fail("IllegalArgumentException expected");
     }
 
     /**


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/dspace-angular/issues/3072

## Description

This PR fixes scenarios where an empty metadata List can result in an "Index 0 out of bounds for length 0" exception.

There are (at least) two scenarios where I've encountered this exception:

1. When versioning an Entity, as described in https://github.com/DSpace/dspace-angular/issues/3072
2. While testing 8.0, I ran into a scenario where an AIP import threw this error:
    ```
    Replacing DSpace object(s) with package located at AIPs/COLLECTION@123456789-1145.zip
    java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0
        at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64)
        at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70)
        at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:266)
        at java.base/java.util.Objects.checkIndex(Objects.java:361)
        at java.base/java.util.ArrayList.get(ArrayList.java:427)
        at org.dspace.content.DSpaceObjectServiceImpl.addMetadata(DSpaceObjectServiceImpl.java:318)
        at org.dspace.content.crosswalk.XSLTIngestionCrosswalk.applyDimField(XSLTIngestionCrosswalk.java:115)
        at org.dspace.content.crosswalk.XSLTIngestionCrosswalk.applyDim(XSLTIngestionCrosswalk.java:81)
        at org.dspace.content.crosswalk.XSLTIngestionCrosswalk.applyDim(XSLTIngestionCrosswalk.java:84)
        at org.dspace.content.crosswalk.XSLTIngestionCrosswalk.ingestDIM(XSLTIngestionCrosswalk.java:231)
        at org.dspace.content.crosswalk.AIPDIMCrosswalk.ingest(AIPDIMCrosswalk.java:185)
        at org.dspace.content.packager.METSManifest.crosswalkXmd(METSManifest.java:1128)
        at org.dspace.content.packager.METSManifest.crosswalkItemDmd(METSManifest.java:1018)
        at org.dspace.content.packager.DSpaceAIPIngester.crosswalkObjectDmd(DSpaceAIPIngester.java:155)
        at org.dspace.content.packager.AbstractMETSIngester.ingestObject(AbstractMETSIngester.java:451)
        at org.dspace.content.packager.AbstractMETSIngester.replace(AbstractMETSIngester.java:1075)
        at org.dspace.content.packager.AbstractPackageIngester.replaceAll(AbstractPackageIngester.java:275)
        at org.dspace.content.packager.AbstractPackageIngester.replaceAll(AbstractPackageIngester.java:303)
        at org.dspace.app.packager.Packager.replace(Packager.java:684)
    ```
    * The code which is referenced is obviously buggy.  If the List in question is ever empty (because code called it with an empty metadata field or some other error occurs), then it fails entirely.

This PR is a small fix to avoid the error.  All it does is ensure the List is **not empty** before returning first value

## Instructions for Reviewers
* See https://github.com/DSpace/dspace-angular/issues/3072 for how to reproduce the error with Entity versioning.
* The error with AIP import may be more difficult to reproduce.  However, the code should be very self explanatory, and it matches the code from the `getMetadataFirstValue()` methods in the same `DSpaceObjectServiceImpl`
    * With this code in place, I was able to complete a successful AIP restoration (with no metadata loss).  Without it, I could not restore from AIPs.