### PR TITLE
Submission scope naming for input field validation fixed

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/DCInput.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/DCInput.java
@@ -163,7 +163,7 @@ public class DCInput {
      * The scope of the input sets, this restricts hidden metadata fields from
      * view by the end user during submission.
      */
-    public static final String SUBMISSION_SCOPE = "submit";
+    public static final String SUBMISSION_SCOPE = "submission";
 
     /**
      * Class constructor for creating a DCInput object based on the contents of

--- a/dspace-api/src/main/java/org/dspace/app/util/DCInput.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/DCInput.java
@@ -262,7 +262,7 @@ public class DCInput {
 
     /**
      * Is this DCInput for display in the given scope? The scope should be
-     * either "workflow" or "submit", as per the input forms definition. If the
+     * either "workflow" or "submission", as per the input forms definition. If the
      * internal visibility is set to "null" then this will always return true.
      *
      * @param scope String identifying the scope that this input's visibility


### PR DESCRIPTION
According to the documentation ([8x/Submission+User+Interface](https://wiki.lyrasis.org/display/DSDOC8x/Submission+User+Interface)), the value for the `<visibility>` property is 'submission' in the 'submission-forms.xml'. Without this change, an empty input field will never be marked as an error, even if the field is marked as 'required'.

## References
* Fixes #9914 

## Description
You are able to scope submission-form fields to a specific visibility like "workflow" or "submission". If you use submission, the validator is not working correctly. The logic checks for "submit"-wording instead of "submission".

## Instructions for Reviewers
Create a submission form field that contains the `<visibility>` property with the value "submission" and also the `<required>` property to make this field mandatory. Restart the containers and create a submission item. If you 'Deposit' the submission item without entering anything in the form field, the backend should return a form error.