### PR TITLE
remove deprecated constructor call in org.dspace.curate.Curation

### DIFF
--- a/dspace-api/src/main/java/org/dspace/curate/Curation.java
+++ b/dspace-api/src/main/java/org/dspace/curate/Curation.java
@@ -185,7 +185,7 @@ public class Curation extends DSpaceRunnable<CurationScriptConfiguration> {
         Curator curator = new Curator(handler);
         OutputStream reporterStream;
         if (null == this.reporter) {
-            reporterStream = new NullOutputStream();
+            reporterStream = NullOutputStream.NULL_OUTPUT_STREAM;
         } else if ("-".equals(this.reporter)) {
             reporterStream = System.out;
         } else {


### PR DESCRIPTION
## Description

This PR removes the usage of a deprecated constructor call in `org.dspace.curate.Curation` to ensure compatibility with future versions (3 and above) of commons-io.
