### PR TITLE
Remove obsolete "version" tag from Docker Compose files

### DIFF
--- a/docker-compose-cli.yml
+++ b/docker-compose-cli.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 networks:
   # Default to using network named 'dspacenet' from docker-compose.yml.
   # Its full name will be prepended with the project name (e.g. "-p d7" means it will be named "d7_dspacenet")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 networks:
   dspacenet:
     ipam:

--- a/dspace/src/main/docker-compose/cli.assetstore.yml
+++ b/dspace/src/main/docker-compose/cli.assetstore.yml
@@ -6,8 +6,6 @@
 # http://www.dspace.org/license/
 #
 
-version: "3.7"
-
 services:
   dspace-cli:
     environment:

--- a/dspace/src/main/docker-compose/cli.ingest.yml
+++ b/dspace/src/main/docker-compose/cli.ingest.yml
@@ -6,8 +6,6 @@
 # http://www.dspace.org/license/
 #
 
-version: "3.7"
-
 services:
   dspace-cli:
     environment:

--- a/dspace/src/main/docker-compose/db.entities.yml
+++ b/dspace/src/main/docker-compose/db.entities.yml
@@ -6,8 +6,6 @@
 # http://www.dspace.org/license/
 #
 
-version: "3.7"
-
 services:
   dspacedb:
     image: dspace/dspace-postgres-pgcrypto:${DSPACE_VER:-latest}-loadsql

--- a/dspace/src/main/docker-compose/db.restore.yml
+++ b/dspace/src/main/docker-compose/db.restore.yml
@@ -6,8 +6,6 @@
 # http://www.dspace.org/license/
 #
 
-version: "3.7"
-
 #
 # Overrides the default "dspacedb" container behavior to load a local SQL file into PostgreSQL.
 #

--- a/dspace/src/main/docker-compose/docker-compose-angular.yml
+++ b/dspace/src/main/docker-compose/docker-compose-angular.yml
@@ -6,7 +6,6 @@
 # http://www.dspace.org/license/
 #
 
-version: '3.7'
 networks:
   # Default to using network named 'dspacenet' from docker-compose.yml.
   # Its full name will be prepended with the project name (e.g. "-p d7" means it will be named "d7_dspacenet")

--- a/dspace/src/main/docker-compose/docker-compose-iiif.yml
+++ b/dspace/src/main/docker-compose/docker-compose-iiif.yml
@@ -10,7 +10,6 @@
 # Test environment for DSpace + Cantaloupe for IIIF support. See README for instructions.
 # This should NEVER be used in production scenarios.
 #
-version: '3.7'
 networks:
   # Default to using network named 'dspacenet' from docker-compose.yml.
   # Its full name will be prepended with the project name (e.g. "-p d7" means it will be named "d7_dspacenet")

--- a/dspace/src/main/docker-compose/docker-compose-shibboleth.yml
+++ b/dspace/src/main/docker-compose/docker-compose-shibboleth.yml
@@ -10,7 +10,6 @@
 # Test environment for DSpace + Shibboleth (running via mod_shib in Apache). See README for instructions.
 # This should NEVER be used in production scenarios.
 #
-version: '3.7'
 networks:
   # Default to using network named 'dspacenet' from docker-compose.yml.
   # Its full name will be prepended with the project name (e.g. "-p d7" means it will be named "d7_dspacenet")


### PR DESCRIPTION
## Description
The "version" tag in a Docker Compose file is now obsolete.  See docs at https://docs.docker.com/compose/compose-file/04-version-and-name/#version-top-level-element-obsolete

This PR just removes all those tags as we are now seeing warnings like this when rebuilding Docker images:
```
time="2024-05-01T11:14:05-05:00" level=warning msg="C:\\DSpace\\docker-compose.yml: `version` is obsolete"
time="2024-05-01T11:14:05-05:00" level=warning msg="C:\\DSpace\\docker-compose-cli.yml: `version` is obsolete"
```

## Instructions for Reviewers
* This is an extremely minor change.  As long as warning disappears & builds all succeed, I'll merge immediately.