### PR TITLE
Add missing wosPublisherContrib key-ref in wos-integration.xml (#9579)

### DIFF
--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/WOSImportMetadataSourceServiceIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/WOSImportMetadataSourceServiceIT.java
@@ -136,6 +136,7 @@ public class WOSImportMetadataSourceServiceIT extends AbstractLiveImportIntegrat
         MetadatumDTO subject15 = createMetadatumDTO("dc", "subject", null, "Coding concepts");
         MetadatumDTO subject16 = createMetadatumDTO("dc", "subject", null, "Lesson design");
         MetadatumDTO subject17 = createMetadatumDTO("dc", "subject", null, "Social Sciences");
+        MetadatumDTO publisher = createMetadatumDTO("dc", "publisher", null, "SPRINGER");
         MetadatumDTO other = createMetadatumDTO("dc", "identifier", "other", "WOS:000805105200003");
         metadatums.add(edition);
         metadatums.add(date);
@@ -166,6 +167,7 @@ public class WOSImportMetadataSourceServiceIT extends AbstractLiveImportIntegrat
         metadatums.add(subject15);
         metadatums.add(subject16);
         metadatums.add(subject17);
+        metadatums.add(publisher);
         metadatums.add(other);
         ImportRecord firstrRecord = new ImportRecord(metadatums);
 
@@ -205,6 +207,7 @@ public class WOSImportMetadataSourceServiceIT extends AbstractLiveImportIntegrat
         MetadatumDTO subject26 = createMetadatumDTO("dc", "subject", null, "Social Sciences");
         MetadatumDTO subject27 = createMetadatumDTO("dc", "subject", null, "Science & Technology");
         MetadatumDTO subject28 = createMetadatumDTO("dc", "subject", null, "Life Sciences & Biomedicine");
+        MetadatumDTO publisher2 = createMetadatumDTO("dc", "publisher", null, "NATURE PORTFOLIO");
         MetadatumDTO other2 = createMetadatumDTO("dc", "identifier", "other", "WOS:000805100600001");
         MetadatumDTO rid = createMetadatumDTO("person", "identifier", "rid", "C-6334-2011");
         MetadatumDTO rid2 = createMetadatumDTO("person", "identifier", "rid", "B-1251-2008");
@@ -236,6 +239,7 @@ public class WOSImportMetadataSourceServiceIT extends AbstractLiveImportIntegrat
         metadatums2.add(subject26);
         metadatums2.add(subject27);
         metadatums2.add(subject28);
+        metadatums2.add(publisher2);
         metadatums2.add(other2);
         metadatums2.add(rid);
         metadatums2.add(rid2);

--- a/dspace/config/spring/api/wos-integration.xml
+++ b/dspace/config/spring/api/wos-integration.xml
@@ -35,6 +35,7 @@
         <entry key-ref="wos.fullName" value-ref="wosFullNameContrib"/>
         <entry key-ref="wos.subject" value-ref="wosSubjectContrib"/>
         <entry key-ref="wos.orcid" value-ref="wosOrcidContrib"/>
+        <entry key-ref="wos.publisher" value-ref="wosPublisherContrib"/>
         <entry key-ref="wos.contributorEditor" value-ref="wosContributorEditorContrib"/>
         <entry key-ref="wos.wosId" value-ref="wosIdContrib"/>
         <entry key-ref="wos.rid" value-ref="wosRidContrib"/>


### PR DESCRIPTION
## References
* Fixes #9579

## Description
Added missing *wosPublisherContrib* key-ref in `wos-integration.xml` file

## Instructions for Reviewers
*No specific instructions*

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
