### PR TITLE
Bump `dspace-7_x` to Spring 5.3.39 and Spring Security 5.7.12

### DIFF
--- a/dspace-server-webapp/pom.xml
+++ b/dspace-server-webapp/pom.xml
@@ -362,6 +362,27 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
             <version>${spring-boot.version}</version>
+            <exclusions>
+                <!-- Use the version of Spring Security that we specify below -->
+                <exclusion>
+                    <groupId>org.springframework.security</groupId>
+                    <artifactId>spring-security-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework.security</groupId>
+                    <artifactId>spring-security-web</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-core</artifactId>
+            <version>${spring-security.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-web</artifactId>
+            <version>${spring-security.version}</version>
         </dependency>
 
         <!-- Add in log4j support by excluding default logging, and using starter-log4j -->

--- a/dspace-server-webapp/pom.xml
+++ b/dspace-server-webapp/pom.xml
@@ -366,6 +366,10 @@
                 <!-- Use the version of Spring Security that we specify below -->
                 <exclusion>
                     <groupId>org.springframework.security</groupId>
+                    <artifactId>spring-security-config</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework.security</groupId>
                     <artifactId>spring-security-core</artifactId>
                 </exclusion>
                 <exclusion>
@@ -373,6 +377,11 @@
                     <artifactId>spring-security-web</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-config</artifactId>
+            <version>${spring-security.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,9 @@
     <properties>
         <!--=== GENERAL / DSPACE-API DEPENDENCIES ===-->
         <java.version>11</java.version>
-        <spring.version>5.3.34</spring.version>
+        <spring.version>5.3.39</spring.version>
         <spring-boot.version>2.7.18</spring-boot.version>
-        <spring-security.version>5.7.11</spring-security.version> <!-- sync with version used by spring-boot-->
+        <spring-security.version>5.8.14</spring-security.version> <!-- sync with version used by spring-boot-->
         <hibernate.version>5.6.15.Final</hibernate.version>
         <hibernate-validator.version>6.2.5.Final</hibernate-validator.version>
         <postgresql.driver.version>42.7.3</postgresql.driver.version>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <java.version>11</java.version>
         <spring.version>5.3.39</spring.version>
         <spring-boot.version>2.7.18</spring-boot.version>
-        <spring-security.version>5.8.14</spring-security.version> <!-- sync with version used by spring-boot-->
+        <spring-security.version>5.7.12</spring-security.version> <!-- sync with version used by spring-boot-->
         <hibernate.version>5.6.15.Final</hibernate.version>
         <hibernate-validator.version>6.2.5.Final</hibernate-validator.version>
         <postgresql.driver.version>42.7.3</postgresql.driver.version>


### PR DESCRIPTION
## References
* Related to #9885 , as this is a similar Spring update for 7.x
* Patches CVE-2024-38809 and CVE-2024-38808 which both impact Spring 5.

## Description
Small PR to bump us to Spring 5.3.39 and Spring Security 5.7.12