### PR TITLE
Cleaning up of filter-media script and service

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScript.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScript.java
@@ -7,11 +7,12 @@
  */
 package org.dspace.app.mediafilter;
 
+import static org.dspace.app.mediafilter.service.MediaFilterService.FILTER_PLUGIN_SEPARATOR;
+
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -29,6 +30,7 @@ import org.dspace.core.SelfNamedPlugin;
 import org.dspace.core.factory.CoreServiceFactory;
 import org.dspace.handle.factory.HandleServiceFactory;
 import org.dspace.scripts.DSpaceRunnable;
+import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.utils.DSpace;
 
@@ -44,7 +46,7 @@ import org.dspace.utils.DSpace;
  */
 public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfiguration> {
 
-    //key (in dspace.cfg) which lists all enabled filters by name
+    //key (in dspace.cfg) which lists al enabled filters by name
     private static final String MEDIA_FILTER_PLUGINS_KEY = "filter.plugins";
 
     //prefix (in dspace.cfg) for all filter properties
@@ -52,6 +54,8 @@ public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfigura
 
     //suffix (in dspace.cfg) for input formats supported by each filter
     private static final String INPUT_FORMATS_SUFFIX = "inputFormats";
+
+    private ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
 
     private boolean help;
     private boolean isVerbose = false;
@@ -65,61 +69,24 @@ public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfigura
     private LocalDate fromDate = null;
 
     public MediaFilterScriptConfiguration getScriptConfiguration() {
-        return new DSpace().getServiceManager()
-                           .getServiceByName("filter-media", MediaFilterScriptConfiguration.class);
+        return new DSpace().getServiceManager().getServiceByName("filter-media", MediaFilterScriptConfiguration.class);
     }
 
     public void setup() throws ParseException {
-
         // set headless for non-gui workstations
         System.setProperty("java.awt.headless", "true");
 
-
         help = commandLine.hasOption('h');
-
-        if (commandLine.hasOption('v')) {
-            isVerbose = true;
-        }
-
+        isVerbose = commandLine.hasOption('v');
         isQuiet = commandLine.hasOption('q');
-
-        if (commandLine.hasOption('f')) {
-            isForce = true;
-        }
-
-        if (commandLine.hasOption('i')) {
-            identifier = commandLine.getOptionValue('i');
-        }
-
-        if (commandLine.hasOption('m')) {
-            max2Process = Integer.parseInt(commandLine.getOptionValue('m'));
-            if (max2Process <= 1) {
-                handler.logWarning("Invalid maximum value '" +
-                                           commandLine.getOptionValue('m') + "' - ignoring");
-                max2Process = Integer.MAX_VALUE;
-            }
-        }
-
-        if (commandLine.hasOption('p')) {
-            //specified which media filter plugins we are using
-            filterNames = commandLine.getOptionValues('p');
-        } else {
-            //retrieve list of all enabled media filter plugins!
-            filterNames = DSpaceServicesFactory.getInstance().getConfigurationService()
-                                               .getArrayProperty(MEDIA_FILTER_PLUGINS_KEY);
-        }
-
-        //save to a global skip list
-        if (commandLine.hasOption('s')) {
-            //specified which identifiers to skip when processing
-            skipIds = commandLine.getOptionValues('s');
-        }
-
-        if (commandLine.hasOption('d')) {
-            fromDate = LocalDate.parse(commandLine.getOptionValue('d'));
-        }
-
-
+        isForce = commandLine.hasOption('f');
+        identifier = commandLine.getOptionValue('i');
+        max2Process = commandLine.hasOption('m') ?
+                Integer.parseInt(commandLine.getOptionValue('m')) : Integer.MAX_VALUE;
+        filterNames = commandLine.hasOption('p') ?
+                commandLine.getOptionValues('p') : configurationService.getArrayProperty(MEDIA_FILTER_PLUGINS_KEY);
+        skipIds = commandLine.hasOption('s') ? commandLine.getOptionValues('s') : null;
+        fromDate = commandLine.hasOption('d') ? LocalDate.parse(commandLine.getOptionValue('d')) : null;
     }
 
     public void internalRun() throws Exception {
@@ -135,116 +102,56 @@ public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfigura
         mediaFilterService.setVerbose(isVerbose);
         mediaFilterService.setMax2Process(max2Process);
 
-        //initialize an array of our enabled filters
         List<FormatFilter> filterList = new ArrayList<>();
-
-
-        //set up each filter
-        for (int i = 0; i < filterNames.length; i++) {
-            //get filter of this name & add to list of filters
-            FormatFilter filter = (FormatFilter) CoreServiceFactory.getInstance().getPluginService()
-                                                                   .getNamedPlugin(FormatFilter.class, filterNames[i]);
-            if (filter == null) {
-                handler.handleException("ERROR: Unknown MediaFilter specified (either from command-line or in " +
-                                                "dspace.cfg): '" + filterNames[i] + "'");
-                handler.logError("ERROR: Unknown MediaFilter specified (either from command-line or in " +
-                                         "dspace.cfg): '" + filterNames[i] + "'");
-            } else {
-                filterList.add(filter);
-
-                String filterClassName = filter.getClass().getName();
-
-                String pluginName = null;
-
-                //If this filter is a SelfNamedPlugin,
-                //then the input formats it accepts may differ for
-                //each "named" plugin that it defines.
-                //So, we have to look for every key that fits the
-                //following format: filter.<class-name>.<plugin-name>.inputFormats
-                if (SelfNamedPlugin.class.isAssignableFrom(filter.getClass())) {
-                    //Get the plugin instance name for this class
-                    pluginName = ((SelfNamedPlugin) filter).getPluginInstanceName();
+        for (String filterName : filterNames) {
+            try {
+                FormatFilter filter = (FormatFilter) CoreServiceFactory.getInstance()
+                                                                       .getPluginService()
+                                                                       .getNamedPlugin(FormatFilter.class, filterName);
+                if (filter == null) {
+                    handler.logError("Unknown MediaFilter specified: '" + filterName + "' will not be processed.");
+                } else {
+                    filterList.add(filter);
+                    String filterClassName = filter.getClass().getName();
+                    String pluginName = SelfNamedPlugin.class.isAssignableFrom(filter.getClass()) ?
+                            ((SelfNamedPlugin) filter).getPluginInstanceName() : null;
+                    String[] formats = configurationService.getArrayProperty(FILTER_PREFIX + "." + filterClassName +
+                            (pluginName != null ? "." + pluginName : "") + "." + INPUT_FORMATS_SUFFIX);
+                    if (ArrayUtils.isNotEmpty(formats)) {
+                        filterFormats.put(filterClassName + (pluginName != null ?
+                                FILTER_PLUGIN_SEPARATOR + pluginName : ""), Arrays.asList(formats));
+                    }
                 }
+            } catch (Exception e) {
+                handler.logError("MediaFilter: '" + filterName +
+                        "' was not initialized successfully and will not be processed", e);
+            }
+        }
 
-
-                //Retrieve our list of supported formats from dspace.cfg
-                //For SelfNamedPlugins, format of key is:
-                //  filter.<class-name>.<plugin-name>.inputFormats
-                //For other MediaFilters, format of key is:
-                //  filter.<class-name>.inputFormats
-                String[] formats =
-                        DSpaceServicesFactory.getInstance().getConfigurationService().getArrayProperty(
-                                FILTER_PREFIX + "." + filterClassName +
-                                        (pluginName != null ? "." + pluginName : "") +
-                                        "." + INPUT_FORMATS_SUFFIX);
-
-                //add to internal map of filters to supported formats
-                if (ArrayUtils.isNotEmpty(formats)) {
-                    //For SelfNamedPlugins, map key is:
-                    //  <class-name><separator><plugin-name>
-                    //For other MediaFilters, map key is just:
-                    //  <class-name>
-                    filterFormats.put(filterClassName +
-                                              (pluginName != null ? MediaFilterService.FILTER_PLUGIN_SEPARATOR +
-                                                      pluginName : ""),
-                                      Arrays.asList(formats));
-                }
-            } //end if filter!=null
-        } //end for
-
-        //If verbose, print out loaded mediafilter info
         if (isVerbose) {
             handler.logInfo("The following MediaFilters are enabled: ");
-            Iterator<String> i = filterFormats.keySet().iterator();
-            while (i.hasNext()) {
-                String filterName = i.next();
+            for (String filterName : filterFormats.keySet()) {
                 handler.logInfo("Full Filter Name: " + filterName);
-                String pluginName = null;
-                if (filterName.contains(MediaFilterService.FILTER_PLUGIN_SEPARATOR)) {
-                    String[] fields = filterName.split(MediaFilterService.FILTER_PLUGIN_SEPARATOR);
-                    filterName = fields[0];
-                    pluginName = fields[1];
-                }
-
+                String pluginName = filterName.contains(FILTER_PLUGIN_SEPARATOR) ?
+                        filterName.split(FILTER_PLUGIN_SEPARATOR)[1] : null;
                 handler.logInfo(filterName + (pluginName != null ? " (Plugin: " + pluginName + ")" : ""));
             }
         }
 
         mediaFilterService.setFilterFormats(filterFormats);
-        //store our filter list into an internal array
         mediaFilterService.setFilterClasses(filterList);
+        mediaFilterService.setSkipList(skipIds != null ? Arrays.asList(skipIds) : null);
+        mediaFilterService.setFromDate(fromDate);
 
-
-        //Retrieve list of identifiers to skip (if any)
-
-        if (skipIds != null && skipIds.length > 0) {
-            //save to a global skip list
-            mediaFilterService.setSkipList(Arrays.asList(skipIds));
-        }
-
-        if (fromDate != null) {
-            mediaFilterService.setFromDate(fromDate);
-        }
-
-        Context c = null;
-
-        try {
-            c = new Context();
-
-            // have to be super-user to do the filtering
+        try (Context c = new Context()) {
             c.turnOffAuthorisationSystem();
-
-            // now apply the filters
             if (identifier == null) {
                 mediaFilterService.applyFiltersAllItems(c);
             } else {
-                // restrict application scope to identifier
                 DSpaceObject dso = HandleServiceFactory.getInstance().getHandleService().resolveToObject(c, identifier);
                 if (dso == null) {
-                    throw new IllegalArgumentException("Cannot resolve "
-                                                               + identifier + " to a DSpace object");
+                    throw new IllegalArgumentException("Cannot resolve " + identifier + " to a DSpace object");
                 }
-
                 switch (dso.getType()) {
                     case Constants.COMMUNITY:
                         mediaFilterService.applyFiltersCommunity(c, (Community) dso);
@@ -259,15 +166,9 @@ public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfigura
                         break;
                 }
             }
-
             c.complete();
-            c = null;
         } catch (Exception e) {
             handler.handleException(e);
-        } finally {
-            if (c != null) {
-                c.abort();
-            }
         }
     }
 }


### PR DESCRIPTION
## References
* Fixes #10272

## Description
- Introduces better error handling with try/catch blocks, making sure the script does not crash on faulty filters or any errors that may be thrown while generating a filtered bitstream
- Cleared up some of the logging
- Introduced configuration property for only generating 1 thumbnail per item as there is no point in generating 500+ thumbnails for an item, only one can ever be shown
- General cleanup of some of the code

## Instructions for Reviewers
- Reproduce the linked issue on the main branch first, and verify these issues are no longer present on this branch
- Create an item with multiple files present for thumbnail generation in the 'ORIGINAL' bundle
   - Set one of them (not the first one) as primary bitstream and make sure only that file gets a filtered version in the 'THUMBNAIL' bundle
   - Make sure none of them are set as primary bitstream and the first **valid** file is picked to create a filtered version of. A file that is not in the supported extensions list should never be picked
   - Disable configuration and ensure generation happens for all files

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
