### PR TITLE
Store date of last filter-media run on Items to limit re-filtering unchanged Items.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScript.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScript.java
@@ -8,8 +8,10 @@
 package org.dspace.app.mediafilter;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -223,7 +225,7 @@ public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfigura
         }
 
         if (fromDate != null) {
-            mediaFilterService.setFromDate(fromDate);
+            mediaFilterService.setFromDate(Date.from(fromDate.atStartOfDay(ZoneId.systemDefault()).toInstant()));
         }
 
         Context c = null;

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
@@ -120,7 +120,7 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
         boolean storeLastDate = false;
         if (fromDate == null) {
             storeLastDate = true;
-            String lastDate = siteService.getMetadata(siteService.findSite(context), "dc.filtermedia.lastdate");
+            String lastDate = siteService.getMetadata(siteService.findSite(context), "dspace.filtermedia.lastdate");
             if (lastDate != null) {
                 fromDate = new DCDate(lastDate).toDate();
             }
@@ -151,9 +151,9 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
         }
         if (storeLastDate) {
             siteService.clearMetadata(context, siteService.findSite(context),
-                "dc", "filtermedia", "lastdate", Item.ANY);
+                "dspace", "filtermedia", "lastdate", Item.ANY);
             siteService.addMetadata(context, siteService.findSite(context),
-                "dc", "filtermedia", "lastdate", null,
+                "dspace", "filtermedia", "lastdate", null,
                 new DCDate(new Date()).toString());
             siteService.update(context, siteService.findSite(context));
         }

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
@@ -9,8 +9,6 @@ package org.dspace.app.mediafilter;
 
 import java.io.InputStream;
 import java.sql.SQLException;
-import java.time.LocalDate;
-import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -37,6 +35,7 @@ import org.dspace.content.service.BundleService;
 import org.dspace.content.service.CollectionService;
 import org.dspace.content.service.CommunityService;
 import org.dspace.content.service.ItemService;
+import org.dspace.content.service.SiteService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.core.SelfNamedPlugin;
@@ -75,6 +74,8 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
     @Autowired(required = true)
     protected ItemService itemService;
     @Autowired(required = true)
+    protected SiteService siteService;
+    @Autowired(required = true)
     protected ConfigurationService configurationService;
 
     protected DSpaceRunnableHandler handler;
@@ -96,7 +97,7 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
     protected boolean isVerbose = false;
     protected boolean isQuiet = false;
     protected boolean isForce = false; // default to not forced
-    protected LocalDate fromDate = null;
+    protected Date fromDate = null;
 
     protected MediaFilterServiceImpl() {
 
@@ -116,6 +117,14 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
 
     @Override
     public void applyFiltersAllItems(Context context) throws Exception {
+        boolean storeLastDate = false;
+        if (fromDate == null) {
+            storeLastDate = true;
+            String lastDate = siteService.getMetadata(siteService.findSite(context), "dc.filtermedia.lastdate");
+            if (lastDate != null) {
+                fromDate = new DCDate(lastDate).toDate();
+            }
+        }
         if (skipList != null) {
             //if a skip-list exists, we need to filter community-by-community
             //so we can respect what is in the skip-list
@@ -128,7 +137,7 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
             Iterator<Item> itemIterator =
                     itemService.findByLastModifiedSince(
                             context,
-                            Date.from(fromDate.atStartOfDay(ZoneId.systemDefault()).toInstant())
+                            fromDate
                     );
             while (itemIterator.hasNext() && processed < max2Process) {
                 applyFiltersItem(context, itemIterator.next());
@@ -139,6 +148,14 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
             while (itemIterator.hasNext() && processed < max2Process) {
                 applyFiltersItem(context, itemIterator.next());
             }
+        }
+        if (storeLastDate) {
+            siteService.clearMetadata(context, siteService.findSite(context),
+                "dc", "filtermedia", "lastdate", Item.ANY);
+            siteService.addMetadata(context, siteService.findSite(context),
+                "dc", "filtermedia", "lastdate", null,
+                new DCDate(new Date()).toString());
+            siteService.update(context, siteService.findSite(context));
         }
     }
 
@@ -172,7 +189,12 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
         collection = context.reloadEntity(collection);
         //only apply filters if collection not in skip-list
         if (!inSkipList(collection.getHandle())) {
-            Iterator<Item> itemIterator = itemService.findAllByCollection(context, collection);
+            Iterator<Item> itemIterator;
+            if (fromDate != null) {
+                itemIterator = itemService.findByCollectionLastModifiedSince(context, collection, fromDate);
+            } else {
+                itemIterator = itemService.findAllByCollection(context, collection);
+            }
             while (itemIterator.hasNext() && processed < max2Process) {
                 applyFiltersItem(context, itemIterator.next());
             }
@@ -603,7 +625,7 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
     }
 
     @Override
-    public void setFromDate(LocalDate fromDate) {
+    public void setFromDate(Date fromDate) {
         this.fromDate = fromDate;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/service/MediaFilterService.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/service/MediaFilterService.java
@@ -8,7 +8,7 @@
 package org.dspace.app.mediafilter.service;
 
 import java.sql.SQLException;
-import java.time.LocalDate;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -151,5 +151,5 @@ public interface MediaFilterService {
      */
     public void setLogHandler(DSpaceRunnableHandler handler);
 
-    public void setFromDate(LocalDate fromDate);
+    public void setFromDate(Date fromDate);
 }

--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -1692,6 +1692,12 @@ prevent the generation of resource policy entry values with null dspace_object a
     }
 
     @Override
+    public Iterator<Item> findByCollectionLastModifiedSince(Context context, Collection collection, Date last)
+        throws SQLException {
+        return itemDAO.findAllByCollectionLastModifiedSince(context, collection, last);
+    }
+
+    @Override
     public int countTotal(Context context) throws SQLException {
         return itemDAO.countRows(context);
     }

--- a/dspace-api/src/main/java/org/dspace/content/dao/ItemDAO.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/ItemDAO.java
@@ -132,6 +132,9 @@ public interface ItemDAO extends DSpaceObjectLegacySupportDAO<Item> {
 
     Iterator<Item> findAllByCollection(Context context, Collection collection) throws SQLException;
 
+    Iterator<Item> findAllByCollectionLastModifiedSince(Context context, Collection collection, Date last)
+        throws SQLException;
+
     Iterator<Item> findAllByCollection(Context context, Collection collection, Integer limit, Integer offset)
         throws SQLException;
 

--- a/dspace-api/src/main/java/org/dspace/content/service/ItemService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/ItemService.java
@@ -857,6 +857,18 @@ public interface ItemService
         throws SQLException;
 
     /**
+     * Get all the archived items in this collection, last modified since a given Date. The order is indeterminate.
+     *
+     * @param context    DSpace context object
+     * @param collection Collection (parent)
+     * @param last       Earliest interesting last-modified date.
+     * @return an iterator over the items in the collection.
+     * @throws SQLException if database error
+     */
+    Iterator<Item> findByCollectionLastModifiedSince(Context context, Collection collection, Date last)
+        throws SQLException;
+
+    /**
      * counts items in the given community
      *
      * @param context   DSpace context object

--- a/dspace/config/registries/dspace-types.xml
+++ b/dspace/config/registries/dspace-types.xml
@@ -93,4 +93,11 @@
         <scope_note>Stores the timestamp related to the user authentication on ORCID</scope_note>
     </dc-type>
 
+    <dc-type>
+        <schema>dspace</schema>
+        <element>filtermedia</element>
+        <qualifier>lastdate</qualifier>
+        <scope_note>Last date filter-media was run</scope_note>
+    </dc-type>
+
 </dspace-dc-types>

--- a/dspace/config/registries/dublin-core-types.xml
+++ b/dspace/config/registries/dublin-core-types.xml
@@ -197,13 +197,6 @@
   </dc-type>
 
   <dc-type>
-    <schema>dc</schema>
-    <element>filtermedia</element>
-    <qualifier>lastdate</qualifier>
-    <scope_note>Last date filter-media was run</scope_note>
-  </dc-type>
-
-  <dc-type>
 	<schema>dc</schema>
     <element>identifier</element>
     <!-- unqualified -->

--- a/dspace/config/registries/dublin-core-types.xml
+++ b/dspace/config/registries/dublin-core-types.xml
@@ -197,6 +197,13 @@
   </dc-type>
 
   <dc-type>
+    <schema>dc</schema>
+    <element>filtermedia</element>
+    <qualifier>lastdate</qualifier>
+    <scope_note>Last date filter-media was run</scope_note>
+  </dc-type>
+
+  <dc-type>
 	<schema>dc</schema>
     <element>identifier</element>
     <!-- unqualified -->


### PR DESCRIPTION
## References
* Fixes #9782 
* Expands upon #9653 
* 7_x version of this PR: #9818 
* 8_x version of this PR: #9819 

## Description
#9653 Added the ability to provide a "from-date" to the "filter-media" script. This date allows us to only process items that were last changed _after_ the provided date.

When **no** date is provided, filter-media would process **all** items. This PR aims to change the default logic (when not providing a date) to only process items that were modified _after_ the last time the script was ran.

This should make the script more performant and avoid it having to scan over potentially a lot of items that have already been processed before, without having to manually provide a "from-date" every time.

## Instructions for Reviewers
Changes:
* After filter-media is done processing all items (only when no parameters were provided, like an identifier or specific date), it will store the current date in the Site's new "dc.filtermedia.lastdate" metadata field. The reason we couldn't just use last-modified date and have to compare it to another is because the last-modified date of an item is already updated by filter-media itself. Site seemed like an appropriate place to store this and metadata values allows more control by administrators.
* At the start of filter-media (again, without any additional parameters), the date stored in Site is checked and if present, only items with a last-modified date _after_ this date are retrieved and processed.
* A custom date can be provided with the `-d` argument. This will override the date found on the Site, but will NOT update the Site's date (otherwise we could end up with non-processed items that are skipped from then)

Version notes:
* For 7_x, I manually applied the code from #9653 to backport its functionality and avoid too many conflicts
* For 7_x, the changes in `ItemDAOImpl` are quite different from 8 and 9 because this class got refactored since, but the functionality should be the exact same.
* 8_x and main (9) contain the commits from PR #9653 to maintain the same codebase and reduce conflicts

How to test:
* Create/update some items/bitstreams
* Run filter-media and confirm it processes them all
* Update some of the same items/bitstreams
* Run filter-media and confirm it only processes the updated ones
* Run filter-media with a `-d` argument and confirm it only processes items from the given date
* Run filter-media with both a `-d` and `-i` argument and confirm they function together (only processing items from the given date and within the given object, e.g. collection)

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).