### PR TITLE
[Port dspace-7_x] Remove unused dependencies from several modules

### DIFF
--- a/dspace-services/pom.xml
+++ b/dspace-services/pom.xml
@@ -133,10 +133,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
-            <artifactId>commons-collections4</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
             <artifactId>commons-configuration2</artifactId>
         </dependency>
         <!-- Required by Commons Configuration -->
@@ -159,6 +155,5 @@
             <artifactId>spring-boot-starter-log4j2</artifactId>
             <version>${spring-boot.version}</version>
         </dependency>
-
     </dependencies>
 </project>

--- a/dspace-sword/pom.xml
+++ b/dspace-sword/pom.xml
@@ -25,15 +25,6 @@
     </properties>
 
     <dependencies>
-
-        <!-- Leave this out for the moment, as the source is in the tree -->
-        <!--
-        <dependency>
-        <groupId>org.dspace</groupId>
-        <artifactId>sword-common</artifactId>
-        <version>1.0.0</version>
-        </dependency>-->
-
         <dependency>
             <groupId>org.dspace</groupId>
             <artifactId>dspace-api</artifactId>
@@ -66,11 +57,6 @@
                     <artifactId>spring-jcl</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>jaxen</groupId>
-            <artifactId>jaxen</artifactId>
         </dependency>
 
         <!-- additional dependencies for the sword-common code -->
@@ -106,10 +92,6 @@
             <groupId>xom</groupId>
             <artifactId>xom</artifactId>
             <version>1.3.9</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
         </dependency>
     </dependencies>
 

--- a/dspace/modules/server/pom.xml
+++ b/dspace/modules/server/pom.xml
@@ -262,11 +262,6 @@ just adding new jar in the classloader</description>
             <artifactId>dspace-server-webapp</artifactId>
             <type>war</type>
         </dependency>
-        <dependency>
-            <groupId>org.apache.solr</groupId>
-            <artifactId>solr-solrj</artifactId>
-            <version>${solr.client.version}</version>
-        </dependency>
 
         <!-- Test Dependencies -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1179,11 +1179,7 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-            <dependency>
-                <groupId>org.swordapp</groupId>
-                <artifactId>sword-common</artifactId>
-                <version>1.1</version>
-            </dependency>
+
             <!-- Explicitly Specify Latest Version of Spring -->
             <dependency>
                 <artifactId>spring-core</artifactId>
@@ -1483,14 +1479,6 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-collections4</artifactId>
                 <version>4.4</version>
-            </dependency>
-            <!-- commons-collections v3 is still required by commons-beanutils,
-                 which is required by commons-configuration. Once those are
-                 upgraded, we should remove this dependency -->
-            <dependency>
-                <groupId>commons-collections</groupId>
-                <artifactId>commons-collections</artifactId>
-                <version>3.2.2</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
## Description
Manual port of #10032 to `dspace-7_x`. 

This PR is smaller, as not all changes in #10032 can be ported to 7.x
* Not all changes to `dspace-services` POM can be ported to 7.x, as some of these dependencies **are necessary** for 7.x
* The changes to `server-boot` POM are not applicable to 7.x, as this didn't exist in 7.x