### PR TITLE
Normalise / fix references to the word "reinstate".

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/AuthorizeUtil.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/AuthorizeUtil.java
@@ -523,9 +523,9 @@ public class AuthorizeUtil {
 
         for (Collection coll : colls) {
             if (!AuthorizeConfiguration
-                .canCollectionAdminPerformItemReinstatiate()) {
+                .canCollectionAdminPerformItemReinstate()) {
                 if (AuthorizeConfiguration
-                    .canCommunityAdminPerformItemReinstatiate()
+                    .canCommunityAdminPerformItemReinstate()
                     && authorizeService.authorizeActionBoolean(context,
                                                                coll.getCommunities().get(0), Constants.ADMIN)) {
                     // authorized

--- a/dspace-api/src/main/java/org/dspace/authorize/AuthorizeConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/AuthorizeConfiguration.java
@@ -174,9 +174,9 @@ public class AuthorizeConfiguration {
      *
      * @return true/false
      */
-    public static boolean canCommunityAdminPerformItemReinstatiate() {
+    public static boolean canCommunityAdminPerformItemReinstate() {
         init();
-        return configurationService.getBooleanProperty("core.authorization.community-admin.item.reinstatiate", true);
+        return configurationService.getBooleanProperty("core.authorization.community-admin.item.reinstate", true);
     }
 
     /**
@@ -306,9 +306,9 @@ public class AuthorizeConfiguration {
      *
      * @return true/false
      */
-    public static boolean canCollectionAdminPerformItemReinstatiate() {
+    public static boolean canCollectionAdminPerformItemReinstate() {
         init();
-        return configurationService.getBooleanProperty("core.authorization.collection-admin.item.reinstatiate", true);
+        return configurationService.getBooleanProperty("core.authorization.collection-admin.item.reinstate", true);
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/rdf/RDFConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/rdf/RDFConsumer.java
@@ -243,7 +243,7 @@ public class RDFConsumer implements Consumer {
             DSOIdentifier id = new DSOIdentifier(dso, ctx);
             // If an item gets withdrawn, a MODIFY event is fired. We have to
             // delete the item from the triple store instead of converting it.
-            // we don't have to take care for reinstantions of items as they can
+            // we don't have to take care for reinstate events on items as they can
             // be processed as normal modify events.
             if (dso instanceof Item
                 && event.getDetail() != null

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/ItemWithdrawReplaceOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/ItemWithdrawReplaceOperation.java
@@ -76,9 +76,9 @@ public class ItemWithdrawReplaceOperation<R> extends PatchOperation<R> {
                     return object;
                 }
             } catch (AuthorizeException e) {
-                throw new RESTAuthorizationException("Unauthorized user for item withdrawal/reinstation");
+                throw new RESTAuthorizationException("Unauthorized user for item withdraw / reinstate operation");
             } catch (SQLException e) {
-                throw new DSpaceBadRequestException("SQL exception during item withdrawal/reinstation");
+                throw new DSpaceBadRequestException("SQL exception during item withdraw / reinstate operation");
             }
         } else {
             throw new DSpaceBadRequestException("ItemWithdrawReplaceOperation does not support this operation");

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/ReinstateFeatureRestIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/ReinstateFeatureRestIT.java
@@ -123,9 +123,9 @@ public class ReinstateFeatureRestIT extends AbstractControllerIntegrationTest {
                     Matchers.is(AuthorizationMatcher.matchAuthorization(authAdminWithdraw))))
             );
 
-        // verify that the property core.authorization.collection-admin.item.reinstatiate = false is respected
+        // verify that the property core.authorization.collection-admin.item.reinstate = false is respected
         // the community admins should be still authorized
-        configurationService.setProperty("core.authorization.collection-admin.item.reinstatiate", false);
+        configurationService.setProperty("core.authorization.collection-admin.item.reinstate", false);
         getClient(comAdminToken).perform(get("/api/authz/authorizations/" + authAdminWithdraw.getID()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$",
@@ -140,11 +140,11 @@ public class ReinstateFeatureRestIT extends AbstractControllerIntegrationTest {
                         Matchers.is(AuthorizationMatcher.matchAuthorization(authAdminWithdraw))))
         );
 
-        // now verify that the property core.authorization.community-admin.item.reinstatiate = false is respected
+        // now verify that the property core.authorization.community-admin.item.reinstate = false is respected
         // and also community admins are blocked
         // Please note that set to false the configuration for community keeping true for collection don't
         // make any sense as a community admin is always also a collection admin
-        configurationService.setProperty("core.authorization.community-admin.item.reinstatiate", false);
+        configurationService.setProperty("core.authorization.community-admin.item.reinstate", false);
         getClient(comAdminToken).perform(get("/api/authz/authorizations/" + authAdminWithdraw.getID()))
                     .andExpect(status().isNotFound());
 
@@ -183,8 +183,8 @@ public class ReinstateFeatureRestIT extends AbstractControllerIntegrationTest {
             .andExpect(jsonPath("$._embedded.authorizations", contains(
                     Matchers.is(AuthorizationMatcher.matchAuthorization(authAdminWithdraw))))
             );
-        // verify that the property core.authorization.collection-admin.item.reinstatiate = false is respected
-        configurationService.setProperty("core.authorization.collection-admin.item.reinstatiate", false);
+        // verify that the property core.authorization.collection-admin.item.reinstate = false is respected
+        configurationService.setProperty("core.authorization.collection-admin.item.reinstate", false);
         getClient(colAdminToken).perform(get("/api/authz/authorizations/" + authAdminWithdraw.getID()))
                     .andExpect(status().isNotFound());
 

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -350,7 +350,7 @@ handle.dir = ${dspace.dir}/handle-server
 # Authorize community administrators to manage item settings (for items owned by collections under the community)
 #core.authorization.community-admin.item.delete = true
 #core.authorization.community-admin.item.withdraw = true
-#core.authorization.community-admin.item.reinstatiate = true
+#core.authorization.community-admin.item.reinstate = true
 #core.authorization.community-admin.item.policies = true
 # Authorize community administrators to manage bundles/bitstreams of those items
 #core.authorization.community-admin.item.create-bitstream = true
@@ -367,7 +367,7 @@ handle.dir = ${dspace.dir}/handle-server
 # Authorize collection administrators to manage item settings (for items owned by the collection)
 #core.authorization.collection-admin.item.delete = true
 #core.authorization.collection-admin.item.withdraw = true
-#core.authorization.collection-admin.item.reinstatiate = true
+#core.authorization.collection-admin.item.reinstate = true
 #core.authorization.collection-admin.item.policies = true
 # Authorize collection administrators to manage bundles/bitstreams of those items (owned by the collection)
 #core.authorization.collection-admin.item.create-bitstream = true


### PR DESCRIPTION
Normalise / fix references to the term "reinstate".

## References
* This work was left out of https://github.com/DSpace/DSpace/pull/9750 as we saw it made changes to configuration property names, and might need some discussion about what term we consistently use for the opposite of 'withdraw'

## Description
There were some spelling errors across the code base referring to reinstate / reinstantiate, which are also not the same word.

I think the noun form might be "reinstatement" rather than "reinstantiation" (reinstantiate being a slightly different word) but to avoid confusion I found it easier to just rewrite a few error messages so that the verb "reinstate" could be used and we can avoid nominalisation.

Two configuration properties are altered with this change and will need to be documented somewhere
```
#core.authorization.community-admin.item.reinstate = true
#core.authorization.collection-admin.item.reinstate = true
```

Feedback / discussion on the decisions here is welcome!

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.