### PR TITLE
[GitHub Actions] Minor bug fix to Docker deployment builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -161,9 +161,10 @@ jobs:
     env:
       # Override defaults dspace.server.url because backend starts at http://127.0.0.1:8080
       dspace__P__server__P__url: http://127.0.0.1:8080/server
-      # Force using "pr-testing" version of all Docker images. The "pr-testing" tag is a temporary tag that we
-      # assign to all PR-built docker images in reusabe-docker-build.yml
-      DSPACE_VER: pr-testing
+      # If this is a PR, force using "pr-testing" version of all Docker images. Otherwise, for branch commits, use the
+      # "latest" tag. NOTE: the "pr-testing" tag is a temporary tag that we assign to all PR-built docker images in
+      # reusabe-docker-build.yml
+      DSPACE_VER: ${{ github.event_name == 'pull_request' && 'pr-testing' || 'latest' }}
     steps:
       # Checkout our codebase (to get access to Docker Compose scripts)
       - name: Checkout codebase


### PR DESCRIPTION
## References
* Fixes a minor bug discovered in #9973

## Description
Minor bug fix to new Docker Deployment testing.  Ensure we use "pr-testing" images for PRs, but use "latest" images for other builds (e.g. after PR is merged to a branch).

While the current code works fine for PRs, I've found it's not working properly after PRs are merged.  In that scenario, we should test deployment using the `latest` tag, as that is the Docker image that was just built after the PR was merged.

NOTE: This cannot be manually tested, as it only impacts GitHub Actions.  Assuming this does not break the PR build/testing, then I'll merge it immediately in order to complete testing for how this works _after a PR is merged_