### PR TITLE
Excluded useless xml-apis dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1269,6 +1269,12 @@
                 <groupId>org.apache.tika</groupId>
                 <artifactId>tika-parsers-standard-package</artifactId>
                 <version>${tika.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>xml-apis</groupId>
+                        <artifactId>xml-apis</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <!-- Tika brings in multiple versions of this. Select the latest version. Always sync with Tika version -->
             <dependency>
@@ -1806,6 +1812,12 @@
                 <groupId>xom</groupId>
                 <artifactId>xom</artifactId>
                 <version>1.3.9</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>xml-apis</groupId>
+                        <artifactId>xml-apis</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <!-- json-path is needed by Spring HATEOAS -->


### PR DESCRIPTION
## References
Fixes #9545

## Description
I force exclusion of the `xml-apis` dependency from dependencies `tika-parsers-standard-package` (used in **dspace-api** and **dspace-server-webapp**) and `xom` (used in **dspace-sword**).

## Instructions for Reviewers
Just replace the parent POM at the root of the codebase tree, build the project, and run. Proper execution may be tested either the standard way through the Angular UI or through the HAL Browser.

List of changes in this PR:
* The root POM now excludes the `xml-apis` from the two dependencies mentioned above. However, I didn't remove the fixed version 1.4.01 in the `<dependencyManagement>` section in case some dependency includes it back in the future.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

**Unchecked items below are not applicable to this PR.**

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
