### PR TITLE
[Port dspace-7_x] Fixing Crossref document type issue with new metadata mapping processor

### DIFF
--- a/dspace-api/src/main/java/org/dspace/importer/external/metadatamapping/transform/StringJsonValueMappingMetadataProcessorService.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/metadatamapping/transform/StringJsonValueMappingMetadataProcessorService.java
@@ -30,7 +30,6 @@ import org.dspace.util.SimpleMapConverter;
  * <code>journal-article = Article<code/>
  * 
  * @author paulo-graca
- *
  */
 public class StringJsonValueMappingMetadataProcessorService implements JsonPathMetadataProcessor {
 

--- a/dspace-api/src/main/java/org/dspace/importer/external/metadatamapping/transform/StringJsonValueMappingMetadataProcessorService.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/metadatamapping/transform/StringJsonValueMappingMetadataProcessorService.java
@@ -1,0 +1,78 @@
+package org.dspace.importer.external.metadatamapping.transform;
+
+import static java.util.Optional.ofNullable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Optional;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.dspace.importer.external.metadatamapping.contributor.JsonPathMetadataProcessor;
+import org.dspace.util.SimpleMapConverter;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
+
+/**
+ * This class is a Metadata processor from a structured JSON Metadata result
+ * and uses a SimpleMapConverter, with a mapping properties file
+ * to map to a single string value based on mapped keys.<br/>
+ * Like:<br/>
+ * <code>journal-article = Article<code/>
+ * 
+ * @author paulo-graca
+ *
+ */
+public class StringJsonValueMappingMetadataProcessorService implements JsonPathMetadataProcessor {
+
+    private final static Logger log = LogManager.getLogger();
+    /**
+     * The value map converter.
+     * a list of values to map from
+     */
+    private SimpleMapConverter valueMapConverter;
+    private String path;
+
+    @Override
+    public Collection<String> processMetadata(String json) {
+        JsonNode rootNode = convertStringJsonToJsonNode(json);
+        Optional<JsonNode> abstractNode = Optional.of(rootNode.at(path));
+        Collection<String> values = new ArrayList<>();
+
+        if (abstractNode.isPresent() && abstractNode.get().getNodeType().equals(JsonNodeType.STRING)) {
+
+            String stringValue = abstractNode.get().asText();
+            values.add(ofNullable(stringValue)
+                         .map(value -> valueMapConverter != null ? valueMapConverter.getValue(value) : value)
+                         .orElse(valueMapConverter.getValue(null)));
+        }
+        return values;
+    }
+
+    private JsonNode convertStringJsonToJsonNode(String json) {
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode body = null;
+        try {
+            body = mapper.readTree(json);
+        } catch (JsonProcessingException e) {
+            log.error("Unable to process json response.", e);
+        }
+        return body;
+    }
+
+    /* Getters and Setters */
+
+    public String convertType(String type) {
+        return valueMapConverter != null ? valueMapConverter.getValue(type) : type;
+    }
+
+    public void setValueMapConverter(SimpleMapConverter valueMapConverter) {
+        this.valueMapConverter = valueMapConverter;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+}

--- a/dspace-api/src/main/java/org/dspace/importer/external/metadatamapping/transform/StringJsonValueMappingMetadataProcessorService.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/metadatamapping/transform/StringJsonValueMappingMetadataProcessorService.java
@@ -1,18 +1,26 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package org.dspace.importer.external.metadatamapping.transform;
 
 import static java.util.Optional.ofNullable;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Optional;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.dspace.importer.external.metadatamapping.contributor.JsonPathMetadataProcessor;
-import org.dspace.util.SimpleMapConverter;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.dspace.importer.external.metadatamapping.contributor.JsonPathMetadataProcessor;
+import org.dspace.util.SimpleMapConverter;
 
 /**
  * This class is a Metadata processor from a structured JSON Metadata result

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CrossRefImportMetadataSourceServiceIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CrossRefImportMetadataSourceServiceIT.java
@@ -163,7 +163,8 @@ public class CrossRefImportMetadataSourceServiceIT extends AbstractLiveImportInt
                 "State of Awareness of Freshers’ Groups Chortkiv State"
                 + " Medical College of Prevention of Iodine Deficiency Diseases");
         MetadatumDTO author = createMetadatumDTO("dc", "contributor", "author", "Senyuk, L.V.");
-        MetadatumDTO type = createMetadatumDTO("dc", "type", null, "journal-article");
+        // is expected the dc.type is mapped from journal-article to Article
+        MetadatumDTO type = createMetadatumDTO("dc", "type", null, "Article");
         MetadatumDTO date = createMetadatumDTO("dc", "date", "issued", "2016-05-19");
         MetadatumDTO ispartof = createMetadatumDTO("dc", "relation", "ispartof",
                                    "Ukraïnsʹkij žurnal medicini, bìologìï ta sportu");
@@ -192,7 +193,8 @@ public class CrossRefImportMetadataSourceServiceIT extends AbstractLiveImportInt
         MetadatumDTO title2 = createMetadatumDTO("dc", "title", null,
                 "Ischemic Heart Disease and Role of Nurse of Cardiology Department");
         MetadatumDTO author2 = createMetadatumDTO("dc", "contributor", "author", "Kozak, K. І.");
-        MetadatumDTO type2 = createMetadatumDTO("dc", "type", null, "journal-article");
+        // is expected the dc.type is mapped from journal-article to Article
+        MetadatumDTO type2 = createMetadatumDTO("dc", "type", null, "Article");
         MetadatumDTO date2 = createMetadatumDTO("dc", "date", "issued", "2016-05-19");
         MetadatumDTO ispartof2 = createMetadatumDTO("dc", "relation", "ispartof",
                                      "Ukraïnsʹkij žurnal medicini, bìologìï ta sportu");

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CrossRefImportMetadataSourceServiceIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CrossRefImportMetadataSourceServiceIT.java
@@ -163,7 +163,7 @@ public class CrossRefImportMetadataSourceServiceIT extends AbstractLiveImportInt
                 "State of Awareness of Freshers’ Groups Chortkiv State"
                 + " Medical College of Prevention of Iodine Deficiency Diseases");
         MetadatumDTO author = createMetadatumDTO("dc", "contributor", "author", "Senyuk, L.V.");
-        // is expected the dc.type is mapped from journal-article to Article
+        // is expected the dc.type to be mapped from journal-article to Article
         MetadatumDTO type = createMetadatumDTO("dc", "type", null, "Article");
         MetadatumDTO date = createMetadatumDTO("dc", "date", "issued", "2016-05-19");
         MetadatumDTO ispartof = createMetadatumDTO("dc", "relation", "ispartof",
@@ -193,7 +193,7 @@ public class CrossRefImportMetadataSourceServiceIT extends AbstractLiveImportInt
         MetadatumDTO title2 = createMetadatumDTO("dc", "title", null,
                 "Ischemic Heart Disease and Role of Nurse of Cardiology Department");
         MetadatumDTO author2 = createMetadatumDTO("dc", "contributor", "author", "Kozak, K. І.");
-        // is expected the dc.type is mapped from journal-article to Article
+        // is expected the dc.type to be mapped from journal-article to Article
         MetadatumDTO type2 = createMetadatumDTO("dc", "type", null, "Article");
         MetadatumDTO date2 = createMetadatumDTO("dc", "date", "issued", "2016-05-19");
         MetadatumDTO ispartof2 = createMetadatumDTO("dc", "relation", "ispartof",

--- a/dspace/config/crosswalks/mapConverter-crossref-to-dspace-publication-type.properties
+++ b/dspace/config/crosswalks/mapConverter-crossref-to-dspace-publication-type.properties
@@ -1,0 +1,29 @@
+# based on Crossref content type at https://crossref.gitlab.io/knowledge_base/docs/topics/content-types/#types-in-cayenne-rest-api
+# Mapping between work type supported by Crossref and the DSpace common publication's types
+journal-article = Article
+journal-issue = Other
+journal-volume = Other
+journal = Other
+proceedings-article = Other
+proceedings = Other
+dataset = Dataset
+component = Other
+report = Other
+report-series = Other
+standard = Other
+standard-series = Other
+edited-book = Other
+monograph = Other
+reference-book = Other
+book = Book
+book-series = Other
+book-set = Other
+book-chapter = Book chapter
+book-section = Other
+book-part = Other
+book-track = Other
+reference-entry = Other
+dissertation = Other
+posted-content = Other
+peer-review = Other
+other = Other

--- a/dspace/config/spring/api/crossref-integration.xml
+++ b/dspace/config/spring/api/crossref-integration.xml
@@ -49,9 +49,19 @@
         <constructor-arg value="dc.relation.ispartof"/>
     </bean>
 
+    <bean name="mapConverterCrossRefToDSpacePublicationType" class="org.dspace.util.SimpleMapConverter" init-method="init">
+        <property name="converterNameFile" value="mapConverter-crossref-to-dspace-publication-type.properties" />
+        <property name="configurationService" ref="org.dspace.services.ConfigurationService" />
+        <property name="defaultValue" value="Other"/>
+    </bean>
+    <bean id="crossrefTypeValueMapping" class="org.dspace.importer.external.metadatamapping.transform.StringJsonValueMappingMetadataProcessorService">
+        <property name="valueMapConverter" ref="mapConverterCrossRefToDSpacePublicationType"/>
+        <property name="path" value="/type"/>
+    </bean>
     <bean id="crossrefDoiTypeContrib" class="org.dspace.importer.external.metadatamapping.contributor.SimpleJsonPathMetadataContributor">
         <property name="field" ref="crossref.type"/>
         <property name="query" value="/type"/>
+        <property name="metadataProcessor" ref="crossrefTypeValueMapping"></property>
     </bean>
     <bean id="crossref.type" class="org.dspace.importer.external.metadatamapping.MetadataFieldConfig">
         <constructor-arg value="dc.type"/>


### PR DESCRIPTION
## References
* Fixes #9900
* Main version: #9910

## Description
This PR makes use of a mechanism available for external sources that enable you to do value mapping. Meaning, you can replace a value by defining something like:
```
journal-article=Article
```
## Instructions for Reviewers
To test this, you can see it on the original issue #9900, you can use the user interface and you just need to go to your "mydspace" area and do an import metadata from crossref. Then, when you try to import a record, You will see "Article" instead the "journal-article" as the Publication type.

List of changes in this PR:
* I've changed crossref integration spring configuration to support to new SimpleMapConverter
* I've added a file with mapped values (I've tried to do my best here)
* I've created a new JSON processor

