### PR TITLE
Fix OpenAIRE import from external source

### DIFF
--- a/dspace-api/src/main/java/org/dspace/importer/external/openaire/service/OpenAireImportMetadataSourceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/openaire/service/OpenAireImportMetadataSourceServiceImpl.java
@@ -187,7 +187,8 @@ public class OpenAireImportMetadataSourceServiceImpl extends AbstractImportMetad
     public void init() throws Exception {
         Client client = ClientBuilder.newClient();
         if (baseAddress == null) {
-            baseAddress = configurationService.getProperty("openaire.base.url");
+            baseAddress = configurationService.getProperty("openaire.search.url",
+                                                           "https://api.openaire.eu/search/publications");
         }
         if (queryParam == null) {
             queryParam = "title";

--- a/dspace-api/src/main/java/org/dspace/importer/external/openaire/service/OpenAireImportMetadataSourceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/openaire/service/OpenAireImportMetadataSourceServiceImpl.java
@@ -252,10 +252,10 @@ public class OpenAireImportMetadataSourceServiceImpl extends AbstractImportMetad
                 Document document = saxBuilder.build(new StringReader(responseString));
                 Element root = document.getRootElement();
 
-                XPathExpression<Element> xpath = XPathFactory.instance().compile("/header/total",
+                XPathExpression<Element> xpath = XPathFactory.instance().compile("//header/total",
                     Filters.element(), null);
 
-                Element totalItem = (Element) xpath.evaluateFirst(root);
+                Element totalItem = xpath.evaluateFirst(root);
                 return totalItem != null ? Integer.parseInt(totalItem.getText()) : null;
 
             } else {

--- a/dspace-api/src/main/java/org/dspace/importer/external/service/components/AbstractRemoteMetadataSource.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/service/components/AbstractRemoteMetadataSource.java
@@ -167,9 +167,9 @@ public abstract class AbstractRemoteMetadataSource {
                 } catch (Exception e) {
                     throwSourceException(retry, e, operationId);
                 }
-                log.info("operation " + operationId + " started");
+                log.debug("Operation {} started. Calling {}", operationId, callable.getClass().getName());
                 T response = callable.call();
-                log.info("operation " + operationId + " successful");
+                log.debug("Operation {} successful", operationId);
                 return response;
             } catch (Exception e) {
                 this.error = e;
@@ -180,7 +180,8 @@ public abstract class AbstractRemoteMetadataSource {
 
                 // No MetadataSourceException has interrupted the loop
                 retry++;
-                log.warn("Error in trying operation " + operationId + " " + retry + " " + warning + ", retrying !", e);
+                log.warn("Error in calling {} in operation {} {} {}, retrying!", callable.getClass().getName(),
+                         operationId, retry, warning, e);
 
             } finally {
                 this.lastRequest = System.currentTimeMillis();

--- a/dspace/config/modules/openaire-client.cfg
+++ b/dspace/config/modules/openaire-client.cfg
@@ -34,4 +34,6 @@ openaire.token.clientSecret = CLIENT_SECRET_HERE
 # URL of Openaire Rest API
 openaire.api.url = https://api.openaire.eu
 
-openaire.base.url = http://api.openaire.eu/search/publications
+# OpenAIRE Search API to use for metadata import via external sources
+# (e.g. importing metadata from OpenAIRE via submission)
+openaire.search.url = https://api.openaire.eu/search/publications

--- a/dspace/config/spring/api/external-services.xml
+++ b/dspace/config/spring/api/external-services.xml
@@ -74,12 +74,24 @@
         <property name="metadataSource" ref="openaireImportServiceByAuthor"/>
         <property name="sourceIdentifier" value="openaire"/>
         <property name="recordIdMetadata" value="dc.identifier.other"/>
+        <property name="supportedEntityTypes">
+            <list>
+                <value>Publication</value>
+                <value>none</value>
+            </list>
+        </property>
     </bean>
 
     <bean id="openaireLiveImportDataProviderByTitle" class="org.dspace.external.provider.impl.LiveImportDataProvider">
         <property name="metadataSource" ref="openaireImportServiceByTitle"/>
         <property name="sourceIdentifier" value="openaireTitle"/>
         <property name="recordIdMetadata" value="dc.identifier.other"/>
+        <property name="supportedEntityTypes">
+            <list>
+                <value>Publication</value>
+                <value>none</value>
+            </list>
+        </property>
     </bean>
 
     <bean id="pubmedLiveImportDataProvider" class="org.dspace.external.provider.impl.LiveImportDataProvider">


### PR DESCRIPTION
## References
* Fixes #9501
* Related Angular PR: https://github.com/DSpace/dspace-angular/pull/3100

## Description
This small PR fixes the core issue with #9501 and makes minor code improvements found during debugging this issue.

1. The first commit is the actual fix for #9501.  The bug was caused by an invalid XPath location for the total number of search results.
2. The second commit is minor cleanup to the logging statements in `AbstractRemoteMetadataSource`.  Two `log.info` statements in that class were called every time a new search is performed against external sources.  These `log.info` provided no useful information (except maybe for debugging).  
    * Moved both `log.info` calls to `log.debug`
    * Updated logging calls in this class to include the *name* of the Callable being run.  This will ensure we are logging *which* external source plugin is being called.
3. The third commit renames the (newly added in 8.0) `openaire.base.url` configuration to `openaire.search.url`.  This configuration is ONLY used for searching OpenAIRE via external source plugins.  (The name `openaire.base.url` also seemed very similar to the existing `openaire.api.url` setting from 7.x and 8.0)
4. The final commit fixes the configuration for the OpenAIRE import sources to _only be enabled_ for Publication and Item types.  Currently on `main`, you can attempt to import from OpenAIRE from _all Entity types_ (which is incorrect)

## Instructions for Reviewers
* Verify OpenAIRE external sources now work properly & #9501 is not reproducible.
* You should be able to import publications or items from OpenAIRE (this same process will NOT work on sandbox.dspace.org).  
* For example:
    * Login & go to MyDSpace
    * Click on Import button
    * Select "Item" or "Publication" type
    * In the search dropdown, select "OpenAIRE Titles" (searches by Title) or "OpenAIRE Authors (searches by Author).
        * Related PR https://github.com/DSpace/dspace-angular/pull/3100 corrects these misleading names. 
    * Ensure you can find results & pagination works.
    * Ensure you can successfully import a new Item/Publication into DSpace.