### PR TITLE
Fix issue where CSV Import / Export can clear metadata if there are metadata values with language "*" (Item.ANY)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/administer/StructBuilder.java
+++ b/dspace-api/src/main/java/org/dspace/administer/StructBuilder.java
@@ -802,7 +802,7 @@ public class StructBuilder {
 
             // default the short description to the empty string
             collectionService.setMetadataSingleValue(context, collection,
-                    MD_SHORT_DESCRIPTION, Item.ANY, " ");
+                    MD_SHORT_DESCRIPTION, null, " ");
 
             // import the rest of the metadata
             for (Map.Entry<String, MetadataFieldName> entry : collectionMap.entrySet()) {

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/DSpaceCSV.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/DSpaceCSV.java
@@ -188,6 +188,15 @@ public class DSpaceCSV implements Serializable {
                     // Verify that the heading is valid in the metadata registry
                     String[] clean = element.split("\\[");
                     String[] parts = clean[0].split("\\.");
+                    // Check language if present, if it's ANY then throw an exception
+                    if (clean.length > 1 && clean[1].equals(Item.ANY + "]")) {
+                        throw new MetadataImportInvalidHeadingException("Language ANY (*) was found in the heading " +
+                                                                                "of the metadata value to import, " +
+                                                                                "this should never be the case",
+                                                                        MetadataImportInvalidHeadingException.ENTRY,
+                                                                        columnCounter);
+
+                    }
 
                     if (parts.length < 2) {
                         throw new MetadataImportInvalidHeadingException(element,
@@ -221,6 +230,15 @@ public class DSpaceCSV implements Serializable {
                                                                                 .ELEMENT,
                                                                             columnCounter);
                         }
+                    }
+
+                    // Verify there isn’t already a header that is the same; if it already exists,
+                    // throw MetadataImportInvalidHeadingException
+                    String header = authorityPrefix + element;
+                    if (headings.contains(header)) {
+                        throw new MetadataImportInvalidHeadingException("Duplicate heading found: " + header,
+                                                                        MetadataImportInvalidHeadingException.ENTRY,
+                                                                        columnCounter);
                     }
 
                     // Store the heading

--- a/dspace-api/src/main/java/org/dspace/content/Collection.java
+++ b/dspace-api/src/main/java/org/dspace/content/Collection.java
@@ -229,7 +229,7 @@ public class Collection extends CacheableDSpaceObject implements DSpaceObjectLeg
      * @throws SQLException if database error
      */
     public void setLicense(Context context, String license) throws SQLException {
-        getCollectionService().setMetadataSingleValue(context, this, MD_LICENSE, Item.ANY, license);
+        getCollectionService().setMetadataSingleValue(context, this, MD_LICENSE, null, license);
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/content/MetadataValue.java
+++ b/dspace-api/src/main/java/org/dspace/content/MetadataValue.java
@@ -19,6 +19,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
+import org.apache.commons.lang3.StringUtils;
 import org.dspace.core.Context;
 import org.dspace.core.HibernateProxyHelper;
 import org.dspace.core.ReloadableEntity;
@@ -139,6 +140,9 @@ public class MetadataValue implements ReloadableEntity<Integer> {
      * @param language new language
      */
     public void setLanguage(String language) {
+        if (StringUtils.equals(language, Item.ANY)) {
+            language = null;
+        }
         this.language = language;
     }
 

--- a/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataImportIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataImportIT.java
@@ -76,6 +76,31 @@ public class MetadataImportIT extends AbstractIntegrationTestWithDatabase {
     }
 
     @Test
+    public void metadataImportTestWithDuplicateHeader() {
+        String[] csv = {"id,collection,dc.title,dc.title,dc.contributor.author",
+            "+," + collection.getHandle() + ",\"Test Import 1\",\"Test Import 2\"," + "\"Donald, SmithImported\"," +
+            "+," + collection.getHandle() + ",\"Test Import 3\",\"Test Import 4\"," + "\"Donald, SmithImported\""};
+        // Should throw an exception because of duplicate header
+        try {
+            performImportScript(csv);
+        } catch (Exception e) {
+            assertTrue(e instanceof MetadataImportInvalidHeadingException);
+        }
+    }
+
+    @Test
+    public void metadataImportTestWithAnyLanguage() {
+        String[] csv = {"id,collection,dc.title[*],dc.contributor.author",
+            "+," + collection.getHandle() + ",\"Test Import 1\"," + "\"Donald, SmithImported\""};
+        // Should throw an exception because of invalid ANY language (*) in metadata field
+        try {
+            performImportScript(csv);
+        } catch (Exception e) {
+            assertTrue(e instanceof MetadataImportInvalidHeadingException);
+        }
+    }
+
+    @Test
     public void metadataImportTest() throws Exception {
         String[] csv = {"id,collection,dc.title,dc.contributor.author",
             "+," + collection.getHandle() + ",\"Test Import 1\"," + "\"Donald, SmithImported\""};
@@ -230,7 +255,7 @@ public class MetadataImportIT extends AbstractIntegrationTestWithDatabase {
                 itemService.getMetadata(item, "dc", "contributor", "author", Item.ANY).get(0).getValue(),
                 "TestAuthorToRemove"));
 
-        String[] csv = {"id,collection,dc.title,dc.contributor.author[*]",
+        String[] csv = {"id,collection,dc.title,dc.contributor.author",
             item.getID().toString() + "," + personCollection.getHandle() + "," + item.getName() + ","};
         performImportScript(csv);
         item = findItemByName(itemTitle);

--- a/dspace-api/src/test/java/org/dspace/builder/AbstractDSpaceObjectBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/AbstractDSpaceObjectBuilder.java
@@ -18,7 +18,6 @@ import org.apache.logging.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.ResourcePolicy;
 import org.dspace.content.DSpaceObject;
-import org.dspace.content.Item;
 import org.dspace.content.service.DSpaceObjectService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
@@ -103,7 +102,7 @@ public abstract class AbstractDSpaceObjectBuilder<T extends DSpaceObject>
                                                                                   final String qualifier,
                                                                                   final String value) {
         try {
-            getService().setMetadataSingleValue(context, dso, schema, element, qualifier, Item.ANY, value);
+            getService().setMetadataSingleValue(context, dso, schema, element, qualifier, null, value);
         } catch (Exception e) {
             return handleException(e);
         }

--- a/dspace-api/src/test/java/org/dspace/content/ItemComparatorTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/ItemComparatorTest.java
@@ -141,37 +141,37 @@ public class ItemComparatorTest extends AbstractUnitTest {
         assertTrue("testCompare 0", result == 0);
 
         ic = new ItemComparator("test", "one", Item.ANY, true);
-        itemService.addMetadata(context, one, "dc", "test", "one", Item.ANY, "1");
+        itemService.addMetadata(context, one, "dc", "test", "one", null, "1");
         result = ic.compare(one, two);
         assertTrue("testCompare 1", result >= 1);
         itemService.clearMetadata(context, one, "dc", "test", "one", Item.ANY);
 
         ic = new ItemComparator("test", "one", Item.ANY, true);
-        itemService.addMetadata(context, two, "dc", "test", "one", Item.ANY, "1");
+        itemService.addMetadata(context, two, "dc", "test", "one", null, "1");
         result = ic.compare(one, two);
         assertTrue("testCompare 2", result <= -1);
         itemService.clearMetadata(context, two, "dc", "test", "one", Item.ANY);
 
         //value in both items
         ic = new ItemComparator("test", "one", Item.ANY, true);
-        itemService.addMetadata(context, one, "dc", "test", "one", Item.ANY, "1");
-        itemService.addMetadata(context, two, "dc", "test", "one", Item.ANY, "2");
+        itemService.addMetadata(context, one, "dc", "test", "one", null, "1");
+        itemService.addMetadata(context, two, "dc", "test", "one", null, "2");
         result = ic.compare(one, two);
         assertTrue("testCompare 3", result <= -1);
         itemService.clearMetadata(context, one, "dc", "test", "one", Item.ANY);
         itemService.clearMetadata(context, two, "dc", "test", "one", Item.ANY);
 
         ic = new ItemComparator("test", "one", Item.ANY, true);
-        itemService.addMetadata(context, one, "dc", "test", "one", Item.ANY, "1");
-        itemService.addMetadata(context, two, "dc", "test", "one", Item.ANY, "1");
+        itemService.addMetadata(context, one, "dc", "test", "one", null, "1");
+        itemService.addMetadata(context, two, "dc", "test", "one", null, "1");
         result = ic.compare(one, two);
         assertTrue("testCompare 4", result == 0);
         itemService.clearMetadata(context, one, "dc", "test", "one", Item.ANY);
         itemService.clearMetadata(context, two, "dc", "test", "one", Item.ANY);
 
         ic = new ItemComparator("test", "one", Item.ANY, true);
-        itemService.addMetadata(context, one, "dc", "test", "one", Item.ANY, "2");
-        itemService.addMetadata(context, two, "dc", "test", "one", Item.ANY, "1");
+        itemService.addMetadata(context, one, "dc", "test", "one", null, "2");
+        itemService.addMetadata(context, two, "dc", "test", "one", null, "1");
         result = ic.compare(one, two);
         assertTrue("testCompare 5", result >= 1);
         itemService.clearMetadata(context, one, "dc", "test", "one", Item.ANY);
@@ -179,60 +179,60 @@ public class ItemComparatorTest extends AbstractUnitTest {
 
         //multiple values (min, max)
         ic = new ItemComparator("test", "one", Item.ANY, true);
-        itemService.addMetadata(context, one, "dc", "test", "one", Item.ANY, "0");
-        itemService.addMetadata(context, one, "dc", "test", "one", Item.ANY, "1");
-        itemService.addMetadata(context, two, "dc", "test", "one", Item.ANY, "2");
-        itemService.addMetadata(context, two, "dc", "test", "one", Item.ANY, "3");
+        itemService.addMetadata(context, one, "dc", "test", "one", null, "0");
+        itemService.addMetadata(context, one, "dc", "test", "one", null, "1");
+        itemService.addMetadata(context, two, "dc", "test", "one", null, "2");
+        itemService.addMetadata(context, two, "dc", "test", "one", null, "3");
         result = ic.compare(one, two);
         assertTrue("testCompare 3", result <= -1);
         itemService.clearMetadata(context, one, "dc", "test", "one", Item.ANY);
         itemService.clearMetadata(context, two, "dc", "test", "one", Item.ANY);
 
         ic = new ItemComparator("test", "one", Item.ANY, true);
-        itemService.addMetadata(context, one, "dc", "test", "one", Item.ANY, "0");
-        itemService.addMetadata(context, one, "dc", "test", "one", Item.ANY, "1");
-        itemService.addMetadata(context, two, "dc", "test", "one", Item.ANY, "-1");
-        itemService.addMetadata(context, two, "dc", "test", "one", Item.ANY, "1");
+        itemService.addMetadata(context, one, "dc", "test", "one", null, "0");
+        itemService.addMetadata(context, one, "dc", "test", "one", null, "1");
+        itemService.addMetadata(context, two, "dc", "test", "one", null, "-1");
+        itemService.addMetadata(context, two, "dc", "test", "one", null, "1");
         result = ic.compare(one, two);
         assertTrue("testCompare 4", result == 0);
         itemService.clearMetadata(context, one, "dc", "test", "one", Item.ANY);
         itemService.clearMetadata(context, two, "dc", "test", "one", Item.ANY);
 
         ic = new ItemComparator("test", "one", Item.ANY, true);
-        itemService.addMetadata(context, one, "dc", "test", "one", Item.ANY, "1");
-        itemService.addMetadata(context, one, "dc", "test", "one", Item.ANY, "2");
-        itemService.addMetadata(context, two, "dc", "test", "one", Item.ANY, "1");
-        itemService.addMetadata(context, two, "dc", "test", "one", Item.ANY, "-1");
+        itemService.addMetadata(context, one, "dc", "test", "one", null, "1");
+        itemService.addMetadata(context, one, "dc", "test", "one", null, "2");
+        itemService.addMetadata(context, two, "dc", "test", "one", null, "1");
+        itemService.addMetadata(context, two, "dc", "test", "one", null, "-1");
         result = ic.compare(one, two);
         assertTrue("testCompare 5", result >= 1);
         itemService.clearMetadata(context, one, "dc", "test", "one", Item.ANY);
         itemService.clearMetadata(context, two, "dc", "test", "one", Item.ANY);
 
         ic = new ItemComparator("test", "one", Item.ANY, false);
-        itemService.addMetadata(context, one, "dc", "test", "one", Item.ANY, "1");
-        itemService.addMetadata(context, one, "dc", "test", "one", Item.ANY, "2");
-        itemService.addMetadata(context, two, "dc", "test", "one", Item.ANY, "2");
-        itemService.addMetadata(context, two, "dc", "test", "one", Item.ANY, "3");
+        itemService.addMetadata(context, one, "dc", "test", "one", null, "1");
+        itemService.addMetadata(context, one, "dc", "test", "one", null, "2");
+        itemService.addMetadata(context, two, "dc", "test", "one", null, "2");
+        itemService.addMetadata(context, two, "dc", "test", "one", null, "3");
         result = ic.compare(one, two);
         assertTrue("testCompare 3", result <= -1);
         itemService.clearMetadata(context, one, "dc", "test", "one", Item.ANY);
         itemService.clearMetadata(context, two, "dc", "test", "one", Item.ANY);
 
         ic = new ItemComparator("test", "one", Item.ANY, false);
-        itemService.addMetadata(context, one, "dc", "test", "one", Item.ANY, "1");
-        itemService.addMetadata(context, one, "dc", "test", "one", Item.ANY, "2");
-        itemService.addMetadata(context, two, "dc", "test", "one", Item.ANY, "1");
-        itemService.addMetadata(context, two, "dc", "test", "one", Item.ANY, "5");
+        itemService.addMetadata(context, one, "dc", "test", "one", null, "1");
+        itemService.addMetadata(context, one, "dc", "test", "one", null, "2");
+        itemService.addMetadata(context, two, "dc", "test", "one", null, "1");
+        itemService.addMetadata(context, two, "dc", "test", "one", null, "5");
         result = ic.compare(one, two);
         assertTrue("testCompare 4", result == 0);
         itemService.clearMetadata(context, one, "dc", "test", "one", Item.ANY);
         itemService.clearMetadata(context, two, "dc", "test", "one", Item.ANY);
 
         ic = new ItemComparator("test", "one", Item.ANY, false);
-        itemService.addMetadata(context, one, "dc", "test", "one", Item.ANY, "2");
-        itemService.addMetadata(context, one, "dc", "test", "one", Item.ANY, "3");
-        itemService.addMetadata(context, two, "dc", "test", "one", Item.ANY, "1");
-        itemService.addMetadata(context, two, "dc", "test", "one", Item.ANY, "4");
+        itemService.addMetadata(context, one, "dc", "test", "one", null, "2");
+        itemService.addMetadata(context, one, "dc", "test", "one", null, "3");
+        itemService.addMetadata(context, two, "dc", "test", "one", null, "1");
+        itemService.addMetadata(context, two, "dc", "test", "one", null, "4");
         result = ic.compare(one, two);
         assertTrue("testCompare 5", result >= 1);
         itemService.clearMetadata(context, one, "dc", "test", "one", Item.ANY);

--- a/dspace-api/src/test/java/org/dspace/content/ItemTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/ItemTest.java
@@ -518,11 +518,11 @@ public class ItemTest extends AbstractDSpaceObjectTest {
         String schema = "dc";
         String element = "contributor";
         String qualifier = "author";
-        String lang = Item.ANY;
+        String lang = null;
         String[] values = {"value0", "value1"};
         itemService.addMetadata(context, it, schema, element, qualifier, lang, Arrays.asList(values));
 
-        List<MetadataValue> dc = itemService.getMetadata(it, schema, element, qualifier, lang);
+        List<MetadataValue> dc = itemService.getMetadata(it, schema, element, qualifier, Item.ANY);
         assertThat("testAddMetadata_5args_1 0", dc, notNullValue());
         assertTrue("testAddMetadata_5args_1 1", dc.size() == 2);
         assertThat("testAddMetadata_5args_1 2", dc.get(0).getMetadataField().getMetadataSchema().getName(),
@@ -563,13 +563,13 @@ public class ItemTest extends AbstractDSpaceObjectTest {
         String schema = "dc";
         String element = "language";
         String qualifier = "iso";
-        String lang = Item.ANY;
+        String lang = null;
         List<String> values = Arrays.asList("en_US", "en");
         List<String> authorities = Arrays.asList("accepted", "uncertain");
         List<Integer> confidences = Arrays.asList(0, 0);
         itemService.addMetadata(context, it, schema, element, qualifier, lang, values, authorities, confidences);
 
-        List<MetadataValue> dc = itemService.getMetadata(it, schema, element, qualifier, lang);
+        List<MetadataValue> dc = itemService.getMetadata(it, schema, element, qualifier, Item.ANY);
         assertThat("testAddMetadata_7args_1 0", dc, notNullValue());
         assertTrue("testAddMetadata_7args_1 1", dc.size() == 2);
         assertThat("testAddMetadata_7args_1 2", dc.get(0).getMetadataField().getMetadataSchema().getName(),
@@ -600,13 +600,13 @@ public class ItemTest extends AbstractDSpaceObjectTest {
         String schema = "dc";
         String element = "contributor";
         String qualifier = "author";
-        String lang = Item.ANY;
+        String lang = null;
         List<String> values = Arrays.asList("value0", "value1");
         List<String> authorities = Arrays.asList("auth0", "auth2");
         List<Integer> confidences = Arrays.asList(0, 0);
         itemService.addMetadata(context, it, schema, element, qualifier, lang, values, authorities, confidences);
 
-        List<MetadataValue> dc = itemService.getMetadata(it, schema, element, qualifier, lang);
+        List<MetadataValue> dc = itemService.getMetadata(it, schema, element, qualifier, Item.ANY);
         assertThat("testAddMetadata_7args_1 0", dc, notNullValue());
         assertTrue("testAddMetadata_7args_1 1", dc.size() == 2);
         assertThat("testAddMetadata_7args_1 2", dc.get(0).getMetadataField().getMetadataSchema().getName(),
@@ -719,13 +719,13 @@ public class ItemTest extends AbstractDSpaceObjectTest {
         String schema = "dc";
         String element = "language";
         String qualifier = "iso";
-        String lang = Item.ANY;
+        String lang = null;
         String values = "en";
         String authorities = "accepted";
         int confidences = 0;
         itemService.addMetadata(context, it, schema, element, qualifier, lang, values, authorities, confidences);
 
-        List<MetadataValue> dc = itemService.getMetadata(it, schema, element, qualifier, lang);
+        List<MetadataValue> dc = itemService.getMetadata(it, schema, element, qualifier, Item.ANY);
         assertThat("testAddMetadata_7args_2 0", dc, notNullValue());
         assertTrue("testAddMetadata_7args_2 1", dc.size() == 1);
         assertThat("testAddMetadata_7args_2 2", dc.get(0).getMetadataField().getMetadataSchema().getName(),
@@ -748,13 +748,13 @@ public class ItemTest extends AbstractDSpaceObjectTest {
         String schema = "dc";
         String element = "contributor";
         String qualifier = "editor";
-        String lang = Item.ANY;
+        String lang = null;
         String values = "value0";
         String authorities = "auth0";
         int confidences = 0;
         itemService.addMetadata(context, it, schema, element, qualifier, lang, values, authorities, confidences);
 
-        List<MetadataValue> dc = itemService.getMetadata(it, schema, element, qualifier, lang);
+        List<MetadataValue> dc = itemService.getMetadata(it, schema, element, qualifier, Item.ANY);
         assertThat("testAddMetadata_7args_2 0", dc, notNullValue());
         assertTrue("testAddMetadata_7args_2 1", dc.size() == 1);
         assertThat("testAddMetadata_7args_2 2", dc.get(0).getMetadataField().getMetadataSchema().getName(),
@@ -811,13 +811,13 @@ public class ItemTest extends AbstractDSpaceObjectTest {
         String schema = "dc";
         String element = "contributor";
         String qualifier = "author";
-        String lang = Item.ANY;
+        String lang = null;
         String values = "value0";
         itemService.addMetadata(context, it, schema, element, qualifier, lang, values);
 
-        itemService.clearMetadata(context, it, schema, element, qualifier, lang);
+        itemService.clearMetadata(context, it, schema, element, qualifier, Item.ANY);
 
-        List<MetadataValue> dc = itemService.getMetadata(it, schema, element, qualifier, lang);
+        List<MetadataValue> dc = itemService.getMetadata(it, schema, element, qualifier, Item.ANY);
         assertThat("testClearMetadata 0", dc, notNullValue());
         assertTrue("testClearMetadata 1", dc.size() == 0);
     }
@@ -859,11 +859,11 @@ public class ItemTest extends AbstractDSpaceObjectTest {
         context.turnOffAuthorisationSystem();
         Collection collection = collectionService.create(context, owningCommunity);
         collectionService.setMetadataSingleValue(context, collection, MetadataSchemaEnum.DC.getName(),
-                                                 "title", null, Item.ANY, "collection B");
+                                                 "title", null, null, "collection B");
         it.addCollection(collection);
         collection = collectionService.create(context, owningCommunity);
         collectionService.setMetadataSingleValue(context, collection, MetadataSchemaEnum.DC.getName(),
-                                                 "title", null, Item.ANY, "collection A");
+                                                 "title", null, null, "collection A");
         it.addCollection(collection);
         context.restoreAuthSystemState();
         assertThat("testGetCollections 0", it.getCollections(), notNullValue());
@@ -1772,7 +1772,7 @@ public class ItemTest extends AbstractDSpaceObjectTest {
 
         // add new metadata to item
         context.turnOffAuthorisationSystem();
-        itemService.addMetadata(context, it, schema, element, qualifier, Item.ANY, value);
+        itemService.addMetadata(context, it, schema, element, qualifier, null, value);
         itemService.update(context, it);
         context.restoreAuthSystemState();
 
@@ -1837,7 +1837,7 @@ public class ItemTest extends AbstractDSpaceObjectTest {
 
         // add new metadata (with authority) to item
         context.turnOffAuthorisationSystem();
-        itemService.addMetadata(context, it, schema, element, qualifier, Item.ANY, value, authority, confidence);
+        itemService.addMetadata(context, it, schema, element, qualifier, null, value, authority, confidence);
         itemService.update(context, it);
         context.restoreAuthSystemState();
 

--- a/dspace-api/src/test/java/org/dspace/content/ItemTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/ItemTest.java
@@ -544,7 +544,7 @@ public class ItemTest extends AbstractDSpaceObjectTest {
         String schema = "dc";
         String element = "contributor";
         String qualifier = "author";
-        String lang = Item.ANY;
+        String lang = null;
         String[] values = {};
         itemService.addMetadata(context, it, schema, element, qualifier, lang, Arrays.asList(values));
         fail("IllegalArgumentException expected");
@@ -632,7 +632,7 @@ public class ItemTest extends AbstractDSpaceObjectTest {
         String schema = "dc";
         String element = "contributor";
         String qualifier = "author";
-        String lang = Item.ANY;
+        String lang = null;
         List<String> values = new ArrayList();
         List<String> authorities = new ArrayList();
         List<Integer> confidences = new ArrayList();
@@ -645,7 +645,7 @@ public class ItemTest extends AbstractDSpaceObjectTest {
         String schema = "dc";
         String element = "contributor";
         String qualifier = "author";
-        String lang = Item.ANY;
+        String lang = null;
         // Create two fake virtual metadata ("virtual::[relationship-id]") values
         List<String> values = new ArrayList<>(Arrays.asList("uuid-1", "uuid-2"));
         List<String> authorities = new ArrayList<>(Arrays.asList(Constants.VIRTUAL_AUTHORITY_PREFIX + "relationship-1",
@@ -674,7 +674,7 @@ public class ItemTest extends AbstractDSpaceObjectTest {
         assertEquals(1, valuesAdded.size());
 
         // Get metadata and ensure new value is the ONLY ONE for this metadata field
-        List<MetadataValue> dc = itemService.getMetadata(it, schema, element, qualifier, lang);
+        List<MetadataValue> dc = itemService.getMetadata(it, schema, element, qualifier, Item.ANY);
         assertNotNull(dc);
         assertEquals(1, dc.size());
         assertEquals(schema, dc.get(0).getMetadataField().getMetadataSchema().getName());
@@ -693,11 +693,11 @@ public class ItemTest extends AbstractDSpaceObjectTest {
         String schema = "dc";
         String element = "contributor";
         String qualifier = "author";
-        String lang = Item.ANY;
+        String lang = null;
         String value = "value0";
         itemService.addMetadata(context, it, schema, element, qualifier, lang, value);
 
-        List<MetadataValue> dc = itemService.getMetadata(it, schema, element, qualifier, lang);
+        List<MetadataValue> dc = itemService.getMetadata(it, schema, element, qualifier, Item.ANY);
         assertThat("testAddMetadata_5args_2 0", dc, notNullValue());
         assertTrue("testAddMetadata_5args_2 1", dc.size() == 1);
         assertThat("testAddMetadata_5args_2 2", dc.get(0).getMetadataField().getMetadataSchema().getName(),
@@ -772,7 +772,7 @@ public class ItemTest extends AbstractDSpaceObjectTest {
         String schema = "dc";
         String element = "contributor";
         String qualifier = "author";
-        String lang = Item.ANY;
+        String lang = null;
         // Create a single fake virtual metadata ("virtual::[relationship-id]") value
         String value = "uuid-1";
         String authority = Constants.VIRTUAL_AUTHORITY_PREFIX + "relationship-1";
@@ -786,7 +786,7 @@ public class ItemTest extends AbstractDSpaceObjectTest {
         assertNull(valuesAdded);
 
         // Verify this metadata field does NOT exist on the item
-        List<MetadataValue> mv = itemService.getMetadata(it, schema, element, qualifier, lang);
+        List<MetadataValue> mv = itemService.getMetadata(it, schema, element, qualifier, Item.ANY);
         assertNotNull(mv);
         assertTrue(mv.isEmpty());
 
@@ -797,7 +797,7 @@ public class ItemTest extends AbstractDSpaceObjectTest {
         assertNull(valuesAdded);
 
         // Verify this metadata field does NOT exist on the item
-        mv = itemService.getMetadata(it, schema, element, qualifier, lang);
+        mv = itemService.getMetadata(it, schema, element, qualifier, Item.ANY);
         assertNotNull(mv);
         assertTrue(mv.isEmpty());
     }

--- a/dspace-api/src/test/java/org/dspace/content/dao/RelationshipDAOImplIT.java
+++ b/dspace-api/src/test/java/org/dspace/content/dao/RelationshipDAOImplIT.java
@@ -87,8 +87,8 @@ public class RelationshipDAOImplIT extends AbstractIntegrationTest {
             WorkspaceItem workspaceItemTwo = workspaceItemService.create(context, collection, false);
             itemOne = installItemService.installItem(context, workspaceItem);
             itemTwo = installItemService.installItem(context, workspaceItemTwo);
-            itemService.addMetadata(context, itemOne, "dspace", "entity", "type", Item.ANY, "Publication");
-            itemService.addMetadata(context, itemTwo, "dspace", "entity", "type", Item.ANY, "Person");
+            itemService.addMetadata(context, itemOne, "dspace", "entity", "type", null, "Publication");
+            itemService.addMetadata(context, itemTwo, "dspace", "entity", "type", null, "Person");
             itemService.update(context, itemOne);
             itemService.update(context, itemTwo);
             entityTypeOne = entityTypeService.create(context, "Person");

--- a/dspace-api/src/test/java/org/dspace/content/dao/RelationshipTypeDAOImplIT.java
+++ b/dspace-api/src/test/java/org/dspace/content/dao/RelationshipTypeDAOImplIT.java
@@ -82,8 +82,8 @@ public class RelationshipTypeDAOImplIT extends AbstractIntegrationTest {
             WorkspaceItem workspaceItemTwo = workspaceItemService.create(context, collection, false);
             itemOne = installItemService.installItem(context, workspaceItem);
             itemTwo = installItemService.installItem(context, workspaceItemTwo);
-            itemService.addMetadata(context, itemOne, "dspace", "entity", "type", Item.ANY, "Publication");
-            itemService.addMetadata(context, itemTwo, "dspace", "entity", "type", Item.ANY, "Person");
+            itemService.addMetadata(context, itemOne, "dspace", "entity", "type", null, "Publication");
+            itemService.addMetadata(context, itemTwo, "dspace", "entity", "type", null, "Person");
             itemService.update(context, itemOne);
             itemService.update(context, itemTwo);
             entityTypeOne = entityTypeService.create(context, "Person");

--- a/dspace-api/src/test/java/org/dspace/content/service/ItemServiceIT.java
+++ b/dspace-api/src/test/java/org/dspace/content/service/ItemServiceIT.java
@@ -198,7 +198,7 @@ public class ItemServiceIT extends AbstractIntegrationTestWithDatabase {
 
         // now just add one metadata to be the last
         itemService.addMetadata(
-            context, item, dcSchema, contributorElement, authorQualifier, Item.ANY, "test, latest", null, 0
+            context, item, dcSchema, contributorElement, authorQualifier, null, "test, latest", null, 0
         );
         // now just remove first metadata
         itemService.removeMetadataValues(context, item, List.of(placeZero));

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/EPersonRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/EPersonRestRepositoryIT.java
@@ -72,7 +72,6 @@ import org.dspace.builder.GroupBuilder;
 import org.dspace.builder.WorkflowItemBuilder;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
-import org.dspace.content.Item;
 import org.dspace.core.I18nUtil;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
@@ -2120,7 +2119,7 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
             .build();
 
         this.ePersonService
-            .addMetadata(context, ePerson, "eperson", "firstname", null, Item.ANY, List.of(first, second, third));
+            .addMetadata(context, ePerson, "eperson", "firstname", null, null, List.of(first, second, third));
 
         context.restoreAuthSystemState();
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/PatchMetadataIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/PatchMetadataIT.java
@@ -261,7 +261,7 @@ public class PatchMetadataIT extends AbstractEntityIntegrationTest {
 
         for (String author : authorsOriginalOrder) {
             itemService.addMetadata(
-                context, publicationItem, "dc", "contributor", "author", Item.ANY, author
+                context, publicationItem, "dc", "contributor", "author", null, author
             );
         }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/RelationshipRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/RelationshipRestRepositoryIT.java
@@ -818,7 +818,7 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         // Make sure we grab the latest instance of the Item from the database
         publication1 = itemService.find(context, publication1.getID());
         // Add a plain text dc.contributor.author value
-        itemService.addMetadata(context, publication1, "dc", "contributor", "author", Item.ANY, "plain text");
+        itemService.addMetadata(context, publication1, "dc", "contributor", "author", null, "plain text");
         itemService.update(context, publication1);
 
         List<MetadataValue> list = itemService.getMetadata(publication1, "dc", "contributor", "author", Item.ANY);
@@ -884,7 +884,7 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         // Ensure we have the latest instance of the Item from the database
         publication1 = itemService.find(context, publication1.getID());
         // Add a fourth dc.contributor.author mdv
-        itemService.addMetadata(context, publication1, "dc", "contributor", "author", Item.ANY, "plain text two");
+        itemService.addMetadata(context, publication1, "dc", "contributor", "author", null, "plain text two");
         itemService.update(context, publication1);
 
         context.restoreAuthSystemState();
@@ -953,7 +953,7 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         context.turnOffAuthorisationSystem();
         // The following additions of Metadata will perform the same sequence of logic and tests as described above
         publication1 = itemService.find(context, publication1.getID());
-        itemService.addMetadata(context, publication1, "dc", "contributor", "author", Item.ANY, "plain text three");
+        itemService.addMetadata(context, publication1, "dc", "contributor", "author", null, "plain text three");
         itemService.update(context, publication1);
 
         context.restoreAuthSystemState();
@@ -983,10 +983,10 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         context.turnOffAuthorisationSystem();
 
         publication1 = itemService.find(context, publication1.getID());
-        itemService.addMetadata(context, publication1, "dc", "contributor", "author", Item.ANY, "plain text four");
-        itemService.addMetadata(context, publication1, "dc", "contributor", "author", Item.ANY, "plain text five");
-        itemService.addMetadata(context, publication1, "dc", "contributor", "author", Item.ANY, "plain text six");
-        itemService.addMetadata(context, publication1, "dc", "contributor", "author", Item.ANY, "plain text seven");
+        itemService.addMetadata(context, publication1, "dc", "contributor", "author", null, "plain text four");
+        itemService.addMetadata(context, publication1, "dc", "contributor", "author", null, "plain text five");
+        itemService.addMetadata(context, publication1, "dc", "contributor", "author", null, "plain text six");
+        itemService.addMetadata(context, publication1, "dc", "contributor", "author", null, "plain text seven");
         itemService.update(context, publication1);
 
         context.restoreAuthSystemState();
@@ -1114,7 +1114,7 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         publication1 = itemService.find(context, publication1.getID());
         // Add a plain text metadatavalue to the publication
         // After this addition, the list of authors should like like "Donald Smith", "plain text"
-        itemService.addMetadata(context, publication1, "dc", "contributor", "author", Item.ANY, "plain text");
+        itemService.addMetadata(context, publication1, "dc", "contributor", "author", null, "plain text");
         itemService.update(context, publication1);
         context.restoreAuthSystemState();
         List<MetadataValue> list = itemService.getMetadata(publication1, "dc", "contributor", "author", Item.ANY);
@@ -1157,7 +1157,7 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         // Get the publication from the DB again to ensure that we have the latest object
         publication1 = itemService.find(context, publication1.getID());
         // Add a fourth metadata value to the publication
-        itemService.addMetadata(context, publication1, "dc", "contributor", "author", Item.ANY, "plain text two");
+        itemService.addMetadata(context, publication1, "dc", "contributor", "author", null, "plain text two");
         itemService.update(context, publication1);
         context.restoreAuthSystemState();
         list = itemService.getMetadata(publication1, "dc", "contributor", "author", Item.ANY);
@@ -1195,7 +1195,7 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         context.turnOffAuthorisationSystem();
         publication1 = itemService.find(context, publication1.getID());
         // Create another plain text metadata value on the publication
-        itemService.addMetadata(context, publication1, "dc", "contributor", "author", Item.ANY, "plain text three");
+        itemService.addMetadata(context, publication1, "dc", "contributor", "author", null, "plain text three");
         itemService.update(context, publication1);
         context.restoreAuthSystemState();
         list = itemService.getMetadata(publication1, "dc", "contributor", "author", Item.ANY);
@@ -1323,7 +1323,7 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         publication1 = itemService.find(context, publication1.getID());
         // Add a plain text metadatavalue to the publication
         // After this addition, the list of authors should like like "Donald Smith", "plain text"
-        itemService.addMetadata(context, publication1, "dc", "contributor", "author", Item.ANY, "plain text");
+        itemService.addMetadata(context, publication1, "dc", "contributor", "author", null, "plain text");
         itemService.update(context, publication1);
         context.restoreAuthSystemState();
         List<MetadataValue> list = itemService.getMetadata(publication1, "dc", "contributor", "author", Item.ANY);
@@ -1367,7 +1367,7 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         // Get the publication from the DB again to ensure that we have the latest object
         publication1 = itemService.find(context, publication1.getID());
         // Add a fourth metadata value to the publication
-        itemService.addMetadata(context, publication1, "dc", "contributor", "author", Item.ANY, "plain text two");
+        itemService.addMetadata(context, publication1, "dc", "contributor", "author", null, "plain text two");
         itemService.update(context, publication1);
         context.restoreAuthSystemState();
         list = itemService.getMetadata(publication1, "dc", "contributor", "author", Item.ANY);
@@ -1405,7 +1405,7 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         context.turnOffAuthorisationSystem();
         publication1 = itemService.find(context, publication1.getID());
         // Create another plain text metadata value on the publication
-        itemService.addMetadata(context, publication1, "dc", "contributor", "author", Item.ANY, "plain text three");
+        itemService.addMetadata(context, publication1, "dc", "contributor", "author", null, "plain text three");
         itemService.update(context, publication1);
         context.restoreAuthSystemState();
         list = itemService.getMetadata(publication1, "dc", "contributor", "author", Item.ANY);

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/signposting/controller/LinksetRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/signposting/controller/LinksetRestControllerIT.java
@@ -748,7 +748,7 @@ public class LinksetRestControllerIT extends AbstractControllerIntegrationTest {
                     .withMimeType(bitstreamMimeType)
                     .build();
         }
-        bitstreamService.addMetadata(context, bitstream, "dc", "type", null, Item.ANY, "Article");
+        bitstreamService.addMetadata(context, bitstream, "dc", "type", null, null, "Article");
 
         context.restoreAuthSystemState();
 
@@ -836,7 +836,7 @@ public class LinksetRestControllerIT extends AbstractControllerIntegrationTest {
                 .withTitle("Workspace Item")
                 .build();
         Item item = workspaceItem.getItem();
-        itemService.addMetadata(context, item, "dc", "identifier", "doi", Item.ANY, doi);
+        itemService.addMetadata(context, item, "dc", "identifier", "doi", null, doi);
 
         Bitstream bitstream = null;
         try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {


### PR DESCRIPTION
## References
* Fixes #9701 
* Port to 7.x: #9710 

## Description
**This PR is a port of #9710 to the latest main branch but the description is copied to make things easier**

This PR adds some extra safety checks to the CSV import procedure:
- A column header can not have the language "*" set, a mdv with no language should have language null
- A CSV import file may not have two identical headers

In both scenarios a relevant exception is thrown.

## Instructions for Reviewers

You can test this by importing following CSV's in a collection:

**CSV With "*" language:**
```
id,collection,dc.title,dc.title[*],dc.title[en]
+,COLLECTION-HANDLE,test1 - null lang
+,COLLECTION-HANDLE,,test2 - * lang
+,COLLECTION-HANDLE,,,test3 - en lang
```

**CSV With duplicate header:**
```
id,collection,dc.title,dc.title,dc.title[en]
+,COLLECTION-HANDLE,test1 - null lang
+,COLLECTION-HANDLE,,test2 - null lang
+,COLLECTION-HANDLE,,,test3 - en lang
```

**Correct CSV:**
```
id,collection,dc.title,dc.title[fr],dc.title[en]
+,COLLECTION-HANDLE,test1 - null lang
+,COLLECTION-HANDLE,,test2 - fr lang
+,COLLECTION-HANDLE,,,test3 - en lang
```

For the last CSV, also export the collection to a csv using the "Metadata export" feature and re-import that file -> verify nothing changed / no data loss.

I have also changed all calls where metadata values are being added with Item.ANY / "*" as this is incorrect.
A failsafe was also added in the `MetadataValue#setLanguage` method to not allow this if it would be passed somewhere.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
