### PR TITLE
Fixed too long classpath bug in test_databaseFixed classpath issue in test_database target

### DIFF
--- a/dspace/src/main/config/build.xml
+++ b/dspace/src/main/config/build.xml
@@ -760,8 +760,25 @@ Common usage:
 
     <!-- Test the connection to the database -->
     <target name="test_database">
+        <path id="jar.classpath">
+            <fileset dir="lib">
+                <include name="**/*.jar" />
+            </fileset>
+        </path>
+        <manifestclasspath property="reduced.classpath" jarfile="pathing.jar">
+            <classpath refid="jar.classpath"/>
+        </manifestclasspath>
+        <jar destfile="pathing.jar">
+            <manifest>
+                <attribute name="Class-Path" value="${reduced.classpath}"/>
+            </manifest>
+        </jar>
+        <path id="class.path.database">
+            <pathelement path="${env.CLASSPATH}" />
+            <pathelement path="pathing.jar" />
+        </path>
         <java classname="org.dspace.app.launcher.ScriptLauncher"
-              classpathref="class.path"
+              classpathref="class.path.database"
               fork="yes"
               failonerror="yes">
             <sysproperty key="log4j.configurationFile"


### PR DESCRIPTION
## References
* No existing references, the previous version of this PR (#9388) seems to have been deleted when I rebased my fork earlier today.
* Fixes #9536

## Description
In the original state of the `test_database` target in `build.xml`, the classpath built within the task becomes too long to be properly handled by the `<java>` task that follows, which causes failure of any task that includes `test_database`. I fixed the task so that the classpath is stored in an alias that is then used in the `<javac>` task, which doesn't fail anymore.

## Instructions for Reviewers
After building the project using Maven, run `fresh_install` (or any task that has `test_database` in its transitive dependencies) in `/dspace/target/dspace-installer/build.xml`.

List of changes in this PR:
* Fixed the `test_database` target in `/dspace/target/dspace-installer/build.xml`.

Please note that I am not sure whether this behaviour will be reproducible in all environments. I work in a Windows 10-based environment.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

Please note that unchecked entries below are not applicable to non-Java files.

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [X] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).