### PR TITLE
[GitHub Actions] Ensure we always do a test Docker deployment from the locally created images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -149,9 +149,9 @@ jobs:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_ACCESS_TOKEN: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
-  ########################################################################
-  # Test Deployment via Docker to ensure images are working properly
-  ########################################################################
+  #################################################################################
+  # Test Deployment via Docker to ensure newly built images are working properly
+  #################################################################################
   docker-deploy:
     # Ensure this job never runs on forked repos. It's only executed for 'dspace/dspace'
     if: github.repository == 'dspace/dspace'
@@ -172,25 +172,23 @@ jobs:
       swordv2__D__server__P__enabled: true
       # If this is a PR, force using "pr-testing" version of all Docker images. Otherwise, if on main branch, use the
       # "latest" tag. Otherwise, use the branch name. NOTE: the "pr-testing" tag is a temporary tag that we assign to
-      # all PR-built docker images in reusabe-docker-build.yml
+      # all PR-built docker images in reusable-docker-build.yml
       DSPACE_VER: ${{ (github.event_name == 'pull_request' && 'pr-testing') || (github.ref_name == github.event.repository.default_branch && 'latest') || github.ref_name }}
     steps:
       # Checkout our codebase (to get access to Docker Compose scripts)
       - name: Checkout codebase
         uses: actions/checkout@v4
-      # For PRs, download Docker image artifacts (built by reusable-docker-build.yml for all PRs)
-      - name: Download Docker image artifacts (for PRs)
-        if: github.event_name == 'pull_request'
+      # Download Docker image artifacts (which were just built by reusable-docker-build.yml)
+      - name: Download Docker image artifacts
         uses: actions/download-artifact@v4
         with:
-          # Download all Docker images (TAR files) into the /tmp/docker directory
-          pattern: docker-image-*
+          # Download all amd64 Docker images (TAR files) into the /tmp/docker directory
+          pattern: docker-image-*-linux-amd64
           path: /tmp/docker
           merge-multiple: true
-      # For PRs, load each of the images into Docker by calling "docker image load" for each.
-      # This ensures we are using the images built from this PR & not the prior versions on DockerHub
-      - name: Load all downloaded Docker images (for PRs)
-        if: github.event_name == 'pull_request'
+      # Load each of the images into Docker by calling "docker image load" for each.
+      # This ensures we are using the images just built & not any prior versions on DockerHub
+      - name: Load all downloaded Docker images
         run: |
           find /tmp/docker -type f -name "*.tar" -exec docker image load --input "{}" \;
           docker image ls -a

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -130,7 +130,7 @@ jobs:
       #------------------------------------------------------------
       # https://github.com/docker/metadata-action
       # Get Metadata for docker_build_deps step below
-      - name: Sync metadata (tags, labels) from GitHub to Docker for image
+      - name: Extract metadata (tags, labels) from GitHub for Docker image
         if: ${{ ! matrix.isPr }}
         id: meta_build
         uses: docker/metadata-action@v5
@@ -151,10 +151,23 @@ jobs:
           context: ${{ inputs.dockerfile_context }}
           file: ${{ inputs.dockerfile_path }}
           platforms: ${{ matrix.arch }}
-          push: true
           # Use tags / labels provided by 'docker/metadata-action' above
           tags: ${{ steps.meta_build.outputs.tags }}
           labels: ${{ steps.meta_build.outputs.labels }}
+          # Export image to both Docker registry & to a local TAR file
+          outputs: |
+            registry
+            type=docker,dest=/tmp/${{ inputs.build_id }}.tar
+
+      # Upload the local docker image (in TAR file) to a build Artifact
+      - name: Upload local image to artifact
+        if: ${{ ! matrix.isPr }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-image-${{ inputs.build_id }}-${{ env.ARCH_NAME }}
+          path: /tmp/${{ inputs.build_id }}.tar
+          if-no-files-found: error
+          retention-days: 1
 
       # Export the digest of Docker build locally (for non PRs only)
       - name: Export Docker build digest
@@ -204,7 +217,7 @@ jobs:
       # brand-new images for automated testing.
       #--------------------------------------------------------------
       # Get Metadata for docker_build_deps step below
-      - name: Create metadata (tags, labels) for local Docker image
+      - name: Extract metadata (tags, labels) for local Docker image
         if: matrix.isPr
         id: meta_build_pr
         uses: docker/metadata-action@v5
@@ -233,7 +246,7 @@ jobs:
         if: matrix.isPr
         uses: actions/upload-artifact@v4
         with:
-          name: docker-image-${{ inputs.build_id }}
+          name: docker-image-${{ inputs.build_id }}-${{ env.ARCH_NAME }}
           path: /tmp/${{ inputs.build_id }}.tar
           if-no-files-found: error
           retention-days: 1


### PR DESCRIPTION
## Description
Update our GitHub Actions to always deploy the locally created image.  This was already being done for all PRs, but now will also be done for non-PRs (i.e. once a PR is merged into a branch).  This ensures consistent behavior, and it also ensures we are not pulling the same images from DockerHub which we just pushed to DockerHub.

## Instructions for Reviewers

Assuming the automated tests pass, this can only be fully tested by merging it.  The behavior that changed is to ensure that after merging a PR, the build on the `main` branch will no longer download everything from DockerHub when running `docker-deploy` step.