### PR TITLE
ItemOwningCollectionUpdateRestController: fix typo in endpoint path

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/ItemOwningCollectionUpdateRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/ItemOwningCollectionUpdateRestController.java
@@ -43,7 +43,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * This controller will handle all the incoming calls on the api/code/items/{uuid}/owningCollection endpoint
+ * This controller will handle all the incoming calls on the api/core/items/{uuid}/owningCollection endpoint
  * where the uuid corresponds to the item of which you want to edit the owning collection.
  */
 @RestController


### PR DESCRIPTION
## Description

This trivial PR fixes a typo in the description of class `ItemOwningCollectionUpdateRestController`.

