### PR TITLE
[dspace-7_x] Minor update to latest Spring version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <!--=== GENERAL / DSPACE-API DEPENDENCIES ===-->
         <java.version>11</java.version>
-        <spring.version>5.3.33</spring.version>
+        <spring.version>5.3.34</spring.version>
         <spring-boot.version>2.7.18</spring-boot.version>
         <spring-security.version>5.7.11</spring-security.version> <!-- sync with version used by spring-boot-->
         <hibernate.version>5.6.15.Final</hibernate.version>


### PR DESCRIPTION
## Description
Minor update for `dspace-7_x` to Spring 5.3.34.  This was a security update for Spring to resolve CVE-2024-22262

(FWIW, I don't believe DSpace is vulnerable to this attack as we don't use `UriComponentsBuilder` in the manner described by that CVE.)

## Instructions for Reviewers
* Assuming all tests pass, this will be merged immediately as this has already been patched on `main`.