### PR TITLE
Add additional DOI prefixes

### DIFF
--- a/dspace-api/src/main/java/org/dspace/importer/external/service/DoiCheck.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/service/DoiCheck.java
@@ -19,7 +19,16 @@ import java.util.regex.Pattern;
  */
 public class DoiCheck {
 
-    private static final List<String> DOI_PREFIXES = Arrays.asList("http://dx.doi.org/", "https://dx.doi.org/");
+    private static final List<String> DOI_PREFIXES = Arrays.asList(
+            "http://dx.doi.org/",
+            "https://dx.doi.org/",
+            "http://www-dx.doi.org/",
+            "https://www-dx.doi.org/",
+            "http://doi.org/",
+            "https://doi.org/",
+            "www.dx.doi.org/",
+            "dx.doi.org/",
+            "doi:");
 
     private static final Pattern PATTERN = Pattern.compile("10.\\d{4,9}/[-._;()/:A-Z0-9]+" +
                                                                "|10.1002/[^\\s]+" +


### PR DESCRIPTION
## References
* Fixes #9561

## Description
Adds additional DOI prefixed, so that more DOIs are being recognized as valid

## Instructions for Reviewers
Check that #9561 is fixed, that is: Doing a crossref search with https://doi.org/10.1108/CAER-03-2020-0040 and similar forms should now return only a single result: The work with the provided DOI.


## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
