### PR TITLE
Ensure potentially large Solr query uses POST, not GET

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/EntityTypeServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/EntityTypeServiceImpl.java
@@ -148,7 +148,7 @@ public class EntityTypeServiceImpl implements EntityTypeService {
         sQuery.setFacetMinCount(1);
         sQuery.setFacetLimit(Integer.MAX_VALUE);
         sQuery.setFacetSort(FacetParams.FACET_SORT_INDEX);
-        QueryResponse qResp = solrSearchCore.getSolr().query(sQuery);
+        QueryResponse qResp = solrSearchCore.getSolr().query(sQuery, solrSearchCore.REQUEST_METHOD);
         FacetField facetField = qResp.getFacetField("search.entitytype");
         if (Objects.nonNull(facetField)) {
             for (Count c : facetField.getValues()) {


### PR DESCRIPTION
## References
* Fixes #9544

## Description
Large SOLR queries should always use `POST` instead of `GET` to avoid hitting a "URI too long" error.   See for example https://sitecore.stackexchange.com/questions/34316/solr-query-error-uri-too-long

We already use `POST` in all larger queries in our codebase, including all in SolrServiceImpl.

This PR is simply a small fix to use `POST` for a query that can be very large if you have a large number of groups.

