### PR TITLE
Add Eclipse JDT .factorypath to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ tags
 .project
 .classpath
 .checkstyle
+.factorypath
 
 ## Ignore project files created by IntelliJ IDEA
 *.iml


### PR DESCRIPTION
Very small change to include `.factorypath` auto-generated by Eclipse JDT / m2eclipse

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
