### PR TITLE
Bump to Spring 6.1.13, Spring Boot 3.3.4 and Spring Security 6.3.3

### DIFF
--- a/dspace-server-webapp/pom.xml
+++ b/dspace-server-webapp/pom.xml
@@ -343,6 +343,18 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
             <version>${spring-boot.version}</version>
+            <exclusions>
+                <!-- Use version brought in by spring-boot-starter-web above -->
+                <exclusion>
+                    <groupId>io.micrometer</groupId>
+                    <artifactId>micrometer-observation</artifactId>
+                </exclusion>
+                <!-- Use version brought in by spring-boot-starter-web above -->
+                <exclusion>
+                    <groupId>io.micrometer</groupId>
+                    <artifactId>micrometer-commons</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -437,7 +449,7 @@
             <artifactId>spring-boot-starter-security</artifactId>
             <version>${spring-boot.version}</version>
             <exclusions>
-                <!-- Later version brought in by spring-boot-starter-web above -->
+                <!-- Use version brought in by spring-boot-starter-web above -->
                 <exclusion>
                     <groupId>io.micrometer</groupId>
                     <artifactId>micrometer-observation</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,9 @@
     <properties>
         <!--=== GENERAL / DSPACE-API DEPENDENCIES ===-->
         <java.version>17</java.version>
-        <spring.version>6.1.8</spring.version>
-        <spring-boot.version>3.2.6</spring-boot.version>
-        <spring-security.version>6.2.4</spring-security.version> <!-- sync with version used by spring-boot-->
+        <spring.version>6.1.13</spring.version>
+        <spring-boot.version>3.3.4</spring-boot.version>
+        <spring-security.version>6.3.3</spring-security.version> <!-- sync with version used by spring-boot-->
         <hibernate.version>6.4.8.Final</hibernate.version>
         <hibernate-validator.version>8.0.1.Final</hibernate-validator.version>
         <postgresql.driver.version>42.7.3</postgresql.driver.version>


### PR DESCRIPTION
## References
* Replaces #9825 and #9851, provided by dependabot to resolve CVE-2024-38809 and CVE-2024-38816

## Description
Bumps us up to Spring 6.1.13, Spring Boot 3.3.4 and Spring Security 6.3.3.  These are the latest versions (as of today)

## Instructions for Reviewers
* Verify all automated tests pass
* Verify no change in behavior for REST API (in Hal Browser or via UI).  (I've tested both Hal Browser and User Interface with this PR and found no issues.)
