### PR TITLE
[GitHub Actions] Ensure PRs against main also use "latest" tag when running test Docker deployment

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -170,9 +170,12 @@ jobs:
       signposting__P__enabled: true
       sword__D__server__P__enabled: true
       swordv2__D__server__P__enabled: true
-      # If this is a PR, used the base branch name. If on main branch, use the "latest" tag. Otherwise, use branch name.
+      # If this is a PR against main (default branch), use "latest".
+      # Else if this is a PR against a different branch, used the base branch name.
+      # Else if this is a commit on main (default branch), use the "latest" tag.
+      # Else, just use the branch name.
       # NOTE: DSPACE_VER is used because our docker compose scripts default to using the "-test" image.
-      DSPACE_VER: ${{ (github.event_name == 'pull_request' && github.event.pull_request.base.ref) || (github.ref_name == github.event.repository.default_branch && 'latest') || github.ref_name }}
+      DSPACE_VER: ${{ (github.event_name == 'pull_request' && github.event.pull_request.base.ref == github.event.repository.default_branch && 'latest') || (github.event_name == 'pull_request' && github.event.pull_request.base.ref) || (github.ref_name == github.event.repository.default_branch && 'latest') || github.ref_name }}
     steps:
       # Checkout our codebase (to get access to Docker Compose scripts)
       - name: Checkout codebase


### PR DESCRIPTION
## Description
Minor follow-up bug fix to #10085 and https://github.com/DSpace/DSpace/commit/5d324b1ead09c4d7cc254c4085c8b193b99bf182

This fixes behavior for PRs against the `main` branch, which should always attempt a test Docker deployment of the "latest" tag in Docker.

## Instructions for Reviewers
* Can only be tested by our GitHub actions, as this is a change to GitHub actions.