### PR TITLE
Add a log to make it clear the exported content is zipped up at the end.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExportServiceImpl.java
@@ -713,6 +713,9 @@ public class ItemExportServiceImpl implements ItemExportService {
                         }
 
                         // now zip up the export directory created above
+                        logInfo("Zipping up export directory " + workParentDir + " and creating file " + downloadDir
+                            + System.getProperty("file.separator")
+                            + fileName + ".zip");
                         zip(workParentDir, downloadDir
                             + System.getProperty("file.separator")
                             + fileName + ".zip");


### PR DESCRIPTION
## References
* Fixes #10239

## Description
Fixes a reported bug by simply adding a missing log message.  After exporting content from the UI, that exported content is zipped up.  However, the logs never state that, which makes it seem like the exported content is missing (if you check the "exports" directory on the server, see #10239).

This tiny PR just adds a single log line to state that the zip is occurring at the end.

## Instructions for Reviewers
* Verify code
* If desired, run and export and verify that the new log is added.