### PR TITLE
Revert to using 'main' for Sandbox redeployment now that Testathon is complete

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -70,7 +70,7 @@ env:
   REDEPLOY_DEMO_URL: ${{ secrets.REDEPLOY_DEMO_URL }}
   # Current DSpace branches (and architecture) which are deployed to demo.dspace.org & sandbox.dspace.org respectively
   DEPLOY_DEMO_BRANCH: 'dspace-7_x'
-  DEPLOY_SANDBOX_BRANCH: 'dspace-8.0-testathon'
+  DEPLOY_SANDBOX_BRANCH: 'main'
   DEPLOY_ARCH: 'linux/amd64'
 
 jobs:


### PR DESCRIPTION
## Description
Now that Testathon is complete, this small PR reverts our `reusable-docker-build.yml` to redeploying https://sandbox.dspace.org whenever updates are made to the **`main`** branch (instead of `dspace-8.0-testathon`)
