### PR TITLE
Fix for Bump org.apache.commons:commons-configuration2 from 2.9.0 to 2.10.1

### DIFF
--- a/dspace-api/src/test/java/org/dspace/util/DSpaceConfigurationInitializer.java
+++ b/dspace-api/src/test/java/org/dspace/util/DSpaceConfigurationInitializer.java
@@ -8,7 +8,7 @@
 package org.dspace.util;
 
 import org.apache.commons.configuration2.Configuration;
-import org.apache.commons.configuration2.spring.ConfigurationPropertySource;
+import org.dspace.servicemanager.config.DSpaceConfigurationPropertySource;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.springframework.context.ApplicationContextInitializer;
@@ -38,8 +38,8 @@ public class DSpaceConfigurationInitializer
         Configuration configuration = configurationService.getConfiguration();
 
         // Create an Apache Commons Configuration Property Source from our configuration
-        ConfigurationPropertySource apacheCommonsConfigPropertySource =
-            new ConfigurationPropertySource(configuration.getClass().getName(), configuration);
+        DSpaceConfigurationPropertySource apacheCommonsConfigPropertySource =
+            new DSpaceConfigurationPropertySource(configuration.getClass().getName(), configuration);
 
         // Prepend it to the Environment's list of PropertySources
         // NOTE: This is added *first* in the list so that settings in DSpace's

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/DSpaceConfigurationInitializer.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/DSpaceConfigurationInitializer.java
@@ -8,7 +8,7 @@
 package org.dspace.app.rest.utils;
 
 import org.apache.commons.configuration2.Configuration;
-import org.apache.commons.configuration2.spring.ConfigurationPropertySource;
+import org.dspace.servicemanager.config.DSpaceConfigurationPropertySource;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.springframework.context.ApplicationContextInitializer;
@@ -34,8 +34,8 @@ public class DSpaceConfigurationInitializer implements ApplicationContextInitial
         Configuration configuration = configurationService.getConfiguration();
 
         // Create an Apache Commons Configuration Property Source from our configuration
-        ConfigurationPropertySource apacheCommonsConfigPropertySource =
-            new ConfigurationPropertySource(configuration.getClass().getName(), configuration);
+        DSpaceConfigurationPropertySource apacheCommonsConfigPropertySource =
+            new DSpaceConfigurationPropertySource(configuration.getClass().getName(), configuration);
 
         // Prepend it to the Environment's list of PropertySources
         // NOTE: This is added *first* in the list so that settings in DSpace's ConfigurationService *override*

--- a/dspace-services/src/main/java/org/dspace/servicemanager/config/DSpaceConfigurationPlaceholderConfigurer.java
+++ b/dspace-services/src/main/java/org/dspace/servicemanager/config/DSpaceConfigurationPlaceholderConfigurer.java
@@ -8,7 +8,6 @@
 package org.dspace.servicemanager.config;
 
 import org.apache.commons.configuration2.Configuration;
-import org.apache.commons.configuration2.spring.ConfigurationPropertySource;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.core.env.MutablePropertySources;
 
@@ -27,8 +26,8 @@ import org.springframework.core.env.MutablePropertySources;
 public class DSpaceConfigurationPlaceholderConfigurer extends PropertySourcesPlaceholderConfigurer {
 
     public DSpaceConfigurationPlaceholderConfigurer(Configuration configuration) {
-        ConfigurationPropertySource apacheCommonsConfigPropertySource =
-            new ConfigurationPropertySource(configuration.getClass().getName(), configuration);
+        DSpaceConfigurationPropertySource apacheCommonsConfigPropertySource =
+            new DSpaceConfigurationPropertySource(configuration.getClass().getName(), configuration);
         MutablePropertySources propertySources = new MutablePropertySources();
         propertySources.addLast(apacheCommonsConfigPropertySource);
         setPropertySources(propertySources);

--- a/dspace-services/src/main/java/org/dspace/servicemanager/config/DSpaceConfigurationPropertySource.java
+++ b/dspace-services/src/main/java/org/dspace/servicemanager/config/DSpaceConfigurationPropertySource.java
@@ -41,13 +41,17 @@ public class DSpaceConfigurationPropertySource extends EnumerablePropertySource<
 
     @Override
     public Object getProperty(final String name) {
-        final String[] propValue = source.getStringArray(name);
-        if (propValue == null || propValue.length == 0) {
-            return null;
-        } else if (propValue.length == 1) {
-            return propValue[0];
+        if (source.getProperty(name) != null) {
+            final String[] propValue = source.getStringArray(name);
+            if (propValue == null || propValue.length == 0) {
+                return "";
+            } else if (propValue.length == 1) {
+                return propValue[0];
+            } else {
+                return propValue;
+            }
         } else {
-            return propValue;
+            return null;
         }
     }
 

--- a/dspace-services/src/main/java/org/dspace/servicemanager/config/DSpaceConfigurationPropertySource.java
+++ b/dspace-services/src/main/java/org/dspace/servicemanager/config/DSpaceConfigurationPropertySource.java
@@ -26,7 +26,7 @@ import org.springframework.core.env.EnumerablePropertySource;
 
 /**
  * Allow use of Apache Commons Configuration Objects as Spring PropertySources.
- * This class is a copy of the ConfigurationPropertySource class in the Apache Commons Configuration
+ * This class is a temporary copy of the ConfigurationPropertySource class in the Apache Commons Configuration
  * project needed until to fix the issue https://issues.apache.org/jira/browse/CONFIGURATION-846
  */
 public class DSpaceConfigurationPropertySource extends EnumerablePropertySource<Configuration> {
@@ -42,7 +42,13 @@ public class DSpaceConfigurationPropertySource extends EnumerablePropertySource<
     @Override
     public Object getProperty(final String name) {
         final String[] propValue = source.getStringArray(name);
-        return propValue != null && propValue.length == 1 ? propValue[0] : propValue;
+        if (propValue == null || propValue.length == 0) {
+            return null;
+        } else if (propValue.length == 1) {
+            return propValue[0];
+        } else {
+            return propValue;
+        }
     }
 
     @Override

--- a/dspace-services/src/main/java/org/dspace/servicemanager/config/DSpaceConfigurationPropertySource.java
+++ b/dspace-services/src/main/java/org/dspace/servicemanager/config/DSpaceConfigurationPropertySource.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dspace.servicemanager.config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.configuration2.Configuration;
+import org.apache.commons.lang3.ArrayUtils;
+import org.springframework.core.env.EnumerablePropertySource;
+
+/**
+ * Allow use of Apache Commons Configuration Objects as Spring PropertySources.
+ * This class is a copy of the ConfigurationPropertySource class in the Apache Commons Configuration
+ * project needed until to fix the issue https://issues.apache.org/jira/browse/CONFIGURATION-846
+ */
+public class DSpaceConfigurationPropertySource extends EnumerablePropertySource<Configuration> {
+
+    protected DSpaceConfigurationPropertySource(final String name) {
+        super(name);
+    }
+
+    public DSpaceConfigurationPropertySource(final String name, final Configuration source) {
+        super(name, source);
+    }
+
+    @Override
+    public Object getProperty(final String name) {
+        final String[] propValue = source.getStringArray(name);
+        return propValue != null && propValue.length == 1 ? propValue[0] : propValue;
+    }
+
+    @Override
+    public String[] getPropertyNames() {
+        final List<String> keys = new ArrayList<>();
+        source.getKeys().forEachRemaining(keys::add);
+        return keys.toArray(ArrayUtils.EMPTY_STRING_ARRAY);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -445,6 +445,8 @@
                     <!-- Add some default DSpace exclusions not covered by <useDefaultExcludes>
                          Individual Maven projects may choose to override these defaults. -->
                     <excludes>
+						<!-- temporary copy of a modified apache commons-configuration2 class, see https://issues.apache.org/jira/browse/CONFIGURATION-846 -->
+                        <exclude>**/src/main/java/org/dspace/servicemanager/config/DSpaceConfigurationPropertySource.java</exclude>
                         <exclude>**/src/test/resources/**</exclude>
                         <exclude>**/src/test/data/**</exclude>
                         <exclude>**/src/main/license/**</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -1472,7 +1472,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-configuration2</artifactId>
-                <version>2.9.0</version>
+                <version>2.10.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
## References
Fix for the issue in https://github.com/DSpace/DSpace/pull/9430
due to https://issues.apache.org/jira/browse/CONFIGURATION-846

## Description
Create a local copy of the fixed version of the class for the DSpace usage.
