### PR TITLE
Docker build: fix FromAsCasing warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ARG JDK_VERSION=17
 ARG DSPACE_VERSION=latest
 
 # Step 1 - Run Maven Build
-FROM dspace/dspace-dependencies:${DSPACE_VERSION} as build
+FROM dspace/dspace-dependencies:${DSPACE_VERSION} AS build
 ARG TARGET_DIR=dspace-installer
 WORKDIR /app
 # The dspace-installer directory will be written to /install
@@ -31,7 +31,7 @@ RUN mvn --no-transfer-progress package ${MAVEN_FLAGS} && \
 RUN rm -rf /install/webapps/server/
 
 # Step 2 - Run Ant Deploy
-FROM eclipse-temurin:${JDK_VERSION} as ant_build
+FROM eclipse-temurin:${JDK_VERSION} AS ant_build
 ARG TARGET_DIR=dspace-installer
 # COPY the /install directory from 'build' container to /dspace-src in this container
 COPY --from=build /install /dspace-src

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -9,7 +9,7 @@ ARG JDK_VERSION=17
 ARG DSPACE_VERSION=latest
 
 # Step 1 - Run Maven Build
-FROM dspace/dspace-dependencies:${DSPACE_VERSION} as build
+FROM dspace/dspace-dependencies:${DSPACE_VERSION} AS build
 ARG TARGET_DIR=dspace-installer
 WORKDIR /app
 # The dspace-installer directory will be written to /install
@@ -25,7 +25,7 @@ RUN mvn --no-transfer-progress package && \
   mvn clean
 
 # Step 2 - Run Ant Deploy
-FROM eclipse-temurin:${JDK_VERSION} as ant_build
+FROM eclipse-temurin:${JDK_VERSION} AS ant_build
 ARG TARGET_DIR=dspace-installer
 # COPY the /install directory from 'build' container to /dspace-src in this container
 COPY --from=build /install /dspace-src

--- a/Dockerfile.dependencies
+++ b/Dockerfile.dependencies
@@ -7,7 +7,7 @@
 ARG JDK_VERSION=17
 
 # Step 1 - Run Maven Build
-FROM maven:3-eclipse-temurin-${JDK_VERSION} as build
+FROM maven:3-eclipse-temurin-${JDK_VERSION} AS build
 ARG TARGET_DIR=dspace-installer
 WORKDIR /app
 # Create the 'dspace' user account & home directory

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -11,7 +11,7 @@ ARG JDK_VERSION=17
 ARG DSPACE_VERSION=latest
 
 # Step 1 - Run Maven Build
-FROM dspace/dspace-dependencies:${DSPACE_VERSION} as build
+FROM dspace/dspace-dependencies:${DSPACE_VERSION} AS build
 ARG TARGET_DIR=dspace-installer
 WORKDIR /app
 # The dspace-installer directory will be written to /install
@@ -30,7 +30,7 @@ RUN mvn --no-transfer-progress package && \
 RUN rm -rf /install/webapps/server/
 
 # Step 2 - Run Ant Deploy
-FROM eclipse-temurin:${JDK_VERSION} as ant_build
+FROM eclipse-temurin:${JDK_VERSION} AS ant_build
 ARG TARGET_DIR=dspace-installer
 # COPY the /install directory from 'build' container to /dspace-src in this container
 COPY --from=build /install /dspace-src


### PR DESCRIPTION
## Description

This PR fixes warn messages that occur when the Docker image is being built: 

```
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 13)                
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 35)                                                                                                                                                                                                                                            ```