### PR TITLE
Crossref metadata import: change order of person name parts

### DIFF
--- a/dspace-api/src/main/java/org/dspace/importer/external/crossref/CrossRefAuthorMetadataProcessor.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/crossref/CrossRefAuthorMetadataProcessor.java
@@ -42,8 +42,8 @@ public class CrossRefAuthorMetadataProcessor implements JsonPathMetadataProcesso
             JsonNode author = authors.next();
             String givenName = author.at("/given").textValue();
             String familyName = author.at("/family").textValue();
-            if (StringUtils.isNoneBlank(givenName) && StringUtils.isNoneBlank(familyName)) {
-                values.add(givenName + " " + familyName);
+            if (StringUtils.isNotBlank(givenName) && StringUtils.isNotBlank(familyName)) {
+                values.add(familyName.trim() + ", " + givenName.trim());
             }
         }
         return values;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CrossRefImportMetadataSourceServiceIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CrossRefImportMetadataSourceServiceIT.java
@@ -162,7 +162,7 @@ public class CrossRefImportMetadataSourceServiceIT extends AbstractLiveImportInt
         MetadatumDTO title = createMetadatumDTO("dc", "title", null,
                 "State of Awareness of Freshers’ Groups Chortkiv State"
                 + " Medical College of Prevention of Iodine Deficiency Diseases");
-        MetadatumDTO author = createMetadatumDTO("dc", "contributor", "author", "L.V. Senyuk");
+        MetadatumDTO author = createMetadatumDTO("dc", "contributor", "author", "Senyuk, L.V.");
         MetadatumDTO type = createMetadatumDTO("dc", "type", null, "journal-article");
         MetadatumDTO date = createMetadatumDTO("dc", "date", "issued", "2016-05-19");
         MetadatumDTO ispartof = createMetadatumDTO("dc", "relation", "ispartof",
@@ -191,7 +191,7 @@ public class CrossRefImportMetadataSourceServiceIT extends AbstractLiveImportInt
         List<MetadatumDTO> metadatums2  = new ArrayList<MetadatumDTO>();
         MetadatumDTO title2 = createMetadatumDTO("dc", "title", null,
                 "Ischemic Heart Disease and Role of Nurse of Cardiology Department");
-        MetadatumDTO author2 = createMetadatumDTO("dc", "contributor", "author", "K. І. Kozak");
+        MetadatumDTO author2 = createMetadatumDTO("dc", "contributor", "author", "Kozak, K. І.");
         MetadatumDTO type2 = createMetadatumDTO("dc", "type", null, "journal-article");
         MetadatumDTO date2 = createMetadatumDTO("dc", "date", "issued", "2016-05-19");
         MetadatumDTO ispartof2 = createMetadatumDTO("dc", "relation", "ispartof",


### PR DESCRIPTION
## Description

The handling of person (i.e., author and editor) name parts differs in Scopus and Crossref metadata import. 

The **Scopus** import creates metadata fields (`dc.contributor.author` / `dc.contributor.editor`) with values of the form `familyName, givenName`. 

In contrast, the **Crossref** import creates field values of the form `givenName familyName`.

This PR changes the order of person (i.e., author and editor) name parts in the **Crossref** import to `familyName, givenName`. 