### PR TITLE
[Port dspace-7_x] Fix "No SLF4J providers were found." issue on all branches

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -342,6 +342,14 @@
             <artifactId>log4j-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
                 <exclusions>

--- a/dspace-oai/pom.xml
+++ b/dspace-oai/pom.xml
@@ -120,10 +120,6 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-        </dependency>
 
         <!-- Testing -->
         <dependency>

--- a/dspace-rdf/pom.xml
+++ b/dspace-rdf/pom.xml
@@ -85,10 +85,6 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/dspace-sword/pom.xml
+++ b/dspace-sword/pom.xml
@@ -83,10 +83,6 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>xom</groupId>

--- a/dspace-swordv2/pom.xml
+++ b/dspace-swordv2/pom.xml
@@ -93,10 +93,6 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-        </dependency>
 
         <!-- Replacement for Abdera (required by sword2-server dependency). Abdera is no longer maintained
              (https://abdera.apache.org/). But Axiom FOM is backwards compatible with Abdera.

--- a/pom.xml
+++ b/pom.xml
@@ -1637,16 +1637,6 @@
                 <artifactId>slf4j-api</artifactId>
                 <version>${slf4j.version}</version>
             </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-jdk14</artifactId>
-                <version>${slf4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>log4j-over-slf4j</artifactId>
-                <version>${slf4j.version}</version>
-            </dependency>
             <!-- http://errorprone.info : used to check for common/obvious code errors during compilation -->
             <dependency>
                 <groupId>com.google.errorprone</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1570,6 +1570,12 @@
                 <artifactId>log4j-core</artifactId>
                 <version>${log4j.version}</version>
             </dependency>
+            <!-- This bridge ensures any logging to slf4j is sent to log4j -->
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-slf4j2-impl</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>org.apache.pdfbox</groupId>


### PR DESCRIPTION
## Description
Manual port of #10036 to `dspace-7_x`

This includes an extra commit which removes unused slf4j dependencies from the main POM.  This is necessary because it's bad practice to include `log4j-slf4j2-impl` and `log4j-over-slf4j`... as these two bridges are opposite.  The first forwards slf4j to log4j, and the second forwards log4j to slf4j.
