### PR TITLE
Remove not unique id from inner beans to avoid xml validation issues

### DIFF
--- a/dspace-api/src/test/data/dspaceFolder/config/spring/api/item-filters.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/spring/api/item-filters.xml
@@ -295,8 +295,7 @@
                 <property name="statements">
                     <list>
                         <!-- Has a non-empty title -->
-                        <bean id="has-title_condition"
-                              class="org.dspace.content.logic.condition.MetadataValueMatchCondition">
+                        <bean class="org.dspace.content.logic.condition.MetadataValueMatchCondition">
                             <property name="parameters">
                                 <map>
                                     <entry key="field" value="dc.title" />
@@ -352,8 +351,7 @@
                 <property name="statements">
                     <list>
                         <!-- Has a non-empty title -->
-                        <bean id="has-title_condition"
-                              class="org.dspace.content.logic.condition.MetadataValueMatchCondition">
+                        <bean class="org.dspace.content.logic.condition.MetadataValueMatchCondition">
                             <property name="parameters">
                                 <map>
                                     <entry key="field" value="dc.title" />


### PR DESCRIPTION
## Description
The item-filters.xml spring configuration file assign an id to two inner beans. This is unnecessary as these bean are not referenced by other but is reported as a xsd validation issue in the IDE (eclipse in my case).

## Instructions for Reviewers
Just check that the CI still pass and the application startup without issues

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [n/a] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [n/a] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [n/a] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [n/a] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [n/a] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
