### PR TITLE
Add "dspace/modules/server" customizations to "server-boot" JAR for embedded Tomcat

### DIFF
--- a/dspace/modules/server-boot/pom.xml
+++ b/dspace/modules/server-boot/pom.xml
@@ -27,6 +27,11 @@
             <artifactId>additions</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.dspace.modules</groupId>
+            <artifactId>server</artifactId>
+            <classifier>classes</classifier>
+        </dependency>
+        <dependency>
             <groupId>org.dspace</groupId>
             <artifactId>dspace-server-webapp</artifactId>
         </dependency>

--- a/dspace/modules/server/pom.xml
+++ b/dspace/modules/server/pom.xml
@@ -63,6 +63,7 @@
                 <artifactId>maven-war-plugin</artifactId>
                 <configuration>
                     <archiveClasses>false</archiveClasses>
+                    <attachClasses>true</attachClasses>
                     <!-- Filter the web.xml (needed for IDE compatibility/debugging) -->
                     <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
                     <!-- Copy any 'additions' (see m-dependency-p above) into WEB-INF/classes.

--- a/pom.xml
+++ b/pom.xml
@@ -1032,6 +1032,12 @@
                 <artifactId>additions</artifactId>
                 <version>9.0-SNAPSHOT</version>
             </dependency>
+            <dependency>
+                <groupId>org.dspace.modules</groupId>
+                <artifactId>server</artifactId>
+                <classifier>classes</classifier>
+                <version>9.0-SNAPSHOT</version>
+            </dependency>
 
             <dependency>
                 <groupId>org.dspace</groupId>


### PR DESCRIPTION
## References

* Fixes #9987 
* Related to #8797

## Description

Adjustments to POM files so that the changes in "modules/server" are 
incorporated into the JAR generated by "server-boot".

This commit adds an "attachClasses" parameter to the "maven-war-plugin" in the "dspace/modules/server/pom.xml", which generates a JAR file that can be referenced in the "dspace/modules/server-boot/pom.xml" (see <https://maven.apache.org/plugins/maven-war-plugin/war-mojo.html#attachClasses>) via

```
        <dependency>
            <groupId>org.dspace.modules</groupId>
            <artifactId>server</artifactId>
            <classifier>classes</classifier>
        </dependency>
```

The dependency is placed *before* the "dspace-server-webapp" dependency, to ensure that it overrides the classes in the "dspace-server-webapp" module. In the "server-boot.jar", the CLASSPATH is determined by the order of JARs in the "BOOT-INF/classpath.idx", which is generated based on the order of dependencies in the POM (see https://stackoverflow.com/a/67997782).

The root "pom.xml" file was modified to provide the version for "modules/server" JAR file, in keeping with how the versions of other JAR files are specified.

## Instructions for Reviewers

1) Checkout the pull request:

```
$ git clone https://github.com/DSpace/DSpace.git
$ cd DSpace
$ git fetch origin pull/10043/head:pull10043
$ git checkout pull10043
```

2) Edit the "dspace-server-webapp/src/main/java/org/dspace/app/rest/AuthenticationRestController.java" file:

```
$ vi dspace-server-webapp/src/main/java/org/dspace/app/rest/AuthenticationRestController.java
```

and add the following "System.out.println" to the beginning of the "status" method:

```
    public AuthenticationStatusResource status(HttpServletRequest request, HttpServletResponse response)
            throws SQLException {
        System.out.println("AUTHN STATUS FROM dspace-server-webapp");
        ...
```

3) Create a "dspace/modules/server/src/main/java/org/dspace/app/rest/" directory and copy the "AuthenticationRestController.java" file to it:

```
$ mkdir -p dspace/modules/server/src/main/java/org/dspace/app/rest/
$ cp dspace-server-webapp/src/main/java/org/dspace/app/rest/AuthenticationRestController.java dspace/modules/server/src/main/java/org/dspace/app/rest/
```

4) Edit the copied file:

```
$ vi dspace/modules/server/src/main/java/org/dspace/app/rest/AuthenticationRestController.java
```

and change the "System.out.println" in the "status" method to:

```
    public AuthenticationStatusResource status(HttpServletRequest request, HttpServletResponse response)
            throws SQLException {
        System.out.println("AUTHN STATUS FROM server module");
        ...
```

5) Build and run the DSpace images:

```
$ docker-compose -f docker-compose.yml -f docker-compose-cli.yml build
$ docker-compose -p d9 up -d
```

6) Follow the "dspace" Docker log in a terminal:

```
$ docker logs -f dspace
```

7) Once DSpace has started, in a web browser, go to

http://localhost:8080/server/#http://localhost:8080/server/api/authn/status

Verify that the following is printed to the log:

```
AUTHN STATUS FROM server module
```

indicating that the "AuthenticationRestController" class in "modules/server" is overriding the "AuthenticationRestController" class in the "dspace-server-webapp" module.

fixes #9987

I have not provided any unit/integrations tests, because it is not clear to me how to do so. Suggestions for doing so are welcome.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

