### PR TITLE
[GitHub Actions] Enable caching of Docker builds using GitHub Actions cache

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -170,10 +170,6 @@ jobs:
       signposting__P__enabled: true
       sword__D__server__P__enabled: true
       swordv2__D__server__P__enabled: true
-      # If this is a PR, force using "pr-testing" version of all Docker images. Otherwise, if on main branch, use the
-      # "latest" tag. Otherwise, use the branch name. NOTE: the "pr-testing" tag is a temporary tag that we assign to
-      # all PR-built docker images in reusable-docker-build.yml
-      DSPACE_VER: ${{ (github.event_name == 'pull_request' && 'pr-testing') || (github.ref_name == github.event.repository.default_branch && 'latest') || github.ref_name }}
     steps:
       # Checkout our codebase (to get access to Docker Compose scripts)
       - name: Checkout codebase

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -155,6 +155,10 @@ jobs:
           # Use tags / labels provided by 'docker/metadata-action' above
           tags: ${{ steps.meta_build.outputs.tags }}
           labels: ${{ steps.meta_build.outputs.labels }}
+          # Use GitHub cache to load cached Docker images and cache the results of this build
+          # This decreases the number of images we need to fetch from DockerHub
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       # Export the digest of Docker build locally (for non PRs only)
       - name: Export Docker build digest
@@ -240,6 +244,7 @@ jobs:
           # for testing in docker.yml
           tags: pr-testing
           flavor: ${{ env.TAGS_FLAVOR }}
+
       # Build local image and stores in a TAR file in /tmp directory
       - name: Build and push image to local image
         if: matrix.isPr
@@ -252,8 +257,13 @@ jobs:
           platforms: ${{ matrix.arch }}
           tags: ${{ steps.meta_build_pr.outputs.tags }}
           labels: ${{ steps.meta_build_pr.outputs.labels }}
+          # Use GitHub cache to load cached Docker images and cache the results of this build
+          # This decreases the number of images we need to fetch from DockerHub
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           # Export image to a local TAR file
           outputs: type=docker,dest=/tmp/${{ inputs.build_id }}.tar
+
       # Upload the local docker image (in TAR file) to a build Artifact
       - name: Upload local image to artifact
         if: matrix.isPr

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -122,16 +122,9 @@ jobs:
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      #------------------------------------------------------------
-      # Build & deploy steps for new commits to a branch (non-PRs)
-      #
-      # These steps build the images, push to DockerHub, and
-      # (if necessary) redeploy demo/sandbox sites.
-      #------------------------------------------------------------
       # https://github.com/docker/metadata-action
-      # Get Metadata for docker_build_deps step below
+      # Extract metadata used for Docker images in all build steps below
       - name: Extract metadata (tags, labels) from GitHub for Docker image
-        if: ${{ ! matrix.isPr }}
         id: meta_build
         uses: docker/metadata-action@v5
         with:
@@ -139,6 +132,12 @@ jobs:
           tags: ${{ env.IMAGE_TAGS }}
           flavor: ${{ env.TAGS_FLAVOR }}
 
+      #------------------------------------------------------------
+      # Build & deploy steps for new commits to a branch (non-PRs)
+      #
+      # These steps build the images, push to DockerHub, and
+      # (if necessary) redeploy demo/sandbox sites.
+      #------------------------------------------------------------
       # https://github.com/docker/build-push-action
       - name: Build and push image to DockerHub
         # Only build & push if not a PR
@@ -178,32 +177,6 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-      # Build local image (again) and store in a TAR file in /tmp directory
-      # NOTE: This cannot be combined with push to DockerHub registry above as it's a different type of output.
-      - name: Build and push image to local image
-        if: ${{ ! matrix.isPr }}
-        uses: docker/build-push-action@v5
-        with:
-          build-contexts: |
-            ${{ inputs.dockerfile_additional_contexts }}
-          context: ${{ inputs.dockerfile_context }}
-          file: ${{ inputs.dockerfile_path }}
-          platforms: ${{ matrix.arch }}
-          tags: ${{ steps.meta_build.outputs.tags }}
-          labels: ${{ steps.meta_build.outputs.labels }}
-          # Export image to a local TAR file
-          outputs: type=docker,dest=/tmp/${{ inputs.build_id }}.tar
-
-      # Upload the local docker image (in TAR file) to a build Artifact
-      - name: Upload local image to artifact
-        if: ${{ ! matrix.isPr }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: docker-image-${{ inputs.build_id }}-${{ env.ARCH_NAME }}
-          path: /tmp/${{ inputs.build_id }}.tar
-          if-no-files-found: error
-          retention-days: 1
-
       # If this build is NOT a PR and passed in a REDEPLOY_SANDBOX_URL secret,
       # Then redeploy https://sandbox.dspace.org if this build is for our deployment architecture and 'main' branch.
       - name: Redeploy sandbox.dspace.org (based on main branch)
@@ -227,27 +200,19 @@ jobs:
           curl -X POST $REDEPLOY_DEMO_URL
 
       #-------------------------------------------------------------
-      # Build steps for PRs only
+      # Shared Build steps.
+      # These are used for PRs as well as new commits to a branch (non-PRs)
       #
-      # These steps build the images and store as a build artifact.
-      # These artifacts can then be used by later jobs to run the
-      # brand-new images for automated testing.
+      # These steps build the images and cache/store as a build artifact.
+      # These artifacts can then be used by later jobs to install the
+      # brand-new images for automated testing. For non-PRs, this cache is
+      # also used to avoid pulling the images we just built from DockerHub.
       #--------------------------------------------------------------
-      # Get Metadata for docker_build_deps step below
-      - name: Extract metadata (tags, labels) for local Docker image
-        if: matrix.isPr
-        id: meta_build_pr
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.IMAGE_NAME }}
-          # Hardcode to use custom "pr-testing" tag because that will allow us to spin up this PR
-          # for testing in docker.yml
-          tags: pr-testing
-          flavor: ${{ env.TAGS_FLAVOR }}
 
-      # Build local image and stores in a TAR file in /tmp directory
-      - name: Build and push image to local image
-        if: matrix.isPr
+      # Build local image (again) and store in a TAR file in /tmp directory
+      # NOTE: This build is run for both PRs and non-PRs as it's used to "cache" our built images as artifacts.
+      # NOTE #2: This cannot be combined with push to DockerHub registry above as it's a different type of output.
+      - name: Build and push image to local TAR file
         uses: docker/build-push-action@v5
         with:
           build-contexts: |
@@ -255,8 +220,8 @@ jobs:
           context: ${{ inputs.dockerfile_context }}
           file: ${{ inputs.dockerfile_path }}
           platforms: ${{ matrix.arch }}
-          tags: ${{ steps.meta_build_pr.outputs.tags }}
-          labels: ${{ steps.meta_build_pr.outputs.labels }}
+          tags: ${{ steps.meta_build.outputs.tags }}
+          labels: ${{ steps.meta_build.outputs.labels }}
           # Use GitHub cache to load cached Docker images and cache the results of this build
           # This decreases the number of images we need to fetch from DockerHub
           cache-from: type=gha
@@ -265,8 +230,7 @@ jobs:
           outputs: type=docker,dest=/tmp/${{ inputs.build_id }}.tar
 
       # Upload the local docker image (in TAR file) to a build Artifact
-      - name: Upload local image to artifact
-        if: matrix.isPr
+      - name: Upload local image TAR to artifact
         uses: actions/upload-artifact@v4
         with:
           name: docker-image-${{ inputs.build_id }}-${{ env.ARCH_NAME }}

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -54,10 +54,13 @@ env:
   # For a new commit on default branch (main), use the literal tag 'latest' on Docker image.
   # For a new commit on other branches, use the branch name as the tag for Docker image.
   # For a new tag, copy that tag name as the tag for Docker image.
+  # For a pull request, use the name of the base branch that the PR was created against or "latest" (for main).
+  #   e.g. PR against 'main' will use "latest". a PR against 'dspace-7_x' will use 'dspace-7_x'.
   IMAGE_TAGS: |
     type=raw,value=latest,enable=${{ github.ref_name == github.event.repository.default_branch }}
     type=ref,event=branch,enable=${{ github.ref_name != github.event.repository.default_branch }}
     type=ref,event=tag
+    type=raw,value=${{ (github.event.pull_request.base.ref == github.event.repository.default_branch && 'latest') || github.event.pull_request.base.ref }},enable=${{ github.event_name == 'pull_request' }}
   # Define default tag "flavor" for docker/metadata-action per
   # https://github.com/docker/metadata-action#flavor-input
   # We manage the 'latest' tag ourselves to the 'main' branch (see settings above)

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -159,8 +159,8 @@ jobs:
           labels: ${{ steps.meta_build.outputs.labels }}
           # Use GitHub cache to load cached Docker images and cache the results of this build
           # This decreases the number of images we need to fetch from DockerHub
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ inputs.build_id }}
+          cache-to: type=gha,scope=${{ inputs.build_id }},mode=max
 
       # Export the digest of Docker build locally (for non PRs only)
       - name: Export Docker build digest
@@ -227,8 +227,8 @@ jobs:
           labels: ${{ steps.meta_build.outputs.labels }}
           # Use GitHub cache to load cached Docker images and cache the results of this build
           # This decreases the number of images we need to fetch from DockerHub
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ inputs.build_id }}
+          cache-to: type=gha,scope=${{ inputs.build_id }},mode=max
           # Export image to a local TAR file
           outputs: type=docker,dest=/tmp/${{ inputs.build_id }}.tar
 


### PR DESCRIPTION
## Description
Currently, our GitHub Actions are being throttled at times by DockerHub.  When this occurs, it can result in build failures (in our Docker GitHub Actions) with errors similar to:
```
429 Too Many Requests - Server message: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
```

To attempt to lessen the throttling, this PR enables two forms of caching for our Docker builds in GitHub actions:

* First, it enables basic caching of our Docker builds using GitHub Actions' cache.  The purpose is to decrease the number of images that we need to pull from DockerHub. See docs at https://docs.docker.com/build/cache/backends/gha/ 
    * A different cache is configured for each job.  This ensures that the cache isn't immediately overwritten by another job.
    * I've verified that if you run the `dspace-dependencies` job twice, the second time it loads base images from the cache.  Same as if you run the `dspace` job twice...the second time, it loads base images from the cache.

## Instructions for Reviewers
This does not modify any code in DSpace.  It only modifies the GitHub actions.

I plan to test this by doing the following:
* Ensure this Docker build succeeds
* Re-run the same build several times to see if it speeds up / uses the cache, instead of downloading images from DockerHub again.