### PR TITLE
New parameter fromdate for media-filter script

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScript.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScript.java
@@ -116,7 +116,7 @@ public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfigura
         }
 
         if (commandLine.hasOption('d')) {
-            fromDate = LocalDate.parse(commandLine.getOptionValue('f'));
+            fromDate = LocalDate.parse(commandLine.getOptionValue('d'));
         }
 
 

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScript.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScript.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.app.mediafilter;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -37,8 +38,9 @@ import org.dspace.utils.DSpace;
  * MFM: -v verbose outputs all extracted text to STDOUT; -f force forces all
  * bitstreams to be processed, even if they have been before; -n noindex does not
  * recreate index after processing bitstreams; -i [identifier] limits processing
- * scope to a community, collection or item; and -m [max] limits processing to a
- * maximum number of items.
+ * scope to a community, collection or item; -m [max] limits processing to a
+ * maximum number of items; -fd [fromdate] takes only items starting from this date,
+ * filtering by last_modified in the item table.
  */
 public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfiguration> {
 
@@ -60,6 +62,7 @@ public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfigura
     private String[] filterNames;
     private String[] skipIds = null;
     private Map<String, List<String>> filterFormats = new HashMap<>();
+    private LocalDate fromDate = null;
 
     public MediaFilterScriptConfiguration getScriptConfiguration() {
         return new DSpace().getServiceManager()
@@ -110,6 +113,10 @@ public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfigura
         if (commandLine.hasOption('s')) {
             //specified which identifiers to skip when processing
             skipIds = commandLine.getOptionValues('s');
+        }
+
+        if (commandLine.hasOption('f')) {
+            fromDate = LocalDate.parse(commandLine.getOptionValue('f'));
         }
 
 
@@ -213,6 +220,10 @@ public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfigura
         if (skipIds != null && skipIds.length > 0) {
             //save to a global skip list
             mediaFilterService.setSkipList(Arrays.asList(skipIds));
+        }
+
+        if (fromDate != null) {
+            mediaFilterService.setFromDate(fromDate);
         }
 
         Context c = null;

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScript.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScript.java
@@ -115,7 +115,7 @@ public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfigura
             skipIds = commandLine.getOptionValues('s');
         }
 
-        if (commandLine.hasOption('f')) {
+        if (commandLine.hasOption('d')) {
             fromDate = LocalDate.parse(commandLine.getOptionValue('f'));
         }
 

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScriptConfiguration.java
@@ -52,7 +52,7 @@ public class MediaFilterScriptConfiguration<T extends MediaFilterScript> extends
                                     .build();
         options.addOption(pluginOption);
 
-        options.addOption("fd", "fromdate", true, "Process only item from specified last modified date");
+        options.addOption("d", "fromdate", true, "Process only item from specified last modified date");
 
         Option skipOption = Option.builder("s")
                                   .longOpt("skip")

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScriptConfiguration.java
@@ -52,6 +52,8 @@ public class MediaFilterScriptConfiguration<T extends MediaFilterScript> extends
                                     .build();
         options.addOption(pluginOption);
 
+        options.addOption("fd", "fromdate", true, "Process only item from specified last modified date");
+
         Option skipOption = Option.builder("s")
                                   .longOpt("skip")
                                   .hasArg()

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
@@ -9,8 +9,11 @@ package org.dspace.app.mediafilter;
 
 import java.io.InputStream;
 import java.sql.SQLException;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -93,6 +96,7 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
     protected boolean isVerbose = false;
     protected boolean isQuiet = false;
     protected boolean isForce = false; // default to not forced
+    protected LocalDate fromDate = null;
 
     protected MediaFilterServiceImpl() {
 
@@ -119,6 +123,15 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
 
             for (Community topLevelCommunity : topLevelCommunities) {
                 applyFiltersCommunity(context, topLevelCommunity);
+            }
+        } else if (fromDate != null) {
+            Iterator<Item> itemIterator =
+                    itemService.findByLastModifiedSince(
+                            context,
+                            Date.from(fromDate.atStartOfDay(ZoneId.systemDefault()).toInstant())
+                    );
+            while (itemIterator.hasNext() && processed < max2Process) {
+                applyFiltersItem(context, itemIterator.next());
             }
         } else {
             //otherwise, just find every item and process
@@ -587,5 +600,10 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
     @Override
     public void setLogHandler(DSpaceRunnableHandler handler) {
         this.handler = handler;
+    }
+
+    @Override
+    public void setFromDate(LocalDate fromDate) {
+        this.fromDate = fromDate;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/service/MediaFilterService.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/service/MediaFilterService.java
@@ -8,6 +8,7 @@
 package org.dspace.app.mediafilter.service;
 
 import java.sql.SQLException;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 
@@ -149,4 +150,6 @@ public interface MediaFilterService {
      * @param handler
      */
     public void setLogHandler(DSpaceRunnableHandler handler);
+
+    public void setFromDate(LocalDate fromDate);
 }

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/ItemDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/ItemDAOImpl.java
@@ -441,7 +441,7 @@ public class ItemDAOImpl extends AbstractHibernateDSODAO<Item> implements ItemDA
     public Iterator<Item> findByLastModifiedSince(Context context, Date since)
         throws SQLException {
         Query query = createQuery(context,
-                "SELECT i.id FROM Item i WHERE last_modified > :last_modified ORDER BY id");
+                "SELECT i.id FROM Item i WHERE lastModified > :last_modified ORDER BY id");
         query.setParameter("last_modified", since, TemporalType.TIMESTAMP);
         @SuppressWarnings("unchecked")
         List<UUID> uuids = query.getResultList();


### PR DESCRIPTION
## Description
In this pull request I've expanded functionality to media-filter. There was added additional parameter "fromdate" to evaluate items only from certain date. This parameter filter items by last_modified field in item table. 

## Instructions for Reviewers

List of changes in this PR:
* Added parameter `d` (full name fromdate) in filter-media script

To test my pr run `./dspace filter-media -d (or fromdate) [YYYY-MM-DD]`.

## Checklist

- [X] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
