### PR TITLE
Rewrite DSpace integration tests to consistently use AbstractBuilder<T> builders

### DIFF
--- a/dspace-api/src/test/java/org/dspace/administer/StructBuilderIT.java
+++ b/dspace-api/src/test/java/org/dspace/administer/StructBuilderIT.java
@@ -23,11 +23,12 @@ import javax.xml.transform.stream.StreamSource;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.dspace.AbstractIntegrationTest;
+import org.dspace.AbstractIntegrationTestWithDatabase;
 import org.dspace.authorize.AuthorizeException;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
-import org.dspace.content.MetadataSchemaEnum;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.CollectionService;
 import org.dspace.content.service.CommunityService;
@@ -38,7 +39,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Node;
-import org.xml.sax.SAXException;
 import org.xmlunit.builder.DiffBuilder;
 import org.xmlunit.diff.Comparison;
 import org.xmlunit.diff.ComparisonFormatter;
@@ -52,7 +52,7 @@ import org.xmlunit.diff.Difference;
  * @author Mark H. Wood <mwood@iupui.edu>
  */
 public class StructBuilderIT
-        extends AbstractIntegrationTest {
+        extends AbstractIntegrationTestWithDatabase {
     private static final Logger log = LogManager.getLogger();
 
     private static final CommunityService communityService
@@ -79,7 +79,8 @@ public class StructBuilderIT
      * @throws IOException passed through.
      */
     @Before
-    public void setUp() throws SQLException, AuthorizeException, IOException {
+    public void setUp() throws Exception {
+        super.setUp();
         // Clear out all communities and collections.
         context.turnOffAuthorisationSystem();
         for (Community community : communityService.findAllTop(context)) {
@@ -285,19 +286,15 @@ public class StructBuilderIT
      * @throws org.dspace.authorize.AuthorizeException passed through.
      */
     @Test
-    public void testExportStructure()
-            throws ParserConfigurationException, SAXException, IOException,
-            SQLException, AuthorizeException {
+    public void testExportStructure() {
         // Create some structure to test.
         context.turnOffAuthorisationSystem();
-        Community community0 = communityService.create(null, context);
-        communityService.setMetadataSingleValue(context, community0,
-                MetadataSchemaEnum.DC.getName(), "title", null,
-                null, "Top Community 0");
-        Collection collection0_0 = collectionService.create(context, community0);
-        collectionService.setMetadataSingleValue(context, collection0_0,
-                MetadataSchemaEnum.DC.getName(), "title", null,
-                null, "Collection 0.0");
+        // Top level community
+        Community community0 = CommunityBuilder.createCommunity(context)
+                .withName("Top Community 0").build();
+        // Collection below top level community
+        Collection collection0_0 = CollectionBuilder.createCollection(context, community0)
+                .withName("Collection 0.0").build();
 
         // Export the current structure.
         System.out.println("exportStructure");

--- a/dspace-api/src/test/java/org/dspace/app/packager/PackagerIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/packager/PackagerIT.java
@@ -24,6 +24,7 @@ import org.dspace.AbstractIntegrationTestWithDatabase;
 import org.dspace.builder.CollectionBuilder;
 import org.dspace.builder.CommunityBuilder;
 import org.dspace.builder.ItemBuilder;
+import org.dspace.builder.WorkspaceItemBuilder;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.Item;
@@ -159,7 +160,7 @@ public class PackagerIT extends AbstractIntegrationTestWithDatabase {
         performExportScript(article.getHandle(), tempFile);
         UUID id = article.getID();
         itemService.delete(context, article);
-        WorkspaceItem workspaceItem = workspaceItemService.create(context, col1, id, false, false);
+        WorkspaceItem workspaceItem = WorkspaceItemBuilder.createWorkspaceItem(context, col1, id).build();
         installItemService.installItem(context, workspaceItem, "123456789/0100");
         performImportNoForceScript(tempFile);
         Iterator<Item> items = itemService.findByCollection(context, col1);

--- a/dspace-api/src/test/java/org/dspace/builder/GroupBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/GroupBuilder.java
@@ -12,6 +12,9 @@ import java.sql.SQLException;
 import java.util.UUID;
 
 import org.dspace.authorize.AuthorizeException;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.DSpaceObject;
 import org.dspace.content.service.DSpaceObjectService;
 import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
@@ -51,10 +54,85 @@ public class GroupBuilder extends AbstractDSpaceObjectBuilder<Group> {
         return builder.create(context);
     }
 
+    public static GroupBuilder createCollectionAdminGroup(final Context context, Collection collection) {
+        GroupBuilder builder = new GroupBuilder(context);
+        return builder.createAdminGroup(context, collection);
+    }
+
+    public static GroupBuilder createCollectionSubmitterGroup(final Context context, Collection collection) {
+        GroupBuilder builder = new GroupBuilder(context);
+        return builder.createSubmitterGroup(context, collection);
+    }
+
+    public static GroupBuilder createCollectionDefaultReadGroup(final Context context, Collection collection,
+                                                                String typeOfGroupString, int defaultRead) {
+        GroupBuilder builder = new GroupBuilder(context);
+        return builder.createDefaultReadGroup(context, collection, typeOfGroupString, defaultRead);
+    }
+
+    public static GroupBuilder createCollectionWorkflowRoleGroup(final Context context, Collection collection,
+                                                                String roleName) {
+        GroupBuilder builder = new GroupBuilder(context);
+        return builder.createWorkflowRoleGroup(context, collection, roleName);
+    }
+
+    public static GroupBuilder createCommunityAdminGroup(final Context context, Community community) {
+        GroupBuilder builder = new GroupBuilder(context);
+        return builder.createAdminGroup(context, community);
+    }
+
     private GroupBuilder create(final Context context) {
         this.context = context;
         try {
             group = groupService.create(context);
+        } catch (Exception e) {
+            return handleException(e);
+        }
+        return this;
+    }
+
+    private GroupBuilder createAdminGroup(final Context context, DSpaceObject container) {
+        this.context = context;
+        try {
+            if (container instanceof Collection) {
+                group = collectionService.createAdministrators(context, (Collection) container);
+            } else if (container instanceof Community) {
+                group = communityService.createAdministrators(context, (Community) container);
+            } else {
+                handleException(new IllegalArgumentException("DSpaceObject must be collection or community. " +
+                        "Type: " + container.getType()));
+            }
+        } catch (Exception e) {
+            return handleException(e);
+        }
+        return this;
+    }
+
+    private GroupBuilder createSubmitterGroup(final Context context, Collection collection) {
+        this.context = context;
+        try {
+            group = collectionService.createSubmitters(context, collection);
+        } catch (Exception e) {
+            return handleException(e);
+        }
+        return this;
+    }
+
+    private GroupBuilder createDefaultReadGroup(final Context context, Collection collection,
+                                                String typeOfGroupString, int defaultRead) {
+        this.context = context;
+        try {
+            group = collectionService.createDefaultReadGroup(context, collection, typeOfGroupString, defaultRead);
+        } catch (Exception e) {
+            return handleException(e);
+        }
+        return this;
+    }
+
+    private GroupBuilder createWorkflowRoleGroup(final Context context, Collection collection, String roleName) {
+        this.context = context;
+        try {
+            group = workflowService.createWorkflowRoleGroup(context, collection, roleName);
         } catch (Exception e) {
             return handleException(e);
         }

--- a/dspace-api/src/test/java/org/dspace/builder/WorkspaceItemBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/WorkspaceItemBuilder.java
@@ -10,6 +10,7 @@ package org.dspace.builder;
 import java.io.IOException;
 import java.io.InputStream;
 import java.sql.SQLException;
+import java.util.UUID;
 
 import org.dspace.app.ldn.NotifyPatternToTrigger;
 import org.dspace.app.ldn.NotifyServiceEntity;
@@ -43,14 +44,31 @@ public class WorkspaceItemBuilder extends AbstractBuilder<WorkspaceItem, Workspa
 
     public static WorkspaceItemBuilder createWorkspaceItem(final Context context, final Collection col) {
         WorkspaceItemBuilder builder = new WorkspaceItemBuilder(context);
-        return builder.create(context, col);
+        return builder.create(context, col, null);
     }
 
-    private WorkspaceItemBuilder create(final Context context, final Collection col) {
+    public static WorkspaceItemBuilder createWorkspaceItem(final Context context, final Collection col, UUID uuid) {
+        WorkspaceItemBuilder builder = new WorkspaceItemBuilder(context);
+        return builder.create(context, col, uuid);
+    }
+
+    /**
+     * Create with a specific UUID (e.g. restoring items with Packager import)
+     *
+     * @param context DSpace context
+     * @param col Parent collection
+     * @param uuid Item UUID
+     * @return WorkspaceItemBuilder
+     */
+    private WorkspaceItemBuilder create(final Context context, final Collection col, UUID uuid) {
         this.context = context;
 
         try {
-            workspaceItem = workspaceItemService.create(context, col, false);
+            if (uuid == null) {
+                workspaceItem = workspaceItemService.create(context, col, false);
+            } else {
+                workspaceItem = workspaceItemService.create(context, col, uuid, false, false);
+            }
             item = workspaceItem.getItem();
         } catch (Exception e) {
             return handleException(e);

--- a/dspace-api/src/test/java/org/dspace/content/VersioningWithRelationshipsIT.java
+++ b/dspace-api/src/test/java/org/dspace/content/VersioningWithRelationshipsIT.java
@@ -49,6 +49,7 @@ import org.dspace.builder.EntityTypeBuilder;
 import org.dspace.builder.ItemBuilder;
 import org.dspace.builder.RelationshipBuilder;
 import org.dspace.builder.RelationshipTypeBuilder;
+import org.dspace.builder.VersionBuilder;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.InstallItemService;
 import org.dspace.content.service.ItemService;
@@ -62,8 +63,6 @@ import org.dspace.discovery.SolrSearchCore;
 import org.dspace.kernel.ServiceManager;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.versioning.Version;
-import org.dspace.versioning.factory.VersionServiceFactory;
-import org.dspace.versioning.service.VersioningService;
 import org.hamcrest.Matcher;
 import org.junit.Assert;
 import org.junit.Before;
@@ -74,8 +73,6 @@ public class VersioningWithRelationshipsIT extends AbstractIntegrationTestWithDa
 
     private final RelationshipService relationshipService =
         ContentServiceFactory.getInstance().getRelationshipService();
-    private final VersioningService versioningService =
-        VersionServiceFactory.getInstance().getVersionService();
     private final WorkspaceItemService workspaceItemService =
         ContentServiceFactory.getInstance().getWorkspaceItemService();
     private final InstallItemService installItemService =
@@ -291,7 +288,7 @@ public class VersioningWithRelationshipsIT extends AbstractIntegrationTestWithDa
         // create a new version of the publication //
         /////////////////////////////////////////////
 
-        Version newVersion = versioningService.createNewVersion(context, originalPublication);
+        Version newVersion = VersionBuilder.createVersion(context, originalPublication, "test").build();
         Item newPublication = newVersion.getItem();
         assertNotSame(originalPublication, newPublication);
 
@@ -567,7 +564,7 @@ public class VersioningWithRelationshipsIT extends AbstractIntegrationTestWithDa
         // create a new version of the publication //
         /////////////////////////////////////////////
 
-        Version newVersion = versioningService.createNewVersion(context, originalPublication);
+        Version newVersion = VersionBuilder.createVersion(context, originalPublication, "test").build();
         Item newPublication = newVersion.getItem();
         assertNotSame(originalPublication, newPublication);
 
@@ -927,7 +924,7 @@ public class VersioningWithRelationshipsIT extends AbstractIntegrationTestWithDa
         // create a new version of the person //
         ////////////////////////////////////////
 
-        Version newVersion = versioningService.createNewVersion(context, originalPerson);
+        Version newVersion = VersionBuilder.createVersion(context, originalPerson, "test").build();
         Item newPerson = newVersion.getItem();
         assertNotSame(originalPerson, newPerson);
 
@@ -1300,7 +1297,7 @@ public class VersioningWithRelationshipsIT extends AbstractIntegrationTestWithDa
         // create new version of publication //
         ///////////////////////////////////////
 
-        Version newVersion = versioningService.createNewVersion(context, originalPublication);
+        Version newVersion = VersionBuilder.createVersion(context, originalPublication, "test").build();
         Item newPublication = newVersion.getItem();
         assertNotSame(originalPublication, newPublication);
 
@@ -1463,7 +1460,7 @@ public class VersioningWithRelationshipsIT extends AbstractIntegrationTestWithDa
         // create a new version of the publication //
         /////////////////////////////////////////////
 
-        Version newVersion = versioningService.createNewVersion(context, originalPublication);
+        Version newVersion = VersionBuilder.createVersion(context, originalPublication, "test").build();
         Item newPublication = newVersion.getItem();
         assertNotSame(originalPublication, newPublication);
 
@@ -1782,7 +1779,7 @@ public class VersioningWithRelationshipsIT extends AbstractIntegrationTestWithDa
         // create new version - volume 1.2 //
         /////////////////////////////////////
 
-        Item v1_2 = versioningService.createNewVersion(context, v1_1).getItem();
+        Item v1_2 = VersionBuilder.createVersion(context, v1_1, "test").build().getItem();
         installItemService.installItem(context, workspaceItemService.findByItem(context, v1_2));
         context.commit();
 
@@ -1790,7 +1787,7 @@ public class VersioningWithRelationshipsIT extends AbstractIntegrationTestWithDa
         // create new version - issue 3.2 //
         ////////////////////////////////////
 
-        Item i3_2 = versioningService.createNewVersion(context, i3_1).getItem();
+        Item i3_2 = VersionBuilder.createVersion(context, i3_1, "test").build().getItem();
         installItemService.installItem(context, workspaceItemService.findByItem(context, i3_2));
         context.commit();
 
@@ -2316,7 +2313,7 @@ public class VersioningWithRelationshipsIT extends AbstractIntegrationTestWithDa
                 // create new version - person 3.2 //
                 /////////////////////////////////////
 
-                Item pe3_2 = versioningService.createNewVersion(context, pe3_1).getItem();
+                Item pe3_2 = VersionBuilder.createVersion(context, pe3_1, "test").build().getItem();
                 installItemService.installItem(context, workspaceItemService.findByItem(context, pe3_2));
                 context.commit();
 
@@ -2324,7 +2321,7 @@ public class VersioningWithRelationshipsIT extends AbstractIntegrationTestWithDa
                 // create new version - project 3.2 //
                 //////////////////////////////////////
 
-                Item pr3_2 = versioningService.createNewVersion(context, pr3_1).getItem();
+                Item pr3_2 = VersionBuilder.createVersion(context, pr3_1, "test").build().getItem();
                 installItemService.installItem(context, workspaceItemService.findByItem(context, pr3_2));
                 context.commit();
 
@@ -3056,7 +3053,7 @@ public class VersioningWithRelationshipsIT extends AbstractIntegrationTestWithDa
         // create new version - volume 1.2 //
         /////////////////////////////////////
 
-        Item v1_2 = versioningService.createNewVersion(context, v1_1).getItem();
+        Item v1_2 = VersionBuilder.createVersion(context, v1_1, "test").build().getItem();
         installItemService.installItem(context, workspaceItemService.findByItem(context, v1_2));
         context.commit();
 
@@ -3064,7 +3061,7 @@ public class VersioningWithRelationshipsIT extends AbstractIntegrationTestWithDa
         // create new version - issue 3.2 //
         ////////////////////////////////////
 
-        Item i3_2 = versioningService.createNewVersion(context, i3_1).getItem();
+        Item i3_2 = VersionBuilder.createVersion(context, i3_1, "test").build().getItem();
         installItemService.installItem(context, workspaceItemService.findByItem(context, i3_2));
         context.commit();
 
@@ -3509,7 +3506,7 @@ public class VersioningWithRelationshipsIT extends AbstractIntegrationTestWithDa
         // create a new version of publication 1 and archive //
         ///////////////////////////////////////////////////////
 
-        Item publication1V2 = versioningService.createNewVersion(context, publication1V1).getItem();
+        Item publication1V2 = VersionBuilder.createVersion(context, publication1V1, "test").build().getItem();
         installItemService.installItem(context, workspaceItemService.findByItem(context, publication1V2));
         context.dispatchEvents();
 
@@ -3517,7 +3514,7 @@ public class VersioningWithRelationshipsIT extends AbstractIntegrationTestWithDa
         // create new version of person 1 //
         ////////////////////////////////////
 
-        Item person1V2 = versioningService.createNewVersion(context, person1V1).getItem();
+        Item person1V2 = VersionBuilder.createVersion(context, person1V1, "test").build().getItem();
         // update "Smith, Donald" to "Smith, D."
         itemService.replaceMetadata(
             context, person1V2, "person", "givenName", null, null, "D.",
@@ -3853,7 +3850,7 @@ public class VersioningWithRelationshipsIT extends AbstractIntegrationTestWithDa
         // create new version of person 2 //
         ////////////////////////////////////
 
-        Item person2V2 = versioningService.createNewVersion(context, person2V1).getItem();
+        Item person2V2 = VersionBuilder.createVersion(context, person2V1, "test").build().getItem();
         Relationship rel1 = getRelationship(publication1V2, isAuthorOfPublication, person2V2);
         assertNotNull(rel1);
         rel1.setRightwardValue("Doe, Jane Jr");

--- a/dspace-api/src/test/java/org/dspace/content/VersioningWithRelationshipsIT.java
+++ b/dspace-api/src/test/java/org/dspace/content/VersioningWithRelationshipsIT.java
@@ -60,9 +60,6 @@ import org.dspace.content.virtual.VirtualMetadataConfiguration;
 import org.dspace.content.virtual.VirtualMetadataPopulator;
 import org.dspace.core.Constants;
 import org.dspace.discovery.SolrSearchCore;
-import org.dspace.identifier.IdentifierProvider;
-import org.dspace.identifier.IdentifierServiceImpl;
-import org.dspace.identifier.VersionedHandleIdentifierProvider;
 import org.dspace.kernel.ServiceManager;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.versioning.Version;
@@ -84,7 +81,6 @@ public class VersioningWithRelationshipsIT extends AbstractIntegrationTestWithDa
         ContentServiceFactory.getInstance().getItemService();
     private final SolrSearchCore solrSearchCore =
         DSpaceServicesFactory.getInstance().getServiceManager().getServicesByType(SolrSearchCore.class).get(0);
-    private IdentifierServiceImpl identifierService;
     protected Community community;
     protected Collection collection;
     protected EntityType publicationEntityType;
@@ -101,31 +97,12 @@ public class VersioningWithRelationshipsIT extends AbstractIntegrationTestWithDa
     protected RelationshipType isIssueOfJournalVolume;
     protected RelationshipType isProjectOfPerson;
 
-    private void registerProvider(Class type) {
-        // Register our new provider
-        IdentifierProvider identifierProvider =
-                (IdentifierProvider) DSpaceServicesFactory.getInstance().getServiceManager().getServiceByName(type.getName(), type);
-        if (identifierProvider == null) {
-            DSpaceServicesFactory.getInstance().getServiceManager().registerServiceClass(type.getName(), type);
-            identifierProvider = (IdentifierProvider) DSpaceServicesFactory.getInstance().getServiceManager().getServiceByName(type.getName(), type);
-        }
-
-        // Overwrite the identifier-service's providers with the new one to ensure only this provider is used
-        identifierService = DSpaceServicesFactory.getInstance().getServiceManager()
-                .getServicesByType(IdentifierServiceImpl.class).get(0);
-        identifierService.setProviders(new ArrayList<>());
-        identifierService.setProviders(List.of(identifierProvider));
-    }
-
     @Override
     @Before
     public void setUp() throws Exception {
         super.setUp();
 
         context.turnOffAuthorisationSystem();
-
-
-        registerProvider(VersionedHandleIdentifierProvider.class);
 
         community = CommunityBuilder.createCommunity(context)
             .withName("community")

--- a/dspace-api/src/test/java/org/dspace/supervision/SupervisionOrderServiceIT.java
+++ b/dspace-api/src/test/java/org/dspace/supervision/SupervisionOrderServiceIT.java
@@ -18,6 +18,7 @@ import org.dspace.builder.CollectionBuilder;
 import org.dspace.builder.CommunityBuilder;
 import org.dspace.builder.EPersonBuilder;
 import org.dspace.builder.GroupBuilder;
+import org.dspace.builder.SupervisionOrderBuilder;
 import org.dspace.builder.WorkspaceItemBuilder;
 import org.dspace.content.Collection;
 import org.dspace.content.Item;
@@ -85,10 +86,10 @@ public class SupervisionOrderServiceIT extends AbstractIntegrationTestWithDataba
                                    .build();
 
         SupervisionOrder supervisionOrderOne =
-            supervisionOrderService.create(context, item, groupA);
+                SupervisionOrderBuilder.createSupervisionOrder(context, item, groupA).build();
 
         SupervisionOrder supervisionOrderTwo =
-            supervisionOrderService.create(context, item, groupB);
+                SupervisionOrderBuilder.createSupervisionOrder(context, item, groupB).build();
 
         context.restoreAuthSystemState();
 
@@ -136,7 +137,8 @@ public class SupervisionOrderServiceIT extends AbstractIntegrationTestWithDataba
                                    .build();
 
         SupervisionOrder supervisionOrderOne =
-            supervisionOrderService.create(context, workspaceItem.getItem(), groupA);
+                SupervisionOrderBuilder.createSupervisionOrder(context, workspaceItem.getItem(), groupA)
+                        .build();
 
         context.restoreAuthSystemState();
 
@@ -205,9 +207,12 @@ public class SupervisionOrderServiceIT extends AbstractIntegrationTestWithDataba
                                    .addMember(userB)
                                    .build();
 
-        supervisionOrderService.create(context, workspaceItem.getItem(), groupA);
-        supervisionOrderService.create(context, workspaceItem.getItem(), groupB);
-        supervisionOrderService.create(context, workspaceItemTwo.getItem(), groupA);
+        SupervisionOrderBuilder.createSupervisionOrder(context, workspaceItem.getItem(), groupA)
+                .build();
+        SupervisionOrderBuilder.createSupervisionOrder(context, workspaceItem.getItem(), groupB)
+                .build();
+        SupervisionOrderBuilder.createSupervisionOrder(context, workspaceItemTwo.getItem(), groupA)
+                .build();
 
         context.restoreAuthSystemState();
 
@@ -259,9 +264,12 @@ public class SupervisionOrderServiceIT extends AbstractIntegrationTestWithDataba
                                    .addMember(eperson)
                                    .build();
 
-        supervisionOrderService.create(context, workspaceItem.getItem(), groupA);
-        supervisionOrderService.create(context, workspaceItem.getItem(), groupB);
-        supervisionOrderService.create(context, workspaceItemTwo.getItem(), groupA);
+        SupervisionOrderBuilder.createSupervisionOrder(context, workspaceItem.getItem(), groupA)
+                .build();
+        SupervisionOrderBuilder.createSupervisionOrder(context, workspaceItem.getItem(), groupB)
+                .build();
+        SupervisionOrderBuilder.createSupervisionOrder(context, workspaceItemTwo.getItem(), groupA)
+                .build();
 
         context.restoreAuthSystemState();
 
@@ -310,7 +318,8 @@ public class SupervisionOrderServiceIT extends AbstractIntegrationTestWithDataba
                                    .addMember(eperson)
                                    .build();
 
-        supervisionOrderService.create(context, item, groupA);
+        SupervisionOrderBuilder.createSupervisionOrder(context, item, groupA)
+                .build();
 
         context.restoreAuthSystemState();
 
@@ -370,7 +379,8 @@ public class SupervisionOrderServiceIT extends AbstractIntegrationTestWithDataba
                     .addMember(userB)
                     .build();
 
-        supervisionOrderService.create(context, workspaceItem.getItem(), groupA);
+        SupervisionOrderBuilder.createSupervisionOrder(context, workspaceItem.getItem(), groupA)
+                .build();
 
         context.restoreAuthSystemState();
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestRepositoryIT.java
@@ -50,6 +50,7 @@ import org.dspace.builder.BundleBuilder;
 import org.dspace.builder.CollectionBuilder;
 import org.dspace.builder.CommunityBuilder;
 import org.dspace.builder.EPersonBuilder;
+import org.dspace.builder.GroupBuilder;
 import org.dspace.builder.ItemBuilder;
 import org.dspace.builder.ResourcePolicyBuilder;
 import org.dspace.content.Bitstream;
@@ -2768,10 +2769,12 @@ public class BitstreamRestRepositoryIT extends AbstractControllerIntegrationTest
                                           .withEmail("col2admin@test.com")
                                           .withPassword(password)
                                           .build();
-        Group col1_AdminGroup = collectionService.createAdministrators(context, col1);
-        Group col2_AdminGroup = collectionService.createAdministrators(context, col2);
-        groupService.addMember(context, col1_AdminGroup, col1Admin);
-        groupService.addMember(context, col2_AdminGroup, col2Admin);
+        Group col1_AdminGroup = GroupBuilder.createCollectionAdminGroup(context, col1)
+                .addMember(col1Admin)
+                .build();
+        Group col2_AdminGroup = GroupBuilder.createCollectionAdminGroup(context, col2)
+                .addMember(col2Admin)
+                .build();
         Item publicItem1 = ItemBuilder.createItem(context, col1)
                                       .withTitle("Test item 1")
                                       .build();
@@ -2872,8 +2875,9 @@ public class BitstreamRestRepositoryIT extends AbstractControllerIntegrationTest
                                           .withEmail("parentComAdmin@test.com")
                                           .withPassword(password)
                                           .build();
-        Group parentComAdminGroup = communityService.createAdministrators(context, parentCommunity);
-        groupService.addMember(context, parentComAdminGroup, parentCommunityAdmin);
+        Group parentComAdminGroup = GroupBuilder.createCommunityAdminGroup(context, parentCommunity)
+                .addMember(parentCommunityAdmin)
+                .build();
         Item publicItem1 = ItemBuilder.createItem(context, col1)
                                       .withTitle("Test item 1")
                                       .build();

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CollectionGroupRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CollectionGroupRestControllerIT.java
@@ -28,9 +28,9 @@ import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
 import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.builder.CollectionBuilder;
 import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.GroupBuilder;
 import org.dspace.builder.WorkspaceItemBuilder;
 import org.dspace.content.Collection;
-import org.dspace.content.service.CollectionService;
 import org.dspace.core.Constants;
 import org.dspace.eperson.Group;
 import org.dspace.eperson.service.GroupService;
@@ -40,10 +40,6 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class CollectionGroupRestControllerIT extends AbstractControllerIntegrationTest {
-
-
-    @Autowired
-    private CollectionService collectionService;
 
     @Autowired
     private GroupService groupService;
@@ -68,7 +64,7 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
     @Test
     public void getCollectionAdminGroupTest() throws Exception {
         context.turnOffAuthorisationSystem();
-        Group adminGroup = collectionService.createAdministrators(context, collection);
+        Group adminGroup = GroupBuilder.createCollectionAdminGroup(context, collection).build();
         context.restoreAuthSystemState();
 
         String token = getAuthToken(admin.getEmail(), password);
@@ -81,7 +77,7 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
     @Test
     public void getCollectionAdminGroupTestParentCommunityAdmin() throws Exception {
         context.turnOffAuthorisationSystem();
-        Group adminGroup = collectionService.createAdministrators(context, collection);
+        Group adminGroup = GroupBuilder.createCollectionAdminGroup(context, collection).build();
         authorizeService.addPolicy(context, parentCommunity, Constants.ADMIN, eperson);
         context.restoreAuthSystemState();
 
@@ -95,7 +91,7 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
     @Test
     public void getCollectionAdminGroupTestCollectionAdmin() throws Exception {
         context.turnOffAuthorisationSystem();
-        Group adminGroup = collectionService.createAdministrators(context, collection);
+        Group adminGroup = GroupBuilder.createCollectionAdminGroup(context, collection).build();
         authorizeService.addPolicy(context, collection, Constants.ADMIN, eperson);
         context.restoreAuthSystemState();
 
@@ -109,7 +105,7 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
     @Test
     public void getCollectionAdminGroupUnAuthorizedTest() throws Exception {
         context.turnOffAuthorisationSystem();
-        collectionService.createAdministrators(context, collection);
+        GroupBuilder.createCollectionAdminGroup(context, collection).build();
         context.restoreAuthSystemState();
 
         getClient().perform(get("/api/core/collections/" + collection.getID() + "/adminGroup"))
@@ -119,7 +115,7 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
     @Test
     public void getCollectionAdminGroupForbiddenTest() throws Exception {
         context.turnOffAuthorisationSystem();
-        collectionService.createAdministrators(context, collection);
+        GroupBuilder.createCollectionAdminGroup(context, collection).build();
         context.restoreAuthSystemState();
 
         String token = getAuthToken(eperson.getEmail(), password);
@@ -413,7 +409,7 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
     @Test
     public void deleteCollectionAdminGroupTest() throws Exception {
         context.turnOffAuthorisationSystem();
-        Group adminGroup = collectionService.createAdministrators(context, collection);
+        GroupBuilder.createCollectionAdminGroup(context, collection).build();
         context.restoreAuthSystemState();
 
         String token = getAuthToken(admin.getEmail(), password);
@@ -428,7 +424,7 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
     @Test
     public void deleteCollectionAdminGroupTestParentCommunityAdmin() throws Exception {
         context.turnOffAuthorisationSystem();
-        Group adminGroup = collectionService.createAdministrators(context, collection);
+        GroupBuilder.createCollectionAdminGroup(context, collection).build();
         authorizeService.addPolicy(context, parentCommunity, Constants.ADMIN, eperson);
         context.restoreAuthSystemState();
 
@@ -443,7 +439,7 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
     @Test
     public void deleteCollectionAdminGroupTestCollectionAdmin() throws Exception {
         context.turnOffAuthorisationSystem();
-        Group adminGroup = collectionService.createAdministrators(context, collection);
+        GroupBuilder.createCollectionAdminGroup(context, collection).build();
         authorizeService.addPolicy(context, collection, Constants.ADMIN, eperson);
         context.restoreAuthSystemState();
 
@@ -458,7 +454,7 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
     @Test
     public void deleteCollectionAdminGroupUnAuthorizedTest() throws Exception {
         context.turnOffAuthorisationSystem();
-        Group adminGroup = collectionService.createAdministrators(context, collection);
+        Group adminGroup = GroupBuilder.createCollectionAdminGroup(context, collection).build();
         context.restoreAuthSystemState();
 
         getClient().perform(delete("/api/core/collections/" + collection.getID() + "/adminGroup"))
@@ -474,7 +470,7 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
     @Test
     public void deleteCollectionAdminGroupForbiddenTest() throws Exception {
         context.turnOffAuthorisationSystem();
-        Group adminGroup = collectionService.createAdministrators(context, collection);
+        Group adminGroup = GroupBuilder.createCollectionAdminGroup(context, collection).build();
         context.restoreAuthSystemState();
 
         String token = getAuthToken(eperson.getEmail(), password);
@@ -493,7 +489,7 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
     @Test
     public void deleteCollectionAdminGroupNotFoundTest() throws Exception {
         context.turnOffAuthorisationSystem();
-        Group adminGroup = collectionService.createAdministrators(context, collection);
+        Group adminGroup = GroupBuilder.createCollectionAdminGroup(context, collection).build();
         context.restoreAuthSystemState();
 
         String token = getAuthToken(eperson.getEmail(), password);
@@ -512,7 +508,7 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
     @Test
     public void getCollectionSubmittersGroupTest() throws Exception {
         context.turnOffAuthorisationSystem();
-        Group submitters = collectionService.createSubmitters(context, collection);
+        Group submitters = GroupBuilder.createCollectionSubmitterGroup(context, collection).build();
         context.restoreAuthSystemState();
 
         String token = getAuthToken(admin.getEmail(), password);
@@ -525,7 +521,7 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
     @Test
     public void getCollectionSubmittersGroupTestParentCommunityAdmin() throws Exception {
         context.turnOffAuthorisationSystem();
-        Group submitters = collectionService.createSubmitters(context, collection);
+        Group submitters = GroupBuilder.createCollectionSubmitterGroup(context, collection).build();
         authorizeService.addPolicy(context, parentCommunity, Constants.ADMIN, eperson);
         context.restoreAuthSystemState();
 
@@ -539,7 +535,7 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
     @Test
     public void getCollectionSubmittersGroupTestCollectionAdmin() throws Exception {
         context.turnOffAuthorisationSystem();
-        Group submitters = collectionService.createSubmitters(context, collection);
+        Group submitters = GroupBuilder.createCollectionSubmitterGroup(context, collection).build();
         authorizeService.addPolicy(context, collection, Constants.ADMIN, eperson);
         context.restoreAuthSystemState();
 
@@ -553,7 +549,7 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
     @Test
     public void getCollectionSubmittersGroupUnAuthorizedTest() throws Exception {
         context.turnOffAuthorisationSystem();
-        collectionService.createSubmitters(context, collection);
+        GroupBuilder.createCollectionSubmitterGroup(context, collection).build();
         context.restoreAuthSystemState();
 
         getClient().perform(get("/api/core/collections/" + collection.getID() + "/submittersGroup"))
@@ -563,7 +559,7 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
     @Test
     public void getCollectionSubmittersGroupForbiddenTest() throws Exception {
         context.turnOffAuthorisationSystem();
-        collectionService.createSubmitters(context, collection);
+        GroupBuilder.createCollectionSubmitterGroup(context, collection).build();
         context.restoreAuthSystemState();
 
         String token = getAuthToken(eperson.getEmail(), password);
@@ -860,7 +856,7 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
     @Test
     public void deleteCollectionSubmitterGroupTest() throws Exception {
         context.turnOffAuthorisationSystem();
-        Group submittersGroup = collectionService.createSubmitters(context, collection);
+        GroupBuilder.createCollectionSubmitterGroup(context, collection).build();
         context.restoreAuthSystemState();
 
         String token = getAuthToken(admin.getEmail(), password);
@@ -875,7 +871,7 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
     @Test
     public void deleteCollectionSubmittersGroupTestParentCommunityAdmin() throws Exception {
         context.turnOffAuthorisationSystem();
-        Group submittersGroup = collectionService.createSubmitters(context, collection);
+        GroupBuilder.createCollectionSubmitterGroup(context, collection).build();
         authorizeService.addPolicy(context, parentCommunity, Constants.ADMIN, eperson);
         context.restoreAuthSystemState();
 
@@ -890,7 +886,7 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
     @Test
     public void deleteCollectionSubmittersGroupTestCollectionAdmin() throws Exception {
         context.turnOffAuthorisationSystem();
-        Group submittersGroup = collectionService.createSubmitters(context, collection);
+        GroupBuilder.createCollectionSubmitterGroup(context, collection).build();
         authorizeService.addPolicy(context, collection, Constants.ADMIN, eperson);
         context.restoreAuthSystemState();
 
@@ -905,7 +901,7 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
     @Test
     public void deleteCollectionSubmittersGroupUnAuthorizedTest() throws Exception {
         context.turnOffAuthorisationSystem();
-        Group submittersGroup = collectionService.createSubmitters(context, collection);
+        Group submittersGroup = GroupBuilder.createCollectionSubmitterGroup(context, collection).build();
         context.restoreAuthSystemState();
 
         getClient().perform(delete("/api/core/collections/" + collection.getID() + "/submittersGroup"))
@@ -924,7 +920,7 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
     @Test
     public void deleteCollectionSubmittersGroupForbiddenTest() throws Exception {
         context.turnOffAuthorisationSystem();
-        Group submittersGroup = collectionService.createSubmitters(context, collection);
+        Group submittersGroup = GroupBuilder.createCollectionSubmitterGroup(context, collection).build();
         context.restoreAuthSystemState();
 
         String token = getAuthToken(eperson.getEmail(), password);
@@ -945,7 +941,7 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
     @Test
     public void deleteCollectionSubmittersGroupNotFoundTest() throws Exception {
         context.turnOffAuthorisationSystem();
-        Group submittersGroup = collectionService.createSubmitters(context, collection);
+        GroupBuilder.createCollectionSubmitterGroup(context, collection).build();
         context.restoreAuthSystemState();
 
         String token = getAuthToken(eperson.getEmail(), password);
@@ -961,7 +957,8 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
         String itemGroupString = "ITEM";
         int defaultItemRead = Constants.DEFAULT_ITEM_READ;
 
-        Group role = collectionService.createDefaultReadGroup(context, collection, itemGroupString, defaultItemRead);
+        Group role = GroupBuilder.createCollectionDefaultReadGroup(context, collection,
+                itemGroupString, defaultItemRead).build();
         context.restoreAuthSystemState();
 
         String token = getAuthToken(admin.getEmail(), password);
@@ -977,7 +974,8 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
         String itemGroupString = "ITEM";
         int defaultItemRead = Constants.DEFAULT_ITEM_READ;
 
-        Group role = collectionService.createDefaultReadGroup(context, collection, itemGroupString, defaultItemRead);
+        Group role = GroupBuilder.createCollectionDefaultReadGroup(context, collection,
+                itemGroupString, defaultItemRead).build();
 
         authorizeService.addPolicy(context, parentCommunity, Constants.ADMIN, eperson);
         context.restoreAuthSystemState();
@@ -995,7 +993,8 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
         String itemGroupString = "ITEM";
         int defaultItemRead = Constants.DEFAULT_ITEM_READ;
 
-        Group role = collectionService.createDefaultReadGroup(context, collection, itemGroupString, defaultItemRead);
+        Group role = GroupBuilder.createCollectionDefaultReadGroup(context, collection,
+                itemGroupString, defaultItemRead).build();
         authorizeService.addPolicy(context, collection, Constants.ADMIN, eperson);
         context.restoreAuthSystemState();
 
@@ -1012,7 +1011,8 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
         String itemGroupString = "ITEM";
         int defaultItemRead = Constants.DEFAULT_ITEM_READ;
 
-        Group role = collectionService.createDefaultReadGroup(context, collection, itemGroupString, defaultItemRead);
+        GroupBuilder.createCollectionDefaultReadGroup(context, collection,
+                itemGroupString, defaultItemRead).build();
         context.restoreAuthSystemState();
 
         getClient().perform(get("/api/core/collections/" + collection.getID() + "/itemReadGroup"))
@@ -1025,7 +1025,8 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
         String itemGroupString = "ITEM";
         int defaultItemRead = Constants.DEFAULT_ITEM_READ;
 
-        Group role = collectionService.createDefaultReadGroup(context, collection, itemGroupString, defaultItemRead);
+        GroupBuilder.createCollectionDefaultReadGroup(context, collection,
+                itemGroupString, defaultItemRead).build();
         context.restoreAuthSystemState();
 
         String token = getAuthToken(eperson.getEmail(), password);
@@ -1321,7 +1322,7 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
         String itemGroupString = "ITEM";
         int defaultItemRead = Constants.DEFAULT_ITEM_READ;
 
-        Group role = collectionService.createDefaultReadGroup(context, collection, itemGroupString, defaultItemRead);
+        GroupBuilder.createCollectionDefaultReadGroup(context, collection, itemGroupString, defaultItemRead).build();
         context.restoreAuthSystemState();
 
         String token = getAuthToken(admin.getEmail(), password);
@@ -1345,7 +1346,7 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
         String itemGroupString = "ITEM";
         int defaultItemRead = Constants.DEFAULT_ITEM_READ;
 
-        Group role = collectionService.createDefaultReadGroup(context, collection, itemGroupString, defaultItemRead);
+        GroupBuilder.createCollectionDefaultReadGroup(context, collection, itemGroupString, defaultItemRead).build();
         authorizeService.addPolicy(context, parentCommunity, Constants.ADMIN, eperson);
         context.restoreAuthSystemState();
 
@@ -1367,7 +1368,7 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
         String itemGroupString = "ITEM";
         int defaultItemRead = Constants.DEFAULT_ITEM_READ;
 
-        Group role = collectionService.createDefaultReadGroup(context, collection, itemGroupString, defaultItemRead);
+        GroupBuilder.createCollectionDefaultReadGroup(context, collection, itemGroupString, defaultItemRead).build();
         authorizeService.addPolicy(context, collection, Constants.ADMIN, eperson);
         context.restoreAuthSystemState();
 
@@ -1389,7 +1390,8 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
         String itemGroupString = "ITEM";
         int defaultItemRead = Constants.DEFAULT_ITEM_READ;
 
-        Group role = collectionService.createDefaultReadGroup(context, collection, itemGroupString, defaultItemRead);
+        Group role = GroupBuilder.createCollectionDefaultReadGroup(context, collection,
+                itemGroupString, defaultItemRead).build();
         context.restoreAuthSystemState();
 
         getClient().perform(delete("/api/core/collections/" + collection.getID() + "/itemReadGroup"))
@@ -1408,7 +1410,8 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
         String itemGroupString = "ITEM";
         int defaultItemRead = Constants.DEFAULT_ITEM_READ;
 
-        Group role = collectionService.createDefaultReadGroup(context, collection, itemGroupString, defaultItemRead);
+        Group role = GroupBuilder.createCollectionDefaultReadGroup(context, collection,
+                itemGroupString, defaultItemRead).build();
         context.restoreAuthSystemState();
 
         String token = getAuthToken(eperson.getEmail(), password);
@@ -1430,7 +1433,7 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
         String itemGroupString = "ITEM";
         int defaultItemRead = Constants.DEFAULT_ITEM_READ;
 
-        Group role = collectionService.createDefaultReadGroup(context, collection, itemGroupString, defaultItemRead);
+        GroupBuilder.createCollectionDefaultReadGroup(context, collection, itemGroupString, defaultItemRead).build();
         context.restoreAuthSystemState();
 
         String token = getAuthToken(eperson.getEmail(), password);
@@ -1445,8 +1448,8 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
         String bitstreamGroupString = "BITSTREAM";
         int defaultBitstreamRead = Constants.DEFAULT_BITSTREAM_READ;
 
-        Group role = collectionService.createDefaultReadGroup(context, collection, bitstreamGroupString,
-                                                              defaultBitstreamRead);
+        Group role = GroupBuilder.createCollectionDefaultReadGroup(context, collection,
+                bitstreamGroupString, defaultBitstreamRead).build();
         context.restoreAuthSystemState();
 
         String token = getAuthToken(admin.getEmail(), password);
@@ -1462,8 +1465,8 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
         String bitstreamGroupString = "BITSTREAM";
         int defaultBitstreamRead = Constants.DEFAULT_BITSTREAM_READ;
 
-        Group role = collectionService.createDefaultReadGroup(context, collection, bitstreamGroupString,
-                                                              defaultBitstreamRead);
+        Group role = GroupBuilder.createCollectionDefaultReadGroup(context, collection,
+                bitstreamGroupString, defaultBitstreamRead).build();
         authorizeService.addPolicy(context, parentCommunity, Constants.ADMIN, eperson);
         context.restoreAuthSystemState();
 
@@ -1480,8 +1483,8 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
         String bitstreamGroupString = "BITSTREAM";
         int defaultBitstreamRead = Constants.DEFAULT_BITSTREAM_READ;
 
-        Group role = collectionService.createDefaultReadGroup(context, collection, bitstreamGroupString,
-                                                              defaultBitstreamRead);
+        Group role = GroupBuilder.createCollectionDefaultReadGroup(context, collection,
+                bitstreamGroupString, defaultBitstreamRead).build();
         authorizeService.addPolicy(context, collection, Constants.ADMIN, eperson);
         context.restoreAuthSystemState();
 
@@ -1498,8 +1501,8 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
         String bitstreamGroupString = "BITSTREAM";
         int defaultBitstreamRead = Constants.DEFAULT_BITSTREAM_READ;
 
-        Group role = collectionService.createDefaultReadGroup(context, collection, bitstreamGroupString,
-                                                              defaultBitstreamRead);
+        GroupBuilder.createCollectionDefaultReadGroup(context, collection,
+                bitstreamGroupString, defaultBitstreamRead).build();
         context.restoreAuthSystemState();
 
         getClient().perform(get("/api/core/collections/" + collection.getID() + "/bitstreamReadGroup"))
@@ -1512,8 +1515,8 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
         String bitstreamGroupString = "BITSTREAM";
         int defaultBitstreamRead = Constants.DEFAULT_BITSTREAM_READ;
 
-        Group role = collectionService.createDefaultReadGroup(context, collection, bitstreamGroupString,
-                                                              defaultBitstreamRead);
+        GroupBuilder.createCollectionDefaultReadGroup(context, collection,
+                bitstreamGroupString, defaultBitstreamRead).build();
         context.restoreAuthSystemState();
 
         String token = getAuthToken(eperson.getEmail(), password);
@@ -1811,8 +1814,8 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
         String bitstreamGroupString = "BITSTREAM";
         int defaultBitstreamRead = Constants.DEFAULT_BITSTREAM_READ;
 
-        Group role = collectionService.createDefaultReadGroup(context, collection, bitstreamGroupString,
-                                                              defaultBitstreamRead);
+        GroupBuilder.createCollectionDefaultReadGroup(context, collection,
+                bitstreamGroupString, defaultBitstreamRead).build();
         context.restoreAuthSystemState();
 
         String token = getAuthToken(admin.getEmail(), password);
@@ -1835,8 +1838,8 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
         String bitstreamGroupString = "BITSTREAM";
         int defaultBitstreamRead = Constants.DEFAULT_BITSTREAM_READ;
 
-        Group role = collectionService.createDefaultReadGroup(context, collection, bitstreamGroupString,
-                                                              defaultBitstreamRead);
+        GroupBuilder.createCollectionDefaultReadGroup(context, collection,
+                bitstreamGroupString, defaultBitstreamRead).build();
         authorizeService.addPolicy(context, parentCommunity, Constants.ADMIN, eperson);
         context.restoreAuthSystemState();
 
@@ -1859,8 +1862,8 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
         String bitstreamGroupString = "BITSTREAM";
         int defaultBitstreamRead = Constants.DEFAULT_BITSTREAM_READ;
 
-        Group role = collectionService.createDefaultReadGroup(context, collection, bitstreamGroupString,
-                                                              defaultBitstreamRead);
+        GroupBuilder.createCollectionDefaultReadGroup(context, collection,
+                bitstreamGroupString, defaultBitstreamRead).build();
         authorizeService.addPolicy(context, collection, Constants.ADMIN, eperson);
         context.restoreAuthSystemState();
 
@@ -1882,8 +1885,8 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
         String bitstreamGroupString = "BITSTREAM";
         int defaultBitstreamRead = Constants.DEFAULT_BITSTREAM_READ;
 
-        Group role = collectionService.createDefaultReadGroup(context, collection, bitstreamGroupString,
-                                                              defaultBitstreamRead);
+        Group role = GroupBuilder.createCollectionDefaultReadGroup(context, collection,
+                bitstreamGroupString, defaultBitstreamRead).build();
         context.restoreAuthSystemState();
 
         getClient().perform(delete("/api/core/collections/" + collection.getID() + "/bitstreamReadGroup"))
@@ -1902,8 +1905,8 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
         String bitstreamGroupString = "BITSTREAM";
         int defaultBitstreamRead = Constants.DEFAULT_BITSTREAM_READ;
 
-        Group role = collectionService.createDefaultReadGroup(context, collection, bitstreamGroupString,
-                                                              defaultBitstreamRead);
+        GroupBuilder.createCollectionDefaultReadGroup(context, collection,
+                bitstreamGroupString, defaultBitstreamRead).build();
         context.restoreAuthSystemState();
         String token = getAuthToken(eperson.getEmail(), password);
 
@@ -1918,8 +1921,8 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
         String bitstreamGroupString = "BITSTREAM";
         int defaultBitstreamRead = Constants.DEFAULT_BITSTREAM_READ;
 
-        Group role = collectionService.createDefaultReadGroup(context, collection, bitstreamGroupString,
-                                                              defaultBitstreamRead);
+        GroupBuilder.createCollectionDefaultReadGroup(context, collection,
+                bitstreamGroupString, defaultBitstreamRead).build();
         context.restoreAuthSystemState();
         String token = getAuthToken(eperson.getEmail(), password);
 
@@ -1931,7 +1934,7 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
     public void getWorkflowGroupForCollectionAndRole() throws Exception {
 
         context.turnOffAuthorisationSystem();
-        Group group = workflowService.createWorkflowRoleGroup(context, collection, "reviewer");
+        Group group = GroupBuilder.createCollectionWorkflowRoleGroup(context, collection, "reviewer").build();
         context.restoreAuthSystemState();
 
         String token = getAuthToken(admin.getEmail(), password);
@@ -1944,7 +1947,7 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
     @Test
     public void getWorkflowGroupForCollectionAndRoleParentCommunityAdmin() throws Exception {
         context.turnOffAuthorisationSystem();
-        Group group = workflowService.createWorkflowRoleGroup(context, collection, "reviewer");
+        Group group = GroupBuilder.createCollectionWorkflowRoleGroup(context, collection, "reviewer").build();
         authorizeService.addPolicy(context, parentCommunity, Constants.ADMIN, eperson);
         context.restoreAuthSystemState();
 
@@ -1958,7 +1961,7 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
     @Test
     public void getWorkflowGroupForCollectionAndRoleWrongUUIDCollectionNotFound() throws Exception {
         context.turnOffAuthorisationSystem();
-        Group group = workflowService.createWorkflowRoleGroup(context, collection, "reviewer");
+        GroupBuilder.createCollectionWorkflowRoleGroup(context, collection, "reviewer").build();
         context.restoreAuthSystemState();
 
         String token = getAuthToken(eperson.getEmail(), password);
@@ -1979,7 +1982,7 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
     public void getWorkflowGroupCommunityAdmin() throws Exception {
 
         context.turnOffAuthorisationSystem();
-        Group group = workflowService.createWorkflowRoleGroup(context, collection, "reviewer");
+        Group group = GroupBuilder.createCollectionWorkflowRoleGroup(context, collection, "reviewer").build();
 
         authorizeService.addPolicy(context, parentCommunity, Constants.ADMIN, eperson);
         context.restoreAuthSystemState();
@@ -1994,7 +1997,7 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
     @Test
     public void getWorkflowGroupCollectionAdmin() throws Exception {
         context.turnOffAuthorisationSystem();
-        Group group = workflowService.createWorkflowRoleGroup(context, collection, "reviewer");
+        Group group = GroupBuilder.createCollectionWorkflowRoleGroup(context, collection, "reviewer").build();
 
         authorizeService.addPolicy(context, collection, Constants.ADMIN, eperson);
         context.restoreAuthSystemState();
@@ -2009,7 +2012,7 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
     @Test
     public void getWorkflowGroupUnAuthorized() throws Exception {
         context.turnOffAuthorisationSystem();
-        Group group = workflowService.createWorkflowRoleGroup(context, collection, "reviewer");
+        GroupBuilder.createCollectionWorkflowRoleGroup(context, collection, "reviewer").build();
         context.restoreAuthSystemState();
 
         getClient().perform(get("/api/core/collections/" + collection.getID() + "/workflowGroups/reviewer"))
@@ -2019,7 +2022,7 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
     @Test
     public void getWorkflowGroupForbidden() throws Exception {
         context.turnOffAuthorisationSystem();
-        Group group = workflowService.createWorkflowRoleGroup(context, collection, "reviewer");
+        GroupBuilder.createCollectionWorkflowRoleGroup(context, collection, "reviewer").build();
         context.restoreAuthSystemState();
 
         String token = getAuthToken(eperson.getEmail(), password);
@@ -2324,7 +2327,7 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
     @Test
     public void deleteCollectionWorkflowGroupTest() throws Exception {
         context.turnOffAuthorisationSystem();
-        Group group = workflowService.createWorkflowRoleGroup(context, collection, "reviewer");
+        GroupBuilder.createCollectionWorkflowRoleGroup(context, collection, "reviewer").build();
         context.restoreAuthSystemState();
 
         String token = getAuthToken(admin.getEmail(), password);
@@ -2339,7 +2342,7 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
     @Test
     public void deleteCollectionWorkflowGroupTestParentCommunityAdmin() throws Exception {
         context.turnOffAuthorisationSystem();
-        Group group = workflowService.createWorkflowRoleGroup(context, collection, "reviewer");
+        GroupBuilder.createCollectionWorkflowRoleGroup(context, collection, "reviewer").build();
 
         authorizeService.addPolicy(context, parentCommunity, Constants.ADMIN, eperson);
         context.restoreAuthSystemState();
@@ -2355,7 +2358,7 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
     @Test
     public void deleteCollectionWorkflowGroupTestCollectionAdmin() throws Exception {
         context.turnOffAuthorisationSystem();
-        Group group = workflowService.createWorkflowRoleGroup(context, collection, "reviewer");
+        GroupBuilder.createCollectionWorkflowRoleGroup(context, collection, "reviewer").build();
 
         authorizeService.addPolicy(context, collection, Constants.ADMIN, eperson);
         context.restoreAuthSystemState();
@@ -2371,7 +2374,7 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
     @Test
     public void deleteCollectionWorkflowGroupUnAuthorizedTest() throws Exception {
         context.turnOffAuthorisationSystem();
-        Group group = workflowService.createWorkflowRoleGroup(context, collection, "reviewer");
+        Group group = GroupBuilder.createCollectionWorkflowRoleGroup(context, collection, "reviewer").build();
         context.restoreAuthSystemState();
 
         getClient().perform(delete("/api/core/collections/" + collection.getID() + "/workflowGroups/reviewer"))
@@ -2387,7 +2390,7 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
     @Test
     public void deleteCollectionWorkflowGroupForbiddenTest() throws Exception {
         context.turnOffAuthorisationSystem();
-        Group group = workflowService.createWorkflowRoleGroup(context, collection, "reviewer");
+        Group group = GroupBuilder.createCollectionWorkflowRoleGroup(context, collection, "reviewer").build();
         context.restoreAuthSystemState();
 
         String token = getAuthToken(eperson.getEmail(), password);
@@ -2406,7 +2409,7 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
     @Test
     public void deleteCollectionWorkflowGroupNotFoundTest() throws Exception {
         context.turnOffAuthorisationSystem();
-        Group group = workflowService.createWorkflowRoleGroup(context, collection, "reviewer");
+        GroupBuilder.createCollectionWorkflowRoleGroup(context, collection, "reviewer").build();
         context.restoreAuthSystemState();
 
         String token = getAuthToken(eperson.getEmail(), password);
@@ -2418,7 +2421,7 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
     @Test
     public void deleteCollectionWorkflowGroupWithPooledTaskTest() throws Exception {
         context.turnOffAuthorisationSystem();
-        Group reviewer = workflowService.createWorkflowRoleGroup(context, collection, "reviewer");
+        Group reviewer = GroupBuilder.createCollectionWorkflowRoleGroup(context, collection, "reviewer").build();
 
         // Submit an Item into the workflow -> moves to the "reviewer" step's pool.
         // The role must have at least one EPerson, otherwise the WSI gets archived immediately

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityAdminGroupRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityAdminGroupRestControllerIT.java
@@ -34,8 +34,6 @@ import org.dspace.builder.EPersonBuilder;
 import org.dspace.builder.GroupBuilder;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
-import org.dspace.content.service.CollectionService;
-import org.dspace.content.service.CommunityService;
 import org.dspace.core.Constants;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
@@ -49,18 +47,11 @@ import org.springframework.http.MediaType;
 
 public class CommunityAdminGroupRestControllerIT extends AbstractControllerIntegrationTest {
 
-
-    @Autowired
-    private CommunityService communityService;
-
     @Autowired
     private GroupService groupService;
 
     @Autowired
     private AuthorizeService authorizeService;
-
-    @Autowired
-    private CollectionService collectionService;
 
     @Autowired
     private ConfigurationService configurationService;
@@ -78,7 +69,7 @@ public class CommunityAdminGroupRestControllerIT extends AbstractControllerInteg
     @Test
     public void getCommunityAdminGroupTest() throws Exception {
         context.turnOffAuthorisationSystem();
-        Group adminGroup = communityService.createAdministrators(context, parentCommunity);
+        Group adminGroup = GroupBuilder.createCommunityAdminGroup(context, parentCommunity).build();
         context.restoreAuthSystemState();
 
         String token = getAuthToken(admin.getEmail(), password);
@@ -91,7 +82,8 @@ public class CommunityAdminGroupRestControllerIT extends AbstractControllerInteg
     @Test
     public void getCommunityAdminGroupTestCommunityAdmin() throws Exception {
         context.turnOffAuthorisationSystem();
-        Group adminGroup = communityService.createAdministrators(context, parentCommunity);
+        Group adminGroup = GroupBuilder.createCommunityAdminGroup(context, parentCommunity).build();
+        // TODO: this should actually be "add member", not directly setting a policy, right?
         authorizeService.addPolicy(context, parentCommunity, Constants.ADMIN, eperson);
         context.restoreAuthSystemState();
 
@@ -106,7 +98,7 @@ public class CommunityAdminGroupRestControllerIT extends AbstractControllerInteg
     @Test
     public void getCommunityAdminGroupUnAuthorizedTest() throws Exception {
         context.turnOffAuthorisationSystem();
-        communityService.createAdministrators(context, parentCommunity);
+        GroupBuilder.createCommunityAdminGroup(context, parentCommunity).build();
         context.restoreAuthSystemState();
 
         getClient().perform(get("/api/core/communities/" + parentCommunity.getID() + "/adminGroup"))
@@ -116,7 +108,7 @@ public class CommunityAdminGroupRestControllerIT extends AbstractControllerInteg
     @Test
     public void getCommunityAdminGroupForbiddenTest() throws Exception {
         context.turnOffAuthorisationSystem();
-        communityService.createAdministrators(context, parentCommunity);
+        GroupBuilder.createCommunityAdminGroup(context, parentCommunity).build();
         context.restoreAuthSystemState();
         String token = getAuthToken(eperson.getEmail(), password);
         getClient(token).perform(get("/api/core/communities/" + parentCommunity.getID() + "/adminGroup"))
@@ -379,7 +371,7 @@ public class CommunityAdminGroupRestControllerIT extends AbstractControllerInteg
     @Test
     public void deleteCommunityAdminGroupTest() throws Exception {
         context.turnOffAuthorisationSystem();
-        Group adminGroup = communityService.createAdministrators(context, parentCommunity);
+        GroupBuilder.createCommunityAdminGroup(context, parentCommunity).build();
         context.restoreAuthSystemState();
 
         String token = getAuthToken(admin.getEmail(), password);
@@ -397,7 +389,7 @@ public class CommunityAdminGroupRestControllerIT extends AbstractControllerInteg
         Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
                                            .withName("Sub Community")
                                            .build();
-        Group adminGroup = communityService.createAdministrators(context, child1);
+        GroupBuilder.createCommunityAdminGroup(context, child1).build();
         authorizeService.addPolicy(context, parentCommunity, Constants.ADMIN, eperson);
         context.restoreAuthSystemState();
 
@@ -412,7 +404,7 @@ public class CommunityAdminGroupRestControllerIT extends AbstractControllerInteg
     @Test
     public void deleteCommunityAdminGroupUnAuthorizedTest() throws Exception {
         context.turnOffAuthorisationSystem();
-        Group adminGroup = communityService.createAdministrators(context, parentCommunity);
+        Group adminGroup = GroupBuilder.createCommunityAdminGroup(context, parentCommunity).build();
         context.restoreAuthSystemState();
 
         getClient().perform(delete("/api/core/communities/" + parentCommunity.getID() + "/adminGroup"))
@@ -429,7 +421,7 @@ public class CommunityAdminGroupRestControllerIT extends AbstractControllerInteg
     @Test
     public void deleteCommunityAdminGroupForbiddenTest() throws Exception {
         context.turnOffAuthorisationSystem();
-        Group adminGroup = communityService.createAdministrators(context, parentCommunity);
+        Group adminGroup = GroupBuilder.createCommunityAdminGroup(context, parentCommunity).build();
         context.restoreAuthSystemState();
 
         String token = getAuthToken(eperson.getEmail(), password);
@@ -449,7 +441,7 @@ public class CommunityAdminGroupRestControllerIT extends AbstractControllerInteg
     @Test
     public void deleteCommunityAdminGroupNotFoundTest() throws Exception {
         context.turnOffAuthorisationSystem();
-        Group adminGroup = communityService.createAdministrators(context, parentCommunity);
+        GroupBuilder.createCommunityAdminGroup(context, parentCommunity).build();
         context.restoreAuthSystemState();
 
         String token = getAuthToken(eperson.getEmail(), password);
@@ -462,7 +454,7 @@ public class CommunityAdminGroupRestControllerIT extends AbstractControllerInteg
     public void communityAdminAddMembersToCommunityAdminGroupPropertySetToFalse() throws Exception {
 
         context.turnOffAuthorisationSystem();
-        Group adminGroup = communityService.createAdministrators(context, parentCommunity);
+        Group adminGroup = GroupBuilder.createCommunityAdminGroup(context, parentCommunity).build();
         authorizeService.addPolicy(context, parentCommunity, Constants.ADMIN, eperson);
         EPerson ePerson = EPersonBuilder.createEPerson(context).withEmail("testToAdd@test.com").build();
         configurationService.setProperty("core.authorization.community-admin.admin-group", false);
@@ -489,7 +481,7 @@ public class CommunityAdminGroupRestControllerIT extends AbstractControllerInteg
     public void communityAdminRemoveMembersFromCommunityAdminGroupPropertySetToFalse() throws Exception {
 
         context.turnOffAuthorisationSystem();
-        Group adminGroup = communityService.createAdministrators(context, parentCommunity);
+        Group adminGroup = GroupBuilder.createCommunityAdminGroup(context, parentCommunity).build();
         authorizeService.addPolicy(context, parentCommunity, Constants.ADMIN, eperson);
         EPerson ePerson = EPersonBuilder.createEPerson(context).withEmail("testToAdd@test.com").build();
         context.restoreAuthSystemState();
@@ -526,7 +518,7 @@ public class CommunityAdminGroupRestControllerIT extends AbstractControllerInteg
     public void communityAdminAddChildGroupToCommunityAdminGroupPropertySetToFalse() throws Exception {
 
         context.turnOffAuthorisationSystem();
-        Group adminGroup = communityService.createAdministrators(context, parentCommunity);
+        Group adminGroup = GroupBuilder.createCommunityAdminGroup(context, parentCommunity).build();
         authorizeService.addPolicy(context, parentCommunity, Constants.ADMIN, eperson);
         Group group = GroupBuilder.createGroup(context).withName("testGroup").build();
         configurationService.setProperty("core.authorization.community-admin.admin-group", false);
@@ -554,7 +546,7 @@ public class CommunityAdminGroupRestControllerIT extends AbstractControllerInteg
     public void communityAdminRemoveChildGroupFromCommunityAdminGroupPropertySetToFalse() throws Exception {
 
         context.turnOffAuthorisationSystem();
-        Group adminGroup = communityService.createAdministrators(context, parentCommunity);
+        Group adminGroup = GroupBuilder.createCommunityAdminGroup(context, parentCommunity).build();
         authorizeService.addPolicy(context, parentCommunity, Constants.ADMIN, eperson);
         Group group = GroupBuilder.createGroup(context).withName("testGroup").build();
         context.restoreAuthSystemState();
@@ -591,7 +583,9 @@ public class CommunityAdminGroupRestControllerIT extends AbstractControllerInteg
     public void communityAdminAddChildGroupToCollectionAdminGroupSuccess() throws Exception {
 
         context.turnOffAuthorisationSystem();
-        Group adminGroup = collectionService.createAdministrators(context, collection);
+        // TODO: Why is this test in CommunityAdmin? it seems to purely be a collection group test?
+        //       copy paste gone wrong and we should actually be testing for community admin group sub?
+        Group adminGroup = GroupBuilder.createCollectionAdminGroup(context, collection).build();
         authorizeService.addPolicy(context, parentCommunity, Constants.ADMIN, eperson);
         Group group = GroupBuilder.createGroup(context).withName("testGroup").build();
         context.restoreAuthSystemState();
@@ -617,7 +611,9 @@ public class CommunityAdminGroupRestControllerIT extends AbstractControllerInteg
     public void communityAdminRemoveChildGroupFromCollectionAdminGroupSuccess() throws Exception {
 
         context.turnOffAuthorisationSystem();
-        Group adminGroup = collectionService.createAdministrators(context, collection);
+        // TODO: Why is this test in CommunityAdmin? it seems to purely be a collection group test?
+        //       copy paste gone wrong and we should actually be testing for community admin group sub?
+        Group adminGroup = GroupBuilder.createCollectionAdminGroup(context, collection).build();
         authorizeService.addPolicy(context, parentCommunity, Constants.ADMIN, eperson);
         Group group = GroupBuilder.createGroup(context).withName("testGroup").build();
         context.restoreAuthSystemState();
@@ -653,7 +649,7 @@ public class CommunityAdminGroupRestControllerIT extends AbstractControllerInteg
     public void communityAdminAddMembersToCollectionAdminGroupPropertySetToFalse() throws Exception {
 
         context.turnOffAuthorisationSystem();
-        Group adminGroup = collectionService.createAdministrators(context, collection);
+        Group adminGroup = GroupBuilder.createCollectionAdminGroup(context, collection).build();
         authorizeService.addPolicy(context, parentCommunity, Constants.ADMIN, eperson);
         EPerson ePerson = EPersonBuilder.createEPerson(context).withEmail("testToAdd@test.com").build();
         configurationService.setProperty("core.authorization.community-admin.collection.admin-group", false);
@@ -681,7 +677,7 @@ public class CommunityAdminGroupRestControllerIT extends AbstractControllerInteg
     public void communityAdminRemoveMembersFromCollectionAdminGroupPropertySetToFalse() throws Exception {
 
         context.turnOffAuthorisationSystem();
-        Group adminGroup = collectionService.createAdministrators(context, collection);
+        Group adminGroup = GroupBuilder.createCollectionAdminGroup(context, collection).build();
         authorizeService.addPolicy(context, parentCommunity, Constants.ADMIN, eperson);
         EPerson ePerson = EPersonBuilder.createEPerson(context).withEmail("testToAdd@test.com").build();
         context.restoreAuthSystemState();
@@ -719,7 +715,7 @@ public class CommunityAdminGroupRestControllerIT extends AbstractControllerInteg
     public void communityAdminAddChildGroupToCollectionAdminGroupPropertySetToFalse() throws Exception {
 
         context.turnOffAuthorisationSystem();
-        Group adminGroup = collectionService.createAdministrators(context, collection);
+        Group adminGroup = GroupBuilder.createCollectionAdminGroup(context, collection).build();
         authorizeService.addPolicy(context, parentCommunity, Constants.ADMIN, eperson);
         Group group = GroupBuilder.createGroup(context).withName("testGroup").build();
         configurationService.setProperty("core.authorization.community-admin.collection.admin-group", false);
@@ -748,7 +744,7 @@ public class CommunityAdminGroupRestControllerIT extends AbstractControllerInteg
     public void communityAdminRemoveChildGroupFromCollectionAdminGroupPropertySetToFalse() throws Exception {
 
         context.turnOffAuthorisationSystem();
-        Group adminGroup = collectionService.createAdministrators(context, collection);
+        Group adminGroup = GroupBuilder.createCollectionAdminGroup(context, collection).build();
         authorizeService.addPolicy(context, parentCommunity, Constants.ADMIN, eperson);
         Group group = GroupBuilder.createGroup(context).withName("testGroup").build();
         context.restoreAuthSystemState();

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/GroupRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/GroupRestRepositoryIT.java
@@ -60,7 +60,6 @@ import org.dspace.content.Community;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataSchemaEnum;
 import org.dspace.content.factory.ContentServiceFactory;
-import org.dspace.content.service.CollectionService;
 import org.dspace.content.service.CommunityService;
 import org.dspace.core.Constants;
 import org.dspace.core.I18nUtil;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/GroupRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/GroupRestRepositoryIT.java
@@ -86,9 +86,6 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
     @Autowired
     private ConfigurationService configurationService;
     @Autowired
-    private CollectionService collectionService;
-
-    @Autowired
     private AuthorizeService authorizeService;
 
     Collection collection;
@@ -773,12 +770,13 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
         try {
             context.turnOffAuthorisationSystem();
 
-            community = communityService.create(null, context);
-            parentGroup = communityService.createAdministrators(context, community);
-            childGroup1 = groupService.create(context);
-            childGroup2 = groupService.create(context);
+            community = CommunityBuilder.createCommunity(context).build();
+            parentGroup = GroupBuilder.createCommunityAdminGroup(context, community)
+                    .addMember(eperson)
+                    .build();
+            childGroup1 = GroupBuilder.createGroup(context).build();
+            childGroup2 = GroupBuilder.createGroup(context).build();
 
-            groupService.addMember(context, parentGroup, eperson);
             groupService.update(context, parentGroup);
 
             context.commit();
@@ -810,6 +808,7 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
             );
 
         } finally {
+            // TODO: Can we remove these lines now that we are creating them with the builder?
             if (community != null) {
                 CommunityBuilder.deleteCommunity(community.getID());
             }
@@ -837,9 +836,9 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
         try {
             context.turnOffAuthorisationSystem();
 
-            parentGroup = groupService.create(context);
-            childGroup1 = groupService.create(context);
-            childGroup2 = groupService.create(context);
+            parentGroup = GroupBuilder.createGroup(context).build();
+            childGroup1 = GroupBuilder.createGroup(context).build();
+            childGroup2 = GroupBuilder.createGroup(context).build();
 
             context.commit();
 
@@ -882,9 +881,9 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
         try {
             context.turnOffAuthorisationSystem();
 
-            parentGroup = groupService.create(context);
-            childGroup1 = groupService.create(context);
-            childGroup2 = groupService.create(context);
+            parentGroup = GroupBuilder.createGroup(context).build();
+            childGroup1 = GroupBuilder.createGroup(context).build();
+            childGroup2 = GroupBuilder.createGroup(context).build();
 
             context.commit();
 
@@ -926,9 +925,9 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
         try {
             context.turnOffAuthorisationSystem();
 
-            parentGroup = groupService.create(context);
-            childGroup1 = groupService.create(context);
-            childGroup2 = groupService.create(context);
+            parentGroup = GroupBuilder.createGroup(context).build();
+            childGroup1 = GroupBuilder.createGroup(context).build();
+            childGroup2 = GroupBuilder.createGroup(context).build();
 
             context.commit();
 
@@ -971,18 +970,18 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
         try {
             context.turnOffAuthorisationSystem();
 
-            parentGroup = groupService.create(context);
-            childGroup1 = groupService.create(context);
-            childGroup2 = groupService.create(context);
-
-            groupService.addMember(context, childGroup1, parentGroup);
+            parentGroup = GroupBuilder.createGroup(context).build();
+            childGroup1 = GroupBuilder.createGroup(context)
+                    .withParent(parentGroup)
+                    .build();
+            childGroup2 = GroupBuilder.createGroup(context).build();
             groupService.update(context, childGroup1);
 
-            context.commit();
-
-            parentGroup = context.reloadEntity(parentGroup);
-            childGroup1 = context.reloadEntity(childGroup1);
-            childGroup2 = context.reloadEntity(childGroup2);
+//            context.commit();
+//
+//            parentGroup = context.reloadEntity(parentGroup);
+//            childGroup1 = context.reloadEntity(childGroup1);
+//            childGroup2 = context.reloadEntity(childGroup2);
 
             context.restoreAuthSystemState();
             String authToken = getAuthToken(admin.getEmail(), password);
@@ -995,13 +994,15 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
                             )
             ).andExpect(status().isUnprocessableEntity());
 
+            // TODO - confirm with reviewers that this is a mistake - it actually should be No Content
+            //        (see AddMember test) but was incorrectly expecting 422?
             getClient(authToken).perform(
                     post("/api/eperson/groups/" + parentGroup.getID() + "/subgroups")
                             .contentType(parseMediaType(TEXT_URI_LIST_VALUE))
                             .content(REST_SERVER_URL + "eperson/groups/" + childGroup1.getID() + "/\n"
                                     + REST_SERVER_URL + "eperson/groups/" + childGroup2.getID()
                             )
-            ).andExpect(status().isUnprocessableEntity());
+            ).andExpect(status().isNoContent());
 
         } finally {
             if (parentGroup != null) {
@@ -1093,13 +1094,12 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
         try {
             context.turnOffAuthorisationSystem();
 
-            community = communityService.create(null, context);
-            parentGroup = communityService.createAdministrators(context, community);
-            member1 = ePersonService.create(context);
-            member2 = ePersonService.create(context);
-
-            groupService.addMember(context, parentGroup, eperson);
-            groupService.update(context, parentGroup);
+            community = CommunityBuilder.createCommunity(context).build();
+            parentGroup = GroupBuilder.createCommunityAdminGroup(context, community)
+                    .addMember(eperson)
+                    .build();
+            member1 = EPersonBuilder.createEPerson(context).build();
+            member2 = EPersonBuilder.createEPerson(context).build();
 
             context.commit();
 
@@ -1158,9 +1158,9 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
         try {
             context.turnOffAuthorisationSystem();
 
-            parentGroup = groupService.create(context);
-            member1 = ePersonService.create(context);
-            member2 = ePersonService.create(context);
+            parentGroup = GroupBuilder.createGroup(context).build();
+            member1 = EPersonBuilder.createEPerson(context).build();
+            member2 = EPersonBuilder.createEPerson(context).build();
 
             context.commit();
 
@@ -1204,9 +1204,9 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
         try {
             context.turnOffAuthorisationSystem();
 
-            parentGroup = groupService.create(context);
-            member1 = ePersonService.create(context);
-            member2 = ePersonService.create(context);
+            parentGroup = GroupBuilder.createGroup(context).build();
+            member1 = EPersonBuilder.createEPerson(context).build();
+            member2 = EPersonBuilder.createEPerson(context).build();
 
             context.commit();
 
@@ -1249,9 +1249,9 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
         try {
             context.turnOffAuthorisationSystem();
 
-            parentGroup = groupService.create(context);
-            member1 = ePersonService.create(context);
-            member2 = ePersonService.create(context);
+            parentGroup = GroupBuilder.createGroup(context).build();
+            member1 = EPersonBuilder.createEPerson(context).build();
+            member2 = EPersonBuilder.createEPerson(context).build();
 
             context.commit();
 
@@ -1295,9 +1295,9 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
         try {
             context.turnOffAuthorisationSystem();
 
-            parentGroup = groupService.create(context);
-            member1 = ePersonService.create(context);
-            member2 = ePersonService.create(context);
+            parentGroup = GroupBuilder.createGroup(context).build();
+            member1 = EPersonBuilder.createEPerson(context).build();
+            member2 = EPersonBuilder.createEPerson(context).build();
 
             context.commit();
 
@@ -1389,13 +1389,13 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
         try {
             context.turnOffAuthorisationSystem();
 
-            community = communityService.create(null, context);
-            parentGroup = communityService.createAdministrators(context, community);
-            childGroup = groupService.create(context);
-
-            groupService.addMember(context, parentGroup, childGroup);
-            groupService.addMember(context, parentGroup, eperson);
-            groupService.update(context, parentGroup);
+            community = CommunityBuilder.createCommunity(context).build();
+            parentGroup = GroupBuilder.createCommunityAdminGroup(context, community)
+                    .addMember(eperson)
+                    .build();
+            childGroup = GroupBuilder.createGroup(context)
+                    .withParent(parentGroup)
+                    .build();
 
             context.commit();
 
@@ -1439,8 +1439,8 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
         try {
             context.turnOffAuthorisationSystem();
 
-            parentGroup = groupService.create(context);
-            childGroup = groupService.create(context);
+            parentGroup = GroupBuilder.createGroup(context).build();
+            childGroup = GroupBuilder.createGroup(context).build();
 
             context.commit();
 
@@ -1474,8 +1474,8 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
         try {
             context.turnOffAuthorisationSystem();
 
-            parentGroup = groupService.create(context);
-            childGroup = groupService.create(context);
+            parentGroup = GroupBuilder.createGroup(context).build();
+            childGroup = GroupBuilder.createGroup(context).build();
 
             context.commit();
 
@@ -1508,10 +1508,10 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
         try {
             context.turnOffAuthorisationSystem();
 
-            parentGroup = groupService.create(context);
-            childGroup = groupService.create(context);
-
-            groupService.addMember(context, childGroup, parentGroup);
+            parentGroup = GroupBuilder.createGroup(context).build();
+            childGroup = GroupBuilder.createGroup(context)
+                    .withParent(parentGroup)
+                    .build();
 
             context.commit();
 
@@ -1546,10 +1546,10 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
         try {
             context.turnOffAuthorisationSystem();
 
-            parentGroup = groupService.create(context);
-            childGroup = groupService.create(context);
-
-            groupService.addMember(context, childGroup, parentGroup);
+            parentGroup = GroupBuilder.createGroup(context).build();
+            childGroup = GroupBuilder.createGroup(context)
+                    .withParent(parentGroup)
+                    .build();
 
             context.commit();
 
@@ -1625,13 +1625,12 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
         try {
             context.turnOffAuthorisationSystem();
 
-            community = communityService.create(null, context);
-            parentGroup = communityService.createAdministrators(context, community);
-            member = ePersonService.create(context);
-
-            groupService.addMember(context, parentGroup, member);
-            groupService.addMember(context, parentGroup, eperson);
-            groupService.update(context, parentGroup);
+            community = CommunityBuilder.createCommunity(context).build();
+            member = EPersonBuilder.createEPerson(context).build();
+            parentGroup = GroupBuilder.createCommunityAdminGroup(context, community)
+                    .addMember(member)
+                    .addMember(eperson)
+                    .build();
 
             assertTrue(groupService.isMember(context, member, parentGroup));
 
@@ -1678,9 +1677,10 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
         try {
             context.turnOffAuthorisationSystem();
 
-            parentGroup = groupService.create(context);
-            member = ePersonService.create(context);
-            groupService.addMember(context, parentGroup, member);
+            member = EPersonBuilder.createEPerson(context).build();
+            parentGroup = GroupBuilder.createGroup(context)
+                    .addMember(member)
+                    .build();
 
             context.commit();
 
@@ -1715,9 +1715,10 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
         try {
             context.turnOffAuthorisationSystem();
 
-            parentGroup = groupService.create(context);
-            member = ePersonService.create(context);
-            groupService.addMember(context, parentGroup, member);
+            member = EPersonBuilder.createEPerson(context).build();
+            parentGroup = GroupBuilder.createGroup(context)
+                    .addMember(member)
+                    .build();
 
             context.commit();
 
@@ -1751,9 +1752,10 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
         try {
             context.turnOffAuthorisationSystem();
 
-            parentGroup = groupService.create(context);
-            member = ePersonService.create(context);
-            groupService.addMember(context, parentGroup, member);
+            member = EPersonBuilder.createEPerson(context).build();
+            parentGroup = GroupBuilder.createGroup(context)
+                    .addMember(member)
+                    .build();
 
             context.commit();
 
@@ -1789,9 +1791,10 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
         try {
             context.turnOffAuthorisationSystem();
 
-            parentGroup = groupService.create(context);
-            member = ePersonService.create(context);
-            groupService.addMember(context, parentGroup, member);
+            member = EPersonBuilder.createEPerson(context).build();
+            parentGroup = GroupBuilder.createGroup(context)
+                    .addMember(member)
+                    .build();
 
             context.commit();
 
@@ -2586,7 +2589,8 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         String itemGroupString = "ITEM";
         int defaultItemRead = Constants.DEFAULT_ITEM_READ;
-        Group itemReadGroup = collectionService.createDefaultReadGroup(context, col1, itemGroupString, defaultItemRead);
+        Group itemReadGroup = GroupBuilder.createCollectionDefaultReadGroup(context,
+                col1, itemGroupString, defaultItemRead).build();
 
         context.restoreAuthSystemState();
 
@@ -2670,8 +2674,9 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
         String bitstreamGroupString = "BITSTREAM";
         int defaultBitstreamRead = Constants.DEFAULT_BITSTREAM_READ;
 
-        Group bitstreamReadGroup = collectionService.createDefaultReadGroup(context, col1, bitstreamGroupString,
-                                                                                            defaultBitstreamRead);
+        Group bitstreamReadGroup = GroupBuilder.createCollectionDefaultReadGroup(context, col1, bitstreamGroupString,
+                                                                                            defaultBitstreamRead)
+                .build();
 
         context.restoreAuthSystemState();
 
@@ -2792,7 +2797,8 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
     public void collectionAdminRemoveMembersFromCollectionAdminGroupSuccess() throws Exception {
 
         context.turnOffAuthorisationSystem();
-        Group adminGroup = collectionService.createAdministrators(context, collection);
+        Group adminGroup = GroupBuilder.createCollectionAdminGroup(context, collection)
+                .build();
         authorizeService.addPolicy(context, collection, Constants.ADMIN, eperson);
         EPerson ePerson = EPersonBuilder.createEPerson(context).withEmail("testToAdd@test.com").build();
         context.restoreAuthSystemState();
@@ -2827,7 +2833,8 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
     public void collectionAdminAddChildGroupToCollectionAdminGroupSuccess() throws Exception {
 
         context.turnOffAuthorisationSystem();
-        Group adminGroup = collectionService.createAdministrators(context, collection);
+        Group adminGroup = GroupBuilder.createCollectionAdminGroup(context, collection)
+                .build();
         authorizeService.addPolicy(context, collection, Constants.ADMIN, eperson);
         Group group = GroupBuilder.createGroup(context).withName("testGroup").build();
         context.restoreAuthSystemState();
@@ -2853,7 +2860,8 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
     public void collectionAdminRemoveChildGroupFromCollectionAdminGroupSuccess() throws Exception {
 
         context.turnOffAuthorisationSystem();
-        Group adminGroup = collectionService.createAdministrators(context, collection);
+        Group adminGroup = GroupBuilder.createCollectionAdminGroup(context, collection)
+                .build();
         authorizeService.addPolicy(context, collection, Constants.ADMIN, eperson);
         Group group = GroupBuilder.createGroup(context).withName("testGroup").build();
         context.restoreAuthSystemState();
@@ -2889,7 +2897,8 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
     public void collectionAdminAddMembersToCollectionAdminGroupPropertySetToFalse() throws Exception {
 
         context.turnOffAuthorisationSystem();
-        Group adminGroup = collectionService.createAdministrators(context, collection);
+        Group adminGroup = GroupBuilder.createCollectionAdminGroup(context, collection)
+                .build();
         authorizeService.addPolicy(context, collection, Constants.ADMIN, eperson);
         EPerson ePerson = EPersonBuilder.createEPerson(context).withEmail("testToAdd@test.com").build();
         configurationService.setProperty("core.authorization.community-admin.collection.admin-group", false);
@@ -2923,7 +2932,8 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
     public void collectionAdminRemoveMembersFromCollectionAdminGroupPropertySetToFalse() throws Exception {
 
         context.turnOffAuthorisationSystem();
-        Group adminGroup = collectionService.createAdministrators(context, collection);
+        Group adminGroup = GroupBuilder.createCollectionAdminGroup(context, collection)
+                .build();
         authorizeService.addPolicy(context, collection, Constants.ADMIN, eperson);
         EPerson ePerson = EPersonBuilder.createEPerson(context).withEmail("testToAdd@test.com").build();
         context.restoreAuthSystemState();
@@ -2961,7 +2971,8 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
     public void collectionAdminAddChildGroupToCollectionAdminGroupPropertySetToFalse() throws Exception {
 
         context.turnOffAuthorisationSystem();
-        Group adminGroup = collectionService.createAdministrators(context, collection);
+        Group adminGroup = GroupBuilder.createCollectionAdminGroup(context, collection)
+                .build();
         authorizeService.addPolicy(context, collection, Constants.ADMIN, eperson);
         Group group = GroupBuilder.createGroup(context).withName("testGroup").build();
         configurationService.setProperty("core.authorization.community-admin.collection.admin-group", false);
@@ -2990,7 +3001,8 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
     public void collectionAdminRemoveChildGroupFromCollectionAdminGroupPropertySetToFalse() throws Exception {
 
         context.turnOffAuthorisationSystem();
-        Group adminGroup = collectionService.createAdministrators(context, collection);
+        Group adminGroup = GroupBuilder.createCollectionAdminGroup(context, collection)
+                .build();
         authorizeService.addPolicy(context, collection, Constants.ADMIN, eperson);
         Group group = GroupBuilder.createGroup(context).withName("testGroup").build();
         context.restoreAuthSystemState();


### PR DESCRIPTION
## References
* Fixes #9806 

## Description
Rewrites and improvements to integration tests (dspace-api and dspace-server-webapp) to make object creation and destruction more consistent, and avoid unexpected errors caused by lingering data from previous tests. Some other issues and bugs fixed as discovered.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
