### PR TITLE
Update spider list URLs to satisfy Cloudflare redirects

### DIFF
--- a/dspace/config/modules/solr-statistics.cfg
+++ b/dspace/config/modules/solr-statistics.cfg
@@ -28,10 +28,10 @@ solr-statistics.configset = statistics
 solr-statistics.autoCommit = true
 
 # URLs to download IP addresses of search engine spiders from
-solr-statistics.spiderips.urls = http://iplists.com/google.txt, \
-                 http://iplists.com/inktomi.txt, \
-                 http://iplists.com/lycos.txt, \
-                 http://iplists.com/infoseek.txt, \
-                 http://iplists.com/altavista.txt, \
-                 http://iplists.com/excite.txt, \
-                 http://iplists.com/misc.txt
+solr-statistics.spiderips.urls = https://www.iplists.com/google.txt, \
+                 https://www.iplists.com/inktomi.txt, \
+                 https://www.iplists.com/lycos.txt, \
+                 https://www.iplists.com/infoseek.txt, \
+                 https://www.iplists.com/altavista.txt, \
+                 https://www.iplists.com/excite.txt, \
+                 https://www.iplists.com/misc.txt


### PR DESCRIPTION
## Description

The `dspace stats-util -u` command currently fails due to some endless redirects in Cloudflare for the specific URLs we're using - this manifests as an SSL-to-cleartext error when the 301 tries to send us back to the http address:
```
Downloading latest spider IP addresses:
 Downloading: https://iplists.com/google.txt
 - Error: Redirection detected from https to http. Protocol switch unsafe, not allowed.
Redirection detected from https to http. Protocol switch unsafe, not allowed.
```

I have updated the URLs and tested that these work properly without a 301 loop (just adding www to hostname, and setting all to https for good measure):

```
solr-statistics.spiderips.urls = https://www.iplists.com/google.txt, \
                 https://www.iplists.com/inktomi.txt, \
                 https://www.iplists.com/lycos.txt, \
                 https://www.iplists.com/infoseek.txt, \
                 https://www.iplists.com/altavista.txt, \
                 https://www.iplists.com/excite.txt, \
                 https://www.iplists.com/misc.txt
```

## Instructions for Reviewers
To test, try running `${dspace.dir}/dspace stats-util -u` with the existing spiderips list, note the failure, then try again with this PR applied.

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- (N/A to the rest)
