### PR TITLE
Update comments in identifier-service.xml

### DIFF
--- a/dspace/config/spring/api/identifier-service.xml
+++ b/dspace/config/spring/api/identifier-service.xml
@@ -41,13 +41,12 @@
     </bean>
     -->
 
-    <!-- provider to mint and register DOIs with DSpace.
-         To mint DOIs you need a registration agency. The DOIIdentifierProvider
-         maintains the doi database table and handling of DSpaceObject. It uses
-         a DOIConnector that handles all API calls to your DOI registration
-         agency. Please configure a DOIConnector as well! -->
+    <!-- DOIIdentifierProvider mints and registers DOIs with DSpace.
+         The DOIIdentifierProvider maintains the doi database table and handling
+         of DSpaceObject. It uses a DOIConnector that handles all API calls to
+         your DOI registration agency. Please configure a DOIConnector as well!
 
-    <!-- In order to mint DOIs with DSpace, get an agreement with a DOI
+         In order to mint DOIs with DSpace, get an agreement with a DOI
          registration agency,  take a look into dspace.cfg, and activate either
          the DOIIdentifierProvider or the VersionedDOIIdentifierProvider,
          depending on whether you have Item Level Versioning activated or not.
@@ -60,7 +59,6 @@
             ref="org.dspace.services.ConfigurationService" />
         <property name="DOIConnector"
             ref="org.dspace.identifier.doi.DOIConnector" />
-        <property name="filter" ref="doi-filter" />
     </bean>
     -->
     <!--
@@ -75,7 +73,9 @@
     -->
 
     <!-- An optional logical item filter can be included in provider configuration based
-    on the filters defined in item-filters.xml, eg. -->
+    on the filters defined in item-filters.xml, eg.
+    Of course, you can use a filter on the VersionedDOIIdentifierProvider as well.
+    -->
     <!--
     <bean id="org.dspace.identifier.DOIIdentifierProvider"
         class="org.dspace.identifier.DOIIdentifierProvider"


### PR DESCRIPTION
The DOIIdentifierProvider using a filter was commented out twice. We should show that it works with and without a filter. Furthermore one comments looked cut off.

## Instructions for Reviewers
If you want to, you can try to run the DOIIdentifierProvider without a filter. I think this is just a comment change, that does not need further checks.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
