### PR TITLE
[Port dspace-7_x] In workflow-attached curation, separate task-list building from execution.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/curate/XmlWorkflowCuratorServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/curate/XmlWorkflowCuratorServiceImpl.java
@@ -140,14 +140,14 @@ public class XmlWorkflowCuratorServiceImpl
             item.setOwningCollection(wfi.getCollection());
             for (Task task : step.tasks) {
                 curator.addTask(task.name);
+            }
 
-                // Check whether the task is configured to be queued rather than automatically run
-                if (StringUtils.isNotEmpty(step.queue)) {
-                    // queue attribute has been set in the FlowStep configuration: add task to configured queue
-                    curator.queue(c, item.getID().toString(), step.queue);
-                } else {
-                    // Task is configured to be run automatically
-                    curator.curate(c, item);
+            if (StringUtils.isNotEmpty(step.queue)) { // Step's tasks are to be queued.
+                curator.queue(c, item.getID().toString(), step.queue);
+            } else { // Step's tasks are to be run now.
+                curator.curate(c, item);
+
+                for (Task task : step.tasks) {
                     int status = curator.getStatus(task.name);
                     String result = curator.getResult(task.name);
                     String action = "none";
@@ -184,14 +184,14 @@ public class XmlWorkflowCuratorServiceImpl
                     }
                 }
                 curator.clear();
-            }
 
-            // Record any reporting done by the tasks.
-            if (reporter.length() > 0) {
-                LOG.info("Curation tasks over item {} for step {} report:%n{}",
-                    () -> wfi.getItem().getID(),
-                    () -> step.step,
-                    () -> reporter.toString());
+                // Record any reporting done by the tasks.
+                if (reporter.length() > 0) {
+                    LOG.info("Curation tasks over item {} for step {} report:\n{}",
+                        () -> wfi.getItem().getID(),
+                        () -> step.step,
+                        () -> reporter.toString());
+                }
             }
         }
         return true;

--- a/dspace-api/src/main/java/org/dspace/curate/package-info.java
+++ b/dspace-api/src/main/java/org/dspace/curate/package-info.java
@@ -20,6 +20,8 @@
  * </dl>
  *
  * <p>Curation requests may be run immediately or queued for batch processing.
+ * See {@link TaskQueue} and its relatives, {@link Curation} and its relatives
+ * for more on queued curation.
  *
  * <p>Tasks may also be attached to a workflow step, so that a set of tasks is
  * applied to each uninstalled Item which passes through that step.  See
@@ -27,5 +29,15 @@
  *
  * <p>A task may return to the Curator a status code, a final status message,
  * and an optional report character stream.
+ *
+ * <p>The {@link Reporter} classes absorb strings of text and preserve it in
+ * various ways.  A Reporter is a simple {@link Appendable} and makes no
+ * assumptions about e.g. whether a string represents a complete line.  If you
+ * want your report formatted, insert appropriate newlines and other whitespace
+ * as needed.  Your tasks can emit marked-up text if you wish, but the stock
+ * Reporter implementations make no attempt to render it.
+ *
+ * <p>Tasks may be annotated to inform the Curator of special properties.  See
+ * {@link Distributive}, {@link Mutative}, {@link Suspendable} etc.
  */
 package org.dspace.curate;


### PR DESCRIPTION
Manual port of #9497 by @mwoodiupui to `dspace-7_x`
