### PR TITLE
[Port dspace-7_x] Orcid revoke token feature

### DIFF
--- a/dspace-api/src/main/java/org/dspace/orcid/client/OrcidClient.java
+++ b/dspace-api/src/main/java/org/dspace/orcid/client/OrcidClient.java
@@ -10,6 +10,7 @@ package org.dspace.orcid.client;
 import java.util.List;
 import java.util.Optional;
 
+import org.dspace.orcid.OrcidToken;
 import org.dspace.orcid.exception.OrcidClientException;
 import org.dspace.orcid.model.OrcidTokenResponseDTO;
 import org.orcid.jaxb.model.v3.release.record.Person;
@@ -160,5 +161,12 @@ public interface OrcidClient {
      * @throws OrcidClientException if some error occurs during the search
      */
     OrcidResponse deleteByPutCode(String accessToken, String orcid, String putCode, String path);
+
+    /**
+     * Revokes the given {@param accessToken} with a POST method.
+     * @param orcidToken   the access token to revoke
+     * @throws OrcidClientException if some error occurs during the search
+     */
+    void revokeToken(OrcidToken orcidToken);
 
 }

--- a/dspace-api/src/main/java/org/dspace/orcid/client/OrcidClientImpl.java
+++ b/dspace-api/src/main/java/org/dspace/orcid/client/OrcidClientImpl.java
@@ -42,6 +42,7 @@ import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicNameValuePair;
+import org.dspace.orcid.OrcidToken;
 import org.dspace.orcid.exception.OrcidClientException;
 import org.dspace.orcid.model.OrcidEntityType;
 import org.dspace.orcid.model.OrcidProfileSectionType;
@@ -179,6 +180,16 @@ public class OrcidClientImpl implements OrcidClient {
     }
 
     @Override
+    public void revokeToken(OrcidToken orcidToken) {
+        List<NameValuePair> params = new ArrayList<>();
+        params.add(new BasicNameValuePair("client_id", orcidConfiguration.getClientId()));
+        params.add(new BasicNameValuePair("client_secret", orcidConfiguration.getClientSecret()));
+        params.add(new BasicNameValuePair("token", orcidToken.getAccessToken()));
+
+        executeSuccessful(buildPostForRevokeToken(new UrlEncodedFormEntity(params, Charset.defaultCharset())));
+    }
+
+    @Override
     public OrcidTokenResponseDTO getReadPublicAccessToken() {
         return getClientCredentialsAccessToken("/read-public");
     }
@@ -220,6 +231,14 @@ public class OrcidClientImpl implements OrcidClient {
             .build();
     }
 
+    private HttpUriRequest buildPostForRevokeToken(HttpEntity entity) {
+        return post(orcidConfiguration.getRevokeUrl())
+            .addHeader("Accept", "application/json")
+            .addHeader("Content-Type", "application/x-www-form-urlencoded")
+            .setEntity(entity)
+            .build();
+    }
+
     private HttpUriRequest buildPutUriRequest(String accessToken, String relativePath, Object object) {
         return put(orcidConfiguration.getApiUrl() + relativePath.trim())
             .addHeader("Content-Type", "application/vnd.orcid+xml")
@@ -232,6 +251,24 @@ public class OrcidClientImpl implements OrcidClient {
         return delete(orcidConfiguration.getApiUrl() + relativePath.trim())
             .addHeader("Authorization", "Bearer " + accessToken)
             .build();
+    }
+
+    private void executeSuccessful(HttpUriRequest httpUriRequest) {
+        try {
+            HttpClient client = HttpClientBuilder.create().build();
+            HttpResponse response = client.execute(httpUriRequest);
+
+            if (isNotSuccessfull(response)) {
+                throw new OrcidClientException(
+                    getStatusCode(response),
+                    "Operation " + httpUriRequest.getMethod() + " for the resource " + httpUriRequest.getURI() +
+                    " was not successful: " + new String(response.getEntity().getContent().readAllBytes(),
+                                                         StandardCharsets.UTF_8)
+                );
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private <T> T executeAndParseJson(HttpUriRequest httpUriRequest, Class<T> clazz) {

--- a/dspace-api/src/main/java/org/dspace/orcid/client/OrcidConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/orcid/client/OrcidConfiguration.java
@@ -35,6 +35,8 @@ public final class OrcidConfiguration {
 
     private String scopes;
 
+    private String revokeUrl;
+
     public String getApiUrl() {
         return apiUrl;
     }
@@ -111,4 +113,11 @@ public final class OrcidConfiguration {
         return !StringUtils.isAnyBlank(clientId, clientSecret);
     }
 
+    public String getRevokeUrl() {
+        return revokeUrl;
+    }
+
+    public void setRevokeUrl(String revokeUrl) {
+        this.revokeUrl = revokeUrl;
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/orcid/service/impl/OrcidSynchronizationServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/orcid/service/impl/OrcidSynchronizationServiceImpl.java
@@ -37,6 +37,7 @@ import org.dspace.discovery.indexobject.IndexableItem;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.service.EPersonService;
 import org.dspace.orcid.OrcidToken;
+import org.dspace.orcid.client.OrcidClient;
 import org.dspace.orcid.model.OrcidEntityType;
 import org.dspace.orcid.model.OrcidTokenResponseDTO;
 import org.dspace.orcid.service.OrcidSynchronizationService;
@@ -47,6 +48,8 @@ import org.dspace.profile.OrcidProfileSyncPreference;
 import org.dspace.profile.OrcidSynchronizationMode;
 import org.dspace.profile.service.ResearcherProfileService;
 import org.dspace.services.ConfigurationService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -57,6 +60,7 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 public class OrcidSynchronizationServiceImpl implements OrcidSynchronizationService {
 
+    private static final Logger log = LoggerFactory.getLogger(OrcidSynchronizationServiceImpl.class);
     @Autowired
     private ItemService itemService;
 
@@ -74,6 +78,9 @@ public class OrcidSynchronizationServiceImpl implements OrcidSynchronizationServ
 
     @Autowired
     private ResearcherProfileService researcherProfileService;
+
+    @Autowired
+    private OrcidClient orcidClient;
 
     @Override
     public void linkProfile(Context context, Item profile, OrcidTokenResponseDTO token) throws SQLException {
@@ -118,7 +125,14 @@ public class OrcidSynchronizationServiceImpl implements OrcidSynchronizationServ
         itemService.clearMetadata(context, profile, "dspace", "orcid", "scope", Item.ANY);
         itemService.clearMetadata(context, profile, "dspace", "orcid", "authenticated", Item.ANY);
 
+        OrcidToken profileToken = orcidTokenService.findByProfileItem(context, profile);
+        if (profileToken == null) {
+            log.warn("Cannot find any token related to the user profile: {}", profile.getID());
+            return;
+        }
+
         orcidTokenService.deleteByProfileItem(context, profile);
+        orcidClient.revokeToken(profileToken);
 
         updateItem(context, profile);
 

--- a/dspace/config/modules/orcid.cfg
+++ b/dspace/config/modules/orcid.cfg
@@ -14,6 +14,7 @@ orcid.disconnection.allowed-users = admin_and_owner
 # ORCID API (https://github.com/ORCID/ORCID-Source/tree/master/orcid-api-web#endpoints)
 orcid.domain-url= https://sandbox.orcid.org
 orcid.authorize-url = ${orcid.domain-url}/oauth/authorize
+orcid.revoke-url = ${orcid.domain-url}/oauth/revoke
 orcid.token-url = ${orcid.domain-url}/oauth/token
 orcid.api-url = https://api.sandbox.orcid.org/v3.0
 orcid.public-url = https://pub.sandbox.orcid.org/v3.0

--- a/dspace/config/spring/api/orcid-services.xml
+++ b/dspace/config/spring/api/orcid-services.xml
@@ -30,6 +30,7 @@
     	<property name="tokenEndpointUrl" value="${orcid.token-url}" />
     	<property name="authorizeEndpointUrl" value="${orcid.authorize-url}" />
     	<property name="scopes" value="${orcid.scope}" />
+		<property name="revokeUrl" value="${orcid.revoke-url}" />
     </bean>
     
     <bean class="org.dspace.orcid.client.OrcidClientImpl" />


### PR DESCRIPTION
#### _Please note that this development has been funded by the [ORCID Global Participation Fund](https://info.orcid.org/global-participation-program/global-participation-fund/)._

DSpace main version here: https://github.com/DSpace/DSpace/pull/9752
DSpace-8_x version here: https://github.com/DSpace/DSpace/pull/9751

---
## References
* Fixes #9088

## Description
This PR introduces futher checks to invalidate the registered access token whenever an user tries to disconnect its ORCID account from the ORCID synchronization page.

## Instructions for Reviewers
1. You would need a registered accoun on the ORCID side (i.e. sandbox or real service)
2. You need to link your profile with this ORCID account
3. You should check the presence of DSpace inside the trusted parties inside your ORCID account
4. You should try to revoke the access by using the "Disconnect from ORCID" button directly from the ORCID Synchronization page
5. You should check that DSpace has been removed from the trusted parties list inside your ORCID account.

List of changes in this PR:
Adds URL configuration `orcid.revoke-url` that specifies the endpoint for token removal
Adds POST method to remove the access token from the `OrcidClient`
Adds specific method to revoke a given `OrcidToken` by using the `OrcidClient`
Adds ITs to verify its behavior.

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
