### PR TITLE
Fix issue with VersionedHandleIdentifierProviderWithCanonicalHandles and com/col handles

### DIFF
--- a/dspace-api/src/test/java/org/dspace/identifier/VersionedHandleIdentifierProviderWithCanonicalHandlesIT.java
+++ b/dspace-api/src/test/java/org/dspace/identifier/VersionedHandleIdentifierProviderWithCanonicalHandlesIT.java
@@ -8,8 +8,10 @@
 package org.dspace.identifier;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.dspace.authorize.AuthorizeException;
@@ -22,14 +24,18 @@ import org.dspace.content.Community;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataValue;
 import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.kernel.ServiceManager;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.junit.Before;
 import org.junit.Test;
 
-public class VersionedHandleIdentifierProviderIT extends AbstractIdentifierProviderIT  {
+public class VersionedHandleIdentifierProviderWithCanonicalHandlesIT extends AbstractIdentifierProviderIT {
+    private ServiceManager serviceManager;
+    private IdentifierServiceImpl identifierService;
 
     private String firstHandle;
     private String dspaceUrl;
+
 
     private Collection collection;
     private Item itemV1;
@@ -42,8 +48,11 @@ public class VersionedHandleIdentifierProviderIT extends AbstractIdentifierProvi
         super.setUp();
         context.turnOffAuthorisationSystem();
 
+        serviceManager = DSpaceServicesFactory.getInstance().getServiceManager();
         dspaceUrl = DSpaceServicesFactory.getInstance().getConfigurationService().getProperty("dspace.ui.url");
+        identifierService = serviceManager.getServicesByType(IdentifierServiceImpl.class).get(0);
         // Clean out providers to avoid any being used for creation of community and collection
+        identifierService.setProviders(new ArrayList<>());
 
         parentCommunity = CommunityBuilder.createCommunity(context)
                                           .withName("Parent Community")
@@ -51,35 +60,46 @@ public class VersionedHandleIdentifierProviderIT extends AbstractIdentifierProvi
         collection = CollectionBuilder.createCollection(context, parentCommunity)
                                       .withName("Collection")
                                       .build();
+
+        registerProvider(VersionedHandleIdentifierProviderWithCanonicalHandles.class);
+    }
+
+    public void destroy() throws Exception {
+        super.destroy();
+        // Unregister this non-default provider
+        unregisterProvider(VersionedHandleIdentifierProviderWithCanonicalHandles.class);
+        // Re-register the default provider (for later tests)
+        registerProvider(VersionedHandleIdentifierProvider.class);
     }
 
     private void createVersions() throws SQLException, AuthorizeException {
         itemV1 = ItemBuilder.createItem(context, collection)
-                .withTitle("First version")
-                .build();
+                            .withTitle("First version")
+                            .build();
         firstHandle = itemV1.getHandle();
         itemV2 = VersionBuilder.createVersion(context, itemV1, "Second version").build().getItem();
         itemV3 = VersionBuilder.createVersion(context, itemV1, "Third version").build().getItem();
     }
 
     @Test
-    public void testDefaultVersionedHandleProvider() throws Exception {
+    public void testCanonicalVersionedHandleProvider() throws Exception {
         createVersions();
 
-        // Confirm the original item only has its original handle
-        assertEquals(firstHandle, itemV1.getHandle());
+        // Confirm the original item only has a version handle
+        assertEquals(firstHandle + ".1", itemV1.getHandle());
         assertEquals(1, itemV1.getHandles().size());
         // Confirm the second item has the correct version handle
         assertEquals(firstHandle + ".2", itemV2.getHandle());
         assertEquals(1, itemV2.getHandles().size());
-        // Confirm the last item has the correct version handle
-        assertEquals(firstHandle + ".3", itemV3.getHandle());
-        assertEquals(1, itemV3.getHandles().size());
+        // Confirm the last item has both the correct version handle and the original handle
+        assertEquals(firstHandle, itemV3.getHandle());
+        assertEquals(2, itemV3.getHandles().size());
+        containsHandle(itemV3, firstHandle + ".3");
     }
 
     @Test
     public void testCollectionHandleMetadata() {
-        registerProvider(VersionedHandleIdentifierProvider.class);
+        registerProvider(VersionedHandleIdentifierProviderWithCanonicalHandles.class);
 
         Community testCommunity = CommunityBuilder.createCommunity(context)
                                                   .withName("Test community")
@@ -99,7 +119,7 @@ public class VersionedHandleIdentifierProviderIT extends AbstractIdentifierProvi
 
     @Test
     public void testCommunityHandleMetadata() {
-        registerProvider(VersionedHandleIdentifierProvider.class);
+        registerProvider(VersionedHandleIdentifierProviderWithCanonicalHandles.class);
 
         Community testCommunity = CommunityBuilder.createCommunity(context)
                                                   .withName("Test community")
@@ -111,5 +131,9 @@ public class VersionedHandleIdentifierProviderIT extends AbstractIdentifierProvi
 
         assertEquals(1, metadata.size());
         assertEquals(dspaceUrl + "/handle/" + testCommunity.getHandle(), metadata.get(0).getValue());
+    }
+
+    private void containsHandle(Item item, String handle) {
+        assertTrue(item.getHandles().stream().anyMatch(h -> handle.equals(h.getHandle())));
     }
 }

--- a/dspace/config/spring/api/identifier-service.xml
+++ b/dspace/config/spring/api/identifier-service.xml
@@ -24,9 +24,9 @@
            The VersionedHandleIdentifierProvider creates a new versioned
            handle for every new version.
            -->
-    <bean id="org.dspace.identifier.HandleIdentifierProvider" class="org.dspace.identifier.VersionedHandleIdentifierProvider" scope="singleton">
-        <property name="configurationService" ref="org.dspace.services.ConfigurationService"/>
-    </bean>
+<!--    <bean id="org.dspace.identifier.HandleIdentifierProvider" class="org.dspace.identifier.VersionedHandleIdentifierProvider" scope="singleton">-->
+<!--        <property name="configurationService" ref="org.dspace.services.ConfigurationService"/>-->
+<!--    </bean>-->
     <!--
            The VersionedHandleIdentifierProviderWithCanonicalHandles
            preserves the first handle for every new version. Whenever
@@ -35,11 +35,10 @@
            newest version, but there is no permanent handle, that
            will always keep pointing to the actual newest one.
            -->
-    <!--
+
     <bean id="org.dspace.identifier.HandleIdentifierProvider" class="org.dspace.identifier.VersionedHandleIdentifierProviderWithCanonicalHandles" scope="singleton">
         <property name="configurationService" ref="org.dspace.services.ConfigurationService"/>
     </bean>
-    -->
 
     <!-- DOIIdentifierProvider mints and registers DOIs with DSpace.
          The DOIIdentifierProvider maintains the doi database table and handling

--- a/dspace/config/spring/api/identifier-service.xml
+++ b/dspace/config/spring/api/identifier-service.xml
@@ -19,14 +19,14 @@
     </bean>
     -->
 
-      <!-- If you enabled versioning, you should use one of the versioned
-           handle identifier provider instead of the default one.
-           The VersionedHandleIdentifierProvider creates a new versioned
-           handle for every new version.
-           -->
-<!--    <bean id="org.dspace.identifier.HandleIdentifierProvider" class="org.dspace.identifier.VersionedHandleIdentifierProvider" scope="singleton">-->
-<!--        <property name="configurationService" ref="org.dspace.services.ConfigurationService"/>-->
-<!--    </bean>-->
+    <!-- If you enabled versioning, you should use one of the versioned
+         handle identifier provider instead of the default one.
+         The VersionedHandleIdentifierProvider creates a new versioned
+         handle for every new version.
+         -->
+    <bean id="org.dspace.identifier.HandleIdentifierProvider" class="org.dspace.identifier.VersionedHandleIdentifierProvider" scope="singleton">
+        <property name="configurationService" ref="org.dspace.services.ConfigurationService"/>
+    </bean>
     <!--
            The VersionedHandleIdentifierProviderWithCanonicalHandles
            preserves the first handle for every new version. Whenever
@@ -35,10 +35,11 @@
            newest version, but there is no permanent handle, that
            will always keep pointing to the actual newest one.
            -->
-
+    <!--
     <bean id="org.dspace.identifier.HandleIdentifierProvider" class="org.dspace.identifier.VersionedHandleIdentifierProviderWithCanonicalHandles" scope="singleton">
         <property name="configurationService" ref="org.dspace.services.ConfigurationService"/>
     </bean>
+    -->
 
     <!-- DOIIdentifierProvider mints and registers DOIs with DSpace.
          The DOIIdentifierProvider maintains the doi database table and handling


### PR DESCRIPTION
## References
Fixes #9709
DSpace 8 version of #10241 

## Description
An issue has been found where the `VersionedHandleIdentifierProviderWithCanonicalHandles` handle provider does not store the created handle for communities and collections. 

This PR fixes that issue. 

## Instructions for Reviewers

To replicate the original issue the following steps can be taken:
1. Enable the `VersionedHandleIdentifierProviderWithCanonicalHandles` handle provider and disable the `VersionedHandleIdentifierProvider` one.
2. Create a new community and/or collection 

Verify that the community/collection does NOT have a handle displayed on its simple page. 

Apply the fix and go through the steps again. The community/collection should now have a link containing the handle displayed on its simple page. 

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
