### PR TITLE
Bugfix: BitstreamRestController etag/content-length calculation incorrect when coverpages are enabled

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
@@ -135,11 +135,16 @@ public class BitstreamRestController {
             long filesize = bit.getSizeBytes();
             Boolean citationEnabledForBitstream = citationDocumentService.isCitationEnabledForBitstream(bit, context);
 
+            var bitstreamResource =
+                    new org.dspace.app.rest.utils.BitstreamResource(name, uuid,
+                            currentUser != null ? currentUser.getID() : null,
+                            context.getSpecialGroupUuids(), citationEnabledForBitstream);
+
             HttpHeadersInitializer httpHeadersInitializer = new HttpHeadersInitializer()
                 .withBufferSize(BUFFER_SIZE)
                 .withFileName(name)
-                .withChecksum(bit.getChecksum())
-                .withLength(bit.getSizeBytes())
+                .withChecksum(bitstreamResource.getChecksum())
+                .withLength(bitstreamResource.contentLength())
                 .withMimetype(mimetype)
                 .with(request)
                 .with(response);
@@ -156,11 +161,6 @@ public class BitstreamRestController {
                     || checkFormatForContentDisposition(format)) {
                 httpHeadersInitializer.withDisposition(HttpHeadersInitializer.CONTENT_DISPOSITION_ATTACHMENT);
             }
-
-            org.dspace.app.rest.utils.BitstreamResource bitstreamResource =
-                new org.dspace.app.rest.utils.BitstreamResource(name, uuid,
-                    currentUser != null ? currentUser.getID() : null,
-                    context.getSpecialGroupUuids(), citationEnabledForBitstream);
 
             //We have all the data we need, close the connection to the database so that it doesn't stay open during
             //download/streaming

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/BitstreamResource.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/BitstreamResource.java
@@ -13,6 +13,7 @@ import java.io.InputStream;
 import java.sql.SQLException;
 import java.util.Set;
 import java.util.UUID;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/BitstreamResource.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/BitstreamResource.java
@@ -13,9 +13,9 @@ import java.io.InputStream;
 import java.sql.SQLException;
 import java.util.Set;
 import java.util.UUID;
-
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.tuple.Pair;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Bitstream;
 import org.dspace.content.factory.ContentServiceFactory;
@@ -27,6 +27,7 @@ import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.eperson.service.EPersonService;
 import org.dspace.utils.DSpace;
 import org.springframework.core.io.AbstractResource;
+import org.springframework.util.DigestUtils;
 
 /**
  * This class acts as a {@link AbstractResource} used by Spring's framework to send the data in a proper and
@@ -36,21 +37,24 @@ import org.springframework.core.io.AbstractResource;
  */
 public class BitstreamResource extends AbstractResource {
 
-    private String name;
-    private UUID uuid;
-    private UUID currentUserUUID;
-    private boolean shouldGenerateCoverPage;
-    private byte[] file;
-    private Set<UUID> currentSpecialGroups;
+    private static final Logger LOG = LogManager.getLogger(BitstreamResource.class);
 
-    private BitstreamService bitstreamService = ContentServiceFactory.getInstance().getBitstreamService();
-    private EPersonService ePersonService = EPersonServiceFactory.getInstance().getEPersonService();
-    private CitationDocumentService citationDocumentService =
-        new DSpace().getServiceManager()
+    private final String name;
+    private final UUID uuid;
+    private final UUID currentUserUUID;
+    private final boolean shouldGenerateCoverPage;
+    private final Set<UUID> currentSpecialGroups;
+
+    private final BitstreamService bitstreamService = ContentServiceFactory.getInstance().getBitstreamService();
+    private final EPersonService ePersonService = EPersonServiceFactory.getInstance().getEPersonService();
+    private final CitationDocumentService citationDocumentService =
+            new DSpace().getServiceManager()
                     .getServicesByType(CitationDocumentService.class).get(0);
 
+    private BitstreamDocument document;
+
     public BitstreamResource(String name, UUID uuid, UUID currentUserUUID, Set<UUID> currentSpecialGroups,
-        boolean shouldGenerateCoverPage) {
+                             boolean shouldGenerateCoverPage) {
         this.name = name;
         this.uuid = uuid;
         this.currentUserUUID = currentUserUUID;
@@ -67,17 +71,15 @@ public class BitstreamResource extends AbstractResource {
      * @return a byte array containing the cover page
      */
     private byte[] getCoverpageByteArray(Context context, Bitstream bitstream)
-        throws IOException, SQLException, AuthorizeException {
-        if (file == null) {
-            try {
-                Pair<byte[], Long> citedDocument = citationDocumentService.makeCitedDocument(context, bitstream);
-                this.file = citedDocument.getLeft();
-            } catch (Exception e) {
-                // Return the original bitstream without the cover page
-                this.file = IOUtils.toByteArray(bitstreamService.retrieve(context, bitstream));
-            }
+            throws IOException, SQLException, AuthorizeException {
+        try {
+            var citedDocument = citationDocumentService.makeCitedDocument(context, bitstream);
+            return citedDocument.getLeft();
+        } catch (Exception e) {
+            LOG.warn("Could not generate cover page. Will fallback to original document", e);
+            // Return the original bitstream without the cover page
+            return IOUtils.toByteArray(bitstreamService.retrieve(context, bitstream));
         }
-        return file;
     }
 
     @Override
@@ -87,22 +89,9 @@ public class BitstreamResource extends AbstractResource {
 
     @Override
     public InputStream getInputStream() throws IOException {
-        try (Context context = initializeContext()) {
+        fetchDocument();
 
-            Bitstream bitstream = bitstreamService.find(context, uuid);
-            InputStream out;
-
-            if (shouldGenerateCoverPage) {
-                out = new ByteArrayInputStream(getCoverpageByteArray(context, bitstream));
-            } else {
-                out = bitstreamService.retrieve(context, bitstream);
-            }
-
-            this.file = null;
-            return out;
-        } catch (SQLException | AuthorizeException e) {
-            throw new IOException(e);
-        }
+        return document.inputStream();
     }
 
     @Override
@@ -111,17 +100,47 @@ public class BitstreamResource extends AbstractResource {
     }
 
     @Override
-    public long contentLength() throws IOException {
+    public long contentLength() {
+        fetchDocument();
+
+        return document.length();
+    }
+
+    public String getChecksum() {
+        fetchDocument();
+
+        return document.etag();
+    }
+
+    private void fetchDocument() {
+        if (document != null) {
+            return;
+        }
+
         try (Context context = initializeContext()) {
             Bitstream bitstream = bitstreamService.find(context, uuid);
             if (shouldGenerateCoverPage) {
-                return getCoverpageByteArray(context, bitstream).length;
+                var coverPage = getCoverpageByteArray(context, bitstream);
+
+                this.document = new BitstreamDocument(etag(coverPage),
+                        coverPage.length,
+                        new ByteArrayInputStream(coverPage));
             } else {
-                return bitstream.getSizeBytes();
+                this.document = new BitstreamDocument(bitstream.getChecksum(),
+                        bitstream.getSizeBytes(),
+                        bitstreamService.retrieve(context, bitstream));
             }
-        } catch (SQLException | AuthorizeException e) {
-            throw new IOException(e);
+        } catch (SQLException | AuthorizeException | IOException e) {
+            throw new RuntimeException(e);
         }
+    }
+
+    private String etag(byte[] data) {
+        var builder = new StringBuilder();
+        builder.append("\"0");
+        DigestUtils.appendMd5DigestAsHex(data, builder);
+        builder.append('"');
+        return builder.toString();
     }
 
     private Context initializeContext() throws SQLException {
@@ -131,4 +150,6 @@ public class BitstreamResource extends AbstractResource {
         currentSpecialGroups.forEach(context::setSpecialGroup);
         return context;
     }
+
+    private record BitstreamDocument(String etag, long length, InputStream inputStream) {}
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
@@ -55,7 +55,6 @@ import java.time.Period;
 import java.util.UUID;
 
 import org.apache.commons.codec.digest.DigestUtils;
-
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.CharEncoding;
 import org.apache.commons.lang3.StringUtils;
@@ -1470,7 +1469,7 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
 
             block.accept(originalPdf);
 
-        }catch (Exception e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
@@ -929,8 +929,6 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
         //2. A public item with a bitstream
         File originalPdf = new File(testProps.getProperty("test.bitstream"));
 
-        System.out.println(originalPdf);
-
         try (InputStream is = new FileInputStream(originalPdf)) {
 
             Item publicItem1 = ItemBuilder.createItem(context, col1)
@@ -975,7 +973,6 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
 
             var etagHeader = getClient().perform(get("/api/core/bitstreams/" + bitstream.getID() + "/content"))
                 .andReturn().getResponse().getHeader("ETag");
-            etagHeader = etagHeader.substring(1, etagHeader.length() - 1);
 
             //A If-None-Match HEAD request on the ETag must tell is the bitstream is not modified
             getClient().perform(head("/api/core/bitstreams/" + bitstream.getID() + "/content")

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
@@ -953,12 +953,11 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
                     //** THEN **
                     .andExpect(status().isOk())
 
-                    //The Content Length must match the full length
+                    // exact content-length and etag values are verified in s separate test
                     .andExpect(header().string("Content-Length", not(nullValue())))
+                    .andExpect(header().string("ETag", not(nullValue())))
                     //The server should indicate we support Range requests
                     .andExpect(header().string("Accept-Ranges", "bytes"))
-                    //The ETag has to be based on the checksum
-                    .andExpect(header().string("ETag", "\"" + bitstream.getChecksum() + "\""))
                     //We expect the content type to match the bitstream mime type
                     .andExpect(content().contentType("application/pdf;charset=UTF-8"))
                     //THe bytes of the content must match the original content

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
@@ -23,6 +23,7 @@ import static org.dspace.core.Constants.WRITE;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -49,8 +50,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.nio.file.Files;
 import java.time.Period;
 import java.util.UUID;
+
+import org.apache.commons.codec.digest.DigestUtils;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.CharEncoding;
@@ -91,6 +95,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
 /**
  * Integration test to test the /api/core/bitstreams/[id]/* endpoints
@@ -1384,4 +1389,90 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
                         header.contains("attachment"));
         }
     }
+
+    @Test
+    public void contentLengthAndEtagUsesOriginalBitstream() throws Exception {
+        givenPdf(false, originalPdf -> {
+            var originalMd5 = md5Checksum(originalPdf);
+            long originalLength = Files.size(originalPdf.toPath());
+
+            assertThat(originalLength, greaterThan(0L));
+
+            getClient().perform(get("/api/core/bitstreams/" + bitstream.getID() + "/content"))
+                    .andDo(MockMvcResultHandlers.print())
+                    .andExpect(status().isOk())
+                    .andExpect(header().longValue("Content-Length", originalLength))
+                    .andExpect(header().string("ETag", "\"" + originalMd5 + "\""));
+        });
+    }
+
+    private static String md5Checksum(File file) throws IOException {
+        final String md5;
+        try (InputStream is = new FileInputStream(file)) {
+            md5 = DigestUtils.md5Hex(is);
+        }
+        return md5;
+    }
+
+    @Test
+    public void withCoverPageContentLengthAndEtagChanges() throws Exception {
+        givenPdf(true, originalPdf -> {
+            var originalMd5 = md5Checksum(originalPdf);
+            long originalLength = Files.size(originalPdf.toPath());
+
+            getClient().perform(get("/api/core/bitstreams/" + bitstream.getID() + "/content"))
+                    .andDo(MockMvcResultHandlers.print())
+                    .andExpect(status().isOk())
+                    .andExpect(header().string("Content-Length", not(Long.toString(originalLength))))
+                    .andExpect(header().string("ETag", not("\"" + originalMd5 + "\"")));
+        });
+    }
+
+    @FunctionalInterface
+    interface ThrowingConsumer<T> {
+        void accept(T t) throws Exception;
+    }
+
+    private void givenPdf(boolean coverPageEnabled, ThrowingConsumer<File> block) {
+        configurationService.setProperty("citation-page.enable_globally", coverPageEnabled);
+
+        try {
+            citationDocumentService.afterPropertiesSet();
+            context.turnOffAuthorisationSystem();
+
+            //** GIVEN **
+            //1. A community-collection structure with one parent community and one collections.
+            parentCommunity = CommunityBuilder.createCommunity(context)
+                    .withName("Parent Community")
+                    .build();
+
+            Collection col1 =
+                    CollectionBuilder.createCollection(context, parentCommunity).withName("Collection 1").build();
+
+            //2. A public item with a bitstream
+            File originalPdf = new File(testProps.getProperty("test.bitstream"));
+
+            try (InputStream is = new FileInputStream(originalPdf)) {
+                Item publicItem1 = ItemBuilder.createItem(context, col1)
+                        .withTitle("Public item citation cover page test 1")
+                        .withIssueDate("2017-10-17")
+                        .withAuthor("Smith, Donald").withAuthor("Doe, John")
+                        .build();
+
+                bitstream = BitstreamBuilder
+                        .createBitstream(context, publicItem1, is)
+                        .withName("Test bitstream")
+                        .withDescription("This is a bitstream to test the citation cover page.")
+                        .withMimeType("application/pdf")
+                        .build();
+            }
+            context.restoreAuthSystemState();
+
+            block.accept(originalPdf);
+
+        }catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
 }


### PR DESCRIPTION
This PR fixes a bug where the etag/content-length calculation did not consider the addition of a coverpage. The controller now will use the post processed pdf if coverpages are enabled.

This PR is provided by The Library Code with support of Gesis Leibniz Institut für Sozialwissenschaften.

## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #9665
* Ported to 7.x in #9895

## Description
Ensure that etag & content-length headers are calculated based on the original pdf OR the postprocessed on (in case coverpages are enabled)

## Instructions for Reviewers

* `BitStreamResource`: Changed to fetch original data only once and to consider coverage mode during etag/content-length calculation
* `BitstreamRestController` delegate to `BitStreamResource``
* `BitstreamRestControllerIT` add 2 testcases

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

Steps to reproduce bug are described in https://github.com/DSpace/DSpace/issues/9665

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
