### PR TITLE
Add `eDisMax` compatibility for filter queries

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/statistics/LogAnalyser.java
+++ b/dspace-api/src/main/java/org/dspace/app/statistics/LogAnalyser.java
@@ -1241,8 +1241,8 @@ public class LogAnalyser {
         }
         accessionedQuery.append("]");
         discoverQuery.addFilterQueries(accessionedQuery.toString());
-        discoverQuery.addFilterQueries("withdrawn: false");
-        discoverQuery.addFilterQueries("archived: true");
+        discoverQuery.addFilterQueries("withdrawn:false");
+        discoverQuery.addFilterQueries("archived:true");
 
         return (int) SearchUtils.getSearchService().search(context, discoverQuery).getTotalSearchResults();
     }

--- a/dspace-api/src/main/java/org/dspace/browse/SolrBrowseDAO.java
+++ b/dspace-api/src/main/java/org/dspace/browse/SolrBrowseDAO.java
@@ -346,9 +346,9 @@ public class SolrBrowseDAO implements BrowseDAO {
         }
 
         if (isAscending) {
-            query.setQuery("bi_" + column + "_sort" + ": [* TO \"" + value + "\"}");
+            query.setQuery("bi_" + column + "_sort" + ":[* TO \"" + value + "\"}");
         } else {
-            query.setQuery("bi_" + column + "_sort" + ": {\"" + value + "\" TO *]");
+            query.setQuery("bi_" + column + "_sort" + ":{\"" + value + "\" TO *]");
             query.addFilterQueries("-(bi_" + column + "_sort" + ":" + value + "*)");
         }
         DiscoverResult resp = null;

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -1302,7 +1302,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
         try {
             SolrQuery solrQuery = new SolrQuery();
             //Set the query to handle since this is unique
-            solrQuery.setQuery(SearchUtils.RESOURCE_UNIQUE_ID + ": " + new IndexableItem(item).getUniqueIndexID());
+            solrQuery.setQuery(SearchUtils.RESOURCE_UNIQUE_ID + ":" + new IndexableItem(item).getUniqueIndexID());
             //Only return obj identifier fields in result doc
             solrQuery.setFields(SearchUtils.RESOURCE_TYPE_FIELD, SearchUtils.RESOURCE_ID_FIELD);
             //Add the more like this parameters !

--- a/dspace-api/src/main/java/org/dspace/search/Harvest.java
+++ b/dspace-api/src/main/java/org/dspace/search/Harvest.java
@@ -117,9 +117,9 @@ public class Harvest {
         }
 
         if (!withdrawn) {
-            discoverQuery.addFilterQueries("archived: true OR withdrawn: false");
+            discoverQuery.addFilterQueries("archived:true OR withdrawn:false");
         } else {
-            discoverQuery.addFilterQueries("archived: true OR withdrawn: true");
+            discoverQuery.addFilterQueries("archived:true OR withdrawn:true");
         }
 
         // Order by item ID, so that for a given harvest the order will be

--- a/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java
@@ -1194,7 +1194,7 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
                     first = false;
                 }
 
-                query.append(" NOT(ip: ").append(ip).append(")");
+                query.append(" NOT(ip:").append(ip).append(")");
             }
             filterQuery = query.toString();
         }

--- a/dspace-api/src/main/java/org/dspace/statistics/StatisticsLoggingConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/StatisticsLoggingConsumer.java
@@ -93,7 +93,7 @@ public class StatisticsLoggingConsumer implements Consumer {
             // We are mapping a new item make sure that the owning collection is
             // updated
             Item newItem = (Item) event.getObject(ctx);
-            String updateQuery = "id: " + newItem.getID() + " AND type:"
+            String updateQuery = "id:" + newItem.getID() + " AND type:"
                 + newItem.getType();
 
             List<String> fieldNames = new ArrayList<String>();
@@ -116,7 +116,7 @@ public class StatisticsLoggingConsumer implements Consumer {
             && event.getObject(ctx) instanceof Item) {
             // Unmapping items
             Item newItem = (Item) event.getObject(ctx);
-            String updateQuery = "id: " + newItem.getID() + " AND type:"
+            String updateQuery = "id:" + newItem.getID() + " AND type:"
                 + newItem.getType();
 
             List<String> fieldNames = new ArrayList<String>();

--- a/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsBSAdapter.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsBSAdapter.java
@@ -68,10 +68,10 @@ public class StatisticsBSAdapter {
         switch (visitType) {
             case ITEM_VISITS:
                 return solrLoggerService
-                    .queryTotal("type: " + Constants.ITEM + " AND id: " + item.getID(), resolveFilterQueries(), 0)
+                    .queryTotal("type:" + Constants.ITEM + " AND id:" + item.getID(), resolveFilterQueries(), 0)
                     .getCount();
             case BITSTREAM_VISITS:
-                return solrLoggerService.queryTotal("type: " + Constants.BITSTREAM + " AND owningItem: " + item.getID(),
+                return solrLoggerService.queryTotal("type:" + Constants.BITSTREAM + " AND owningItem:" + item.getID(),
                                                     resolveFilterQueries(), 0).getCount();
             case TOTAL_VISITS:
                 return getNumberOfVisits(ITEM_VISITS, item) + getNumberOfVisits(BITSTREAM_VISITS, item);

--- a/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataSearches.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataSearches.java
@@ -209,7 +209,7 @@ public class StatisticsDataSearches extends StatisticsData {
     protected String getQuery() {
         String query;
         if (currentDso != null) {
-            query = "scopeType: " + currentDso.getType() + " AND ";
+            query = "scopeType:" + currentDso.getType() + " AND ";
             if (currentDso instanceof DSpaceObjectLegacySupport) {
                 query += " (scopeId:" + currentDso.getID() + " OR scopeId:" + ((DSpaceObjectLegacySupport) currentDso)
                     .getLegacyId() + ")";

--- a/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataVisits.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataVisits.java
@@ -237,7 +237,7 @@ public class StatisticsDataVisits extends StatisticsData {
                                              false, null, facetMinCount);
                         for (int j = 0; j < maxObjectCounts.length; j++) {
                             ObjectCount firstCount = maxObjectCounts[j];
-                            String newQuery = dataSetQuery.getFacetField() + ": " + ClientUtils
+                            String newQuery = dataSetQuery.getFacetField() + ":" + ClientUtils
                                 .escapeQueryChars(firstCount.getValue()) + " AND " + query;
                             ObjectCount[] maxDateFacetCounts = solrLoggerService
                                 .queryFacetDate(newQuery, filterQuery, dataSetQuery.getMax(), dateFacet.getDateType(),
@@ -813,7 +813,7 @@ public class StatisticsDataVisits extends StatisticsData {
             String query = "";
             //Check (& add if needed) the dsoType
             if (dsoType != -1) {
-                query += "type: " + dsoType;
+                query += "type:" + dsoType;
             }
 
             //Check (& add if needed) the dsoId

--- a/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataWorkflow.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataWorkflow.java
@@ -145,7 +145,7 @@ public class StatisticsDataWorkflow extends StatisticsData {
      */
     protected String getQuery() {
         String query = "statistics_type:" + SolrLoggerServiceImpl.StatisticsType.WORKFLOW.text();
-        query += " AND NOT(previousWorkflowStep: SUBMIT)";
+        query += " AND NOT(previousWorkflowStep:SUBMIT)";
         if (currentDso != null) {
             if (currentDso.getType() == Constants.COMMUNITY) {
                 query += " AND owningComm:";

--- a/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataExportSearchIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataExportSearchIT.java
@@ -123,7 +123,7 @@ public class MetadataExportSearchIT extends AbstractIntegrationTestWithDatabase 
         checkItemsPresentInFile(filename, itemsSubject1);
 
 
-        result = runDSpaceScript("metadata-export-search", "-q", "subject: " + subject2, "-n", filename);
+        result = runDSpaceScript("metadata-export-search", "-q", "subject:" + subject2, "-n", filename);
 
         assertEquals(0, result);
         checkItemsPresentInFile(filename, itemsSubject2);


### PR DESCRIPTION
## Description
In DSpace, we use the `DisMax` query parser for Solr. However, when you switch to [`eDisMax`](https://solr.apache.org/guide/6_6/the-extended-dismax-query-parser.html), some functionality and tests fail. This is because `eDisMax` doesn't allow syntax like `subject: subject1`; it only supports `subject:subject1`. Since `DisMax` supports both, it might be worth adding these fixes to prevent others from encountering the same issue. 😅

## Instructions for Reviewers
List of changes in this PR:
* Removed spaces around `:` in filter queries to prevent the `eDisMax` query parser from breaking
* Also fixed a `DiscoveryIT` test that can fail due to its reliance on the order of returned items

**Guidance for how to test or review this PR:**
Verify that everything still works like expected

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
