### PR TITLE
several optimizations in HAL browser login page

### DIFF
--- a/dspace-server-webapp/src/main/resources/static/login.html
+++ b/dspace-server-webapp/src/main/resources/static/login.html
@@ -120,7 +120,7 @@
                 // Check for WWW-Authenticate header. If found, this means we are not yet authenticated, and
                 // therefore we need to display available authentication options.
                 var authenticate = xhr.getResponseHeader("WWW-Authenticate");
-                if (authenticate !== null && authenticate.contains('location=')) {
+                if (authenticate !== null && authenticate.includes('location=')) {
                     var element = $('div.other-login-methods');
                     var realms = authenticate.match(/(\w+ (\w+=((".*?")|[^,]*)(, )?)*)/g);
                     if (realms.length === 1){

--- a/dspace-server-webapp/src/main/resources/static/login.html
+++ b/dspace-server-webapp/src/main/resources/static/login.html
@@ -32,7 +32,7 @@
             border-radius: 5px;
             box-shadow: 0 1px 2px rgba(0, 0, 0, .05);
         }
-        .form-signin .form-signin-heading, .form-signin .checkbox {
+        .form-signin .form-signin-heading, .form-signin {
             margin-bottom: 10px;
         }
         .form-signin input[type="text"], .form-signin input[type="password"] {
@@ -94,63 +94,71 @@
             "onclick" : function() { toastr.remove(); }
         }
 
+        // retrieves a valid CSRF token (please note that this method works both in DS 7 and DS 8)
+        // HTTP response code 403 is expected at this point (the response contains the DSPACE-XSRF-TOKEN header)
+        $.ajax({
+            url : window.location.href.replace("login.html", "") + 'api/authn/login',
+            type : 'POST',
+            error : function(xhr) {
+                // Check for an update to the CSRF Token & save to a MyHalBrowserCsrfToken cookie (if found)
+                checkForUpdatedCSRFTokenInResponse(xhr);
+            }
+        });
+
         // When the login page loads, we do *two* AJAX requests.
-        // (1) Call GET /api/authn/status. This call has two purposes. First, it checks to see if you are logged in,
-        //     (if not, WWW-Authenticate will return login options). Second, it retrieves the CSRF token, if a
-        //     new one has been assigned (as a valid CSRF token is required for the POST call).
+        // (1) Call GET /api/authn/status. This call checks to see if you are logged in
+        //     (if not, WWW-Authenticate will return login options).
         // (2) If that /api/authn/status call finds authentication data, call POST /api/authn/login.
-        //     This scenario occurs when you login via an external authentication system (e.g. Shibboleth)...
+        //     This scenario occurs when you log in via an external authentication system (e.g. Shibboleth)
         //     in which case the main role of /api/authn/login is to simply ensure the "Authorization" header
         //     is sent back to the client (based on your authentication data).
         $.ajax({
-          url : window.location.href.replace("login.html", "") + 'api/authn/status',
-          type : 'GET',
-          success : function(result, status, xhr) {
-            // Check for an update to the CSRF Token & save to a MyHalBrowserCsrfToken cookie (if found)
-            checkForUpdatedCSRFTokenInResponse(xhr);
+            url : window.location.href.replace("login.html", "") + 'api/authn/status',
+            type : 'GET',
+            success : function(result, status, xhr) {
 
-            // Check for WWW-Authenticate header. If found, this means we are not yet authenticated, and
-            // therefore we need to display available authentication options.
-            var authenticate = xhr.getResponseHeader("WWW-Authenticate");
-            if (authenticate !== null) {
-                var element = $('div.other-login-methods');
-                var realms = authenticate.match(/(\w+ (\w+=((".*?")|[^,]*)(, )?)*)/g);
-                if (realms.length == 1){
-                    var loc = /location="([^,]*)"/.exec(authenticate);
-                    if (loc !== null && loc.length === 2) {
-                        document.location = loc[1];
+                // Check for WWW-Authenticate header. If found, this means we are not yet authenticated, and
+                // therefore we need to display available authentication options.
+                var authenticate = xhr.getResponseHeader("WWW-Authenticate");
+                if (authenticate !== null && authenticate.contains('location=')) {
+                    var element = $('div.other-login-methods');
+                    var realms = authenticate.match(/(\w+ (\w+=((".*?")|[^,]*)(, )?)*)/g);
+                    if (realms.length === 1){
+                        var loc = /location="([^,]*)"/.exec(authenticate);
+                        if (loc !== null && loc.length === 2) {
+                            document.location = loc[1];
+                        }
+                    } else if (realms.length > 1){
+                        for (var i = 0; i < realms.length; i++){
+                            addLocationButton(realms[i], element);
+                        }
                     }
-                } else if (realms.length > 1){
-                    for (var i = 0; i < realms.length; i++){
-                        addLocationButton(realms[i], element);
-                    }
+                } else {
+                    // If Authentication data was found, do a POST /api/authn/login to ensure that data's JWT
+                    // is sent back in the "Authorization" header. This simply completes an external authentication
+                    // process (e.g. Shibboleth)
+                    $.ajax({
+                        url : window.location.href.replace("login.html", "") + 'api/authn/login',
+                        type : 'POST',
+                        beforeSend: function (xhr) {
+                            // If CSRF token found in cookie, send it back as X-XSRF-Token header
+                            var csrfToken = getCSRFToken();
+                            if (csrfToken != null) {
+                                xhr.setRequestHeader('X-XSRF-Token', csrfToken);
+                            }
+                        },
+                        success : successHandler,
+                        error : function(xhr) {
+                            // Check for an update to the CSRF Token & save to a MyHalBrowserCsrfToken cookie (if found)
+                            checkForUpdatedCSRFTokenInResponse(xhr);
+                            toastr.error('Failed to logged in. Please check for errors in Javascript console.', 'Login Failed');
+                        }
+                    });
                 }
-            } else {
-                // If Authentication data was found, do a POST /api/authn/login to ensure that data's JWT
-                // is sent back in the "Authorization" header. This simply completes an external authentication
-                // process (e.g. Shibboleth)
-                $.ajax({
-                  url : window.location.href.replace("login.html", "") + 'api/authn/login',
-                  type : 'POST',
-                  beforeSend: function (xhr, settings) {
-                       // If CSRF token found in cookie, send it back as X-XSRF-Token header
-                       var csrfToken = getCSRFToken();
-                       if (csrfToken != null) {
-                           xhr.setRequestHeader('X-XSRF-Token', csrfToken);
-                       }
-                  },
-                  success : successHandler,
-                  error : function(xhr, textStatus, errorThrown) {
-                      // Check for an update to the CSRF Token & save to a MyHalBrowserCsrfToken cookie (if found)
-                      checkForUpdatedCSRFTokenInResponse(xhr);
-                      toastr.error('Failed to logged in. Please check for errors in Javascript console.', 'Login Failed');
-                  }
-                });
+            },
+            error : function() {
+                toastr.error('Failed to connect with backend. Please check for errors in Javascript console.', 'Could Not Load');
             }
-          },
-          error : function(xhr, textStatus, errorThrown) {
-            toastr.error('Failed to connect with backend. Please check for errors in Javascript console.', 'Could Not Load');
-          }
         });
 
         function addLocationButton(realm, element){
@@ -166,22 +174,22 @@
             return string.charAt(0).toUpperCase() + string.slice(1);
         }
 
-       /**
-        * Check current response headers to see if the CSRF Token has changed. If a new value is found in headers,
-        * save the new value into our "MyHalBrowserCsrfToken" cookie.
-        **/
+        /**
+         * Check current response headers to see if the CSRF Token has changed. If a new value is found in headers,
+         * save the new value into our "MyHalBrowserCsrfToken" cookie.
+         **/
         function checkForUpdatedCSRFTokenInResponse(jqxhr) {
             // look for DSpace-XSRF-TOKEN header & save to our MyHalBrowserCsrfToken cookie (if found)
             var updatedCsrfToken = jqxhr.getResponseHeader('DSPACE-XSRF-TOKEN');
             if (updatedCsrfToken != null) {
-               document.cookie = "MyHalBrowserCsrfToken=" + updatedCsrfToken;
+                document.cookie = "MyHalBrowserCsrfToken=" + updatedCsrfToken;
             }
         }
 
-       /**
-        * Get CSRF Token by parsing it out of the "MyHalBrowserCsrfToken" cookie.
-        * This cookie is set in login.html after a successful login occurs.
-        **/
+        /**
+         * Get CSRF Token by parsing it out of the "MyHalBrowserCsrfToken" cookie.
+         * This cookie is set in login.html after a successful login occurs.
+         **/
         function getCSRFToken() {
             var cookie = document.cookie.match('(^|;)\\s*' + 'MyHalBrowserCsrfToken' + '\\s*=\\s*([^;]+)');
             if (cookie != null) {
@@ -204,11 +212,11 @@
                     user: $("#username").val(),
                     password: $("#password").val()
                 },
-                beforeSend: function (xhr, settings) {
+                beforeSend: function (xhr) {
                     // If CSRF token found in cookie, send it back as X-XSRF-Token header
                     var csrfToken = getCSRFToken();
                     if (csrfToken != null) {
-                       xhr.setRequestHeader('X-XSRF-Token', csrfToken);
+                        xhr.setRequestHeader('X-XSRF-Token', csrfToken);
                     }
                 },
                 success : successHandler,


### PR DESCRIPTION
## Description

This PR fixes **3 problems** in the login page of the HAL browser:

1. The **first** login attempt is always failing. Open a new **private** browser tab, go to https://demo.dspace.org/server/login.html and insert the DSpace admin credentials. You'll get a red error message:

![image](https://github.com/user-attachments/assets/dd7e4dfe-fb9a-40fc-9269-1378165ee30a)

The **second** login attempt is successful. This PR fixes this bug and the proposed bugfix works with DS 7 and 8.

2. In case, the DSpace instance supports **multiple authentication methods** the login form shows a section _Other login methods:_

![image](https://github.com/user-attachments/assets/8092aa59-f05e-4bb3-9e0c-79fbc9d3eb75)

The authentication methods are extracted from the `WWW-Authenticate` response header. In case, the DSpace instance supports only password-based and LDAP-based authentication the `WWW-Authenticate` header does **not** contain `location=`:

```
WWW-Authenticate: password realm="DSpace REST API", ldap realm="DSpace REST API"
```

In this case the login form has an empty _Other login methods:_ section:

![image](https://github.com/user-attachments/assets/865fb4cf-ff29-4573-a80e-bff8592a6425)

This PR fixes this bug as it shows the _Other login methods:_ section only if at least one authentication method provides a `location=` in the `WWW-Authenticate` header. This results in:

![image](https://github.com/user-attachments/assets/e8abbe0d-7b39-46ac-b623-2564fa616c78)

3. This PR removes obsolete code fragments (method parameters, CSS classes) from the CSS and JS code in `login.html`.
