### PR TITLE
Improve Group2GroupCache computation

### DIFF
--- a/dspace-api/src/main/java/org/dspace/eperson/Group2GroupCache.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/Group2GroupCache.java
@@ -15,6 +15,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import org.dspace.core.HibernateProxyHelper;
 
 /**
@@ -23,7 +24,7 @@ import org.dspace.core.HibernateProxyHelper;
  * @author kevinvandevelde at atmire.com
  */
 @Entity
-@Table(name = "group2groupcache")
+@Table(name = "group2groupcache", uniqueConstraints = { @UniqueConstraint(columnNames = {"parent_id", "child_id"}) })
 public class Group2GroupCache implements Serializable {
 
     @Id

--- a/dspace-api/src/main/java/org/dspace/eperson/GroupServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/GroupServiceImpl.java
@@ -725,19 +725,19 @@ public class GroupServiceImpl extends DSpaceObjectServiceImpl<Group> implements 
      */
     protected void rethinkGroupCache(Context context, boolean flushQueries) throws SQLException {
         // current cache in the database
-        var oldCache = group2GroupCacheDAO.getCache(context);
+        Set<Pair<UUID, UUID>> oldCache = group2GroupCacheDAO.getCache(context);
 
         // correct cache, computed from the Group table
-        var newCache = computeNewCache(context, flushQueries);
+        Set<Pair<UUID, UUID>> newCache = computeNewCache(context, flushQueries);
 
-        var toDelete = SetUtils.difference(oldCache, newCache);
-        var toCreate = SetUtils.difference(newCache, oldCache);
+        SetUtils.SetView<Pair<UUID, UUID>> toDelete = SetUtils.difference(oldCache, newCache);
+        SetUtils.SetView<Pair<UUID, UUID>> toCreate = SetUtils.difference(newCache, oldCache);
 
-        for (var pair : toDelete ) {
+        for (Pair<UUID, UUID> pair : toDelete ) {
             group2GroupCacheDAO.deleteFromCache(context, pair.getLeft(), pair.getRight());
         }
 
-        for (var pair : toCreate ) {
+        for (Pair<UUID, UUID> pair : toCreate ) {
             group2GroupCacheDAO.addToCache(context, pair.getLeft(), pair.getRight());
         }
     }

--- a/dspace-api/src/main/java/org/dspace/eperson/GroupServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/GroupServiceImpl.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import java.util.UUID;
 
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.SetUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
@@ -673,15 +674,14 @@ public class GroupServiceImpl extends DSpaceObjectServiceImpl<Group> implements 
 
 
     /**
-     * Regenerate the group cache AKA the group2groupcache table in the database -
-     * meant to be called when a group is added or removed from another group
+     * Returns a set with pairs of parent and child group UUIDs, representing the new cache table rows.
      *
-     * @param context      The relevant DSpace Context.
-     * @param flushQueries flushQueries Flush all pending queries
+     * @param context       The relevant DSpace Context.
+     * @param flushQueries  flushQueries Flush all pending queries
+     * @return              Pairs of parent and child group UUID of the new cache.
      * @throws SQLException An exception that provides information on a database access error or other errors.
      */
-    protected void rethinkGroupCache(Context context, boolean flushQueries) throws SQLException {
-
+    private Set<Pair<UUID, UUID>> computeNewCache(Context context, boolean flushQueries) throws SQLException {
         Map<UUID, Set<UUID>> parents = new HashMap<>();
 
         List<Pair<UUID, UUID>> group2groupResults = groupDAO.getGroup2GroupResults(context, flushQueries);
@@ -689,19 +689,8 @@ public class GroupServiceImpl extends DSpaceObjectServiceImpl<Group> implements 
             UUID parent = group2groupResult.getLeft();
             UUID child = group2groupResult.getRight();
 
-            // if parent doesn't have an entry, create one
-            if (!parents.containsKey(parent)) {
-                Set<UUID> children = new HashSet<>();
-
-                // add child id to the list
-                children.add(child);
-                parents.put(parent, children);
-            } else {
-                // parent has an entry, now add the child to the parent's record
-                // of children
-                Set<UUID> children = parents.get(parent);
-                children.add(child);
-            }
+            parents.putIfAbsent(parent, new HashSet<>());
+            parents.get(parent).add(child);
         }
 
         // now parents is a hash of all of the IDs of groups that are parents
@@ -714,27 +703,42 @@ public class GroupServiceImpl extends DSpaceObjectServiceImpl<Group> implements 
             parent.getValue().addAll(myChildren);
         }
 
-        // empty out group2groupcache table
-        group2GroupCacheDAO.deleteAll(context);
-
-        // write out new one
+        // write out new cache IN MEMORY ONLY and returns it
+        Set<Pair<UUID, UUID>> newCache = new HashSet<>();
         for (Map.Entry<UUID, Set<UUID>> parent : parents.entrySet()) {
             UUID key = parent.getKey();
-
             for (UUID child : parent.getValue()) {
-
-                Group parentGroup = find(context, key);
-                Group childGroup = find(context, child);
-
-
-                if (parentGroup != null && childGroup != null && group2GroupCacheDAO
-                    .find(context, parentGroup, childGroup) == null) {
-                    Group2GroupCache group2GroupCache = group2GroupCacheDAO.create(context, new Group2GroupCache());
-                    group2GroupCache.setParent(parentGroup);
-                    group2GroupCache.setChild(childGroup);
-                    group2GroupCacheDAO.save(context, group2GroupCache);
-                }
+                newCache.add(Pair.of(key, child));
             }
+        }
+        return newCache;
+    }
+
+
+    /**
+     * Regenerate the group cache AKA the group2groupcache table in the database -
+     * meant to be called when a group is added or removed from another group
+     *
+     * @param context      The relevant DSpace Context.
+     * @param flushQueries flushQueries Flush all pending queries
+     * @throws SQLException An exception that provides information on a database access error or other errors.
+     */
+    protected void rethinkGroupCache(Context context, boolean flushQueries) throws SQLException {
+        // current cache in the database
+        var oldCache = group2GroupCacheDAO.getCache(context);
+
+        // correct cache, computed from the Group table
+        var newCache = computeNewCache(context, flushQueries);
+
+        var toDelete = SetUtils.difference(oldCache, newCache);
+        var toCreate = SetUtils.difference(newCache, oldCache);
+
+        for (var pair : toDelete ) {
+            group2GroupCacheDAO.deleteFromCache(context, pair.getLeft(), pair.getRight());
+        }
+
+        for (var pair : toCreate ) {
+            group2GroupCacheDAO.addToCache(context, pair.getLeft(), pair.getRight());
         }
     }
 

--- a/dspace-api/src/main/java/org/dspace/eperson/dao/Group2GroupCacheDAO.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/dao/Group2GroupCacheDAO.java
@@ -9,7 +9,10 @@ package org.dspace.eperson.dao;
 
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.dspace.core.Context;
 import org.dspace.core.GenericDAO;
 import org.dspace.eperson.Group;
@@ -25,13 +28,74 @@ import org.dspace.eperson.Group2GroupCache;
  */
 public interface Group2GroupCacheDAO extends GenericDAO<Group2GroupCache> {
 
-    public List<Group2GroupCache> findByParent(Context context, Group group) throws SQLException;
+    /**
+     * Returns the current cache table as a set of UUID pairs.
+     * @param context The relevant DSpace Context.
+     * @return Set of UUID pairs, where the first element is the parent UUID and the second one is the child UUID.
+     * @throws SQLException An exception that provides information on a database access error or other errors.
+     */
+    Set<Pair<UUID, UUID>> getCache(Context context) throws SQLException;
 
-    public List<Group2GroupCache> findByChildren(Context context, Iterable<Group> groups) throws SQLException;
+    /**
+     * Returns all cache entities that are children of a given parent Group entity.
+     * @param context The relevant DSpace Context.
+     * @param group Parent group to perform the search.
+     * @return List of cached groups that are children of the parent group.
+     * @throws SQLException An exception that provides information on a database access error or other errors.
+     */
+    List<Group2GroupCache> findByParent(Context context, Group group) throws SQLException;
 
-    public Group2GroupCache findByParentAndChild(Context context, Group parent, Group child) throws SQLException;
+    /**
+     * Returns all cache entities that are parents of at least one group from a children groups list.
+     * @param context The relevant DSpace Context.
+     * @param groups Children groups to perform the search.
+     * @return List of cached groups that are parents of at least one group from the children groups list.
+     * @throws SQLException An exception that provides information on a database access error or other errors.
+     */
+    List<Group2GroupCache> findByChildren(Context context, Iterable<Group> groups) throws SQLException;
 
-    public Group2GroupCache find(Context context, Group parent, Group child) throws SQLException;
+    /**
+     * Returns the cache entity given specific parent and child groups.
+     * @param context The relevant DSpace Context.
+     * @param parent Parent group.
+     * @param child Child gruoup.
+     * @return Cached group.
+     * @throws SQLException An exception that provides information on a database access error or other errors.
+     */
+    Group2GroupCache findByParentAndChild(Context context, Group parent, Group child) throws SQLException;
 
-    public void deleteAll(Context context) throws SQLException;
+    /**
+     * Returns the cache entity given specific parent and child groups.
+     * @param context The relevant DSpace Context.
+     * @param parent Parent group.
+     * @param child Child gruoup.
+     * @return Cached group.
+     * @throws SQLException An exception that provides information on a database access error or other errors.
+     */
+    Group2GroupCache find(Context context, Group parent, Group child) throws SQLException;
+
+    /**
+     * Completely deletes the current cache table.
+     * @param context The relevant DSpace Context.
+     * @throws SQLException An exception that provides information on a database access error or other errors.
+     */
+    void deleteAll(Context context) throws SQLException;
+
+    /**
+     * Deletes a specific cache row given parent and child groups UUIDs.
+     * @param context The relevant DSpace Context.
+     * @param parent Parent group UUID.
+     * @param child Child group UUID.
+     * @throws SQLException An exception that provides information on a database access error or other errors.
+     */
+    void deleteFromCache(Context context, UUID parent, UUID child) throws SQLException;
+
+    /**
+     * Adds a single row to the cache table given parent and child groups UUIDs.
+     * @param context The relevant DSpace Context.
+     * @param parent Parent group UUID.
+     * @param child Child group UUID.
+     * @throws SQLException An exception that provides information on a database access error or other errors.
+     */
+    void addToCache(Context context, UUID parent, UUID child) throws SQLException;
 }

--- a/dspace-api/src/main/java/org/dspace/eperson/dao/impl/Group2GroupCacheDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/dao/impl/Group2GroupCacheDAOImpl.java
@@ -8,14 +8,18 @@
 package org.dspace.eperson.dao.impl;
 
 import java.sql.SQLException;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 
 import jakarta.persistence.Query;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
+import org.apache.commons.lang3.tuple.Pair;
 import org.dspace.core.AbstractHibernateDAO;
 import org.dspace.core.Context;
 import org.dspace.eperson.Group;
@@ -33,6 +37,16 @@ import org.dspace.eperson.dao.Group2GroupCacheDAO;
 public class Group2GroupCacheDAOImpl extends AbstractHibernateDAO<Group2GroupCache> implements Group2GroupCacheDAO {
     protected Group2GroupCacheDAOImpl() {
         super();
+    }
+
+    @Override
+    public Set<Pair<UUID, UUID>> getCache(Context context) throws SQLException {
+        Query query = createQuery(
+            context,
+            "SELECT new org.apache.commons.lang3.tuple.ImmutablePair(g.parent.id, g.child.id) FROM Group2GroupCache g"
+        );
+        List<Pair<UUID, UUID>> results = query.getResultList();
+        return new HashSet<Pair<UUID, UUID>>(results);
     }
 
     @Override
@@ -89,5 +103,25 @@ public class Group2GroupCacheDAOImpl extends AbstractHibernateDAO<Group2GroupCac
     @Override
     public void deleteAll(Context context) throws SQLException {
         createQuery(context, "delete from Group2GroupCache").executeUpdate();
+    }
+
+    @Override
+    public void deleteFromCache(Context context, UUID parent, UUID child) throws SQLException {
+        Query query = getHibernateSession(context).createNativeQuery(
+            "delete from group2groupcache g WHERE g.parent_id = :parent AND g.child_id = :child"
+        );
+        query.setParameter("parent", parent);
+        query.setParameter("child", child);
+        query.executeUpdate();
+    }
+
+    @Override
+    public void addToCache(Context context, UUID parent, UUID child) throws SQLException {
+        Query query = getHibernateSession(context).createNativeQuery(
+            "insert into group2groupcache (parent_id, child_id) VALUES (:parent, :child)"
+        );
+        query.setParameter("parent", parent);
+        query.setParameter("child", child);
+        query.executeUpdate();
     }
 }


### PR DESCRIPTION
## References

* Possible fix for #8197

## Description
Changes the way the Group2GroupCache table is computed to improve its performance. 

## Instructions for Reviewers

### Previous implementation

The Group2GroupCache table is computed by the `GroupServiceImpl::rethinkGroupCache` method.

In the older version the table is deleted and computed from scratch every time a group operation (adding/removing a group or subgroup) is performed.

The [previous `rethinkGroupCache` implementation](https://github.com/DSpace/DSpace/blob/main/dspace-api/src/main/java/org/dspace/eperson/GroupServiceImpl.java#L683) follows these basic steps:
- reads from the DB a `Map<UUID, Set<UUID>>`, mapping the parent group UUID to a set of its immediate child groups UUIDs 
- updates the sets of children, adding all children's children recursively
- deletes the current `Group2GroupCache table
- iterates over each map entry to store in the new cache table:
  1. first, gets the `Group` entity from the parent and child UUIDs
  2. checks if this (parent, child) pair already exists in the table
  3. then, creates the new row   

Running a Intellij IDEA profiler, it turned out that most of the time was spent on these last three steps, specially i and ii.

i. This is necessary because we get only UUIDs from the `GroupDAO`, and to create the `Group2GroupCache` entity we need to pass the related `Group` entities.
ii. This operation seems unnecessary. Since the data is stored in a `Map<UUID, Set<UUID>>`, where the key is the parent, there will never be a duplicated (parent, child) pair.
iii. Becomes costly because the entire table is deleted and rewritten

### PR changes

The changes made to address those points above are:
* Adds a unique constraint to the `Group2GroupCache` to assert the data integrity
* In `Group2GroupCacheDAO`:
  * Adds a method to get the entire table as a `Set<Pair<UUID, UUID>>`
  * Adds a method to delete a single row, given parent and child UUIDs
  * Adds a method to create a new row, given parent and child UUIDs 
* In `GroupServiceImpl::rethinkGroupCache`
  * Reads the current `Group2GroupCache` table and stores it in a `Set`
  * Creates the updated cache table in another `Set`, only in memory
  * Computes the set differences and find which rows to delete and to add
  * Executes the individual create/delete operations using the `Group2GroupCacheDAO`

@vitorsilverio also contributed to this PR.

### Testing

An easy way to test is to log in as an admin on the front-end, go to any collection, Edit Collection > Assign roles tab > open some group, like *Submitters*, Add Subgroup, search and add any subgroup or delete a current one.

Note that you will need to have a fair amount of groups in the DSpace instance, so the operation is slow in the previous implementation.

In our tests we had around 5k groups, which generated a 13k rows cache table.
In the previous version any group/subgroup operation took about 90s, and in this PR between 1s to 3s. 

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
