### PR TITLE
Cleanup doi filters

### DIFF
--- a/dspace/config/modules/identifiers.cfg
+++ b/dspace/config/modules/identifiers.cfg
@@ -15,17 +15,12 @@
 # Default: false
 #identifiers.submission.register = true
 
-# This configuration property can be set to a filter name to determine if a PENDING DOI for an item
-# should be queued for registration. If the filter doesn't match, the DOI will stay in PENDING or MINTED status
-# so that the identifier itself persists in case it is considered for registration in the future.
-# See doi-filter and other example filters in item-filters.xml.
-# Default (always_true_filter)
-#identifiers.submission.filter.install = doi-filter
-
 # This optional configuration property can be set to a filter name, in case there are some initial rules to apply
 # when first deciding whether a DOI should be be created for a new workspace item with a PENDING status.
 # This filter is only applied if identifiers.submission.register is true.
 # This filter is updated as submission data is saved.
+# If you're looking for the filter that decides whether a DOI of an installed item should be queued for registration
+# at DataCite, please check the filter in the identifier service spring configuration.
 # Default: (always_true_filter)
 #identifiers.submission.filter.workspace = always_true_filter
 


### PR DESCRIPTION
We can set filters in identifier-service.xml. Setting them in modules/identifiers.cfg is just overidding the other one. To keep things simple, we should avoid having two different filters for the same issue. The filter configured in spring is working for any new DOI, while the one we take out here, is just working for items being run through the install item service.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
