### PR TITLE
Enable dependabot dependency updates for 8.x and 7.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@
 #-------------------
 version: 2
 updates:
+  ###############
+  ## Main branch
+  ###############
+  # NOTE: At this time, "security-updates" rules only apply if "target-branch" is unspecified
+  # So, only this first section can include "applies-to: security-updates"
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
@@ -116,3 +121,235 @@ updates:
       # Ignore all major version updates for all dependencies. We'll only automate minor/patch updates.
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+  ######################
+  ## dspace-8_x branch
+  ######################
+  - package-ecosystem: "maven"
+    directory: "/"
+    target-branch: dspace-8_x
+    schedule:
+      interval: "weekly"
+    # Allow up to 10 open PRs for dependencies
+    open-pull-requests-limit: 10
+    # Group together some upgrades in a single PR
+    groups:
+      # Group together all Build Tools in a single PR
+      build-tools:
+        applies-to: version-updates
+        patterns:
+          - "org.apache.maven.plugins:*"
+          - "*:*-maven-plugin"
+          - "*:maven-*-plugin"
+          - "com.github.spotbugs:spotbugs"
+          - "com.google.code.findbugs:*"
+          - "com.google.errorprone:*"
+          - "com.puppycrawl.tools:checkstyle"
+          - "org.sonatype.plugins:*"
+        exclude-patterns:
+          # Exclude anything from Spring, as that is in a separate group
+          - "org.springframework.*:*"
+        update-types:
+          - "minor"
+          - "patch"
+      test-tools:
+        applies-to: version-updates
+        patterns:
+          - "junit:*"
+          - "com.github.stefanbirker:system-rules"
+          - "com.h2database:*"
+          - "io.findify:s3mock*"
+          - "io.netty:*"
+          - "org.hamcrest:*"
+          - "org.mock-server:*"
+          - "org.mockito:*"
+        update-types:
+          - "minor"
+          - "patch"
+      # Group together all Apache Commons deps in a single PR
+      apache-commons:
+        applies-to: version-updates
+        patterns:
+          - "org.apache.commons:*"
+          - "commons-*:commons-*"
+        update-types:
+          - "minor"
+          - "patch"
+      # Group together all fasterxml deps in a single PR
+      fasterxml:
+        applies-to: version-updates
+        patterns:
+          - "com.fasterxml:*"
+          - "com.fasterxml.*:*"
+        update-types:
+          - "minor"
+          - "patch"
+        # Group together all Hibernate deps in a single PR
+      hibernate:
+        applies-to: version-updates
+        patterns:
+          - "org.hibernate.*:*"
+        update-types:
+          - "minor"
+          - "patch"
+      # Group together all Jakarta deps in a single PR
+      jakarta:
+        applies-to: version-updates
+        patterns:
+          - "jakarta.*:*"
+          - "org.eclipse.angus:jakarta.mail"
+          - "org.glassfish.jaxb:jaxb-runtime"
+        update-types:
+          - "minor"
+          - "patch"
+      # Group together all Google deps in a single PR
+      google-apis:
+        applies-to: version-updates
+        patterns:
+          - "com.google.apis:*"
+          - "com.google.api-client:*"
+          - "com.google.http-client:*"
+          - "com.google.oauth-client:*"
+        update-types:
+          - "minor"
+          - "patch"
+      # Group together all Spring deps in a single PR
+      spring:
+        applies-to: version-updates
+        patterns:
+          - "org.springframework:*"
+          - "org.springframework.*:*"
+        update-types:
+          - "minor"
+          - "patch"
+      # Group together all WebJARs deps in a single PR
+      webjars:
+        applies-to: version-updates
+        patterns:
+          - "org.webjars:*"
+          - "org.webjars.*:*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      # Don't try to auto-update any DSpace dependencies
+      - dependency-name: "org.dspace:*"
+      - dependency-name: "org.dspace.*:*"
+      # Ignore all major version updates for all dependencies. We'll only automate minor/patch updates.
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major" ]
+  ######################
+  ## dspace-7_x branch
+  ######################
+  - package-ecosystem: "maven"
+    directory: "/"
+    target-branch: dspace-7_x
+    schedule:
+      interval: "weekly"
+    # Allow up to 10 open PRs for dependencies
+    open-pull-requests-limit: 10
+    # Group together some upgrades in a single PR
+    groups:
+      # Group together all Build Tools in a single PR
+      build-tools:
+        applies-to: version-updates
+        patterns:
+          - "org.apache.maven.plugins:*"
+          - "*:*-maven-plugin"
+          - "*:maven-*-plugin"
+          - "com.github.spotbugs:spotbugs"
+          - "com.google.code.findbugs:*"
+          - "com.google.errorprone:*"
+          - "com.puppycrawl.tools:checkstyle"
+          - "org.sonatype.plugins:*"
+        exclude-patterns:
+          # Exclude anything from Spring, as that is in a separate group
+          - "org.springframework.*:*"
+        update-types:
+          - "minor"
+          - "patch"
+      test-tools:
+        applies-to: version-updates
+        patterns:
+          - "junit:*"
+          - "com.github.stefanbirker:system-rules"
+          - "com.h2database:*"
+          - "io.findify:s3mock*"
+          - "io.netty:*"
+          - "org.hamcrest:*"
+          - "org.mock-server:*"
+          - "org.mockito:*"
+        update-types:
+          - "minor"
+          - "patch"
+      # Group together all Apache Commons deps in a single PR
+      apache-commons:
+        applies-to: version-updates
+        patterns:
+          - "org.apache.commons:*"
+          - "commons-*:commons-*"
+        update-types:
+          - "minor"
+          - "patch"
+      # Group together all fasterxml deps in a single PR
+      fasterxml:
+        applies-to: version-updates
+        patterns:
+          - "com.fasterxml:*"
+          - "com.fasterxml.*:*"
+        update-types:
+          - "minor"
+          - "patch"
+        # Group together all Hibernate deps in a single PR
+      hibernate:
+        applies-to: version-updates
+        patterns:
+          - "org.hibernate.*:*"
+        update-types:
+          - "minor"
+          - "patch"
+      # Group together all Jakarta deps in a single PR
+      jakarta:
+        applies-to: version-updates
+        patterns:
+          - "jakarta.*:*"
+          - "org.eclipse.angus:jakarta.mail"
+          - "org.glassfish.jaxb:jaxb-runtime"
+        update-types:
+          - "minor"
+          - "patch"
+      # Group together all Google deps in a single PR
+      google-apis:
+        applies-to: version-updates
+        patterns:
+          - "com.google.apis:*"
+          - "com.google.api-client:*"
+          - "com.google.http-client:*"
+          - "com.google.oauth-client:*"
+        update-types:
+          - "minor"
+          - "patch"
+      # Group together all Spring deps in a single PR
+      spring:
+        applies-to: version-updates
+        patterns:
+          - "org.springframework:*"
+          - "org.springframework.*:*"
+        update-types:
+          - "minor"
+          - "patch"
+      # Group together all WebJARs deps in a single PR
+      webjars:
+        applies-to: version-updates
+        patterns:
+          - "org.webjars:*"
+          - "org.webjars.*:*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      # Don't try to auto-update any DSpace dependencies
+      - dependency-name: "org.dspace:*"
+      - dependency-name: "org.dspace.*:*"
+      # Ignore all major version updates for all dependencies. We'll only automate minor/patch updates.
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major" ]


### PR DESCRIPTION
## References
* Follow-up to #9926 
* Replaces #10205 and #10204

## Description
This small PR enables `@dependabot` dependency updates for `dspace-8_x` and `dspace-7_x`. The settings applied to those branches are copy & pasted from the `main` branch settings.   

NOTE: `@dependabot` only follows configurations that are on the `main` branch.  So, this PR updates our `dependabot.yml` on the `main` branch to include configurations that tell `@dependabot` to create PRs against those branches as well.

## Instructions for Reviewers
* Unfortunately, this can only be tested by merging it, as `@dependabot` will only obey the configs that are on the `main` branch.  So, this PR is just for documentation purposes.