### PR TITLE
Fix "No SLF4J providers were found." issue on `main`

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -342,6 +342,14 @@
             <artifactId>log4j-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.hibernate.orm</groupId>
             <artifactId>hibernate-core</artifactId>
         </dependency>

--- a/dspace-oai/pom.xml
+++ b/dspace-oai/pom.xml
@@ -119,10 +119,6 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-        </dependency>
 
         <!-- Testing -->
         <dependency>

--- a/dspace-rdf/pom.xml
+++ b/dspace-rdf/pom.xml
@@ -85,10 +85,6 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/dspace-sword/pom.xml
+++ b/dspace-sword/pom.xml
@@ -73,10 +73,6 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>xom</groupId>

--- a/dspace-swordv2/pom.xml
+++ b/dspace-swordv2/pom.xml
@@ -91,10 +91,6 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-        </dependency>
     </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1594,6 +1594,12 @@
                 <artifactId>log4j-core</artifactId>
                 <version>${log4j.version}</version>
             </dependency>
+            <!-- This bridge ensures any logging to slf4j is sent to log4j -->
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-slf4j2-impl</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>org.apache.pdfbox</groupId>


### PR DESCRIPTION
## Description
After various dependency cleanup work on `main` and `dspace-8_x, I've realized that the following warning appears frequently in our logs:  `No SLF4J providers were found`

It appears to be the result of slf4j being used by many of our dependencies, without any implementation of slf4j appearing in our CLASSPATH.  See also https://www.slf4j.org/codes.html#noProviders

This PR now ensures the `log4j-slf4j2-impl` bridge is added to our classpath.   This bridge is an implementation of slf4j which cause any logs sent to slf4j to instead be forwarded to log4j.

Minor POM cleanup also made in this PR to ensure that bridge & `log4j-core` are included in `dspace-api` so that it is inherited to all our other modules.

## Instructions for Reviewers
* Verify tests succeed
* Verify logging still works right.  I've tested it and it does.
