### PR TITLE
OpenAIRE v4 compliance updates

### DIFF
--- a/dspace/config/crosswalks/oai/metadataFormats/oai_openaire.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/oai_openaire.xsl
@@ -888,13 +888,13 @@
             <xsl:attribute name="mimeType">
             <xsl:value-of select="doc:field[@name='format']"/>
          </xsl:attribute>
-            <xsl:attribute name="objectType">
+            <!-- Currently there is no available way to identify the type of the bitstream -->
+            <!--<xsl:attribute name="objectType">
             <xsl:choose>
-                <!-- Currently there is no available way to identify the type of the bitstream -->
                 <xsl:when test="1">
                     <xsl:text>fulltext</xsl:text>
                 </xsl:when>
-                <!--xsl:when test="$type='dataset'">
+                xsl:when test="$type='dataset'">
                     <xsl:text>dataset</xsl:text>
                 </xsl:when>
                 <xsl:when test="$type='software'">
@@ -902,12 +902,12 @@
                 </xsl:when>
                 <xsl:when test="$type='article'">
                     <xsl:text>fulltext</xsl:text>
-                </xsl:when-->
+                </xsl:when
                 <xsl:otherwise>                  
                     <xsl:text>other</xsl:text>
                 </xsl:otherwise>
              </xsl:choose>
-           </xsl:attribute>
+           </xsl:attribute>-->
             <xsl:value-of select="doc:field[@name='url']"/>
         </oaire:file>
     </xsl:template>

--- a/dspace/config/crosswalks/oai/metadataFormats/oai_openaire.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/oai_openaire.xsl
@@ -731,7 +731,7 @@
     <!-- datacite.date @name=issued or @name=accepted -->
     <!-- https://openaire-guidelines-for-literature-repository-managers.readthedocs.io/en/v4.0.0/field_publicationdate.html -->
     <xsl:template
-        match="doc:element[@name='dc']/doc:element[@name='date']/doc:element[@name='issued' or @name='accepted']"
+        match="doc:element[@name='dc']/doc:element[@name='date']/doc:element[@name='issued']"
         mode="datacite">
         <xsl:variable name="dc_date_value" select="doc:element/doc:field[@name='value']/text()"/>
         <datacite:date dateType="Accepted">

--- a/dspace/config/crosswalks/oai/metadataFormats/oai_openaire.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/oai_openaire.xsl
@@ -1039,6 +1039,8 @@
     </xsl:template>
 
     <!-- This template will retrieve the type of a date based on the element name -->
+    <!-- https://openaire-guidelines-for-literature-repository-managers.readthedocs.io/en/v4.0.0/vocab_datetype.html -->
+    <!-- Accepted and Issued date types are handled separately above. -->
     <xsl:template name="getDateType">
         <xsl:param name="elementName"/>
         <xsl:variable name="lc_dc_date_type">
@@ -1049,24 +1051,6 @@
         <xsl:choose>
             <xsl:when test="$lc_dc_date_type='available' or  $lc_dc_date_type = 'embargo'">
                 <xsl:text>Available</xsl:text>
-            </xsl:when>
-            <xsl:when test="$lc_dc_date_type='collected'">
-                <xsl:text>Collected</xsl:text>
-            </xsl:when>
-            <xsl:when test="$lc_dc_date_type='copyrighted' or $lc_dc_date_type='copyright'">
-                <xsl:text>Copyrighted</xsl:text>
-            </xsl:when>
-            <xsl:when test="$lc_dc_date_type='created'">
-                <xsl:text>Created</xsl:text>
-            </xsl:when>
-            <xsl:when test="$lc_dc_date_type='submitted'">
-                <xsl:text>Submitted</xsl:text>
-            </xsl:when>
-            <xsl:when test="$lc_dc_date_type='updated'">
-                <xsl:text>Updated</xsl:text>
-            </xsl:when>
-            <xsl:when test="$lc_dc_date_type='valid'">
-                <xsl:text>Valid</xsl:text>
             </xsl:when>
         </xsl:choose>
     </xsl:template>

--- a/dspace/config/crosswalks/oai/metadataFormats/oai_openaire.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/oai_openaire.xsl
@@ -1049,7 +1049,9 @@
             </xsl:call-template>
         </xsl:variable>
         <xsl:choose>
-            <xsl:when test="$lc_dc_date_type='available' or  $lc_dc_date_type = 'embargo'">
+            <xsl:when test="$lc_dc_date_type = 'embargo'">
+                <!-- Indicates the end of the embargo period. -->
+                <!-- https://openaire-guidelines-for-literature-repository-managers.readthedocs.io/en/v4.0.0/field_embargoenddate.html -->
                 <xsl:text>Available</xsl:text>
             </xsl:when>
         </xsl:choose>

--- a/dspace/config/item-submission.xml
+++ b/dspace/config/item-submission.xml
@@ -379,6 +379,10 @@
 
             <!--Step will be to Sign off on the License -->
             <step id="license"/>
+
+            <!-- Step allows the user to select a Creative Commons License -->
+            <!-- Required for OpenAIREv4 support -->
+            <step id="cclicense"/>
         </submission-process>
         <submission-process name="openAIREPersonSubmission">
             <step id="collection"/>

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -1136,29 +1136,6 @@
             <row>
                 <field>
                     <dc-schema>dc</dc-schema>
-                    <dc-element>rights</dc-element>
-                    <repeatable>false</repeatable>
-                    <label>Access Type</label>
-                    <input-type value-pairs-name="openaire_rights">dropdown</input-type>
-                    <hint>Select the access type of the resource.</hint>
-                    <required></required>
-                </field>
-            </row>
-            <row>
-                <field>
-                    <dc-schema>oaire</dc-schema>
-                    <dc-element>license</dc-element>
-                    <dc-qualifier>condition</dc-qualifier>
-                    <repeatable>false</repeatable>
-                    <label>License</label>
-                    <input-type value-pairs-name="openaire_license_types">dropdown</input-type>
-                    <hint>Select the license of the resource.</hint>
-                    <required></required>
-                </field>
-            </row>
-            <row>
-                <field>
-                    <dc-schema>dc</dc-schema>
                     <dc-element>coverage</dc-element>
                     <dc-qualifier></dc-qualifier>
                     <repeatable>false</repeatable>


### PR DESCRIPTION
## References

* Fixes #9669
* Fixes #9715
* Fixes #9664
* Fixes #9716
* Fixes #9867


* Port for 8.x: #10175 
* Port for 7.x: #10174

## Description

This PR adjusts the [oai_openaire crosswalk](https://github.com/atmire/DSpace/blob/w2p-121971_openaire-compliance-updates-main/dspace/config/crosswalks/oai/metadataFormats/oai_openaire.xsl) and the [OpenAIRE submission form](https://github.com/atmire/DSpace/blob/w2p-121971_openaire-compliance-updates-main/dspace/config/submission-forms.xml#L1074) to make them more compliant with OpenAIRE v4.

_**This improvement has received funding from Ireland’s National Open Research Forum (NORF) under the 2022 Open Research Fund. NORF is funded by the Higher Education Authority (HEA) on behalf of the Department of Further and Higher Education, Research Innovation and Science (DFHERIS).**_

## Instructions for Reviewers

**Changes**
- In the crosswalk:
   - Remove unsupported date types (Collected, Copyrighted, Created, Submitted, Updated, Valid).
   - Remove `dc.date.accepted` clause to ensure only `dc.date.issued` gets the date types Accepted and Issued.
   - Remove `dc.date.available` clause to ensure only `dc.date.embargo` gets the date type Available.
   - Remove the `objectType` attribute from bitstream entries.
- In submission config:
   - Remove the `dc.rights` and `oaire.license.condition` fields from the `openairePublicationPagetwoForm` form.
   - Make the `cclicense` step mandatory in the `openAIREPublicationSubmission` process.

**Instructions for reviewers**
- Ensure you're submitting in a collection that has the `openAIREPublicationSubmission` submission process enabled.
- Create an item with values for `dc.date.accepted`, `dc.date.issued`, `dc.date.available`, `dc.date.embargo` and `dc.date.created`. Upload a bitstream to it. Choose a license in the CC License section.
- Run `[dspace.dir]/bin/dspace oai import`.
- Verify the item is available in the OpenAIRE 4 context on the OAI endpoint and that:
   - the record only contains the `dc.date.issued` and `dc.date.embargo` values.
   - the `dc.date.issued` values have date types Accepted and Issued.
   - the `dc.date.embargo` values have date type Available.
   - the `oaire:file` property doesn't have a `objectType` attribute.
   - the `oaire:licenseCondition` entry contains the license you chose.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
