### PR TITLE
Fixed dso endpoint returning 500 for unauthorized users

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/UUIDLookupRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/UUIDLookupRestController.java
@@ -24,9 +24,11 @@ import org.dspace.app.rest.model.DSpaceObjectRest;
 import org.dspace.app.rest.utils.ContextUtil;
 import org.dspace.app.rest.utils.DSpaceObjectUtils;
 import org.dspace.app.rest.utils.Utils;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.content.DSpaceObject;
+import org.dspace.core.Constants;
 import org.dspace.core.Context;
-import org.dspace.discovery.SearchServiceException;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.Link;
@@ -66,6 +68,9 @@ public class UUIDLookupRestController implements InitializingBean {
     private DiscoverableEndpointsService discoverableEndpointsService;
 
     @Autowired
+    private AuthorizeService authorizeService;
+
+    @Autowired
     private ConverterService converter;
 
     @Override
@@ -85,13 +90,14 @@ public class UUIDLookupRestController implements InitializingBean {
     public void getDSObyIdentifier(HttpServletRequest request,
                                    HttpServletResponse response,
                                    @RequestParam(PARAM) UUID uuid)
-            throws IOException, SQLException, SearchServiceException {
+        throws IOException, SQLException, AuthorizeException {
 
         Context context = null;
         try {
             context = ContextUtil.obtainContext(request);
             DSpaceObject dso = dspaceObjectUtil.findDSpaceObject(context, uuid);
             if (dso != null) {
+                authorizeService.authorizeAction(context, dso, Constants.READ);
                 DSpaceObjectRest dsor = converter.toRest(dso, utils.obtainProjection());
                 URI link = linkTo(dsor.getController(), dsor.getCategory(), dsor.getTypePlural()).slash(dsor.getId())
                         .toUri();

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/UUIDLookupRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/UUIDLookupRestControllerIT.java
@@ -17,6 +17,8 @@ import java.util.UUID;
 import org.apache.commons.codec.CharEncoding;
 import org.apache.commons.io.IOUtils;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.authorize.ResourcePolicy;
+import org.dspace.authorize.service.ResourcePolicyService;
 import org.dspace.builder.BitstreamBuilder;
 import org.dspace.builder.CollectionBuilder;
 import org.dspace.builder.CommunityBuilder;
@@ -31,6 +33,7 @@ import org.dspace.content.Site;
 import org.dspace.eperson.Group;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * Integration test for the UUIDLookup endpoint
@@ -38,6 +41,9 @@ import org.junit.Test;
  * @author Andrea Bollini (andrea.bollini at 4science.it)
  */
 public class UUIDLookupRestControllerIT extends AbstractControllerIntegrationTest {
+
+    @Autowired
+    ResourcePolicyService resourcePolicyService;
 
     @Test
     /**
@@ -305,6 +311,37 @@ public class UUIDLookupRestControllerIT extends AbstractControllerIntegrationTes
     public void testMissingIdentifierParameter() throws Exception {
         getClient().perform(get("/api/dso/find"))
                         .andExpect(status().isUnprocessableEntity());
+    }
+
+    @Test
+    public void testUnauthorized() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Community community = CommunityBuilder.createCommunity(context)
+            .build();
+        for (ResourcePolicy rp : resourcePolicyService.find(context, community)) {
+            resourcePolicyService.delete(context, rp);
+        }
+        context.restoreAuthSystemState();
+
+        getClient().perform(get("/api/dso/find")
+                                .param("uuid", community.getID().toString()))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void testForbidden() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Community community = CommunityBuilder.createCommunity(context)
+            .build();
+        for (ResourcePolicy rp : resourcePolicyService.find(context, community)) {
+            resourcePolicyService.delete(context, rp);
+        }
+        context.restoreAuthSystemState();
+
+        String authToken = getAuthToken(eperson.getEmail(), password);
+        getClient(authToken).perform(get("/api/dso/find")
+                                .param("uuid", community.getID().toString()))
+            .andExpect(status().isForbidden());
     }
 
 }


### PR DESCRIPTION
## References
* Fixes #9154

## Description
Fixed a 500 error being returned by the `/api/dso/find?uuid={uuid}` endpoint when you are unauthorised/unauthenticated.

## Instructions for Reviewers
List of changes in this PR:
* Added an `AuthorizeService#authorizeAction` check to the endpoint to return the correct authorization response code

**Guidance for how to test or review this PR:**
- Create a DSpaceObject for example a community and remove the READ resource policies on `/communities/{uuid}/edit/authorizations`
- Request the community as an unauthenticated user, it should return 401
- Request the community as an regular user, it should return a 403 

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
