### PR TITLE
Fix random test failures in LinksetRestControllerIT and ManageGroupsFeatureIT

### DIFF
--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/ManageGroupsFeatureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/ManageGroupsFeatureIT.java
@@ -176,7 +176,7 @@ public class ManageGroupsFeatureIT extends AbstractControllerIntegrationTest {
 
         // Verify an ePerson in a subgroup of the site administrators has this feature
         getClient(token).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
-            + "http://localhost/api/core/sites/" + siteService.findSite(context).getID()))
+            + "http://localhost/api/core/sites/" + siteService.findSite(context).getID() + "&feature=canManageGroups"))
             .andExpect(status().isOk())
             .andExpect(
                 jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='canManageGroups')]")
@@ -285,7 +285,7 @@ public class ManageGroupsFeatureIT extends AbstractControllerIntegrationTest {
 
         // Verify an ePerson in a sub-subgroup of the site administrators has this feature
         getClient(token).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
-            + "http://localhost/api/core/sites/" + siteService.findSite(context).getID()))
+            + "http://localhost/api/core/sites/" + siteService.findSite(context).getID() + "&feature=canManageGroups"))
             .andExpect(status().isOk())
             .andExpect(
                 jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='canManageGroups')]")
@@ -502,7 +502,7 @@ public class ManageGroupsFeatureIT extends AbstractControllerIntegrationTest {
 
         // Verify an ePerson in a subgroup of the site administrators has this feature
         getClient(token).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
-            + "http://localhost/api/core/sites/" + siteService.findSite(context).getID()))
+            + "http://localhost/api/core/sites/" + siteService.findSite(context).getID() + "&feature=canManageGroups"))
             .andExpect(status().isOk())
             .andExpect(
                 jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='canManageGroups')]")
@@ -636,7 +636,7 @@ public class ManageGroupsFeatureIT extends AbstractControllerIntegrationTest {
 
         // Verify an ePerson in a sub-subgroup of the site administrators has this feature
         getClient(token).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
-            + "http://localhost/api/core/sites/" + siteService.findSite(context).getID()))
+            + "http://localhost/api/core/sites/" + siteService.findSite(context).getID() + "&feature=canManageGroups"))
             .andExpect(status().isOk())
             .andExpect(
                 jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='canManageGroups')]")
@@ -897,7 +897,7 @@ public class ManageGroupsFeatureIT extends AbstractControllerIntegrationTest {
 
         // Verify an ePerson in a subgroup of the site administrators has this feature
         getClient(token).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
-            + "http://localhost/api/core/sites/" + siteService.findSite(context).getID()))
+            + "http://localhost/api/core/sites/" + siteService.findSite(context).getID() + "&feature=canManageGroups"))
             .andExpect(status().isOk())
             .andExpect(
                 jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='canManageGroups')]")
@@ -1051,7 +1051,7 @@ public class ManageGroupsFeatureIT extends AbstractControllerIntegrationTest {
 
         // Verify an ePerson in a sub-subgroup of the site administrators has this feature
         getClient(token).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
-            + "http://localhost/api/core/sites/" + siteService.findSite(context).getID()))
+            + "http://localhost/api/core/sites/" + siteService.findSite(context).getID() + "&feature=canManageGroups"))
             .andExpect(status().isOk())
             .andExpect(
                 jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='canManageGroups')]")
@@ -1352,7 +1352,7 @@ public class ManageGroupsFeatureIT extends AbstractControllerIntegrationTest {
 
         // Verify an ePerson in a subgroup of the site administrators has this feature
         getClient(token).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
-            + "http://localhost/api/core/sites/" + siteService.findSite(context).getID()))
+            + "http://localhost/api/core/sites/" + siteService.findSite(context).getID() + "&feature=canManageGroups"))
             .andExpect(status().isOk())
             .andExpect(
                 jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='canManageGroups')]")
@@ -1526,7 +1526,7 @@ public class ManageGroupsFeatureIT extends AbstractControllerIntegrationTest {
 
         // Verify an ePerson in a sub-subgroup of the site administrators has this feature
         getClient(token).perform(get("/api/authz/authorizations/search/object?embed=feature&uri="
-            + "http://localhost/api/core/sites/" + siteService.findSite(context).getID()))
+            + "http://localhost/api/core/sites/" + siteService.findSite(context).getID() + "&feature=canManageGroups"))
             .andExpect(status().isOk())
             .andExpect(
                 jsonPath("$._embedded.authorizations[?(@._embedded.feature.id=='canManageGroups')]")

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/signposting/controller/LinksetRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/signposting/controller/LinksetRestControllerIT.java
@@ -41,15 +41,12 @@ import org.dspace.content.MetadataSchemaEnum;
 import org.dspace.content.RelationshipType;
 import org.dspace.content.WorkspaceItem;
 import org.dspace.content.authority.Choices;
-import org.dspace.content.authority.service.ChoiceAuthorityService;
-import org.dspace.content.authority.service.MetadataAuthorityService;
 import org.dspace.content.service.BitstreamService;
 import org.dspace.content.service.ItemService;
 import org.dspace.content.service.RelationshipTypeService;
 import org.dspace.core.Constants;
 import org.dspace.eperson.Group;
 import org.dspace.services.ConfigurationService;
-import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.util.SimpleMapConverter;
 import org.hamcrest.Matchers;
 import org.junit.Before;
@@ -67,12 +64,6 @@ public class LinksetRestControllerIT extends AbstractControllerIntegrationTest {
 
     @Autowired
     private ConfigurationService configurationService;
-
-    @Autowired
-    private MetadataAuthorityService metadataAuthorityService;
-
-    @Autowired
-    private ChoiceAuthorityService choiceAuthorityService;
 
     @Autowired
     private ItemService itemService;
@@ -736,10 +727,6 @@ public class LinksetRestControllerIT extends AbstractControllerIntegrationTest {
                 .andExpect(jsonPath("$[?(@.href == '" + uiUrl + "/signposting/linksets/" + item.getID() + "/json" +
                         "' && @.rel == 'linkset' " +
                         "&& @.type == 'application/linkset+json')]").exists());
-
-        DSpaceServicesFactory.getInstance().getConfigurationService().reloadConfig();
-        metadataAuthorityService.clearCache();
-        choiceAuthorityService.clearCache();
     }
 
     @Test
@@ -781,10 +768,6 @@ public class LinksetRestControllerIT extends AbstractControllerIntegrationTest {
                         "&& @.type == 'application/linkset+json')]").exists())
                 .andExpect(jsonPath("$[?(@.href == 'https://schema.org/ScholarlyArticle' " +
                         "&& @.rel == 'type')]").exists());
-
-        DSpaceServicesFactory.getInstance().getConfigurationService().reloadConfig();
-        metadataAuthorityService.clearCache();
-        choiceAuthorityService.clearCache();
     }
 
     @Test
@@ -814,10 +797,6 @@ public class LinksetRestControllerIT extends AbstractControllerIntegrationTest {
 
         getClient().perform(get("/signposting/links/" + bitstream.getID()))
                 .andExpect(status().isUnauthorized());
-
-        DSpaceServicesFactory.getInstance().getConfigurationService().reloadConfig();
-        metadataAuthorityService.clearCache();
-        choiceAuthorityService.clearCache();
     }
 
     @Test
@@ -845,10 +824,6 @@ public class LinksetRestControllerIT extends AbstractControllerIntegrationTest {
 
         getClient().perform(get("/signposting/links/" + bitstream.getID()))
                 .andExpect(status().isUnauthorized());
-
-        DSpaceServicesFactory.getInstance().getConfigurationService().reloadConfig();
-        metadataAuthorityService.clearCache();
-        choiceAuthorityService.clearCache();
     }
 
     @Test
@@ -875,10 +850,6 @@ public class LinksetRestControllerIT extends AbstractControllerIntegrationTest {
 
         getClient().perform(get("/signposting/links/" + bitstream.getID()))
                 .andExpect(status().isUnauthorized());
-
-        DSpaceServicesFactory.getInstance().getConfigurationService().reloadConfig();
-        metadataAuthorityService.clearCache();
-        choiceAuthorityService.clearCache();
     }
 
     @Test
@@ -891,10 +862,6 @@ public class LinksetRestControllerIT extends AbstractControllerIntegrationTest {
 
         getClient().perform(get("/signposting/links/" + item.getID()))
                 .andExpect(status().isUnauthorized());
-
-        DSpaceServicesFactory.getInstance().getConfigurationService().reloadConfig();
-        metadataAuthorityService.clearCache();
-        choiceAuthorityService.clearCache();
     }
 
     @Test


### PR DESCRIPTION
## Description

In recent CI builds, we are seeing some random failures coming from two ITs:

1. Failures in `LinksetRestControllerIT` which look like this:
    ```
    [INFO] Running org.dspace.app.rest.signposting.controller.LinksetRestControllerIT
    Error:  Tests run: 41, Failures: 0, Errors: 18, Skipped: 0, Time elapsed: 9.099 s <<< FAILURE! - in 
    org.dspace.app.rest.signposting.controller.LinksetRestControllerIT
    Error:  findTypedLinkForBitstreamWithType(org.dspace.app.rest.signposting.controller.LinksetRestControllerIT)  Time elapsed: 0.292 s  <<< ERROR!
    java.lang.NullPointerException
	at org.dspace.content.authority.ChoiceAuthorityServiceImpl.clearCache(ChoiceAuthorityServiceImpl.java:273)
	at org.dspace.app.rest.signposting.controller.LinksetRestControllerIT.findTypedLinkForBitstreamWithType(LinksetRestControllerIT.java:786)
	...
    ```
    * The `NullPointerException` appears to occur when the `ChoiceAuthorityServiceImpl` has **not yet been initialized**.  The NPE appears randomly as it depends on the order in which ITs are run.  If that `ChoiceAuthorityServiceImpl` has been initialized by a different IT, then this code succeeds. If not, then it fails with an NPE.
        * Strangely, `LinksetRestControllerIT` does NOT even use this service, so there's no need to call it at all.
    * This PR removes unused services & unnecessary cache cleanup from `LinksetRestControllerIT`.  Some tests appear to do cleanup which is unnecessary & I've removed the unnecessary code.
2. Failures in `ManageGroupsFeatureIT` which look like this:
    ```
    [INFO] Running org.dspace.app.rest.authorization.ManageGroupsFeatureIT
    Error:  Tests run: 76, Failures: 24, Errors: 0, Skipped: 0, Time elapsed: 16.88 s <<< FAILURE! -- in 
    org.dspace.app.rest.authorization.ManageGroupsFeatureIT
    Error:  org.dspace.app.rest.authorization.ManageGroupsFeatureIT.testSubGroupOfAdminGroup -- Time elapsed: 0.217 s <<< FAILURE!
    java.lang.AssertionError: No value at JSON path "$._embedded.authorizations[?(@._embedded.feature.id=='canManageGroups')]"
    ```
    * In this situation, the failure is caused by pagination, where the `canManageGroups` feature is returned on page 2 of the results, while the test _assumes_ it will always be on the first page.  This pagination issue occurs mostly for full Administrator tests, because Admins have a larger number of "features" returned.
    * This PR fixes the issue by updating all Admin tests to use `&feature=canManageGroups` parameter to filter by the feature we are looking for.  This ensures it will never be on page 2.


## Instructions for Reviewers
* No code in DSpace was changed. Only ITs (`LinksetRestControllerIT` and `ManageGroupsFeatureIT`) were modified.  Simply review the code and verify that tests are succeeding in GitHub Actions.
