### PR TITLE
[Port dspace-7_x] remove outdated comment as RSS feeds are supported in DS 7.3+

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1276,8 +1276,6 @@ plugin.named.org.dspace.content.license.LicenseArgumentFormatter = \
 	org.dspace.content.license.SimpleDSpaceObjectLicenseFormatter = eperson
 
 #### Syndication Feed (RSS) Settings ######
-# TODO: UNSUPPORTED in DSpace 7.0. Will be added in a later release
-
 # URLs returned by the feed will point at the global handle server
 # (e.g. https://hdl.handle.net/123456789/1).  Set to true to use local server
 # URLs (i.e. https://myserver.myorg/handle/123456789/1)


### PR DESCRIPTION
Manual port of #9573 by @saschaszott to `dspace-7_x`