### PR TITLE
Improve statistics adding totals and aggregated collection level reports

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportPointRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportPointRest.java
@@ -23,7 +23,7 @@ public abstract class UsageReportPointRest extends BaseObjectRest<String> {
     public static final String CATEGORY = RestModel.STATISTICS;
     protected String id;
     protected String label;
-    private Map<String, Integer> values;
+    private Map<String, Object> values;
 
     /**
      * Returns the category of this Rest object, {@link #CATEGORY}
@@ -70,7 +70,7 @@ public abstract class UsageReportPointRest extends BaseObjectRest<String> {
      *
      * @return The values of this {@link UsageReportPointRest} object, containing the amount of views
      */
-    public Map<String, Integer> getValues() {
+    public Map<String, Object> getValues() {
         return values;
     }
 
@@ -98,7 +98,7 @@ public abstract class UsageReportPointRest extends BaseObjectRest<String> {
      * @param key   Key of new value pair
      * @param value Value of new value pair
      */
-    public void addValue(String key, Integer value) {
+    public void addValue(String key, Object value) {
         if (values == null) {
             values = new HashMap<>();
         }
@@ -110,7 +110,7 @@ public abstract class UsageReportPointRest extends BaseObjectRest<String> {
      *
      * @param values All values of this {@link UsageReportPointRest} object
      */
-    public void setValues(Map<String, Integer> values) {
+    public void setValues(Map<String, Object> values) {
         this.values = values;
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/UsageReportRest.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.dspace.app.rest.RestResourceController;
+import org.dspace.statistics.Dataset;
 
 /**
  * This class serves as a REST representation of a Usage Report from the DSpace statistics
@@ -121,5 +122,29 @@ public class UsageReportRest extends BaseObjectRest<String> {
      */
     public void setPoints(List<UsageReportPointRest> points) {
         this.points = points;
+    }
+
+    /**
+     * Append or Update Total point {@link UsageReportPointRest} object on this {@link UsageReportRest} object
+     * Assumes the last item in the provided dataset represents the total.
+     * Sometimes the point representing the total has already been added, sometime it hasn't.
+     * If it hasn't, then a new point will be created for it.
+     * In both cases, the capitalization in the Label will be normalized.
+     * @param dataset {@link Dataset} upon which this {@link UsageReportRest} object is based
+     */
+    public void appendTotal(Dataset dataset) {
+        if (this.points == null) {
+            return;
+        }
+        UsageReportPointDsoTotalVisitsRest totalPoint = new UsageReportPointDsoTotalVisitsRest();
+        totalPoint.setId("total");
+        totalPoint.setLabel("Total");
+        totalPoint.setType("total");
+        totalPoint.addValue("views", Integer.valueOf(dataset.getMatrix()[0][dataset.getColLabels().size() - 1]));
+        if (this.points.get(this.points.size() - 1).getLabel().toLowerCase().equals("total")) {
+            this.points.set(this.points.size() - 1, totalPoint);
+        } else {
+            this.addPoint(totalPoint);
+        }
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/UsageReportMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/UsageReportMatcher.java
@@ -57,7 +57,7 @@ public class UsageReportMatcher {
             hasJsonPath("$.points", Matchers.containsInAnyOrder(
                 points.stream()
                       .map(point -> UsageReportPointMatcher.matchUsageReportPoint(
-                          point.getId(), point.getLabel(), point.getType(), point.getValues().get("views")
+                          point.getId(), point.getLabel(), point.getType(), (Integer) point.getValues().get("views")
                       ))
                       .collect(Collectors.toList()))
             )


### PR DESCRIPTION
## References
* Related to https://github.com/DSpace/dspace-angular/pull/3507, which utilizes the new statistics report features

## Description
Improves view statistic reporting by adding totals and new reports which aggregate item and bitstream vists at the Site, Community and Collection levels.
Examples can be seen at https://scholarworks.iu.edu/iuswrtest/home

## Instructions for Reviewers
To enable the new reports, changes in the dspace-angular PR referenced above must be included in the UI code.

List of changes in this PR:
* Adds totals to existing and new reports. 
* Replaces reports at the Collection and Community statistics pages (which previously included only visits to the Collection 
 and Community home pages) with reports that aggregate visit counts of all items and bitstreams owned by those collections and communities  