### PR TITLE
expose search filterfacet isOpenByDefault as rest property

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/DiscoverFacetConfigurationConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/DiscoverFacetConfigurationConverter.java
@@ -42,6 +42,7 @@ public class DiscoverFacetConfigurationConverter {
             SearchFacetEntryRest facetEntry = new SearchFacetEntryRest(discoverySearchFilterFacet.getIndexFieldName());
             facetEntry.setFacetType(discoverySearchFilterFacet.getType());
             facetEntry.setFacetLimit(discoverySearchFilterFacet.getFacetLimit());
+            facetEntry.setOpenByDefault(discoverySearchFilterFacet.isOpenByDefault());
 
             facetConfigurationRest.addSidebarFacet(facetEntry);
         }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/DiscoverFacetResultsConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/DiscoverFacetResultsConverter.java
@@ -109,6 +109,7 @@ public class DiscoverFacetResultsConverter {
         }
 
         facetEntryRest.setFacetLimit(field.getFacetLimit());
+        facetEntryRest.setOpenByDefault(field.isOpenByDefault());
 
         //We requested one extra facet value. Check if that value is present to indicate that there are more results
         facetEntryRest.setHasMore(facetResults.size() > page.getPageSize());

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/DiscoverFacetsConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/DiscoverFacetsConverter.java
@@ -83,6 +83,7 @@ public class DiscoverFacetsConverter {
             if (field.exposeMinAndMaxValue()) {
                 handleExposeMinMaxValues(context, field, facetEntry);
             }
+            facetEntry.setOpenByDefault(field.isOpenByDefault());
             facetEntry.setExposeMinMax(field.exposeMinAndMaxValue());
             facetEntry.setFacetType(field.getType());
             for (DiscoverResult.FacetResult value : CollectionUtils.emptyIfNull(facetValues)) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/SearchFacetEntryRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/SearchFacetEntryRest.java
@@ -13,6 +13,7 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import org.dspace.app.rest.DiscoveryRestController;
+import org.dspace.discovery.configuration.DiscoverySearchFilter;
 import org.dspace.discovery.configuration.DiscoverySearchFilterFacet;
 
 /**
@@ -30,6 +31,9 @@ public class SearchFacetEntryRest extends RestAddressableModel {
     @JsonIgnore
     private Boolean hasMore = null;
     private int facetLimit;
+
+    @JsonIgnore
+    private Boolean isOpenByDefault;
 
     @JsonIgnore
     private boolean exposeMinMax = false;
@@ -105,6 +109,16 @@ public class SearchFacetEntryRest extends RestAddressableModel {
 
     public void setFacetLimit(final int facetLimit) {
         this.facetLimit = facetLimit;
+    }
+
+    public void setOpenByDefault(boolean isOpenByDefault) {
+        this.isOpenByDefault = Boolean.valueOf(isOpenByDefault);
+    }
+    /**
+     * See documentation at {@link DiscoverySearchFilter#isOpenByDefault()}
+     */
+    public Boolean isOpenByDefault() {
+        return this.isOpenByDefault;
     }
 
     /**

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/FacetEntryMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/FacetEntryMatcher.java
@@ -28,6 +28,7 @@ public class FacetEntryMatcher {
             hasJsonPath("$.name", is("author")),
             hasJsonPath("$.facetType", is("text")),
             hasJsonPath("$.facetLimit", any(Integer.class)),
+            hasJsonPath("$.openByDefault", any(Boolean.class)),
             hasJsonPath("$._links.self.href", containsString("api/discover/facets/author")),
             hasJsonPath("$._links", matchNextLink(hasNext, "api/discover/facets/author"))
         );
@@ -40,6 +41,7 @@ public class FacetEntryMatcher {
             hasJsonPath("$.facetLimit", any(Integer.class)),
             hasJsonPath("$.minValue", is(min)),
             hasJsonPath("$.maxValue", is(max)),
+            hasJsonPath("$.openByDefault", any(Boolean.class)),
             hasJsonPath("$._links.self.href", containsString("api/discover/facets/author")),
             hasJsonPath("$._links", matchNextLink(hasNext, "api/discover/facets/author"))
         );
@@ -50,6 +52,7 @@ public class FacetEntryMatcher {
             hasJsonPath("$.name", is("subject")),
             hasJsonPath("$.facetType", is("hierarchical")),
             hasJsonPath("$.facetLimit", any(Integer.class)),
+            hasJsonPath("$.openByDefault", any(Boolean.class)),
             hasJsonPath("$._links.self.href", containsString("api/discover/facets/subject")),
             hasJsonPath("$._links", matchNextLink(hasNext, "api/discover/facets/subject"))
 
@@ -61,6 +64,7 @@ public class FacetEntryMatcher {
             hasJsonPath("$.name", is("submitter")),
             hasJsonPath("$.facetType", is("authority")),
             hasJsonPath("$.facetLimit", any(Integer.class)),
+            hasJsonPath("$.openByDefault", any(Boolean.class)),
             hasJsonPath("$._links.self.href", containsString("api/discover/facets/submitter")),
             hasJsonPath("$._links", matchNextLink(hasNext, "api/discover/facets/submitter"))
 
@@ -72,6 +76,7 @@ public class FacetEntryMatcher {
             hasJsonPath("$.name", is("supervisedBy")),
             hasJsonPath("$.facetType", is("authority")),
             hasJsonPath("$.facetLimit", any(Integer.class)),
+            hasJsonPath("$.openByDefault", any(Boolean.class)),
             hasJsonPath("$._links.self.href", containsString("api/discover/facets/supervisedBy")),
             hasJsonPath("$._links", matchNextLink(hasNext, "api/discover/facets/supervisedBy"))
 
@@ -83,6 +88,7 @@ public class FacetEntryMatcher {
             hasJsonPath("$.name", is("dateIssued")),
             hasJsonPath("$.facetType", is("date")),
             hasJsonPath("$.facetLimit", any(Integer.class)),
+            hasJsonPath("$.openByDefault", any(Boolean.class)),
             hasJsonPath("$._links.self.href", containsString("api/discover/facets/dateIssued")),
             hasJsonPath("$._links", matchNextLink(hasNext, "api/discover/facets/dateIssued"))
         );
@@ -95,6 +101,7 @@ public class FacetEntryMatcher {
             hasJsonPath("$.facetLimit", any(Integer.class)),
             hasJsonPath("$.minValue", is(min)),
             hasJsonPath("$.maxValue", is(max)),
+            hasJsonPath("$.openByDefault", any(Boolean.class)),
             hasJsonPath("$._links.self.href", containsString("api/discover/facets/dateIssued")),
             hasJsonPath("$._links", matchNextLink(hasNext, "api/discover/facets/dateIssued"))
         );
@@ -105,6 +112,7 @@ public class FacetEntryMatcher {
             hasJsonPath("$.name", is("has_content_in_original_bundle")),
             hasJsonPath("$.facetType", is("standard")),
             hasJsonPath("$.facetLimit", any(Integer.class)),
+            hasJsonPath("$.openByDefault", any(Boolean.class)),
             hasJsonPath("$._links.self.href", containsString("api/discover/facets/has_content_in_original_bundle")),
             hasJsonPath("$._links", matchNextLink(hasNext, "api/discover/facets/has_content_in_original_bundle"))
         );
@@ -115,6 +123,7 @@ public class FacetEntryMatcher {
                 hasJsonPath("$.name", is(name)),
                 hasJsonPath("$.facetType", is(facetType)),
                 hasJsonPath("$.facetLimit", any(Integer.class)),
+                hasJsonPath("$.openByDefault", any(Boolean.class)),
                 hasJsonPath("$._links.self.href", containsString("api/discover/facets/" + name)),
                 hasJsonPath("$._links", matchNextLink(hasNext, "api/discover/facets/" + name))
         );
@@ -133,6 +142,7 @@ public class FacetEntryMatcher {
                 hasJsonPath("$.name", is("itemtype")),
                 hasJsonPath("$.facetType", is("text")),
                 hasJsonPath("$.facetLimit", any(Integer.class)),
+                hasJsonPath("$.openByDefault", any(Boolean.class)),
                 hasJsonPath("$._links.self.href", containsString("api/discover/facets/itemtype")),
                 hasJsonPath("$._links", matchNextLink(b, "api/discover/facets/itemtype"))
             );
@@ -151,6 +161,7 @@ public class FacetEntryMatcher {
                 hasJsonPath("$.name", is("namedresourcetype")),
                 hasJsonPath("$.facetType", is("authority")),
                 hasJsonPath("$.facetLimit", any(Integer.class)),
+                hasJsonPath("$.openByDefault", any(Boolean.class)),
                 hasJsonPath("$._links.self.href", containsString("api/discover/facets/namedresourcetype")),
                 hasJsonPath("$._links", matchNextLink(b, "api/discover/facets/namedresourcetype"))
             );
@@ -165,6 +176,7 @@ public class FacetEntryMatcher {
         return allOf(
             hasJsonPath("$.name", is("entityType")),
             hasJsonPath("$.facetLimit", any(Integer.class)),
+            hasJsonPath("$.openByDefault", any(Boolean.class)),
             hasJsonPath("$._links.self.href", containsString("api/discover/facets/entityType")),
             hasJsonPath("$._links", matchNextLink(hasNext, "api/discover/facets/entityType"))
         );
@@ -175,6 +187,7 @@ public class FacetEntryMatcher {
             hasJsonPath("$.name", is("relateditem")),
             hasJsonPath("$.facetType", is("text")),
             hasJsonPath("$.facetLimit", any(Integer.class)),
+            hasJsonPath("$.openByDefault", any(Boolean.class)),
             hasJsonPath("$._links.self.href", containsString("api/discover/facets/relateditem")),
             hasJsonPath("$._links", matchNextLink(b, "api/discover/facets/relateditem"))
         );
@@ -185,6 +198,7 @@ public class FacetEntryMatcher {
             hasJsonPath("$.name", is("origin")),
             hasJsonPath("$.facetType", is("text")),
             hasJsonPath("$.facetLimit", any(Integer.class)),
+            hasJsonPath("$.openByDefault", any(Boolean.class)),
             hasJsonPath("$._links.self.href", containsString("api/discover/facets/origin")),
             hasJsonPath("$._links", matchNextLink(b, "api/discover/facets/origin"))
         );
@@ -195,6 +209,7 @@ public class FacetEntryMatcher {
             hasJsonPath("$.name", is("target")),
             hasJsonPath("$.facetType", is("text")),
             hasJsonPath("$.facetLimit", any(Integer.class)),
+            hasJsonPath("$.openByDefault", any(Boolean.class)),
             hasJsonPath("$._links.self.href", containsString("api/discover/facets/target")),
             hasJsonPath("$._links", matchNextLink(b, "api/discover/facets/target"))
         );
@@ -205,6 +220,7 @@ public class FacetEntryMatcher {
             hasJsonPath("$.name", is("queue_status")),
             hasJsonPath("$.facetType", is("text")),
             hasJsonPath("$.facetLimit", any(Integer.class)),
+            hasJsonPath("$.openByDefault", any(Boolean.class)),
             hasJsonPath("$._links.self.href", containsString("api/discover/facets/queue_status")),
             hasJsonPath("$._links", matchNextLink(b, "api/discover/facets/queue_status"))
         );
@@ -215,6 +231,7 @@ public class FacetEntryMatcher {
             hasJsonPath("$.name", is("activity_stream_type")),
             hasJsonPath("$.facetType", is("text")),
             hasJsonPath("$.facetLimit", any(Integer.class)),
+            hasJsonPath("$.openByDefault", any(Boolean.class)),
             hasJsonPath("$._links.self.href", containsString("api/discover/facets/activity_stream_type")),
             hasJsonPath("$._links", matchNextLink(b, "api/discover/facets/activity_stream_type"))
         );
@@ -225,6 +242,7 @@ public class FacetEntryMatcher {
             hasJsonPath("$.name", is("coar_notify_type")),
             hasJsonPath("$.facetType", is("text")),
             hasJsonPath("$.facetLimit", any(Integer.class)),
+            hasJsonPath("$.openByDefault", any(Boolean.class)),
             hasJsonPath("$._links.self.href", containsString("api/discover/facets/coar_notify_type")),
             hasJsonPath("$._links", matchNextLink(b, "api/discover/facets/coar_notify_type"))
         );
@@ -235,6 +253,7 @@ public class FacetEntryMatcher {
             hasJsonPath("$.name", is("notification_type")),
             hasJsonPath("$.facetType", is("text")),
             hasJsonPath("$.facetLimit", any(Integer.class)),
+            hasJsonPath("$.openByDefault", any(Boolean.class)),
             hasJsonPath("$._links.self.href", containsString("api/discover/facets/notification_type")),
             hasJsonPath("$._links", matchNextLink(b, "api/discover/facets/notification_type"))
         );


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #9404 
* Related to DSpace/RestContract#299 
* Counterpart frontend (https://github.com/DSpace/dspace-angular/pull/3785

## Description
Expose the `isOpenByDefault` property of some SearchFilter in it's rest representation.

## Instructions for Reviewers

List of changes in this PR:
* added a new property isOpenByDefault to the Rest Represenation and Conversion of the dspace object `SearchFacetEntry`. It returns, whether the search facet should be displayed initally opened or closed. Due to naming issues it is returned as `openByDefault`.
* Adopted Tests.

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

- Before: 
- Check the response of the search configuration for filter or facets,
  - without the feature: e.g. https://sandbox.dspace.org/server/api/discover/facets/subject 
  - it contains no information about the initially facet state
   
  - with the feature: locally http://localhost:8080/server/api/discover/facets/subject
  - The response with the feature should now include the `openByDefault` property.

- Run `DiscoveryRestControllerIT,DiscoveryScopeBasedRestControllerIT`. Both IT handles the cases of the facets representations.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
