### PR TITLE
Add limit, offset, and total facet count to Solr query for the metadata browse index

### DIFF
--- a/dspace-api/src/main/java/org/dspace/browse/BrowseEngine.java
+++ b/dspace-api/src/main/java/org/dspace/browse/BrowseEngine.java
@@ -422,9 +422,6 @@ public class BrowseEngine {
                 }
             }
 
-            // this is the total number of results in answer to the query
-            int total = getTotalResults(true);
-
             // set the ordering field (there is only one option)
             dao.setOrderField("sort_value");
 
@@ -443,6 +440,9 @@ public class BrowseEngine {
             // assemble the offset and limit
             dao.setOffset(offset);
             dao.setLimit(scope.getResultsPerPage());
+
+            // this is the total number of results in answer to the query
+            int total = getTotalResults(true);
 
             // Holder for the results
             List<String[]> results = null;
@@ -680,32 +680,8 @@ public class BrowseEngine {
         // tell the browse query whether we are distinct
         dao.setDistinct(distinct);
 
-        // ensure that the select is set to "*"
-        String[] select = {"*"};
-        dao.setCountValues(select);
-
-        // FIXME: it would be nice to have a good way of doing this in the DAO
-        // now reset all of the fields that we don't want to have constraining
-        // our count, storing them locally to reinstate later
-        String focusField = dao.getJumpToField();
-        String focusValue = dao.getJumpToValue();
-        int limit = dao.getLimit();
-        int offset = dao.getOffset();
-
-        dao.setJumpToField(null);
-        dao.setJumpToValue(null);
-        dao.setLimit(-1);
-        dao.setOffset(-1);
-
         // perform the query and get the result
         int count = dao.doCountQuery();
-
-        // now put back the values we removed for this method
-        dao.setJumpToField(focusField);
-        dao.setJumpToValue(focusValue);
-        dao.setLimit(limit);
-        dao.setOffset(offset);
-        dao.setCountValues(null);
 
         log.debug(LogHelper.getHeader(context, "get_total_results_return", "return=" + count));
 

--- a/dspace-api/src/main/java/org/dspace/browse/SolrBrowseDAO.java
+++ b/dspace-api/src/main/java/org/dspace/browse/SolrBrowseDAO.java
@@ -13,6 +13,8 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.apache.solr.client.solrj.util.ClientUtils;
@@ -180,18 +182,33 @@ public class SolrBrowseDAO implements BrowseDAO {
             addDefaultFilterQueries(query);
             if (distinct) {
                 DiscoverFacetField dff;
+
+                // To get the number of distinct values we use the next "json.facet" query param
+                // {"entries_count": {"type":"terms","field": "<fieldName>_filter", "limit":0, "numBuckets":true}}"
+                ObjectNode jsonFacet = JsonNodeFactory.instance.objectNode();
+                ObjectNode entriesCount = JsonNodeFactory.instance.objectNode();
+                entriesCount.put("type", "terms");
+                entriesCount.put("field", facetField + "_filter");
+                entriesCount.put("limit", 0);
+                entriesCount.put("numBuckets", true);
+                jsonFacet.set("entries_count", entriesCount);
+
                 if (StringUtils.isNotBlank(startsWith)) {
                     dff = new DiscoverFacetField(facetField,
-                        DiscoveryConfigurationParameters.TYPE_TEXT, -1,
-                        DiscoveryConfigurationParameters.SORT.VALUE, startsWith);
+                        DiscoveryConfigurationParameters.TYPE_TEXT, limit,
+                        DiscoveryConfigurationParameters.SORT.VALUE, startsWith, offset);
+
+                    // Add the prefix to the json facet query
+                    entriesCount.put("prefix", startsWith);
                 } else {
                     dff = new DiscoverFacetField(facetField,
-                        DiscoveryConfigurationParameters.TYPE_TEXT, -1,
-                        DiscoveryConfigurationParameters.SORT.VALUE);
+                        DiscoveryConfigurationParameters.TYPE_TEXT, limit,
+                        DiscoveryConfigurationParameters.SORT.VALUE, offset);
                 }
                 query.addFacetField(dff);
                 query.setFacetMinCount(1);
                 query.setMaxResults(0);
+                query.addProperty("json.facet", jsonFacet.toString());
             } else {
                 query.setMaxResults(limit/* > 0 ? limit : 20*/);
                 if (offset > 0) {
@@ -248,8 +265,7 @@ public class SolrBrowseDAO implements BrowseDAO {
         DiscoverResult resp = getSolrResponse();
         int count = 0;
         if (distinct) {
-            List<FacetResult> facetResults = resp.getFacetResult(facetField);
-            count = facetResults.size();
+            count = (int) resp.getTotalEntries();
         } else {
             // we need to cast to int to respect the BrowseDAO contract...
             count = (int) resp.getTotalSearchResults();
@@ -266,8 +282,8 @@ public class SolrBrowseDAO implements BrowseDAO {
         DiscoverResult resp = getSolrResponse();
         List<FacetResult> facet = resp.getFacetResult(facetField);
         int count = doCountQuery();
-        int start = offset > 0 ? offset : 0;
-        int max = limit > 0 ? limit : count; //if negative, return everything
+        int start = 0;
+        int max = facet.size();
         List<String[]> result = new ArrayList<>();
         if (ascending) {
             for (int i = start; i < (start + max) && i < count; i++) {

--- a/dspace-api/src/main/java/org/dspace/discovery/DiscoverResult.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/DiscoverResult.java
@@ -32,6 +32,9 @@ public class DiscoverResult {
     private List<IndexableObject> indexableObjects;
     private Map<String, List<FacetResult>> facetResults;
 
+    // Total count of facet entries calculated for a metadata browsing query
+    private long totalEntries;
+
     /**
      * A map that contains all the documents sougth after, the key is a string representation of the Indexable Object
      */
@@ -62,6 +65,14 @@ public class DiscoverResult {
 
     public void setTotalSearchResults(long totalSearchResults) {
         this.totalSearchResults = totalSearchResults;
+    }
+
+    public long getTotalEntries() {
+        return totalEntries;
+    }
+
+    public void setTotalEntries(long totalEntries) {
+        this.totalEntries = totalEntries;
     }
 
     public int getStart() {

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -1055,6 +1055,8 @@ public class SolrServiceImpl implements SearchService, IndexingService {
                 }
                 //Resolve our facet field values
                 resolveFacetFields(context, query, result, skipLoadingResponse, solrQueryResponse);
+                //Add total entries count for metadata browsing
+                resolveEntriesCount(result, solrQueryResponse);
             }
             // If any stale entries are found in the current page of results,
             // we remove those stale entries and rerun the same query again.
@@ -1080,7 +1082,39 @@ public class SolrServiceImpl implements SearchService, IndexingService {
         return result;
     }
 
+    /**
+     * Stores the total count of entries for metadata index browsing. The count is calculated by the
+     * <code>json.facet</code> parameter with the following value:
+     *
+     * <pre><code>
+     * {
+     *     "entries_count": {
+     *         "type": "terms",
+     *         "field": "facetNameField_filter",
+     *         "limit": 0,
+     *         "prefix": "prefix_value",
+     *         "numBuckets": true
+     *     }
+     * }
+     * </code></pre>
+     *
+     * This value is returned in the <code>facets</code> field of the Solr response.
+     *
+     * @param result DiscoverResult object where the total entries count will be stored
+     * @param solrQueryResponse QueryResponse object containing the solr response
+     */
+    private void resolveEntriesCount(DiscoverResult result, QueryResponse solrQueryResponse) {
 
+        Object facetsObj = solrQueryResponse.getResponse().get("facets");
+        if (facetsObj instanceof NamedList) {
+            NamedList<Object> facets = (NamedList<Object>) facetsObj;
+            Object bucketsInfoObj = facets.get("entries_count");
+            if (bucketsInfoObj instanceof NamedList) {
+                NamedList<Object> bucketsInfo = (NamedList<Object>) bucketsInfoObj;
+                result.setTotalEntries((int) bucketsInfo.get("numBuckets"));
+            }
+        }
+    }
 
     private void resolveFacetFields(Context context, DiscoverQuery query, DiscoverResult result,
             boolean skipLoadingResponse, QueryResponse solrQueryResponse) throws SQLException {


### PR DESCRIPTION
## References

* Fixes #9244

## Description
This modifies the Solr query for the metadata browse index to include `limit` and `offset` parameters. Additionally, it uses the `json.facet` parameter to calculate the total number of values the query would return without applying limits. This significantly improves performance for metadata indices with a large number of values.

## Instructions for Reviewers

The current Solr query used to retrieve values for a metadata browse index does not include limits, as retrieving the total number of entries in the facet is necessary for paginating the results.

After exploring alternatives, I found that the functionality offered by the [JSON Facet API](https://solr.apache.org/guide/8_1/json-facet-api.html) makes it possible to retrieve the total number of facet entries without fetching all the data. This can be achieved by adding something like the following to the Solr query:

```
json.facet={
  "entries_count": {
    "type": "terms",
    "field": "bi_2_dis_filter",
    "limit": 0,
    "numBuckets": true
  }
}
```

This query returns the total number of entries in the `numBuckets` attribute, in a response snippet like this::

```
"facets": {
  "count": 218359,
  "entries_count": {
    "numBuckets": 157086,
    "buckets": []
  }
}
```

For example, the following query uses this approach:

http://localhost:8983/solr/search/select?f.bi_2_dis_filter.facet.limit=20&f.bi_2_dis_filter.facet.offset=0&f.bi_2_dis_filter.facet.sort=index&facet.field=bi_2_dis_filter&facet.mincount=1&facet.offset=0&facet=true&fl=search.resourcetype%2Csearch.resourceid%2Csearch.uniqueid%2Cdatabase_status&fq=(search.resourcetype%3AItem%20AND%20latestVersion%3Atrue)%20OR%20search.resourcetype%3ACollection%20OR%20search.resourcetype%3ACommunity&fq=-withdrawn%3Atrue%20AND%20-discoverable%3Afalse&fq=NOT(discoverable%3Afalse)&indent=true&json.facet=%7B%22entries_count%22%3A%7B%22type%22%3A%22terms%22%2C%22field%22%3A%22bi_2_dis_filter%22%2C%22limit%22%3A0%2C%22numBuckets%22%3Atrue%7D%7D&q.op=OR&q=*%3A*&rows=0&start=0&version=2&wt=json

With this type of query, it is no longer necessary to fetch all values, resulting in much faster responses. In a test repository with 157,082 author entries, the API query execution time dropped from 3,40 seconds to 100 ms. (request /api/discover/browses/author/entries?sort=default,ASC&page=0&size=20)

### Testing

To review, verify that the author and subject indices work correctly and accurately return the total number of values, regardless of whether filters are applied.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).