### PR TITLE
Make statistics autocommit much more frequently

### DIFF
--- a/dspace/solr/statistics/conf/solrconfig.xml
+++ b/dspace/solr/statistics/conf/solrconfig.xml
@@ -32,14 +32,16 @@
 
     <codecFactory class="solr.SchemaCodecFactory"/>
 
-    <!-- Use classic schema.xml & disallow programmatic changes to schema at runtime -->
+    <!-- Use classic schema.xml & disallow programmatic changes to
+         schema at runtime -->
     <schemaFactory class="ClassicIndexSchemaFactory"/>
 
     <indexConfig>
         <ramBufferSizeMB>32</ramBufferSizeMB>
         <maxBufferedDocs>1000</maxBufferedDocs>
         <lockType>${solr.lock.type:native}</lockType>
-        <!-- Set to true to "write detailed debug information from the indexing process as Solr log messages" -->
+        <!-- Set to true to "write detailed debug information from the
+             indexing process as Solr log messages" -->
         <infoStream>false</infoStream>
     </indexConfig>
 
@@ -48,7 +50,7 @@
         <!-- How often should commits be done automatically -->
         <autoCommit>
             <maxDocs>10000</maxDocs> <!--Commit every 10.000 documents-->
-            <maxTime>${solr.autoCommit.maxTime:900000}</maxTime> <!--Default commit every 15 minutes-->
+            <maxTime>${solr.autoCommit.maxTime:10000}</maxTime> <!--Ten seconds-->
             <openSearcher>true</openSearcher>
         </autoCommit>
 
@@ -62,14 +64,16 @@
         <maxBooleanClauses>${solr.max.booleanClauses:1024}</maxBooleanClauses>
 
         <!-- Cache used by SolrIndexSearcher for filters (DocSets) for
-             unordered sets of *all* documents that match a query. Caches results of 'fq' search param. -->
+             unordered sets of *all* documents that match a
+             query. Caches results of 'fq' search param. -->
         <filterCache class="solr.search.CaffeineCache"
                      size="512"
                      initialSize="512"
                      autowarmCount="0"/>
 
-        <!-- Caches results of previous searches - ordered lists of document ids
-         (DocList) based on a query, a sort, and the range of documents requested. -->
+        <!-- Caches results of previous searches - ordered lists of
+             document ids (DocList) based on a query, a sort, and the
+             range of documents requested. -->
         <queryResultCache class="solr.search.CaffeineCache"
                           size="512"
                           initialSize="512"
@@ -91,7 +95,8 @@
         <slowQueryThresholdMillis>1000</slowQueryThresholdMillis>
     </query>
 
-    <!-- Controls how the Solr HTTP RequestDispatcher responds to requests -->
+    <!-- Controls how the Solr HTTP RequestDispatcher responds to
+         requests -->
     <requestDispatcher handleSelect="false" >
         <requestParsers enableRemoteStreaming="true"
                         multipartUploadLimitInKB="-1"
@@ -113,7 +118,8 @@
 
     <!-- Processes updates to the index -->
     <requestHandler name="/update" class="solr.UpdateRequestHandler">
-        <!-- Update chain processor required by DSpace to auto generate the UUID field in solr -->
+        <!-- Update chain processor required by DSpace to auto
+             generate the UUID field in solr -->
         <lst name="defaults">
             <str name="update.chain">uuid</str>
         </lst>
@@ -126,7 +132,8 @@
         </lst>
     </requestHandler>
 
-    <!-- Required for DSpace to ensure that unique identifiers are added to each solr document -->
+    <!-- Required for DSpace to ensure that unique identifiers are
+         added to each solr document -->
     <updateRequestProcessorChain name="uuid">
         <processor class="solr.UUIDUpdateProcessorFactory">
             <str name="fieldName">uid</str>


### PR DESCRIPTION
## Description
The time between auto-commits of the Solr statistiscs core, as distributed, is 15 minutes.  This is painfully long for development and test, and much longer than necessary for production.  On a busy site the maximum updates count will turn over well before 15 minutes, and we want frequent TLOG roll-forwards to keep them short and unobtrusive.  On a seldom-used site, a few I/Os every ten seconds is negligible.

## Instructions for Reviewers
List of changes in this PR:
* First, decreased the timeout from 15 minutes to ten seconds.
* Second, tidied up some unfortunate wrapping in commentary.

You should notice little, if any, difference in performance, and much more timely statistics.

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).