### PR TITLE
Improve and enhance AuthorityValue

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authority/UpdateAuthorities.java
+++ b/dspace-api/src/main/java/org/dspace/authority/UpdateAuthorities.java
@@ -168,7 +168,7 @@ public class UpdateAuthorities {
             while (itemIterator.hasNext()) {
                 Item next = itemIterator.next();
                 List<MetadataValue> metadata = itemService.getMetadata(next, authority.getField(), authority.getId());
-                authority.updateItem(context, next, metadata.get(0)); //should be only one
+                authority.updateItem(context, metadata.get(0)); //should be only one
                 List<MetadataValue> metadataAfter = itemService
                     .getMetadata(next, authority.getField(), authority.getId());
                 if (!metadata.get(0).getValue().equals(metadataAfter.get(0).getValue())) {

--- a/dspace-api/src/main/java/org/dspace/authority/indexer/DSpaceAuthorityIndexer.java
+++ b/dspace-api/src/main/java/org/dspace/authority/indexer/DSpaceAuthorityIndexer.java
@@ -107,7 +107,7 @@ public class DSpaceAuthorityIndexer implements AuthorityIndexerInterface, Initia
                 }
                 if (value != null) {
                     if (requiresItemUpdate) {
-                        value.updateItem(context, item, metadataValue);
+                        value.updateItem(context, metadataValue);
                         try {
                             itemService.update(context, item);
                         } catch (Exception e) {


### PR DESCRIPTION
## References
* Related to (but does not require or block) https://github.com/DSpace/DSpace/pull/9842

## Description
Some small but meaningful updates to the `AuthorityValue` class so that it can do some basic things to work with ChoiceAuthority and other authority functionality without requiring an extended class like PersonAuthority.
This reduces complexity and development when implementing new authority schemes in DSpace.

One change that may need discussion is removing "field" from the list of things to compare in `hasSameInformationAs` - I do not think it is helpful to make "field" unique across authority records - a Person authority record should not be duplicated for the same VIAF / Sherpa / Scopus / GND / ORCID / etc for each field or context used in DSpace (dc.contributor.author, dc.contributor.editor) but rather should be unique to the identifier itself.

Also happy to review or change the `label_` prefix if there is a better option - it is really handle for storing metadata from external data objects which can then be re-used elsewhere (I have some future PRs which make use of this pattern)

## Instructions for Reviewers
Other than integration tests and code reviews, I recommend setting up some basic authority for e.g. dc.subject with a controlled vocabulary, or try an import from metadata.

List of changes in this PR:
- Sets labels and otherMetadataMap (using a `label_` prefix in the Solr document as per ORCID authority precedent)
- Doesn't require field to be equal when comparing 'hasSameInformationAs'
- Reordered some methods to align better with other AuthorityValue classes and added javadoc
- Took out 'item' param from `updateItem` and calling classes (not used or necessary)

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
