### PR TITLE
Metadata Import via Scopus API: improved handling of empty search results

### DIFF
--- a/dspace-api/src/main/java/org/dspace/importer/external/metadatamapping/contributor/AuthorMetadataContributor.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/metadatamapping/contributor/AuthorMetadataContributor.java
@@ -71,7 +71,7 @@ public class AuthorMetadataContributor extends SimpleXpathMetadatumContributor {
     }
 
     /**
-     * Retrieve the the ScopusID, orcid, author name and affiliationID
+     * Retrieve the ScopusID, orcid, author name and affiliationID
      * metadata associated with the given element object.
      * If the value retrieved from the element is empty
      * it is set PLACEHOLDER_PARENT_METADATA_VALUE
@@ -82,11 +82,19 @@ public class AuthorMetadataContributor extends SimpleXpathMetadatumContributor {
     private List<MetadatumDTO> getMetadataOfAuthors(Element element) throws JaxenException {
         List<MetadatumDTO> metadatums = new ArrayList<MetadatumDTO>();
         Element authname = element.getChild("authname", NAMESPACE);
+        Element surname = element.getChild("surname", NAMESPACE);
+        Element givenName = element.getChild("given-name", NAMESPACE);
         Element scopusId = element.getChild("authid", NAMESPACE);
         Element orcid = element.getChild("orcid", NAMESPACE);
         Element afid = element.getChild("afid", NAMESPACE);
 
-        addMetadatum(metadatums, getMetadata(getElementValue(authname), this.authname));
+        if (authname != null) {
+            addMetadatum(metadatums, getMetadata(getElementValue(authname), this.authname));
+        } else {
+            addMetadatum(metadatums, getMetadata(getElementValue(surname) + ", " +
+                    getElementValue(givenName), this.authname));
+        }
+
         addMetadatum(metadatums, getMetadata(getElementValue(scopusId), this.scopusId));
         addMetadatum(metadatums, getMetadata(getElementValue(orcid), this.orcid));
         addMetadatum(metadatums, getMetadata(StringUtils.isNotBlank(afid.getValue())

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ScopusImportMetadataSourceServiceIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ScopusImportMetadataSourceServiceIT.java
@@ -96,7 +96,7 @@ public class ScopusImportMetadataSourceServiceIT extends AbstractLiveImportInteg
     }
 
     @Test
-    public void scopusImportMetadataGetRecordsEmptyResponceTest() throws Exception {
+    public void scopusImportMetadataGetRecordsEmptyResponseTest() throws Exception {
         context.turnOffAuthorisationSystem();
         String originApiKey = scopusServiceImpl.getApiKey();
         if (StringUtils.isBlank(originApiKey)) {
@@ -113,8 +113,7 @@ public class ScopusImportMetadataSourceServiceIT extends AbstractLiveImportInteg
 
             context.restoreAuthSystemState();
             Collection<ImportRecord> recordsImported = scopusServiceImpl.getRecords("roma", 0, 20);
-            ImportRecord  importedRecord = recordsImported.iterator().next();
-            assertTrue(importedRecord.getValueList().isEmpty());
+            assertTrue(recordsImported.isEmpty());
         } finally {
             liveImportClientImpl.setHttpClient(originalHttpClient);
             scopusServiceImpl.setApiKey(originApiKey);

--- a/dspace-server-webapp/src/test/resources/org/dspace/app/rest/scopus-empty-resp.xml
+++ b/dspace-server-webapp/src/test/resources/org/dspace/app/rest/scopus-empty-resp.xml
@@ -3,8 +3,10 @@
     <opensearch:totalResults>0</opensearch:totalResults>
     <opensearch:startIndex>0</opensearch:startIndex>
     <opensearch:itemsPerPage>0</opensearch:itemsPerPage>
-    <opensearch:Query role="request" searchTerms="(probizna)" startPage="0"/>
-    <link ref="self" href="https://api.elsevier.com/content/search/scopus?start=0&amp;count=2&amp;query=%28testemptyresp%29&amp;view=COMPLETE" type="application/xml"/>
+    <opensearch:Query role="request" searchTerms="a-query-without-hits" startPage="0"/>
+    <link ref="self"
+          href="https://api.elsevier.com/content/search/scopus?start=0&amp;count=10&amp;query=a-query-without-hits&amp;httpAccept=application%2Fxml"
+          type="application/xml"/>
     <entry>
         <error>Result set was empty</error>
     </entry>


### PR DESCRIPTION
## Description

This is a reduced version of PR https://github.com/DSpace/DSpace/pull/9375/ which improves the handling of empty Scopus API results.

It does not contain changes made by 4Science.