### PR TITLE
[GitHub Actions] Ensure all optional modules are enabled in our test Docker deployment

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -161,6 +161,15 @@ jobs:
     env:
       # Override defaults dspace.server.url because backend starts at http://127.0.0.1:8080
       dspace__P__server__P__url: http://127.0.0.1:8080/server
+      # Enable all optional modules / controllers for this test deployment.
+      # This helps check for errors in deploying these modules via Spring Boot
+      iiif__P__enabled: true
+      ldn__P__enabled: true
+      oai__P__enabled: true
+      rdf__P__enabled: true
+      signposting__P__enabled: true
+      sword-server__P__enabled: true
+      swordv2-server__P__enabled: true
       # If this is a PR, force using "pr-testing" version of all Docker images. Otherwise, if on main branch, use the
       # "latest" tag. Otherwise, use the branch name. NOTE: the "pr-testing" tag is a temporary tag that we assign to
       # all PR-built docker images in reusabe-docker-build.yml


### PR DESCRIPTION
## Description

I've recently run into an error on `dspace-7_x` where tests all succeed, but a simple deployment of SWORDv2 **fails**.  I've tracked down the cause of the failure (a bean that failed to load cause of a missing dependency) and will apply it to the `dspace-7_x` version of this PR.

This small PR is helping to **avoid** those scenarios in the future by enabling **all** currently optional modules / controllers in our test Docker deployment in GitHub actions.  The purpose of this PR is simply to ensure that the test deployment will attempt to initialize all these features in Spring Boot.  This will help us to locate code changes which result in *runtime* errors during deployment (e.g. beans that fail to load because a dependency is missing, or similar)

## Instructions for Reviewers
* This PR does not change DSpace code.  It just improves our test Docker deployment that is run in GitHub Actions for every PR / commit.

NOTE: When this is auto-ported to 7.x, I expect it to fail because SWORDv2 cannot currently be deployed.  I'll update that ported PR manually to fix the issue (it's a Spring bean error related to a dependency on the log4jv1 -> log4jv2 bridge removed in #10020).