### PR TITLE
[Port dspace-7_x] Add a GET `/csrf` endpoint to allow for forcing refresh of CSRF token

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/CsrfRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/CsrfRestController.java
@@ -1,0 +1,62 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.data.rest.webmvc.ControllerUtils;
+import org.springframework.hateoas.RepresentationModel;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.security.web.csrf.CsrfTokenRepository;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Define GET /api/security/csrf endpoint which may be used to obtain a CSRF token from Spring Security.
+ * This is useful to force a CSRF token to be generated prior to a POST/PUT/PATCH request that requires it.
+ * <P>
+ * NOTE: This endpoint should be used sparingly to ensure clients are NOT performing two requests for every modifying
+ * request (e.g. a GET /csrf followed by a POST/PUT/PATCH to another endpoint). Ideally, calling this endpoint is only
+ * necessary BEFORE the first POST/PUT/PATCH (if a CSRF token has not yet been obtained), or in scenarios where the
+ * client must *force* the CSRF token to be reloaded.
+ */
+@RequestMapping(value = "/api/security")
+@RestController
+public class CsrfRestController {
+
+    @Lazy
+    @Autowired
+    CsrfTokenRepository csrfTokenRepository;
+
+    /**
+     * Return the current CSRF token as defined by Spring Security.
+     * Inspired by
+     * https://docs.spring.io/spring-security/reference/5.8/migration/servlet/exploits.html#_i_am_using_a_single_page_application_with_httpsessioncsrftokenrepository
+     * @param request HTTP Request
+     * @param response HTTP response
+     * @param csrfToken injected CsrfToken by Spring Security
+     * @return An empty response with CSRF in header & cookie
+     */
+    @GetMapping("/csrf")
+    @PreAuthorize("permitAll()")
+    public ResponseEntity<RepresentationModel<?>> getCsrf(HttpServletRequest request,
+                                                          HttpServletResponse response,
+                                                          CsrfToken csrfToken) {
+        // Save the CSRF token to our response using the currently enabled CsrfTokenRepository
+        csrfTokenRepository.saveToken(csrfToken, request, response);
+
+        // Return a 204 No Content status
+        return ControllerUtils.toEmptyResponse(HttpStatus.NO_CONTENT);
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/CsrfRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/CsrfRestController.java
@@ -7,8 +7,9 @@
  */
 package org.dspace.app.rest;
 
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.data.rest.webmvc.ControllerUtils;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/DSpaceCsrfTokenRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/DSpaceCsrfTokenRepository.java
@@ -53,11 +53,16 @@ import org.springframework.web.util.WebUtils;
 public class DSpaceCsrfTokenRepository implements CsrfTokenRepository {
     // This cookie name is changed from the default "XSRF-TOKEN" to ensure it is uniquely named and doesn't conflict
     // with any other XSRF-TOKEN cookies (e.g. in Angular UI, the XSRF-TOKEN cookie is a *client-side* only cookie)
-    static final String DEFAULT_CSRF_COOKIE_NAME = "DSPACE-XSRF-COOKIE";
+    public static final String DEFAULT_CSRF_COOKIE_NAME = "DSPACE-XSRF-COOKIE";
 
-    static final String DEFAULT_CSRF_PARAMETER_NAME = "_csrf";
+    // The HTTP header that is sent back to the client whenever a new CSRF token is created
+    // (NOTE: This is purposefully different from DEFAULT_CSRF_HEADER_NAME below!)
+    public static final String DSPACE_CSRF_HEADER_NAME = "DSPACE-XSRF-TOKEN";
 
-    static final String DEFAULT_CSRF_HEADER_NAME = "X-XSRF-TOKEN";
+    public static final String DEFAULT_CSRF_PARAMETER_NAME = "_csrf";
+
+    // The HTTP header that Spring Security expects to receive from the client in order to validate a CSRF token
+    public static final String DEFAULT_CSRF_HEADER_NAME = "X-XSRF-TOKEN";
 
     private String parameterName = DEFAULT_CSRF_PARAMETER_NAME;
 
@@ -132,7 +137,7 @@ public class DSpaceCsrfTokenRepository implements CsrfTokenRepository {
         // We send our token via a custom header because client can be on a different domain.
         // Cookies cannot be reliably sent cross-domain.
         if (StringUtils.hasLength(tokenValue)) {
-            response.setHeader("DSPACE-XSRF-TOKEN", tokenValue);
+            response.setHeader(DSPACE_CSRF_HEADER_NAME, tokenValue);
         }
     }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CsrfRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CsrfRestControllerIT.java
@@ -1,0 +1,44 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.dspace.app.rest.security.DSpaceCsrfTokenRepository;
+import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Integration test for the /api/security/csrf endpoint
+ * <P>
+ * NOTE: This test will autoconfigure the MockMvc (@AutoConfigureMockMvc) in order to avoid using
+ * AbstractControllerIntegrationTest.getClient() because that method may use this /api/security/csrf endpoint to
+ * obtain a CSRF token.
+ **/
+@AutoConfigureMockMvc
+public class CsrfRestControllerIT extends AbstractControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    public void getCsrf() throws Exception {
+        // NOTE: We avoid using getClient() here because that method may also call this "/api/security/csrf" endpoint.
+        mockMvc.perform(get("/api/security/csrf"))
+               .andExpect(status().isNoContent())
+               // Expect this endpoint to send back the proper HTTP Header & Cookie as set by DSpaceCsrfTokenRepository
+               .andExpect(cookie().exists(DSpaceCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME))
+               .andExpect(header().exists(DSpaceCsrfTokenRepository.DSPACE_CSRF_HEADER_NAME));
+    }
+}


### PR DESCRIPTION
## References
* Ports `/api/security/csrf` endpoint from #9321 (see commits 3b461417ed8a92a0fbdc6a373997d33f27bc9d18 and 41fe757 ) to `dspace-7_x`
* Fixes #9236 for 7.x (requires frontend changes as well)
* REST Contract: https://github.com/DSpace/RestContract/pull/269

## Description
Add `/api/security/csrf` endpoint which can be used to automatically obtain or refresh CSRF token

