### PR TITLE
[GitHub Actions]  Ensure our Docker build process authenticates in an early step, so nothing is unauthenticated

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -105,13 +105,22 @@ jobs:
       - name: Checkout codebase
         uses: actions/checkout@v4
 
-      # https://github.com/docker/setup-buildx-action
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      # https://github.com/docker/login-action
+      - name: Login to DockerHub
+      # Only login if not a PR, as PRs only trigger a Docker build and not a push
+        if: ${{ ! matrix.isPr }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU emulation to build for multiple architectures
         uses: docker/setup-qemu-action@v3
+
+      # https://github.com/docker/setup-buildx-action
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       #------------------------------------------------------------
       # Build & deploy steps for new commits to a branch (non-PRs)
@@ -119,15 +128,6 @@ jobs:
       # These steps build the images, push to DockerHub, and
       # (if necessary) redeploy demo/sandbox sites.
       #------------------------------------------------------------
-      # https://github.com/docker/login-action
-      - name: Login to DockerHub
-        # Only login if not a PR, as PRs only trigger a Docker build and not a push
-        if: ${{ ! matrix.isPr }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
-
       # https://github.com/docker/metadata-action
       # Get Metadata for docker_build_deps step below
       - name: Sync metadata (tags, labels) from GitHub to Docker for image
@@ -257,6 +257,12 @@ jobs:
           pattern: digests-${{ inputs.build_id }}-*
           merge-multiple: true
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -267,12 +273,6 @@ jobs:
           images: ${{ env.IMAGE_NAME }}
           tags: ${{ env.IMAGE_TAGS }}
           flavor: ${{ env.TAGS_FLAVOR }}
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
       - name: Create manifest list from digests and push
         working-directory: /tmp/digests


### PR DESCRIPTION
## Description
Minor update to our `reusable-docker-build.yml` GitHub Action:
- Ensure login occurs *before* setup-buildx, as some buildx commands appear to be unauthenticated.

This just reorders a few steps in our build to ensure the login-action step occurs earlier (so that all steps are authenticated). This ordering update is based on the samples at https://docs.docker.com/build/ci/github-actions/multi-platform/

