### PR TITLE
Install unzip util in built dspace-cli image

### DIFF
--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -34,9 +34,9 @@ WORKDIR /dspace-src
 ENV ANT_VERSION 1.10.13
 ENV ANT_HOME /tmp/ant-$ANT_VERSION
 ENV PATH $ANT_HOME/bin:$PATH
-# Need wget to install ant, and unzip for managing AIPs
+# Need wget to install ant
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends wget unzip \
+    && apt-get install -y --no-install-recommends wget \
     && apt-get purge -y --auto-remove \
     && rm -rf /var/lib/apt/lists/*
 # Download and install 'ant'
@@ -53,3 +53,8 @@ ENV DSPACE_INSTALL=/dspace
 COPY --from=ant_build /dspace $DSPACE_INSTALL
 # Give java extra memory (1GB)
 ENV JAVA_OPTS=-Xmx1000m
+# Install unzip for AIPs
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends unzip \
+    && apt-get purge -y --auto-remove \
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Description
`unzip` utility seems to not be available in the final `dspace-cli` image causing an error when trying to [ingest content from AIP files](https://github.com/DSpace/DSpace/blob/main/dspace/src/main/docker-compose/README.md#ingesting-test-content-from-aip-files). Issue initially found in `dspace-7_x`, but was reproduced with a locally built `latest`

## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* Move the `unzip` install to final block of `Dockerfile.cli` so that it's available where needed

### Testing
Start up the docker-compose environment locally using `:latest` or `:dspace-7_x` versions, create a test admin user, then ingest content from AIPs:
``` sh
docker-compose -p d7 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-angular.yml up -d
docker-compose -p d7 -f docker-compose-cli.yml run --rm dspace-cli create-administrator -e test@test.edu -f admin -l user -p admin -c en
docker-compose -p d7 -f docker-compose-cli.yml -f dspace/src/main/docker-compose/cli.ingest.yml run --rm dspace-cli
```

Prior to this change, the following error would occur during ingest ultimately caused by the AIP zip not being decompressed due to missing `unzip`:
```
:~/workspace/dspace/DSpace$ docker-compose -p d7 -f docker-compose-cli.yml -f dspace/src/main/docker-compose/cli.ingest.yml run dspace-cli

[+] Building 0.0s (0/0)                                                                                                                                                                                                                                                                docker-container:trusting_williamson
mkdir: cannot create directory ‘/dspace/upload’: File exists
/tmp/aip-dir
help: line 6: unzip: command not found
Beginning replacement process...

Package located at SITE*.zip does not exist!
Running org/dspace/storage/rdbms/sqlmigration/postgres/update-sequences.sql
Caught exception:
org.postgresql.util.PSQLException: ERROR: setval: value 0 is out of bounds for sequence "handle_seq" (1..9223372036854775807)
        at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2725)
        at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2412)
        at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:371)
        at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:502)
        at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:419)
        at org.postgresql.jdbc.PgStatement.executeWithFlags(PgStatement.java:341)
        at org.postgresql.jdbc.PgStatement.executeCachedSql(PgStatement.java:326)
        at org.postgresql.jdbc.PgStatement.executeWithFlags(PgStatement.java:302)
        at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:297)
        at org.apache.commons.dbcp2.DelegatingStatement.execute(DelegatingStatement.java:182)
        at org.apache.commons.dbcp2.DelegatingStatement.execute(DelegatingStatement.java:182)
        at org.dspace.storage.rdbms.DatabaseUtils.main(DatabaseUtils.java:405)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.dspace.app.launcher.ScriptLauncher.runOneCommand(ScriptLauncher.java:283)
        at org.dspace.app.launcher.ScriptLauncher.handleScript(ScriptLauncher.java:134)
        at org.dspace.app.launcher.ScriptLauncher.main(ScriptLauncher.java:99)
OAI 2.0 manager action started
There are no indexed documents, using full import.
Full import
Total: 0 items
Total: 0 items
OAI 2.0 manager action ended. It took 1 seconds.
OAI 2.0 manager action started
Purging cached OAI responses.
OAI 2.0 manager action ended. It took 0 seconds.
```

Local testing involved bringing the docker environment down and clearing volumes, building the new dspace-cli, and rerunning the above, making sure to use the new version of dspace-cli. The operations completed successfully for me.

``` sh
docker-compose -p d7 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-angular.yml down -v
DSPACE_VER=test docker-compose -f docker-compose-cli.yml build
docker-compose -p d7 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-angular.yml up -d
docker-compose -p d7 -f docker-compose-cli.yml run --rm dspace-cli create-administrator -e test@test.edu -f admin -l user -p admin -c en
DSPACE_VER=test docker-compose -p d7 -f docker-compose-cli.yml -f dspace/src/main/docker-compose/cli.ingest.yml run --rm dspace-cli
```

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
