### PR TITLE
Handles versioning for ORCID publications.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -81,6 +81,9 @@ import org.dspace.orcid.service.OrcidTokenService;
 import org.dspace.profile.service.ResearcherProfileService;
 import org.dspace.qaevent.dao.QAEventsDAO;
 import org.dspace.services.ConfigurationService;
+import org.dspace.versioning.Version;
+import org.dspace.versioning.VersionHistory;
+import org.dspace.versioning.service.VersionHistoryService;
 import org.dspace.versioning.service.VersioningService;
 import org.dspace.workflow.WorkflowItemService;
 import org.dspace.workflow.factory.WorkflowServiceFactory;
@@ -175,6 +178,9 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
 
     @Autowired
     private QAEventsDAO qaEventsDao;
+
+    @Autowired
+    private VersionHistoryService versionHistoryService;
 
     protected ItemServiceImpl() {
     }
@@ -1929,6 +1935,42 @@ prevent the generation of resource policy entry values with null dspace_object a
         for (OrcidQueue orcidQueueRecord : orcidQueueRecords) {
             orcidQueueService.delete(context, orcidQueueRecord);
         }
+    }
+
+    @Override
+    public boolean isLatestVersion(Context context, Item item) throws SQLException {
+
+        VersionHistory history = versionHistoryService.findByItem(context, item);
+        if (history == null) {
+            // not all items have a version history
+            // if an item does not have a version history, it is by definition the latest
+            // version
+            return true;
+        }
+
+        // start with the very latest version of the given item (may still be in
+        // workspace)
+        Version latestVersion = versionHistoryService.getLatestVersion(context, history);
+
+        // find the latest version of the given item that is archived
+        while (latestVersion != null && !latestVersion.getItem().isArchived()) {
+            latestVersion = versionHistoryService.getPrevious(context, history, latestVersion);
+        }
+
+        // could not find an archived version of the given item
+        if (latestVersion == null) {
+            // this scenario should never happen, but let's err on the side of showing too
+            // many items vs. to little
+            // (see discovery.xml, a lot of discovery configs filter out all items that are
+            // not the latest version)
+            return true;
+        }
+
+        // sanity check
+        assert latestVersion.getItem().isArchived();
+
+        return item.equals(latestVersion.getItem());
+
     }
 
 }

--- a/dspace-api/src/main/java/org/dspace/content/service/ItemService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/ItemService.java
@@ -1009,4 +1009,14 @@ public interface ItemService
      */
     EntityType getEntityType(Context context, Item item) throws SQLException;
 
+
+    /**
+     * Check whether the given item is the latest version. If the latest item cannot
+     * be determined, because either the version history or the latest version is
+     * not present, assume the item is latest.
+     * @param  context the DSpace context.
+     * @param  item    the item that should be checked.
+     * @return         true if the item is the latest version, false otherwise.
+     */
+    public boolean isLatestVersion(Context context, Item item) throws SQLException;
 }

--- a/dspace-api/src/main/java/org/dspace/discovery/indexobject/ItemIndexFactoryImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/indexobject/ItemIndexFactoryImpl.java
@@ -67,8 +67,6 @@ import org.dspace.handle.service.HandleService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.util.MultiFormatDateParser;
 import org.dspace.util.SolrUtils;
-import org.dspace.versioning.Version;
-import org.dspace.versioning.VersionHistory;
 import org.dspace.versioning.service.VersionHistoryService;
 import org.dspace.xmlworkflow.storedcomponents.XmlWorkflowItem;
 import org.dspace.xmlworkflow.storedcomponents.service.XmlWorkflowItemService;
@@ -151,7 +149,7 @@ public class ItemIndexFactoryImpl extends DSpaceObjectIndexFactoryImpl<Indexable
         doc.addField("withdrawn", item.isWithdrawn());
         doc.addField("discoverable", item.isDiscoverable());
         doc.addField("lastModified", SolrUtils.getDateFormatter().format(item.getLastModified()));
-        doc.addField("latestVersion", isLatestVersion(context, item));
+        doc.addField("latestVersion", itemService.isLatestVersion(context, item));
 
         EPerson submitter = item.getSubmitter();
         if (submitter != null) {
@@ -173,43 +171,6 @@ public class ItemIndexFactoryImpl extends DSpaceObjectIndexFactoryImpl<Indexable
         }
 
         return doc;
-    }
-
-    /**
-     * Check whether the given item is the latest version.
-     * If the latest item cannot be determined, because either the version history or the latest version is not present,
-     * assume the item is latest.
-     * @param context the DSpace context.
-     * @param item the item that should be checked.
-     * @return true if the item is the latest version, false otherwise.
-     */
-    protected boolean isLatestVersion(Context context, Item item) throws SQLException {
-        VersionHistory history = versionHistoryService.findByItem(context, item);
-        if (history == null) {
-            // not all items have a version history
-            // if an item does not have a version history, it is by definition the latest version
-            return true;
-        }
-
-        // start with the very latest version of the given item (may still be in workspace)
-        Version latestVersion = versionHistoryService.getLatestVersion(context, history);
-
-        // find the latest version of the given item that is archived
-        while (latestVersion != null && !latestVersion.getItem().isArchived()) {
-            latestVersion = versionHistoryService.getPrevious(context, history, latestVersion);
-        }
-
-        // could not find an archived version of the given item
-        if (latestVersion == null) {
-            // this scenario should never happen, but let's err on the side of showing too many items vs. to little
-            // (see discovery.xml, a lot of discovery configs filter out all items that are not the latest version)
-            return true;
-        }
-
-        // sanity check
-        assert latestVersion.getItem().isArchived();
-
-        return item.equals(latestVersion.getItem());
     }
 
     @Override
@@ -704,7 +665,7 @@ public class ItemIndexFactoryImpl extends DSpaceObjectIndexFactoryImpl<Indexable
             return List.copyOf(workflowItemIndexFactory.getIndexableObjects(context, xmlWorkflowItem));
         }
 
-        if (!isLatestVersion(context, item)) {
+        if (!itemService.isLatestVersion(context, item)) {
             // the given item is an older version of another item
             return List.of(new IndexableItem(item));
         }

--- a/dspace-api/src/main/java/org/dspace/orcid/consumer/OrcidQueueConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/orcid/consumer/OrcidQueueConsumer.java
@@ -14,9 +14,10 @@ import static java.util.Comparator.nullsFirst;
 import static org.apache.commons.collections.CollectionUtils.isNotEmpty;
 
 import java.sql.SQLException;
-import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -82,7 +83,7 @@ public class OrcidQueueConsumer implements Consumer {
 
     private RelationshipService relationshipService;
 
-    private final List<UUID> alreadyConsumedItems = new ArrayList<>();
+    private final Set<UUID> itemsToConsume = new HashSet<>();
 
     @Override
     public void initialize() throws Exception {
@@ -117,17 +118,26 @@ public class OrcidQueueConsumer implements Consumer {
             return;
         }
 
-        if (alreadyConsumedItems.contains(item.getID())) {
-            return;
+        itemsToConsume.add(item.getID());
+    }
+
+    @Override
+    public void end(Context context) throws Exception {
+
+        for (UUID itemId : itemsToConsume) {
+
+            Item item = itemService.find(context, itemId);
+
+            context.turnOffAuthorisationSystem();
+            try {
+                consumeItem(context, item);
+            } finally {
+                context.restoreAuthSystemState();
+            }
+
         }
 
-        context.turnOffAuthorisationSystem();
-        try {
-            consumeItem(context, item);
-        } finally {
-            context.restoreAuthSystemState();
-        }
-
+        itemsToConsume.clear();
     }
 
     /**
@@ -146,7 +156,7 @@ public class OrcidQueueConsumer implements Consumer {
             consumeProfile(context, item);
         }
 
-        alreadyConsumedItems.add(item.getID());
+        itemsToConsume.add(item.getID());
 
     }
 
@@ -166,6 +176,10 @@ public class OrcidQueueConsumer implements Consumer {
             }
 
             if (shouldNotBeSynchronized(relatedItem, entity) || isAlreadyQueued(context, relatedItem, entity)) {
+                continue;
+            }
+
+            if (isNotLatestVersion(context, entity)) {
                 continue;
             }
 
@@ -329,6 +343,14 @@ public class OrcidQueueConsumer implements Consumer {
         return !getProfileType().equals(itemService.getEntityTypeLabel(profileItemItem));
     }
 
+    private boolean isNotLatestVersion(Context context, Item entity) {
+        try {
+            return !itemService.isLatestVersion(context, entity);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     private String getMetadataValue(Item item, String metadataField) {
         return itemService.getMetadataFirstValue(item, new MetadataFieldName(metadataField), Item.ANY);
     }
@@ -343,11 +365,6 @@ public class OrcidQueueConsumer implements Consumer {
 
     private boolean isOrcidSynchronizationDisabled() {
         return !configurationService.getBooleanProperty("orcid.synchronization-enabled", true);
-    }
-
-    @Override
-    public void end(Context context) throws Exception {
-        alreadyConsumedItems.clear();
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/orcid/dao/OrcidQueueDAO.java
+++ b/dspace-api/src/main/java/org/dspace/orcid/dao/OrcidQueueDAO.java
@@ -75,6 +75,16 @@ public interface OrcidQueueDAO extends GenericDAO<OrcidQueue> {
     public List<OrcidQueue> findByProfileItemOrEntity(Context context, Item item) throws SQLException;
 
     /**
+     * Get the OrcidQueue records where the given item is the entity.
+     *
+     * @param  context      DSpace context object
+     * @param  item         the item to search for
+     * @return              the found OrcidQueue entities
+     * @throws SQLException if database error
+     */
+    public List<OrcidQueue> findByEntity(Context context, Item item) throws SQLException;
+
+    /**
      * Find all the OrcidQueue records with the given entity and record type.
      *
      * @param  context      DSpace context object

--- a/dspace-api/src/main/java/org/dspace/orcid/dao/impl/OrcidQueueDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/orcid/dao/impl/OrcidQueueDAOImpl.java
@@ -64,6 +64,13 @@ public class OrcidQueueDAOImpl extends AbstractHibernateDAO<OrcidQueue> implemen
     }
 
     @Override
+    public List<OrcidQueue> findByEntity(Context context, Item item) throws SQLException {
+        Query query = createQuery(context, "FROM OrcidQueue WHERE entity.id = :itemId");
+        query.setParameter("itemId", item.getID());
+        return query.getResultList();
+    }
+
+    @Override
     public List<OrcidQueue> findByEntityAndRecordType(Context context, Item entity, String type) throws SQLException {
         Query query = createQuery(context, "FROM OrcidQueue WHERE entity = :entity AND recordType = :type");
         query.setParameter("entity", entity);

--- a/dspace-api/src/main/java/org/dspace/orcid/service/OrcidQueueService.java
+++ b/dspace-api/src/main/java/org/dspace/orcid/service/OrcidQueueService.java
@@ -165,6 +165,16 @@ public interface OrcidQueueService {
     public List<OrcidQueue> findByProfileItemOrEntity(Context context, Item item) throws SQLException;
 
     /**
+     * Get the OrcidQueue records where the given item is the entity.
+     *
+     * @param  context      DSpace context object
+     * @param  item         the item to search for
+     * @return              the found OrcidQueue records
+     * @throws SQLException if database error
+     */
+    public List<OrcidQueue> findByEntity(Context context, Item item) throws SQLException;
+
+    /**
      * Get all the OrcidQueue records with attempts less than the given attempts.
      *
      * @param  context      DSpace context object

--- a/dspace-api/src/main/java/org/dspace/orcid/service/impl/OrcidQueueServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/orcid/service/impl/OrcidQueueServiceImpl.java
@@ -71,6 +71,11 @@ public class OrcidQueueServiceImpl implements OrcidQueueService {
     }
 
     @Override
+    public List<OrcidQueue> findByEntity(Context context, Item item) throws SQLException {
+        return orcidQueueDAO.findByEntity(context, item);
+    }
+
+    @Override
     public long countByProfileItemId(Context context, UUID profileItemId) throws SQLException {
         return orcidQueueDAO.countByProfileItemId(context, profileItemId);
     }

--- a/dspace-api/src/test/java/org/dspace/content/service/ItemServiceIT.java
+++ b/dspace-api/src/test/java/org/dspace/content/service/ItemServiceIT.java
@@ -11,6 +11,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -988,6 +989,40 @@ public class ItemServiceIT extends AbstractIntegrationTestWithDatabase {
         assertEquals("test, one", mvAuthor.get().getValue());
 
         context.restoreAuthSystemState();
+    }
+
+    @Test
+    public void testIsLatestVersion() throws Exception {
+        assertTrue("Original should be the latest version", this.itemService.isLatestVersion(context, item));
+
+        context.turnOffAuthorisationSystem();
+
+        Version firstVersion = versioningService.createNewVersion(context, item);
+        Item firstPublication = firstVersion.getItem();
+        WorkspaceItem firstPublicationWSI = workspaceItemService.findByItem(context, firstPublication);
+        installItemService.installItem(context, firstPublicationWSI);
+
+        context.commit();
+        context.restoreAuthSystemState();
+
+        assertTrue("First version should be valid", this.itemService.isLatestVersion(context, firstPublication));
+        assertFalse("Original version should not be valid", this.itemService.isLatestVersion(context, item));
+
+        context.turnOffAuthorisationSystem();
+
+        Version secondVersion = versioningService.createNewVersion(context, item);
+        Item secondPublication = secondVersion.getItem();
+        WorkspaceItem secondPublicationWSI = workspaceItemService.findByItem(context, secondPublication);
+        installItemService.installItem(context, secondPublicationWSI);
+
+        context.commit();
+        context.restoreAuthSystemState();
+
+        assertTrue("Second version should be valid", this.itemService.isLatestVersion(context, secondPublication));
+        assertFalse("First version should not be valid", this.itemService.isLatestVersion(context, firstPublication));
+        assertFalse("Original version should not be valid", this.itemService.isLatestVersion(context, item));
+
+        context.turnOffAuthorisationSystem();
     }
 
 }


### PR DESCRIPTION
#### _Please note that this development has been funded by the [ORCID Global Participation Fund](https://info.orcid.org/global-participation-program/global-participation-fund/)._
---
DSpace 8_x version here: [#9723](https://github.com/DSpace/DSpace/pull/9723)
DSpace 7_x version here: [#9722](https://github.com/DSpace/DSpace/pull/9722)

## References
* Fixes #8662

## Description
This PR adds improvements to the ORCID synchronization feature.
Whenever an item is versioned, and is queued for synchronization, its reference will be updated in order to have an updated publication on the ORCID side.
Whenever an item is versioned, but its already published, it will be updated.

## Instructions for Reviewers
Just try to create a new publication, and leave it inside the ORCID synchronization queue.
Now try to create a new version of it, and check that the pending publication is updated with the new version (you can check it inside the `orcid_queue` table).
In the same way you should publish the update to the ORCID servers and then try to versionate it again. In this case you should check that the entry inside the `orcid_history` table has been updated correctly.

List of changes in this PR:
The changes will introduce the followings:

Consumer
  - orcid queue will be populated only by latest version of items
Versioning
  - Items in orcid queue that are related to an older version will be deleted
  - Older items' version in the orcid history will be updated with the last one in order to have only one entry per-item.

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
