### PR TITLE
DataCite DOI error fixes

### DIFF
--- a/dspace-api/src/main/java/org/dspace/identifier/DOIIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/DOIIdentifierProvider.java
@@ -70,6 +70,7 @@ public class DOIIdentifierProvider extends FilteredIdentifierProvider {
     static final char SLASH = '/';
 
     // Metadata field name elements
+    // Warning: If this metadata field is changed for whatever reason, DIM2DataCite.xsl's template needs to reflect this
     // TODO: move these to MetadataSchema or some such?
     public static final String MD_SCHEMA = "dc";
     public static final String DOI_ELEMENT = "identifier";

--- a/dspace-api/src/main/java/org/dspace/identifier/DOIIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/DOIIdentifierProvider.java
@@ -70,7 +70,6 @@ public class DOIIdentifierProvider extends FilteredIdentifierProvider {
     static final char SLASH = '/';
 
     // Metadata field name elements
-    // Warning: If this metadata field is changed for whatever reason, DIM2DataCite.xsl's template needs to reflect this
     // TODO: move these to MetadataSchema or some such?
     public static final String MD_SCHEMA = "dc";
     public static final String DOI_ELEMENT = "identifier";

--- a/dspace-api/src/main/java/org/dspace/identifier/doi/DataCiteConnector.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/doi/DataCiteConnector.java
@@ -7,6 +7,10 @@
  */
 package org.dspace.identifier.doi;
 
+import static org.dspace.identifier.DOIIdentifierProvider.DOI_ELEMENT;
+import static org.dspace.identifier.DOIIdentifierProvider.DOI_QUALIFIER;
+import static org.dspace.identifier.DOIIdentifierProvider.MD_SCHEMA;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -384,6 +388,10 @@ public class DataCiteConnector
             parameters.put("hostinginstitution",
                            configurationService.getProperty(CFG_HOSTINGINSTITUTION));
         }
+        parameters.put("mdSchema", MD_SCHEMA);
+        parameters.put("mdElement", DOI_ELEMENT);
+        // Pass an empty string for qualifier if the metadata field doesn't have any
+        parameters.put("mdQualifier", DOI_QUALIFIER);
 
         Element root = null;
         try {

--- a/dspace-api/src/main/java/org/dspace/identifier/doi/DataCiteConnector.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/doi/DataCiteConnector.java
@@ -15,6 +15,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
@@ -410,7 +411,7 @@ public class DataCiteConnector
         }
 
         String metadataDOI = extractDOI(root);
-        if (null == metadataDOI) {
+        if (StringUtils.isBlank(metadataDOI)) {
             // The DOI will be saved as metadata of dso after successful
             // registration. To register a doi it has to be part of the metadata
             // sent to DataCite. So we add it to the XML we'll send to DataCite

--- a/dspace/config/crosswalks/DIM2DataCite.xsl
+++ b/dspace/config/crosswalks/DIM2DataCite.xsl
@@ -333,7 +333,8 @@
         company as well. We have to ensure to use URIs of our prefix
         as primary identifiers only.
     -->
-    <xsl:template match="dspace:field[@mdschema='dc' and @element='identifier' and @qualifier and (contains(., $prefix))]">
+    <!-- Warning: If the metadata field changes for whatever reason, DOIIdentifierProvider needs to reflect this -->
+    <xsl:template match="dspace:field[@mdschema='dc' and @element='identifier' and @qualifier='uri' and (contains(., $prefix))]">
         <identifier identifierType="DOI">
             <xsl:if test="starts-with(string(text()), 'https://doi.org/')">
                 <xsl:value-of select="substring(., 17)"/>

--- a/dspace/config/crosswalks/DIM2DataCite.xsl
+++ b/dspace/config/crosswalks/DIM2DataCite.xsl
@@ -36,6 +36,10 @@
     <xsl:param name="hostinginstitution"><xsl:value-of select="$publisher" /></xsl:param>
     <!-- Please take a look into the DataCite schema documentation if you want to know how to use these elements.
          http://schema.datacite.org -->
+    <!-- Metadata-field to retrieve DOI from items -->
+    <xsl:param name="mdSchema">dc</xsl:param>
+    <xsl:param name="mdElement">identifier</xsl:param>
+    <xsl:param name="mdQualifier">uri</xsl:param>
 
     <xsl:output method="xml" indent="yes" encoding="utf-8" />
 
@@ -333,16 +337,17 @@
         company as well. We have to ensure to use URIs of our prefix
         as primary identifiers only.
     -->
-    <!-- Warning: If the metadata field changes for whatever reason, DOIIdentifierProvider needs to reflect this -->
-    <xsl:template match="dspace:field[@mdschema='dc' and @element='identifier' and @qualifier='uri' and (contains(., $prefix))]">
-        <identifier identifierType="DOI">
-            <xsl:if test="starts-with(string(text()), 'https://doi.org/')">
-                <xsl:value-of select="substring(., 17)"/>
-            </xsl:if>
-            <xsl:if test="starts-with(string(text()), 'http://dx.doi.org/')">
-                <xsl:value-of select="substring(., 19)"/>
-            </xsl:if>
-        </identifier>
+    <xsl:template match="dspace:field[@mdschema=$mdSchema and @element=$mdElement and (contains(., $prefix))]">
+        <xsl:if test="(($mdQualifier and $mdQualifier != '') and @qualifier=$mdQualifier) or ((not($mdQualifier) or $mdQualifier = '') and not(@qualifier))">
+            <identifier identifierType="DOI">
+                <xsl:if test="starts-with(string(text()), 'https://doi.org/')">
+                    <xsl:value-of select="substring(., 17)"/>
+                </xsl:if>
+                <xsl:if test="starts-with(string(text()), 'http://dx.doi.org/')">
+                    <xsl:value-of select="substring(., 19)"/>
+                </xsl:if>
+            </identifier>
+        </xsl:if>
     </xsl:template>
 
     <!-- DataCite (2) :: Creator -->


### PR DESCRIPTION
## References
* Fixes #9641 

## Description
`DIM2DataCite.xsl` matched against `dc.identifier.*` to retrieve the DOI from the item's metadata, but this caused the DOI to be empty sometimes (not null), when it was present in another identifier field, but not properly structured (e.g. in the middle of a `dc.identifier.citation`).
This PR aims to fix the issue by specifying `dc.identifier.uri` in the xsl, as well as a fallback change inside `DataCiteConnector` to catch empty values and retrieve the DOI from the database instead (it already did this for null values, but not empty strings).

## Instructions for Reviewers
List of changes in this PR:
* Changed xsl match to target just `dc.identifier.uri`
* Added fallback to empty strings

How to test:
* Setup DOI DataCite registration ([docs](https://wiki.lyrasis.org/display/DSDOC7x/DOI+Digital+Object+Identifier))
* Submit an item and ensure the new DOI is present in the "doi" database table
* Add metadata to the item for `dc.identifier.citation` containing a DOI using the configured prefix, but excluding the URI part (e.g. _without_ "https://doi.org/")
* Run script `doi-organiser -u`

Before my changes, this script would produce errors because it finds a metadata value containing a DOI, but since it's not structured like a uri, it'll return an empty string and cause an error.
After my changes, it should ignore all other identifier fields.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
