### PR TITLE
Ensure work directory is cleaned up even when Zip export fails

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExportServiceImpl.java
@@ -490,7 +490,7 @@ public class ItemExportServiceImpl implements ItemExportService {
 
         File wkDir = new File(workDir);
         if (!wkDir.exists() && !wkDir.mkdirs()) {
-            logError("Unable to create working direcory");
+            logError("Unable to create working directory");
         }
 
         File dnDir = new File(destDirName);
@@ -498,11 +498,18 @@ public class ItemExportServiceImpl implements ItemExportService {
             logError("Unable to create destination directory");
         }
 
-        // export the items using normal export method
-        exportItem(context, items, workDir, seqStart, migrate, excludeBitstreams);
+        try {
+            // export the items using normal export method (this exports items to our workDir)
+            exportItem(context, items, workDir, seqStart, migrate, excludeBitstreams);
 
-        // now zip up the export directory created above
-        zip(workDir, destDirName + System.getProperty("file.separator") + zipFileName);
+            // now zip up the workDir directory created above
+            zip(workDir, destDirName + System.getProperty("file.separator") + zipFileName);
+        } finally {
+            // Cleanup workDir created above, if it still exists
+            if (wkDir.exists()) {
+                deleteDirectory(wkDir);
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
## References
* Fixes #9499 

## Description
In debugging #9499, I found that the cause of the issue is that the `ItemExportServiceImpl.exportAsZip()` method creates its own `workDir` folder. (See https://github.com/DSpace/DSpace/blob/main/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExportServiceImpl.java#L492-L494)

When a Zip export *succeeds* this `workDir` folder is deleted in the `zip()` method. (See https://github.com/DSpace/DSpace/blob/main/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExportServiceImpl.java#L1019)

However, when the Zip **fails**, the `workDir` was never being deleted.  

This PR simply adds a try/finally clause to ensure the `exportAsZip()` method will **always** delete its `workDir` (if it still exists). 
 This ensures the directory is never left around, even after an error occurs.  The new code uses the same `deleteDirectory()` method that was already being used to remove this directory after a _successful_ export.

## Instructions for Reviewers
* Repeat the steps described in #9499 to force a Zip export failure (by temporarily changing the `internal_id` of a bitstream in the database, which forces it to not be found).  Then undo that change, and ensure the export **succeeds**.
    * I can verify that I tried the steps in #9499 and this PR solves the bug.
    * I could not find an easy way to reproduce this bug in tests (as forcing a Zip failure is not straightforward to do).  So, this code has no automated tests.
