### PR TITLE
Use a readonly context for some GET API request

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authorize/AuthorizeServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/AuthorizeServiceImpl.java
@@ -246,9 +246,16 @@ public class AuthorizeServiceImpl implements AuthorizeService {
         }
 
         // If authorization was given before and cached
-        Boolean cachedResult = c.getCachedAuthorizationResult(o, action, e);
-        if (cachedResult != null) {
-            return cachedResult;
+        if (useInheritance) {
+            Boolean cachedResult = c.getCachedAuthorizationResultWithInheritance(o, action, e);
+            if (cachedResult != null) {
+                return cachedResult;
+            }
+        } else {
+            Boolean cachedResult = c.getCachedAuthorizationResult(o, action, e);
+            if (cachedResult != null) {
+                return cachedResult;
+            }
         }
 
         // is eperson set? if not, userToCheck = null (anonymous)
@@ -305,7 +312,7 @@ public class AuthorizeServiceImpl implements AuthorizeService {
             // check policies for date validity
             if (resourcePolicyService.isDateValid(rp)) {
                 if (rp.getEPerson() != null && rp.getEPerson().equals(userToCheck)) {
-                    c.cacheAuthorizedAction(o, action, e, true, rp);
+                    c.cacheAuthorizedAction(o, action, e, true, false, rp);
                     return true; // match
                 }
 
@@ -313,7 +320,7 @@ public class AuthorizeServiceImpl implements AuthorizeService {
                     && groupService.isMember(c, e, rp.getGroup())) {
                     // group was set, and eperson is a member
                     // of that group
-                    c.cacheAuthorizedAction(o, action, e, true, rp);
+                    c.cacheAuthorizedAction(o, action, e, true, false, rp);
                     return true;
                 }
             }
@@ -331,12 +338,12 @@ public class AuthorizeServiceImpl implements AuthorizeService {
                                                                       .getAdminObject(c, o, action) : null;
 
             if (isAdmin(c, e, adminObject)) {
-                c.cacheAuthorizedAction(o, action, e, true, null);
+                c.cacheAuthorizedAction(o, action, e, true, useInheritance, null);
                 return true;
             }
         }
         // default authorization is denial
-        c.cacheAuthorizedAction(o, action, e, false, null);
+        c.cacheAuthorizedAction(o, action, e, false, useInheritance, null);
         return false;
     }
 
@@ -376,7 +383,7 @@ public class AuthorizeServiceImpl implements AuthorizeService {
             return false;
         }
 
-        Boolean cachedResult = c.getCachedAuthorizationResult(o, Constants.ADMIN, e);
+        Boolean cachedResult = c.getCachedAuthorizationResultWithInheritance(o, Constants.ADMIN, e);
         if (cachedResult != null) {
             return cachedResult;
         }
@@ -390,7 +397,7 @@ public class AuthorizeServiceImpl implements AuthorizeService {
             // check policies for date validity
             if (resourcePolicyService.isDateValid(rp)) {
                 if (rp.getEPerson() != null && rp.getEPerson().equals(e)) {
-                    c.cacheAuthorizedAction(o, Constants.ADMIN, e, true, rp);
+                    c.cacheAuthorizedAction(o, Constants.ADMIN, e, true, false, rp);
                     return true; // match
                 }
 
@@ -398,7 +405,7 @@ public class AuthorizeServiceImpl implements AuthorizeService {
                     && groupService.isMember(c, e, rp.getGroup())) {
                     // group was set, and eperson is a member
                     // of that group
-                    c.cacheAuthorizedAction(o, Constants.ADMIN, e, true, rp);
+                    c.cacheAuthorizedAction(o, Constants.ADMIN, e, true, false, rp);
                     return true;
                 }
             }
@@ -410,6 +417,9 @@ public class AuthorizeServiceImpl implements AuthorizeService {
             }
         }
 
+        // Without inheritance, there are no admin permissions on this object
+        c.cacheAuthorizedAction(o, Constants.ADMIN, e, false, false, null);
+
         // If user doesn't have specific Admin permissions on this object,
         // check the *parent* objects of this object.  This allows Admin
         // permissions to be inherited automatically (e.g. Admin on Community
@@ -417,11 +427,11 @@ public class AuthorizeServiceImpl implements AuthorizeService {
         DSpaceObject parent = serviceFactory.getDSpaceObjectService(o).getParentObject(c, o);
         if (parent != null) {
             boolean admin = isAdmin(c, e, parent);
-            c.cacheAuthorizedAction(o, Constants.ADMIN, e, admin, null);
+            c.cacheAuthorizedAction(o, Constants.ADMIN, e, admin, true, null);
             return admin;
         }
 
-        c.cacheAuthorizedAction(o, Constants.ADMIN, e, false, null);
+        c.cacheAuthorizedAction(o, Constants.ADMIN, e, false, true, null);
         return false;
     }
 

--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -664,6 +664,10 @@ public class Context implements AutoCloseable {
      * @param groupID UUID of group
      */
     public void setSpecialGroup(UUID groupID) {
+        if (isReadOnly()) {
+            // Clear the cache to prevent any inconsistencies
+            readOnlyCache.clear();
+        }
         specialGroups.add(groupID);
     }
 

--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -906,10 +906,25 @@ public class Context implements AutoCloseable {
         }
     }
 
-    public void cacheAuthorizedAction(DSpaceObject dspaceObject, int action, EPerson eperson, Boolean result,
-                                      ResourcePolicy rp) {
+    public Boolean getCachedAuthorizationResultWithInheritance(DSpaceObject dspaceObject, int action, EPerson eperson) {
         if (isReadOnly()) {
-            readOnlyCache.cacheAuthorizedAction(dspaceObject, action, eperson, result);
+            return readOnlyCache.getCachedAuthorizationResultWithInheritance(dspaceObject, action, eperson);
+        } else {
+            return null;
+        }
+    }
+
+    public void cacheAuthorizedAction(DSpaceObject dspaceObject, int action, EPerson eperson, Boolean result,
+                                      boolean useInheritance, ResourcePolicy rp) {
+        if (isReadOnly()) {
+            if (useInheritance) {
+                readOnlyCache.cacheAuthorizedActionWithInheritance(dspaceObject, action, eperson, result);
+            } else {
+                readOnlyCache.cacheAuthorizedAction(dspaceObject, action, eperson, result);
+                if (result) {
+                    readOnlyCache.cacheAuthorizedActionWithInheritance(dspaceObject, action, eperson, result);
+                }
+            }
             try {
                 uncacheEntity(rp);
             } catch (SQLException e) {

--- a/dspace-api/src/main/java/org/dspace/core/ContextReadOnlyCache.java
+++ b/dspace-api/src/main/java/org/dspace/core/ContextReadOnlyCache.java
@@ -31,6 +31,14 @@ public class ContextReadOnlyCache {
     private final HashMap<Triple<String, Integer, String>, Boolean> authorizedActionsCache = new HashMap<>();
 
     /**
+     * Authorized actions cache that is used when the context is in READ_ONLY mode and the authorization could be
+     * inherited.
+     * The key of the cache is: DSpace Object ID, action ID, Eperson ID.
+     */
+    private final HashMap<Triple<String, Integer, String>, Boolean> authorizedActionsWithInheritanceCache =
+        new HashMap<>();
+
+    /**
      * Group membership cache that is used when the context is in READ_ONLY mode.
      * The key of the cache is: Group Name, Eperson ID.
      */
@@ -45,8 +53,17 @@ public class ContextReadOnlyCache {
         return authorizedActionsCache.get(buildAuthorizedActionKey(dspaceObject, action, eperson));
     }
 
+    public Boolean getCachedAuthorizationResultWithInheritance(DSpaceObject dspaceObject, int action, EPerson eperson) {
+        return authorizedActionsWithInheritanceCache.get(buildAuthorizedActionKey(dspaceObject, action, eperson));
+    }
+
     public void cacheAuthorizedAction(DSpaceObject dspaceObject, int action, EPerson eperson, Boolean result) {
         authorizedActionsCache.put(buildAuthorizedActionKey(dspaceObject, action, eperson), result);
+    }
+
+    public void cacheAuthorizedActionWithInheritance(DSpaceObject dspaceObject, int action, EPerson eperson,
+                                                     Boolean result) {
+        authorizedActionsWithInheritanceCache.put(buildAuthorizedActionKey(dspaceObject, action, eperson), result);
     }
 
     public Boolean getCachedGroupMembership(Group group, EPerson eperson) {
@@ -81,6 +98,7 @@ public class ContextReadOnlyCache {
 
     public void clear() {
         authorizedActionsCache.clear();
+        authorizedActionsWithInheritanceCache.clear();
         groupMembershipCache.clear();
         allMemberGroupsCache.clear();
     }

--- a/dspace-api/src/test/java/org/dspace/authorize/AuthorizationCacheIT.java
+++ b/dspace-api/src/test/java/org/dspace/authorize/AuthorizationCacheIT.java
@@ -1,0 +1,175 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.authorize;
+
+import java.sql.SQLException;
+
+import org.dspace.AbstractIntegrationTestWithDatabase;
+import org.dspace.authorize.factory.AuthorizeServiceFactory;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.ItemBuilder;
+import org.dspace.content.Collection;
+import org.dspace.content.Item;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+import org.dspace.eperson.Group;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * Integration test to test the authorization cache used with ReadOnly Context
+ */
+public class AuthorizationCacheIT extends AbstractIntegrationTestWithDatabase {
+
+    AuthorizeService authorizeService = AuthorizeServiceFactory.getInstance().getAuthorizeService();
+
+    @Test
+    public void testCachedAuthorizationAfterAddSpecialGroupWithReadOnlyContext() throws Exception {
+
+        context.turnOffAuthorisationSystem();
+
+        // First disable the index consumer. The indexing process calls the authorizeService
+        // function used in this test and may affect the test
+        context.setDispatcher("noindex");
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .withAdminGroup(admin)
+            .build();
+        context.restoreAuthSystemState();
+
+        context.setCurrentUser(eperson);
+
+        context.setMode(Context.Mode.READ_ONLY);
+
+        // check if the user is a community admin, this should cache the response
+        Assert.assertFalse("Should not be a community admin",
+            authorizeService.authorizeActionBoolean(context, parentCommunity,
+                Constants.ADMIN, false));
+
+        Group adminGroup = parentCommunity.getAdministrators();
+
+        // Add a special group to the current user, this should invalidate the cached response
+        context.setSpecialGroup(adminGroup.getID());
+
+        // check if the user is a community admin, this could return the cached response
+        // if the cache is not invalidated
+        Assert.assertTrue("Should be a community admin because of the special group",
+            authorizeService.authorizeActionBoolean(context, parentCommunity,
+                Constants.ADMIN, false));
+
+    }
+
+    @Test
+    public void testCachedAuthorizationWihInheritanceWithReadOnlyContext() throws SQLException, AuthorizeException {
+
+        context.turnOffAuthorisationSystem();
+
+        // First disable the index consumer. The indexing process calls the authorizeService
+        // function used in this test and may affect the test
+        context.setDispatcher("noindex");
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .withAdminGroup(eperson)
+            .build();
+
+        Collection col = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Collection")
+            .build();
+
+        Item item = ItemBuilder.createItem(context, col)
+            .withTitle("Item")
+            .build();
+
+        context.restoreAuthSystemState();
+
+        context.setCurrentUser(eperson);
+
+        context.setMode(Context.Mode.READ_ONLY);
+
+        // Do a first request to cache the authorization result with inheritance
+        authorizeService.authorizeActionBoolean(context, eperson, item, Constants.WRITE, true);
+
+        Assert.assertFalse("Should return false without inheritance",
+            authorizeService.authorizeActionBoolean(context, eperson, item, Constants.WRITE, false));
+        Assert.assertFalse("Should return false without inheritance",
+            authorizeService.authorizeActionBoolean(context, eperson, col, Constants.ADMIN, false));
+        Assert.assertTrue("Should return true without inheritance",
+            authorizeService.authorizeActionBoolean(context, eperson, parentCommunity, Constants.ADMIN, false));
+
+    }
+
+    @Ignore
+    @Test
+    public void testValuesCachedAuthorizationWihInheritanceWithReadOnlyContext()
+        throws SQLException, AuthorizeException {
+
+        context.turnOffAuthorisationSystem();
+
+        // First disable the index consumer. The indexing process calls the authorizeService
+        // function used in this test and may affect the test
+        context.setDispatcher("noindex");
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .withAdminGroup(eperson)
+            .build();
+
+        Collection col = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Collection")
+            .build();
+
+        Item item = ItemBuilder.createItem(context, col)
+            .withTitle("Item")
+            .build();
+
+        context.restoreAuthSystemState();
+
+        context.setCurrentUser(eperson);
+
+        context.setMode(Context.Mode.READ_ONLY);
+
+        // Do a first request to cache the authorization result without inheritance
+        authorizeService.authorizeActionBoolean(context, eperson, item, Constants.WRITE, false);
+
+        Assert.assertFalse("Should return a cached response false",
+            context.getCachedAuthorizationResult(item, Constants.WRITE, eperson));
+        Assert.assertNull("Should not be cached the admin permission",
+            context.getCachedAuthorizationResult(col, Constants.ADMIN, eperson));
+        Assert.assertNull("Should not be cached the admin permission",
+            context.getCachedAuthorizationResult(parentCommunity, Constants.ADMIN, eperson));
+
+        //Change context mode to clear cache
+        context.setMode(Context.Mode.READ_WRITE);
+        context.setMode(Context.Mode.READ_ONLY);
+
+        // Do a second request to cache the authorization result with inheritance
+        authorizeService.authorizeActionBoolean(context, eperson, item, Constants.WRITE, true);
+
+        // Test cache without inheritance
+        Assert.assertFalse("Should return a cached response false without inheritance",
+            context.getCachedAuthorizationResult(item, Constants.WRITE, eperson));
+        Assert.assertFalse("Should return a cached response false for collection without inheritance",
+            context.getCachedAuthorizationResult(col, Constants.ADMIN, eperson));
+        Assert.assertTrue("Should return a cached response true for parentCommunity without inheritance",
+            context.getCachedAuthorizationResult(parentCommunity, Constants.ADMIN, eperson));
+
+        // Test cache with inheritance
+        Assert.assertTrue("Should return a cached response true with inheritance",
+            context.getCachedAuthorizationResultWithInheritance(item, Constants.WRITE, eperson));
+        Assert.assertTrue("Should return a cached response true for collection with inheritance",
+            context.getCachedAuthorizationResultWithInheritance(col, Constants.ADMIN, eperson));
+        Assert.assertTrue("Should return a cached response true for parentCommunity with inheritance",
+            context.getCachedAuthorizationResultWithInheritance(parentCommunity, Constants.ADMIN, eperson));
+    }
+
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/AbstractDSpaceRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/AbstractDSpaceRestRepository.java
@@ -37,6 +37,10 @@ public abstract class AbstractDSpaceRestRepository {
         return ContextUtil.obtainCurrentRequestContext();
     }
 
+    protected Context obtainReadOnlyContext() {
+        return ContextUtil.obtainCurrentRequestContextAsReadOnly();
+    }
+
     public RequestService getRequestService() {
         return requestService;
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BrowseEntryLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BrowseEntryLinkRepository.java
@@ -65,7 +65,7 @@ public class BrowseEntryLinkRepository extends AbstractDSpaceRestRepository
         }
 
 
-        Context context = obtainContext();
+        Context context = obtainReadOnlyContext();
         BrowseEngine be = new BrowseEngine(context);
         BrowserScope bs = new BrowserScope(context);
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BrowseItemLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BrowseItemLinkRepository.java
@@ -64,7 +64,7 @@ public class BrowseItemLinkRepository extends AbstractDSpaceRestRepository
             filterAuthority = request.getParameter("filterAuthority");
             startsWith = request.getParameter("startsWith");
         }
-        Context context = obtainContext();
+        Context context = obtainReadOnlyContext();
         BrowseEngine be = new BrowseEngine(context);
         BrowserScope bs = new BrowserScope(context);
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BundleBitstreamLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BundleBitstreamLinkRepository.java
@@ -45,7 +45,7 @@ public class BundleBitstreamLinkRepository extends AbstractDSpaceRestRepository
                                              @Nullable Pageable optionalPageable,
                                              Projection projection) {
         try {
-            Context context = obtainContext();
+            Context context = obtainReadOnlyContext();
             Bundle bundle = bundleService.find(context, bundleId);
             if (bundle == null) {
                 throw new ResourceNotFoundException("No such bundle: " + bundleId);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CollectionMappedItemLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CollectionMappedItemLinkRepository.java
@@ -48,7 +48,7 @@ public class CollectionMappedItemLinkRepository extends AbstractDSpaceRestReposi
                                          @Nullable Pageable optionalPageable,
                                          Projection projection) {
         try {
-            Context context = obtainContext();
+            Context context = obtainReadOnlyContext();
             Collection collection = collectionService.find(context, collectionId);
             if (collection == null) {
                 throw new ResourceNotFoundException("No such collection: " + collectionId);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CommunityCollectionLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CommunityCollectionLinkRepository.java
@@ -56,7 +56,7 @@ public class CommunityCollectionLinkRepository extends AbstractDSpaceRestReposit
                                                @Nullable Pageable optionalPageable,
                                                Projection projection) {
         try {
-            Context context = obtainContext();
+            Context context = obtainReadOnlyContext();
             Community community = communityService.find(context, communityId);
             if (community == null) {
                 throw new ResourceNotFoundException("No such community: " + communityId);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CommunityRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CommunityRestRepository.java
@@ -195,7 +195,7 @@ public class CommunityRestRepository extends DSpaceObjectRestRepository<Communit
     @SearchRestMethod(name = "top")
     public Page<CommunityRest> findAllTop(Pageable pageable) {
         try {
-            Context context = obtainContext();
+            Context context = obtainReadOnlyContext();
             List<Community> topLevelCommunities = new LinkedList<Community>();
             DiscoverQuery discoverQuery = new DiscoverQuery();
             discoverQuery.setQuery("*:*");

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CommunitySubcommunityLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CommunitySubcommunityLinkRepository.java
@@ -54,7 +54,7 @@ public class CommunitySubcommunityLinkRepository extends AbstractDSpaceRestRepos
                                                  @Nullable Pageable optionalPageable,
                                                  Projection projection) {
         try {
-            Context context = obtainContext();
+            Context context = obtainReadOnlyContext();
             Community community = communityService.find(context, communityId);
             if (community == null) {
                 throw new ResourceNotFoundException("No such community: " + communityId);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/DiscoveryRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/DiscoveryRestRepository.java
@@ -93,7 +93,7 @@ public class DiscoveryRestRepository extends AbstractDSpaceRestRepository {
                                               final String configuration,
                                               final List<SearchFilter> searchFilters, final Pageable page,
                                               final Projection projection) {
-        Context context = obtainContext();
+        Context context = obtainReadOnlyContext();
         IndexableObject scopeObject = scopeResolver.resolveScope(context, dsoScope);
         DiscoveryConfiguration discoveryConfiguration = searchConfigurationService
             .getDiscoveryConfigurationByNameOrIndexableObject(context, configuration, scopeObject);
@@ -134,7 +134,7 @@ public class DiscoveryRestRepository extends AbstractDSpaceRestRepository {
             String dsoScope, final String configuration, List<SearchFilter> searchFilters, Pageable page)
                     throws SearchServiceException {
 
-        Context context = obtainContext();
+        Context context = obtainReadOnlyContext();
 
         IndexableObject scopeObject = scopeResolver.resolveScope(context, dsoScope);
         DiscoveryConfiguration discoveryConfiguration = searchConfigurationService
@@ -153,7 +153,7 @@ public class DiscoveryRestRepository extends AbstractDSpaceRestRepository {
     public SearchResultsRest getAllFacets(String query, List<String> dsoTypes, String dsoScope, String configuration,
                                           List<SearchFilter> searchFilters) {
 
-        Context context = obtainContext();
+        Context context = obtainReadOnlyContext();
         Pageable page = PageRequest.of(1, 1);
         IndexableObject scopeObject = scopeResolver.resolveScope(context, dsoScope);
         DiscoveryConfiguration discoveryConfiguration = searchConfigurationService

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ItemBundleLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ItemBundleLinkRepository.java
@@ -41,7 +41,7 @@ public class ItemBundleLinkRepository extends AbstractDSpaceRestRepository
                                        @Nullable Pageable optionalPageable,
                                        Projection projection) {
         try {
-            Context context = obtainContext();
+            Context context = obtainReadOnlyContext();
             Item item = itemService.find(context, itemId);
             if (item == null) {
                 throw new ResourceNotFoundException("No such item: " + itemId);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ItemRelationshipLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ItemRelationshipLinkRepository.java
@@ -47,7 +47,7 @@ public class ItemRelationshipLinkRepository extends AbstractDSpaceRestRepository
                                                    @Nullable Pageable optionalPageable,
                                                    Projection projection) {
         try {
-            Context context = obtainContext();
+            Context context = obtainReadOnlyContext();
             Item item = itemService.find(context, itemId);
             if (item == null) {
                 throw new ResourceNotFoundException("No such item: " + itemId);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/ContextUtil.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/ContextUtil.java
@@ -106,6 +106,30 @@ public class ContextUtil {
         return context;
     }
 
+    /**
+     * Similar to {@link #obtainCurrentRequestContext()} but returns a READ_ONLY context if the current
+     * request is a GET
+     *
+     * @return the DSpace Context associated with the current thread-bound request in READ_ONLY mode
+     * if the request is a GET
+     */
+    public static Context obtainCurrentRequestContextAsReadOnly() {
+        Context context = null;
+        RequestService requestService = new DSpace().getRequestService();
+        Request currentRequest = requestService.getCurrentRequest();
+        if (currentRequest != null) {
+            context = ContextUtil.obtainContext(currentRequest.getHttpServletRequest());
+            // Only set the context to READ_ONLY if this is a GET request
+            if (currentRequest.getHttpServletRequest().getMethod().equals("GET")) {
+                if (context != null && !context.isReadOnly()) {
+                    context.setMode(Context.Mode.READ_ONLY);
+                }
+            }
+        }
+
+        return context;
+    }
+
     private static Locale getLocale(Context context, HttpServletRequest request) {
         Locale userLocale = null;
         Locale supportedLocale = null;


### PR DESCRIPTION
## Description

Modification to use a readonly context for certain GET requests. Using a readonly context can significantly improve performance for request that use many database entities, primarily because Hibernate's MANUAL flush mode is used, which avoids many checks to determine whether an automatic flush is required.

In addition to the main commit (the last one), two commits are included to fix cache-related issues discovered during testing and another to add a test to demonstrate these bugs:

1. Clear the cache when a special group is added, as it may modify cached permissions.
2. Fix the use of the authorization cache when the parameter controlling whether or not to inherit permissions from the parent object is used. Currently, this parameter is not taken into account, which can lead to errors when retrieving cached permissions.

## Instructions for Reviewers

Based on the tests I've conducted, it should be safe to use this readonly context, as most GET requests do not modify the database. The only exception I’ve observed is for authentication-related requests.

This PR only changes the context mode for certain queries. It should notably improve performance for search or navigation requests that return many items, or when querying with a local administrator, which may require additional permission checks. I’ve tested another modification that I will submit in a separate PR, applying the change more broadly to all GET requests except those related to authentication (#10077).

To test it, verify that performance improves when performing searches or browsing through lists that return many records and check that these changes do not affect normal functionality during editing.

To provide an example of the improvement, I include response times for some calls, mainly to search or browsing endpoints, with times before and after applying the change.

For search endpoint:

```bash
$ time curl -s -o /dev/null  'http://localhost:8080/server/api/discover/search/objects?sort=score,DESC&page=0&size=10&embed=thumbnail&embed=item/thumbnail'
With patch: 	real	0m0,218s
Without patch: 	real	0m0,586s

$ time curl -s -o /dev/null 'http://localhost:8080/server/api/discover/search/objects?sort=score,DESC&page=0&size=100&embed=thumbnail&embed=item/thumbnail'
With patch: 	real	0m2,456s
Without patch: 	real	0m16,310s
```

For title browse endpoint:

```bash
$ time curl -s -o /dev/null 'http://localhost:8080/server/api/discover/browses/title/items?sort=dc.title,ASC&page=0&size=20&embed=thumbnail'
With patch: 	real	0m0,229s
Without patch: 	real	0m0,818s

$ time curl -s -o /dev/null 'http://localhost:8080/server/api/discover/browses/title/items?sort=dc.title,ASC&page=0&size=100&embed=thumbnail'
With patch: 	real	0m0,729s
Without patch: 	real	0m15,978s

$ time curl -s -o /dev/null 'http://localhost:8080/server/api/discover/browses/title/items?sort=dc.title,ASC&page=0&size=1000&embed=thumbnail'
With patch: 	real	0m16,157s
Without patch: 	real	23m6,786s
```

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
