### PR TITLE
Bump Spring Boot from 3.2.5 to 3.2.6. 

### DIFF
--- a/dspace-iiif/pom.xml
+++ b/dspace-iiif/pom.xml
@@ -75,6 +75,13 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
             <version>${spring-boot.version}</version>
+            <exclusions>
+                <!-- Later version brought in by spring-boot-starter-web above -->
+                <exclusion>
+                    <groupId>io.micrometer</groupId>
+                    <artifactId>micrometer-observation</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-cache
              Caching dependencies for iiif endpoint. -->

--- a/dspace-server-webapp/pom.xml
+++ b/dspace-server-webapp/pom.xml
@@ -436,6 +436,13 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
             <version>${spring-boot.version}</version>
+            <exclusions>
+                <!-- Later version brought in by spring-boot-starter-web above -->
+                <exclusion>
+                    <groupId>io.micrometer</groupId>
+                    <artifactId>micrometer-observation</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Add in log4j support by excluding default logging, and using starter-log4j -->

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <description>
    	DSpace open source software is a turnkey institutional repository application.
     </description>
-    <url>https://github.com/dspace/DSpace</url>
+    <url>https://github.com/DSpace/DSpace</url>
 
     <organization>
         <name>LYRASIS</name>
@@ -19,10 +19,10 @@
     <properties>
         <!--=== GENERAL / DSPACE-API DEPENDENCIES ===-->
         <java.version>17</java.version>
-        <spring.version>6.1.6</spring.version>
-        <spring-boot.version>3.2.5</spring-boot.version>
+        <spring.version>6.1.8</spring.version>
+        <spring-boot.version>3.2.6</spring-boot.version>
         <spring-security.version>6.2.4</spring-security.version> <!-- sync with version used by spring-boot-->
-        <hibernate.version>6.4.4.Final</hibernate.version>
+        <hibernate.version>6.4.8.Final</hibernate.version>
         <hibernate-validator.version>8.0.1.Final</hibernate-validator.version>
         <postgresql.driver.version>42.7.3</postgresql.driver.version>
         <flyway.version>10.10.0</flyway.version>


### PR DESCRIPTION
Minor updates to other dependen…cies where required.

## Description
Minor update to Spring Boot from 3.2.5 to 3.2.6.  This required minor updates to a few other dependencies for dependency convergence:
* Bump Spring from 6.1.6 to 6.1.8
* Bump Hibernate from 6.4.4.Final to 6.4.8.Final
* Fixed a few minor dependency convergence issues related to `io.micrometer`

## Instructions for Reviewers
* Verify tests pass
* Verify backend builds properly (I've tested it and it does)
* Verify Backend works with frontend.