### PR TITLE
Fix malformed dates creating unreliable browse-by date year options

### DIFF
--- a/dspace-api/src/main/java/org/dspace/sort/OrderFormatDate.java
+++ b/dspace-api/src/main/java/org/dspace/sort/OrderFormatDate.java
@@ -7,6 +7,9 @@
  */
 package org.dspace.sort;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+
 /**
  * Standard date ordering delegate implementation. The only "special" need is
  * to treat dates with less than 4-digit year.
@@ -14,6 +17,8 @@ package org.dspace.sort;
  * @author Andrea Bollini
  */
 public class OrderFormatDate implements OrderFormatDelegate {
+    private final SimpleDateFormat yearIso = new SimpleDateFormat("yyyy");
+
     @Override
     public String makeSortString(String value, String language) {
         int padding = 0;
@@ -25,13 +30,27 @@ public class OrderFormatDate implements OrderFormatDelegate {
             padding = 4 - value.length();
         }
 
+        String newValue = value;
         if (padding > 0) {
             // padding the value from left with 0 so that 87 -> 0087, 687-11-24
             // -> 0687-11-24
-            return String.format("%1$0" + padding + "d", 0)
+            newValue = String.format("%1$0" + padding + "d", 0)
                 + value;
-        } else {
-            return value;
         }
+
+        if (isValidDate(newValue)) {
+            return newValue;
+        } else {
+            return null;
+        }
+    }
+
+    private boolean isValidDate(String value) {
+        try {
+            yearIso.parse(value);
+        } catch (ParseException e) {
+            return false;
+        }
+        return true;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/sort/OrderFormatDate.java
+++ b/dspace-api/src/main/java/org/dspace/sort/OrderFormatDate.java
@@ -21,6 +21,10 @@ public class OrderFormatDate implements OrderFormatDelegate {
 
     @Override
     public String makeSortString(String value, String language) {
+        if (!isValidDate(value)) {
+            return null;
+        }
+
         int padding = 0;
         int endYearIdx = value.indexOf('-');
 
@@ -30,18 +34,13 @@ public class OrderFormatDate implements OrderFormatDelegate {
             padding = 4 - value.length();
         }
 
-        String newValue = value;
         if (padding > 0) {
             // padding the value from left with 0 so that 87 -> 0087, 687-11-24
             // -> 0687-11-24
-            newValue = String.format("%1$0" + padding + "d", 0)
+            return String.format("%1$0" + padding + "d", 0)
                 + value;
-        }
-
-        if (isValidDate(newValue)) {
-            return newValue;
         } else {
-            return null;
+            return value;
         }
     }
 


### PR DESCRIPTION
## References
* Fixes #9944 

## Description
The solr sort-field used for browse-by indexes of type "date" has been updated to reject malformed dates (a date is considered malformed if it cannot be parsed to a year).
The sort-field missing for items with malformed date results in those items _always_ ending up at the bottom of a browse sorted by their date, meaning they cannot influence the start/end range of years.

## Instructions for Reviewers
Updated `OrderFormatDate` to return null if the value is a malformed date (cannot be parsed to a year). Returning null results in the order/sort field to not be indexed at all.

How to test:
- Create/Edit an item with dc.date.issued set to "nd" (or any String that doesn't represent a date)
- Visit browse-by page for dateissued (/browse/dateissued)
- Open the "choose year" dropdown
- It should contain years ranging from the earliest available item with a valid date to the current year, unaffected by the malformed date.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
