### PR TITLE
Fixed item edit relationships with same type name but different entities all being shown under same label

### DIFF
--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/RelationshipRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/RelationshipRestRepositoryIT.java
@@ -2324,6 +2324,61 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
     }
 
     @Test
+    public void findRelationshipByLabelWithRelatedEntityTypeTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        RelationshipType isAuthorOfPublicationRelationshipTypePublication = relationshipTypeService
+            .findbyTypesAndTypeName(context, entityTypeService.findByEntityType(context, "Publication"),
+                                    entityTypeService.findByEntityType(context, "Person"),
+                                    "isAuthorOfPublication", "isPublicationOfAuthor");
+        RelationshipType isAuthorOfPublicationRelationshipTypeOrgUnit = relationshipTypeService
+            .findbyTypesAndTypeName(context, entityTypeService.findByEntityType(context, "Publication"),
+                                    entityTypeService.findByEntityType(context, "OrgUnit"),
+                                    "isAuthorOfPublication", "isPublicationOfAuthor");
+
+        // We're creating a Relationship of type isAuthorOfPublication between a Publication and a Person
+        Relationship relationship1 = RelationshipBuilder
+            .createRelationshipBuilder(context, publication1, author1, isAuthorOfPublicationRelationshipTypePublication)
+            .build();
+
+        // We're creating a Relationship of type isAuthorOfPublication between a Publication and an OrgUnit
+        Relationship relationship2 = RelationshipBuilder
+            .createRelationshipBuilder(context, publication1, orgUnit1, isAuthorOfPublicationRelationshipTypeOrgUnit)
+            .build();
+        context.restoreAuthSystemState();
+
+        // Perform a GET request to the searchByLabel endpoint, asking for Relationships of type isAuthorOfPublication
+        // With an extra parameter namely DSO which resolves to the publication used by both relationships.
+        // Both relationships should be returned if we don't specify the DSO's related entity type
+        getClient().perform(get("/api/core/relationships/search/byLabel")
+                                .param("label", "isAuthorOfPublication")
+                                .param("dso", publication1.getID().toString())
+                                .param("projection", "full"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page", is(PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 2))))
+            .andExpect(jsonPath("$._embedded.relationships", containsInAnyOrder(
+                RelationshipMatcher.matchRelationship(relationship1),
+                RelationshipMatcher.matchRelationship(relationship2)
+            )))
+        ;
+
+        // Perform a GET request to the searchByLabel endpoint, asking for Relationships of type isAuthorOfPublication
+        // With an extra parameter namely DSO which resolves to the publication used by both relationships.
+        // Only the Person relationship should be returned if we specify the DSO's related entity type
+        getClient().perform(get("/api/core/relationships/search/byLabel")
+                                .param("label", "isAuthorOfPublication")
+                                .param("dso", publication1.getID().toString())
+                                .param("relatedEntityType", "Person")
+                                .param("projection", "full"))
+
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page", is(PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 1))))
+            .andExpect(jsonPath("$._embedded.relationships", containsInAnyOrder(
+                RelationshipMatcher.matchRelationship(relationship1)
+            )))
+        ;
+    }
+
+    @Test
     public void putRelationshipWithNonexistentID() throws Exception {
         context.turnOffAuthorisationSystem();
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/RelationshipRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/RelationshipRestRepositoryIT.java
@@ -2375,6 +2375,22 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
                 RelationshipMatcher.matchRelationship(relationship1)
             )))
         ;
+
+        // Perform a GET request to the searchByLabel endpoint, asking for Relationships of type isAuthorOfPublication
+        // With an extra parameter namely DSO which resolves to the publication used by both relationships.
+        // Only the OrgUnit relationship should be returned if we specify the DSO's related entity type
+        getClient().perform(get("/api/core/relationships/search/byLabel")
+                                .param("label", "isAuthorOfPublication")
+                                .param("dso", publication1.getID().toString())
+                                .param("relatedEntityType", "OrgUnit")
+                                .param("projection", "full"))
+
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page", is(PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 1))))
+            .andExpect(jsonPath("$._embedded.relationships", containsInAnyOrder(
+                RelationshipMatcher.matchRelationship(relationship2)
+            )))
+        ;
     }
 
     @Test


### PR DESCRIPTION
## References
* Fixes DSpace/dspace-angular#1387
* Requires DSpace/dspace-angular#3098
* RestContract DSpace/RestContract#270

## Description
Fixes the item edit relationships tab showing relationships under multiple labels when those relationship types have the same `leftwardType`/`rightwardType` (but different entity types).

## Instructions for Reviewers
List of changes in this PR:
* Added the `relatedEntityType` parameter to the `/server/api/core/relationships/search/byLabel` endpoint. This parameter only works when the `dso` parameter is provided and will filter out the relationship types that don't have the dso's entity type & the given related entity type as `leftType`/`rightType`.

**Guidance for how to test/review this PR:** See DSpace/dspace-angular#1387

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
