### PR TITLE
Support virtual metadata for authority-controlled values

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
@@ -1145,12 +1145,12 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
             }
 
             // look up the value and authority in solr
-            List<AuthorityValue> byValue = authorityValueService.findByValue(c, schema, element, qualifier, value);
+            List<AuthorityValue> byValue = authorityValueService.findByValue(schema, element, qualifier, value);
             AuthorityValue authorityValue = null;
             if (byValue.isEmpty()) {
                 String toGenerate = fromAuthority.generateString() + value;
                 String field = schema + "_" + element + (StringUtils.isNotBlank(qualifier) ? "_" + qualifier : "");
-                authorityValue = authorityValueService.generate(c, toGenerate, value, field);
+                authorityValue = authorityValueService.generate(toGenerate, value, field);
                 dcv.setAuthority(toGenerate);
             } else {
                 authorityValue = byValue.get(0);

--- a/dspace-api/src/main/java/org/dspace/authority/AuthorityValueServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authority/AuthorityValueServiceImpl.java
@@ -34,7 +34,7 @@ public class AuthorityValueServiceImpl implements AuthorityValueService {
 
     private final Logger log = org.apache.logging.log4j.LogManager.getLogger(AuthorityValueServiceImpl.class);
 
-    @Autowired(required = true)
+    @Autowired()
     protected AuthorityTypes authorityTypes;
 
     protected AuthorityValueServiceImpl() {

--- a/dspace-api/src/main/java/org/dspace/authority/AuthorityValueServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authority/AuthorityValueServiceImpl.java
@@ -20,8 +20,6 @@ import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrDocument;
 import org.dspace.authority.service.AuthorityValueService;
 import org.dspace.content.authority.SolrAuthority;
-import org.dspace.core.Context;
-import org.dspace.core.LogHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -44,7 +42,7 @@ public class AuthorityValueServiceImpl implements AuthorityValueService {
     }
 
     @Override
-    public AuthorityValue generate(Context context, String authorityKey, String content, String field) {
+    public AuthorityValue generate(String authorityKey, String content, String field) {
         AuthorityValue nextValue = null;
 
         nextValue = generateRaw(authorityKey, content, field);
@@ -55,7 +53,7 @@ public class AuthorityValueServiceImpl implements AuthorityValueService {
             if (StringUtils.isBlank(authorityKey)) {
                 // An existing metadata without authority is being indexed
                 // If there is an exact match in the index, reuse it before adding a new one.
-                List<AuthorityValue> byValue = findByExactValue(context, field, content);
+                List<AuthorityValue> byValue = findByExactValue(field, content);
                 if (byValue != null && !byValue.isEmpty()) {
                     authorityKey = byValue.get(0).getId();
                 } else {
@@ -118,71 +116,70 @@ public class AuthorityValueServiceImpl implements AuthorityValueService {
     /**
      * Item.ANY does not work here.
      *
-     * @param context     Context
      * @param authorityID authority id
      * @return AuthorityValue
      */
     @Override
-    public AuthorityValue findByUID(Context context, String authorityID) {
+    public AuthorityValue findByUID(String authorityID) {
         //Ensure that if we use the full identifier to match on
         String queryString = "id:\"" + authorityID + "\"";
-        List<AuthorityValue> findings = find(context, queryString);
+        List<AuthorityValue> findings = find(queryString);
         return findings.size() > 0 ? findings.get(0) : null;
     }
 
     @Override
-    public List<AuthorityValue> findByValue(Context context, String field, String value) {
+    public List<AuthorityValue> findByValue(String field, String value) {
         String queryString = "value:" + value + " AND field:" + field;
-        return find(context, queryString);
+        return find(queryString);
     }
 
     @Override
-    public AuthorityValue findByOrcidID(Context context, String orcid_id) {
+    public AuthorityValue findByOrcidID(String orcid_id) {
         String queryString = "orcid_id:" + orcid_id;
-        List<AuthorityValue> findings = find(context, queryString);
+        List<AuthorityValue> findings = find(queryString);
         return findings.size() > 0 ? findings.get(0) : null;
     }
 
     @Override
-    public List<AuthorityValue> findByExactValue(Context context, String field, String value) {
+    public List<AuthorityValue> findByExactValue(String field, String value) {
         String queryString = "value:\"" + value + "\" AND field:" + field;
-        return find(context, queryString);
+        return find(queryString);
     }
 
     @Override
-    public List<AuthorityValue> findByValue(Context context, String schema, String element, String qualifier,
+    public List<AuthorityValue> findByValue(String schema, String element, String qualifier,
                                             String value) {
         String field = fieldParameter(schema, element, qualifier);
-        return findByValue(context, field, value);
+        return findByValue(field, value);
     }
 
     @Override
-    public List<AuthorityValue> findByName(Context context, String schema, String element, String qualifier,
+    public List<AuthorityValue> findByName(String schema, String element, String qualifier,
                                            String name) {
         String field = fieldParameter(schema, element, qualifier);
         String queryString = "first_name:" + name + " OR last_name:" + name + " OR name_variant:" + name + " AND " +
             "field:" + field;
-        return find(context, queryString);
+        return find(queryString);
     }
 
     @Override
-    public List<AuthorityValue> findByAuthorityMetadata(Context context, String schema, String element,
+    public List<AuthorityValue> findByAuthorityMetadata(String schema, String element,
                                                         String qualifier, String value) {
         String field = fieldParameter(schema, element, qualifier);
         String queryString = "all_Labels:" + value + " AND field:" + field;
-        return find(context, queryString);
+        return find(queryString);
     }
 
     @Override
-    public List<AuthorityValue> findOrcidHolders(Context context) {
+    public List<AuthorityValue> findOrcidHolders() {
         String queryString = "orcid_id:*";
-        return find(context, queryString);
+        return find(queryString);
     }
 
     @Override
-    public List<AuthorityValue> findAll(Context context) {
+    public List<AuthorityValue> findAll() {
         String queryString = "*:*";
-        return find(context, queryString);
+        return find(queryString);
     }
 
     @Override
@@ -204,7 +201,7 @@ public class AuthorityValueServiceImpl implements AuthorityValueService {
         return fromAuthority;
     }
 
-    protected List<AuthorityValue> find(Context context, String queryString) {
+    protected List<AuthorityValue> find(String queryString) {
         List<AuthorityValue> findings = new ArrayList<AuthorityValue>();
         try {
             SolrQuery solrQuery = new SolrQuery();
@@ -220,8 +217,7 @@ public class AuthorityValueServiceImpl implements AuthorityValueService {
                 }
             }
         } catch (Exception e) {
-            log.error(LogHelper.getHeader(context, "Error while retrieving AuthorityValue from solr",
-                                           "query: " + queryString), e);
+            log.error("Error while retrieving AuthorityValue from solr. query: " + queryString, e);
         }
 
         return findings;

--- a/dspace-api/src/main/java/org/dspace/authority/UpdateAuthorities.java
+++ b/dspace-api/src/main/java/org/dspace/authority/UpdateAuthorities.java
@@ -133,11 +133,11 @@ public class UpdateAuthorities {
         if (selectedIDs != null && !selectedIDs.isEmpty()) {
             authorities = new ArrayList<>();
             for (String selectedID : selectedIDs) {
-                AuthorityValue byUID = authorityValueService.findByUID(context, selectedID);
+                AuthorityValue byUID = authorityValueService.findByUID(selectedID);
                 authorities.add(byUID);
             }
         } else {
-            authorities = authorityValueService.findAll(context);
+            authorities = authorityValueService.findAll();
         }
 
         if (authorities != null) {

--- a/dspace-api/src/main/java/org/dspace/authority/UpdateAuthorities.java
+++ b/dspace-api/src/main/java/org/dspace/authority/UpdateAuthorities.java
@@ -168,7 +168,7 @@ public class UpdateAuthorities {
             while (itemIterator.hasNext()) {
                 Item next = itemIterator.next();
                 List<MetadataValue> metadata = itemService.getMetadata(next, authority.getField(), authority.getId());
-                authority.updateItem(context, next, metadata.get(0)); //should be only one
+                authority.updateItem(context, metadata.get(0)); //should be only one
                 List<MetadataValue> metadataAfter = itemService
                     .getMetadata(next, authority.getField(), authority.getId());
                 if (!metadata.get(0).getValue().equals(metadataAfter.get(0).getValue())) {

--- a/dspace-api/src/main/java/org/dspace/authority/indexer/DSpaceAuthorityIndexer.java
+++ b/dspace-api/src/main/java/org/dspace/authority/indexer/DSpaceAuthorityIndexer.java
@@ -148,12 +148,12 @@ public class DSpaceAuthorityIndexer implements AuthorityIndexerInterface, Initia
                 !metadataAuthorityKey.startsWith(AuthorityValueService.GENERATE)) {
             // !uid.startsWith(AuthorityValueGenerator.GENERATE) is not strictly
             // necessary here but it prevents exceptions in solr
-            AuthorityValue value = authorityValueService.findByUID(context, metadataAuthorityKey);
+            AuthorityValue value = authorityValueService.findByUID(metadataAuthorityKey);
             if (value != null) {
                 return value;
             }
         }
-        return authorityValueService.generate(context, metadataAuthorityKey,
+        return authorityValueService.generate(metadataAuthorityKey,
                 metadataContent, metadataField.replaceAll("\\.", "_"));
     }
 

--- a/dspace-api/src/main/java/org/dspace/authority/indexer/DSpaceAuthorityIndexer.java
+++ b/dspace-api/src/main/java/org/dspace/authority/indexer/DSpaceAuthorityIndexer.java
@@ -107,7 +107,7 @@ public class DSpaceAuthorityIndexer implements AuthorityIndexerInterface, Initia
                 }
                 if (value != null) {
                     if (requiresItemUpdate) {
-                        value.updateItem(context, item, metadataValue);
+                        value.updateItem(context, metadataValue);
                         try {
                             itemService.update(context, item);
                         } catch (Exception e) {

--- a/dspace-api/src/main/java/org/dspace/authority/service/AuthorityValueService.java
+++ b/dspace-api/src/main/java/org/dspace/authority/service/AuthorityValueService.java
@@ -24,32 +24,125 @@ public interface AuthorityValueService {
     public static final String SPLIT = "::";
     public static final String GENERATE = "will be generated" + SPLIT;
 
+    /**
+     * Generates an {@link AuthorityValue} based on the given parameters.
+     *
+     * @param authorityKey  the authority key to be assigned to the generated authority value
+     * @param content       the content of the generated authority value
+     * @param field         the field of the generated authority value
+     * @return the generated {@link AuthorityValue}
+     */
     public AuthorityValue generate(String authorityKey, String content, String field);
 
+    /**
+     * Updates an AuthorityValue.
+     *
+     * @param value the AuthorityValue to be updated
+     * @return the updated AuthorityValue
+     */
     public AuthorityValue update(AuthorityValue value);
 
+    /**
+     * Finds an AuthorityValue based on the provided authorityID.
+     *
+     * @param authorityID the authority ID used to search for the AuthorityValue
+     * @return the found AuthorityValue, or null if no match is found
+     */
     public AuthorityValue findByUID(String authorityID);
 
+    /**
+     * Finds AuthorityValues in the given context based on field and value.
+     *
+     * @param field the field to search for AuthorityValues
+     * @param value the value to search for AuthorityValues
+     * @return a list of found AuthorityValues matching the given field and value, or an empty list if no match is found
+     */
     public List<AuthorityValue> findByValue(String field, String value);
 
+    /**
+     * Finds an {@link AuthorityValue} based on the provided ORCID ID.
+     *
+     * @param orcid_id the ORCID ID used to search for the AuthorityValue
+     * @return the found AuthorityValue, or null if no match is found
+     */
     public AuthorityValue findByOrcidID(String orcid_id);
 
+    /**
+     * Finds {@link AuthorityValue}s based on the provided metadata schema, element, qualifier, and name.
+     *
+     * @param schema    the schema of the AuthorityValue
+     * @param element   the element of the AuthorityValue
+     * @param qualifier the qualifier of the AuthorityValue
+     * @param name      the name of the AuthorityValue
+     * @return a list of found AuthorityValues matching the given schema, element, qualifier, and name,
+     *         or an empty list if no match is found
+     */
     public List<AuthorityValue> findByName(String schema, String element, String qualifier,
                                            String name);
 
+    /**
+     * Finds {@link AuthorityValue}s based on the provided metadata schema, element, qualifier, and value.
+     *
+     * @param schema    the schema of the AuthorityValue
+     * @param element   the element of the AuthorityValue
+     * @param qualifier the qualifier of the AuthorityValue
+     * @param value     the value of the AuthorityValue
+     * @return a list of found AuthorityValues matching the given schema, element, qualifier, and value,
+     *         or an empty list if no match is found
+     */
     public List<AuthorityValue> findByAuthorityMetadata(String schema, String element,
                                                         String qualifier, String value);
 
+    /**
+     * Finds {@link AuthorityValue}s in the given context based on the exact field and value.
+     *
+     * @param field the field to search for AuthorityValues
+     * @param value the value to search for AuthorityValues
+     * @return a list of found AuthorityValues matching the given field and value,
+     *         or an empty list if no match is found
+     */
     public List<AuthorityValue> findByExactValue(String field, String value);
 
+    /**
+     * Finds {@link AuthorityValue}s based on the provided metadata schema, element, qualifier, and value.
+     *
+     * @param schema    the schema of the AuthorityValue
+     * @param element   the element of the AuthorityValue
+     * @param qualifier the qualifier of the AuthorityValue
+     * @param value     the value of the AuthorityValue
+     * @return a list of found AuthorityValues matching the given schema, element, qualifier, and value,
+     *         or an empty list if no match is found
+     */
     public List<AuthorityValue> findByValue(String schema, String element, String qualifier,
                                             String value);
 
+    /**
+     * Finds AuthorityValues that are ORCID person authority values.
+     *
+     * @return a list of AuthorityValues or an empty list if no matching values are found
+     */
     public List<AuthorityValue> findOrcidHolders();
 
+    /**
+     * Retrieves all AuthorityValues from Solr.
+     *
+     * @return A list of all AuthorityValues.
+     */
     public List<AuthorityValue> findAll();
 
+    /**
+     * Converts a SolrDocument into an AuthorityValue object.
+     *
+     * @param solrDocument the SolrDocument to convert
+     * @return the converted AuthorityValue object
+     */
     public AuthorityValue fromSolr(SolrDocument solrDocument);
 
+    /**
+     * Retrieves the type of authority value based on the provided metadata string.
+     *
+     * @param metadataString the metadata string used to determine the authority value type
+     * @return the {@link AuthorityValue} representing the type of authority value, or null if no match is found
+     */
     public AuthorityValue getAuthorityValueType(String metadataString);
 }

--- a/dspace-api/src/main/java/org/dspace/authority/service/AuthorityValueService.java
+++ b/dspace-api/src/main/java/org/dspace/authority/service/AuthorityValueService.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 import org.apache.solr.common.SolrDocument;
 import org.dspace.authority.AuthorityValue;
-import org.dspace.core.Context;
 
 /**
  * This service contains all methods for using authority values
@@ -25,30 +24,30 @@ public interface AuthorityValueService {
     public static final String SPLIT = "::";
     public static final String GENERATE = "will be generated" + SPLIT;
 
-    public AuthorityValue generate(Context context, String authorityKey, String content, String field);
+    public AuthorityValue generate(String authorityKey, String content, String field);
 
     public AuthorityValue update(AuthorityValue value);
 
-    public AuthorityValue findByUID(Context context, String authorityID);
+    public AuthorityValue findByUID(String authorityID);
 
-    public List<AuthorityValue> findByValue(Context context, String field, String value);
+    public List<AuthorityValue> findByValue(String field, String value);
 
-    public AuthorityValue findByOrcidID(Context context, String orcid_id);
+    public AuthorityValue findByOrcidID(String orcid_id);
 
-    public List<AuthorityValue> findByName(Context context, String schema, String element, String qualifier,
+    public List<AuthorityValue> findByName(String schema, String element, String qualifier,
                                            String name);
 
-    public List<AuthorityValue> findByAuthorityMetadata(Context context, String schema, String element,
+    public List<AuthorityValue> findByAuthorityMetadata(String schema, String element,
                                                         String qualifier, String value);
 
-    public List<AuthorityValue> findByExactValue(Context context, String field, String value);
+    public List<AuthorityValue> findByExactValue(String field, String value);
 
-    public List<AuthorityValue> findByValue(Context context, String schema, String element, String qualifier,
+    public List<AuthorityValue> findByValue(String schema, String element, String qualifier,
                                             String value);
 
-    public List<AuthorityValue> findOrcidHolders(Context context);
+    public List<AuthorityValue> findOrcidHolders();
 
-    public List<AuthorityValue> findAll(Context context);
+    public List<AuthorityValue> findAll();
 
     public AuthorityValue fromSolr(SolrDocument solrDocument);
 

--- a/dspace-api/src/main/java/org/dspace/content/AuthorityVirtualMetadataService.java
+++ b/dspace-api/src/main/java/org/dspace/content/AuthorityVirtualMetadataService.java
@@ -1,0 +1,31 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content;
+
+import java.util.List;
+
+/**
+ * Simple service to handle authority virtual metadata operations.
+ * Separated from item service for better separation of concerns and because the field lookups
+ * required by this service require a context which is not provided in
+ * {@link org.dspace.content.service.ItemService#getMetadata}
+ *
+ * @author Kim Shepherd
+ */
+public interface AuthorityVirtualMetadataService {
+
+    /**
+     * This method retrieves a list of authority virtual metadata values for a given item.
+     *
+     * @param item The item for which to retrieve the authority virtual metadata values.
+     * @param dbMetadataValues The list of regular metadata values associated with the item.
+     * @return The list of authority virtual metadata values for the item.
+     */
+    List<MetadataValue> getAuthorityVirtualMetadata(Item item, List<MetadataValue> dbMetadataValues);
+
+}

--- a/dspace-api/src/main/java/org/dspace/content/AuthorityVirtualMetadataServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/AuthorityVirtualMetadataServiceImpl.java
@@ -55,8 +55,10 @@ public class AuthorityVirtualMetadataServiceImpl implements AuthorityVirtualMeta
     public void init() {
         validVirtualFieldNames = new HashMap<>();
         authorityVirtualMaps = new HashMap<>();
+        Context context = null;
         // Obtain new context and initialise lists and maps
-        try (Context context = new Context(Context.Mode.READ_ONLY)) {
+        try {
+            context = new Context(Context.Mode.READ_ONLY);
             // Get field maps configured in virtual metadata spring configuration
              authorityVirtualMaps = authorityVirtualMetadataPopulator.getMap();
             // Iterate map of maps, just to check each virtual field name (key of 2nd-level map) exists
@@ -72,6 +74,10 @@ public class AuthorityVirtualMetadataServiceImpl implements AuthorityVirtualMeta
         } catch (SQLException e) {
             log.error("Could not obtain context" + e.getMessage(), e);
             throw new RuntimeException(e);
+        } finally {
+            if (context != null) {
+                context.close();
+            }
         }
     }
 

--- a/dspace-api/src/main/java/org/dspace/content/AuthorityVirtualMetadataServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/AuthorityVirtualMetadataServiceImpl.java
@@ -1,0 +1,161 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content;
+
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.dspace.authority.AuthorityValue;
+import org.dspace.authority.service.AuthorityValueService;
+import org.dspace.content.authority.service.MetadataAuthorityService;
+import org.dspace.content.service.MetadataFieldService;
+import org.dspace.content.virtual.AuthorityVirtualMetadataConfiguration;
+import org.dspace.content.virtual.AuthorityVirtualMetadataPopulator;
+import org.dspace.content.virtual.VirtualMetadataPopulator;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Simple service to handle authority virtual metadata operations.
+ * Separated from item service for better separation of concerns and because the field lookups
+ * required by this service require a context which is not provided in
+ * {@link org.dspace.content.service.ItemService#getMetadata}
+ *
+ * @author Kim Shepherd
+ */
+public class AuthorityVirtualMetadataServiceImpl implements AuthorityVirtualMetadataService {
+
+    @Autowired
+    protected VirtualMetadataPopulator virtualMetadataPopulator;
+    @Autowired
+    protected AuthorityVirtualMetadataPopulator authorityVirtualMetadataPopulator;
+    @Autowired
+    protected AuthorityValueService authorityValueService;
+    @Autowired
+    protected MetadataFieldService metadataFieldService;
+    @Autowired
+    protected MetadataAuthorityService metadataAuthorityService;
+
+    private HashMap<String, MetadataField> validVirtualFieldNames;
+    private Map<String, HashMap<String, AuthorityVirtualMetadataConfiguration>> authorityVirtualMaps;
+
+    private static final Logger log = LogManager.getLogger();
+
+    public void init() {
+        validVirtualFieldNames = new HashMap<>();
+        authorityVirtualMaps = new HashMap<>();
+        // Obtain new context and initialise lists and maps
+        try (Context context = new Context(Context.Mode.READ_ONLY)) {
+            // Get field maps configured in virtual metadata spring configuration
+             authorityVirtualMaps = authorityVirtualMetadataPopulator.getMap();
+            // Iterate map of maps, just to check each virtual field name (key of 2nd-level map) exists
+            // and populate the virtual field names list so we can look it up later without further database calls
+            for (String configuredAuthorityField : authorityVirtualMaps.keySet()) {
+                for (String virtualFieldName : authorityVirtualMaps.get(configuredAuthorityField).keySet()) {
+                    MetadataField virtualField = metadataFieldService.findByString(context, virtualFieldName, '.');
+                    if (virtualField != null) {
+                        validVirtualFieldNames.put(virtualFieldName, virtualField);
+                    }
+                }
+            }
+        } catch (SQLException e) {
+            log.error("Could not obtain context" + e.getMessage(), e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * This method retrieves a list of authority virtual metadata values for a given item.
+     * For each metadata value that is authority controlled and configured in the spring virtual metadata config,
+     * the authority document values will be populated (via collection, concatenation, etc) and returned to
+     * add to an existing metadata list for the item.
+     *
+     * @param item The item for which to retrieve the authority virtual metadata values.
+     * @param dbMetadataValues The list of regular metadata values associated with the item.
+     * @return The list of authority virtual metadata values for the item.
+     */
+    public List<MetadataValue> getAuthorityVirtualMetadata(Item item, List<MetadataValue> dbMetadataValues) {
+        List<MetadataValue> authorityMetadataValues = new LinkedList<>();
+        // Make a map of counts - we want to calc a real 'place'
+        Map<String, Integer> fieldCounts = new HashMap<>();
+        for (MetadataValue mv : dbMetadataValues) {
+            String mvfn = mv.getMetadataField().toString('.');
+            if (!fieldCounts.containsKey(mvfn)) {
+                fieldCounts.put(mvfn, 1);
+            } else {
+                fieldCounts.put(mvfn, fieldCounts.get(mvfn) + 1);
+            }
+        }
+        for (MetadataValue dbValue : dbMetadataValues) {
+            if (null != dbValue.getAuthority()) {
+                // Get field
+                MetadataField dbField = dbValue.getMetadataField();
+                // In the virtual authority metadata spring XML, the map keys are field names of
+                // authority-controlled fields
+                String dbFieldName = dbField.toString('.');
+                // Check if this field is mapped *and* is configured for authority control
+                if (authorityVirtualMaps.containsKey(dbFieldName)
+                        && metadataAuthorityService.isAuthorityControlled(
+                        dbFieldName.replace('.', '_')) ) {
+                    AuthorityValue authorityValue = authorityValueService.findByUID(dbValue.getAuthority());
+                    if (authorityValue == null) {
+                        continue;
+                    }
+                    // Get map from config
+                    HashMap<String, AuthorityVirtualMetadataConfiguration> authorityVirtualFieldMap =
+                            authorityVirtualMaps.get(dbField.toString('.'));
+                    // Iterate mapped fields
+                    for (String virtualFieldName : authorityVirtualFieldMap.keySet()) {
+                        // The field must exist
+                        if (!validVirtualFieldNames.containsKey(virtualFieldName)) {
+                            log.error("Could not find configured virtual metadata field: " + virtualFieldName);
+                            continue;
+                        }
+                        // Don't process fields which match the db field
+                        if (virtualFieldName.equals(dbFieldName)) {
+                            log.debug("Skipping virtual metadata field which matches current db field: "
+                                    + virtualFieldName);
+                            continue;
+                        }
+                        MetadataField virtualField = validVirtualFieldNames.get(virtualFieldName);
+                        AuthorityVirtualMetadataConfiguration authorityVirtualMetadataConfiguration =
+                                authorityVirtualFieldMap.get(virtualFieldName);
+                        List<String> virtualAuthorityValues =
+                                authorityVirtualMetadataConfiguration.getValues(authorityValue);
+                        // Iterate virtual authority values and insert them as authority virtual metadata
+                        for (String virtualAuthorityValue : virtualAuthorityValues) {
+                            AuthorityVirtualMetadataValue metadataValue = new AuthorityVirtualMetadataValue();
+                            metadataValue.setMetadataField(virtualField);
+                            // There is no information in the source authority object to help determine the
+                            // place so instead we use the running count to set an appropriate place at the
+                            // end of the existing metadata values for this field
+                            int place = (fieldCounts.getOrDefault(virtualFieldName, 0));
+                            metadataValue.setPlace(place);
+                            fieldCounts.put(virtualFieldName, ++place);
+                            // In RelationVirtualMetadata, the authority uses the prefix and the relationship
+                            // ID, but we will instead use the authority ID as the second component
+                            metadataValue.setAuthority(Constants.VIRTUAL_AUTHORITY_PREFIX
+                                    + authorityValue.getId());
+                            metadataValue.setValue(virtualAuthorityValue);
+                            metadataValue.setDSpaceObject(item);
+                            authorityMetadataValues.add(metadataValue);
+                        }
+                    }
+                }
+            }
+        }
+        return authorityMetadataValues;
+    }
+
+}

--- a/dspace-api/src/main/java/org/dspace/content/AuthorityVirtualMetadataValue.java
+++ b/dspace-api/src/main/java/org/dspace/content/AuthorityVirtualMetadataValue.java
@@ -1,0 +1,36 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content;
+
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.dspace.core.Constants;
+
+/**
+ * Implementation of {@link VirtualMetadataValue} specifically for authority-based virtual metadata.
+ * It is a more simple implementation than {@link RelationshipMetadataValue} as it doesn't have a way to calculate
+ * relative place (place is set during value creation based on number of other values in the field) and does not
+ * override {@link VirtualMetadataValue#getID()}
+ *
+ * @author Kim Shepherd
+ */
+public class AuthorityVirtualMetadataValue extends VirtualMetadataValue {
+
+    /**
+     * Use authority key (URI, UUID, etc), value, metadatafield ID, and place number to generate hash code
+     * @return unique hash code
+     */
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().append(getAuthority()
+                .substring(Constants.VIRTUAL_AUTHORITY_PREFIX.length()))
+                .append(getMetadataFieldId())
+                .append(getValue())
+                .append(getPlace()).hashCode();
+    }
+
+}

--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -1829,7 +1829,8 @@ prevent the generation of resource policy entry values with null dspace_object a
                     // Check if this field is mapped *and* is configured for authority control
                     if (authorityVirtualMaps.containsKey(dbFieldName)
                             && metadataAuthorityService.isAuthorityControlled(dbFieldName) ) {
-                        AuthorityValue authorityValue = authorityValueService.findByUID(dbValue.getAuthority());
+                        AuthorityValue authorityValue = authorityValueService.findByUID(context,
+                                dbValue.getAuthority());
                         if (authorityValue == null) {
                             continue;
                         }

--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -13,7 +13,6 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -31,7 +30,6 @@ import org.apache.logging.log4j.Logger;
 import org.dspace.app.requestitem.RequestItem;
 import org.dspace.app.requestitem.service.RequestItemService;
 import org.dspace.app.util.AuthorizeUtil;
-import org.dspace.authority.AuthorityValue;
 import org.dspace.authority.service.AuthorityValueService;
 import org.dspace.authorize.AuthorizeConfiguration;
 import org.dspace.authorize.AuthorizeException;
@@ -52,8 +50,6 @@ import org.dspace.content.service.ItemService;
 import org.dspace.content.service.MetadataSchemaService;
 import org.dspace.content.service.RelationshipService;
 import org.dspace.content.service.WorkspaceItemService;
-import org.dspace.content.virtual.AuthorityVirtualMetadataConfiguration;
-import org.dspace.content.virtual.AuthorityVirtualMetadataPopulator;
 import org.dspace.content.virtual.VirtualMetadataPopulator;
 import org.dspace.contentreport.QueryPredicate;
 import org.dspace.core.Constants;
@@ -149,16 +145,13 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
     @Autowired(required = true)
     protected RelationshipService relationshipService;
 
-    @Autowired(required = true)
-    protected VirtualMetadataPopulator virtualMetadataPopulator;
-
-    @Autowired
-    protected AuthorityVirtualMetadataPopulator authorityVirtualMetadataPopulator;
     @Autowired
     protected AuthorityValueService authorityValueService;
 
     @Autowired(required = true)
     private RelationshipMetadataService relationshipMetadataService;
+    @Autowired(required = true)
+    private AuthorityVirtualMetadataService authorityVirtualMetadataService;
 
     @Autowired(required = true)
     private EntityTypeService entityTypeService;
@@ -1784,7 +1777,8 @@ prevent the generation of resource policy entry values with null dspace_object a
             // Now get authority virtual metadata - note this requires the configuration property *and* the
             // enableVirtualMetadata parameter to be true
             if (configurationService.getBooleanProperty("authority.metadata.virtual", false)) {
-                fullMetadataValueList.addAll(getAuthorityVirtualMetadata(item, dbMetadataValues));
+                fullMetadataValueList.addAll(authorityVirtualMetadataService
+                        .getAuthorityVirtualMetadata(item, dbMetadataValues));
             }
 
             item.setCachedMetadata(MetadataValueComparators.sort(fullMetadataValueList));
@@ -1801,88 +1795,6 @@ prevent the generation of resource policy entry values with null dspace_object a
 
         // Create an array of matching values
         return values;
-    }
-
-    private List<MetadataValue> getAuthorityVirtualMetadata(Item item, List<MetadataValue> dbMetadataValues) {
-        Map<String, HashMap<String, AuthorityVirtualMetadataConfiguration>> authorityVirtualMaps
-                = authorityVirtualMetadataPopulator.getMap();
-        List<MetadataValue> authorityMetadataValues = new LinkedList<>();
-        // Make a map of counts - we want to calc a real 'place'
-        Map<String, Integer> fieldCounts = new HashMap<>();
-        for (MetadataValue mv : dbMetadataValues) {
-            String mvfn = mv.getMetadataField().toString('.');
-            if (!fieldCounts.containsKey(mvfn)) {
-                fieldCounts.put(mvfn, 1);
-            } else {
-                fieldCounts.put(mvfn, fieldCounts.get(mvfn) + 1);
-            }
-        }
-        Context context = new Context();
-        try {
-            for (MetadataValue dbValue : dbMetadataValues) {
-                if (null != dbValue.getAuthority()) {
-                    // Get field
-                    MetadataField dbField = dbValue.getMetadataField();
-                    // In the virtual authority metadata spring XML, the map keys are field names of
-                    // authority-controlled fields
-                    String dbFieldName = dbField.toString('.');
-                    // Check if this field is mapped *and* is configured for authority control
-                    if (authorityVirtualMaps.containsKey(dbFieldName)
-                            && metadataAuthorityService.isAuthorityControlled(dbFieldName) ) {
-                        AuthorityValue authorityValue = authorityValueService.findByUID(context,
-                                dbValue.getAuthority());
-                        if (authorityValue == null) {
-                            continue;
-                        }
-                        // Get map from config
-                        HashMap<String, AuthorityVirtualMetadataConfiguration> authorityVirtualFieldMap =
-                                authorityVirtualMaps.get(dbField.toString('.'));
-                        // Iterate mapped fields
-                        for (String virtualFieldName : authorityVirtualFieldMap.keySet()) {
-                            if (virtualFieldName.equals(dbFieldName)) {
-                                // Special case - we don't want to override / add to the actual field associated with
-                                // this authority
-                                // even if it is mapped, right?
-                                continue;
-                            }
-                            AuthorityVirtualMetadataConfiguration authorityVirtualMetadataConfiguration =
-                                    authorityVirtualFieldMap.get(virtualFieldName);
-                            MetadataField virtualField = metadataFieldService.findByString(context,
-                                    virtualFieldName, '.');
-                            if (virtualField != null) {
-                                List<String> virtualAuthorityValues =
-                                        authorityVirtualMetadataConfiguration.getValues(authorityValue);
-                                // Iterate virtual authority values and insert them as authority virtual metadata
-                                for (String virtualAuthorityValue : virtualAuthorityValues) {
-                                    AuthorityVirtualMetadataValue metadataValue = new AuthorityVirtualMetadataValue();
-                                    metadataValue.setMetadataField(virtualField);
-                                    // There is no information in the source authority object to help determine the
-                                    // place so instead we use the running count to set an appropriate place at the
-                                    // end of the existing metadata values for this field
-                                    int place = (fieldCounts.getOrDefault(virtualFieldName, 0));
-                                    metadataValue.setPlace(place);
-                                    fieldCounts.put(virtualFieldName, ++place);
-                                    // In RelationVirtualMetadata, the authority uses the prefix and the relationship
-                                    // ID, but we will instead use the authority ID as the second component
-                                    metadataValue.setAuthority(Constants.VIRTUAL_AUTHORITY_PREFIX
-                                            + authorityValue.getId());
-                                    metadataValue.setValue(virtualAuthorityValue);
-                                    metadataValue.setDSpaceObject(item);
-                                    authorityMetadataValues.add(metadataValue);
-                                }
-                            } else {
-                                log.error("Could not find virtual field specified in authority" +
-                                        "virtual metadata config: {}", virtualFieldName);
-                            }
-                        }
-                    }
-                }
-            }
-        } catch (SQLException e) {
-            log.error(e.getMessage());
-            throw new RuntimeException(e);
-        }
-        return authorityMetadataValues;
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/content/RelationshipMetadataValue.java
+++ b/dspace-api/src/main/java/org/dspace/content/RelationshipMetadataValue.java
@@ -16,7 +16,7 @@ import org.dspace.core.Constants;
  * whether these Values should be counted for place calculation on both the native MetadataValues and the
  * Relationship's place attributes.
  */
-public class RelationshipMetadataValue extends MetadataValue {
+public class RelationshipMetadataValue extends VirtualMetadataValue {
 
     /**
      * This property determines whether this RelationshipMetadataValue should be used in place calculation or not

--- a/dspace-api/src/main/java/org/dspace/content/VirtualMetadataValue.java
+++ b/dspace-api/src/main/java/org/dspace/content/VirtualMetadataValue.java
@@ -1,0 +1,32 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content;
+
+/**
+ * A simple abstraction to allow {@link RelationshipMetadataValue} and {@link AuthorityVirtualMetadataValue}
+ * extend it while allowing reflection or instance checking for MetadataValue and VirtualMetadataValue
+ *
+ * @author Kim Shepherd
+ */
+public class VirtualMetadataValue extends MetadataValue {
+
+    /**
+     * This is a bit of a hack, much like {@link RelationshipMetadataValue} - the ID is not something that corresponds
+     * to a real metadata value, but instead the source object. Unfortunately metadata value and relationships both
+     * use integers and not Strings like authority values.
+     * Returning -1 guarantees that any erroneous calls to an AuthorityVirtualMetadataValue object will not send
+     * the caller off to a real, unrelated MetadataValue, so this default behaviour is implemented
+     *
+     * @return integerised authority key
+     */
+    @Override
+    public Integer getID() {
+        return -1;
+    }
+
+}

--- a/dspace-api/src/main/java/org/dspace/content/factory/ContentServiceFactory.java
+++ b/dspace-api/src/main/java/org/dspace/content/factory/ContentServiceFactory.java
@@ -9,6 +9,7 @@ package org.dspace.content.factory;
 
 import java.util.List;
 
+import org.dspace.content.AuthorityVirtualMetadataService;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.InProgressSubmission;
 import org.dspace.content.RelationshipMetadataService;
@@ -83,6 +84,7 @@ public abstract class ContentServiceFactory {
      */
     public abstract RelationshipTypeService getRelationshipTypeService();
 
+    public abstract AuthorityVirtualMetadataService getAuthorityVirtualMetadataService();
     /**
      * Return the implementation of the RelationshipService interface
      *

--- a/dspace-api/src/main/java/org/dspace/content/factory/ContentServiceFactoryImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/factory/ContentServiceFactoryImpl.java
@@ -9,6 +9,7 @@ package org.dspace.content.factory;
 
 import java.util.List;
 
+import org.dspace.content.AuthorityVirtualMetadataService;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.RelationshipMetadataService;
 import org.dspace.content.service.BitstreamFormatService;
@@ -78,6 +79,8 @@ public class ContentServiceFactoryImpl extends ContentServiceFactory {
     private RelationshipTypeService relationshipTypeService;
     @Autowired(required = true)
     private RelationshipMetadataService relationshipMetadataService;
+    @Autowired(required = true)
+    private AuthorityVirtualMetadataService authorityVirtualMetadataService;
     @Autowired(required = true)
     private EntityTypeService entityTypeService;
     @Autowired(required = true)
@@ -183,6 +186,11 @@ public class ContentServiceFactoryImpl extends ContentServiceFactory {
     @Override
     public RelationshipMetadataService getRelationshipMetadataService() {
         return relationshipMetadataService;
+    }
+
+    @Override
+    public AuthorityVirtualMetadataService getAuthorityVirtualMetadataService() {
+        return authorityVirtualMetadataService;
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/content/virtual/AuthorityCollected.java
+++ b/dspace-api/src/main/java/org/dspace/content/virtual/AuthorityCollected.java
@@ -1,0 +1,68 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.virtual;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import org.dspace.authority.AuthorityValue;
+
+/**
+ * Implements the {@link AuthorityVirtualMetadataConfiguration} interface to achieve the generation of Virtual
+ * metadata for authority values, in a similar way to the entity-driven {@link VirtualMetadataConfiguration}.
+ * The Collected bean will take all the Solr document values for the defined fields and create a list of
+ * virtual metadata fields for use by the {@link AuthorityVirtualMetadataPopulator}.
+ *
+ * @author Kim Shepherd
+ *
+ */
+public class AuthorityCollected implements AuthorityVirtualMetadataConfiguration {
+    /**
+     * The field names to retrieve from the Authority Solr document - note these do NOT have to match
+     * the field names of the resulting virtual metadata values - they are set as the key of the map that contains
+     * this map. (e.g. 'dcterms.spatial -> ['my_solr_spatial_field' -> [x, y, z], 'another_field' -> [x, y, z]])
+     */
+    private List<String> fields;
+
+    /**
+     * Generic getter for the fields property
+     * @return The list of field names
+     */
+    public List<String> getFields() {
+        return fields;
+    }
+
+    /**
+     * Generic setter for the fields property
+     * @param fields the list of field names
+     */
+    public void setFields(List<String> fields) {
+        this.fields = fields;
+    }
+
+    /**
+     * Retrieve the values from the given AuthorityValue "otherMetadataMap" for each configured fields property
+     * and return as a list. The authority value is responsible for how to store and return this map.
+     *
+     * @param authorityValue The authority value from which to build the list of values
+     * @return The String values for each field configured
+     */
+    public List<String> getValues(AuthorityValue authorityValue) {
+        List<String> resultValues = new LinkedList<>();
+        List<String> fieldsToRetrieve = this.getFields();
+        Map<String, List<String>> metadataMap = authorityValue.getOtherMetadataMap();
+        for (String field : fieldsToRetrieve) {
+            List<String> otherMetadata = metadataMap.get(field);
+            if (otherMetadata != null) {
+                resultValues.addAll(otherMetadata);
+            }
+        }
+        return resultValues;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/content/virtual/AuthorityConcatenate.java
+++ b/dspace-api/src/main/java/org/dspace/content/virtual/AuthorityConcatenate.java
@@ -1,0 +1,94 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.virtual;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.dspace.authority.AuthorityValue;
+
+/**
+ * Implements the {@link AuthorityVirtualMetadataConfiguration} interface to achieve the generation of Virtual
+ * metadata for authority values, in a similar way to the entity-driven {@link VirtualMetadataConfiguration}.
+ * The Concatenate bean will take all the Solr document values for the defined fields and concatenate them together
+ * with separators for use with the {@link AuthorityVirtualMetadataPopulator}.
+ *
+ * @author Kim Shepherd
+ *
+ */
+public class AuthorityConcatenate implements AuthorityVirtualMetadataConfiguration {
+    /**
+     * The field names to retrieve from the Authority Solr document - note these do NOT have to match
+     * the field names of the resulting virtual metadata values - they are set as the key of the map that contains
+     * this map. (e.g. 'dcterms.spatial -> ['my_solr_spatial_field' -> [x, y, z], 'another_field' -> [x, y, z]])
+     */
+    private List<String> fields;
+    /**
+     * The separator used in concatenation
+     */
+    private String separator;
+
+    /**
+     * Generic getter for the fields property
+     * @return The list of field names
+     */
+    public List<String> getFields() {
+        return fields;
+    }
+
+    /**
+     * Generic setter for the fields property
+     * @param fields the list of field names
+     */
+    public void setFields(List<String> fields) {
+        this.fields = fields;
+    }
+
+    /**
+     * Generic getter for the separator
+     * @return The separator used in concatenation
+     */
+    public String getSeparator() {
+        return separator;
+    }
+
+    /**
+     * Generic setter for the separator property
+     * @param separator The separator used in concatenation
+     */
+    public void setSeparator(String separator) {
+        this.separator = separator;
+    }
+
+    /**
+     * Retrieve the values from the given AuthorityValue "otherMetadataMap" for each configured fields property
+     * and return as a list. The authority value is responsible for how to store and return this map.
+     *
+     * @param authorityValue The authority value from which to build the list of values
+     * @return The String values for each field configured
+     */
+    public List<String> getValues(AuthorityValue authorityValue) {
+        List<String> resultValues = new LinkedList<>();
+        List<String> fieldsToRetrieve = this.getFields();
+        Map<String, List<String>> metadataMap = authorityValue.getOtherMetadataMap();
+        List<String> concatenatedValues = new LinkedList<>();
+        for (String field : fieldsToRetrieve) {
+            List<String> otherMetadata = metadataMap.get(field);
+            if (otherMetadata != null) {
+                // Concatenate all values of this particular field (e.g. label_keyword)
+                concatenatedValues.add(otherMetadata.stream().collect(Collectors.joining(separator)));
+            }
+        }
+        // Concatenate all the individual concatenated values together (e.g. person.lastName with person.firstName)
+        resultValues.add(concatenatedValues.stream().collect(Collectors.joining(separator)));
+
+        return resultValues;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/content/virtual/AuthorityVirtualMetadataConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/content/virtual/AuthorityVirtualMetadataConfiguration.java
@@ -1,0 +1,34 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.virtual;
+
+import java.util.List;
+
+import org.dspace.authority.AuthorityValue;
+
+/**
+ * This interface describes beans to be used for the {@link AuthorityVirtualMetadataPopulator} implementation.
+ * It achieves virtual metadata that looks and acts identical to the entity-driven {@link VirtualMetadataConfiguration}
+ * but uses Authority values as the source for metadata values instead of a related DSpace Item
+ *
+ * Functionality like 'useNameVariants' and 'useForPlace' are not implemented as authority values typically don't
+ * have enough information to derive this.
+ *
+ * @author Kim Shepherd
+ */
+public interface AuthorityVirtualMetadataConfiguration {
+
+    /**
+     * Retrieve the values from the given AuthorityValue "otherMetadataMap" for each configured fields property
+     * and return as a list. The authority value is responsible for how to store and return this map.
+     *
+     * @param authorityValue The authority value from which to build the list of values
+     * @return The String values for each field configured
+     */
+    List<String> getValues(AuthorityValue authorityValue);
+}

--- a/dspace-api/src/main/java/org/dspace/content/virtual/AuthorityVirtualMetadataPopulator.java
+++ b/dspace-api/src/main/java/org/dspace/content/virtual/AuthorityVirtualMetadataPopulator.java
@@ -1,0 +1,47 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.virtual;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This class simply sets and gets maps of maps of string-{@link AuthorityVirtualMetadataConfiguration}s, where the key
+ * is an authority-controlled metadata field like dc.subject, and the key in the value map is the virtual field name
+ * to set / transform for a given set of values (e.g. dc.description, dcterms.spatial).
+ * It operates in a similar way to entity {@link VirtualMetadataPopulator}
+ *
+ * @author Kim Shepherd
+ */
+public class AuthorityVirtualMetadataPopulator {
+
+    /**
+     * The map of authority controlled field names, to a map of virtual metadata field names and configurations.
+     */
+    private Map<String, HashMap<String, AuthorityVirtualMetadataConfiguration>> map;
+
+    /**
+     * Sets the map of authority controlled field names to a map of virtual metadata field names and configurations.
+     * The map is used for authority virtual metadata population.
+     *
+     * @param map the map of authority controlled field names to virtual metadata field names and configurations
+     */
+    public void setMap(Map<String, HashMap<String, AuthorityVirtualMetadataConfiguration>> map) {
+        this.map = map;
+    }
+
+    /**
+     * Retrieves the map of authority controlled field names to a map of virtual metadata field names and configurations.
+     *
+     * @return the map of authority controlled field names to virtual metadata field names and configurations
+     */
+    public Map<String, HashMap<String, AuthorityVirtualMetadataConfiguration>> getMap() {
+        return map;
+    }
+
+}

--- a/dspace-api/src/main/java/org/dspace/content/virtual/AuthorityVirtualMetadataPopulator.java
+++ b/dspace-api/src/main/java/org/dspace/content/virtual/AuthorityVirtualMetadataPopulator.java
@@ -36,7 +36,7 @@ public class AuthorityVirtualMetadataPopulator {
     }
 
     /**
-     * Retrieves the map of authority controlled field names to a map of virtual metadata field names and configurations.
+     * Retrieves the map of authority controlled field names to a map of virtual metadata field names and configurations
      *
      * @return the map of authority controlled field names to virtual metadata field names and configurations
      */

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SearchFilterToAppliedFilterConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SearchFilterToAppliedFilterConverter.java
@@ -35,7 +35,7 @@ public class SearchFilterToAppliedFilterConverter {
             // facet as the authority is bind at the metadata level and so a facet could contains values from multiple
             // authorities
             // https://jira.duraspace.org/browse/DS-4209
-            authorityValue = authorityValueService.findByUID(context, searchFilter.getValue());
+            authorityValue = authorityValueService.findByUID(searchFilter.getValue());
         }
 
         SearchResultsRest.AppliedFilter appliedFilter;

--- a/dspace/config/spring/api/core-services.xml
+++ b/dspace/config/spring/api/core-services.xml
@@ -57,6 +57,7 @@
     <bean class="org.dspace.content.EntityServiceImpl"/>
     <bean class="org.dspace.content.RelationshipTypeServiceImpl"/>
     <bean class="org.dspace.content.RelationshipMetadataServiceImpl"/>
+    <bean class="org.dspace.content.AuthorityVirtualMetadataServiceImpl" init-method="init"/>
     <bean class="org.dspace.content.FeedbackServiceImpl"/>
     <bean class="org.dspace.content.DuplicateDetectionServiceImpl"/>
 

--- a/dspace/config/spring/api/core-services.xml
+++ b/dspace/config/spring/api/core-services.xml
@@ -57,7 +57,7 @@
     <bean class="org.dspace.content.EntityServiceImpl"/>
     <bean class="org.dspace.content.RelationshipTypeServiceImpl"/>
     <bean class="org.dspace.content.RelationshipMetadataServiceImpl"/>
-    <bean class="org.dspace.content.AuthorityVirtualMetadataServiceImpl" init-method="init"/>
+    <bean class="org.dspace.content.AuthorityVirtualMetadataServiceImpl"/>
     <bean class="org.dspace.content.FeedbackServiceImpl"/>
     <bean class="org.dspace.content.DuplicateDetectionServiceImpl"/>
 

--- a/dspace/config/spring/api/virtual-metadata.xml
+++ b/dspace/config/spring/api/virtual-metadata.xml
@@ -254,4 +254,25 @@
         <property name="virtualMetadataConfiguration" ref="volumeJournal_uuid"/>
     </bean>
     <bean class="org.dspace.content.virtual.UUIDValue" id="volumeJournal_uuid"/>
+
+    <!-- Authority virtual metadata -->
+    <bean class="org.dspace.content.virtual.AuthorityVirtualMetadataPopulator">
+        <property name="map">
+            <map>
+                <entry key="dc.contributor.author" value-ref="orcidContributorAuthorityMap" />
+            </map>
+        </property>
+    </bean>
+    <util:map id="orcidContributorAuthorityMap">
+        <entry key="dc.contributor" value-ref="orcid-details"/>
+    </util:map>
+    <bean class="org.dspace.content.virtual.AuthorityConcatenate" id="orcid-details">
+        <property name="fields">
+            <util:list>
+                <value>label_external_identifier</value>
+                <value>label_researcher_url</value>
+                <value>label_biography</value>
+            </util:list>
+        </property>
+    </bean>
 </beans>

--- a/dspace/config/spring/api/virtual-metadata.xml
+++ b/dspace/config/spring/api/virtual-metadata.xml
@@ -267,6 +267,7 @@
         <entry key="dc.contributor" value-ref="orcid-details"/>
     </util:map>
     <bean class="org.dspace.content.virtual.AuthorityConcatenate" id="orcid-details">
+        <property name="separator" value=", "/>
         <property name="fields">
             <util:list>
                 <value>label_external_identifier</value>


### PR DESCRIPTION
## References
* Includes the (as yet unmerged) changes in https://github.com/DSpace/DSpace/pull/9845 (a small PR that just enhances the core AuthorityValue class to support additional metadata maps, like its subclasses)
 (I may just close that one in favour of including all changes here)
* Includes the (as yet unmerged) changes in https://github.com/DSpace/DSpace/pull/9842 (a small PR that removes unnecessary context parameter from AuthorityValueService find methods)

## Work in progress
* Integration / Unit tests are still in development

## Description
Changes and new simple beans to support virtual metadata for authority-controlled values.

If enabled, and if `enableVirtualMetadata` is true, the `ItemServiceImpl#getMetadata(..., enableVirtualMetadata)` method will additionally populate the metadata list with values collected from linked authority records.

The Spring configuration and beans are set up in a very similar way to the relationship-based classes, with one key difference being the lack of ability to set a designated `place` for the virtual metadata value (instead, the place is calculated at the time of population to ensure all virtual values are effectively appended).

The result of this is that  for an authority-controlled value like:

`dc.subject = Twain, Mark [authority = '12345']`

The authority key will be resolved to a record, the additional metadata in the authority record retrieved and mapped to virtual field names, and populated with the list of returned metadata.

## Dev notes

* As noted, place has to be calculated and not specified, as there is no equivalent of the places in related item metadata values to use as a basis
* The `MetadataValue#getID()` method must return an integer. Authority record field values cannot be addressed this way. Nor can relationship-based virtual metadata as they currently return the relationship ID, not a value ID (and they might be a concatenation or derived value anyway, not resolvable to a single metadata value).
To avoid any accidental mix-up with a real metadata value that is *not* this virtual authority metadata value, `-1` is always returned from the new `VirtualMetadataValue` subclass of `MetadataValue`.

## Instructions for Reviewers

List of changes in this PR:
* Changes to `AuthorityValue` to support maps of additional metadata (map of of lists of strings) like `PersonAuthorityValue`, `ORCIDv3AuthorityValue`, etc., just to bring the super class in line with implementations and make it more flexible
* New `VirtualMetadataValue` interface for type checking and inheritance (with both `RelationshipMetadataValue` and `AuthorityVirtualMetadataValue` inheriting), and a default safe `getID()` override
* New set of classes and config to implement configuration, collection, population of authority virtual metadata in a similar way to relationship virtual metadata:
   * `AuthorityVirtualMetadataValue`
   * `AuthorityVirtualMetadataConfiguration`
   * `AuthorityCollected`
   * `AuthorityVirtualMetadataPopulator`
   * Additional spring configuration included as example in `virtual-metadata.xml`
* Modify `ItemServiceImpl#getMetadata` to populate authority virtual metadata after relationship virtual metadata, if enabled
* Integration and unit test coverage (**TODO**)

To test:
* Set up authority control where the records will store some more complex data than a simple string value (e.g. ORCID author authority)
* Add some authors
* Set up virtual metadata field mapping as appropriate in `virtual-metadata.xml`
    * For example, include the orcid ID value, or an institutional affiliation from the Solr authority record 
* After building and deploying, visit the item page and view the full metadata page to check if the virtual metadata is present

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature..
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
