### PR TITLE
Remove old UI references from OpenSearch / RSS feeds

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/OpenSearchServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/OpenSearchServiceImpl.java
@@ -155,7 +155,7 @@ public class OpenSearchServiceImpl implements OpenSearchService {
             format = "atom_1.0";
         }
 
-        SyndicationFeed feed = new SyndicationFeed(labels.get(SyndicationFeed.MSG_UITYPE));
+        SyndicationFeed feed = new SyndicationFeed();
         feed.populate(null, context, scope, results, labels);
         feed.setType(format);
         feed.addModule(openSearchMarkup(query, totalResults, start, pageSize));

--- a/dspace-api/src/main/java/org/dspace/app/util/SyndicationFeed.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/SyndicationFeed.java
@@ -84,11 +84,6 @@ public class SyndicationFeed {
     public static final String MSG_FEED_TITLE = "feed.title";
     public static final String MSG_FEED_DESCRIPTION = "general-feed.description";
     public static final String MSG_METADATA = "metadata.";
-    public static final String MSG_UITYPE = "ui.type";
-
-    // UI keywords
-    public static final String UITYPE_XMLUI = "xmlui";
-    public static final String UITYPE_JSPUI = "jspui";
 
     // default DC fields for entry
     protected String defaultTitleField = "dc.title";
@@ -145,10 +140,6 @@ public class SyndicationFeed {
     // the feed object we are building
     protected SyndFeed feed = null;
 
-    // memory of UI that called us, "xmlui" or "jspui"
-    // affects Bitstream retrieval URL and I18N keys
-    protected String uiType = null;
-
     protected HttpServletRequest request = null;
 
     protected CollectionService collectionService;
@@ -157,12 +148,9 @@ public class SyndicationFeed {
 
     /**
      * Constructor.
-     *
-     * @param ui either "xmlui" or "jspui"
      */
-    public SyndicationFeed(String ui) {
+    public SyndicationFeed() {
         feed = new SyndFeedImpl();
-        uiType = ui;
         ContentServiceFactory contentServiceFactory = ContentServiceFactory.getInstance();
         itemService = contentServiceFactory.getItemService();
         collectionService = contentServiceFactory.getCollectionService();
@@ -518,8 +506,7 @@ public class SyndicationFeed {
     protected String urlOfBitstream(HttpServletRequest request, Bitstream logo) {
         String name = logo.getName();
         return resolveURL(request, null) +
-            (uiType.equalsIgnoreCase(UITYPE_XMLUI) ? "/bitstream/id/" : "/retrieve/") +
-            logo.getID() + "/" + (name == null ? "" : name);
+            "/bitstreams/" + logo.getID() + "/download";
     }
 
     protected String baseURL = null;  // cache the result for null

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/OpenSearchController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/OpenSearchController.java
@@ -285,7 +285,6 @@ public class OpenSearchController {
         labelMap.put(SyndicationFeed.MSG_UNTITLED, "notitle");
         labelMap.put(SyndicationFeed.MSG_LOGO_TITLE, "logo.title");
         labelMap.put(SyndicationFeed.MSG_FEED_DESCRIPTION, "general-feed.description");
-        labelMap.put(SyndicationFeed.MSG_UITYPE, SyndicationFeed.UITYPE_JSPUI);
         for (String selector : SyndicationFeed.getDescriptionSelectors()) {
             labelMap.put("metadata." + selector, selector);
         }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/opensearch/OpenSearchControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/opensearch/OpenSearchControllerIT.java
@@ -96,7 +96,12 @@ public class OpenSearchControllerIT extends AbstractControllerIntegrationTest {
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
                                            .withName("Sub Community")
                                            .build();
-        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+        // Add a fake logo to the Collection
+        Collection col1 = CollectionBuilder.createCollection(context, child1)
+                                           .withName("Collection 1")
+                                           .withLogo("logo_collection")
+                                           .build();
+        String colLogoUuid = col1.getLogo().getID().toString();
 
         Item publicItem1 = ItemBuilder.createItem(context, col1)
                                           .withTitle("Boars at Yellowstone")
@@ -118,10 +123,24 @@ public class OpenSearchControllerIT extends AbstractControllerIntegrationTest {
                    .andExpect(xpath("feed/Query/@searchTerms").string("Yellowstone"))
                    .andExpect(xpath("feed/totalResults").string("2"))
         ;
+
+        // When we search at the Collection level (scope = Collection UUID)
+        getClient().perform(get("/opensearch/search")
+                                .param("scope", col1.getID().toString())
+                                .param("query", "Yellowstone"))
+                   //The status has to be 200 OK
+                   .andExpect(status().isOk())
+                   // We expect the content type to be "application/atom+xml;charset=UTF-8"
+                   .andExpect(content().contentType("application/atom+xml;charset=UTF-8"))
+                   .andExpect(xpath("feed/Query/@searchTerms").string("Yellowstone"))
+                   .andExpect(xpath("feed/totalResults").string("2"))
+                   // We expect feed will have the Collection logo
+                   .andExpect(xpath("feed/logo")
+                                  .string("http://localhost:4000/bitstreams/" + colLogoUuid + "/download"))
+        ;
     }
 
     // This test does not find the record, so there are obviously issues with special chars
-    @Ignore
     @Test
     public void findResultWithSpecialCharsTest() throws Exception {
         //Turn off the authorization system, otherwise we can't make the objects
@@ -144,12 +163,12 @@ public class OpenSearchControllerIT extends AbstractControllerIntegrationTest {
                                           .build();
         //When we call the root endpoint
         getClient().perform(get("/opensearch/search")
-                                .param("query", "Bär"))
+                                .param("query", "Bären"))
                    //The status has to be 200 OK
                    .andExpect(status().isOk())
                    //We expect the content type to be "application/atom+xml;charset=UTF-8"
                    .andExpect(content().contentType("application/atom+xml;charset=UTF-8"))
-                   .andExpect(xpath("feed/Query/@searchTerms").string("B%C3%A4r"))
+                   .andExpect(xpath("feed/Query/@searchTerms").string("B%C3%A4ren"))
                    .andExpect(xpath("feed/totalResults").string("1"))
         ;
     }


### PR DESCRIPTION
## References
* Fixes #9572 

## Description
Removes UI-type related functionality from OpenSearch & RSS feeds.  It was still being used to generate Bitstream URLs (for community/collection logos) but these URLs **were incorrect for DSpace 7+**.

This code fixes the Bitstream URL to be of the format: `[dspace.ui.url]/bitstreams/[uuid]/download`

It also adds a basic IT to verify these logo URLs are correct now.

In fixing this bug, I found a disabled test which uses OpenSearch for special characters.  I added a minor fix to get it to work, and enabled it.
