### PR TITLE
Duplicate data from an existing Item to a new WorskpaceItem, aka clone/copy item

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/MetadataFieldName.java
+++ b/dspace-api/src/main/java/org/dspace/content/MetadataFieldName.java
@@ -8,6 +8,7 @@
 package org.dspace.content;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 import jakarta.annotation.Nonnull;
 
@@ -152,5 +153,23 @@ public class MetadataFieldName {
                     .append(qualifier);
         }
         return buffer.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        MetadataFieldName that = (MetadataFieldName) o;
+        return Objects.equals(schema, that.schema) && Objects.equals(element, that.element) &&
+            Objects.equals(qualifier, that.qualifier);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(schema, element, qualifier);
     }
 }

--- a/dspace-api/src/main/java/org/dspace/content/service/ItemService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/ItemService.java
@@ -13,6 +13,7 @@ import java.sql.SQLException;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import org.dspace.authorize.AuthorizeException;
@@ -23,6 +24,7 @@ import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.EntityType;
 import org.dspace.content.Item;
+import org.dspace.content.MetadataFieldName;
 import org.dspace.content.MetadataValue;
 import org.dspace.content.Thumbnail;
 import org.dspace.content.WorkspaceItem;
@@ -1009,4 +1011,62 @@ public interface ItemService
      */
     EntityType getEntityType(Context context, Item item) throws SQLException;
 
+    /**
+     * Clone the given item, using existing data to create a new item with a new ID. This operation includes cloning of
+     * metadata, relationships, and bundles with bitstreams.
+     * Metadata of the given item are also copied to the new item.
+     * @param context the DSpace context.
+     * @param item the item to be cloned.
+     * @return item the cloned item.
+     * @throws SQLException if database error
+     * @throws IOException if IO error
+     * @throws AuthorizeException if authorization error
+     */
+    Item clone(Context context, Item item) throws SQLException, IOException, AuthorizeException;
+
+    /**
+     * Clone the given item, using existing data to create a new item with a new ID. This operation includes cloning of
+     * metadata, relationships, and bundles with bitstreams. It also moves cloned item to the new collection.
+     * Metadata of the given item are also copied to the new item.
+     * @param context the DSpace context.
+     * @param item the item to be cloned.
+     * @param collection the collection where the cloned item should belong.
+     * @return item the cloned item.
+     * @throws SQLException if database error
+     * @throws IOException if IO error
+     * @throws AuthorizeException if authorization error
+     */
+    Item clone(Context context, Item item, Collection collection) throws SQLException, IOException, AuthorizeException;
+
+    /**
+     * Use the existing properties of the source item to add them to the target item. By default, this method aims
+     * to duplicate as many of item's attributes as possible, including existing metadata, relationships, and bundles
+     * with bitstreams.
+     * A copy operation is similar to creating a new version of item, but the return item acts as a standalone entity.
+     * @param context the DSpace context.
+     * @param target the target item to copy properties from.
+     * @param source the source item.
+     * @throws SQLException if database error
+     * @throws IOException if IO error
+     * @throws AuthorizeException if authorization error
+     */
+    void copy(Context context, Item target, Item source) throws IOException, SQLException, AuthorizeException;
+
+    /**
+     * Use the existing properties of the source item to add them to the target item. This method adds flexibility to
+     * include or exclude a copy of existing metadata, relationships, and bundles with bitstreams.
+     * A copy operation is similar to creating a new version of item, but the return item acts as a standalone entity.
+     * @param context the DSpace context.
+     * @param target
+     * @param source
+     * @param ignoredMetadataFields , can be null
+     * @param withRelationships
+     * @param withBundlesAndBitstreams
+     * @throws SQLException if database error
+     * @throws IOException if IO error
+     * @throws AuthorizeException if authorization error
+     */
+    void copy(Context context, Item target, Item source, Set<MetadataFieldName> ignoredMetadataFields,
+              boolean withRelationships, boolean withBundlesAndBitstreams, boolean withPolicies)
+        throws SQLException, AuthorizeException, IOException;
 }

--- a/dspace-api/src/main/java/org/dspace/versioning/AbstractVersionProvider.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/AbstractVersionProvider.java
@@ -7,25 +7,12 @@
  */
 package org.dspace.versioning;
 
-import java.io.IOException;
-import java.sql.SQLException;
-import java.util.List;
 import java.util.Set;
 
-import org.dspace.authorize.AuthorizeException;
-import org.dspace.authorize.ResourcePolicy;
 import org.dspace.authorize.service.AuthorizeService;
-import org.dspace.content.Bitstream;
-import org.dspace.content.Bundle;
-import org.dspace.content.Item;
-import org.dspace.content.MetadataField;
-import org.dspace.content.MetadataSchema;
-import org.dspace.content.MetadataValue;
-import org.dspace.content.RelationshipMetadataValue;
 import org.dspace.content.service.BitstreamService;
 import org.dspace.content.service.BundleService;
 import org.dspace.content.service.ItemService;
-import org.dspace.core.Context;
 import org.dspace.storage.bitstore.service.BitstreamStorageService;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -48,77 +35,6 @@ public abstract class AbstractVersionProvider {
     protected BundleService bundleService;
     @Autowired(required = true)
     protected ItemService itemService;
-
-    protected void copyMetadata(Context context, Item itemNew, Item nativeItem) throws SQLException {
-        List<MetadataValue> md = itemService.getMetadata(nativeItem, Item.ANY, Item.ANY, Item.ANY, Item.ANY);
-        for (MetadataValue aMd : md) {
-            MetadataField metadataField = aMd.getMetadataField();
-            MetadataSchema metadataSchema = metadataField.getMetadataSchema();
-            String unqualifiedMetadataField = metadataSchema.getName() + "." + metadataField.getElement();
-            if (getIgnoredMetadataFields().contains(metadataField.toString('.')) ||
-                getIgnoredMetadataFields().contains(unqualifiedMetadataField + "." + Item.ANY) ||
-                aMd instanceof RelationshipMetadataValue) {
-                //Skip this metadata field (ignored and/or virtual)
-                continue;
-            }
-
-            itemService.addMetadata(
-                context,
-                itemNew,
-                metadataField.getMetadataSchema().getName(),
-                metadataField.getElement(),
-                metadataField.getQualifier(),
-                aMd.getLanguage(),
-                aMd.getValue(),
-                aMd.getAuthority(),
-                aMd.getConfidence(),
-                aMd.getPlace()
-            );
-        }
-    }
-
-    protected void createBundlesAndAddBitstreams(Context c, Item itemNew, Item nativeItem)
-        throws SQLException, AuthorizeException, IOException {
-        for (Bundle nativeBundle : nativeItem.getBundles()) {
-            Bundle bundleNew = bundleService.create(c, itemNew, nativeBundle.getName());
-            // DSpace knows several types of resource policies (see the class
-            // org.dspace.authorize.ResourcePolicy): Submission, Workflow, Custom
-            // and inherited. Submission, Workflow and Inherited policies will be
-            // set automatically as necessary. We need to copy the custom policies
-            // only to preserve customly set policies and embargoes (which are
-            // realized by custom policies with a start date).
-            List<ResourcePolicy> bundlePolicies =
-                authorizeService.findPoliciesByDSOAndType(c, nativeBundle, ResourcePolicy.TYPE_CUSTOM);
-            authorizeService.addPolicies(c, bundlePolicies, bundleNew);
-
-            for (Bitstream nativeBitstream : nativeBundle.getBitstreams()) {
-                // Metadata and additional information like internal identifier,
-                // file size, checksum, and checksum algorithm are set by the bitstreamStorageService.clone(...)
-                // and respectively bitstreamService.clone(...) method.
-                Bitstream bitstreamNew =  bitstreamStorageService.clone(c, nativeBitstream);
-
-                bundleService.addBitstream(c, bundleNew, bitstreamNew);
-
-                // NOTE: bundle.addBitstream() causes Bundle policies to be inherited by default.
-                // So, we need to REMOVE any inherited TYPE_CUSTOM policies before copying over the correct ones.
-                authorizeService.removeAllPoliciesByDSOAndType(c, bitstreamNew, ResourcePolicy.TYPE_CUSTOM);
-
-                // Now, we need to copy the TYPE_CUSTOM resource policies from old bitstream
-                // to the new bitstream, like we did above for bundles
-                List<ResourcePolicy> bitstreamPolicies =
-                    authorizeService.findPoliciesByDSOAndType(c, nativeBitstream, ResourcePolicy.TYPE_CUSTOM);
-                authorizeService.addPolicies(c, bitstreamPolicies, bitstreamNew);
-
-                if (nativeBundle.getPrimaryBitstream() != null && nativeBundle.getPrimaryBitstream()
-                                                                              .equals(nativeBitstream)) {
-                    bundleNew.setPrimaryBitstreamID(bitstreamNew);
-                }
-
-                bitstreamService.update(c, bitstreamNew);
-            }
-        }
-    }
-
 
     public void setIgnoredMetadataFields(Set<String> ignoredMetadataFields) {
         this.ignoredMetadataFields = ignoredMetadataFields;

--- a/dspace-api/src/main/java/org/dspace/versioning/DefaultItemVersionProvider.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/DefaultItemVersionProvider.java
@@ -102,7 +102,7 @@ public class DefaultItemVersionProvider extends AbstractVersionProvider implemen
     @Override
     public Item updateItemState(Context c, Item itemNew, Item previousItem) {
         try {
-            itemService.copy(c, itemNew, previousItem);
+            itemService.copy(c, itemNew, previousItem, getIgnoredMetadataFields(), true, true, true);
         } catch (IOException | SQLException | AuthorizeException e) {
             throw new RuntimeException(e.getMessage(), e);
         }

--- a/dspace-api/src/test/java/org/dspace/content/ItemTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/ItemTest.java
@@ -203,9 +203,6 @@ public class ItemTest extends AbstractDSpaceObjectTest {
 
     @Test
     public void testClone() throws Exception {
-        // Allow Collection WRITE perms
-        doNothing().when(authorizeServiceSpy).authorizeAction(context, collection, Constants.ADD);
-
         Item source = it;
         Item target = itemService.clone(context, source, collection);
 
@@ -234,9 +231,7 @@ public class ItemTest extends AbstractDSpaceObjectTest {
         assertThat("testCopy 1", target, notNullValue());
 
         // Set appropriate permissions
-        doNothing().when(authorizeServiceSpy).authorizeAction(context, target, Constants.ADD);
         doNothing().when(authorizeServiceSpy).authorizeAction(context, target, Constants.WRITE);
-        doNothing().when(authorizeServiceSpy).authorizeAction(context, source, Constants.WRITE);
 
         // Add new metadata to source item
         String schema = "dc";

--- a/dspace-api/src/test/java/org/dspace/content/ItemTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/ItemTest.java
@@ -209,9 +209,14 @@ public class ItemTest extends AbstractDSpaceObjectTest {
         Item source = it;
         Item target = itemService.clone(context, source, collection);
 
-        assertThat("testClone 0", source, notNullValue());
-        assertThat("testClone 1", target, notNullValue());
-        assertThat("testClone 2", target.getMetadata().size() == source.getMetadata().size());
+        assertThat("testClone 0", source != target);
+        assertThat("testClone 1", source, notNullValue());
+        assertThat("testClone 2", target, notNullValue());
+        assertThat("testClone 3", target.getMetadata() != null && source.getMetadata() != null);
+
+        context.turnOffAuthorisationSystem();
+        itemService.delete(context, target);
+        context.restoreAuthSystemState();
     }
 
     @Test

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/handler/ExternalSourceEntryWorkspaceItemUriListHandler.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/handler/ExternalSourceEntryWorkspaceItemUriListHandler.java
@@ -14,6 +14,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.WorkspaceItem;
 import org.dspace.core.Context;
+import org.dspace.util.UUIDUtils;
 import org.springframework.stereotype.Component;
 
 /**
@@ -27,10 +28,16 @@ public class ExternalSourceEntryWorkspaceItemUriListHandler
 
     @Override
     public boolean supports(List<String> uriList, String method, Class clazz) {
-        if (!super.supports(uriList, method, clazz)) {
+        if (clazz != WorkspaceItem.class) {
             return false;
         }
-        if (clazz != WorkspaceItem.class) {
+        for (String possibleUuid : uriList) {
+            String[] possibleUrl = possibleUuid.split("/");
+            if (UUIDUtils.fromString(possibleUuid) != null || UUIDUtils.fromString(possibleUrl[possibleUrl.length - 1]) != null) {
+                return true;
+            }
+        }
+        if (!super.supports(uriList, method, clazz)) {
             return false;
         }
         return true;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/handler/ExternalSourceEntryWorkspaceItemUriListHandler.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/handler/ExternalSourceEntryWorkspaceItemUriListHandler.java
@@ -33,7 +33,8 @@ public class ExternalSourceEntryWorkspaceItemUriListHandler
         }
         for (String possibleUuid : uriList) {
             String[] possibleUrl = possibleUuid.split("/");
-            if (UUIDUtils.fromString(possibleUuid) != null || UUIDUtils.fromString(possibleUrl[possibleUrl.length - 1]) != null) {
+            if (UUIDUtils.fromString(possibleUuid) != null ||
+                UUIDUtils.fromString(possibleUrl[possibleUrl.length - 1]) != null) {
                 return true;
             }
         }

--- a/dspace/config/spring/api/core-services.xml
+++ b/dspace/config/spring/api/core-services.xml
@@ -45,7 +45,17 @@
     <bean class="org.dspace.content.BundleServiceImpl"/>
     <bean class="org.dspace.content.CommunityServiceImpl"/>
     <bean class="org.dspace.content.InstallItemServiceImpl"/>
-    <bean class="org.dspace.content.ItemServiceImpl"/>
+    <bean class="org.dspace.content.ItemServiceImpl">
+        <property name="nonCopyableMetadataFields">
+            <set>
+                <value>dc.date.accessioned</value>
+                <value>dspace.entity.type</value>
+                <value>dc.identifier.uri</value>
+                <value>dc.provenance</value>
+                <value>dc.description.provenance</value>
+            </set>
+        </property>
+    </bean>
     <bean class="org.dspace.content.MetadataDSpaceCsvExportServiceImpl"/>
     <bean class="org.dspace.content.MetadataFieldServiceImpl"/>
     <bean class="org.dspace.content.MetadataSchemaServiceImpl"/>


### PR DESCRIPTION
## References
* Fixes DSpace/dspace-angular#1757
* Angular PR DSpace/DSpace-angular#3076

## Description
This PR introduces the ability to create a new WorkspaceItem by reusing properties from an existing Item, kind of like how versioning works now, but resulting in a partially completed edit form of a new Item. Some existing code from the versioning infrastructure was adapted and integrated as two new methods, `copy` and `clone`, within the ItemService, and tweaked, just to make things work more smoothly.

Here's a preview:

https://github.com/DSpace/dspace-angular/assets/17811486/ad5f70b1-f14f-49d2-884c-63fb906fd642

## Instructions for Reviewers

On the REST side:

Example request (endpoint, header, body):
```
POST /api/submission/workspaceitems?owningCollection=:collectionUuid
Content-Type: text/uri-list

http://localhost:8080/server/api/core/items/:itemUuid
```

Response should show a new WorkspaceItem with some of the metadata copied from the specified :itemUuid. Although some of the metadata **will be omitted** to prevent duplicates or multiple values in places they shouldn't occur – see `nonCopyableMetadataFields` in `core-services.xml`.

On the Angular side:

* Login as admin and either deposit a new item or locate an existing one.
* Navigate to the _item management page_ (edit -> status).
* Between _move_ and _delete_, a new button should be visible for _cloning_ the item. Click it, select any collection, then click _save_.
* The browser should redirect the user to the edit form, similar to what happens after creating a new item. However, most of the metadata should be copied from the previous item.

## Checklist
- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [X] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
