### PR TITLE
conditional rendering of metadata section in style.xsl

### DIFF
--- a/dspace-oai/src/main/resources/static/style.xsl
+++ b/dspace-oai/src/main/resources/static/style.xsl
@@ -378,14 +378,16 @@
                                 </xsl:for-each>
                             </div>
                     </div>
-                    <div class="card">
-                            <div class="card-header">
-                                <h5>Metadata</h5>
-                            </div>
-                            <div class="card-body">
-                                <xsl:apply-templates select="oai:metadata/*" />
-                            </div>
-                    </div>
+                    <xsl:if test="oai:metadata">
+	                    <div class="card">
+	                            <div class="card-header">
+	                                <h5>Metadata</h5>
+	                            </div>
+	                            <div class="card-body">
+	                                <xsl:apply-templates select="oai:metadata/*" />
+	                            </div>
+	                    </div>
+                    </xsl:if>
                 </div>
             </div>
         </xsl:for-each>

--- a/dspace-oai/src/main/resources/static/style.xsl
+++ b/dspace-oai/src/main/resources/static/style.xsl
@@ -319,20 +319,22 @@
                             </div>
                         </div>
                     </div>
-                    <div class="card">
-                        <a data-toggle="collapse">
-                            <xsl:attribute name="href">#<xsl:value-of select="translate(oai:header/oai:identifier/text(), ':/.', '')"></xsl:value-of></xsl:attribute>
-                            <div class="card-header">
-                                <h5>Metadata</h5>
-                            </div>
-                        </a>
-                        <div class="collapse">
-                            <xsl:attribute name="id"><xsl:value-of select="translate(oai:header/oai:identifier/text(), ':/.', '')"></xsl:value-of></xsl:attribute>
-                            <div class="card-body">
-                                <xsl:apply-templates select="oai:metadata/*" />
-                            </div>
-                        </div>
-                    </div>
+                    <xsl:if test="oai:metadata">
+	                    <div class="card">
+	                        <a data-toggle="collapse">
+	                            <xsl:attribute name="href">#<xsl:value-of select="translate(oai:header/oai:identifier/text(), ':/.', '')"></xsl:value-of></xsl:attribute>
+	                            <div class="card-header">
+	                                <h5>Metadata</h5>
+	                            </div>
+	                        </a>
+	                        <div class="collapse">
+	                            <xsl:attribute name="id"><xsl:value-of select="translate(oai:header/oai:identifier/text(), ':/.', '')"></xsl:value-of></xsl:attribute>
+	                            <div class="card-body">
+	                                <xsl:apply-templates select="oai:metadata/*" />
+	                            </div>
+	                        </div>
+	                    </div>
+		    </xsl:if>
                 </div>
             </div>
         </xsl:for-each>


### PR DESCRIPTION
## Description

This minor PR improves the rendering of OAI-PMH responses. 

In case of deleted / withdrawn items, the rendering shows an empty "metadata" section:

![image](https://github.com/user-attachments/assets/dab5ee89-6aef-4dbf-96bb-68edcbcf8d7a)

This PR adds a conditional rendering of section "metadata" in `style.xsl`.