### PR TITLE
Feature curation link checker customizations 7.6

### DIFF
--- a/dspace-api/src/main/java/org/dspace/ctask/general/BasicLinkChecker.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/BasicLinkChecker.java
@@ -132,10 +132,18 @@ public class BasicLinkChecker extends AbstractCurationTask {
         try {
             URL theURL = new URL(url);
             HttpURLConnection connection = (HttpURLConnection) theURL.openConnection();
-            int code = connection.getResponseCode();
-            connection.disconnect();
+            connection.setInstanceFollowRedirects(true);
+            int statusCode = connection.getResponseCode();
+            if ((statusCode == HttpURLConnection.HTTP_MOVED_TEMP || statusCode == HttpURLConnection.HTTP_MOVED_PERM ||
+                    statusCode == HttpURLConnection.HTTP_SEE_OTHER)) {
+                connection.disconnect();
+                String newUrl = connection.getHeaderField("Location");
+                if (newUrl != null) {
+                    return getResponseStatus(newUrl);
+                }
 
-            return code;
+            }
+            return statusCode;
 
         } catch (IOException ioe) {
             // Must be a bad URL

--- a/dspace-server-webapp/src/test/java/org/dspace/app/scripts/handler/impl/TestDSpaceRunnableHandler.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/scripts/handler/impl/TestDSpaceRunnableHandler.java
@@ -7,6 +7,9 @@
  */
 package org.dspace.app.scripts.handler.impl;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.dspace.scripts.handler.impl.CommandLineDSpaceRunnableHandler;
 
 /**
@@ -16,6 +19,12 @@ import org.dspace.scripts.handler.impl.CommandLineDSpaceRunnableHandler;
 public class TestDSpaceRunnableHandler extends CommandLineDSpaceRunnableHandler {
 
     private Exception exception = null;
+
+    private final List<String> infoMessages = new ArrayList<>();
+
+    private final List<String> errorMessages = new ArrayList<>();
+
+    private final List<String> warningMessages = new ArrayList<>();
 
     /**
      * We're overriding this method so that we can stop the script from doing the System.exit() if
@@ -32,5 +41,35 @@ public class TestDSpaceRunnableHandler extends CommandLineDSpaceRunnableHandler 
      */
     public Exception getException() {
         return exception;
+    }
+
+    @Override
+    public void logInfo(String message) {
+        super.logInfo(message);
+        infoMessages.add(message);
+    }
+
+    @Override
+    public void logWarning(String message) {
+        super.logWarning(message);
+        warningMessages.add(message);
+    }
+
+    @Override
+    public void logError(String message) {
+        super.logError(message);
+        errorMessages.add(message);
+    }
+
+    public List<String> getInfoMessages() {
+        return infoMessages;
+    }
+
+    public List<String> getErrorMessages() {
+        return errorMessages;
+    }
+
+    public List<String> getWarningMessages() {
+        return warningMessages;
     }
 }


### PR DESCRIPTION
## Description
Fixes an issue with the link checker in DSpace which fails if a link provided ends up being redirect to a new one and follows the link making sure both resolve correctly. Also adds a new configuration 
```
linkchecker.metadatafield.ignore = dc.identifier.uri, dc.identifier.olduri, dc.rights.uri
```
`linkchecker.metadatafield.ignore` provides a `,` delimited list of metadata fields to ignore when running the link checker.

## Instructions for Reviewers

* TestDspaceRunnableHandler
  * DSpace-api already has this for its Runnable Handler we are just implementing this improvment here which allows for us to view debug logs that the runner encountered 
*  BasicLinkChecker
   * Set the connection instance to follow redirects and then follow that and view its status.

To test take the following steps:

- Make a new dspace item with a metadata field not inside of `linkchcker.metadatafield.ignore` that redirects and another metadata field inside of that configuration
- Check that when running the `check links` curation task the URI inside of the ignore list is ignored and that the redirect link passes

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
