### PR TITLE
Remove context parameter from AuthorityValueService methods

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
@@ -1143,12 +1143,12 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
             }
 
             // look up the value and authority in solr
-            List<AuthorityValue> byValue = authorityValueService.findByValue(c, schema, element, qualifier, value);
+            List<AuthorityValue> byValue = authorityValueService.findByValue(schema, element, qualifier, value);
             AuthorityValue authorityValue = null;
             if (byValue.isEmpty()) {
                 String toGenerate = fromAuthority.generateString() + value;
                 String field = schema + "_" + element + (StringUtils.isNotBlank(qualifier) ? "_" + qualifier : "");
-                authorityValue = authorityValueService.generate(c, toGenerate, value, field);
+                authorityValue = authorityValueService.generate(toGenerate, value, field);
                 dcv.setAuthority(toGenerate);
             } else {
                 authorityValue = byValue.get(0);

--- a/dspace-api/src/main/java/org/dspace/authority/AuthorityValueServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authority/AuthorityValueServiceImpl.java
@@ -34,7 +34,7 @@ public class AuthorityValueServiceImpl implements AuthorityValueService {
 
     private final Logger log = org.apache.logging.log4j.LogManager.getLogger(AuthorityValueServiceImpl.class);
 
-    @Autowired()
+    @Autowired
     protected AuthorityTypes authorityTypes;
 
     protected AuthorityValueServiceImpl() {

--- a/dspace-api/src/main/java/org/dspace/authority/AuthorityValueServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authority/AuthorityValueServiceImpl.java
@@ -34,7 +34,7 @@ public class AuthorityValueServiceImpl implements AuthorityValueService {
 
     private final Logger log = org.apache.logging.log4j.LogManager.getLogger(AuthorityValueServiceImpl.class);
 
-    @Autowired(required = true)
+    @Autowired()
     protected AuthorityTypes authorityTypes;
 
     protected AuthorityValueServiceImpl() {

--- a/dspace-api/src/main/java/org/dspace/authority/AuthorityValueServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authority/AuthorityValueServiceImpl.java
@@ -20,8 +20,6 @@ import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrDocument;
 import org.dspace.authority.service.AuthorityValueService;
 import org.dspace.content.authority.SolrAuthority;
-import org.dspace.core.Context;
-import org.dspace.core.LogHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -44,7 +42,7 @@ public class AuthorityValueServiceImpl implements AuthorityValueService {
     }
 
     @Override
-    public AuthorityValue generate(Context context, String authorityKey, String content, String field) {
+    public AuthorityValue generate(String authorityKey, String content, String field) {
         AuthorityValue nextValue = null;
 
         nextValue = generateRaw(authorityKey, content, field);
@@ -55,7 +53,7 @@ public class AuthorityValueServiceImpl implements AuthorityValueService {
             if (StringUtils.isBlank(authorityKey)) {
                 // An existing metadata without authority is being indexed
                 // If there is an exact match in the index, reuse it before adding a new one.
-                List<AuthorityValue> byValue = findByExactValue(context, field, content);
+                List<AuthorityValue> byValue = findByExactValue(field, content);
                 if (byValue != null && !byValue.isEmpty()) {
                     authorityKey = byValue.get(0).getId();
                 } else {
@@ -118,71 +116,70 @@ public class AuthorityValueServiceImpl implements AuthorityValueService {
     /**
      * Item.ANY does not work here.
      *
-     * @param context     Context
      * @param authorityID authority id
      * @return AuthorityValue
      */
     @Override
-    public AuthorityValue findByUID(Context context, String authorityID) {
+    public AuthorityValue findByUID(String authorityID) {
         //Ensure that if we use the full identifier to match on
         String queryString = "id:\"" + authorityID + "\"";
-        List<AuthorityValue> findings = find(context, queryString);
+        List<AuthorityValue> findings = find(queryString);
         return findings.size() > 0 ? findings.get(0) : null;
     }
 
     @Override
-    public List<AuthorityValue> findByValue(Context context, String field, String value) {
+    public List<AuthorityValue> findByValue(String field, String value) {
         String queryString = "value:" + value + " AND field:" + field;
-        return find(context, queryString);
+        return find(queryString);
     }
 
     @Override
-    public AuthorityValue findByOrcidID(Context context, String orcid_id) {
+    public AuthorityValue findByOrcidID(String orcid_id) {
         String queryString = "orcid_id:" + orcid_id;
-        List<AuthorityValue> findings = find(context, queryString);
+        List<AuthorityValue> findings = find(queryString);
         return findings.size() > 0 ? findings.get(0) : null;
     }
 
     @Override
-    public List<AuthorityValue> findByExactValue(Context context, String field, String value) {
+    public List<AuthorityValue> findByExactValue(String field, String value) {
         String queryString = "value:\"" + value + "\" AND field:" + field;
-        return find(context, queryString);
+        return find(queryString);
     }
 
     @Override
-    public List<AuthorityValue> findByValue(Context context, String schema, String element, String qualifier,
+    public List<AuthorityValue> findByValue(String schema, String element, String qualifier,
                                             String value) {
         String field = fieldParameter(schema, element, qualifier);
-        return findByValue(context, field, value);
+        return findByValue(field, value);
     }
 
     @Override
-    public List<AuthorityValue> findByName(Context context, String schema, String element, String qualifier,
+    public List<AuthorityValue> findByName(String schema, String element, String qualifier,
                                            String name) {
         String field = fieldParameter(schema, element, qualifier);
         String queryString = "first_name:" + name + " OR last_name:" + name + " OR name_variant:" + name + " AND " +
             "field:" + field;
-        return find(context, queryString);
+        return find(queryString);
     }
 
     @Override
-    public List<AuthorityValue> findByAuthorityMetadata(Context context, String schema, String element,
+    public List<AuthorityValue> findByAuthorityMetadata(String schema, String element,
                                                         String qualifier, String value) {
         String field = fieldParameter(schema, element, qualifier);
         String queryString = "all_Labels:" + value + " AND field:" + field;
-        return find(context, queryString);
+        return find(queryString);
     }
 
     @Override
-    public List<AuthorityValue> findOrcidHolders(Context context) {
+    public List<AuthorityValue> findOrcidHolders() {
         String queryString = "orcid_id:*";
-        return find(context, queryString);
+        return find(queryString);
     }
 
     @Override
-    public List<AuthorityValue> findAll(Context context) {
+    public List<AuthorityValue> findAll() {
         String queryString = "*:*";
-        return find(context, queryString);
+        return find(queryString);
     }
 
     @Override
@@ -204,7 +201,7 @@ public class AuthorityValueServiceImpl implements AuthorityValueService {
         return fromAuthority;
     }
 
-    protected List<AuthorityValue> find(Context context, String queryString) {
+    protected List<AuthorityValue> find(String queryString) {
         List<AuthorityValue> findings = new ArrayList<AuthorityValue>();
         try {
             SolrQuery solrQuery = new SolrQuery();
@@ -220,8 +217,7 @@ public class AuthorityValueServiceImpl implements AuthorityValueService {
                 }
             }
         } catch (Exception e) {
-            log.error(LogHelper.getHeader(context, "Error while retrieving AuthorityValue from solr",
-                                           "query: " + queryString), e);
+            log.error("Error while retrieving AuthorityValue from solr. query: " + queryString, e);
         }
 
         return findings;

--- a/dspace-api/src/main/java/org/dspace/authority/UpdateAuthorities.java
+++ b/dspace-api/src/main/java/org/dspace/authority/UpdateAuthorities.java
@@ -133,11 +133,11 @@ public class UpdateAuthorities {
         if (selectedIDs != null && !selectedIDs.isEmpty()) {
             authorities = new ArrayList<>();
             for (String selectedID : selectedIDs) {
-                AuthorityValue byUID = authorityValueService.findByUID(context, selectedID);
+                AuthorityValue byUID = authorityValueService.findByUID(selectedID);
                 authorities.add(byUID);
             }
         } else {
-            authorities = authorityValueService.findAll(context);
+            authorities = authorityValueService.findAll();
         }
 
         if (authorities != null) {

--- a/dspace-api/src/main/java/org/dspace/authority/indexer/DSpaceAuthorityIndexer.java
+++ b/dspace-api/src/main/java/org/dspace/authority/indexer/DSpaceAuthorityIndexer.java
@@ -148,12 +148,12 @@ public class DSpaceAuthorityIndexer implements AuthorityIndexerInterface, Initia
                 !metadataAuthorityKey.startsWith(AuthorityValueService.GENERATE)) {
             // !uid.startsWith(AuthorityValueGenerator.GENERATE) is not strictly
             // necessary here but it prevents exceptions in solr
-            AuthorityValue value = authorityValueService.findByUID(context, metadataAuthorityKey);
+            AuthorityValue value = authorityValueService.findByUID(metadataAuthorityKey);
             if (value != null) {
                 return value;
             }
         }
-        return authorityValueService.generate(context, metadataAuthorityKey,
+        return authorityValueService.generate(metadataAuthorityKey,
                 metadataContent, metadataField.replaceAll("\\.", "_"));
     }
 

--- a/dspace-api/src/main/java/org/dspace/authority/service/AuthorityValueService.java
+++ b/dspace-api/src/main/java/org/dspace/authority/service/AuthorityValueService.java
@@ -24,32 +24,125 @@ public interface AuthorityValueService {
     public static final String SPLIT = "::";
     public static final String GENERATE = "will be generated" + SPLIT;
 
+    /**
+     * Generates an {@link AuthorityValue} based on the given parameters.
+     *
+     * @param authorityKey  the authority key to be assigned to the generated authority value
+     * @param content       the content of the generated authority value
+     * @param field         the field of the generated authority value
+     * @return the generated {@link AuthorityValue}
+     */
     public AuthorityValue generate(String authorityKey, String content, String field);
 
+    /**
+     * Updates an AuthorityValue.
+     *
+     * @param value the AuthorityValue to be updated
+     * @return the updated AuthorityValue
+     */
     public AuthorityValue update(AuthorityValue value);
 
+    /**
+     * Finds an AuthorityValue based on the provided authorityID.
+     *
+     * @param authorityID the authority ID used to search for the AuthorityValue
+     * @return the found AuthorityValue, or null if no match is found
+     */
     public AuthorityValue findByUID(String authorityID);
 
+    /**
+     * Finds AuthorityValues in the given context based on field and value.
+     *
+     * @param field the field to search for AuthorityValues
+     * @param value the value to search for AuthorityValues
+     * @return a list of found AuthorityValues matching the given field and value, or an empty list if no match is found
+     */
     public List<AuthorityValue> findByValue(String field, String value);
 
+    /**
+     * Finds an {@link AuthorityValue} based on the provided ORCID ID.
+     *
+     * @param orcid_id the ORCID ID used to search for the AuthorityValue
+     * @return the found AuthorityValue, or null if no match is found
+     */
     public AuthorityValue findByOrcidID(String orcid_id);
 
+    /**
+     * Finds {@link AuthorityValue}s based on the provided metadata schema, element, qualifier, and name.
+     *
+     * @param schema    the schema of the AuthorityValue
+     * @param element   the element of the AuthorityValue
+     * @param qualifier the qualifier of the AuthorityValue
+     * @param name      the name of the AuthorityValue
+     * @return a list of found AuthorityValues matching the given schema, element, qualifier, and name,
+     *         or an empty list if no match is found
+     */
     public List<AuthorityValue> findByName(String schema, String element, String qualifier,
                                            String name);
 
+    /**
+     * Finds {@link AuthorityValue}s based on the provided metadata schema, element, qualifier, and value.
+     *
+     * @param schema    the schema of the AuthorityValue
+     * @param element   the element of the AuthorityValue
+     * @param qualifier the qualifier of the AuthorityValue
+     * @param value     the value of the AuthorityValue
+     * @return a list of found AuthorityValues matching the given schema, element, qualifier, and value,
+     *         or an empty list if no match is found
+     */
     public List<AuthorityValue> findByAuthorityMetadata(String schema, String element,
                                                         String qualifier, String value);
 
+    /**
+     * Finds {@link AuthorityValue}s in the given context based on the exact field and value.
+     *
+     * @param field the field to search for AuthorityValues
+     * @param value the value to search for AuthorityValues
+     * @return a list of found AuthorityValues matching the given field and value,
+     *         or an empty list if no match is found
+     */
     public List<AuthorityValue> findByExactValue(String field, String value);
 
+    /**
+     * Finds {@link AuthorityValue}s based on the provided metadata schema, element, qualifier, and value.
+     *
+     * @param schema    the schema of the AuthorityValue
+     * @param element   the element of the AuthorityValue
+     * @param qualifier the qualifier of the AuthorityValue
+     * @param value     the value of the AuthorityValue
+     * @return a list of found AuthorityValues matching the given schema, element, qualifier, and value,
+     *         or an empty list if no match is found
+     */
     public List<AuthorityValue> findByValue(String schema, String element, String qualifier,
                                             String value);
 
+    /**
+     * Finds AuthorityValues that are ORCID person authority values.
+     *
+     * @return a list of AuthorityValues or an empty list if no matching values are found
+     */
     public List<AuthorityValue> findOrcidHolders();
 
+    /**
+     * Retrieves all AuthorityValues from Solr.
+     *
+     * @return A list of all AuthorityValues.
+     */
     public List<AuthorityValue> findAll();
 
+    /**
+     * Converts a SolrDocument into an AuthorityValue object.
+     *
+     * @param solrDocument the SolrDocument to convert
+     * @return the converted AuthorityValue object
+     */
     public AuthorityValue fromSolr(SolrDocument solrDocument);
 
+    /**
+     * Retrieves the type of authority value based on the provided metadata string.
+     *
+     * @param metadataString the metadata string used to determine the authority value type
+     * @return the {@link AuthorityValue} representing the type of authority value, or null if no match is found
+     */
     public AuthorityValue getAuthorityValueType(String metadataString);
 }

--- a/dspace-api/src/main/java/org/dspace/authority/service/AuthorityValueService.java
+++ b/dspace-api/src/main/java/org/dspace/authority/service/AuthorityValueService.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 import org.apache.solr.common.SolrDocument;
 import org.dspace.authority.AuthorityValue;
-import org.dspace.core.Context;
 
 /**
  * This service contains all methods for using authority values
@@ -25,30 +24,30 @@ public interface AuthorityValueService {
     public static final String SPLIT = "::";
     public static final String GENERATE = "will be generated" + SPLIT;
 
-    public AuthorityValue generate(Context context, String authorityKey, String content, String field);
+    public AuthorityValue generate(String authorityKey, String content, String field);
 
     public AuthorityValue update(AuthorityValue value);
 
-    public AuthorityValue findByUID(Context context, String authorityID);
+    public AuthorityValue findByUID(String authorityID);
 
-    public List<AuthorityValue> findByValue(Context context, String field, String value);
+    public List<AuthorityValue> findByValue(String field, String value);
 
-    public AuthorityValue findByOrcidID(Context context, String orcid_id);
+    public AuthorityValue findByOrcidID(String orcid_id);
 
-    public List<AuthorityValue> findByName(Context context, String schema, String element, String qualifier,
+    public List<AuthorityValue> findByName(String schema, String element, String qualifier,
                                            String name);
 
-    public List<AuthorityValue> findByAuthorityMetadata(Context context, String schema, String element,
+    public List<AuthorityValue> findByAuthorityMetadata(String schema, String element,
                                                         String qualifier, String value);
 
-    public List<AuthorityValue> findByExactValue(Context context, String field, String value);
+    public List<AuthorityValue> findByExactValue(String field, String value);
 
-    public List<AuthorityValue> findByValue(Context context, String schema, String element, String qualifier,
+    public List<AuthorityValue> findByValue(String schema, String element, String qualifier,
                                             String value);
 
-    public List<AuthorityValue> findOrcidHolders(Context context);
+    public List<AuthorityValue> findOrcidHolders();
 
-    public List<AuthorityValue> findAll(Context context);
+    public List<AuthorityValue> findAll();
 
     public AuthorityValue fromSolr(SolrDocument solrDocument);
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SearchFilterToAppliedFilterConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SearchFilterToAppliedFilterConverter.java
@@ -35,7 +35,7 @@ public class SearchFilterToAppliedFilterConverter {
             // facet as the authority is bind at the metadata level and so a facet could contains values from multiple
             // authorities
             // https://jira.duraspace.org/browse/DS-4209
-            authorityValue = authorityValueService.findByUID(context, searchFilter.getValue());
+            authorityValue = authorityValueService.findByUID(searchFilter.getValue());
         }
 
         SearchResultsRest.AppliedFilter appliedFilter;


### PR DESCRIPTION
## Description
Context is not used in any AuthorityValueService methods - it was only needed in `find()` for a log error message formatted with LogHeader.

This PR attempts to simplify the service and make it easier to use with tools that can't easily obtain an existing Context and would rather not create a new one (e.g. command line tools).

## Instructions for Reviewers
Please review code changes and give authority control some basic practical testing (e.g. ORCID sandbox author, or controlled vocabulary subject authority)

List of changes in this PR:
* Removed context from method signatures in `AuthorityValueService` and `AuthorityValueServiceImpl`
* Removed context parameter from calling code

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).