### PR TITLE
[Port dspace-7_x] updates creativecommons.org links to https

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/CCLicenseAddPatchOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/CCLicenseAddPatchOperation.java
@@ -26,7 +26,7 @@ import org.springframework.beans.factory.annotation.Autowired;
  * Example: <code>
  * curl -X PATCH http://${dspace.server.url}/api/submission/workspaceitems/31599 -H "Content-Type:
  * application/json" -d '[{ "op": "add", "path": "/sections/cclicense/uri",
- * "value":"http://creativecommons.org/licenses/by-nc-sa/3.0/us/"}]'
+ * "value":"https://creativecommons.org/licenses/by-nc-sa/3.0/us/"}]'
  * </code>
  */
 public class CCLicenseAddPatchOperation extends AddPatchOperation<String> {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CCLicenseAddPatchOperationIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CCLicenseAddPatchOperationIT.java
@@ -63,7 +63,7 @@ public class CCLicenseAddPatchOperationIT extends AbstractControllerIntegrationT
 
         List<Operation> ops = new ArrayList<>();
         AddOperation addOperation = new AddOperation("/sections/cclicense/uri",
-                                                     "http://creativecommons.org/licenses/by-nc-sa/4.0/");
+                                                     "https://creativecommons.org/licenses/by-nc-sa/4.0/");
 
         ops.add(addOperation);
         String patchBody = getPatchContent(ops);
@@ -74,7 +74,7 @@ public class CCLicenseAddPatchOperationIT extends AbstractControllerIntegrationT
                                               .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                              .andExpect(status().isOk())
                              .andExpect(jsonPath("$.sections.cclicense", allOf(
-                                     hasJsonPath("$.uri", is("http://creativecommons.org/licenses/by-nc-sa/4.0/")),
+                                     hasJsonPath("$.uri", is("https://creativecommons.org/licenses/by-nc-sa/4.0/")),
                                      hasJsonPath("$.rights",
                                                  is("Attribution-NonCommercial-ShareAlike 4.0 International")),
                                      hasJsonPath("$.file.name", is("license_rdf"))

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CCLicenseRemovePatchOperationIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CCLicenseRemovePatchOperationIT.java
@@ -64,7 +64,7 @@ public class CCLicenseRemovePatchOperationIT extends AbstractControllerIntegrati
         // First add a license and verify it is added
         List<Operation> ops = new ArrayList<>();
         AddOperation addOperation = new AddOperation("/sections/cclicense/uri",
-                                                     "http://creativecommons.org/licenses/by-nc-sa/4.0/");
+                                                     "https://creativecommons.org/licenses/by-nc-sa/4.0/");
 
         ops.add(addOperation);
         String patchBody = getPatchContent(ops);
@@ -75,7 +75,7 @@ public class CCLicenseRemovePatchOperationIT extends AbstractControllerIntegrati
                                               .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
                              .andExpect(status().isOk())
                              .andExpect(jsonPath("$.sections.cclicense", allOf(
-                                     hasJsonPath("$.uri", is("http://creativecommons.org/licenses/by-nc-sa/4.0/")),
+                                     hasJsonPath("$.uri", is("https://creativecommons.org/licenses/by-nc-sa/4.0/")),
                                      hasJsonPath("$.rights",
                                                  is("Attribution-NonCommercial-ShareAlike 4.0 International")),
                                      hasJsonPath("$.file.name", is("license_rdf"))

--- a/dspace-server-webapp/src/test/resources/org/dspace/app/rest/cinii-second.xml
+++ b/dspace-server-webapp/src/test/resources/org/dspace/app/rest/cinii-second.xml
@@ -57,7 +57,7 @@
             <prism:startingPage>322</prism:startingPage>
             <prism:endingPage>331</prism:endingPage>
         </publication>
-        <dc:rights>© 2022 The Author(s). Published by National Institute for Materials Science in partnership with Taylor &amp; Francis Group. This is an Open Access article distributed under the terms of the Creative Commons Attribution License (http://creativecommons.org/licenses/by/4.0/), which permits unrestricted use, distribution, and reproduction in any medium, provided the original work is properly cited.</dc:rights>
+        <dc:rights>© 2022 The Author(s). Published by National Institute for Materials Science in partnership with Taylor &amp; Francis Group. This is an Open Access article distributed under the terms of the Creative Commons Attribution License (https://creativecommons.org/licenses/by/4.0/), which permits unrestricted use, distribution, and reproduction in any medium, provided the original work is properly cited.</dc:rights>
         <url>
             <rdf:Description rdf:about="http://www.lib.kobe-u.ac.jp/handle_kernel/90009212">
         </rdf:Description>

--- a/dspace-server-webapp/src/test/resources/org/dspace/license/cc-license-rdf.xml
+++ b/dspace-server-webapp/src/test/resources/org/dspace/license/cc-license-rdf.xml
@@ -1,31 +1,31 @@
 <?xml version='1.0' encoding='utf-8'?>
 <result>
-    <license-uri>http://creativecommons.org/licenses/by-nc-sa/4.0/</license-uri>
+    <license-uri>https://creativecommons.org/licenses/by-nc-sa/4.0/</license-uri>
     <license-name>Attribution-NonCommercial-ShareAlike 4.0 International</license-name>
     <deprecated>false</deprecated>
     <rdf>
-        <rdf:RDF xmlns="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-            <Work xmlns:dc="http://purl.org/dc/elements/1.1/" rdf:about=""><license rdf:resource="http://creativecommons.org/licenses/by-nc-sa/4.0/"/></Work><License rdf:about="http://creativecommons.org/licenses/by-nc-sa/4.0/">
-            <permits rdf:resource="http://creativecommons.org/ns#DerivativeWorks"/>
-            <permits rdf:resource="http://creativecommons.org/ns#Distribution"/>
-            <permits rdf:resource="http://creativecommons.org/ns#Reproduction"/>
-            <requires rdf:resource="http://creativecommons.org/ns#Attribution"/>
-            <requires rdf:resource="http://creativecommons.org/ns#Notice"/>
-            <requires rdf:resource="http://creativecommons.org/ns#ShareAlike"/>
+        <rdf:RDF xmlns="https://creativecommons.org/ns#" xmlns:rdf="https://www.w3.org/1999/02/22-rdf-syntax-ns#">
+            <Work xmlns:dc="https://purl.org/dc/elements/1.1/" rdf:about=""><license rdf:resource="https://creativecommons.org/licenses/by-nc-sa/4.0/"/></Work><License rdf:about="https://creativecommons.org/licenses/by-nc-sa/4.0/">
+            <permits rdf:resource="https://creativecommons.org/ns#DerivativeWorks"/>
+            <permits rdf:resource="https://creativecommons.org/ns#Distribution"/>
+            <permits rdf:resource="https://creativecommons.org/ns#Reproduction"/>
+            <requires rdf:resource="https://creativecommons.org/ns#Attribution"/>
+            <requires rdf:resource="https://creativecommons.org/ns#Notice"/>
+            <requires rdf:resource="https://creativecommons.org/ns#ShareAlike"/>
         </License>
         </rdf:RDF>
     </rdf>
     <licenserdf>
-        <rdf:RDF xmlns="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-            <License rdf:about="http://creativecommons.org/licenses/by-nc-sa/4.0/">
-                <permits rdf:resource="http://creativecommons.org/ns#DerivativeWorks"/>
-                <permits rdf:resource="http://creativecommons.org/ns#Distribution"/>
-                <permits rdf:resource="http://creativecommons.org/ns#Reproduction"/>
-                <requires rdf:resource="http://creativecommons.org/ns#Attribution"/>
-                <requires rdf:resource="http://creativecommons.org/ns#Notice"/>
-                <requires rdf:resource="http://creativecommons.org/ns#ShareAlike"/>
+        <rdf:RDF xmlns="https://creativecommons.org/ns#" xmlns:rdf="https://www.w3.org/1999/02/22-rdf-syntax-ns#">
+            <License rdf:about="https://creativecommons.org/licenses/by-nc-sa/4.0/">
+                <permits rdf:resource="httasp://creativecommons.org/ns#DerivativeWorks"/>
+                <permits rdf:resource="https://creativecommons.org/ns#Distribution"/>
+                <permits rdf:resource="https://creativecommons.org/ns#Reproduction"/>
+                <requires rdf:resource="https://creativecommons.org/ns#Attribution"/>
+                <requires rdf:resource="https://creativecommons.org/ns#Notice"/>
+                <requires rdf:resource="https://creativecommons.org/ns#ShareAlike"/>
             </License>
         </rdf:RDF>
     </licenserdf>
-    <html><a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="http://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png"/></a><br/>This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License</a>.</html>
+    <html><a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png"/></a><br/>This work is licensed under a <a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License</a>.</html>
 </result>

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1011,7 +1011,7 @@ cc.license.classfilter = publicdomain, recombo, mark
 
 # Jurisdiction of the creative commons license -- is it ported or not?
 # Use the key from the url seen in the response from the api call,
-# http://api.creativecommons.org/rest/1.5/support/jurisdictions
+# https://api.creativecommons.org/rest/1.5/support/jurisdictions
 # Commented out means the license is unported.
 # (e.g. nz = New Zealand, uk = England and Wales, jp = Japan)
 # or set value none for user-selected jurisdiction

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -1549,27 +1549,27 @@
             </pair>
             <pair>
                 <displayed-value>Attribution (CC-BY)</displayed-value>
-                <stored-value>http://creativecommons.org/licenses/by/4.0/</stored-value>
+                <stored-value>https://creativecommons.org/licenses/by/4.0/</stored-value>
             </pair>
             <pair>
                 <displayed-value>Attribution, No Derivative Works (CC-BY-ND)</displayed-value>
-                <stored-value>http://creativecommons.org/licenses/by-nd/4.0/</stored-value>
+                <stored-value>https://creativecommons.org/licenses/by-nd/4.0/</stored-value>
             </pair>
             <pair>
                 <displayed-value>Attribution, Share-alike (CC-BY-SA)</displayed-value>
-                <stored-value>http://creativecommons.org/licenses/by-sa/4.0/</stored-value>
+                <stored-value>https://creativecommons.org/licenses/by-sa/4.0/</stored-value>
             </pair>
             <pair>
                 <displayed-value>Attribution, Non-commercial (CC-BY-NC)</displayed-value>
-                <stored-value>http://creativecommons.org/licenses/by-nc/4.0/</stored-value>
+                <stored-value>https://creativecommons.org/licenses/by-nc/4.0/</stored-value>
             </pair>
             <pair>
                 <displayed-value>Attribution, Non-commercial, No Derivative Works (CC-BY-NC-ND)</displayed-value>
-                <stored-value>http://creativecommons.org/licenses/by-nc-nd/4.0/</stored-value>
+                <stored-value>https://creativecommons.org/licenses/by-nc-nd/4.0/</stored-value>
             </pair>
             <pair>
                 <displayed-value>Attribution, Non-commercial, Share-alike (CC-BY-NC-SA)</displayed-value>
-                <stored-value>http://creativecommons.org/licenses/by-nc-sa/4.0/</stored-value>
+                <stored-value>https://creativecommons.org/licenses/by-nc-sa/4.0/</stored-value>
             </pair>
             <!-- Add here other licenses -->
             <pair>


### PR DESCRIPTION
Manual port of #9625 by @nwoodward to `dspace-7_x`.  This PR required a manual port as a few of the test files updated in #9625 did not exist in 7.x.