### PR TITLE
DS-10133: make several usage statistics parameters configurable

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/UsageReportUtils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/UsageReportUtils.java
@@ -27,6 +27,7 @@ import org.dspace.content.Site;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.handle.service.HandleService;
+import org.dspace.services.ConfigurationService;
 import org.dspace.statistics.Dataset;
 import org.dspace.statistics.content.DatasetDSpaceObjectGenerator;
 import org.dspace.statistics.content.DatasetTimeGenerator;
@@ -45,6 +46,9 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class UsageReportUtils {
+
+    @Autowired
+    private ConfigurationService configurationService;
 
     @Autowired
     private HandleService handleService;
@@ -135,13 +139,14 @@ public class UsageReportUtils {
      */
     private UsageReportRest resolveGlobalUsageReport(Context context)
         throws SQLException, IOException, ParseException, SolrServerException {
+        int topItemsLimit = configurationService.getIntProperty("usage-statistics.topItemsLimit", 10);
+
         StatisticsListing statListing = new StatisticsListing(
             new StatisticsDataVisits());
 
-        // Adding a new generator for our top 10 items without a name length delimiter
+        // Adding a new generator for our top n items without a name length delimiter
         DatasetDSpaceObjectGenerator dsoAxis = new DatasetDSpaceObjectGenerator();
-        // TODO make max nr of top items (views wise)? Must be set
-        dsoAxis.addDsoChild(Constants.ITEM, 10, false, -1);
+        dsoAxis.addDsoChild(Constants.ITEM, topItemsLimit, false, -1);
         statListing.addDatasetGenerator(dsoAxis);
 
         Dataset dataset = statListing.getDataset(context, 1);
@@ -182,7 +187,7 @@ public class UsageReportUtils {
         UsageReportPointDsoTotalVisitsRest totalVisitPoint = new UsageReportPointDsoTotalVisitsRest();
         totalVisitPoint.setType(StringUtils.substringAfterLast(dso.getClass().getName().toLowerCase(), "."));
         totalVisitPoint.setId(dso.getID().toString());
-        if (dataset.getColLabels().size() > 0) {
+        if (!dataset.getColLabels().isEmpty()) {
             totalVisitPoint.setLabel(dso.getName());
             totalVisitPoint.addValue("views", Integer.valueOf(dataset.getMatrix()[0][0]));
         } else {
@@ -205,10 +210,14 @@ public class UsageReportUtils {
      */
     private UsageReportRest resolveTotalVisitsPerMonth(Context context, DSpaceObject dso)
         throws SQLException, IOException, ParseException, SolrServerException {
+        String startDateInterval =
+            configurationService.getProperty("usage-statistics.startDateInterval", "-6");
+        String endDateInterval =
+            configurationService.getProperty("usage-statistics.endDateInterval", "+1");
+
         StatisticsTable statisticsTable = new StatisticsTable(new StatisticsDataVisits(dso));
         DatasetTimeGenerator timeAxis = new DatasetTimeGenerator();
-        // TODO month start and end as request para?
-        timeAxis.setDateInterval("month", "-6", "+1");
+        timeAxis.setDateInterval("month", startDateInterval, endDateInterval);
         statisticsTable.addDatasetGenerator(timeAxis);
         DatasetDSpaceObjectGenerator dsoAxis = new DatasetDSpaceObjectGenerator();
         dsoAxis.addDsoChild(dso.getType(), 10, false, -1);
@@ -275,7 +284,10 @@ public class UsageReportUtils {
      */
     private UsageReportRest resolveTopCountries(Context context, DSpaceObject dso)
         throws SQLException, IOException, ParseException, SolrServerException {
-        Dataset dataset = this.getTypeStatsDataset(context, dso, "countryCode", 1);
+        int topCountriesLimit =
+            configurationService.getIntProperty("usage-statistics.topCountriesLimit", 100);
+
+        Dataset dataset = this.getTypeStatsDataset(context, dso, "countryCode", topCountriesLimit, 1);
 
         UsageReportRest usageReportRest = new UsageReportRest();
         for (int i = 0; i < dataset.getColLabels().size(); i++) {
@@ -299,7 +311,10 @@ public class UsageReportUtils {
      */
     private UsageReportRest resolveTopCities(Context context, DSpaceObject dso)
         throws SQLException, IOException, ParseException, SolrServerException {
-        Dataset dataset = this.getTypeStatsDataset(context, dso, "city", 1);
+        int topCitiesLimit =
+            configurationService.getIntProperty("usage-statistics.topCitiesLimit", 100);
+
+        Dataset dataset = this.getTypeStatsDataset(context, dso, "city", topCitiesLimit, 1);
 
         UsageReportRest usageReportRest = new UsageReportRest();
         for (int i = 0; i < dataset.getColLabels().size(); i++) {
@@ -339,16 +354,17 @@ public class UsageReportUtils {
      * @param dso            DSO we want the stats dataset of
      * @param typeAxisString String of the type we want on the axis of the dataset (corresponds to solr field),
      *                       examples: countryCode, city
+     * @param typeAxisMax    Maximum amount of results to return in the dataset
      * @param facetMinCount  Minimum amount of results on a facet data point for it to be added to dataset
      * @return Stats dataset with the given type on the axis, of the given DSO and with given facetMinCount
      */
-    private Dataset getTypeStatsDataset(Context context, DSpaceObject dso, String typeAxisString, int facetMinCount)
+    private Dataset getTypeStatsDataset(Context context, DSpaceObject dso, String typeAxisString, int typeAxisMax,
+                                        int facetMinCount)
         throws SQLException, IOException, ParseException, SolrServerException {
         StatisticsListing statListing = new StatisticsListing(new StatisticsDataVisits(dso));
         DatasetTypeGenerator typeAxis = new DatasetTypeGenerator();
         typeAxis.setType(typeAxisString);
-        // TODO make max nr of top countries/cities a request para? Must be set
-        typeAxis.setMax(100);
+        typeAxis.setMax(typeAxisMax);
         statListing.addDatasetGenerator(typeAxis);
         return statListing.getDataset(context, facetMinCount);
     }

--- a/dspace/config/modules/usage-statistics.cfg
+++ b/dspace/config/modules/usage-statistics.cfg
@@ -61,3 +61,20 @@ usage-statistics.shardedByYear = false
 
 # Only anonymize statistics records older than this threshold (expressed in days)
 #anonymize_statistics.time_threshold = 90
+
+# Maximum number of items to display in the usage statistics report for an entire repository
+usage-statistics.topItemsLimit = 10
+
+# Number of months to begin retrieving usage statistics for total visits per month of a DSpace object
+# For example, -6 means include the previous six months
+usage-statistics.startDateInterval = -6
+
+# Number of months to end retrieving usage statistics for total visits per month of a DSpace object
+# For example, +1 means include the current month
+usage-statistics.endDateInterval = +1
+
+# Maximum number of countries to display in the usage statistics reports
+usage-statistics.topCountriesLimit = 100
+
+# Maximum number of cities to display in the usage statistics reports
+usage-statistics.topCitiesLimit = 100


### PR DESCRIPTION
## References
* Fixes #10133 

## Description
This small PR moves a few of the parameters for usage statistics reports of DSpace objects into the configuration.

## Instructions for Reviewers
Deploy this PR in a repository with at least some usage statistics, particularly one configured with geolocation for statistics (`usage-statistics.dbfile = /usr/share/GeoIP/GeoLite2-City.mmdb`). Modify the new configuration parameters in `usage-statistics.cfg` and see that they impact the usage statistics pages in the frontend. Note: any changes to the configuration require restarting Tomcat.

## Checklist
- [X] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [X] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [X] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
