### PR TITLE
Thumbnail with a given page number

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/PDFBoxThumbnail.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/PDFBoxThumbnail.java
@@ -16,9 +16,6 @@ import org.apache.pdfbox.pdmodel.encryption.InvalidPasswordException;
 import org.apache.pdfbox.rendering.PDFRenderer;
 import org.dspace.content.Item;
 
-import org.dspace.content.MetadataSchemaEnum;
-import org.dspace.content.service.ItemService;
-
 /**
  * Create JPEG thumbnails from PDF cover page using PDFBox.
  * Based on JPEGFilter:

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/PDFBoxThumbnail.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/PDFBoxThumbnail.java
@@ -71,7 +71,7 @@ public class PDFBoxThumbnail extends MediaFilter {
         BufferedImage buf;
 
         String pageNumberStr =  currentItem.getItemService()
-            .getMetadataFirstValue(currentItem, "dspace", "filter-media", "page", Item.ANY);
+            .getMetadataFirstValue(currentItem, "dspace", "thumbnail", "page", Item.ANY);
 
         int pageNumber = 0;
 
@@ -92,6 +92,9 @@ public class PDFBoxThumbnail extends MediaFilter {
             buf = renderer.renderImage(pageNumber);
         } catch (InvalidPasswordException ex) {
             log.error("PDF is encrypted. Cannot create thumbnail (item: {})", currentItem::getHandle);
+            return null;
+        } catch (IndexOutOfBoundsException ex) {
+            log.error("Cannot create thumbnail with the given page number: {}", pageNumber + 1);
             return null;
         }
 


### PR DESCRIPTION
## References
There is no any issue or pr for this PR. The goal was to be able to specifiy anyhow the page number of a PDF document to be converted to the thumbnail instead converting always the first page.

## Description
If an item has a metadata of `dspace.filter-media.page` having a number greater than 0 then the command `filter-media` converts this given page number of the attached PDF bitstream into a thumbnail.

## Instructions for Reviewers
I modified the file `dspace-api/src/main/java/org/dspace/app/mediafilter/PDFBoxThumbnail.java`. I have imported the `MetadataSchemaEnum` and `ItemService` service. With these, I check if the item has the metadata `dspace.filter-media.page` and whether is set to a valid number or not.
If there is no metadata with this name or if the metadata contains an invalid integer then the default page number of 1 will be converted. Invalid number will be logged as an error.
If there is the metadata and if it contains a valid number then that page number will be converted.

For testing run the command `filter-media -i [ITEM-HANDLE]` with these properties:
 - The item has a PDF bitstream.
 - The item has no metadata `dspace.filter-media.page`. -> PDF first page should be converted to thumbnail.
 - The item has metadata `dspace.filter-media.page` but it has an invalid integer. -> DSpace log should contain an error and PDF first page should be converted to thumbnail.
 - The item has metadata `dspace.filter-media.page` and it has a valid number greater then zero [N]. -> PDF [Nth] page should be converted to a thumbnail.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
