### PR TITLE
Fixing issue #7464 for DSpace 7

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/METSRightsCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/METSRightsCrosswalk.java
@@ -552,8 +552,9 @@ public class METSRightsCrosswalk
                                       ex);
                         }
 
-                        //set permissions on policy add to list of policies
+                        //set permissions and type on policy and add to list of policies
                         rp.setAction(parsePermissions(permsElement));
+                        rp.setRpType(ResourcePolicy.TYPE_CUSTOM);
                         policies.add(rp);
                     }
                 } //end if "Context" element


### PR DESCRIPTION
## References
* Fixes #7464 
* Related with #(PR DS8)

## Description
When depositing via Sword, if you specify restricting policies (like embargo or restricted), the resource policy table will have a null value for the type. This PR fixes that for DSpace 7.