### PR TITLE
Ensure Process `user_id` is nullified when referenced EPerson is deleted

### DIFF
--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V7.6_2024.05.07__process_eperson_constraint.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V7.6_2024.05.07__process_eperson_constraint.sql
@@ -1,0 +1,13 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+-- If Process references an EPerson that no longer exists, set the "user_id" to null.
+UPDATE process SET user_id = null WHERE NOT EXISTS (SELECT * FROM EPerson where uuid = process.user_id);
+
+-- Add new constraint where process.user_id is nullified if referenced EPerson is deleted.
+ALTER TABLE process ADD CONSTRAINT process_eperson FOREIGN KEY (user_id) REFERENCES EPerson(uuid) ON DELETE SET NULL;

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.6_2024.05.07__process_eperson_constraint.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.6_2024.05.07__process_eperson_constraint.sql
@@ -1,0 +1,13 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+-- If Process references an EPerson that no longer exists, set the "user_id" to null.
+UPDATE process SET user_id = null WHERE NOT EXISTS (SELECT * FROM EPerson where uuid = process.user_id);
+
+-- Add new constraint where process.user_id is nullified if referenced EPerson is deleted.
+ALTER TABLE process ADD CONSTRAINT process_eperson FOREIGN KEY (user_id) REFERENCES EPerson(uuid) ON DELETE SET NULL;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ProcessConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ProcessConverter.java
@@ -14,7 +14,6 @@ import org.dspace.app.rest.model.ProcessRest;
 import org.dspace.app.rest.projection.Projection;
 import org.dspace.scripts.Process;
 import org.dspace.scripts.service.ProcessService;
-import org.hibernate.ObjectNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
@@ -40,10 +39,8 @@ public class ProcessConverter implements DSpaceConverter<Process, ProcessRest> {
         processRest.setId(process.getID());
         processRest.setScriptName(process.getName());
         processRest.setProcessId(process.getID());
-        try {
+        if (process.getEPerson() != null) {
             processRest.setUserId(process.getEPerson().getID());
-        } catch (ObjectNotFoundException e ) {
-            processRest.setUserId(null);
         }
         processRest.setProcessStatus(process.getProcessStatus());
         processRest.setStartTime(process.getStartTime());


### PR DESCRIPTION
## References
* Fixes backend issues found in https://github.com/DSpace/dspace-angular/pull/3014#pullrequestreview-2044224424

## Description
When an EPerson who created a Process is deleted, a reference to the deleted EPerson remains in the process `user_id` column.  This fixes that by nullifying any references to deleted EPerson objects and adding a constraint to ensure they are nullified automatically in the future.

Also fixes a bug in ProcessConverter to ensure when EPerson is null, a NullPointerException doesn't occur.

## Instructions for Reviewers
* To be tested with https://github.com/DSpace/dspace-angular/pull/3014   This PR should allow the Process Details page to also work even if the EPerson (who created the process) is deleted.