### PR TITLE
Support for multiple input files per process

### DIFF
--- a/dspace-api/src/main/java/org/dspace/scripts/DSpaceRunnable.java
+++ b/dspace-api/src/main/java/org/dspace/scripts/DSpaceRunnable.java
@@ -10,6 +10,7 @@ package org.dspace.scripts;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.apache.commons.cli.CommandLine;
@@ -207,5 +208,9 @@ public abstract class DSpaceRunnable<T extends ScriptConfiguration> implements R
 
     public enum StepResult {
         Continue, Exit;
+    }
+
+    public Optional<String> fileParameterToBitstreamType(String fileParameter) {
+        return Optional.empty();
     }
 }

--- a/dspace-api/src/main/java/org/dspace/scripts/DSpaceRunnable.java
+++ b/dspace-api/src/main/java/org/dspace/scripts/DSpaceRunnable.java
@@ -210,6 +210,14 @@ public abstract class DSpaceRunnable<T extends ScriptConfiguration> implements R
         Continue, Exit;
     }
 
+    /*
+     * This method can optionally be overridden by the implementing class to provide an actual 'type' for a file
+     * parameter. By default, all file parameters are given the 'inputfile' type.
+     * This method can be used to provide a more specific type for a file parameter.
+     * Which is especially useful for scripts that should take multiple file parameters.
+     *
+     * @param fileParameter the file parameter passed to the script, e.g. 'example.pdf'
+     */
     public Optional<String> fileParameterToBitstreamType(String fileParameter) {
         return Optional.empty();
     }

--- a/dspace-api/src/main/java/org/dspace/scripts/ProcessServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/scripts/ProcessServiceImpl.java
@@ -175,10 +175,6 @@ public class ProcessServiceImpl implements ProcessService {
     public void appendFile(Context context, Process process, InputStream is, String type, String fileName)
         throws IOException, SQLException, AuthorizeException {
         Bitstream bitstream = bitstreamService.create(context, is);
-        if (getBitstream(context, process, type) != null) {
-            throw new IllegalArgumentException("Cannot create another file of type: " + type + " for this process" +
-                                                   " with id: " + process.getID());
-        }
         bitstream.setName(context, fileName);
         bitstreamService.setFormat(context, bitstream, bitstreamFormatService.guessFormat(context, bitstream));
         MetadataField dspaceProcessFileTypeField = metadataFieldService

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ScriptRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ScriptRestRepository.java
@@ -154,7 +154,7 @@ public class ScriptRestRepository extends DSpaceRestRepository<ScriptRest, Strin
             dSpaceRunnable.initialize(args.toArray(new String[0]), restDSpaceRunnableHandler, context.getCurrentUser());
             if (files != null && !files.isEmpty()) {
                 checkFileNames(dSpaceRunnable, files);
-                processFiles(context, restDSpaceRunnableHandler, files);
+                processFiles(context, restDSpaceRunnableHandler, files, dSpaceRunnable);
             }
             restDSpaceRunnableHandler.schedule(dSpaceRunnable);
         } catch (ParseException e) {
@@ -171,11 +171,12 @@ public class ScriptRestRepository extends DSpaceRestRepository<ScriptRest, Strin
     }
 
     private void processFiles(Context context, RestDSpaceRunnableHandler restDSpaceRunnableHandler,
-                              List<MultipartFile> files)
-        throws IOException, SQLException, AuthorizeException {
+                              List<MultipartFile> files, DSpaceRunnable dspaceRunnable)
+            throws IOException, SQLException, AuthorizeException {
         for (MultipartFile file : files) {
-            restDSpaceRunnableHandler
-                .writeFilestream(context, file.getOriginalFilename(), file.getInputStream(), "inputfile");
+            String type = (String) dspaceRunnable.fileParameterToBitstreamType(file.getName())
+                                                          .orElse("inputfile");
+            restDSpaceRunnableHandler.writeFilestream(context, file.getOriginalFilename(), file.getInputStream(), type);
         }
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ScriptRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ScriptRestRepository.java
@@ -174,7 +174,7 @@ public class ScriptRestRepository extends DSpaceRestRepository<ScriptRest, Strin
                               List<MultipartFile> files, DSpaceRunnable dspaceRunnable)
             throws IOException, SQLException, AuthorizeException {
         for (MultipartFile file : files) {
-            String type = (String) dspaceRunnable.fileParameterToBitstreamType(file.getName())
+            String type = (String) dspaceRunnable.fileParameterToBitstreamType(file.getOriginalFilename())
                                                           .orElse("inputfile");
             restDSpaceRunnableHandler.writeFilestream(context, file.getOriginalFilename(), file.getInputStream(), type);
         }

--- a/dspace-server-webapp/src/test/java/org/dspace/scripts/impl/MockDSpaceRunnableScript.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/scripts/impl/MockDSpaceRunnableScript.java
@@ -7,7 +7,10 @@
  */
 package org.dspace.scripts.impl;
 
+import java.util.Optional;
+
 import org.apache.commons.cli.ParseException;
+import org.apache.commons.lang3.StringUtils;
 import org.dspace.scripts.DSpaceRunnable;
 import org.dspace.scripts.MockDSpaceRunnableScriptConfiguration;
 import org.dspace.utils.DSpace;
@@ -32,5 +35,12 @@ public class MockDSpaceRunnableScript extends DSpaceRunnable<MockDSpaceRunnableS
         if (!commandLine.hasOption("i")) {
             throw new ParseException("-i is a mandatory parameter");
         }
+    }
+
+    @Override
+    public Optional<String> fileParameterToBitstreamType(String fileParameter) {
+        // Return the type of the file if possible
+        String extension = StringUtils.substringAfterLast(fileParameter, ".");
+        return StringUtils.isNotBlank(extension) ? Optional.of(extension) : Optional.empty();
     }
 }


### PR DESCRIPTION
## References
* Fixes #9695

## Description
Introduces a new `fileParameterToBitstreamType` method in the DSpaceRunnable class.
This method is then used in `ScriptRestRepository#processFiles` to set the type of the file being processed.
Instead of hardcoding all files to "inputfile" like done before. (we still default to this if method isn't implemented by the script)

## Instructions for Reviewers
In any script, override the `fileParameterToBitstreamType` method and implement it to set the type based on the file name (or some other way). Verify multiple inputfiles can be upload on a process now as long as they differ in type.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
