### PR TITLE
remove outdated comment on RSS feeds in dspace.cfg

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1289,8 +1289,6 @@ plugin.named.org.dspace.content.license.LicenseArgumentFormatter = \
 	org.dspace.content.license.SimpleDSpaceObjectLicenseFormatter = eperson
 
 #### Syndication Feed (RSS) Settings ######
-# TODO: UNSUPPORTED in DSpace 7.0. Will be added in a later release
-
 # URLs returned by the feed will point at the global handle server
 # (e.g. https://hdl.handle.net/123456789/1).  Set to true to use local server
 # URLs (i.e. https://myserver.myorg/handle/123456789/1)


### PR DESCRIPTION
## Description

RSS/Atom feeds are supported as of DSpace 7.3. The documentation on it is available in the Configuration Reference in the DSDOC7x page: https://wiki.lyrasis.org/display/DSDOC7x/Configuration+Reference#ConfigurationReference-SyndicationFeed(RSS)Settings

@tdonohue suggested in Slack that the line in the `dspace.cfg` likely should be removed though as it's not accurate.