### PR TITLE
Enable proxy for outgoing connections in many features

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/sherpa/SHERPAService.java
+++ b/dspace-api/src/main/java/org/dspace/app/sherpa/SHERPAService.java
@@ -30,6 +30,7 @@ import org.dspace.app.sherpa.v2.SHERPAPublisherResponse;
 import org.dspace.app.sherpa.v2.SHERPAResponse;
 import org.dspace.app.sherpa.v2.SHERPAUtils;
 import org.dspace.services.ConfigurationService;
+import org.dspace.util.ProxyUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
 
@@ -63,13 +64,14 @@ public class SHERPAService {
      * Create a new HTTP builder with sensible defaults in constructor
      */
     public SHERPAService() {
-        HttpClientBuilder builder = HttpClientBuilder.create();
-        // httpclient 4.3+ doesn't appear to have any sensible defaults any more. Setting conservative defaults as
-        // not to hammer the SHERPA service too much.
-        client = builder
+        // httpclient 4.3+ doesn't appear to have any sensible defaults any
+        // more. Setting conservative defaults so as not to hammer the SHERPA
+        // service too much.
+        HttpClientBuilder builder = HttpClientBuilder.create()
             .disableAutomaticRetries()
-            .setMaxConnTotal(5)
-            .build();
+            .setMaxConnTotal(5);
+        ProxyUtils.addProxy(builder);
+        client = builder.build();
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/authority/orcid/Orcidv3SolrAuthorityImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authority/orcid/Orcidv3SolrAuthorityImpl.java
@@ -27,6 +27,7 @@ import org.dspace.authority.AuthorityValue;
 import org.dspace.authority.SolrAuthorityInterface;
 import org.dspace.external.OrcidRestConnector;
 import org.dspace.external.provider.orcid.xml.XMLtoBio;
+import org.dspace.util.ProxyUtils;
 import org.json.JSONObject;
 import org.orcid.jaxb.model.v3.release.common.OrcidIdentifier;
 import org.orcid.jaxb.model.v3.release.record.Person;
@@ -78,7 +79,9 @@ public class Orcidv3SolrAuthorityImpl implements SolrAuthorityInterface {
                 httpPost.addHeader("Accept", "application/json");
                 httpPost.addHeader("Content-Type", "application/x-www-form-urlencoded");
 
-                HttpClient httpClient = HttpClientBuilder.create().build();
+                HttpClientBuilder builder = HttpClientBuilder.create();
+                ProxyUtils.addProxy(builder);
+                HttpClient httpClient = builder.build();
                 HttpResponse getResponse = httpClient.execute(httpPost);
 
                 JSONObject responseObject = null;
@@ -112,7 +115,8 @@ public class Orcidv3SolrAuthorityImpl implements SolrAuthorityInterface {
     /**
      * Makes an instance of the AuthorityValue with the given information.
      * @param text search string
-     * @return List<AuthorityValue>
+     * @param max no more than this many
+     * @return all authority values found
      */
     @Override
     public List<AuthorityValue> queryAuthorities(String text, int max) {
@@ -164,7 +168,7 @@ public class Orcidv3SolrAuthorityImpl implements SolrAuthorityInterface {
      * @param text search string
      * @param start offset to use
      * @param rows how many rows to return
-     * @return List<Person>
+     * @return {@code Person}s found
      */
     public List<Person> queryBio(String text, int start, int rows) {
         init();
@@ -201,7 +205,7 @@ public class Orcidv3SolrAuthorityImpl implements SolrAuthorityInterface {
      * Retrieve a list of Person objects.
      * @param text search string
      * @param max how many rows to return
-     * @return List<Person>
+     * @return {@code Person}s found
      */
     public List<Person> queryBio(String text, int max) {
         return queryBio(text, 0, max);

--- a/dspace-api/src/main/java/org/dspace/content/packager/AbstractMETSIngester.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/AbstractMETSIngester.java
@@ -49,6 +49,7 @@ import org.dspace.handle.factory.HandleServiceFactory;
 import org.dspace.handle.service.HandleService;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.util.ProxyUtils;
 import org.dspace.workflow.WorkflowException;
 import org.dspace.workflow.factory.WorkflowServiceFactory;
 import org.jdom2.Element;
@@ -1313,7 +1314,7 @@ public abstract class AbstractMETSIngester extends AbstractPackageIngester {
             try {
                 // attempt to open a connection to given URL
                 URL fileURL = new URL(path);
-                URLConnection connection = fileURL.openConnection();
+                URLConnection connection = fileURL.openConnection(ProxyUtils.getProxy());
 
                 // open stream to access file contents
                 return connection.getInputStream();

--- a/dspace-api/src/main/java/org/dspace/ctask/general/MicrosoftTranslator.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/MicrosoftTranslator.java
@@ -20,6 +20,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.util.ProxyUtils;
 
 /**
  * MicrosoftTranslator translates metadata fields using Microsoft Translation API v2
@@ -60,7 +61,9 @@ public class MicrosoftTranslator extends AbstractTranslator {
         String url = baseUrl + "?appId=" + apiKey;
         url += "&to=" + to + "&from=" + from + "&text=" + text;
 
-        try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
+        HttpClientBuilder builder = HttpClientBuilder.create();
+        ProxyUtils.addProxy(builder);
+        try (CloseableHttpClient client = builder.build()) {
             HttpGet hm = new HttpGet(url);
             HttpResponse httpResponse = client.execute(hm);
             log.debug("Response code from API call is " + httpResponse);

--- a/dspace-api/src/main/java/org/dspace/eperson/CaptchaServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/CaptchaServiceImpl.java
@@ -28,6 +28,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.eperson.service.CaptchaService;
 import org.dspace.services.ConfigurationService;
+import org.dspace.util.ProxyUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.StringUtils;
 
@@ -40,7 +41,7 @@ public class CaptchaServiceImpl implements CaptchaService {
 
     private static final Logger log = LogManager.getLogger(CaptchaServiceImpl.class);
 
-    private static Pattern RESPONSE_PATTERN = Pattern.compile("[A-Za-z0-9_-]+");
+    private static final Pattern RESPONSE_PATTERN = Pattern.compile("[A-Za-z0-9_-]+");
 
     private CaptchaSettings captchaSettings;
 
@@ -67,7 +68,7 @@ public class CaptchaServiceImpl implements CaptchaService {
 
         URI verifyUri = URI.create(captchaSettings.getSiteVerify());
 
-        List<NameValuePair> params = new ArrayList<NameValuePair>(3);
+        List<NameValuePair> params = new ArrayList<>(3);
         params.add(new BasicNameValuePair("secret", captchaSettings.getSecret()));
         params.add(new BasicNameValuePair("response", response));
         params.add(new BasicNameValuePair("remoteip", ""));
@@ -82,7 +83,9 @@ public class CaptchaServiceImpl implements CaptchaService {
             throw new RuntimeException(e.getMessage(), e);
         }
 
-        HttpClient httpClient = HttpClientBuilder.create().build();
+        HttpClientBuilder builder = HttpClientBuilder.create();
+        ProxyUtils.addProxy(builder);
+        HttpClient httpClient = builder.build();
         HttpResponse httpResponse;
         GoogleCaptchaResponse googleResponse;
         final ObjectMapper objectMapper = new ObjectMapper();

--- a/dspace-api/src/main/java/org/dspace/external/OpenaireRestConnector.java
+++ b/dspace-api/src/main/java/org/dspace/external/OpenaireRestConnector.java
@@ -35,6 +35,7 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.util.Util;
+import org.dspace.util.ProxyUtils;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -49,7 +50,7 @@ public class OpenaireRestConnector {
     /**
      * log4j logger
      */
-    private static Logger log = org.apache.logging.log4j.LogManager.getLogger(OpenaireRestConnector.class);
+    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
     /**
      * Openaire API Url
@@ -93,7 +94,7 @@ public class OpenaireRestConnector {
 
 
     /**
-     * This method grabs an accessToken an sets the expiration time Based.<br/>
+     * This method grabs an accessToken and sets the expiration time.<br>
      * Based on https://develop.openaire.eu/basic.html
      * 
      * @throws IOException
@@ -116,11 +117,13 @@ public class OpenaireRestConnector {
         httpPost.setHeader(HttpHeaders.AUTHORIZATION, authHeader);
 
         // Request parameters and other properties.
-        List<NameValuePair> params = new ArrayList<NameValuePair>(1);
+        List<NameValuePair> params = new ArrayList<>(1);
         params.add(new BasicNameValuePair("grant_type", "client_credentials"));
         httpPost.setEntity(new UrlEncodedFormEntity(params, "UTF-8"));
 
-        HttpClient httpClient = HttpClientBuilder.create().build();
+        HttpClientBuilder builder = HttpClientBuilder.create();
+        ProxyUtils.addProxy(builder);
+        HttpClient httpClient = builder.build();
         HttpResponse getResponse = httpClient.execute(httpPost);
 
         JSONObject responseObject = null;
@@ -171,7 +174,9 @@ public class OpenaireRestConnector {
                 httpGet.addHeader("Authorization", "Bearer " + accessToken);
             }
 
-            HttpClient httpClient = HttpClientBuilder.create().build();
+            HttpClientBuilder builder = HttpClientBuilder.create();
+            ProxyUtils.addProxy(builder);
+            HttpClient httpClient = builder.build();
             getResponse = httpClient.execute(httpGet);
 
             StatusLine status = getResponse.getStatusLine();

--- a/dspace-api/src/main/java/org/dspace/external/OrcidRestConnector.java
+++ b/dspace-api/src/main/java/org/dspace/external/OrcidRestConnector.java
@@ -18,6 +18,7 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.dspace.util.ProxyUtils;
 
 /**
  * @author Antoine Snyers (antoine at atmire.com)
@@ -49,8 +50,10 @@ public class OrcidRestConnector {
             httpGet.addHeader("Content-Type", "application/vnd.orcid+xml");
             httpGet.addHeader("Authorization","Bearer " + accessToken);
         }
+        HttpClientBuilder builder = HttpClientBuilder.create();
+        ProxyUtils.addProxy(builder);
         try {
-            HttpClient httpClient = HttpClientBuilder.create().build();
+            HttpClient httpClient = builder.build();
             getResponse = httpClient.execute(httpGet);
             //do not close this httpClient
             result = getResponse.getEntity().getContent();

--- a/dspace-api/src/main/java/org/dspace/external/provider/impl/OrcidV3AuthorDataProvider.java
+++ b/dspace-api/src/main/java/org/dspace/external/provider/impl/OrcidV3AuthorDataProvider.java
@@ -32,6 +32,7 @@ import org.dspace.external.OrcidRestConnector;
 import org.dspace.external.model.ExternalDataObject;
 import org.dspace.external.provider.AbstractExternalDataProvider;
 import org.dspace.external.provider.orcid.xml.XMLtoBio;
+import org.dspace.util.ProxyUtils;
 import org.json.JSONObject;
 import org.orcid.jaxb.model.v3.release.common.OrcidIdentifier;
 import org.orcid.jaxb.model.v3.release.record.Person;
@@ -58,7 +59,7 @@ public class OrcidV3AuthorDataProvider extends AbstractExternalDataProvider {
 
     private String orcidUrl;
 
-    private XMLtoBio converter;
+    private final XMLtoBio converter;
 
     public static final String ORCID_ID_SYNTAX = "\\d{4}-\\d{4}-\\d{4}-(\\d{3}X|\\d{4})";
     private static final int MAX_INDEX = 10000;
@@ -87,7 +88,9 @@ public class OrcidV3AuthorDataProvider extends AbstractExternalDataProvider {
             httpPost.addHeader("Accept", "application/json");
             httpPost.addHeader("Content-Type", "application/x-www-form-urlencoded");
 
-            HttpClient httpClient = HttpClientBuilder.create().build();
+            HttpClientBuilder builder = HttpClientBuilder.create();
+            ProxyUtils.addProxy(builder);
+            HttpClient httpClient = builder.build();
             HttpResponse getResponse = httpClient.execute(httpPost);
 
             JSONObject responseObject = null;

--- a/dspace-api/src/main/java/org/dspace/google/client/GoogleAnalyticsClientImpl.java
+++ b/dspace-api/src/main/java/org/dspace/google/client/GoogleAnalyticsClientImpl.java
@@ -18,10 +18,11 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.google.GoogleAnalyticsEvent;
+import org.dspace.util.ProxyUtils;
 
 /**
  * Implementation of {@link GoogleAnalyticsClient}.
@@ -42,7 +43,9 @@ public class GoogleAnalyticsClientImpl implements GoogleAnalyticsClient {
     public GoogleAnalyticsClientImpl(String keyPrefix, GoogleAnalyticsClientRequestBuilder requestBuilder) {
         this.keyPrefix = keyPrefix;
         this.requestBuilder = requestBuilder;
-        this.httpclient = HttpClients.createDefault();
+        HttpClientBuilder clientBuilder = HttpClientBuilder.create();
+        ProxyUtils.addProxy(clientBuilder);
+        this.httpclient = clientBuilder.build();
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/identifier/doi/DataCiteConnector.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/doi/DataCiteConnector.java
@@ -52,6 +52,7 @@ import org.dspace.core.factory.CoreServiceFactory;
 import org.dspace.handle.service.HandleService;
 import org.dspace.identifier.DOI;
 import org.dspace.services.ConfigurationService;
+import org.dspace.util.ProxyUtils;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.JDOMException;
@@ -699,7 +700,9 @@ public class DataCiteConnector
         httpContext.setCredentialsProvider(credentialsProvider);
 
         HttpEntity entity = null;
-        try ( CloseableHttpClient httpclient = HttpClientBuilder.create().build(); ) {
+        HttpClientBuilder builder = HttpClientBuilder.create();
+        builder = ProxyUtils.addProxy(builder);
+        try ( CloseableHttpClient httpclient = builder.build(); ) {
             HttpResponse response = httpclient.execute(req, httpContext);
 
             StatusLine status = response.getStatusLine();

--- a/dspace-api/src/main/java/org/dspace/identifier/ezid/EZIDRequest.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/ezid/EZIDRequest.java
@@ -31,6 +31,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.identifier.DOI;
 import org.dspace.identifier.IdentifierException;
+import org.dspace.util.ProxyUtils;
 
 /**
  * A request to EZID concerning a given (or expected) identifier.
@@ -87,7 +88,9 @@ public class EZIDRequest {
             this.authority = authority;
         }
 
-        client = HttpClientBuilder.create().build();
+        HttpClientBuilder builder = HttpClientBuilder.create();
+        ProxyUtils.addProxy(builder);
+        client = builder.build();
         httpContext = HttpClientContext.create();
         if (null != username) {
             URI uri = new URI(scheme, host, path, null);
@@ -124,7 +127,9 @@ public class EZIDRequest {
             this.authority = authority;
         }
 
-        client = HttpClientBuilder.create().build();
+        HttpClientBuilder builder = HttpClientBuilder.create();
+        ProxyUtils.addProxy(builder);
+        client = builder.build();
         httpContext = HttpClientContext.create();
         if (null != username) {
             CredentialsProvider credentialsProvider = new BasicCredentialsProvider();

--- a/dspace-api/src/main/java/org/dspace/license/CCLicenseConnectorServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/license/CCLicenseConnectorServiceImpl.java
@@ -345,7 +345,7 @@ public class CCLicenseConnectorServiceImpl implements CCLicenseConnectorService,
         } catch (MalformedURLException e) {
             return null;
         }
-        URLConnection connection = request_url.openConnection();
+        URLConnection connection = request_url.openConnection(ProxyUtils.getProxy());
         connection.setDoOutput(true);
         try {
             // parsing document from input stream

--- a/dspace-api/src/main/java/org/dspace/util/ProxyUtils.java
+++ b/dspace-api/src/main/java/org/dspace/util/ProxyUtils.java
@@ -10,21 +10,27 @@ package org.dspace.util;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHost;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 
 /**
  * Utility methods for HTTP proxies.
+ * See configuration properties {@code http.proxy.host}, {@code http.proxy.port}.
+ * If host is set and port is not, or if host is not set, then proxying is
+ * disabled.
  *
  * @author mwood
  */
 public class ProxyUtils {
     public static final String C_HTTP_PROXY_HOST = "http.proxy.host";
     public static final String C_HTTP_PROXY_PORT = "http.proxy.port";
-    public static final int D_HTTP_PROXY_PORT = -1;
 
+    private static final Logger LOG = LogManager.getLogger();
     private static final ConfigurationService configurationService
             = DSpaceServicesFactory.getInstance().getConfigurationService();
 
@@ -32,20 +38,21 @@ public class ProxyUtils {
 
     /**
      * Add a proxy to an HttpClientBuilder if a proxy is configured.
-     * See configuration properties {@code http.proxy.host}, {@code http.proxy.port}.
-     * If host is set and port is not, use the default port for the scheme.  If
-     * host is not set, return the builder unaltered.
      *
      * @param builder the builder to be configured.
      * @return the builder, possibly configured with a proxy.
      */
     public static HttpClientBuilder addProxy(HttpClientBuilder builder) {
         String proxyHost = configurationService.getProperty(C_HTTP_PROXY_HOST);
-        if (null != proxyHost) {
-            int proxyPort = configurationService.getIntProperty(C_HTTP_PROXY_PORT,
-                    D_HTTP_PROXY_PORT);
-            HttpHost proxy = new HttpHost(proxyHost, proxyPort);
-            builder.setProxy(proxy);
+        if (StringUtils.isNotBlank(proxyHost)) {
+            int proxyPort = getPort();
+            if (proxyPort >= 0) {
+                HttpHost proxy = new HttpHost(proxyHost, proxyPort);
+                builder.setProxy(proxy);
+            } else {
+                LOG.warn(C_HTTP_PROXY_HOST + " is set but " + C_HTTP_PROXY_PORT
+                        + " is not.  Proxy disabled.");
+            }
         }
         return builder;
     }
@@ -54,15 +61,40 @@ public class ProxyUtils {
      * Create a {@link Proxy} instance from our configuration for a
      * {@link java.net.URLConnection}, if configured.
      *
-     * @return a configured Proxy, or {@link Proxy.NO_PROXY} if unconfigured.
+     * @return a configured Proxy, or {@link Proxy.NO_PROXY} if not configured.
      */
     public static Proxy getProxy() {
         Proxy proxy = Proxy.NO_PROXY;
         String proxyHost = configurationService.getProperty(C_HTTP_PROXY_HOST);
-        if (null != proxyHost) {
-            int proxyPort = configurationService.getIntProperty(C_HTTP_PROXY_PORT);
-            proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, proxyPort));
+        if (StringUtils.isNotBlank(proxyHost)) {
+            int proxyPort = getPort();
+            if (proxyPort >= 0) {
+                proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, proxyPort));
+            } else {
+                LOG.warn(C_HTTP_PROXY_HOST + " is set but " + C_HTTP_PROXY_PORT
+                        + " is not.  Proxy disabled.");
+            }
         }
         return proxy;
+    }
+
+    /**
+     * Get the configured proxy port.  Return a default if not configured or not
+     * a positive number.
+     *
+     * @return the port number, or -1 if none.
+     */
+    private static int getPort() {
+        String proxyPort = configurationService.getProperty(C_HTTP_PROXY_PORT);
+        if (StringUtils.isNumeric(proxyPort)) {
+            return Integer.parseUnsignedInt(proxyPort);
+        } else {
+            if (configurationService.hasProperty(C_HTTP_PROXY_PORT)) {
+                LOG.warn("Proxy port setting " + C_HTTP_PROXY_PORT +
+                        " = '{}' is not a positive number.  Treating as unset",
+                        proxyPort);
+            }
+            return -1;
+        }
     }
 }

--- a/dspace-api/src/main/java/org/dspace/util/ProxyUtils.java
+++ b/dspace-api/src/main/java/org/dspace/util/ProxyUtils.java
@@ -1,0 +1,40 @@
+package org.dspace.util;
+
+import org.apache.http.HttpHost;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
+
+/**
+ * Utility methods for HTTP proxies.
+ *
+ * @author mwood
+ */
+public class ProxyUtils {
+    public static final String C_HTTP_PROXY_HOST = "http.proxy.host";
+    public static final String C_HTTP_PROXY_PORT = "http.proxy.port";
+    public static final int D_HTTP_PROXY_PORT = -1;
+
+    private static final ConfigurationService configurationService
+            = DSpaceServicesFactory.getInstance().getConfigurationService();
+
+    /**
+     * Add a proxy to the builder if one is configured.
+     * See configuration properties {@code http.proxy.host}, {@code http.proxy.port}.
+     * If host is set and port is not, use the default port for the scheme.  If
+     * host is not set, return the builder unaltered.
+     *
+     * @param builder the builder to be configured.
+     * @return the builder, possibly configured with a proxy.
+     */
+    public static HttpClientBuilder addProxy(HttpClientBuilder builder) {
+        String proxyHost = configurationService.getProperty(C_HTTP_PROXY_HOST);
+        if (null != proxyHost) {
+            int proxyPort = configurationService.getIntProperty(C_HTTP_PROXY_PORT,
+                    D_HTTP_PROXY_PORT);
+            HttpHost proxy = new HttpHost(proxyHost, proxyPort);
+            builder.setProxy(proxy);
+        }
+        return builder;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/util/ProxyUtils.java
+++ b/dspace-api/src/main/java/org/dspace/util/ProxyUtils.java
@@ -31,8 +31,6 @@ public class ProxyUtils {
     public static final String C_HTTP_PROXY_PORT = "http.proxy.port";
 
     private static final Logger LOG = LogManager.getLogger();
-    private static final ConfigurationService configurationService
-            = DSpaceServicesFactory.getInstance().getConfigurationService();
 
     private ProxyUtils() {}
 
@@ -43,9 +41,11 @@ public class ProxyUtils {
      * @return the builder, possibly configured with a proxy.
      */
     public static HttpClientBuilder addProxy(HttpClientBuilder builder) {
-        String proxyHost = configurationService.getProperty(C_HTTP_PROXY_HOST);
+        ConfigurationService cfg = DSpaceServicesFactory.getInstance()
+                .getConfigurationService();
+        String proxyHost = cfg.getProperty(C_HTTP_PROXY_HOST);
         if (StringUtils.isNotBlank(proxyHost)) {
-            int proxyPort = getPort();
+            int proxyPort = getPort(cfg);
             if (proxyPort >= 0) {
                 HttpHost proxy = new HttpHost(proxyHost, proxyPort);
                 builder.setProxy(proxy);
@@ -64,10 +64,12 @@ public class ProxyUtils {
      * @return a configured Proxy, or {@link Proxy.NO_PROXY} if not configured.
      */
     public static Proxy getProxy() {
+        ConfigurationService cfg = DSpaceServicesFactory.getInstance()
+                .getConfigurationService();
         Proxy proxy = Proxy.NO_PROXY;
-        String proxyHost = configurationService.getProperty(C_HTTP_PROXY_HOST);
+        String proxyHost = cfg.getProperty(C_HTTP_PROXY_HOST);
         if (StringUtils.isNotBlank(proxyHost)) {
-            int proxyPort = getPort();
+            int proxyPort = getPort(cfg);
             if (proxyPort >= 0) {
                 proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, proxyPort));
             } else {
@@ -84,12 +86,12 @@ public class ProxyUtils {
      *
      * @return the port number, or -1 if none.
      */
-    private static int getPort() {
-        String proxyPort = configurationService.getProperty(C_HTTP_PROXY_PORT);
+    private static int getPort(ConfigurationService cfg) {
+        String proxyPort = cfg.getProperty(C_HTTP_PROXY_PORT);
         if (StringUtils.isNumeric(proxyPort)) {
             return Integer.parseUnsignedInt(proxyPort);
         } else {
-            if (configurationService.hasProperty(C_HTTP_PROXY_PORT)) {
+            if (cfg.hasProperty(C_HTTP_PROXY_PORT)) {
                 LOG.warn("Proxy port setting " + C_HTTP_PROXY_PORT +
                         " = '{}' is not a positive number.  Treating as unset",
                         proxyPort);

--- a/dspace-api/src/main/java/org/dspace/util/ProxyUtils.java
+++ b/dspace-api/src/main/java/org/dspace/util/ProxyUtils.java
@@ -1,4 +1,14 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package org.dspace.util;
+
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 
 import org.apache.http.HttpHost;
 import org.apache.http.impl.client.HttpClientBuilder;
@@ -18,8 +28,10 @@ public class ProxyUtils {
     private static final ConfigurationService configurationService
             = DSpaceServicesFactory.getInstance().getConfigurationService();
 
+    private ProxyUtils() {}
+
     /**
-     * Add a proxy to the builder if one is configured.
+     * Add a proxy to an HttpClientBuilder if a proxy is configured.
      * See configuration properties {@code http.proxy.host}, {@code http.proxy.port}.
      * If host is set and port is not, use the default port for the scheme.  If
      * host is not set, return the builder unaltered.
@@ -36,5 +48,21 @@ public class ProxyUtils {
             builder.setProxy(proxy);
         }
         return builder;
+    }
+
+    /**
+     * Create a {@link Proxy} instance from our configuration for a
+     * {@link java.net.URLConnection}, if configured.
+     *
+     * @return a configured Proxy, or {@link Proxy.NO_PROXY} if unconfigured.
+     */
+    public static Proxy getProxy() {
+        Proxy proxy = Proxy.NO_PROXY;
+        String proxyHost = configurationService.getProperty(C_HTTP_PROXY_HOST);
+        if (null != proxyHost) {
+            int proxyPort = configurationService.getIntProperty(C_HTTP_PROXY_PORT);
+            proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, proxyPort));
+        }
+        return proxy;
     }
 }

--- a/dspace-api/src/test/java/org/dspace/util/ProxyUtilsTest.java
+++ b/dspace-api/src/test/java/org/dspace/util/ProxyUtilsTest.java
@@ -1,0 +1,88 @@
+package org.dspace.util;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.apache.http.HttpHost;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.dspace.AbstractUnitTest;
+import org.dspace.services.ConfigurationService;
+import org.dspace.utils.DSpace;
+import static org.junit.Assert.assertEquals;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
+
+/**
+ *
+ * @author mwood
+ */
+public class ProxyUtilsTest
+        extends AbstractUnitTest {
+    private static ConfigurationService cfg;
+
+    @BeforeClass
+    public static void initme() {
+        cfg = new DSpace().getConfigurationService();
+    }
+
+    private static final String PROXY_HOST = "proxy.example.com";
+    private static final int PROXY_PORT = 8888;
+
+    /**
+     * Test of addProxy method when no proxy is set.
+     */
+    @Test
+    public void testAddProxyNone() {
+        HttpClientBuilder builder = HttpClientBuilder.create();
+        HttpClientBuilder builderSpy = spy(builder);
+
+        // Test no proxy
+        cfg.setProperty(ProxyUtils.C_HTTP_PROXY_HOST, null);
+        builderSpy = ProxyUtils.addProxy(builderSpy);
+        verify(builderSpy,never()).setProxy(any(HttpHost.class));
+    }
+
+    /**
+     * Test of addProxy method when only host is set.
+     */
+//    @Ignore
+    @Test
+    public void testAddProxyNoPort() {
+        HttpClientBuilder builder = HttpClientBuilder.create();
+        HttpClientBuilder builderSpy = spy(builder);
+        HttpHost hostSpy = mock(HttpHost.class,
+                withSettings().useConstructor("bogus." + PROXY_HOST, Integer.valueOf(-1)));
+
+        cfg.setProperty(ProxyUtils.C_HTTP_PROXY_HOST, PROXY_HOST);
+        cfg.setProperty(ProxyUtils.C_HTTP_PROXY_PORT, null);
+        builderSpy = ProxyUtils.addProxy(builderSpy);
+        verify(builderSpy,times(1)).setProxy(any(HttpHost.class));
+        // FIXME this fails with null host name.  How to get at the HttpHost?
+        // FIXME assertEquals("Wrong proxy host", PROXY_HOST, hostSpy.getHostName());
+        // FIXME assertEquals("Wrong proxy port", PROXY_PORT, hostSpy.getPort()); // FIXME nope?
+    }
+
+    /**
+     * Test of addProxy method when host and port are set.
+     */
+    @Test
+    public void testAddProxyWithPort() {
+        HttpClientBuilder builder = HttpClientBuilder.create();
+        HttpClientBuilder builderSpy = spy(builder);
+        HttpHost hostSpy = mock(HttpHost.class,
+                withSettings().useConstructor("bogus." + PROXY_HOST, PROXY_PORT));
+
+        cfg.setProperty(ProxyUtils.C_HTTP_PROXY_HOST, PROXY_HOST);
+        cfg.setProperty(ProxyUtils.C_HTTP_PROXY_PORT, PROXY_PORT);
+        builderSpy = ProxyUtils.addProxy(builderSpy);
+        verify(builderSpy,times(1)).setProxy(any(HttpHost.class));
+        // FIXME assertEquals("Wrong proxy host", PROXY_HOST, hostSpy.getHostName());
+        // FIXME assertEquals("Wrong proxy port", PROXY_PORT, hostSpy.getPort());
+    }
+}

--- a/dspace-api/src/test/java/org/dspace/util/ProxyUtilsTest.java
+++ b/dspace-api/src/test/java/org/dspace/util/ProxyUtilsTest.java
@@ -1,22 +1,31 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package org.dspace.util;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.withSettings;
+
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 
 import org.apache.http.HttpHost;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.dspace.AbstractUnitTest;
 import org.dspace.services.ConfigurationService;
 import org.dspace.utils.DSpace;
-import static org.junit.Assert.assertEquals;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.withSettings;
 
 /**
  *
@@ -32,6 +41,7 @@ public class ProxyUtilsTest
     }
 
     private static final String PROXY_HOST = "proxy.example.com";
+    private static final String PROXY_IP_ADDRESS = "192.168.1.1";
     private static final int PROXY_PORT = 8888;
 
     /**
@@ -84,5 +94,23 @@ public class ProxyUtilsTest
         verify(builderSpy,times(1)).setProxy(any(HttpHost.class));
         // FIXME assertEquals("Wrong proxy host", PROXY_HOST, hostSpy.getHostName());
         // FIXME assertEquals("Wrong proxy port", PROXY_PORT, hostSpy.getPort());
+    }
+
+    @Test
+    public void TestGetProxy() {
+        cfg.setProperty(ProxyUtils.C_HTTP_PROXY_HOST, PROXY_IP_ADDRESS);
+        cfg.setProperty(ProxyUtils.C_HTTP_PROXY_PORT, PROXY_PORT);
+        Proxy proxy = ProxyUtils.getProxy();
+        Proxy expected = new Proxy(Proxy.Type.HTTP,
+                new InetSocketAddress(PROXY_IP_ADDRESS, PROXY_PORT));
+        assertEquals("Wrong proxy", expected, proxy);
+    }
+
+    @Test
+    public void TestGetProxyNone() {
+        cfg.setProperty(ProxyUtils.C_HTTP_PROXY_HOST, null);
+        Proxy proxy = ProxyUtils.getProxy();
+        Proxy expected = Proxy.NO_PROXY;
+        assertEquals("Wrong proxy", expected, proxy);
     }
 }

--- a/dspace-api/src/test/java/org/dspace/util/ProxyUtilsTest.java
+++ b/dspace-api/src/test/java/org/dspace/util/ProxyUtilsTest.java
@@ -42,7 +42,8 @@ public class ProxyUtilsTest
 
     private static final String PROXY_HOST = "proxy.example.com";
     private static final String PROXY_IP_ADDRESS = "192.168.1.1";
-    private static final int PROXY_PORT = 8888;
+    private static final String PROXY_PORT = "8888";
+    private static final int PROXY_PORT_INT = 8888;
 
     /**
      * Test of addProxy method when no proxy is set.
@@ -72,7 +73,7 @@ public class ProxyUtilsTest
         cfg.setProperty(ProxyUtils.C_HTTP_PROXY_HOST, PROXY_HOST);
         cfg.setProperty(ProxyUtils.C_HTTP_PROXY_PORT, null);
         builderSpy = ProxyUtils.addProxy(builderSpy);
-        verify(builderSpy,times(1)).setProxy(any(HttpHost.class));
+        verify(builderSpy,never()).setProxy(any(HttpHost.class));
         // FIXME this fails with null host name.  How to get at the HttpHost?
         // FIXME assertEquals("Wrong proxy host", PROXY_HOST, hostSpy.getHostName());
         // FIXME assertEquals("Wrong proxy port", PROXY_PORT, hostSpy.getPort()); // FIXME nope?
@@ -86,7 +87,7 @@ public class ProxyUtilsTest
         HttpClientBuilder builder = HttpClientBuilder.create();
         HttpClientBuilder builderSpy = spy(builder);
         HttpHost hostSpy = mock(HttpHost.class,
-                withSettings().useConstructor("bogus." + PROXY_HOST, PROXY_PORT));
+                withSettings().useConstructor("bogus." + PROXY_HOST, PROXY_PORT_INT));
 
         cfg.setProperty(ProxyUtils.C_HTTP_PROXY_HOST, PROXY_HOST);
         cfg.setProperty(ProxyUtils.C_HTTP_PROXY_PORT, PROXY_PORT);
@@ -102,7 +103,7 @@ public class ProxyUtilsTest
         cfg.setProperty(ProxyUtils.C_HTTP_PROXY_PORT, PROXY_PORT);
         Proxy proxy = ProxyUtils.getProxy();
         Proxy expected = new Proxy(Proxy.Type.HTTP,
-                new InetSocketAddress(PROXY_IP_ADDRESS, PROXY_PORT));
+                new InetSocketAddress(PROXY_IP_ADDRESS, PROXY_PORT_INT));
         assertEquals("Wrong proxy", expected, proxy);
     }
 


### PR DESCRIPTION
## References
* Fixes #8603

## Description
In many places DSpace does not pay attention to configuration properties `http.proxy.host` and `http.proxy.port` when it should.  When the back-end is behind a reverse proxy and running on a host that has no public address, these features fail.

## Instructions for Reviewers
List of changes in this PR:
* Invented a `ProxyUtils` class exposing static methods for adding proxy information to connection creators, using the DSpace configuration properties noted above.
* Added `ProxyUtils` calls to a number of client classes.

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
