### PR TITLE
[GitHub Actions] Fix Docker build by exporting local image separate from DockerHub image

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -151,23 +151,10 @@ jobs:
           context: ${{ inputs.dockerfile_context }}
           file: ${{ inputs.dockerfile_path }}
           platforms: ${{ matrix.arch }}
+          push: true
           # Use tags / labels provided by 'docker/metadata-action' above
           tags: ${{ steps.meta_build.outputs.tags }}
           labels: ${{ steps.meta_build.outputs.labels }}
-          # Export image to both Docker registry & to a local TAR file
-          outputs: |
-            registry
-            type=docker,dest=/tmp/${{ inputs.build_id }}.tar
-
-      # Upload the local docker image (in TAR file) to a build Artifact
-      - name: Upload local image to artifact
-        if: ${{ ! matrix.isPr }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: docker-image-${{ inputs.build_id }}-${{ env.ARCH_NAME }}
-          path: /tmp/${{ inputs.build_id }}.tar
-          if-no-files-found: error
-          retention-days: 1
 
       # Export the digest of Docker build locally (for non PRs only)
       - name: Export Docker build digest
@@ -184,6 +171,32 @@ jobs:
         with:
           name: digests-${{ inputs.build_id }}-${{ env.ARCH_NAME }}
           path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+      # Build local image (again) and store in a TAR file in /tmp directory
+      # NOTE: This cannot be combined with push to DockerHub registry above as it's a different type of output.
+      - name: Build and push image to local image
+        if: ${{ ! matrix.isPr }}
+        uses: docker/build-push-action@v5
+        with:
+          build-contexts: |
+            ${{ inputs.dockerfile_additional_contexts }}
+          context: ${{ inputs.dockerfile_context }}
+          file: ${{ inputs.dockerfile_path }}
+          platforms: ${{ matrix.arch }}
+          tags: ${{ steps.meta_build.outputs.tags }}
+          labels: ${{ steps.meta_build.outputs.labels }}
+          # Export image to a local TAR file
+          outputs: type=docker,dest=/tmp/${{ inputs.build_id }}.tar
+
+      # Upload the local docker image (in TAR file) to a build Artifact
+      - name: Upload local image to artifact
+        if: ${{ ! matrix.isPr }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-image-${{ inputs.build_id }}-${{ env.ARCH_NAME }}
+          path: /tmp/${{ inputs.build_id }}.tar
           if-no-files-found: error
           retention-days: 1
 


### PR DESCRIPTION

## References
* Fixes this error which occurs after merging #10079 
```
ERROR: docker exporter does not support exporting manifest lists, use the oci exporter instead
```

## Description

Initially, I tried the suggestion in that error, and attempted to use the `oci` exporter.  However, this didn't work with our `docker-deploy` process, as that's not a Docker images we can deploy easily.

So, this PR instead ensure non-PRs run two image builds:
* First build the image for DockerHub and push there
* Second, build a local Docker image which can be deployed in `docker-deploy`

These cannot seem to be combined (at least I haven't found a way) because they create separate image types.