### PR TITLE
Fix for DSpace#9667: Request-a-copy link generation for base URLs that have sub-paths

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RequestItemRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RequestItemRepository.java
@@ -15,7 +15,11 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.UUID;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -295,11 +299,16 @@ public class RequestItemRepository
     public String getLinkTokenEmail(String token)
             throws URISyntaxException, MalformedURLException {
         final String base = configurationService.getProperty("dspace.ui.url");
+
         URIBuilder uriBuilder = new URIBuilder(base);
-        // Add request-a-copy/token to the existing path (without breaking /sub/dir dspace URLs)
-        URI uri = uriBuilder.setPath(
-                (uriBuilder.getPath() == null ? "" : StringUtils.stripEnd(uriBuilder.getPath(), ""))
-                        + "/request-a-copy/" + token).build();
+        List<String> segments = new LinkedList<>();
+        if (StringUtils.isNotBlank(uriBuilder.getPath())) {
+            segments.add(StringUtils.strip(uriBuilder.getPath(), "/"));
+        }
+        segments.add("request-a-copy");
+        segments.add(token);
+        URI uri = uriBuilder.setPathSegments(segments).build();
+
         return uri.toURL().toExternalForm();
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RequestItemRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RequestItemRepository.java
@@ -21,6 +21,7 @@ import java.util.UUID;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.validator.routines.EmailValidator;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.logging.log4j.LogManager;
@@ -287,19 +288,17 @@ public class RequestItemRepository
      * Generate a link back to DSpace, to act on a request.
      *
      * @param token identifies the request.
-     * @return URL to the item request API, with the token as request parameter
-     *          "token".
+     * @return URL to the item request API, with /request-a-copy/{token} as the last URL segments
      * @throws URISyntaxException passed through.
      * @throws MalformedURLException passed through.
      */
     private String getLinkTokenEmail(String token)
             throws URISyntaxException, MalformedURLException {
         final String base = configurationService.getProperty("dspace.ui.url");
-
-        URI link = new URIBuilder(base)
-                .setPathSegments("request-a-copy", token)
-                .build();
-
-        return link.toURL().toExternalForm();
+        URIBuilder uriBuilder = new URIBuilder(base);
+        // Add request-a-copy/token to the existing path (without breaking /sub/dir dspace URLs)
+        URI uri = uriBuilder.setPath(StringUtils.stripEnd(uriBuilder.getPath(), "")
+                + "/request-a-copy/" + token).build();
+        return uri.toURL().toExternalForm();
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RequestItemRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RequestItemRepository.java
@@ -292,7 +292,7 @@ public class RequestItemRepository
      * @throws URISyntaxException passed through.
      * @throws MalformedURLException passed through.
      */
-    private String getLinkTokenEmail(String token)
+    public String getLinkTokenEmail(String token)
             throws URISyntaxException, MalformedURLException {
         final String base = configurationService.getProperty("dspace.ui.url");
         URIBuilder uriBuilder = new URIBuilder(base);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RequestItemRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RequestItemRepository.java
@@ -300,6 +300,7 @@ public class RequestItemRepository
             throws URISyntaxException, MalformedURLException {
         final String base = configurationService.getProperty("dspace.ui.url");
 
+        // Construct the link, making sure to support sub-paths
         URIBuilder uriBuilder = new URIBuilder(base);
         List<String> segments = new LinkedList<>();
         if (StringUtils.isNotBlank(uriBuilder.getPath())) {
@@ -307,8 +308,8 @@ public class RequestItemRepository
         }
         segments.add("request-a-copy");
         segments.add(token);
-        URI uri = uriBuilder.setPathSegments(segments).build();
 
-        return uri.toURL().toExternalForm();
+        // Build and return the URL from segments (or throw exception)
+        return uriBuilder.setPathSegments(segments).build().toURL().toExternalForm();
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RequestItemRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RequestItemRepository.java
@@ -12,11 +12,8 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RequestItemRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RequestItemRepository.java
@@ -297,8 +297,9 @@ public class RequestItemRepository
         final String base = configurationService.getProperty("dspace.ui.url");
         URIBuilder uriBuilder = new URIBuilder(base);
         // Add request-a-copy/token to the existing path (without breaking /sub/dir dspace URLs)
-        URI uri = uriBuilder.setPath(StringUtils.stripEnd(uriBuilder.getPath(), "")
-                + "/request-a-copy/" + token).build();
+        URI uri = uriBuilder.setPath(
+                (uriBuilder.getPath() == null ? "" : StringUtils.stripEnd(uriBuilder.getPath(), ""))
+                        + "/request-a-copy/" + token).build();
         return uri.toURL().toExternalForm();
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/RequestItemRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/RequestItemRepositoryIT.java
@@ -606,10 +606,10 @@ public class RequestItemRepositoryIT
     }
 
     /**
-     * Test that generated links include the correct base URL, even if it has extra URL segments
+     * Test that generated links include the correct base URL, where the UI URL has a subpath like /subdir
      */
     @Test
-    public void testGetLinkTokenEmail() throws MalformedURLException, URISyntaxException {
+    public void testGetLinkTokenEmailWithSubPath() throws MalformedURLException, URISyntaxException {
         RequestItemRepository instance = applicationContext.getBean(
                 RequestItemRest.CATEGORY + '.' + RequestItemRest.PLURAL_NAME,
                 RequestItemRepository.class);
@@ -618,6 +618,22 @@ public class RequestItemRepositoryIT
         // Add a /subdir to the url for this test
         configurationService.setProperty("dspace.ui.url", newDspaceUrl);
         String expectedUrl = newDspaceUrl + "/request-a-copy/token";
+        String generatedLink = instance.getLinkTokenEmail("token");
+        // The URLs should match
+        assertEquals(expectedUrl, generatedLink);
+        configurationService.reloadConfig();
+    }
+
+    /**
+     * Test that generated links include the correct base URL, with NO subpath elements
+     */
+    @Test
+    public void testGetLinkTokenEmailWithoutSubPath() throws MalformedURLException, URISyntaxException {
+        RequestItemRepository instance = applicationContext.getBean(
+                RequestItemRest.CATEGORY + '.' + RequestItemRest.PLURAL_NAME,
+                RequestItemRepository.class);
+        String currentDspaceUrl = configurationService.getProperty("dspace.ui.url");
+        String expectedUrl = currentDspaceUrl + "/request-a-copy/token";
         String generatedLink = instance.getLinkTokenEmail("token");
         // The URLs should match
         assertEquals(expectedUrl, generatedLink);

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/RequestItemRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/RequestItemRepositoryIT.java
@@ -28,6 +28,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.sql.SQLException;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
@@ -55,10 +57,12 @@ import org.dspace.builder.RequestItemBuilder;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Collection;
 import org.dspace.content.Item;
+import org.dspace.services.ConfigurationService;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
 
 /**
  *
@@ -80,6 +84,12 @@ public class RequestItemRepositoryIT
 
     @Autowired(required = true)
     RequestItemService requestItemService;
+
+    @Autowired
+    ApplicationContext applicationContext;
+
+    @Autowired
+    private ConfigurationService configurationService;
 
     private Collection collection;
 
@@ -593,5 +603,24 @@ public class RequestItemRepositoryIT
         RequestItemRepository instance = new RequestItemRepository();
         Class instanceClass = instance.getDomainClass();
         assertEquals("Wrong domain class", RequestItemRest.class, instanceClass);
+    }
+
+    /**
+     * Test that generated links include the correct base URL, even if it has extra URL segments
+     */
+    @Test
+    public void testGetLinkTokenEmail() throws MalformedURLException, URISyntaxException {
+        RequestItemRepository instance = applicationContext.getBean(
+                RequestItemRest.CATEGORY + '.' + RequestItemRest.PLURAL_NAME,
+                RequestItemRepository.class);
+        String currentDspaceUrl = configurationService.getProperty("dspace.ui.url");
+        String newDspaceUrl = currentDspaceUrl + "/subdir";
+        // Add a /subdir to the url for this test
+        configurationService.setProperty("dspace.ui.url", newDspaceUrl);
+        String expectedUrl = newDspaceUrl + "/request-a-copy/token";
+        String generatedLink = instance.getLinkTokenEmail("token");
+        // The URLs should match
+        assertEquals(expectedUrl, generatedLink);
+        configurationService.reloadConfig();
     }
 }


### PR DESCRIPTION
Ensure DSpace URLs with extra segments are included fully in the generated link, instead of replacing all segments so that just the hostname and port are in the generated link (some dspace.ui.url values may have /sub/paths/)

## References
* Fixes #9667 

## Description
URIBuilder is still used to build the URL but instead of using `setPathSegments(...)`, I use `getPath()`, trim any trailing slash, and concatenate with `/request-a-copy/{token}` in `setPath(...)`.

## Instructions for Reviewers
To reproduce in main branch:
1. Set `dspace.ui.url` (backend) and `dspace.ui.nameSpace` (frontend) so that the frontend URL includes an extra URL segment like "http://localhost:4000/dspace". (also, update `rest.cors.allowed-origins` to include http://localhost:4000 as an additional allowed origin)
2. Enable request-a-copy and disable mail server (`mail.server.disabled=true`) so that mails will be logged instead of sent
3. Request a restricted file and inspect the link in the logged email: the link with the token for the approver will not contain the /dspace/ segment

To test the fix:
1. Repeat previous steps with this PR applied
2. This time when you inspect the link in the logged email, the /dspace/ segment should appear, and the link will work

List of changes in this PR:
* Updated `RequestItemRepository#getLinkTokenEmail` to build URIs using the existing full path instead of replacing segments, and made this a public method for testing
* Added new `RequestItemRepositoryIT#testGetLinkTokenEmail` test to the integration tests for this repository

Didn't see a big issue with making the method public, even if it is just so I can call it from the IT (but if there is something else we should do while we're changing it, like move it to RequestItemService, or a utility class, let me know)

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
