### PR TITLE
Allow multiple DSpace backends to be started on different ports via Docker compose

### DIFF
--- a/docker-compose-cli.yml
+++ b/docker-compose-cli.yml
@@ -1,3 +1,14 @@
+#
+# The contents of this file are subject to the license and copyright
+# detailed in the LICENSE and NOTICE files at the root of the source
+# tree and available online at
+#
+# http://www.dspace.org/license/
+#
+
+#
+# DSpace Backend Command-Line (CLI) Docker Compose script
+#
 networks:
   # Default to using network named 'dspacenet' from docker-compose.yml.
   # Its full name will be prepended with the project name (e.g. "-p d7" means it will be named "d7_dspacenet")
@@ -19,9 +30,11 @@ services:
       # dspace.dir: Must match with Dockerfile's DSPACE_INSTALL directory.
       dspace__P__dir: /dspace
       # db.url: Ensure we are using the 'dspacedb' image for our database
-      db__P__url: 'jdbc:postgresql://dspacedb:5432/dspace'
-      # solr.server: Ensure we are using the 'dspacesolr' image for Solr
-      solr__P__server: http://dspacesolr:8983/solr
+      # Note: DB Port in this URL is the internal (target) port. So this is hardcoded.
+      db__P__url: "jdbc:postgresql://${COMPOSE_PROJECT_NAME}_dspacedb:5432/dspace"
+      # solr.server: Ensure we are using the 'dspacesolr' image for Solr.
+      # Note: Solr Port in this URL is the internal (target) port. So this is hardcoded.
+      solr__P__server: "http://${COMPOSE_PROJECT_NAME}_dspacesolr:8983/solr"
     volumes:
     # Keep DSpace assetstore directory between reboots
     - assetstore:/dspace/assetstore

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,39 @@
+#
+# The contents of this file are subject to the license and copyright
+# detailed in the LICENSE and NOTICE files at the root of the source
+# tree and available online at
+#
+# http://www.dspace.org/license/
+#
+
+#
+# DSpace Backend (REST API) Docker Compose script
+#
+# The following environment variables may be used to modify the behavior of this script:
+# * DSPACE_VER = version of DSpace docker images to use (default = latest & latest-test)
+# * DSPACE_NETWORK_ID = First 3 digits of subnet to use for containers (default = 172.23.0)
+# * DSPACE_REST_PROTO = Protocol to use in dspace.server.url config (default = http)
+# * DSPACE_REST_HOST = Hostname to use in dspace.server.url config (default = localhost)
+# * DSPACE_REST_PORT = Port to use in dspace.server.url config & backend container (default = 8080)
+# * DSPACE_UI_PROTO = Protocol to use in dspace.ui.url config (default = http)
+# * DSPACE_UI_HOST = Hostname to use in dspace.ui.url config (default = localhost)
+# * DSPACE_UI_PORT = Port to use in dspace.ui.url config (default = 4000)
+# * DSPACE_DB_PORT = Port to use for database container (default = 5432)
+# * DSPACE_SOLR_PORT = Port to use for Solr container (default = 8983)
+#
+# Example of running DSpace backend containers on non-default ports & network:
+# DSPACE_UI_PORT=4001 DSPACE_REST_PORT=8081 DSPACE_DB_PORT=5433 DSPACE_SOLR_PORT=8984 DSPACE_SUBNET=172.24.0 docker-compose -p d8 up -d
 networks:
   dspacenet:
     ipam:
       config:
         # Define a custom subnet for our DSpace network, so that we can easily trust requests from host to container.
         # If you customize this value, be sure to customize the 'proxies.trusted.ipranges' env variable below.
-        - subnet: 172.23.0.0/16
+        - subnet: "${DSPACE_NETWORK_ID:-172.23.0}.0/16"
 services:
   # DSpace (backend) webapp container
   dspace:
-    container_name: dspace
+    container_name: "${COMPOSE_PROJECT_NAME}_dspace"
     environment:
       # Below syntax may look odd, but it is how to override dspace.cfg settings via env variables.
       # See https://github.com/DSpace/DSpace/blob/main/dspace/config/config-definition.xml
@@ -16,17 +41,21 @@ services:
       # __D__ => "-" (e.g. google__D__metadata => google-metadata)
       # dspace.dir: Must match with Dockerfile's DSPACE_INSTALL directory.
       dspace__P__dir: /dspace
-      # Uncomment to set a non-default value for dspace.server.url or dspace.ui.url
-      # dspace__P__server__P__url: http://localhost:8080/server
-      # dspace__P__ui__P__url: http://localhost:4000
-      dspace__P__name: 'DSpace Started with Docker Compose'
+      # Set sane defaults using environment variables. This allows you to override parts of the URL
+      # using these environment vars, or the entire URL by passing in a new value for these env variables
+      dspace__P__server__P__url: "${DSPACE_REST_PROTO:-http}://${DSPACE_REST_HOST:-localhost}:${DSPACE_REST_PORT:-8080}/server"
+      dspace__P__ui__P__url: "${DSPACE_UI_PROTO:-http}://${DSPACE_UI_HOST:-localhost}:${DSPACE_UI_PORT:-4000}"
+      dspace__P__name: "DSpace via Docker Compose project ${COMPOSE_PROJECT_NAME}"
       # db.url: Ensure we are using the 'dspacedb' image for our database
-      db__P__url: 'jdbc:postgresql://dspacedb:5432/dspace'
-      # solr.server: Ensure we are using the 'dspacesolr' image for Solr
-      solr__P__server: http://dspacesolr:8983/solr
+      # Note: DB Port in this URL is the internal (target) port. So this is hardcoded.
+      db__P__url: "jdbc:postgresql://${COMPOSE_PROJECT_NAME}_dspacedb:5432/dspace"
+      # solr.server: Ensure we are using the 'dspacesolr' image for Solr.
+      # Note: Solr Port in this URL is the internal (target) port. So this is hardcoded.
+      solr__P__server: "http://${COMPOSE_PROJECT_NAME}_dspacesolr:8983/solr"
       # proxies.trusted.ipranges: This setting is required for a REST API running in Docker to trust requests
       # from the host machine. This IP range MUST correspond to the 'dspacenet' subnet defined above.
-      proxies__P__trusted__P__ipranges: '172.23.0'
+      proxies__P__trusted__P__ipranges: "${DSPACE_NETWORK_ID:-172.23.0}"
+      # Location of log4j configuration to use for this container
       LOGGING_CONFIG: /dspace/config/log4j2-container.xml
     image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace:${DSPACE_VER:-latest-test}"
     build:
@@ -35,12 +64,10 @@ services:
     depends_on:
     - dspacedb
     networks:
-      - dspacenet
+      dspacenet:
     ports:
-    - published: 8080
+    - published: "${DSPACE_REST_PORT:-8080}"
       target: 8080
-    - published: 8000
-      target: 8000
     stdin_open: true
     tty: true
     volumes:
@@ -62,7 +89,7 @@ services:
       java -jar /dspace/webapps/server-boot.jar --dspace.dir=/dspace
   # DSpace PostgreSQL database container
   dspacedb:
-    container_name: dspacedb
+    container_name: "${COMPOSE_PROJECT_NAME}_dspacedb"
     # Uses a custom Postgres image with pgcrypto installed
     image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-postgres-pgcrypto:${DSPACE_VER:-latest}"
     build:
@@ -74,7 +101,7 @@ services:
     networks:
       dspacenet:
     ports:
-    - published: 5432
+    - published: "${DSPACE_DB_PORT:-5432}"
       target: 5432
     stdin_open: true
     tty: true
@@ -83,7 +110,7 @@ services:
     - pgdata:/pgdata
   # DSpace Solr container
   dspacesolr:
-    container_name: dspacesolr
+    container_name: "${COMPOSE_PROJECT_NAME}_dspacesolr"
     image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-solr:${DSPACE_VER:-latest}"
     build:
       context: ./dspace/src/main/docker/dspace-solr/
@@ -95,7 +122,7 @@ services:
     networks:
       dspacenet:
     ports:
-    - published: 8983
+    - published: "${DSPACE_SOLR_PORT:-8983}"
       target: 8983
     stdin_open: true
     tty: true

--- a/dspace/src/main/docker-compose/README.md
+++ b/dspace/src/main/docker-compose/README.md
@@ -66,12 +66,32 @@ OPTIONALLY, you can build DSpace images using a different JDK_VERSION like this:
 ```
 docker compose -f docker-compose.yml -f docker-compose-cli.yml build --build-arg JDK_VERSION=17
 ```
-Default is Java 11, but other LTS releases (e.g. 17) are also supported.
+Default is Java 17, but other LTS releases may be supported.
 
 ## Run DSpace 8 REST from your current branch
+
+This runs the DSpace backend (REST API) in a new compose project on standard ports.
 ```
 docker compose -p d8 up -d
 ```
+
+It is also possible to run several DSpace backends at once using this same script. To do so, you MUST define
+a **different** compose project (-p), along with **different** ports and a **different** network. (If any of these 
+overlap with an existing DSpace backend, you will see conflicts / errors thrown by Docker compose.)
+
+Here's an example of running a second DSpace backend in a "ds-second" project using a different network (172.24.0.x), 
+and non-default ports for backend (8081), frontend (4001), Postgres (5433) and Solr (8984):
+```
+DSPACE_UI_PORT=4001 DSPACE_REST_PORT=8081 DSPACE_DB_PORT=5433 DSPACE_SOLR_PORT=8984 DSPACE_NETWORK_ID=172.24.0 docker compose -p d7 up -d
+```
+* **IMPORTANT:** When using non-standard ports, these environment variables will need to be passed into EVERY 
+`docker compose` command you run.  Otherwise, the default ports will be assumed.
+* _NOTE:_ The `DSPACE_UI_PORT` is only necessary if you plan to run a user interface from a non-standard port to connect to
+this backend. This env variable is simply used to set the `dspace.ui.url` config properly.
+* _NOTE:_ For Windows you MUST either set the environment variable separately, or use the `env` command provided with Git/Cygwin
+(you may already have this command if you are running Git for Windows). See https://superuser.com/a/1079563
+
+Additional environment variables can be found in the comments of `docker-compose.yml`.
 
 ## Run DSpace 8 REST and Angular from your branch
 


### PR DESCRIPTION
## Description
This small PR updates our `docker-compose.yml` script to allow for **multiple DSpace backends to be running at the same time** using the same code/configurations (but different databases/Solr).  

The changes to `docker-compose.yml` are as follows:
1. Update all Docker containers to have a name prefixed with the Docker Compose project name (passed via `-p`).  
    * For example, previously the database container was hardcoded to `dspacedb`.  Now, if you start container with `-p d8`, then it will be named `d8_dspacedb`. 
2. Added environment variables which allow you to customize ports/network that Docker will use.

By default, everything works the same as before.  Running the following will start the backend on port 8080, using Postgres on port 5432 and Solr on port 8983.  This also uses a default network of 172.23.0.x for containers.
```
docker compose -p d8 up -d
```

However, now, you can start a **second** instance by just specifying different ports / network / project name.  

Running the following uses a new compose project named "d8_second" and starts the backend on port 8081, using Postgres on port 5433 and Solr on port 8984.  This uses a new network of 172.24.0.x for containers
```
DSPACE_REST_PORT=8081 DSPACE_DB_PORT=5433 DSPACE_SOLR_PORT=8984 DSPACE_NETWORK_ID=172.24.0 docker compose -p d8_second up -d
```

This same process can be used to start additional DSpace backend instances beyond that.  The important thing is that **all instances** must have unique ports, a unique network and a unique project name.


## Instructions for Reviewers
* Try out the commands above to try to spin up two backends at once.
* Using a single frontend (UI), you should be able to swap between them by simply changing the `port` in your `rest` settings.
  ```
  rest:
    ssl: false
    host: localhost
    port: 8080
    nameSpace: /server
  ```
