### PR TITLE
potential array index out of bounds access in SubscriptionDsoMetadataForEmailCompose

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/SubscriptionDsoMetadataForEmailCompose.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/SubscriptionDsoMetadataForEmailCompose.java
@@ -49,7 +49,7 @@ public class SubscriptionDsoMetadataForEmailCompose implements StreamDisseminati
             for (String actualMetadata : metadata) {
                 String[] splitted = actualMetadata.split("\\.");
                 String qualifier = null;
-                if (splitted.length == 1) {
+                if (splitted.length == 3) {
                     qualifier = splitted[2];
                 }
                 var metadataValue = itemService.getMetadataFirstValue(item, splitted[0], splitted[1], qualifier, ANY);


### PR DESCRIPTION
## Description

In `SubscriptionDsoMetadataForEmailCompose` it is possible to access array `splitted` out of bounds. This PR fixes this problem.