### PR TITLE
filter-media:  make POI record buffer size adjustable.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/TikaTextExtractionFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/TikaTextExtractionFilter.java
@@ -18,6 +18,7 @@ import java.nio.charset.StandardCharsets;
 import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.poi.util.IOUtils;
 import org.apache.tika.Tika;
 import org.apache.tika.exception.TikaException;
 import org.apache.tika.metadata.Metadata;
@@ -72,21 +73,23 @@ public class TikaTextExtractionFilter
         // Not using temporary file. We'll use Tika's default in-memory parsing.
         // Get maximum characters to extract. Default is 100,000 chars, which is also Tika's default setting.
         String extractedText;
-        int maxChars = configurationService.getIntProperty("textextractor.max-chars", 100000);
+        int maxChars = configurationService.getIntProperty("textextractor.max-chars", 100_000);
         try {
             // Use Tika to extract text from input. Tika will automatically detect the file type.
             Tika tika = new Tika();
             tika.setMaxStringLength(maxChars); // Tell Tika the maximum number of characters to extract
+            IOUtils.setByteArrayMaxOverride(
+                    configurationService.getIntProperty("textextractor.max-array", 1_000_000));
             extractedText = tika.parseToString(source);
         } catch (IOException e) {
             System.err.format("Unable to extract text from bitstream in Item %s%n", currentItem.getID().toString());
-            e.printStackTrace();
+            e.printStackTrace(System.err);
             log.error("Unable to extract text from bitstream in Item {}", currentItem.getID().toString(), e);
             throw e;
         } catch (OutOfMemoryError oe) {
             System.err.format("OutOfMemoryError occurred when extracting text from bitstream in Item %s. " +
                 "You may wish to enable 'textextractor.use-temp-file'.%n", currentItem.getID().toString());
-            oe.printStackTrace();
+            oe.printStackTrace(System.err);
             log.error("OutOfMemoryError occurred when extracting text from bitstream in Item {}. " +
                           "You may wish to enable 'textextractor.use-temp-file'.", currentItem.getID().toString(), oe);
             throw oe;

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/TikaTextExtractionFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/TikaTextExtractionFilter.java
@@ -79,7 +79,7 @@ public class TikaTextExtractionFilter
             Tika tika = new Tika();
             tika.setMaxStringLength(maxChars); // Tell Tika the maximum number of characters to extract
             IOUtils.setByteArrayMaxOverride(
-                    configurationService.getIntProperty("textextractor.max-array", 1_000_000));
+                    configurationService.getIntProperty("textextractor.max-array", 100_000_000));
             extractedText = tika.parseToString(source);
         } catch (IOException e) {
             System.err.format("Unable to extract text from bitstream in Item %s%n", currentItem.getID().toString());

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -524,7 +524,7 @@ filter.org.dspace.app.mediafilter.PDFBoxThumbnail.inputFormats = Adobe PDF
 # 'dspace filter-media'.  It is likely that you will need to increase the
 # size of the Java heap if you greatly increase this value -- see JAVA_OPTS
 # in 'bin/dspace' or 'bin/dspace/bat'.
-#textextractor.max-array = 1000000
+#textextractor.max-array = 100000000
 
 # Custom settings for ImageMagick Thumbnail Filters
 # ImageMagick and GhostScript must be installed on the server, set the path to ImageMagick and GhostScript executable

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -519,6 +519,13 @@ filter.org.dspace.app.mediafilter.PDFBoxThumbnail.inputFormats = Adobe PDF
 # text ("filter-media -f" ) and then reindex your site ("index-discovery -b").
 #textextractor.use-temp-file = false
 
+# Maximum size of a record buffer for text extraction.  Set this if you are
+# seeing RecordFormatException calling out excessive array length from
+# 'dspace filter-media'.  It is likely that you will need to increase the
+# size of the Java heap if you greatly increase this value -- see JAVA_OPTS
+# in 'bin/dspace' or 'bin/dspace/bat'.
+#textextractor.max-array = 1000000
+
 # Custom settings for ImageMagick Thumbnail Filters
 # ImageMagick and GhostScript must be installed on the server, set the path to ImageMagick and GhostScript executable
 #   http://www.imagemagick.org/


### PR DESCRIPTION
`bin/dspace filter-media` was giving us RecordFormatException on OOXML files with enormous records.

## Description
Adds a configuration property to set the maximum record size in POI, defaulting to POI's internal default of 100_000_000.

## Instructions for Reviewers
List of changes in this PR:
* Invent configuration property `textextractor.max-array` and set its value into POI's `IOUtils` package.
* Tidy up IDE warnings about niladic `printStackTrace`.
* Add underscores to an existing large constant to make it more readable and align with the format of the default for the property that I added.

Testing requires a document with very large records:  over 100_000_000 bytes.  These should fail to filter until you set a large enough `textextractor.max-array` in `local.cfg`.

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
