### PR TITLE
Allow remote debugging (replacing CATALINA_OPTS with JAVA_TOOL_OPTIONS)

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -66,7 +66,7 @@ RUN apt-get update \
 EXPOSE 8080 8000
 # Give java extra memory (2GB)
 ENV JAVA_OPTS=-Xmx2000m
-# Set up debugging
-ENV CATALINA_OPTS=-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=*:8000
+# enable JVM debugging via JDWP
+ENV JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8000
 # On startup, run DSpace Runnable JAR
 ENTRYPOINT ["java", "-jar", "webapps/server-boot.jar", "--dspace.dir=$DSPACE_INSTALL"]


### PR DESCRIPTION
## Description

Currently, it is not possible to debug the DSpace 8 Java app that runs in an embedded Tomcat (in a Docker container). I've figured out that the `CATALINA_OPTS`environment variable is ignored.

This PR fixes the problem by using the `JAVA_TOOLS_OPTIONS` environment variable instead. This allows to debug the Java app remotely. 

To check the debug port (8000) is bound correctly, you can run `telnet localhost 8000` on the Docker host after the DSpace Java container has been successfully started.

Please note that `-Xrunjdwp` is deprecated (since Java 1.5) and should replaced by `-agentlib:jdwp`.
