### PR TITLE
Fix SWORDv2 Deletion for Workflow / Archived Items

### DIFF
--- a/dspace-swordv2/src/main/java/org/dspace/sword2/ContainerManagerDSpace.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/ContainerManagerDSpace.java
@@ -755,11 +755,14 @@ public class ContainerManagerDSpace extends DSpaceSwordAPI
             WorkflowTools wft = new WorkflowTools();
             if (wft.isItemInWorkspace(swordContext.getContext(), item)) {
                 WorkspaceItem wsi = wft.getWorkspaceItem(context, item);
-                workspaceItemService.deleteAll(context, wsi);
+                workspaceItemService.deleteWrapper(context, wsi);
             } else if (wft.isItemInWorkflow(context, item)) {
                 WorkflowItem wfi = wft.getWorkflowItem(context, item);
                 workflowItemService.deleteWrapper(context, wfi);
             }
+
+            // then delete the item
+            itemService.delete(context, item);
         } catch (SQLException | IOException e) {
             throw new DSpaceSwordException(e);
         } catch (AuthorizeException e) {


### PR DESCRIPTION
## References
* Follow-up to #9285  which fixed SWORDv2 deletion of WorkspaceItems, but accidentally **broke** deletion of Archived & Workflow Items

## Description
Fixes an issue caused by #9285.  Currently, on `main` the `Swordv2IT.depositAndEditViaSwordTest()` is **failing** because it attempts to delete an "archived" Item via SWORDv2.  That deletion was accidentally broken by the changes in #9285.

In this PR, I've added new ITs which test SWORD deletion for WorkspaceItems & WorkflowItems (as we already have a test for archived items as noted above).  These tests prove that WorkspaceItem deletion works but Workflow & Archived doesn't.

I've also added a fix which passes all tests.

## Instructions for Reviewers
* ITs are sufficient to prove the behavior is working properly as we now are covering all three scenarios...deletion of workspace, workflow and archived items.

**As soon as ITs all pass, I'm going to merge this immediately because the `Swordv2IT.depositAndEditViaSwordTest()` is failing on `main`.**