### PR TITLE
[GitHub Actions] Add a job to test Docker deployment with newly built images & test Handle Server

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -158,6 +158,12 @@ jobs:
     runs-on: ubuntu-latest
     # Must run after all major images are built
     needs: [dspace, dspace-test, dspace-cli, dspace-postgres-pgcrypto, dspace-solr]
+    env:
+      # Override defaults dspace.server.url because backend starts at http://127.0.0.1:8080
+      dspace__P__server__P__url: http://127.0.0.1:8080/server
+      # Force using "pr-testing" version of all Docker images. The "pr-testing" tag is a temporary tag that we
+      # assign to all PR-built docker images in reusabe-docker-build.yml
+      DSPACE_VER: pr-testing
     steps:
       # Checkout our codebase (to get access to Docker Compose scripts)
       - name: Checkout codebase
@@ -180,12 +186,6 @@ jobs:
           docker image ls -a
       # Start backend using our compose script in the codebase.
       - name: Start backend in Docker
-        env:
-          # Override defaults dspace.server.url because backend starts at http://127.0.0.1:8080
-          dspace__P__server__P__url: http://127.0.0.1:8080/server
-          # Force using "pr-testing" version of Docker images. The "pr-testing" tag is a temporary tag that we assign to
-          # all PR-built docker images in reusabe-docker-build.yml
-          DSPACE_VER: pr-testing
         run: |
           docker compose -f docker-compose.yml up -d
           sleep 10
@@ -214,6 +214,7 @@ jobs:
       - name: Verify Handle Server is working properly
         run: |
           docker exec -i dspace /dspace/bin/make-handle-config
+          echo "Starting Handle Server..."
           docker exec -i dspace /dspace/bin/start-handle-server
           sleep 20
           echo "Checking for errors in handle-server.log..."

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -217,6 +217,10 @@ jobs:
           echo "Starting Handle Server..."
           docker exec -i dspace /dspace/bin/start-handle-server
           sleep 20
+          echo "Checking for errors in error.log"
+          result=$(docker exec -i dspace sh -c "cat /dspace/handle-server/logs/error.log* || echo ''")
+          echo "$result"
+          echo "$result" | grep -vqz "Exception"
           echo "Checking for errors in handle-server.log..."
           result=$(docker exec -i dspace cat /dspace/log/handle-server.log)
           echo "$result"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -157,27 +157,47 @@ jobs:
     if: github.repository == 'dspace/dspace'
     runs-on: ubuntu-latest
     # Must run after all major images are built
-    needs: [dspace-test, dspace-cli, dspace-postgres-pgcrypto, dspace-solr]
+    needs: [dspace, dspace-test, dspace-cli, dspace-postgres-pgcrypto, dspace-solr]
     steps:
+      # Checkout our codebase (to get access to Docker Compose scripts)
       - name: Checkout codebase
         uses: actions/checkout@v4
-        # Start backend using our compose script in the codebase.
+      # For PRs, download Docker image artifacts (built by reusable-docker-build.yml for all PRs)
+      - name: Download Docker image artifacts (for PRs)
+        if: github.event_name == 'pull_request'
+        uses: actions/download-artifact@v4
+        with:
+          # Download all Docker images (TAR files) into the /tmp/docker directory
+          pattern: docker-image-*
+          path: /tmp/docker
+          merge-multiple: true
+      # For PRs, load each of the images into Docker by calling "docker image load" for each.
+      # This ensures we are using the images built from this PR & not the prior versions on DockerHub
+      - name: Load all downloaded Docker images (for PRs)
+        if: github.event_name == 'pull_request'
+        run: |
+          find /tmp/docker -type f -name "*.tar" -exec docker image load --input "{}" \;
+          docker image ls -a
+      # Start backend using our compose script in the codebase.
       - name: Start backend in Docker
         env:
           # Override defaults dspace.server.url because backend starts at http://127.0.0.1:8080
           dspace__P__server__P__url: http://127.0.0.1:8080/server
+          # Force using "pr-testing" version of Docker images. The "pr-testing" tag is a temporary tag that we assign to
+          # all PR-built docker images in reusabe-docker-build.yml
+          DSPACE_VER: pr-testing
         run: |
           docker compose -f docker-compose.yml up -d
           sleep 10
           docker container ls
-        # Create a test admin account. Load test data from a simple set of AIPs as defined in cli.ingest.yml
+      # Create a test admin account. Load test data from a simple set of AIPs as defined in cli.ingest.yml
       - name: Load test data into Backend
         run: |
           docker compose -f docker-compose-cli.yml run --rm dspace-cli create-administrator -e test@test.edu -f admin -l user -p admin -c en
           docker compose -f docker-compose-cli.yml -f dspace/src/main/docker-compose/cli.ingest.yml run --rm dspace-cli
-        # Verify backend started successfully.
-        # 1. Make sure root endpoint is responding (check for dspace.name defined in docker-compose.yml)
-        # 2. Also check /collections endpoint to ensure the test data loaded properly (check for a collection name in AIPs)
+      # Verify backend started successfully.
+      # 1. Make sure root endpoint is responding (check for dspace.name defined in docker-compose.yml)
+      # 2. Also check /collections endpoint to ensure the test data loaded properly (check for a collection name in AIPs)
       - name: Verify backend is responding properly
         run: |
           result=$(wget -O- -q http://127.0.0.1:8080/server/api)
@@ -204,7 +224,7 @@ jobs:
           result=$(wget -O- -q http://127.0.0.1:8000/)
           echo "$result"
           echo "$result" | grep -oE "Handle Proxy"
-        # Shutdown our containers
+      # Shutdown our containers
       - name: Shutdown Docker containers
         run: |
           docker compose -f docker-compose.yml down

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -148,3 +148,44 @@ jobs:
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_ACCESS_TOKEN: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+
+  ########################################################################
+  # Test Deployment via Docker to ensure images are working properly
+  ########################################################################
+  docker-deploy:
+    # Ensure this job never runs on forked repos. It's only executed for 'dspace/dspace'
+    if: github.repository == 'dspace/dspace'
+    runs-on: ubuntu-latest
+    # Must run after all major images are built
+    needs: [dspace-test, dspace-cli, dspace-postgres-pgcrypto, dspace-solr]
+    steps:
+      - name: Checkout codebase
+        uses: actions/checkout@v4
+        # Start backend using our compose script in the codebase.
+      - name: Start backend in Docker
+        env:
+          # Override defaults dspace.server.url because backend starts at http://127.0.0.1:8080
+          dspace__P__server__P__url: http://127.0.0.1:8080/server
+        run: |
+          docker compose -f docker-compose.yml up -d
+          sleep 10
+          docker container ls
+        # Create a test admin account. Load test data from a simple set of AIPs as defined in cli.ingest.yml
+      - name: Load test data into Backend
+        run: |
+          docker compose -f docker-compose-cli.yml run --rm dspace-cli create-administrator -e test@test.edu -f admin -l user -p admin -c en
+          docker compose -f docker-compose-cli.yml -f dspace/src/main/docker-compose/cli.ingest.yml run --rm dspace-cli
+        # Verify backend started successfully.
+        # 1. Make sure root endpoint is responding (check for dspace.name defined in docker-compose.yml)
+        # 2. Also check /collections endpoint to ensure the test data loaded properly (check for a collection name in AIPs)
+      - name: Verify backend is responding properly
+        run: |
+          result=$(wget -O- -q http://127.0.0.1:8080/server/api)
+          echo "$result"
+          echo "$result" |  grep -oE "\"DSpace Started with Docker Compose\","
+          result=$(wget -O- -q http://127.0.0.1:8080/server/api/core/collections)
+          echo "$result"
+          echo "$result" |  grep -oE "\"Dog in Yard\","
+      - name: Shutdown Docker containers
+        run: |
+          docker compose -f docker-compose.yml down

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -186,6 +186,25 @@ jobs:
           result=$(wget -O- -q http://127.0.0.1:8080/server/api/core/collections)
           echo "$result"
           echo "$result" |  grep -oE "\"Dog in Yard\","
+      # Verify Handle Server can be stared and is working properly
+      # 1. First generate the "[dspace]/handle-server" folder with the sitebndl.zip
+      # 2. Start the Handle Server (and wait 20 seconds to let it start up)
+      # 3. Verify logs do NOT include "Exception" in the text (as that means an error occurred)
+      # 4. Check that Handle Proxy HTML page is responding on default port (8000)
+      - name: Verify Handle Server is working properly
+        run: |
+          docker exec -i dspace /dspace/bin/make-handle-config
+          docker exec -i dspace /dspace/bin/start-handle-server
+          sleep 20
+          echo "Checking for errors in handle-server.log..."
+          result=$(docker exec -i dspace cat /dspace/log/handle-server.log)
+          echo "$result"
+          echo "$result" | grep -vqz "Exception"
+          echo "Checking to see if Handle Proxy webpage is available..."
+          result=$(wget -O- -q http://127.0.0.1:8000/)
+          echo "$result"
+          echo "$result" | grep -oE "Handle Proxy"
+        # Shutdown our containers
       - name: Shutdown Docker containers
         run: |
           docker compose -f docker-compose.yml down

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -113,6 +113,12 @@ jobs:
       - name: Set up QEMU emulation to build for multiple architectures
         uses: docker/setup-qemu-action@v3
 
+      #------------------------------------------------------------
+      # Build & deploy steps for new commits to a branch (non-PRs)
+      #
+      # These steps build the images, push to DockerHub, and
+      # (if necessary) redeploy demo/sandbox sites.
+      #------------------------------------------------------------
       # https://github.com/docker/login-action
       - name: Login to DockerHub
         # Only login if not a PR, as PRs only trigger a Docker build and not a push
@@ -125,6 +131,7 @@ jobs:
       # https://github.com/docker/metadata-action
       # Get Metadata for docker_build_deps step below
       - name: Sync metadata (tags, labels) from GitHub to Docker for image
+        if: ${{ ! matrix.isPr }}
         id: meta_build
         uses: docker/metadata-action@v5
         with:
@@ -133,7 +140,9 @@ jobs:
           flavor: ${{ env.TAGS_FLAVOR }}
 
       # https://github.com/docker/build-push-action
-      - name: Build and push image
+      - name: Build and push image to DockerHub
+        # Only build & push if not a PR
+        if: ${{ ! matrix.isPr }}
         id: docker_build
         uses: docker/build-push-action@v5
         with:
@@ -142,9 +151,7 @@ jobs:
           context: ${{ inputs.dockerfile_context }}
           file: ${{ inputs.dockerfile_path }}
           platforms: ${{ matrix.arch }}
-          # For pull requests, we run the Docker build (to ensure no PR changes break the build),
-          # but we ONLY do an image push to DockerHub if it's NOT a PR
-          push: ${{ ! matrix.isPr }}
+          push: true
           # Use tags / labels provided by 'docker/metadata-action' above
           tags: ${{ steps.meta_build.outputs.tags }}
           labels: ${{ steps.meta_build.outputs.labels }}
@@ -189,11 +196,54 @@ jobs:
         run: |
           curl -X POST $REDEPLOY_DEMO_URL
 
+      #-------------------------------------------------------------
+      # Build steps for PRs only
+      #
+      # These steps build the images and store as a build artifact.
+      # These artifacts can then be used by later jobs to run the
+      # brand-new images for automated testing.
+      #--------------------------------------------------------------
+      # Get Metadata for docker_build_deps step below
+      - name: Create metadata (tags, labels) for local Docker image
+        if: matrix.isPr
+        id: meta_build_pr
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          # Hardcode to use custom "pr-testing" tag because that will allow us to spin up this PR
+          # for testing in docker.yml
+          tags: pr-testing
+          flavor: ${{ env.TAGS_FLAVOR }}
+      # Build local image and stores in a TAR file in /tmp directory
+      - name: Build and push image to local image
+        if: matrix.isPr
+        uses: docker/build-push-action@v5
+        with:
+          build-contexts: |
+            ${{ inputs.dockerfile_additional_contexts }}
+          context: ${{ inputs.dockerfile_context }}
+          file: ${{ inputs.dockerfile_path }}
+          platforms: ${{ matrix.arch }}
+          tags: ${{ steps.meta_build_pr.outputs.tags }}
+          labels: ${{ steps.meta_build_pr.outputs.labels }}
+          # Export image to a local TAR file
+          outputs: type=docker,dest=/tmp/${{ inputs.build_id }}.tar
+      # Upload the local docker image (in TAR file) to a build Artifact
+      - name: Upload local image to artifact
+        if: matrix.isPr
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-image-${{ inputs.build_id }}
+          path: /tmp/${{ inputs.build_id }}.tar
+          if-no-files-found: error
+          retention-days: 1
+
   # Merge Docker digests (from various architectures) into a manifest.
   # This runs after all Docker builds complete above, and it tells hub.docker.com
   # that these builds should be all included in the manifest for this tag.
   # (e.g. AMD64 and ARM64 should be listed as options under the same tagged Docker image)
   docker-build_manifest:
+    # Only run if this is NOT a PR
     if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     needs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,11 @@ ENV DSPACE_INSTALL=/dspace
 # Copy the /dspace directory from 'ant_build' container to /dspace in this container
 COPY --from=ant_build /dspace $DSPACE_INSTALL
 WORKDIR $DSPACE_INSTALL
+# Need host command for "[dspace]/bin/make-handle-config"
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends host \
+    && apt-get purge -y --auto-remove \
+    && rm -rf /var/lib/apt/lists/*
 # Expose Tomcat port
 EXPOSE 8080
 # Give java extra memory (2GB)

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,8 +63,8 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends host \
     && apt-get purge -y --auto-remove \
     && rm -rf /var/lib/apt/lists/*
-# Expose Tomcat port
-EXPOSE 8080
+# Expose Tomcat port (8080) & Handle Server HTTP port (8000)
+EXPOSE 8080 8000
 # Give java extra memory (2GB)
 ENV JAVA_OPTS=-Xmx2000m
 # On startup, run DSpace Runnable JAR

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -57,6 +57,11 @@ ENV DSPACE_INSTALL=/dspace
 # Copy the /dspace directory from 'ant_build' container to /dspace in this container
 COPY --from=ant_build /dspace $DSPACE_INSTALL
 WORKDIR $DSPACE_INSTALL
+# Need host command for "[dspace]/bin/make-handle-config"
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends host \
+    && apt-get purge -y --auto-remove \
+    && rm -rf /var/lib/apt/lists/*
 # Expose Tomcat port and debugging port
 EXPOSE 8080 8000
 # Give java extra memory (2GB)

--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -413,6 +413,16 @@
                     <groupId>org.mortbay.jasper</groupId>
                     <artifactId>apache-jsp</artifactId>
                 </exclusion>
+                <!-- Excluded BouncyCastle dependencies because we use a later version of BouncyCastle.
+                     Having two versions of BouncyCastle in the classpath can cause Handle Server to throw errors. -->
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcpkix-jdk15on</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk15on</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -388,6 +388,13 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-orm</artifactId>
+            <exclusions>
+                <!-- Spring JCL is unnecessary and conflicts with commons-logging when both are on classpath -->
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-jcl</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/dspace-iiif/pom.xml
+++ b/dspace-iiif/pom.xml
@@ -44,6 +44,11 @@
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-starter-logging</artifactId>
                 </exclusion>
+                <!-- Spring JCL is unnecessary and conflicts with commons-logging when both are on classpath -->
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-jcl</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/dspace-oai/pom.xml
+++ b/dspace-oai/pom.xml
@@ -80,6 +80,11 @@
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-starter-logging</artifactId>
                 </exclusion>
+                <!-- Spring JCL is unnecessary and conflicts with commons-logging when both are on classpath -->
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-jcl</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/dspace-rdf/pom.xml
+++ b/dspace-rdf/pom.xml
@@ -67,6 +67,11 @@
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-starter-logging</artifactId>
                 </exclusion>
+                <!-- Spring JCL is unnecessary and conflicts with commons-logging when both are on classpath -->
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-jcl</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/dspace-server-webapp/pom.xml
+++ b/dspace-server-webapp/pom.xml
@@ -468,6 +468,11 @@
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-starter-logging</artifactId>
                 </exclusion>
+                <!-- Spring JCL is unnecessary and conflicts with commons-logging when both are on classpath -->
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-jcl</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/dspace-services/pom.xml
+++ b/dspace-services/pom.xml
@@ -90,6 +90,13 @@
             <artifactId>spring-context-support</artifactId>
             <version>${spring.version}</version>
             <scope>compile</scope>
+            <exclusions>
+                <!-- Spring JCL is unnecessary and conflicts with commons-logging when both are on classpath -->
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-jcl</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/dspace-sword/pom.xml
+++ b/dspace-sword/pom.xml
@@ -55,6 +55,11 @@
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-starter-logging</artifactId>
                 </exclusion>
+                <!-- Spring JCL is unnecessary and conflicts with commons-logging when both are on classpath -->
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-jcl</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/dspace-swordv2/pom.xml
+++ b/dspace-swordv2/pom.xml
@@ -78,6 +78,11 @@
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-starter-logging</artifactId>
                 </exclusion>
+                <!-- Spring JCL is unnecessary and conflicts with commons-logging when both are on classpath -->
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-jcl</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1155,6 +1155,13 @@
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-orm</artifactId>
                 <version>${spring.version}</version>
+                <exclusions>
+                    <!-- Spring JCL is unnecessary and conflicts with commons-logging when both are on classpath -->
+                    <exclusion>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-jcl</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.swordapp</groupId>


### PR DESCRIPTION
## Description
Enhances our GitHub actions defined in `docker.yml` to include a new `docker-deploy` action which does the following:
1. Takes the Docker images just built (by the code in a PR), and runs our `docker-compose.yml` script to spin them up as Docker Containers.
2. Runs the `cli.ingest.yml` to test a basic ingest from a set of AIPs
3. Tests the root endpoint (/server/api) and Collections endpoint (/server/api/core/collections) to ensure they seem to be working properly
4. Starts up Handle Server & performs basic tests to verify it is working.
5. Shuts down all containers.

The purpose of this code is to provide a better test that our backend will start up properly, by using existing Docker Compose scripts in GitHub actions.  This will allow us to more easily tell when simple dependency updates cause issues after deployment.

## Instructions for Reviewers

* In building this automated test of the Handle Server, a few minor dependency issues were found in our POMs.  These dependency issues resulted in errors when the Handle Server was started up in GitHub actions.
    * `spring-jcl` **must** be excluded in our dependencies, as it conflicts with `commons-logging`.  This doesn't appear to result in major errors, but it does result in a warning: `Standard Commons Logging discovery in action with spring-jcl: please remove commons-logging.jar from classpath in order to avoid potential conflicts`
        *  While the warning says to remove `commons-logging`, I removed "spring-jcl" instead simply because more of our dependencies pull in `commons-logging`.
    * Multiple versions of Bouncycastle were being included in our CLASSPATH (and in `[dspace]/lib`).  This resulted in startup errors from the Handle Server which looked like this:
        ```
        Exception in thread "main" java.lang.NoSuchFieldError: id_RSASSA_PSS_SHAKE128
	    at org.bouncycastle.operator.DefaultSignatureNameFinder.<clinit>(Unknown Source)
	    at org.bouncycastle.operator.jcajce.OperatorHelper.<clinit>(Unknown Source)
	    at org.bouncycastle.operator.jcajce.JcaContentSignerBuilder.<init>(Unknown Source)
	    at net.handle.util.X509HSCertificateGenerator.generateWithCnAndUid(X509HSCertificateGenerator.java:108)
	    at net.handle.util.X509HSCertificateGenerator.generateWithUid(X509HSCertificateGenerator.java:83)
	    at net.handle.util.X509HSCertificateGenerator.generate(X509HSCertificateGenerator.java:56)
	    at net.handle.server.HandleServer.buildCertificate(HandleServer.java:222)
	    at net.handle.server.HandleServer.initKeysAndCertsAndSignatures(HandleServer.java:522)
	    at net.handle.server.HandleServer.<init>(HandleServer.java:[36]
	    at net.handle.server.AbstractServer.getInstance(AbstractServer.java:120)
	    at net.handle.server.Main.initialize(Main.java:255)
	    at net.handle.server.Main.main(Main.java:122)
        ```
* Finally, minor changes to our existing Docker images were necessary:
    * Added `host` linux command to the `dspace` and `dspace-test` images. This command is used/required by DSpace's `make-handle-config` script.

I've tested all these changes locally, and the new automated tests in this PR also prove they work in GitHub actions.  No direct code changes to DSpace have been made.  Just minor dependency updates & minor fixes to Docker images.