### PR TITLE
Improve observability of running processes + Fail them during startup

### DIFF
--- a/dspace-api/src/main/java/org/dspace/scripts/ProcessServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/scripts/ProcessServiceImpl.java
@@ -88,6 +88,9 @@ public class ProcessServiceImpl implements ProcessService, InitializingBean {
             log.info("Process with ID {} did not complete before tomcat shutdown, failing it now.", process.getID());
             fail(context, process);
             // But still attach its log to the process.
+            appendLog(process.getID(), process.getName(),
+                      "Process did not complete before tomcat shutdown.",
+                      ProcessLogLevel.ERROR);
             createLogBitstream(context, process);
         }
 

--- a/dspace-api/src/main/java/org/dspace/scripts/ProcessServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/scripts/ProcessServiceImpl.java
@@ -45,14 +45,15 @@ import org.dspace.core.Context;
 import org.dspace.core.LogHelper;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
-import org.dspace.eperson.service.EPersonService;
 import org.dspace.scripts.service.ProcessService;
+import org.dspace.services.ConfigurationService;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * The implementation for the {@link ProcessService} class
  */
-public class ProcessServiceImpl implements ProcessService {
+public class ProcessServiceImpl implements ProcessService, InitializingBean {
 
     private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(ProcessService.class);
 
@@ -72,7 +73,26 @@ public class ProcessServiceImpl implements ProcessService {
     private MetadataFieldService metadataFieldService;
 
     @Autowired
-    private EPersonService ePersonService;
+    private ConfigurationService configurationService;
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        Context context = new Context();
+
+        // Processes that were running or scheduled when tomcat crashed, should be cleaned up during startup.
+        List<Process> processesToBeFailed = findByStatusAndCreationTimeOlderThan(
+            context, List.of(ProcessStatus.RUNNING, ProcessStatus.SCHEDULED), new Date());
+        for (Process process : processesToBeFailed) {
+            context.setCurrentUser(process.getEPerson());
+            // Fail the process.
+            log.info("Process with ID {} did not complete before tomcat shutdown, failing it now.", process.getID());
+            fail(context, process);
+            // But still attach its log to the process.
+            createLogBitstream(context, process);
+        }
+
+        context.complete();
+    }
 
     @Override
     public Process create(Context context, EPerson ePerson, String scriptName,
@@ -286,8 +306,8 @@ public class ProcessServiceImpl implements ProcessService {
     @Override
     public void appendLog(int processId, String scriptName, String output, ProcessLogLevel processLogLevel)
             throws IOException {
-        File tmpDir = FileUtils.getTempDirectory();
-        File tempFile = new File(tmpDir, scriptName + processId + ".log");
+        File logsDir = getLogsDirectory();
+        File tempFile = new File(logsDir, processId + "-" + scriptName + ".log");
         FileWriter out = new FileWriter(tempFile, true);
         try {
             try (BufferedWriter writer = new BufferedWriter(out)) {
@@ -302,12 +322,15 @@ public class ProcessServiceImpl implements ProcessService {
     @Override
     public void createLogBitstream(Context context, Process process)
             throws IOException, SQLException, AuthorizeException {
-        File tmpDir = FileUtils.getTempDirectory();
-        File tempFile = new File(tmpDir, process.getName() + process.getID() + ".log");
-        FileInputStream inputStream = FileUtils.openInputStream(tempFile);
-        appendFile(context, process, inputStream, Process.OUTPUT_TYPE, process.getName() + process.getID() + ".log");
-        inputStream.close();
-        tempFile.delete();
+        File logsDir = getLogsDirectory();
+        File tempFile = new File(logsDir, process.getID() + "-" + process.getName() + ".log");
+        if (tempFile.exists()) {
+            FileInputStream inputStream = FileUtils.openInputStream(tempFile);
+            appendFile(context, process, inputStream, Process.OUTPUT_TYPE,
+                       process.getID() + "-" + process.getName() + ".log");
+            inputStream.close();
+            tempFile.delete();
+        }
     }
 
     @Override
@@ -336,4 +359,15 @@ public class ProcessServiceImpl implements ProcessService {
         return  sb.toString();
     }
 
+    private File getLogsDirectory() {
+        String pathStr = configurationService.getProperty("dspace.dir")
+            + File.separator + "log" + File.separator + "processes";
+        File logsDir = new File(pathStr);
+        if (!logsDir.exists()) {
+            if (!logsDir.mkdirs()) {
+                throw new RuntimeException("Couldn't create [dspace.dir]/log/processes/ directory.");
+            }
+        }
+        return logsDir;
+    }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/scripts/handler/impl/RestDSpaceRunnableHandler.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/scripts/handler/impl/RestDSpaceRunnableHandler.java
@@ -130,7 +130,7 @@ public class RestDSpaceRunnableHandler implements DSpaceRunnableHandler {
 
     @Override
     public void handleException(Exception e) {
-        handleException(null, e);
+        handleException(e.getMessage(), e);
     }
 
     @Override

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProcessRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProcessRestRepositoryIT.java
@@ -856,10 +856,10 @@ public class ProcessRestRepositoryIT extends AbstractControllerIntegrationTest {
         getClient(token).perform(get("/api/system/processes/" + process1.getID() + "/output"))
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$.name",
-                                            is(process1.getName() + process1.getID() + ".log")))
+                                            is(process1.getID() + "-" + process1.getName() + ".log")))
                         .andExpect(jsonPath("$.type", is("bitstream")))
                         .andExpect(jsonPath("$.metadata['dc.title'][0].value",
-                                            is(process1.getName() + process1.getID() + ".log")))
+                                            is(process1.getID() + "-" + process1.getName() + ".log")))
                         .andExpect(jsonPath("$.metadata['dspace.process.filetype'][0].value",
                                             is("script_output")));
 
@@ -869,10 +869,10 @@ public class ProcessRestRepositoryIT extends AbstractControllerIntegrationTest {
                         .perform(get("/api/system/processes/" + process1.getID() + "/output"))
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$.name",
-                                            is(process1.getName() + process1.getID() + ".log")))
+                                            is(process1.getID() + "-" + process1.getName() + ".log")))
                         .andExpect(jsonPath("$.type", is("bitstream")))
                         .andExpect(jsonPath("$.metadata['dc.title'][0].value",
-                                            is(process1.getName() + process1.getID() + ".log")))
+                                            is(process1.getID() + "-" + process1.getName() + ".log")))
                         .andExpect(jsonPath("$.metadata['dspace.process.filetype'][0].value",
                                             is("script_output")));
 


### PR DESCRIPTION
## References
- Fixes #9727 

## Description
Logs of running processes are currently kept in the temp directory. This PR moves them to `[dspace]/log/processes`.
It also cleans up running and scheduled processes during startup, by:
- attaching the log files which are still in `[dspace]/log/processes`, to their respective processes.
- setting their status to `FAILED`.

## Instructions for Reviewers
List of changes:
- add a `afterPropertiesSet()` method in ProcessServiceImpl to handle processes that were running or scheduled during a tomcat crash.
- adjust the `appendLog()` and `createLogBitstream()` methods to use the `[dspace]/log/processes` directory.
- prevent `handleException()` in RestDSpaceRunnableHandler from passing `null` messages

How to test:
- Start a long-running process in a local DSpace (e.g. `index-discovery -b -f`)
- Verify you can now find the log in `[dspace]/log/processes`.
- Verify the log is gone after the process has completed.
- Start another process.
- Verify in the UI the process is running.
- Restart Tomcat (while the process was still running).
- Verify in the UI the process has failed.
- Verify its log is attached.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
