### PR TITLE
shorten orcid description value and orcid contributor name values

### DIFF
--- a/dspace-api/src/main/java/org/dspace/orcid/model/factory/OrcidCommonObjectFactory.java
+++ b/dspace-api/src/main/java/org/dspace/orcid/model/factory/OrcidCommonObjectFactory.java
@@ -90,4 +90,12 @@ public interface OrcidCommonObjectFactory {
     public Optional<Country> createCountry(Context context, MetadataValue metadataValue)
         throws OrcidValidationException;
 
+
+    /**
+     * Shorten the value aligned to orcid short-description data type and add some ellipses value
+     * @param metadataValue
+     * @return shortened value when to long or the original value
+     */
+    public String shortenDescription(String metadataValue);
+
 }

--- a/dspace-api/src/main/java/org/dspace/orcid/model/factory/impl/OrcidCommonObjectFactoryImpl.java
+++ b/dspace-api/src/main/java/org/dspace/orcid/model/factory/impl/OrcidCommonObjectFactoryImpl.java
@@ -82,6 +82,10 @@ public class OrcidCommonObjectFactoryImpl implements OrcidCommonObjectFactory {
 
     private Map<String, String> disambiguatedOrganizationIdentifierFields = new HashMap<>();
 
+    private int maxContributorValueLength;
+
+    private int maxDescriptionValueLength;
+
     @Override
     public Optional<FuzzyDate> createFuzzyDate(MetadataValue metadataValue) {
 
@@ -119,7 +123,7 @@ public class OrcidCommonObjectFactoryImpl implements OrcidCommonObjectFactory {
         }
 
         Contributor contributor = new Contributor();
-        contributor.setCreditName(new CreditName(metadataValue.getValue()));
+        contributor.setCreditName(new CreditName(shortenContributorName(metadataValue.getValue())));
         contributor.setContributorAttributes(getContributorAttributes(metadataValue, role));
 
         return of(contributor);
@@ -134,7 +138,7 @@ public class OrcidCommonObjectFactoryImpl implements OrcidCommonObjectFactory {
         }
 
         FundingContributor contributor = new FundingContributor();
-        contributor.setCreditName(new CreditName(metadataValue.getValue()));
+        contributor.setCreditName(new CreditName(shortenContributorName(metadataValue.getValue())));
         contributor.setContributorAttributes(getFundingContributorAttributes(metadataValue, role));
 
         return of(contributor);
@@ -164,6 +168,28 @@ public class OrcidCommonObjectFactoryImpl implements OrcidCommonObjectFactory {
         }
 
         return country.map(isoCountry -> new Country(isoCountry));
+    }
+
+    @Override
+    public String shortenDescription(String metadataValue) {
+        if (getMaxContributorValueLength() > 4 && StringUtils.isNotBlank(metadataValue)
+            && metadataValue.length() > getMaxDescriptionValueLength()) {
+            return metadataValue.substring(0, getMaxDescriptionValueLength() - 4) + "...";
+        }
+        return metadataValue;
+    }
+
+    /**
+     * Shorten the value aligned to orcid string-150 data type and add some ellipses value
+     * @param metadataValue
+     * @return shortened value when to long or the original value
+     */
+    private String shortenContributorName(String metadataValue) {
+        if (getMaxContributorValueLength() > 4 && StringUtils.isNotBlank(metadataValue)
+            && metadataValue.length() > getMaxContributorValueLength()) {
+            return metadataValue.substring(0, getMaxContributorValueLength() - 4) + "...";
+        }
+        return metadataValue;
     }
 
     private ContributorAttributes getContributorAttributes(MetadataValue metadataValue, ContributorRole role) {
@@ -297,4 +323,19 @@ public class OrcidCommonObjectFactoryImpl implements OrcidCommonObjectFactory {
         this.organizationTitleField = organizationTitleField;
     }
 
+    public int getMaxContributorValueLength() {
+        return maxContributorValueLength;
+    }
+
+    public void setMaxContributorValueLength(int maxContributorValueLength) {
+        this.maxContributorValueLength = maxContributorValueLength;
+    }
+
+    public int getMaxDescriptionValueLength() {
+        return maxDescriptionValueLength;
+    }
+
+    public void setMaxDescriptionValueLength(int maxDescriptionValueLength) {
+        this.maxDescriptionValueLength = maxDescriptionValueLength;
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/orcid/model/factory/impl/OrcidFundingFactory.java
+++ b/dspace-api/src/main/java/org/dspace/orcid/model/factory/impl/OrcidFundingFactory.java
@@ -82,7 +82,7 @@ public class OrcidFundingFactory implements OrcidEntityFactory {
     public Activity createOrcidObject(Context context, Item item) {
         Funding funding = new Funding();
         funding.setContributors(getContributors(context, item));
-        funding.setDescription(getDescription(context, item));
+        funding.setDescription(orcidCommonObjectFactory.shortenDescription(getDescription(context, item)));
         funding.setEndDate(getEndDate(context, item));
         funding.setExternalIdentifiers(getExternalIds(context, item));
         funding.setOrganization(getOrganization(context, item));

--- a/dspace-api/src/main/java/org/dspace/orcid/model/factory/impl/OrcidWorkFactory.java
+++ b/dspace-api/src/main/java/org/dspace/orcid/model/factory/impl/OrcidWorkFactory.java
@@ -80,7 +80,7 @@ public class OrcidWorkFactory implements OrcidEntityFactory {
         work.setWorkTitle(getWorkTitle(context, item));
         work.setPublicationDate(getPublicationDate(context, item));
         work.setWorkExternalIdentifiers(getWorkExternalIds(context, item, work));
-        work.setShortDescription(getShortDescription(context, item));
+        work.setShortDescription(orcidCommonObjectFactory.shortenDescription(getShortDescription(context, item)));
         work.setLanguageCode(getLanguageCode(context, item));
         work.setUrl(getUrl(context, item));
         return work;

--- a/dspace-api/src/test/java/org/dspace/orcid/service/OrcidEntityFactoryServiceIT.java
+++ b/dspace-api/src/test/java/org/dspace/orcid/service/OrcidEntityFactoryServiceIT.java
@@ -13,11 +13,13 @@ import static org.dspace.app.matcher.LambdaMatcher.matches;
 import static org.dspace.builder.RelationshipTypeBuilder.createRelationshipTypeBuilder;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.startsWith;
 import static org.orcid.jaxb.model.common.ContributorRole.AUTHOR;
 import static org.orcid.jaxb.model.common.ContributorRole.EDITOR;
 import static org.orcid.jaxb.model.common.FundingContributorRole.LEAD;
@@ -38,6 +40,9 @@ import org.dspace.content.EntityType;
 import org.dspace.content.Item;
 import org.dspace.content.RelationshipType;
 import org.dspace.orcid.factory.OrcidServiceFactory;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
+import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.orcid.jaxb.model.common.ContributorRole;
@@ -72,6 +77,8 @@ public class OrcidEntityFactoryServiceIT extends AbstractIntegrationTestWithData
     private Collection publications;
 
     private Collection projects;
+
+    private ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
 
     private static final String isbn = "978-0-439-02348-1";
     private static final String issn = "1234-1234X";
@@ -250,6 +257,108 @@ public class OrcidEntityFactoryServiceIT extends AbstractIntegrationTestWithData
     }
 
     @Test
+    public void testWorkCreationWithShortenedValues() {
+
+        context.turnOffAuthorisationSystem();
+
+        String desc = "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor." +
+            " Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus." +
+            " Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim." +
+            " Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut,imperdiet" +
+            " a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras" +
+            " dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula, porttitor" +
+            " eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a,tellus." +
+            " Phasellus viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi" +
+            " vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. Maecenas tempus, tellus" +
+            " eget condimentum rhoncus, sem quam semper libero, sit amet adipiscing sem neque sed ipsum. Nam quam" +
+            " nunc, blandit vel, luctus pulvinar, hendrerit id, lorem. Maecenas nec odio et ante tincidunt tempus." +
+            " Donec vitae sapien ut libero venenatis faucibus. Nullam quis ante. Etiam sit amet orci eget eros" +
+            " faucibus tincidunt. Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. Sed" +
+            " consequat, leo eget bibendum sodales, augue velit cursus nunc, quis gravida magna mi a libero. Fusce" +
+            " vulputate eleifend sapien. Vestibulum purus quam, scelerisque ut, mollis sed, nonummy id, metus. Nullam" +
+            " accumsan lorem in dui. Cras ultricies mi eu turpis hendrerit fringilla. Vestibulum ante ipsum primis in" +
+            " faucibus orci luctus et ultrices posuere cubilia Curae; In ac dui quis mi consectetuer lacinia. Nam" +
+            " pretium turpis et arcu. Duis arcu tortor, suscipit eget, imperdiet nec, imperdiet iaculis, ipsum. Sed" +
+            " aliquam ultrices mauris. Integer ante arcu, accumsan a, consectetuer eget, posuere ut, mauris." +
+            " Praesent adipiscing. Phasellus ullamcorper ipsum rutrum nunc. Nunc nonummy metus. Vestibulum volutpat" +
+            " pretium libero. Cras id dui. Aenean ut eros et nisl sagittis vestibulum. Nullam nulla eros, ultricies" +
+            " sit amet, nonummy id, imperdiet feugiat, pede. Sed lectus. Donec mollis hendrerit risus. Phasellus nec" +
+            " sem in justo pellentesque facilisis. Etiam imperdiet imperdiet orci. Nunc nec neque. Phasellus leo" +
+            " dolor, tempus non, auctor et, hendrerit quis, nisi. Curabitur ligula sapien, tincidunt non, euismod" +
+            " vitae, posuere imperdiet, leo. Maecenas malesuada. Praesent congue erat at massa. Sed cursus turpis" +
+            " vitae tortor. Donec posuere vulputate arcu. Phasellus accumsan cursus velit. Vestibulum ante ipsum" +
+            " primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed aliquam, nisi quis porttitor" +
+            " congue, elit erat euismod orci, ac placerat dolor lectus quis orci. Phasellus consectetuer vestibulum" +
+            " elit. Aenean tellus metus, bibendum sed, posuere ac, mattis non, nunc. Vestibulum fringilla pede sit" +
+            " amet augue. In turpis. Pellentesque posuere. Praesent turpis. Aenean posuere, tortor sed cursus" +
+            " feugiat, nunc augue blandit nunc, eu sollicitudin urna dolor sagittis lacus. Donec elit libero, sodales" +
+            " nec, volutpat a, suscipit non, turpis. Nullam sagittis. Suspendisse pulvinar, augue ac venenatis" +
+            " condimentum, sem libero volutpat nibh, nec pellentesque velit pede quis nunc. Vestibulum ante ipsum" +
+            " primis in faucibus orci luctus et ultrices posuere cubilia Curae; Fusce id purus. Ut varius tincidunt" +
+            " libero. Phasellus dolor. Maecenas vestibulum mollis diam. Pellentesque ut neque. Pellentesque habitant" +
+            " morbi tristique senectus et netus et malesuada fames ac turpis egestas. In dui magna, posuere eget," +
+            " vestibulum et, tempor auctor, justo. In ac felis quis tortor malesuada pretium. Pellentesque auctor" +
+            " neque nec urna. Proin sapien ipsum, porta a, auctor quis, euismod ut, mi. Aenean viverra rhoncus pede." +
+            " Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Ut non" +
+            " enim eleifend felis pretium feugiat. Vivamus quis mi. Phasellus a est. Phasellus";
+
+        assertThat(desc.length(), greaterThan(4000));
+        String longAuthor = "Walter White William Wisdom Wilfired Winter Willa Winnie Wendy Waylon Winona " +
+            "Willow Walker Wade Waverly Whitney Whitley Watson Wanda Wren Warren Wesley Wynter";
+        assertThat(longAuthor.length(), greaterThan(150));
+        Item publication = ItemBuilder.createItem(context, publications)
+            .withTitle("Test publication")
+            .withAuthor(longAuthor)
+            .withAuthor("Jesse Pinkman")
+            .withEditor("Editor")
+            .withIssueDate("2021-04-30")
+            .withDescriptionAbstract(desc)
+            .withLanguage("en_US")
+            .withType("Book")
+            .withIsPartOf("Journal")
+            .withDoiIdentifier("doi-id")
+            .withScopusIdentifier("scopus-id")
+            .build();
+
+        context.restoreAuthSystemState();
+
+        Activity activity = entityFactoryService.createOrcidObject(context, publication);
+        assertThat(activity, instanceOf(Work.class));
+
+        Work work = (Work) activity;
+        assertThat(work.getJournalTitle(), notNullValue());
+        assertThat(work.getJournalTitle().getContent(), is("Journal"));
+        assertThat(work.getLanguageCode(), is("en"));
+        assertThat(work.getPublicationDate(), matches(date("2021", "04", "30")));
+        assertThat(work.getShortDescription(), startsWith(desc.substring(0, 3996)));
+        assertThat(work.getShortDescription().length(), Matchers.lessThan(desc.length()));
+        assertThat(work.getShortDescription().length(), Matchers.lessThan(4001));
+        assertThat(work.getPutCode(), nullValue());
+        assertThat(work.getWorkType(), is(WorkType.BOOK));
+        assertThat(work.getWorkTitle(), notNullValue());
+        assertThat(work.getWorkTitle().getTitle(), notNullValue());
+        assertThat(work.getWorkTitle().getTitle().getContent(), is("Test publication"));
+        assertThat(work.getWorkContributors(), notNullValue());
+        assertThat(work.getUrl(), matches(urlEndsWith(publication.getHandle())));
+
+        List<Contributor> contributors = work.getWorkContributors().getContributor();
+        assertThat(contributors, hasSize(3));
+        assertThat(contributors,
+            has(shortenedContributor(longAuthor.substring(0, 150 - 4), AUTHOR, FIRST, 151)));
+        assertThat(contributors, has(contributor("Editor", EDITOR, FIRST)));
+        assertThat(contributors, has(contributor("Jesse Pinkman", AUTHOR, ADDITIONAL)));
+
+        assertThat(work.getExternalIdentifiers(), notNullValue());
+
+        List<ExternalID> externalIds = work.getExternalIdentifiers().getExternalIdentifier();
+        assertThat(externalIds, hasSize(3));
+        assertThat(externalIds, has(selfExternalId("doi", "doi-id")));
+        assertThat(externalIds, has(selfExternalId("eid", "scopus-id")));
+        assertThat(externalIds, has(selfExternalId("handle", publication.getHandle())));
+
+    }
+
+    @Test
     public void testEmptyWorkWithUnknownTypeCreation() {
 
         context.turnOffAuthorisationSystem();
@@ -369,6 +478,14 @@ public class OrcidEntityFactoryServiceIT extends AbstractIntegrationTestWithData
 
     private Predicate<Contributor> contributor(String name, ContributorRole role, SequenceType sequence) {
         return contributor -> contributor.getCreditName().getContent().equals(name)
+            && role.value().equals(contributor.getContributorAttributes().getContributorRole())
+            && contributor.getContributorAttributes().getContributorSequence() == sequence;
+    }
+
+    private Predicate<Contributor> shortenedContributor(String name, ContributorRole role, SequenceType sequence,
+                                                        int maxlength) {
+        return contributor -> contributor.getCreditName().getContent().startsWith(name)
+            && contributor.getCreditName().getContent().length() <= maxlength
             && role.value().equals(contributor.getContributorAttributes().getContributorRole())
             && contributor.getContributorAttributes().getContributorSequence() == sequence;
     }

--- a/dspace/config/modules/orcid.cfg
+++ b/dspace/config/modules/orcid.cfg
@@ -126,6 +126,13 @@ orcid.mapping.organization.identifiers = organization.identifier.ror::ROR
 orcid.mapping.contributor.email = person.email
 orcid.mapping.contributor.orcid = person.identifier.orcid
 
+### maximal length for values of some orcid objects ###
+# Orcid objects uses some special data types which are not reflected in the generated orcid model ###
+# This might lead to problems when pushing items with long abstracts or contributor names.
+# these values are shortened by ....
+orcid.mapping.contributor.maxvaluelength = 150
+orcid.mapping.description.maxvaluelength = 4000
+
 #------------------------------------------------------------------#
 #--------------ORCID OBJECTS VALIDATION CONFIGURATIONS-------------#
 #------------------------------------------------------------------#

--- a/dspace/config/spring/api/orcid-services.xml
+++ b/dspace/config/spring/api/orcid-services.xml
@@ -109,6 +109,8 @@
     	<property name="organizationCityField" value="${orcid.mapping.organization.city}" />
     	<property name="organizationCountryField" value="${orcid.mapping.organization.country}" />
     	<property name="disambiguatedOrganizationIdentifierFields" value="${orcid.mapping.organization.identifiers}" />
+		<property name="maxDescriptionValueLength" value="${orcid.mapping.description.maxvaluelength}" />
+		<property name="maxContributorValueLength" value="${orcid.mapping.contributor.maxvaluelength}" />
     </bean>
     
     <!-- Configuration of ORCID profile sections factory. 


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/DSpace/issues/9951

## Description
Add configurable option to set the orcid contributor names and orcid (short) description values to some maximum length. This mitigates error on the orcid data types which are currently not considered in the dspace orcid validation. We prefer to shorten (or better substring, I'm not sure about the correct english wording) the values, because the profile owner seldom has the possibility to correct the values himself. 

## Instructions for Reviewers

List of changes in this PR:
* add some configurable options
```
orcid.mapping.contributor.maxvaluelength = 150
orcid.mapping.description.maxvaluelength = 4000
```

to enable/disable the option 
* during creation of the orcid objects the values for contributor and short description are shortened. Three ellipses/dots are added to the end as a symbol for shortening the value.
* added some IT to test if the value has been shortened.

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 
- enable configurable entities
- set up orcid integration
- Try to push some publication/funding to orcid which has some very long abstract (>4000 chars).
  - With this fix the value should be shortened and the object pushed successfully.
  - Without the fix the object should not be pushed and some log message from orcid remains mentioning the data type (see issue)

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
