### PR TITLE
Refactor AbstractIntegrationTestWithDatabase to use EPersonBuilder for test users

### DIFF
--- a/dspace-api/src/test/java/org/dspace/AbstractIntegrationTestWithDatabase.java
+++ b/dspace-api/src/test/java/org/dspace/AbstractIntegrationTestWithDatabase.java
@@ -20,8 +20,8 @@ import org.dspace.app.launcher.ScriptLauncher;
 import org.dspace.app.scripts.handler.impl.TestDSpaceRunnableHandler;
 import org.dspace.authority.AuthoritySearchService;
 import org.dspace.authority.MockAuthoritySolrServiceImpl;
-import org.dspace.authorize.AuthorizeException;
 import org.dspace.builder.AbstractBuilder;
+import org.dspace.builder.EPersonBuilder;
 import org.dspace.content.Community;
 import org.dspace.core.Context;
 import org.dspace.core.I18nUtil;
@@ -127,19 +127,16 @@ public class AbstractIntegrationTestWithDatabase extends AbstractDSpaceIntegrati
             EPersonService ePersonService = EPersonServiceFactory.getInstance().getEPersonService();
             eperson = ePersonService.findByEmail(context, "test@email.com");
             if (eperson == null) {
-                // This EPerson creation should only happen once (i.e. for first test run)
-                log.info("Creating initial EPerson (email=test@email.com) for Unit Tests");
-                eperson = ePersonService.create(context);
-                eperson.setFirstName(context, "first");
-                eperson.setLastName(context, "last");
-                eperson.setEmail("test@email.com");
-                eperson.setCanLogIn(true);
-                eperson.setLanguage(context, I18nUtil.getDefaultLocale().getLanguage());
-                ePersonService.setPassword(eperson, password);
-                // actually save the eperson to unit testing DB
-                ePersonService.update(context, eperson);
+                // Create test EPerson for usage in all tests
+                log.info("Creating Test EPerson (email=test@email.com) for Integration Tests");
+                eperson = EPersonBuilder.createEPerson(context)
+                                        .withNameInMetadata("first", "last")
+                                        .withEmail("test@email.com")
+                                        .withCanLogin(true)
+                                        .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
+                                        .withPassword(password)
+                                        .build();
             }
-
             // Set our global test EPerson as the current user in DSpace
             context.setCurrentUser(eperson);
 
@@ -148,26 +145,23 @@ public class AbstractIntegrationTestWithDatabase extends AbstractDSpaceIntegrati
 
             admin = ePersonService.findByEmail(context, "admin@email.com");
             if (admin == null) {
-                // This EPerson creation should only happen once (i.e. for first test run)
-                log.info("Creating initial EPerson (email=admin@email.com) for Unit Tests");
-                admin = ePersonService.create(context);
-                admin.setFirstName(context, "first (admin)");
-                admin.setLastName(context, "last (admin)");
-                admin.setEmail("admin@email.com");
-                admin.setCanLogIn(true);
-                admin.setLanguage(context, I18nUtil.getDefaultLocale().getLanguage());
-                ePersonService.setPassword(admin, password);
-                // actually save the eperson to unit testing DB
-                ePersonService.update(context, admin);
+                // Create test Administrator for usage in all tests
+                log.info("Creating Test Admin EPerson (email=admin@email.com) for Integration Tests");
+                admin = EPersonBuilder.createEPerson(context)
+                                      .withNameInMetadata("first (admin)", "last (admin)")
+                                      .withEmail("admin@email.com")
+                                      .withCanLogin(true)
+                                      .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
+                                      .withPassword(password)
+                                      .build();
+
+                // Add Test Administrator to the ADMIN group in test database
                 GroupService groupService = EPersonServiceFactory.getInstance().getGroupService();
                 Group adminGroup = groupService.findByName(context, Group.ADMIN);
                 groupService.addMember(context, adminGroup, admin);
             }
 
             context.restoreAuthSystemState();
-        } catch (AuthorizeException ex) {
-            log.error("Error creating initial eperson or default groups", ex);
-            fail("Error creating initial eperson or default groups in AbstractUnitTest init()");
         } catch (SQLException ex) {
             log.error(ex.getMessage(), ex);
             fail("SQL Error on AbstractUnitTest init()");

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/test/AbstractWebClientIntegrationTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/test/AbstractWebClientIntegrationTest.java
@@ -12,6 +12,7 @@ import org.dspace.AbstractIntegrationTestWithDatabase;
 import org.dspace.app.TestApplication;
 import org.dspace.app.rest.utils.DSpaceConfigurationInitializer;
 import org.dspace.app.rest.utils.DSpaceKernelInitializer;
+import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -63,6 +64,21 @@ public class AbstractWebClientIntegrationTest extends AbstractIntegrationTestWit
     // Spring Application context
     @Autowired
     protected ApplicationContext applicationContext;
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+
+        // Because AbstractWebClientIntegrationTest starts a new webserver, we need to ensure *everything* created by
+        // the "super.setUp()" script is committed to the test database. Otherwise, the new webserver may not see the
+        // created test data in the database.
+        // NOTE: This commit() does NOT occur in AbstractIntegrationTestDatabase because it will remove newly created
+        // Hibernate entities from the current Hibernate session. For most ITs we don't want that as it may result
+        // in "could not initialize proxy - no Session" errors when using those entities in other tests (or other tests
+        // would need to reload each test entity back into the Hibernate session)
+        context.commit();
+    }
 
     /**
      * Get client TestRestTemplate for making HTTP requests to test webserver


### PR DESCRIPTION
## References
* Related to #9690.  (This PR fixes an Integration Test failure which is currently occurring in #9690)

## Description

In #9690, we've encountered an odd scenario where `BulkAccessControlIT` is failing every time its internal/private method `findItems()` is called.  The [`findItems()` method](https://github.com/DSpace/DSpace/blob/main/dspace-api/src/test/java/org/dspace/app/bulkaccesscontrol/BulkAccessControlIT.java#L1834-L1846) is used to search Solr to locate all Items that are *indexed* as belonging to a particular Community.

The failure throws the following exception:
```
[ERROR] org.dspace.app.bulkaccesscontrol.BulkAccessControlIT.performBulkAccessWithReplaceModeTest -- Time elapsed: 2.121 s <<< ERROR!
org.dspace.discovery.SearchServiceException: failed to lazily initialize a collection of role: org.dspace.content.DSpaceObject.metadata: could not initialize proxy - no Session
        at org.dspace.discovery.SolrServiceImpl.search(SolrServiceImpl.java:774)
        at org.dspace.app.bulkaccesscontrol.BulkAccessControlIT.findItems(BulkAccessControlIT.java:1840)
        at org.dspace.app.bulkaccesscontrol.BulkAccessControlIT.performBulkAccessWithReplaceModeTest(BulkAccessControlIT.java:1456)
...
Caused by: org.hibernate.LazyInitializationException: failed to lazily initialize a collection of role: org.dspace.content.DSpaceObject.metadata: could not initialize proxy - no Session
        at org.hibernate.collection.spi.AbstractPersistentCollection.throwLazyInitializationException(AbstractPersistentCollection.java:634)
        at org.hibernate.collection.spi.AbstractPersistentCollection.withTemporarySessionIfNeeded(AbstractPersistentCollection.java:217)
        at org.hibernate.collection.spi.AbstractPersistentCollection.initialize(AbstractPersistentCollection.java:613)
        at org.hibernate.collection.spi.AbstractPersistentCollection.read(AbstractPersistentCollection.java:136)
        at org.hibernate.collection.spi.PersistentBag.iterator(PersistentBag.java:371)
        at org.dspace.content.DSpaceObjectServiceImpl.getMetadata(DSpaceObjectServiceImpl.java:123)
        at org.dspace.content.DSpaceObjectServiceImpl.getMetadataFirstValue(DSpaceObjectServiceImpl.java:435)
        at org.dspace.eperson.EPerson.getFirstName(EPerson.java:250)
        at org.dspace.eperson.EPerson.getFullName(EPerson.java:232)
        at org.dspace.eperson.EPerson.equals(EPerson.java:145)
        at org.dspace.eperson.GroupServiceImpl.allMemberGroupsSet(GroupServiceImpl.java:359)
        at org.dspace.discovery.SolrServiceResourceRestrictionPlugin.additionalSearchParameters(SolrServiceResourceRestrictionPlugin.java:157)
        at org.dspace.discovery.SolrServiceImpl.resolveToSolrQuery(SolrServiceImpl.java:973)
        at org.dspace.discovery.SolrServiceImpl.retrieveResult(SolrServiceImpl.java:985)
        at org.dspace.discovery.SolrServiceImpl.search(SolrServiceImpl.java:771)
```

The **most important** part of this error is the `Caused by` section of the stacktrace, which shows that the error begins when the Solr search attempts to append the currently authenticated user's Groups (in [`SolrServiceResourceRestrictionPlugin`](https://github.com/DSpace/DSpace/blob/main/dspace-api/src/main/java/org/dspace/discovery/SolrServiceResourceRestrictionPlugin.java#L157)

After debugging the issue, I've discovered it appears the bug is caused by how `AbstractIntegrationTestWithDatabase` creates our test EPerson accounts. In the above stacktrace, a test EPerson account is the one which "fails to lazily initialize" in Hibernate (when the session is closed before its metadata can be read).  If this EPerson account is initialized *earlier* in the test, then this error will not occur, but the change in #9690 results in the EPerson account no longer being initialized early in the test.

The current code uses EPersonService and attempts to share the same test EPerson accounts across several tests.

**This PR makes two changes**
1. Updates our `AbstractIntegrationTestWithDatabase` to use EPersonBuilder, in order to ensure these test users are destroyed after each IT and recreated for the next one.  **This provides better test separation. These EPerson objects are no longer shared between tests**
    * This simple switch to using EPersonBuilder solves the error in the tests.  The reason this simple change appears to work is that EPersonBuilder also ensure the EPerson is *indexed* into (Mock) Solr, which initializes the EPerson properly for all tests.
2. Updates `AbstractWebClientIntegrationTest` to force a `context.commit()` as part of its `setUp()`.  This is necessary because these tests will run in a separate test web server spun up by Spring Boot.  Therefore, any initialized test data **must** be committed to the database for that new web server to have access to it.
    * The context.commit() cannot be placed in `AbstractIntegrationTestWithDatabase` as it will remove the newly created test data from the Hibernate session. This can have side effects on other ITs because they expect to be able to use or update that test data without establishing a new Context object or reloading the entities into the Hibernate session.
    * NOTE: the primary reason this is now necessary is because the test EPersons are now *destroyed* after every test and recreated for the next test.  That provides better test separation, but it means that tests using `AbstractWebClientIntegrationTest` no longer can depend on having those test EPersons already saved in the database.

## Instructions for Reviewers
* Ensure all tests pass.  This only changes `AbstractIntegrationWithDatabase` and `AbstractWebClientIntegrationTest`
