### PR TITLE
[Port dspace-8_x] Add missing wosPublisherContrib key-ref in wos-integration.xml

### DIFF
--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/WOSImportMetadataSourceServiceIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/WOSImportMetadataSourceServiceIT.java
@@ -136,6 +136,7 @@ public class WOSImportMetadataSourceServiceIT extends AbstractLiveImportIntegrat
         MetadatumDTO subject15 = createMetadatumDTO("dc", "subject", null, "Coding concepts");
         MetadatumDTO subject16 = createMetadatumDTO("dc", "subject", null, "Lesson design");
         MetadatumDTO subject17 = createMetadatumDTO("dc", "subject", null, "Social Sciences");
+        MetadatumDTO publisher = createMetadatumDTO("dc", "publisher", null, "SPRINGER");
         MetadatumDTO other = createMetadatumDTO("dc", "identifier", "other", "WOS:000805105200003");
         metadatums.add(edition);
         metadatums.add(date);
@@ -166,6 +167,7 @@ public class WOSImportMetadataSourceServiceIT extends AbstractLiveImportIntegrat
         metadatums.add(subject15);
         metadatums.add(subject16);
         metadatums.add(subject17);
+        metadatums.add(publisher);
         metadatums.add(other);
         ImportRecord firstrRecord = new ImportRecord(metadatums);
 
@@ -205,6 +207,7 @@ public class WOSImportMetadataSourceServiceIT extends AbstractLiveImportIntegrat
         MetadatumDTO subject26 = createMetadatumDTO("dc", "subject", null, "Social Sciences");
         MetadatumDTO subject27 = createMetadatumDTO("dc", "subject", null, "Science & Technology");
         MetadatumDTO subject28 = createMetadatumDTO("dc", "subject", null, "Life Sciences & Biomedicine");
+        MetadatumDTO publisher2 = createMetadatumDTO("dc", "publisher", null, "NATURE PORTFOLIO");
         MetadatumDTO other2 = createMetadatumDTO("dc", "identifier", "other", "WOS:000805100600001");
         MetadatumDTO rid = createMetadatumDTO("person", "identifier", "rid", "C-6334-2011");
         MetadatumDTO rid2 = createMetadatumDTO("person", "identifier", "rid", "B-1251-2008");
@@ -236,6 +239,7 @@ public class WOSImportMetadataSourceServiceIT extends AbstractLiveImportIntegrat
         metadatums2.add(subject26);
         metadatums2.add(subject27);
         metadatums2.add(subject28);
+        metadatums2.add(publisher2);
         metadatums2.add(other2);
         metadatums2.add(rid);
         metadatums2.add(rid2);

--- a/dspace/config/spring/api/wos-integration.xml
+++ b/dspace/config/spring/api/wos-integration.xml
@@ -35,6 +35,7 @@
         <entry key-ref="wos.fullName" value-ref="wosFullNameContrib"/>
         <entry key-ref="wos.subject" value-ref="wosSubjectContrib"/>
         <entry key-ref="wos.orcid" value-ref="wosOrcidContrib"/>
+        <entry key-ref="wos.publisher" value-ref="wosPublisherContrib"/>
         <entry key-ref="wos.contributorEditor" value-ref="wosContributorEditorContrib"/>
         <entry key-ref="wos.wosId" value-ref="wosIdContrib"/>
         <entry key-ref="wos.rid" value-ref="wosRidContrib"/>


### PR DESCRIPTION
Port of https://github.com/DSpace/DSpace/pull/9581, already approved and merged to main and 7.x but I missed the tag out for the autogenerated 8.x port