### PR TITLE
fix for #9311: set default configFile

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/statistics/LogAnalyser.java
+++ b/dspace-api/src/main/java/org/dspace/app/statistics/LogAnalyser.java
@@ -281,10 +281,14 @@ public class LogAnalyser {
      */
     private static String fileTemplate = "dspace\\.log.*";
 
+    private static final ConfigurationService configurationService =
+            DSpaceServicesFactory.getInstance().getConfigurationService();
+
     /**
      * the configuration file from which to configure the analyser
      */
-    private static String configFile;
+    private static String configFile = configurationService.getProperty("dspace.dir")
+            + File.separator + "config" + File.separator + "dstat.cfg";
 
     /**
      * the output file to which to write aggregation data
@@ -616,8 +620,6 @@ public class LogAnalyser {
         }
 
         // now do the host name and url lookup
-        ConfigurationService configurationService
-                = DSpaceServicesFactory.getInstance().getConfigurationService();
         hostName = Utils.getHostName(configurationService.getProperty("dspace.ui.url"));
         name = configurationService.getProperty("dspace.name").trim();
         url = configurationService.getProperty("dspace.ui.url").trim();
@@ -658,8 +660,6 @@ public class LogAnalyser {
                                      String myConfigFile, String myOutFile,
                                      Date myStartDate, Date myEndDate,
                                      boolean myLookUp) {
-        ConfigurationService configurationService
-                = DSpaceServicesFactory.getInstance().getConfigurationService();
 
         if (myLogDir != null) {
             logDir = myLogDir;
@@ -673,9 +673,6 @@ public class LogAnalyser {
 
         if (myConfigFile != null) {
             configFile = myConfigFile;
-        } else {
-            configFile = configurationService.getProperty("dspace.dir")
-                    + File.separator + "config" + File.separator + "dstat.cfg";
         }
 
         if (myStartDate != null) {


### PR DESCRIPTION
## References
* Fixes #9311

## Description
fix stats-log-converter command that was throwing a NullPointerException because the configFile is not set properly

List of changes in this PR:
Adds default value to configFile variable in DSpace/dspace-api/src/main/java/org/dspace/app/statistics/LogAnalyser.java

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
