### PR TITLE
Translate underscores to dashes in xml:lang attr for DIM2DataCite.xsl

### DIFF
--- a/dspace/config/crosswalks/DIM2DataCite.xsl
+++ b/dspace/config/crosswalks/DIM2DataCite.xsl
@@ -25,6 +25,10 @@
          to register DOIs anymore. Please follow and reuse the examples
          included in this file. For more information on the DataCite
          Schema, see https://schema.datacite.org. -->
+    <!-- Note regarding language codes: xml:lang regional language codes require a hyphen, whereas many
+         repositories use underscores when storing these language codes (e.g. en_GB, de_CH).
+         This template translates all underscores to hyphens when selecting value of @lang in an attribute
+         so the output will be e.g. xml:lang="en-GB", xml:lang="de-CH". -->
     
     <!-- We need the prefix to determine DOIs that were minted by ourself. -->
     <xsl:param name="prefix">10.5072/dspace-</xsl:param>
@@ -362,20 +366,20 @@
     <!-- DataCite (3) :: Title -->
     <xsl:template match="dspace:field[@mdschema='dc' and @element='title']">
         <xsl:element name="title">
-            <xsl:attribute name="xml:lang"><xsl:value-of select="@lang" /></xsl:attribute>
+            <xsl:attribute name="xml:lang"><xsl:value-of select="translate(@lang, '_', '-')" /></xsl:attribute>
             <xsl:if test="@qualifier='alternative'">
-                <xsl:attribute name="xml:lang"><xsl:value-of select="@lang" /></xsl:attribute>
+                <xsl:attribute name="xml:lang"><xsl:value-of select="translate(@lang, '_', '-')" /></xsl:attribute>
                 <xsl:attribute name="titleType">AlternativeTitle</xsl:attribute>
             </xsl:if>
-            <!-- DSpace does include niehter a dc.title.subtitle nor a 
+            <!-- DSpace doesn't include a dc.title.subtitle nor a
                  dc.title.translated. If necessary, please create those in the 
                  metadata field registry. -->
             <xsl:if test="@qualifier='subtitle'">
-                <xsl:attribute name="xml:lang"><xsl:value-of select="@lang" /></xsl:attribute>
+                <xsl:attribute name="xml:lang"><xsl:value-of select="translate(@lang, '_', '-')" /></xsl:attribute>
                 <xsl:attribute name="titleType">Subtitle</xsl:attribute>
             </xsl:if>
             <xsl:if test="@qualifier='translated'">
-                <xsl:attribute name="xml:lang"><xsl:value-of select="@lang" /></xsl:attribute>
+                <xsl:attribute name="xml:lang"><xsl:value-of select="translate(@lang, '_', '-')" /></xsl:attribute>
                 <xsl:attribute name="titleType">TranslatedTitle</xsl:attribute>
             </xsl:if>
             <xsl:value-of select="." />
@@ -394,7 +398,7 @@
     -->
     <xsl:template match="//dspace:field[@mdschema='dc' and @element='subject']">
         <xsl:element name="subject">
-            <xsl:attribute name="xml:lang"><xsl:value-of select="@lang" /></xsl:attribute>
+            <xsl:attribute name="xml:lang"><xsl:value-of select="translate(@lang, '_', '-')" /></xsl:attribute>
             <xsl:if test="@qualifier">
                 <xsl:attribute name="subjectScheme"><xsl:value-of select="@qualifier" /></xsl:attribute>
             </xsl:if>
@@ -626,7 +630,7 @@
     -->
     <xsl:template match="//dspace:field[@mdschema='dc' and @element='description' and (@qualifier='abstract' or @qualifier='tableofcontents' or not(@qualifier))]">
         <xsl:element name="description">
-            <xsl:attribute name="xml:lang"><xsl:value-of select="@lang" /></xsl:attribute>
+            <xsl:attribute name="xml:lang"><xsl:value-of select="translate(@lang, '_', '-')" /></xsl:attribute>
             <xsl:attribute name="descriptionType">
            	<xsl:choose>
                     <xsl:when test="@qualifier='abstract'">Abstract</xsl:when>


### PR DESCRIPTION
As per https://www.w3.org/International/articles/language-tags/#region , regional language codes should use hyphens e.g. en-GB, de-CH. However, a lot of DSpace instances use underscores instead of hyphens.

This PR modifies the DataCite crosswalk (used in DOI registration and metadata update) to translate any underscores in the value of `@lang` to dashes.

## Instructions for Reviewers

You can test this by
* Make sure you are configured with a DataCite DOI test account
* Configuring a language code like `en_NZ` for a title or description metadata value in an item
* Try to reserve, register or update that item for a DOI and observe the error message

Then apply this PR and try again. This operation should now succeed.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
