### PR TITLE
Minor Dependency cleanup in POMs

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -793,11 +793,13 @@
         <dependency>
             <groupId>org.apache.velocity</groupId>
             <artifactId>velocity-engine-core</artifactId>
+            <version>2.3</version>
         </dependency>
 
         <dependency>
             <groupId>org.xmlunit</groupId>
             <artifactId>xmlunit-core</artifactId>
+            <version>2.10.0</version>
             <scope>test</scope>
         </dependency>
 
@@ -873,75 +875,4 @@
             </exclusions>
         </dependency>
     </dependencies>
-
-    <dependencyManagement>
-        <dependencies>
-          <!-- for mockserver -->
-          <!-- Solve dependency convergence issues related to Solr and
-               'mockserver-junit-rule' by selecting the versions we want to use. -->
-          <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-buffer</artifactId>
-            <version>4.1.114.Final</version>
-          </dependency>
-          <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-transport</artifactId>
-            <version>4.1.114.Final</version>
-          </dependency>
-          <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-transport-native-unix-common</artifactId>
-            <version>4.1.114.Final</version>
-           </dependency>
-          <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-common</artifactId>
-            <version>4.1.114.Final</version>
-          </dependency>
-          <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-handler</artifactId>
-            <version>4.1.114.Final</version>
-          </dependency>
-          <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec</artifactId>
-            <version>4.1.114.Final</version>
-          </dependency>
-          <dependency>
-            <groupId>org.apache.velocity</groupId>
-            <artifactId>velocity-engine-core</artifactId>
-            <version>2.3</version>
-          </dependency>
-          <dependency>
-              <groupId>org.xmlunit</groupId>
-              <artifactId>xmlunit-core</artifactId>
-              <version>2.10.0</version>
-              <scope>test</scope>
-          </dependency>
-          <dependency>
-            <groupId>com.github.java-json-tools</groupId>
-            <artifactId>json-schema-validator</artifactId>
-            <version>2.2.14</version>
-          </dependency>
-          <dependency>
-            <groupId>jakarta.validation</groupId>
-            <artifactId>jakarta.validation-api</artifactId>
-            <version>3.1.0</version>
-          </dependency>
-          <dependency>
-            <groupId>io.swagger</groupId>
-            <artifactId>swagger-core</artifactId>
-            <version>1.6.2</version>
-          </dependency>
-          <dependency>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-library</artifactId>
-            <version>2.13.11</version>
-            <scope>test</scope>
-          </dependency>
-        </dependencies>
-    </dependencyManagement>
-
 </project>

--- a/dspace/modules/server/pom.xml
+++ b/dspace/modules/server/pom.xml
@@ -27,7 +27,7 @@
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>unpack</id>
+                        <id>unpack-additions</id>
                         <phase>prepare-package</phase>
                         <goals>
                             <goal>unpack-dependencies</goal>
@@ -40,6 +40,20 @@
                             -->
                             <outputDirectory>${project.build.directory}/additions</outputDirectory>
                             <excludes>META-INF/**</excludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>unpack-server</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeScope>runtime</includeScope>
+                            <includeGroupIds>org.dspace</includeGroupIds>
+                            <includeArtifactIds>dspace-server-webapp</includeArtifactIds>
+                            <includes>**/static/**,**/*.properties</includes>
+                            <outputDirectory>${project.build.directory}/additions</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>
@@ -65,26 +79,6 @@
                 <executions>
                     <execution>
                         <phase>prepare-package</phase>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>unpack</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>unpack-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <includeScope>runtime</includeScope>
-                            <includeGroupIds>org.dspace</includeGroupIds>
-                            <includeArtifactIds>dspace-server-webapp</includeArtifactIds>
-                            <includes>**/static/**,**/*.properties</includes>
-                            <outputDirectory>${project.build.directory}/additions</outputDirectory>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
## References
* Fixes #9942
* Also relates to several `@dependabot` PRs:  #9983 and #9990

## Description
In reviewing `@dependabot` PRs #9983 and #9990, I found some unnecessary dependency management in `dspace-api`.  This removes that.  It also fixes #9942 with a minor refactor to `server/pom.xml`.

## Instructions for Reviewers
* No code changes, only dependency cleanup in POMs
* Automated tests should sufficiently verify if these changes are problematic, especially since we also do a test deploy now of the server webapp (see #9973 )