### PR TITLE
Disable DTD parsing to avoid XXEs

### DIFF
--- a/dspace-api/src/main/java/org/dspace/administer/RegistryLoader.java
+++ b/dspace-api/src/main/java/org/dspace/administer/RegistryLoader.java
@@ -210,8 +210,11 @@ public class RegistryLoader {
      */
     private static Document loadXML(String filename) throws IOException,
         ParserConfigurationException, SAXException {
-        DocumentBuilder builder = DocumentBuilderFactory.newInstance()
-                                                        .newDocumentBuilder();
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        // disallow DTD parsing to ensure no XXE attacks can occur.
+        // See https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        DocumentBuilder builder = factory.newDocumentBuilder();
 
         return builder.parse(new File(filename));
     }

--- a/dspace-api/src/main/java/org/dspace/administer/StructBuilder.java
+++ b/dspace-api/src/main/java/org/dspace/administer/StructBuilder.java
@@ -613,8 +613,11 @@ public class StructBuilder {
      */
     private static org.w3c.dom.Document loadXML(InputStream input)
         throws IOException, ParserConfigurationException, SAXException {
-        DocumentBuilder builder = DocumentBuilderFactory.newInstance()
-                                                        .newDocumentBuilder();
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        // disallow DTD parsing to ensure no XXE attacks can occur.
+        // See https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        DocumentBuilder builder = factory.newDocumentBuilder();
 
         org.w3c.dom.Document document = builder.parse(input);
 

--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
@@ -1888,8 +1888,11 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
      */
     protected Document loadXML(String filename) throws IOException,
         ParserConfigurationException, SAXException {
-        DocumentBuilder builder = DocumentBuilderFactory.newInstance()
-                                                        .newDocumentBuilder();
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        // disallow DTD parsing to ensure no XXE attacks can occur.
+        // See https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        DocumentBuilder builder = factory.newDocumentBuilder();
 
         return builder.parse(new File(filename));
     }

--- a/dspace-api/src/main/java/org/dspace/app/itemupdate/ItemArchive.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemupdate/ItemArchive.java
@@ -128,8 +128,12 @@ public class ItemArchive {
 
     protected static DocumentBuilder getDocumentBuilder()
         throws ParserConfigurationException {
-        if (builder == null) {
-            builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+        if (builder == null) {    
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            // disallow DTD parsing to ensure no XXE attacks can occur.
+            // See https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            builder = factory.newDocumentBuilder();
         }
         return builder;
     }

--- a/dspace-api/src/main/java/org/dspace/app/util/DCInputsReader.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/DCInputsReader.java
@@ -125,6 +125,9 @@ public class DCInputsReader {
             factory.setValidating(false);
             factory.setIgnoringComments(true);
             factory.setIgnoringElementContentWhitespace(true);
+            // disallow DTD parsing to ensure no XXE attacks can occur.
+            // See https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
 
             DocumentBuilder db = factory.newDocumentBuilder();
             Document doc = db.parse(uri);

--- a/dspace-api/src/main/java/org/dspace/app/util/InitializeEntities.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/InitializeEntities.java
@@ -106,6 +106,9 @@ public class InitializeEntities {
         try {
             File fXmlFile = new File(fileLocation);
             DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+            // disallow DTD parsing to ensure no XXE attacks can occur.
+            // See https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html
+            dbFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
             DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
             Document doc = dBuilder.parse(fXmlFile);
 

--- a/dspace-api/src/main/java/org/dspace/app/util/SubmissionConfigReader.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/SubmissionConfigReader.java
@@ -175,6 +175,9 @@ public class SubmissionConfigReader {
             factory.setValidating(false);
             factory.setIgnoringComments(true);
             factory.setIgnoringElementContentWhitespace(true);
+            // disallow DTD parsing to ensure no XXE attacks can occur.
+            // See https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
 
             DocumentBuilder db = factory.newDocumentBuilder();
             Document doc = db.parse(uri);

--- a/dspace-api/src/main/java/org/dspace/content/packager/RoleIngester.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/RoleIngester.java
@@ -422,6 +422,9 @@ public class RoleIngester implements PackageIngester {
             DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
             dbf.setIgnoringComments(true);
             dbf.setCoalescing(true);
+            // disallow DTD parsing to ensure no XXE attacks can occur.
+            // See https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
             DocumentBuilder db = dbf.newDocumentBuilder();
             document = db.parse(pkgFile);
         } catch (ParserConfigurationException e) {


### PR DESCRIPTION
## References
Fixes a number of potential XXE vulnerabilities in the codebase. . The related changes can be referenced in  #8854 .

The risk of exploiting these vulnerabilities is considered very low, as some of the content originates from configuration settings. However, following the principle of least privilege, it is advisable to disable DTD if it does not impact functionality.

## Description
The patch directly implements the code from #8854 , which is based on the OWASP cheat sheet.
https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html

## Instructions for Reviewers
* Review code changes
* Check if there are any test failures.
* Determine if there are any XML files that require support for external entity parsing.

List of changes in this PR:
* RegistryLoader
* StructBuilder
* ItemImportServiceImpl
* ItemArchive
* DCInputsReader
* InitializeEntities
* SubmissionConfigReader
* RoleIngester 
