### PR TITLE
Display the access status (embargo) for the bitstream

### DIFF
--- a/dspace-api/src/main/java/org/dspace/access/status/AccessStatusHelper.java
+++ b/dspace-api/src/main/java/org/dspace/access/status/AccessStatusHelper.java
@@ -10,6 +10,7 @@ package org.dspace.access.status;
 import java.sql.SQLException;
 import java.time.LocalDate;
 
+import org.dspace.content.Bitstream;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
 
@@ -39,4 +40,25 @@ public interface AccessStatusHelper {
      * @throws SQLException An exception that provides information on a database access error or other errors.
      */
     public String getEmbargoFromItem(Context context, Item item, LocalDate threshold) throws SQLException;
+
+    /**
+     * Retrieve the availability date for the bitstream
+     *
+     * @param context the DSpace context
+     * @param bitstream the bitstream to check for embargo information
+     * @param threshold the embargo threshold date
+     * @return an availability date
+     * @throws SQLException An exception that provides information on a database access error or other errors.
+     */
+    public LocalDate getAvailabilityDateFromBitstream(Context context, Bitstream bitstream, LocalDate threshold)
+        throws SQLException;
+
+    /**
+     * Look at the DSpace object availability date to determine an access status value.
+     *
+     * @param availabilityDate the DSpace object availability date
+     * @param threshold the embargo threshold date
+     * @return an access status value
+     */
+    public String getAccessStatusFromAvailabilityDate(LocalDate availabilityDate, LocalDate threshold);
 }

--- a/dspace-api/src/main/java/org/dspace/access/status/AccessStatusHelper.java
+++ b/dspace-api/src/main/java/org/dspace/access/status/AccessStatusHelper.java
@@ -22,12 +22,13 @@ public interface AccessStatusHelper {
      * Calculate the access status for the item.
      *
      * @param context the DSpace context
-     * @param item    the item
+     * @param item the item
      * @param threshold the embargo threshold date
+     * @param type the type of calculation
      * @return an access status value
      * @throws SQLException An exception that provides information on a database access error or other errors.
      */
-    public String getAccessStatusFromItem(Context context, Item item, LocalDate threshold)
+    public String getAccessStatusFromItem(Context context, Item item, LocalDate threshold, String type)
         throws SQLException;
 
     /**
@@ -47,10 +48,11 @@ public interface AccessStatusHelper {
      * @param context the DSpace context
      * @param bitstream the bitstream to check for embargo information
      * @param threshold the embargo threshold date
+     * @param type the type of calculation
      * @return an availability date
      * @throws SQLException An exception that provides information on a database access error or other errors.
      */
-    public LocalDate getAvailabilityDateFromBitstream(Context context, Bitstream bitstream, LocalDate threshold)
+    public LocalDate getAvailabilityDateFromBitstream(Context context, Bitstream bitstream, LocalDate threshold, String type)
         throws SQLException;
 
     /**

--- a/dspace-api/src/main/java/org/dspace/access/status/AccessStatusHelper.java
+++ b/dspace-api/src/main/java/org/dspace/access/status/AccessStatusHelper.java
@@ -10,6 +10,7 @@ package org.dspace.access.status;
 import java.sql.SQLException;
 import java.time.LocalDate;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
@@ -25,11 +26,11 @@ public interface AccessStatusHelper {
      * @param item the item
      * @param threshold the embargo threshold date
      * @param type the type of calculation
-     * @return an access status value
+     * @return a pair with an access status value and the availability date
      * @throws SQLException An exception that provides information on a database access error or other errors.
      */
-    public String getAccessStatusFromItem(Context context, Item item, LocalDate threshold, String type)
-        throws SQLException;
+    public Pair<String, LocalDate> getAccessStatusFromItem(Context context,
+        Item item, LocalDate threshold, String type) throws SQLException;
 
     /**
      * Retrieve embargo information for the item
@@ -43,24 +44,15 @@ public interface AccessStatusHelper {
     public String getEmbargoFromItem(Context context, Item item, LocalDate threshold) throws SQLException;
 
     /**
-     * Retrieve the availability date for the bitstream
+     * Calculate the access status for the bitstream.
      *
      * @param context the DSpace context
-     * @param bitstream the bitstream to check for embargo information
+     * @param bitstream the bitstream
      * @param threshold the embargo threshold date
      * @param type the type of calculation
-     * @return an availability date
+     * @return a pair with an access status value and the availability date
      * @throws SQLException An exception that provides information on a database access error or other errors.
      */
-    public LocalDate getAvailabilityDateFromBitstream(Context context,
+    public Pair<String, LocalDate> getAccessStatusFromBitstream(Context context,
         Bitstream bitstream, LocalDate threshold, String type) throws SQLException;
-
-    /**
-     * Look at the DSpace object availability date to determine an access status value.
-     *
-     * @param availabilityDate the DSpace object availability date
-     * @param threshold the embargo threshold date
-     * @return an access status value
-     */
-    public String getAccessStatusFromAvailabilityDate(LocalDate availabilityDate, LocalDate threshold);
 }

--- a/dspace-api/src/main/java/org/dspace/access/status/AccessStatusHelper.java
+++ b/dspace-api/src/main/java/org/dspace/access/status/AccessStatusHelper.java
@@ -10,7 +10,7 @@ package org.dspace.access.status;
 import java.sql.SQLException;
 import java.time.LocalDate;
 
-import org.apache.commons.lang3.tuple.Pair;
+import org.dspace.content.AccessStatus;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
@@ -26,10 +26,10 @@ public interface AccessStatusHelper {
      * @param item the item
      * @param threshold the embargo threshold date
      * @param type the type of calculation
-     * @return a pair with an access status value and the availability date
+     * @return the access status
      * @throws SQLException An exception that provides information on a database access error or other errors.
      */
-    public Pair<String, LocalDate> getAccessStatusFromItem(Context context,
+    public AccessStatus getAccessStatusFromItem(Context context,
         Item item, LocalDate threshold, String type) throws SQLException;
 
     /**
@@ -50,9 +50,9 @@ public interface AccessStatusHelper {
      * @param bitstream the bitstream
      * @param threshold the embargo threshold date
      * @param type the type of calculation
-     * @return a pair with an access status value and the availability date
+     * @return the access status
      * @throws SQLException An exception that provides information on a database access error or other errors.
      */
-    public Pair<String, LocalDate> getAccessStatusFromBitstream(Context context,
+    public AccessStatus getAccessStatusFromBitstream(Context context,
         Bitstream bitstream, LocalDate threshold, String type) throws SQLException;
 }

--- a/dspace-api/src/main/java/org/dspace/access/status/AccessStatusHelper.java
+++ b/dspace-api/src/main/java/org/dspace/access/status/AccessStatusHelper.java
@@ -33,15 +33,16 @@ public interface AccessStatusHelper {
         Item item, LocalDate threshold, String type) throws SQLException;
 
     /**
-     * Retrieve embargo information for the item
+     * Calculate the anonymous access status for the item.
      *
      * @param context the DSpace context
      * @param item the item to check for embargo information
      * @param threshold the embargo threshold date
-     * @return an embargo date
+     * @return the access status
      * @throws SQLException An exception that provides information on a database access error or other errors.
      */
-    public String getEmbargoFromItem(Context context, Item item, LocalDate threshold) throws SQLException;
+    public AccessStatus getAnonymousAccessStatusFromItem(Context context,
+        Item item, LocalDate threshold) throws SQLException;
 
     /**
      * Calculate the access status for the bitstream.

--- a/dspace-api/src/main/java/org/dspace/access/status/AccessStatusHelper.java
+++ b/dspace-api/src/main/java/org/dspace/access/status/AccessStatusHelper.java
@@ -52,8 +52,8 @@ public interface AccessStatusHelper {
      * @return an availability date
      * @throws SQLException An exception that provides information on a database access error or other errors.
      */
-    public LocalDate getAvailabilityDateFromBitstream(Context context, Bitstream bitstream, LocalDate threshold, String type)
-        throws SQLException;
+    public LocalDate getAvailabilityDateFromBitstream(Context context,
+        Bitstream bitstream, LocalDate threshold, String type) throws SQLException;
 
     /**
      * Look at the DSpace object availability date to determine an access status value.

--- a/dspace-api/src/main/java/org/dspace/access/status/AccessStatusServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/access/status/AccessStatusServiceImpl.java
@@ -12,10 +12,10 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.access.status.service.AccessStatusService;
+import org.dspace.content.AccessStatus;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
@@ -76,7 +76,7 @@ public class AccessStatusServiceImpl implements AccessStatusService {
     }
 
     @Override
-    public Pair<String, LocalDate> getAccessStatus(Context context, Item item) throws SQLException {
+    public AccessStatus getAccessStatus(Context context, Item item) throws SQLException {
         return helper.getAccessStatusFromItem(context, item, forever_date, itemCalculationType);
     }
 
@@ -86,7 +86,7 @@ public class AccessStatusServiceImpl implements AccessStatusService {
     }
 
     @Override
-    public Pair<String, LocalDate> getAccessStatus(Context context, Bitstream bitstream) throws SQLException {
+    public AccessStatus getAccessStatus(Context context, Bitstream bitstream) throws SQLException {
         return helper.getAccessStatusFromBitstream(context, bitstream, forever_date, bitstreamCalculationType);
     }
 

--- a/dspace-api/src/main/java/org/dspace/access/status/AccessStatusServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/access/status/AccessStatusServiceImpl.java
@@ -81,8 +81,8 @@ public class AccessStatusServiceImpl implements AccessStatusService {
     }
 
     @Override
-    public String getEmbargoFromItem(Context context, Item item) throws SQLException {
-        return helper.getEmbargoFromItem(context, item, forever_date);
+    public AccessStatus getAnonymousAccessStatus(Context context, Item item) throws SQLException {
+        return helper.getAnonymousAccessStatusFromItem(context, item, forever_date);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/access/status/AccessStatusServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/access/status/AccessStatusServiceImpl.java
@@ -12,6 +12,7 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 
 import org.dspace.access.status.service.AccessStatusService;
+import org.dspace.content.Bitstream;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
 import org.dspace.core.service.PluginService;
@@ -70,5 +71,15 @@ public class AccessStatusServiceImpl implements AccessStatusService {
     @Override
     public String getEmbargoFromItem(Context context, Item item) throws SQLException {
         return helper.getEmbargoFromItem(context, item, forever_date);
+    }
+
+    @Override
+    public Date getAvailabilityDateFromBitstream(Context context, Bitstream bitstream) throws SQLException {
+        return helper.getAvailabilityDateFromBitstream(context, bitstream, forever_date);
+    }
+
+    @Override
+    public String getAccessStatusFromAvailabilityDate(Date availabilityDate) {
+        return helper.getAccessStatusFromAvailabilityDate(availabilityDate, forever_date);
     }
 }

--- a/dspace-api/src/main/java/org/dspace/access/status/DefaultAccessStatusHelper.java
+++ b/dspace-api/src/main/java/org/dspace/access/status/DefaultAccessStatusHelper.java
@@ -35,16 +35,11 @@ import org.dspace.eperson.service.GroupService;
 
 /**
  * Default plugin implementation of the access status helper.
- * The getAccessStatusFromItem method provides a simple logic to
- * calculate the access status of an item based on the policies of
- * the primary or the first bitstream in the original bundle.
- * Users can override this method for enhanced functionality.
- *
- * The getEmbargoFromItem method provides a simple logic to retrieve
- * an embargo date based on information of bitstreams from an item
- * based on the policies of the primary or the first bitstream in the
- * original bundle. Users can override this method for enhanced
- * functionality.
+ * 
+ * The methods provides a simple logic to calculate the access status
+ * of an item based on the policies of the primary or the first bitstream
+ * in the original bundle. Users can override those methods for
+ * enhanced functionality.
  */
 public class DefaultAccessStatusHelper implements AccessStatusHelper {
     public static final String STATUS_FOR_CURRENT_USER  = "current";
@@ -123,32 +118,15 @@ public class DefaultAccessStatusHelper implements AccessStatusHelper {
      * Look at the anonymous policies of the primary (or first)
      * bitstream of the item to retrieve its embargo.
      *
-     * If the item is null, simply returns an empty map with no embargo information.
-     *
      * @param context       the DSpace context
      * @param item          the item
      * @param threshold     the embargo threshold date
-     * @return an embargo date
+     * @return the access status
      */
     @Override
-    public String getEmbargoFromItem(Context context, Item item, LocalDate threshold)
+    public AccessStatus getAnonymousAccessStatusFromItem(Context context, Item item, LocalDate threshold)
             throws SQLException {
-        if (item == null) {
-            return null;
-        }
-        Bitstream bitstream = getPrimaryOrFirstBitstreamInOriginalBundle(item);
-        if (bitstream == null) {
-            return null;
-        }
-        // Only calculate the status for the anonymous group read policies
-        List<ResourcePolicy> policies = getReadPolicies(context, bitstream, STATUS_FOR_ANONYMOUS);
-        LocalDate availabilityDate = findAvailabilityDate(policies, threshold);
-        // If the date is null, it's an open access
-        // If the date is equal of after the threshold, it's a restriction
-        if (availabilityDate == null || !availabilityDate.isBefore(threshold)) {
-            return null;
-        }
-        return availabilityDate.toString();
+        return getAccessStatusFromItem(context, item, threshold, STATUS_FOR_ANONYMOUS);
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/access/status/DefaultAccessStatusHelper.java
+++ b/dspace-api/src/main/java/org/dspace/access/status/DefaultAccessStatusHelper.java
@@ -8,7 +8,6 @@
 package org.dspace.access.status;
 
 import java.sql.SQLException;
-import java.time.Instant;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -310,7 +309,7 @@ public class DefaultAccessStatusHelper implements AccessStatusHelper {
             return threshold;
         }
         LocalDate availabilityDate = null;
-        LocalDate currentDate = LocalDate.from(Instant.now());
+        LocalDate currentDate = LocalDate.now();
         boolean takeMostRecentDate = true;
         // Looks at all read policies
         for (ResourcePolicy policy : readPolicies) {

--- a/dspace-api/src/main/java/org/dspace/access/status/DefaultAccessStatusHelper.java
+++ b/dspace-api/src/main/java/org/dspace/access/status/DefaultAccessStatusHelper.java
@@ -15,11 +15,11 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.dspace.authorize.ResourcePolicy;
 import org.dspace.authorize.factory.AuthorizeServiceFactory;
 import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.authorize.service.ResourcePolicyService;
+import org.dspace.content.AccessStatus;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Bundle;
 import org.dspace.content.DSpaceObject;
@@ -79,17 +79,17 @@ public class DefaultAccessStatusHelper implements AccessStatusHelper {
      * @param item        the item to check for embargoes
      * @param threshold   the embargo threshold date
      * @param type        the type of calculation
-     * @return a pair with an access status value and the availability date
+     * @return the access status
      */
     @Override
-    public Pair<String, LocalDate> getAccessStatusFromItem(Context context, Item item, LocalDate threshold, String type)
+    public AccessStatus getAccessStatusFromItem(Context context, Item item, LocalDate threshold, String type)
             throws SQLException {
         if (item == null) {
-            return Pair.of(UNKNOWN, null);
+            return new AccessStatus(UNKNOWN, null);
         }
         Bitstream bitstream = getPrimaryOrFirstBitstreamInOriginalBundle(item);
         if (bitstream == null) {
-            return Pair.of(METADATA_ONLY, null);
+            return new AccessStatus(METADATA_ONLY, null);
         }
         return getAccessStatusFromBitstream(context, bitstream, threshold, type);
     }
@@ -104,19 +104,19 @@ public class DefaultAccessStatusHelper implements AccessStatusHelper {
      * @param bitstream   the bitstream to check for embargoes
      * @param threshold   the embargo threshold date
      * @param type        the type of calculation
-     * @return a pair with an access status value and the availability date
+     * @return the access status
      */
     @Override
-    public Pair<String, LocalDate> getAccessStatusFromBitstream(Context context,
+    public AccessStatus getAccessStatusFromBitstream(Context context,
         Bitstream bitstream, LocalDate threshold, String type) throws SQLException {
         if (bitstream == null) {
-            return Pair.of(UNKNOWN, null);
+            return new AccessStatus(UNKNOWN, null);
         }
         List<ResourcePolicy> policies = getReadPolicies(context, bitstream, type);
         LocalDate availabilityDate = findAvailabilityDate(policies, threshold);
         // Get the access status based on the availability date
         String accessStatus = getAccessStatusFromAvailabilityDate(availabilityDate, threshold);
-        return Pair.of(accessStatus, availabilityDate);
+        return new AccessStatus(accessStatus, availabilityDate);
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/access/status/service/AccessStatusService.java
+++ b/dspace-api/src/main/java/org/dspace/access/status/service/AccessStatusService.java
@@ -48,14 +48,14 @@ public interface AccessStatusService {
     public AccessStatus getAccessStatus(Context context, Item item) throws SQLException;
 
     /**
-     * Retrieve embargo information for the item
+     * Calculate the anonymous access status for an Item while considering the forever embargo date threshold.
      *
      * @param context the DSpace context
      * @param item the item to check for embargo information
-     * @return an embargo date
+     * @return the access status
      * @throws SQLException An exception that provides information on a database access error or other errors.
      */
-    public String getEmbargoFromItem(Context context, Item item) throws SQLException;
+    public AccessStatus getAnonymousAccessStatus(Context context, Item item) throws SQLException;
 
     /**
      * Calculate the access status for a bitstream while considering the forever embargo date threshold.

--- a/dspace-api/src/main/java/org/dspace/access/status/service/AccessStatusService.java
+++ b/dspace-api/src/main/java/org/dspace/access/status/service/AccessStatusService.java
@@ -8,9 +8,8 @@
 package org.dspace.access.status.service;
 
 import java.sql.SQLException;
-import java.time.LocalDate;
 
-import org.apache.commons.lang3.tuple.Pair;
+import org.dspace.content.AccessStatus;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
@@ -43,10 +42,10 @@ public interface AccessStatusService {
      *
      * @param context the DSpace context
      * @param item the item
-     * @return a pair with an access status value and the availability date
+     * @return the access status
      * @throws SQLException An exception that provides information on a database access error or other errors.
      */
-    public Pair<String, LocalDate> getAccessStatus(Context context, Item item) throws SQLException;
+    public AccessStatus getAccessStatus(Context context, Item item) throws SQLException;
 
     /**
      * Retrieve embargo information for the item
@@ -63,8 +62,8 @@ public interface AccessStatusService {
      *
      * @param context the DSpace context
      * @param bitstream the bitstream
-     * @return a pair with an access status value and the availability date
+     * @return the access status
      * @throws SQLException An exception that provides information on a database access error or other errors.
      */
-    public Pair<String, LocalDate> getAccessStatus(Context context, Bitstream bitstream) throws SQLException;
+    public AccessStatus getAccessStatus(Context context, Bitstream bitstream) throws SQLException;
 }

--- a/dspace-api/src/main/java/org/dspace/access/status/service/AccessStatusService.java
+++ b/dspace-api/src/main/java/org/dspace/access/status/service/AccessStatusService.java
@@ -10,6 +10,7 @@ package org.dspace.access.status.service;
 import java.sql.SQLException;
 import java.time.LocalDate;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
@@ -41,11 +42,11 @@ public interface AccessStatusService {
      * Calculate the access status for an Item while considering the forever embargo date threshold.
      *
      * @param context the DSpace context
-     * @param item    the item
-     * @return an access status value
+     * @param item the item
+     * @return a pair with an access status value and the availability date
      * @throws SQLException An exception that provides information on a database access error or other errors.
      */
-    public String getAccessStatus(Context context, Item item) throws SQLException;
+    public Pair<String, LocalDate> getAccessStatus(Context context, Item item) throws SQLException;
 
     /**
      * Retrieve embargo information for the item
@@ -58,20 +59,12 @@ public interface AccessStatusService {
     public String getEmbargoFromItem(Context context, Item item) throws SQLException;
 
     /**
-     * Retrieve the availability date for the bitstream
+     * Calculate the access status for a bitstream while considering the forever embargo date threshold.
      *
      * @param context the DSpace context
-     * @param bitstream the bitstream to check for embargo information
-     * @return an availability date
+     * @param bitstream the bitstream
+     * @return a pair with an access status value and the availability date
      * @throws SQLException An exception that provides information on a database access error or other errors.
      */
-    public LocalDate getAvailabilityDateFromBitstream(Context context, Bitstream bitstream) throws SQLException;
-
-    /**
-     * Retrieve the access status information based on the availability date
-     *
-     * @param availabilityDate the DSpace object availability date
-     * @return an access status value
-     */
-    public String getAccessStatusFromAvailabilityDate(LocalDate availabilityDate) throws SQLException;
+    public Pair<String, LocalDate> getAccessStatus(Context context, Bitstream bitstream) throws SQLException;
 }

--- a/dspace-api/src/main/java/org/dspace/access/status/service/AccessStatusService.java
+++ b/dspace-api/src/main/java/org/dspace/access/status/service/AccessStatusService.java
@@ -8,7 +8,7 @@
 package org.dspace.access.status.service;
 
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.LocalDate;
 
 import org.dspace.content.Bitstream;
 import org.dspace.content.Item;
@@ -65,7 +65,7 @@ public interface AccessStatusService {
      * @return an availability date
      * @throws SQLException An exception that provides information on a database access error or other errors.
      */
-    public Date getAvailabilityDateFromBitstream(Context context, Bitstream bitstream) throws SQLException;
+    public LocalDate getAvailabilityDateFromBitstream(Context context, Bitstream bitstream) throws SQLException;
 
     /**
      * Retrieve the access status information based on the availability date
@@ -73,5 +73,5 @@ public interface AccessStatusService {
      * @param availabilityDate the DSpace object availability date
      * @return an access status value
      */
-    public String getAccessStatusFromAvailabilityDate(Date availabilityDate) throws SQLException;
+    public String getAccessStatusFromAvailabilityDate(LocalDate availabilityDate) throws SQLException;
 }

--- a/dspace-api/src/main/java/org/dspace/access/status/service/AccessStatusService.java
+++ b/dspace-api/src/main/java/org/dspace/access/status/service/AccessStatusService.java
@@ -8,7 +8,9 @@
 package org.dspace.access.status.service;
 
 import java.sql.SQLException;
+import java.util.Date;
 
+import org.dspace.content.Bitstream;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
 
@@ -54,4 +56,22 @@ public interface AccessStatusService {
      * @throws SQLException An exception that provides information on a database access error or other errors.
      */
     public String getEmbargoFromItem(Context context, Item item) throws SQLException;
+
+    /**
+     * Retrieve the availability date for the bitstream
+     *
+     * @param context the DSpace context
+     * @param bitstream the bitstream to check for embargo information
+     * @return an availability date
+     * @throws SQLException An exception that provides information on a database access error or other errors.
+     */
+    public Date getAvailabilityDateFromBitstream(Context context, Bitstream bitstream) throws SQLException;
+
+    /**
+     * Retrieve the access status information based on the availability date
+     *
+     * @param availabilityDate the DSpace object availability date
+     * @return an access status value
+     */
+    public String getAccessStatusFromAvailabilityDate(Date availabilityDate) throws SQLException;
 }

--- a/dspace-api/src/main/java/org/dspace/content/AccessStatus.java
+++ b/dspace-api/src/main/java/org/dspace/content/AccessStatus.java
@@ -1,0 +1,64 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content;
+
+import java.time.LocalDate;
+
+/**
+ * Utility class for access status
+ */
+public class AccessStatus {
+    /**
+     * the status value
+     */
+    private String status;
+
+    /**
+     * the availability date if required
+     */
+    private LocalDate availabilityDate;
+
+    /**
+     * Construct a new access status
+     *
+     * @param status           the status value
+     * @param availabilityDate the availability date
+     */
+    public AccessStatus(String status, LocalDate availabilityDate) {
+        this.status = status;
+        this.availabilityDate = availabilityDate;
+    }
+
+    /**
+     * @return Returns the status value.
+     */
+    public String getStatus() {
+        return status;
+    }
+
+    /**
+     * @param status The status value.
+     */
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    /**
+     * @return Returns the availability date.
+     */
+    public LocalDate getAvailabilityDate() {
+        return availabilityDate;
+    }
+
+    /**
+     * @param availabilityDate The availability date.
+     */
+    public void setAvailabilityDate(LocalDate availabilityDate) {
+        this.availabilityDate = availabilityDate;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceIndexAccessStatusPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceIndexAccessStatusPlugin.java
@@ -8,13 +8,12 @@
 package org.dspace.discovery;
 
 import java.sql.SQLException;
-import java.time.LocalDate;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.solr.common.SolrInputDocument;
 import org.dspace.access.status.DefaultAccessStatusHelper;
 import org.dspace.access.status.factory.AccessStatusServiceFactory;
 import org.dspace.access.status.service.AccessStatusService;
+import org.dspace.content.AccessStatus;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
 import org.dspace.discovery.indexobject.IndexableItem;
@@ -63,7 +62,7 @@ public class SolrServiceIndexAccessStatusPlugin implements SolrServiceIndexPlugi
         UNKNOWN = "unknown"
      */
     private String retrieveItemAccessStatus(Context context, Item item) throws SQLException {
-        Pair<String, LocalDate> accessStatus = accessStatusService.getAccessStatus(context, item);
-        return accessStatus.getLeft();
+        AccessStatus accessStatus = accessStatusService.getAccessStatus(context, item);
+        return accessStatus.getStatus();
     }
 }

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceIndexAccessStatusPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceIndexAccessStatusPlugin.java
@@ -8,7 +8,9 @@
 package org.dspace.discovery;
 
 import java.sql.SQLException;
+import java.time.LocalDate;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.solr.common.SolrInputDocument;
 import org.dspace.access.status.DefaultAccessStatusHelper;
 import org.dspace.access.status.factory.AccessStatusServiceFactory;
@@ -61,6 +63,7 @@ public class SolrServiceIndexAccessStatusPlugin implements SolrServiceIndexPlugi
         UNKNOWN = "unknown"
      */
     private String retrieveItemAccessStatus(Context context, Item item) throws SQLException {
-        return accessStatusService.getAccessStatus(context, item);
+        Pair<String, LocalDate> accessStatus = accessStatusService.getAccessStatus(context, item);
+        return accessStatus.getLeft();
     }
 }

--- a/dspace-api/src/test/java/org/dspace/access/status/AccessStatusServiceTest.java
+++ b/dspace-api/src/test/java/org/dspace/access/status/AccessStatusServiceTest.java
@@ -17,6 +17,7 @@ import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.time.LocalDate;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.Logger;
 import org.dspace.AbstractUnitTest;
 import org.dspace.access.status.factory.AccessStatusServiceFactory;
@@ -154,9 +155,10 @@ public class AccessStatusServiceTest extends AbstractUnitTest {
     }
 
     @Test
-    public void testGetAccessStatus() throws Exception {
-        String status = accessStatusService.getAccessStatus(context, item);
-        assertNotEquals("testGetAccessStatus 0", status, DefaultAccessStatusHelper.UNKNOWN);
+    public void testGetAccessStatusItem() throws Exception {
+        Pair<String, LocalDate> accessStatus = accessStatusService.getAccessStatus(context, item);
+        String status = accessStatus.getLeft();
+        assertNotEquals("testGetAccessStatusItem 0", status, DefaultAccessStatusHelper.UNKNOWN);
     }
 
     @Test
@@ -166,15 +168,9 @@ public class AccessStatusServiceTest extends AbstractUnitTest {
     }
 
     @Test
-    public void testGetAvailabilityDateFromBitstream() throws Exception {
-        LocalDate availabilityDate = accessStatusService.getAvailabilityDateFromBitstream(context, bitstream);
-        assertNull("testGetAvailabilityDateFromBitstream 0", availabilityDate);
-    }
-
-    @Test
-    public void testGetAccessStatusFromAvailabilityDate() throws Exception {
-        LocalDate availabilityDate = accessStatusService.getAvailabilityDateFromBitstream(context, bitstream);
-        String status = accessStatusService.getAccessStatusFromAvailabilityDate(availabilityDate);
-        assertNotEquals("testGetAccessStatusFromAvailabilityDate 0", status, DefaultAccessStatusHelper.UNKNOWN);
+    public void testGetAccessStatusBitstream() throws Exception {
+        Pair<String, LocalDate> accessStatus = accessStatusService.getAccessStatus(context, bitstream);
+        String status = accessStatus.getLeft();
+        assertNotEquals("testGetAccessStatusBitstream 0", status, DefaultAccessStatusHelper.UNKNOWN);
     }
 }

--- a/dspace-api/src/test/java/org/dspace/access/status/AccessStatusServiceTest.java
+++ b/dspace-api/src/test/java/org/dspace/access/status/AccessStatusServiceTest.java
@@ -15,14 +15,13 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
-import java.time.LocalDate;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.Logger;
 import org.dspace.AbstractUnitTest;
 import org.dspace.access.status.factory.AccessStatusServiceFactory;
 import org.dspace.access.status.service.AccessStatusService;
 import org.dspace.authorize.AuthorizeException;
+import org.dspace.content.AccessStatus;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Bundle;
 import org.dspace.content.Collection;
@@ -156,8 +155,8 @@ public class AccessStatusServiceTest extends AbstractUnitTest {
 
     @Test
     public void testGetAccessStatusItem() throws Exception {
-        Pair<String, LocalDate> accessStatus = accessStatusService.getAccessStatus(context, item);
-        String status = accessStatus.getLeft();
+        AccessStatus accessStatus = accessStatusService.getAccessStatus(context, item);
+        String status = accessStatus.getStatus();
         assertNotEquals("testGetAccessStatusItem 0", status, DefaultAccessStatusHelper.UNKNOWN);
     }
 
@@ -169,8 +168,8 @@ public class AccessStatusServiceTest extends AbstractUnitTest {
 
     @Test
     public void testGetAccessStatusBitstream() throws Exception {
-        Pair<String, LocalDate> accessStatus = accessStatusService.getAccessStatus(context, bitstream);
-        String status = accessStatus.getLeft();
+        AccessStatus accessStatus = accessStatusService.getAccessStatus(context, bitstream);
+        String status = accessStatus.getStatus();
         assertNotEquals("testGetAccessStatusBitstream 0", status, DefaultAccessStatusHelper.UNKNOWN);
     }
 }

--- a/dspace-api/src/test/java/org/dspace/access/status/AccessStatusServiceTest.java
+++ b/dspace-api/src/test/java/org/dspace/access/status/AccessStatusServiceTest.java
@@ -15,6 +15,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
+import java.time.LocalDate;
 
 import org.apache.logging.log4j.Logger;
 import org.dspace.AbstractUnitTest;
@@ -157,19 +158,26 @@ public class AccessStatusServiceTest extends AbstractUnitTest {
     public void testGetAccessStatusItem() throws Exception {
         AccessStatus accessStatus = accessStatusService.getAccessStatus(context, item);
         String status = accessStatus.getStatus();
+        LocalDate availabilityDate = accessStatus.getAvailabilityDate();
         assertNotEquals("testGetAccessStatusItem 0", status, DefaultAccessStatusHelper.UNKNOWN);
+        assertNull("testGetAccessStatusItem 1", availabilityDate);
     }
 
     @Test
-    public void testGetEmbargoFromItem() throws Exception {
-        String embargo = accessStatusService.getEmbargoFromItem(context, item);
-        assertNull("testGetEmbargoFromItem 0", embargo);
+    public void testGetAnonymousAccessStatusItem() throws Exception {
+        AccessStatus accessStatus = accessStatusService.getAnonymousAccessStatus(context, item);
+        String status = accessStatus.getStatus();
+        LocalDate availabilityDate = accessStatus.getAvailabilityDate();
+        assertNotEquals("testGetAnonymousAccessStatusItem 0", status, DefaultAccessStatusHelper.UNKNOWN);
+        assertNull("testGetAnonymousAccessStatusItem 1", availabilityDate);
     }
 
     @Test
     public void testGetAccessStatusBitstream() throws Exception {
         AccessStatus accessStatus = accessStatusService.getAccessStatus(context, bitstream);
         String status = accessStatus.getStatus();
+        LocalDate availabilityDate = accessStatus.getAvailabilityDate();
         assertNotEquals("testGetAccessStatusBitstream 0", status, DefaultAccessStatusHelper.UNKNOWN);
+        assertNull("testGetAccessStatusBitstream 1", availabilityDate);
     }
 }

--- a/dspace-api/src/test/java/org/dspace/access/status/AccessStatusServiceTest.java
+++ b/dspace-api/src/test/java/org/dspace/access/status/AccessStatusServiceTest.java
@@ -15,7 +15,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.LocalDate;
 
 import org.apache.logging.log4j.Logger;
 import org.dspace.AbstractUnitTest;
@@ -167,13 +167,13 @@ public class AccessStatusServiceTest extends AbstractUnitTest {
 
     @Test
     public void testGetAvailabilityDateFromBitstream() throws Exception {
-        Date availabilityDate = accessStatusService.getAvailabilityDateFromBitstream(context, bitstream);
+        LocalDate availabilityDate = accessStatusService.getAvailabilityDateFromBitstream(context, bitstream);
         assertNull("testGetAvailabilityDateFromBitstream 0", availabilityDate);
     }
 
     @Test
     public void testGetAccessStatusFromAvailabilityDate() throws Exception {
-        Date availabilityDate = accessStatusService.getAvailabilityDateFromBitstream(context, bitstream);
+        LocalDate availabilityDate = accessStatusService.getAvailabilityDateFromBitstream(context, bitstream);
         String status = accessStatusService.getAccessStatusFromAvailabilityDate(availabilityDate);
         assertNotEquals("testGetAccessStatusFromAvailabilityDate 0", status, DefaultAccessStatusHelper.UNKNOWN);
     }

--- a/dspace-api/src/test/java/org/dspace/access/status/DefaultAccessStatusHelperTest.java
+++ b/dspace-api/src/test/java/org/dspace/access/status/DefaultAccessStatusHelperTest.java
@@ -209,12 +209,16 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
      */
     @Test
     public void testWithNullItem() throws Exception {
+        // getAccessStatusFromItem
         Pair<String, LocalDate> accessStatus = helper.getAccessStatusFromItem(context,
                 null, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String status = accessStatus.getLeft();
         assertThat("testWithNullItem 0", status, equalTo(DefaultAccessStatusHelper.UNKNOWN));
+        LocalDate availabilityDate = accessStatus.getRight();
+        assertNull("testWithNullItem 1", availabilityDate);
+        // getEmbargoFromItem
         String embargoDate = helper.getEmbargoFromItem(context, null, threshold);
-        assertNull("testWithNullItem 1", embargoDate);
+        assertNull("testWithNullItem 2", embargoDate);
     }
 
     /**
@@ -223,12 +227,16 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
      */
     @Test
     public void testWithoutBundle() throws Exception {
+        // getAccessStatusFromItem
         Pair<String, LocalDate> accessStatus = helper.getAccessStatusFromItem(context,
                 itemWithoutBundle, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String status = accessStatus.getLeft();
         assertThat("testWithoutBundle 0", status, equalTo(DefaultAccessStatusHelper.METADATA_ONLY));
+        LocalDate availabilityDate = accessStatus.getRight();
+        assertNull("testWithoutBundle 1", availabilityDate);
+        // getEmbargoFromItem
         String embargoDate = helper.getEmbargoFromItem(context, itemWithoutBundle, threshold);
-        assertNull("testWithoutBundle 1", embargoDate);
+        assertNull("testWithoutBundle 2", embargoDate);
     }
 
     /**
@@ -240,18 +248,23 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         context.turnOffAuthorisationSystem();
         bundleService.create(context, itemWithoutBitstream, Constants.CONTENT_BUNDLE_NAME);
         context.restoreAuthSystemState();
+        // getAccessStatusFromItem
         Pair<String, LocalDate> accessStatus = helper.getAccessStatusFromItem(context,
                 itemWithoutBitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String status = accessStatus.getLeft();
         assertThat("testWithoutBitstream 0", status, equalTo(DefaultAccessStatusHelper.METADATA_ONLY));
+        LocalDate availabilityDate = accessStatus.getRight();
+        assertNull("testWithoutBitstream 1", availabilityDate);
+        // getEmbargoFromItem
         String embargoDate = helper.getEmbargoFromItem(context, itemWithoutBitstream, threshold);
-        assertNull("testWithoutBitstream 1", embargoDate);
+        assertNull("testWithoutBitstream 2", embargoDate);
+        // getAccessStatusFromBitstream
         Pair<String, LocalDate> accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
                 null, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String bitstreamStatus = accessStatusBitstream.getLeft();
-        assertThat("testWithoutBitstream 2", bitstreamStatus, equalTo(DefaultAccessStatusHelper.UNKNOWN));
-        LocalDate availabilityDate = accessStatusBitstream.getRight();
-        assertNull("testWithoutBitstream 3", availabilityDate);
+        assertThat("testWithoutBitstream 3", bitstreamStatus, equalTo(DefaultAccessStatusHelper.UNKNOWN));
+        LocalDate bitstreamAvailabilityDate = accessStatusBitstream.getRight();
+        assertNull("testWithoutBitstream 4", bitstreamAvailabilityDate);
     }
 
     /**
@@ -267,18 +280,23 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         bitstream.setName(context, "primary");
         bundle.setPrimaryBitstreamID(bitstream);
         context.restoreAuthSystemState();
+        // getAccessStatusFromItem
         Pair<String, LocalDate> accessStatus = helper.getAccessStatusFromItem(context,
                 itemWithBitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String status = accessStatus.getLeft();
         assertThat("testWithBitstream 0", status, equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
+        LocalDate availabilityDate = accessStatus.getRight();
+        assertNull("testWithBitstream 1", availabilityDate);
+        // getEmbargoFromItem
         String embargoDate = helper.getEmbargoFromItem(context, itemWithBitstream, threshold);
-        assertNull("testWithBitstream 1", embargoDate);
+        assertNull("testWithBitstream 2", embargoDate);
+        // getAccessStatusFromBitstream
         Pair<String, LocalDate> accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
                 bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String bitstreamStatus = accessStatusBitstream.getLeft();
-        assertThat("testWithBitstream 2", bitstreamStatus, equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
-        LocalDate availabilityDate = accessStatusBitstream.getRight();
-        assertNull("testWithBitstream 3", availabilityDate);
+        assertThat("testWithBitstream 3", bitstreamStatus, equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
+        LocalDate bitstreamAvailabilityDate = accessStatusBitstream.getRight();
+        assertNull("testWithBitstream 4", bitstreamAvailabilityDate);
     }
 
     /**
@@ -304,18 +322,23 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         authorizeService.removeAllPolicies(context, bitstream);
         authorizeService.addPolicies(context, policies, bitstream);
         context.restoreAuthSystemState();
+        // getAccessStatusFromItem
         Pair<String, LocalDate> accessStatus = helper.getAccessStatusFromItem(context,
                 itemWithEmbargo, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String status = accessStatus.getLeft();
         assertThat("testWithEmbargo 0", status, equalTo(DefaultAccessStatusHelper.EMBARGO));
+        LocalDate availabilityDate = accessStatus.getRight();
+        assertThat("testWithEmbargo 1", availabilityDate, equalTo(startDate));
+        // getEmbargoFromItem
         String embargoDate = helper.getEmbargoFromItem(context, itemWithEmbargo, threshold);
-        assertThat("testWithEmbargo 1", embargoDate, equalTo(startDate.toString()));
+        assertThat("testWithEmbargo 2", embargoDate, equalTo(startDate.toString()));
+        // getAccessStatusFromBitstream
         Pair<String, LocalDate> accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
                 bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String bitstreamStatus = accessStatusBitstream.getLeft();
-        assertThat("testWithEmbargo 2", bitstreamStatus, equalTo(DefaultAccessStatusHelper.EMBARGO));
-        LocalDate availabilityDate = accessStatusBitstream.getRight();
-        assertThat("testWithEmbargo 3", availabilityDate, equalTo(startDate));
+        assertThat("testWithEmbargo 3", bitstreamStatus, equalTo(DefaultAccessStatusHelper.EMBARGO));
+        LocalDate bitstreamAvailabilityDate = accessStatusBitstream.getRight();
+        assertThat("testWithEmbargo 4", bitstreamAvailabilityDate, equalTo(startDate));
     }
 
     /**
@@ -341,18 +364,23 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         authorizeService.removeAllPolicies(context, bitstream);
         authorizeService.addPolicies(context, policies, bitstream);
         context.restoreAuthSystemState();
+        // getAccessStatusFromItem
         Pair<String, LocalDate> accessStatus = helper.getAccessStatusFromItem(context,
                 itemWithDateRestriction, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String status = accessStatus.getLeft();
         assertThat("testWithDateRestriction 0", status, equalTo(DefaultAccessStatusHelper.RESTRICTED));
+        LocalDate availabilityDate = accessStatus.getRight();
+        assertThat("testWithDateRestriction 1", availabilityDate, equalTo(startDate));
+        // getEmbargoFromItem
         String embargoDate = helper.getEmbargoFromItem(context, itemWithDateRestriction, threshold);
-        assertNull("testWithDateRestriction 1", embargoDate);
+        assertNull("testWithDateRestriction 2", embargoDate);
+        // getAccessStatusFromBitstream
         Pair<String, LocalDate> accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
                 bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String bitstreamStatus = accessStatusBitstream.getLeft();
-        assertThat("testWithDateRestriction 2", bitstreamStatus, equalTo(DefaultAccessStatusHelper.RESTRICTED));
-        LocalDate availabilityDate = accessStatusBitstream.getRight();
-        assertThat("testWithDateRestriction 3", availabilityDate, equalTo(startDate));
+        assertThat("testWithDateRestriction 3", bitstreamStatus, equalTo(DefaultAccessStatusHelper.RESTRICTED));
+        LocalDate bistreamAvailabilityDate = accessStatusBitstream.getRight();
+        assertThat("testWithDateRestriction 4", bistreamAvailabilityDate, equalTo(startDate));
     }
 
     /**
@@ -376,18 +404,23 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         authorizeService.removeAllPolicies(context, bitstream);
         authorizeService.addPolicies(context, policies, bitstream);
         context.restoreAuthSystemState();
+        // getAccessStatusFromItem
         Pair<String, LocalDate> accessStatus = helper.getAccessStatusFromItem(context,
                 itemWithGroupRestriction, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String status = accessStatus.getLeft();
         assertThat("testWithGroupRestriction 0", status, equalTo(DefaultAccessStatusHelper.RESTRICTED));
+        LocalDate availabilityDate = accessStatus.getRight();
+        assertThat("testWithGroupRestriction 1", availabilityDate, equalTo(threshold));
+        // getEmbargoFromItem
         String embargoDate = helper.getEmbargoFromItem(context, itemWithGroupRestriction, threshold);
-        assertNull("testWithGroupRestriction 1", embargoDate);
+        assertNull("testWithGroupRestriction 2", embargoDate);
+        // getAccessStatusFromBitstream
         Pair<String, LocalDate> accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
                 bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String bitstreamStatus = accessStatusBitstream.getLeft();
-        assertThat("testWithGroupRestriction 2", bitstreamStatus, equalTo(DefaultAccessStatusHelper.RESTRICTED));
-        LocalDate availabilityDate = accessStatusBitstream.getRight();
-        assertThat("testWithGroupRestriction 3", availabilityDate, equalTo(threshold));
+        assertThat("testWithGroupRestriction 3", bitstreamStatus, equalTo(DefaultAccessStatusHelper.RESTRICTED));
+        LocalDate bitstreamAvailabilityDate = accessStatusBitstream.getRight();
+        assertThat("testWithGroupRestriction 4", bitstreamAvailabilityDate, equalTo(threshold));
     }
 
     /**
@@ -404,18 +437,23 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         bundle.setPrimaryBitstreamID(bitstream);
         authorizeService.removeAllPolicies(context, bitstream);
         context.restoreAuthSystemState();
+        // getAccessStatusFromItem
         Pair<String, LocalDate> accessStatus = helper.getAccessStatusFromItem(context,
                 itemWithoutPolicy, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String status = accessStatus.getLeft();
         assertThat("testWithoutPolicy 0", status, equalTo(DefaultAccessStatusHelper.RESTRICTED));
+        LocalDate availabilityDate = accessStatus.getRight();
+        assertThat("testWithoutPolicy 1", availabilityDate, equalTo(threshold));
+        // getEmbargoFromItem
         String embargoDate = helper.getEmbargoFromItem(context, itemWithoutPolicy, threshold);
-        assertNull("testWithoutPolicy 1", embargoDate);
+        assertNull("testWithoutPolicy 2", embargoDate);
+        // getAccessStatusFromBitstream
         Pair<String, LocalDate> accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
                 bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String bitstreamStatus = accessStatusBitstream.getLeft();
-        assertThat("testWithoutPolicy 2", bitstreamStatus, equalTo(DefaultAccessStatusHelper.RESTRICTED));
-        LocalDate availabilityDate = accessStatusBitstream.getRight();
-        assertThat("testWithoutPolicy 3", availabilityDate, equalTo(threshold));
+        assertThat("testWithoutPolicy 3", bitstreamStatus, equalTo(DefaultAccessStatusHelper.RESTRICTED));
+        LocalDate bitstreamAvailabilityDate = accessStatusBitstream.getRight();
+        assertThat("testWithoutPolicy 4", bitstreamAvailabilityDate, equalTo(threshold));
     }
 
     /**
@@ -430,18 +468,23 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
                 new ByteArrayInputStream("1".getBytes(StandardCharsets.UTF_8)));
         bitstream.setName(context, "first");
         context.restoreAuthSystemState();
+        // getAccessStatusFromItem
         Pair<String, LocalDate> accessStatus = helper.getAccessStatusFromItem(context,
                 itemWithoutPrimaryBitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String status = accessStatus.getLeft();
         assertThat("testWithoutPrimaryBitstream 0", status, equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
+        LocalDate availabilityDate = accessStatus.getRight();
+        assertNull("testWithoutPrimaryBitstream 1", availabilityDate);
+        // getEmbargoFromItem
         String embargoDate = helper.getEmbargoFromItem(context, itemWithoutPrimaryBitstream, threshold);
-        assertNull("testWithoutPrimaryBitstream 1", embargoDate);
+        assertNull("testWithoutPrimaryBitstream 2", embargoDate);
+        // getAccessStatusFromBitstream
         Pair<String, LocalDate> accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
                 bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String bitstreamStatus = accessStatusBitstream.getLeft();
-        assertThat("testWithoutPrimaryBitstream 2", bitstreamStatus, equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
-        LocalDate availabilityDate = accessStatusBitstream.getRight();
-        assertNull("testWithoutPrimaryBitstream 3", availabilityDate);
+        assertThat("testWithoutPrimaryBitstream 3", bitstreamStatus, equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
+        LocalDate bitstreamAvailabilityDate = accessStatusBitstream.getRight();
+        assertNull("testWithoutPrimaryBitstream 4", bitstreamAvailabilityDate);
     }
 
     /**
@@ -470,26 +513,32 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         authorizeService.removeAllPolicies(context, primaryBitstream);
         authorizeService.addPolicies(context, policies, primaryBitstream);
         context.restoreAuthSystemState();
+        // getAccessStatusFromItem
         Pair<String, LocalDate> accessStatus = helper.getAccessStatusFromItem(context,
                 itemWithPrimaryAndMultipleBitstreams, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String status = accessStatus.getLeft();
         assertThat("testWithPrimaryAndMultipleBitstreams 0", status, equalTo(DefaultAccessStatusHelper.EMBARGO));
+        LocalDate availabilityDate = accessStatus.getRight();
+        assertThat("testWithPrimaryAndMultipleBitstreams 1", availabilityDate, equalTo(startDate));
+        // getEmbargoFromItem
         String embargoDate = helper.getEmbargoFromItem(context, itemWithPrimaryAndMultipleBitstreams, threshold);
-        assertThat("testWithPrimaryAndMultipleBitstreams 1", embargoDate, equalTo(startDate.toString()));
+        assertThat("testWithPrimaryAndMultipleBitstreams 2", embargoDate, equalTo(startDate.toString()));
+        // getAccessStatusFromBitstream -> primary
         Pair<String, LocalDate> accessStatusPrimaryBitstream = helper.getAccessStatusFromBitstream(context,
                 primaryBitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String primaryBitstreamStatus = accessStatusPrimaryBitstream.getLeft();
-        assertThat("testWithPrimaryAndMultipleBitstreams 2", primaryBitstreamStatus,
+        assertThat("testWithPrimaryAndMultipleBitstreams 3", primaryBitstreamStatus,
                 equalTo(DefaultAccessStatusHelper.EMBARGO));
         LocalDate primaryAvailabilityDate = accessStatusPrimaryBitstream.getRight();
-        assertThat("testWithPrimaryAndMultipleBitstreams 3", primaryAvailabilityDate, equalTo(startDate));
+        assertThat("testWithPrimaryAndMultipleBitstreams 4", primaryAvailabilityDate, equalTo(startDate));
+        // getAccessStatusFromBitstream -> other
         Pair<String, LocalDate> accessStatusOtherBitstream = helper.getAccessStatusFromBitstream(context,
                 otherBitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String otherBitstreamStatus = accessStatusOtherBitstream.getLeft();
-        assertThat("testWithPrimaryAndMultipleBitstreams 4", otherBitstreamStatus,
+        assertThat("testWithPrimaryAndMultipleBitstreams 5", otherBitstreamStatus,
                 equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
         LocalDate otherAvailabilityDate = accessStatusOtherBitstream.getRight();
-        assertNull("testWithPrimaryAndMultipleBitstreams 5", otherAvailabilityDate);
+        assertNull("testWithPrimaryAndMultipleBitstreams 6", otherAvailabilityDate);
     }
 
     /**
@@ -517,35 +566,41 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         authorizeService.removeAllPolicies(context, anotherBitstream);
         authorizeService.addPolicies(context, policies, anotherBitstream);
         context.restoreAuthSystemState();
+        // getAccessStatusFromItem
         Pair<String, LocalDate> accessStatus = helper.getAccessStatusFromItem(context,
                 itemWithoutPrimaryAndMultipleBitstreams, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String status = accessStatus.getLeft();
         assertThat("testWithNoPrimaryAndMultipleBitstreams 0", status,
                 equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
+        LocalDate availabilityDate = accessStatus.getRight();
+        assertNull("testWithNoPrimaryAndMultipleBitstreams 1", availabilityDate);
+        // getEmbargoFromItem
         String embargoDate = helper.getEmbargoFromItem(context, itemWithEmbargo, threshold);
-        assertNull("testWithNoPrimaryAndMultipleBitstreams 1", embargoDate);
+        assertNull("testWithNoPrimaryAndMultipleBitstreams 2", embargoDate);
+        // getAccessStatusFromBitstream -> first
         Pair<String, LocalDate> accessStatusFirstBitstream = helper.getAccessStatusFromBitstream(context,
                 firstBitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String firstBitstreamStatus = accessStatusFirstBitstream.getLeft();
-        assertThat("testWithNoPrimaryAndMultipleBitstreams 2", firstBitstreamStatus,
+        assertThat("testWithNoPrimaryAndMultipleBitstreams 3", firstBitstreamStatus,
                 equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
         LocalDate firstAvailabilityDate = accessStatusFirstBitstream.getRight();
-        assertNull("testWithNoPrimaryAndMultipleBitstreams 3", firstAvailabilityDate);
+        assertNull("testWithNoPrimaryAndMultipleBitstreams 4", firstAvailabilityDate);
+        // getAccessStatusFromBitstream -> other
         Pair<String, LocalDate> accessStatusOtherBitstream = helper.getAccessStatusFromBitstream(context,
                 anotherBitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String otherBitstreamStatus = accessStatusOtherBitstream.getLeft();
-        assertThat("testWithNoPrimaryAndMultipleBitstreams 4", otherBitstreamStatus,
+        assertThat("testWithNoPrimaryAndMultipleBitstreams 5", otherBitstreamStatus,
                 equalTo(DefaultAccessStatusHelper.EMBARGO));
         LocalDate otherAvailabilityDate = accessStatusOtherBitstream.getRight();
-        assertThat("testWithNoPrimaryAndMultipleBitstreams 5", otherAvailabilityDate, equalTo(startDate));
+        assertThat("testWithNoPrimaryAndMultipleBitstreams 6", otherAvailabilityDate, equalTo(startDate));
     }
 
     /**
-     * Test for an item with an embargo
+     * Test for an item with an embargo for both configurations (current, anonymous) and as a guest
      * @throws java.lang.Exception passed through.
      */
     @Test
-    public void testWithEmbargoForAnonymousOrAdminUser() throws Exception {
+    public void testWithEmbargoForCurrentOrAnonymousAsGuest() throws Exception {
         context.turnOffAuthorisationSystem();
         Bundle bundle = bundleService.create(context, itemWithEmbargo, Constants.CONTENT_BUNDLE_NAME);
         Bitstream bitstream = bitstreamService.create(context, bundle,
@@ -569,31 +624,112 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         authorizeService.removeAllPolicies(context, bitstream);
         authorizeService.addPolicies(context, policies, bitstream);
         context.restoreAuthSystemState();
+        // getEmbargoFromItem
+        String embargoDate = helper.getEmbargoFromItem(context, itemWithEmbargo, threshold);
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsGuest 0", embargoDate, equalTo(startDate.toString()));
+        // Configuration: current
+        // getAccessStatusFromItem
         Pair<String, LocalDate> accessStatus = helper.getAccessStatusFromItem(context,
                 itemWithEmbargo, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String status = accessStatus.getLeft();
-        assertThat("testWithEmbargoForAnonymousOrAdminUser 0", status, equalTo(DefaultAccessStatusHelper.EMBARGO));
-        String embargoDate = helper.getEmbargoFromItem(context, itemWithEmbargo, threshold);
-        assertThat("testWithEmbargoForAnonymousOrAdminUser 1", embargoDate, equalTo(startDate.toString()));
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsGuest 1", status,
+                equalTo(DefaultAccessStatusHelper.EMBARGO));
+        LocalDate availabilityDate = accessStatus.getRight();
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsGuest 2", availabilityDate, equalTo(startDate));
+        // getAccessStatusFromBitstream
         Pair<String, LocalDate> accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
                 bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String bitstreamStatus = accessStatusBitstream.getLeft();
-        assertThat("testWithEmbargoForAnonymousOrAdminUser 2", bitstreamStatus,
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsGuest 3", bitstreamStatus,
                 equalTo(DefaultAccessStatusHelper.EMBARGO));
-        LocalDate availabilityDate = accessStatusBitstream.getRight();
-        assertThat("testWithEmbargoForAnonymousOrAdminUser 3", availabilityDate, equalTo(startDate));
+        LocalDate bistreamAvailabilityDate = accessStatusBitstream.getRight();
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsGuest 4", bistreamAvailabilityDate, equalTo(startDate));
+        // Configuration: anonymous
+        // getAccessStatusFromItem
+        accessStatus = helper.getAccessStatusFromItem(context,
+                itemWithEmbargo, threshold, DefaultAccessStatusHelper.STATUS_FOR_ANONYMOUS);
+        status = accessStatus.getLeft();
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsGuest 5", status,
+                equalTo(DefaultAccessStatusHelper.EMBARGO));
+        availabilityDate = accessStatus.getRight();
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsGuest 6", availabilityDate, equalTo(startDate));
+        // getAccessStatusFromBitstream
+        accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
+                bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_ANONYMOUS);
+        bitstreamStatus = accessStatusBitstream.getLeft();
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsGuest 7", bitstreamStatus,
+                equalTo(DefaultAccessStatusHelper.EMBARGO));
+        bistreamAvailabilityDate = accessStatusBitstream.getRight();
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsGuest 8", bistreamAvailabilityDate, equalTo(startDate));
+    }
+
+    /**
+     * Test for an item with an embargo for both configurations (current, anonymous) and as an admin
+     * @throws java.lang.Exception passed through.
+     */
+    @Test
+    public void testWithEmbargoForCurrentOrAnonymousAsAdmin() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Bundle bundle = bundleService.create(context, itemWithEmbargo, Constants.CONTENT_BUNDLE_NAME);
+        Bitstream bitstream = bitstreamService.create(context, bundle,
+                new ByteArrayInputStream("1".getBytes(StandardCharsets.UTF_8)));
+        bitstream.setName(context, "primary");
+        bundle.setPrimaryBitstreamID(bitstream);
+        List<ResourcePolicy> policies = new ArrayList<>();
+        Group group = groupService.findByName(context, Group.ANONYMOUS);
+        ResourcePolicy policy = resourcePolicyService.create(context, null, group);
+        policy.setRpName("Embargo");
+        policy.setAction(Constants.READ);
+        LocalDate startDate = LocalDate.of(9999, 12, 31);
+        policy.setStartDate(startDate);
+        policies.add(policy);
+        EPerson admin = ePersonService.create(context);
+        Group adminGroup = groupService.findByName(context, Group.ADMIN);
+        ResourcePolicy adminPolicy = resourcePolicyService.create(context, admin, adminGroup);
+        adminPolicy.setRpName("Open Access For Admin");
+        adminPolicy.setAction(Constants.READ);
+        policies.add(adminPolicy);
+        authorizeService.removeAllPolicies(context, bitstream);
+        authorizeService.addPolicies(context, policies, bitstream);
+        context.restoreAuthSystemState();
         EPerson currentUser = context.getCurrentUser();
         context.setCurrentUser(admin);
-        Pair<String, LocalDate> accessStatusAdmin = helper.getAccessStatusFromItem(context,
+        // getEmbargoFromItem
+        String embargoDate = helper.getEmbargoFromItem(context, itemWithEmbargo, threshold);
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsAdmin 0", embargoDate, equalTo(startDate.toString()));
+        // Configuration: current
+        // getAccessStatusFromItem
+        Pair<String, LocalDate> accessStatus = helper.getAccessStatusFromItem(context,
                 itemWithEmbargo, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
-        String statusAdmin = accessStatusAdmin.getLeft();
-        assertThat("testWithEmbargoForAnonymousOrAdminUser 4", statusAdmin,
+        String status = accessStatus.getLeft();
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsAdmin 1", status,
                 equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
-        Pair<String, LocalDate> accessStatusAnonymous = helper.getAccessStatusFromItem(context,
+        LocalDate availabilityDate = accessStatus.getRight();
+        assertNull("testWithEmbargoForCurrentOrAnonymousAsAdmin 2", availabilityDate);
+        // getAccessStatusFromBitstream
+        Pair<String, LocalDate> accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
+                bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
+        String bitstreamStatus = accessStatusBitstream.getLeft();
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsAdmin 3", bitstreamStatus,
+                equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
+        LocalDate bitstreamAvailabilityDate = accessStatusBitstream.getRight();
+        assertNull("testWithEmbargoForCurrentOrAnonymousAsAdmin 4", bitstreamAvailabilityDate);
+        // Configuration: anonymous
+        accessStatus = helper.getAccessStatusFromItem(context,
                 itemWithEmbargo, threshold, DefaultAccessStatusHelper.STATUS_FOR_ANONYMOUS);
-        String statusAnonymous = accessStatusAnonymous.getLeft();
-        assertThat("testWithEmbargoForAnonymousOrAdminUser 5", statusAnonymous,
+        status = accessStatus.getLeft();
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsAdmin 5", status,
                 equalTo(DefaultAccessStatusHelper.EMBARGO));
+        availabilityDate = accessStatus.getRight();
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsAdmin 6", availabilityDate, equalTo(startDate));
+        // getAccessStatusFromBitstream
+        accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
+                bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_ANONYMOUS);
+        bitstreamStatus = accessStatusBitstream.getLeft();
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsAdmin 7", bitstreamStatus,
+                equalTo(DefaultAccessStatusHelper.EMBARGO));
+        bitstreamAvailabilityDate = accessStatusBitstream.getRight();
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsAdmin 8", bitstreamAvailabilityDate, equalTo(startDate));
         context.setCurrentUser(currentUser);
     }
 }

--- a/dspace-api/src/test/java/org/dspace/access/status/DefaultAccessStatusHelperTest.java
+++ b/dspace-api/src/test/java/org/dspace/access/status/DefaultAccessStatusHelperTest.java
@@ -216,9 +216,6 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         assertThat("testWithNullItem 0", status, equalTo(DefaultAccessStatusHelper.UNKNOWN));
         LocalDate availabilityDate = accessStatus.getAvailabilityDate();
         assertNull("testWithNullItem 1", availabilityDate);
-        // getEmbargoFromItem
-        String embargoDate = helper.getEmbargoFromItem(context, null, threshold);
-        assertNull("testWithNullItem 2", embargoDate);
     }
 
     /**
@@ -234,9 +231,6 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         assertThat("testWithoutBundle 0", status, equalTo(DefaultAccessStatusHelper.METADATA_ONLY));
         LocalDate availabilityDate = accessStatus.getAvailabilityDate();
         assertNull("testWithoutBundle 1", availabilityDate);
-        // getEmbargoFromItem
-        String embargoDate = helper.getEmbargoFromItem(context, itemWithoutBundle, threshold);
-        assertNull("testWithoutBundle 2", embargoDate);
     }
 
     /**
@@ -255,9 +249,6 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         assertThat("testWithoutBitstream 0", status, equalTo(DefaultAccessStatusHelper.METADATA_ONLY));
         LocalDate availabilityDate = accessStatus.getAvailabilityDate();
         assertNull("testWithoutBitstream 1", availabilityDate);
-        // getEmbargoFromItem
-        String embargoDate = helper.getEmbargoFromItem(context, itemWithoutBitstream, threshold);
-        assertNull("testWithoutBitstream 2", embargoDate);
         // getAccessStatusFromBitstream
         AccessStatus accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
                 null, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
@@ -287,9 +278,6 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         assertThat("testWithBitstream 0", status, equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
         LocalDate availabilityDate = accessStatus.getAvailabilityDate();
         assertNull("testWithBitstream 1", availabilityDate);
-        // getEmbargoFromItem
-        String embargoDate = helper.getEmbargoFromItem(context, itemWithBitstream, threshold);
-        assertNull("testWithBitstream 2", embargoDate);
         // getAccessStatusFromBitstream
         AccessStatus accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
                 bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
@@ -329,9 +317,6 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         assertThat("testWithEmbargo 0", status, equalTo(DefaultAccessStatusHelper.EMBARGO));
         LocalDate availabilityDate = accessStatus.getAvailabilityDate();
         assertThat("testWithEmbargo 1", availabilityDate, equalTo(startDate));
-        // getEmbargoFromItem
-        String embargoDate = helper.getEmbargoFromItem(context, itemWithEmbargo, threshold);
-        assertThat("testWithEmbargo 2", embargoDate, equalTo(startDate.toString()));
         // getAccessStatusFromBitstream
         AccessStatus accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
                 bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
@@ -371,9 +356,6 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         assertThat("testWithDateRestriction 0", status, equalTo(DefaultAccessStatusHelper.RESTRICTED));
         LocalDate availabilityDate = accessStatus.getAvailabilityDate();
         assertThat("testWithDateRestriction 1", availabilityDate, equalTo(startDate));
-        // getEmbargoFromItem
-        String embargoDate = helper.getEmbargoFromItem(context, itemWithDateRestriction, threshold);
-        assertNull("testWithDateRestriction 2", embargoDate);
         // getAccessStatusFromBitstream
         AccessStatus accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
                 bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
@@ -411,9 +393,6 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         assertThat("testWithGroupRestriction 0", status, equalTo(DefaultAccessStatusHelper.RESTRICTED));
         LocalDate availabilityDate = accessStatus.getAvailabilityDate();
         assertThat("testWithGroupRestriction 1", availabilityDate, equalTo(threshold));
-        // getEmbargoFromItem
-        String embargoDate = helper.getEmbargoFromItem(context, itemWithGroupRestriction, threshold);
-        assertNull("testWithGroupRestriction 2", embargoDate);
         // getAccessStatusFromBitstream
         AccessStatus accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
                 bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
@@ -444,9 +423,6 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         assertThat("testWithoutPolicy 0", status, equalTo(DefaultAccessStatusHelper.RESTRICTED));
         LocalDate availabilityDate = accessStatus.getAvailabilityDate();
         assertThat("testWithoutPolicy 1", availabilityDate, equalTo(threshold));
-        // getEmbargoFromItem
-        String embargoDate = helper.getEmbargoFromItem(context, itemWithoutPolicy, threshold);
-        assertNull("testWithoutPolicy 2", embargoDate);
         // getAccessStatusFromBitstream
         AccessStatus accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
                 bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
@@ -475,9 +451,6 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         assertThat("testWithoutPrimaryBitstream 0", status, equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
         LocalDate availabilityDate = accessStatus.getAvailabilityDate();
         assertNull("testWithoutPrimaryBitstream 1", availabilityDate);
-        // getEmbargoFromItem
-        String embargoDate = helper.getEmbargoFromItem(context, itemWithoutPrimaryBitstream, threshold);
-        assertNull("testWithoutPrimaryBitstream 2", embargoDate);
         // getAccessStatusFromBitstream
         AccessStatus accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
                 bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
@@ -520,9 +493,6 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         assertThat("testWithPrimaryAndMultipleBitstreams 0", status, equalTo(DefaultAccessStatusHelper.EMBARGO));
         LocalDate availabilityDate = accessStatus.getAvailabilityDate();
         assertThat("testWithPrimaryAndMultipleBitstreams 1", availabilityDate, equalTo(startDate));
-        // getEmbargoFromItem
-        String embargoDate = helper.getEmbargoFromItem(context, itemWithPrimaryAndMultipleBitstreams, threshold);
-        assertThat("testWithPrimaryAndMultipleBitstreams 2", embargoDate, equalTo(startDate.toString()));
         // getAccessStatusFromBitstream -> primary
         AccessStatus accessStatusPrimaryBitstream = helper.getAccessStatusFromBitstream(context,
                 primaryBitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
@@ -574,9 +544,6 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
                 equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
         LocalDate availabilityDate = accessStatus.getAvailabilityDate();
         assertNull("testWithNoPrimaryAndMultipleBitstreams 1", availabilityDate);
-        // getEmbargoFromItem
-        String embargoDate = helper.getEmbargoFromItem(context, itemWithEmbargo, threshold);
-        assertNull("testWithNoPrimaryAndMultipleBitstreams 2", embargoDate);
         // getAccessStatusFromBitstream -> first
         AccessStatus accessStatusFirstBitstream = helper.getAccessStatusFromBitstream(context,
                 firstBitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
@@ -624,9 +591,6 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         authorizeService.removeAllPolicies(context, bitstream);
         authorizeService.addPolicies(context, policies, bitstream);
         context.restoreAuthSystemState();
-        // getEmbargoFromItem
-        String embargoDate = helper.getEmbargoFromItem(context, itemWithEmbargo, threshold);
-        assertThat("testWithEmbargoForCurrentOrAnonymousAsGuest 0", embargoDate, equalTo(startDate.toString()));
         // Configuration: current
         // getAccessStatusFromItem
         AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
@@ -694,9 +658,6 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         context.restoreAuthSystemState();
         EPerson currentUser = context.getCurrentUser();
         context.setCurrentUser(admin);
-        // getEmbargoFromItem
-        String embargoDate = helper.getEmbargoFromItem(context, itemWithEmbargo, threshold);
-        assertThat("testWithEmbargoForCurrentOrAnonymousAsAdmin 0", embargoDate, equalTo(startDate.toString()));
         // Configuration: current
         // getAccessStatusFromItem
         AccessStatus accessStatus = helper.getAccessStatusFromItem(context,

--- a/dspace-api/src/test/java/org/dspace/access/status/DefaultAccessStatusHelperTest.java
+++ b/dspace-api/src/test/java/org/dspace/access/status/DefaultAccessStatusHelperTest.java
@@ -19,7 +19,6 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.AbstractUnitTest;
@@ -27,6 +26,7 @@ import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.ResourcePolicy;
 import org.dspace.authorize.factory.AuthorizeServiceFactory;
 import org.dspace.authorize.service.ResourcePolicyService;
+import org.dspace.content.AccessStatus;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Bundle;
 import org.dspace.content.Collection;
@@ -210,11 +210,11 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
     @Test
     public void testWithNullItem() throws Exception {
         // getAccessStatusFromItem
-        Pair<String, LocalDate> accessStatus = helper.getAccessStatusFromItem(context,
+        AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
                 null, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
-        String status = accessStatus.getLeft();
+        String status = accessStatus.getStatus();
         assertThat("testWithNullItem 0", status, equalTo(DefaultAccessStatusHelper.UNKNOWN));
-        LocalDate availabilityDate = accessStatus.getRight();
+        LocalDate availabilityDate = accessStatus.getAvailabilityDate();
         assertNull("testWithNullItem 1", availabilityDate);
         // getEmbargoFromItem
         String embargoDate = helper.getEmbargoFromItem(context, null, threshold);
@@ -228,11 +228,11 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
     @Test
     public void testWithoutBundle() throws Exception {
         // getAccessStatusFromItem
-        Pair<String, LocalDate> accessStatus = helper.getAccessStatusFromItem(context,
+        AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
                 itemWithoutBundle, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
-        String status = accessStatus.getLeft();
+        String status = accessStatus.getStatus();
         assertThat("testWithoutBundle 0", status, equalTo(DefaultAccessStatusHelper.METADATA_ONLY));
-        LocalDate availabilityDate = accessStatus.getRight();
+        LocalDate availabilityDate = accessStatus.getAvailabilityDate();
         assertNull("testWithoutBundle 1", availabilityDate);
         // getEmbargoFromItem
         String embargoDate = helper.getEmbargoFromItem(context, itemWithoutBundle, threshold);
@@ -249,21 +249,21 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         bundleService.create(context, itemWithoutBitstream, Constants.CONTENT_BUNDLE_NAME);
         context.restoreAuthSystemState();
         // getAccessStatusFromItem
-        Pair<String, LocalDate> accessStatus = helper.getAccessStatusFromItem(context,
+        AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
                 itemWithoutBitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
-        String status = accessStatus.getLeft();
+        String status = accessStatus.getStatus();
         assertThat("testWithoutBitstream 0", status, equalTo(DefaultAccessStatusHelper.METADATA_ONLY));
-        LocalDate availabilityDate = accessStatus.getRight();
+        LocalDate availabilityDate = accessStatus.getAvailabilityDate();
         assertNull("testWithoutBitstream 1", availabilityDate);
         // getEmbargoFromItem
         String embargoDate = helper.getEmbargoFromItem(context, itemWithoutBitstream, threshold);
         assertNull("testWithoutBitstream 2", embargoDate);
         // getAccessStatusFromBitstream
-        Pair<String, LocalDate> accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
+        AccessStatus accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
                 null, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
-        String bitstreamStatus = accessStatusBitstream.getLeft();
+        String bitstreamStatus = accessStatusBitstream.getStatus();
         assertThat("testWithoutBitstream 3", bitstreamStatus, equalTo(DefaultAccessStatusHelper.UNKNOWN));
-        LocalDate bitstreamAvailabilityDate = accessStatusBitstream.getRight();
+        LocalDate bitstreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
         assertNull("testWithoutBitstream 4", bitstreamAvailabilityDate);
     }
 
@@ -281,21 +281,21 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         bundle.setPrimaryBitstreamID(bitstream);
         context.restoreAuthSystemState();
         // getAccessStatusFromItem
-        Pair<String, LocalDate> accessStatus = helper.getAccessStatusFromItem(context,
+        AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
                 itemWithBitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
-        String status = accessStatus.getLeft();
+        String status = accessStatus.getStatus();
         assertThat("testWithBitstream 0", status, equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
-        LocalDate availabilityDate = accessStatus.getRight();
+        LocalDate availabilityDate = accessStatus.getAvailabilityDate();
         assertNull("testWithBitstream 1", availabilityDate);
         // getEmbargoFromItem
         String embargoDate = helper.getEmbargoFromItem(context, itemWithBitstream, threshold);
         assertNull("testWithBitstream 2", embargoDate);
         // getAccessStatusFromBitstream
-        Pair<String, LocalDate> accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
+        AccessStatus accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
                 bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
-        String bitstreamStatus = accessStatusBitstream.getLeft();
+        String bitstreamStatus = accessStatusBitstream.getStatus();
         assertThat("testWithBitstream 3", bitstreamStatus, equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
-        LocalDate bitstreamAvailabilityDate = accessStatusBitstream.getRight();
+        LocalDate bitstreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
         assertNull("testWithBitstream 4", bitstreamAvailabilityDate);
     }
 
@@ -323,21 +323,21 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         authorizeService.addPolicies(context, policies, bitstream);
         context.restoreAuthSystemState();
         // getAccessStatusFromItem
-        Pair<String, LocalDate> accessStatus = helper.getAccessStatusFromItem(context,
+        AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
                 itemWithEmbargo, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
-        String status = accessStatus.getLeft();
+        String status = accessStatus.getStatus();
         assertThat("testWithEmbargo 0", status, equalTo(DefaultAccessStatusHelper.EMBARGO));
-        LocalDate availabilityDate = accessStatus.getRight();
+        LocalDate availabilityDate = accessStatus.getAvailabilityDate();
         assertThat("testWithEmbargo 1", availabilityDate, equalTo(startDate));
         // getEmbargoFromItem
         String embargoDate = helper.getEmbargoFromItem(context, itemWithEmbargo, threshold);
         assertThat("testWithEmbargo 2", embargoDate, equalTo(startDate.toString()));
         // getAccessStatusFromBitstream
-        Pair<String, LocalDate> accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
+        AccessStatus accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
                 bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
-        String bitstreamStatus = accessStatusBitstream.getLeft();
+        String bitstreamStatus = accessStatusBitstream.getStatus();
         assertThat("testWithEmbargo 3", bitstreamStatus, equalTo(DefaultAccessStatusHelper.EMBARGO));
-        LocalDate bitstreamAvailabilityDate = accessStatusBitstream.getRight();
+        LocalDate bitstreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
         assertThat("testWithEmbargo 4", bitstreamAvailabilityDate, equalTo(startDate));
     }
 
@@ -365,21 +365,21 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         authorizeService.addPolicies(context, policies, bitstream);
         context.restoreAuthSystemState();
         // getAccessStatusFromItem
-        Pair<String, LocalDate> accessStatus = helper.getAccessStatusFromItem(context,
+        AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
                 itemWithDateRestriction, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
-        String status = accessStatus.getLeft();
+        String status = accessStatus.getStatus();
         assertThat("testWithDateRestriction 0", status, equalTo(DefaultAccessStatusHelper.RESTRICTED));
-        LocalDate availabilityDate = accessStatus.getRight();
+        LocalDate availabilityDate = accessStatus.getAvailabilityDate();
         assertThat("testWithDateRestriction 1", availabilityDate, equalTo(startDate));
         // getEmbargoFromItem
         String embargoDate = helper.getEmbargoFromItem(context, itemWithDateRestriction, threshold);
         assertNull("testWithDateRestriction 2", embargoDate);
         // getAccessStatusFromBitstream
-        Pair<String, LocalDate> accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
+        AccessStatus accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
                 bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
-        String bitstreamStatus = accessStatusBitstream.getLeft();
+        String bitstreamStatus = accessStatusBitstream.getStatus();
         assertThat("testWithDateRestriction 3", bitstreamStatus, equalTo(DefaultAccessStatusHelper.RESTRICTED));
-        LocalDate bistreamAvailabilityDate = accessStatusBitstream.getRight();
+        LocalDate bistreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
         assertThat("testWithDateRestriction 4", bistreamAvailabilityDate, equalTo(startDate));
     }
 
@@ -405,21 +405,21 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         authorizeService.addPolicies(context, policies, bitstream);
         context.restoreAuthSystemState();
         // getAccessStatusFromItem
-        Pair<String, LocalDate> accessStatus = helper.getAccessStatusFromItem(context,
+        AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
                 itemWithGroupRestriction, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
-        String status = accessStatus.getLeft();
+        String status = accessStatus.getStatus();
         assertThat("testWithGroupRestriction 0", status, equalTo(DefaultAccessStatusHelper.RESTRICTED));
-        LocalDate availabilityDate = accessStatus.getRight();
+        LocalDate availabilityDate = accessStatus.getAvailabilityDate();
         assertThat("testWithGroupRestriction 1", availabilityDate, equalTo(threshold));
         // getEmbargoFromItem
         String embargoDate = helper.getEmbargoFromItem(context, itemWithGroupRestriction, threshold);
         assertNull("testWithGroupRestriction 2", embargoDate);
         // getAccessStatusFromBitstream
-        Pair<String, LocalDate> accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
+        AccessStatus accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
                 bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
-        String bitstreamStatus = accessStatusBitstream.getLeft();
+        String bitstreamStatus = accessStatusBitstream.getStatus();
         assertThat("testWithGroupRestriction 3", bitstreamStatus, equalTo(DefaultAccessStatusHelper.RESTRICTED));
-        LocalDate bitstreamAvailabilityDate = accessStatusBitstream.getRight();
+        LocalDate bitstreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
         assertThat("testWithGroupRestriction 4", bitstreamAvailabilityDate, equalTo(threshold));
     }
 
@@ -438,21 +438,21 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         authorizeService.removeAllPolicies(context, bitstream);
         context.restoreAuthSystemState();
         // getAccessStatusFromItem
-        Pair<String, LocalDate> accessStatus = helper.getAccessStatusFromItem(context,
+        AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
                 itemWithoutPolicy, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
-        String status = accessStatus.getLeft();
+        String status = accessStatus.getStatus();
         assertThat("testWithoutPolicy 0", status, equalTo(DefaultAccessStatusHelper.RESTRICTED));
-        LocalDate availabilityDate = accessStatus.getRight();
+        LocalDate availabilityDate = accessStatus.getAvailabilityDate();
         assertThat("testWithoutPolicy 1", availabilityDate, equalTo(threshold));
         // getEmbargoFromItem
         String embargoDate = helper.getEmbargoFromItem(context, itemWithoutPolicy, threshold);
         assertNull("testWithoutPolicy 2", embargoDate);
         // getAccessStatusFromBitstream
-        Pair<String, LocalDate> accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
+        AccessStatus accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
                 bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
-        String bitstreamStatus = accessStatusBitstream.getLeft();
+        String bitstreamStatus = accessStatusBitstream.getStatus();
         assertThat("testWithoutPolicy 3", bitstreamStatus, equalTo(DefaultAccessStatusHelper.RESTRICTED));
-        LocalDate bitstreamAvailabilityDate = accessStatusBitstream.getRight();
+        LocalDate bitstreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
         assertThat("testWithoutPolicy 4", bitstreamAvailabilityDate, equalTo(threshold));
     }
 
@@ -469,21 +469,21 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         bitstream.setName(context, "first");
         context.restoreAuthSystemState();
         // getAccessStatusFromItem
-        Pair<String, LocalDate> accessStatus = helper.getAccessStatusFromItem(context,
+        AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
                 itemWithoutPrimaryBitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
-        String status = accessStatus.getLeft();
+        String status = accessStatus.getStatus();
         assertThat("testWithoutPrimaryBitstream 0", status, equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
-        LocalDate availabilityDate = accessStatus.getRight();
+        LocalDate availabilityDate = accessStatus.getAvailabilityDate();
         assertNull("testWithoutPrimaryBitstream 1", availabilityDate);
         // getEmbargoFromItem
         String embargoDate = helper.getEmbargoFromItem(context, itemWithoutPrimaryBitstream, threshold);
         assertNull("testWithoutPrimaryBitstream 2", embargoDate);
         // getAccessStatusFromBitstream
-        Pair<String, LocalDate> accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
+        AccessStatus accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
                 bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
-        String bitstreamStatus = accessStatusBitstream.getLeft();
+        String bitstreamStatus = accessStatusBitstream.getStatus();
         assertThat("testWithoutPrimaryBitstream 3", bitstreamStatus, equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
-        LocalDate bitstreamAvailabilityDate = accessStatusBitstream.getRight();
+        LocalDate bitstreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
         assertNull("testWithoutPrimaryBitstream 4", bitstreamAvailabilityDate);
     }
 
@@ -514,30 +514,30 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         authorizeService.addPolicies(context, policies, primaryBitstream);
         context.restoreAuthSystemState();
         // getAccessStatusFromItem
-        Pair<String, LocalDate> accessStatus = helper.getAccessStatusFromItem(context,
+        AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
                 itemWithPrimaryAndMultipleBitstreams, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
-        String status = accessStatus.getLeft();
+        String status = accessStatus.getStatus();
         assertThat("testWithPrimaryAndMultipleBitstreams 0", status, equalTo(DefaultAccessStatusHelper.EMBARGO));
-        LocalDate availabilityDate = accessStatus.getRight();
+        LocalDate availabilityDate = accessStatus.getAvailabilityDate();
         assertThat("testWithPrimaryAndMultipleBitstreams 1", availabilityDate, equalTo(startDate));
         // getEmbargoFromItem
         String embargoDate = helper.getEmbargoFromItem(context, itemWithPrimaryAndMultipleBitstreams, threshold);
         assertThat("testWithPrimaryAndMultipleBitstreams 2", embargoDate, equalTo(startDate.toString()));
         // getAccessStatusFromBitstream -> primary
-        Pair<String, LocalDate> accessStatusPrimaryBitstream = helper.getAccessStatusFromBitstream(context,
+        AccessStatus accessStatusPrimaryBitstream = helper.getAccessStatusFromBitstream(context,
                 primaryBitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
-        String primaryBitstreamStatus = accessStatusPrimaryBitstream.getLeft();
+        String primaryBitstreamStatus = accessStatusPrimaryBitstream.getStatus();
         assertThat("testWithPrimaryAndMultipleBitstreams 3", primaryBitstreamStatus,
                 equalTo(DefaultAccessStatusHelper.EMBARGO));
-        LocalDate primaryAvailabilityDate = accessStatusPrimaryBitstream.getRight();
+        LocalDate primaryAvailabilityDate = accessStatusPrimaryBitstream.getAvailabilityDate();
         assertThat("testWithPrimaryAndMultipleBitstreams 4", primaryAvailabilityDate, equalTo(startDate));
         // getAccessStatusFromBitstream -> other
-        Pair<String, LocalDate> accessStatusOtherBitstream = helper.getAccessStatusFromBitstream(context,
+        AccessStatus accessStatusOtherBitstream = helper.getAccessStatusFromBitstream(context,
                 otherBitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
-        String otherBitstreamStatus = accessStatusOtherBitstream.getLeft();
+        String otherBitstreamStatus = accessStatusOtherBitstream.getStatus();
         assertThat("testWithPrimaryAndMultipleBitstreams 5", otherBitstreamStatus,
                 equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
-        LocalDate otherAvailabilityDate = accessStatusOtherBitstream.getRight();
+        LocalDate otherAvailabilityDate = accessStatusOtherBitstream.getAvailabilityDate();
         assertNull("testWithPrimaryAndMultipleBitstreams 6", otherAvailabilityDate);
     }
 
@@ -567,31 +567,31 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         authorizeService.addPolicies(context, policies, anotherBitstream);
         context.restoreAuthSystemState();
         // getAccessStatusFromItem
-        Pair<String, LocalDate> accessStatus = helper.getAccessStatusFromItem(context,
+        AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
                 itemWithoutPrimaryAndMultipleBitstreams, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
-        String status = accessStatus.getLeft();
+        String status = accessStatus.getStatus();
         assertThat("testWithNoPrimaryAndMultipleBitstreams 0", status,
                 equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
-        LocalDate availabilityDate = accessStatus.getRight();
+        LocalDate availabilityDate = accessStatus.getAvailabilityDate();
         assertNull("testWithNoPrimaryAndMultipleBitstreams 1", availabilityDate);
         // getEmbargoFromItem
         String embargoDate = helper.getEmbargoFromItem(context, itemWithEmbargo, threshold);
         assertNull("testWithNoPrimaryAndMultipleBitstreams 2", embargoDate);
         // getAccessStatusFromBitstream -> first
-        Pair<String, LocalDate> accessStatusFirstBitstream = helper.getAccessStatusFromBitstream(context,
+        AccessStatus accessStatusFirstBitstream = helper.getAccessStatusFromBitstream(context,
                 firstBitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
-        String firstBitstreamStatus = accessStatusFirstBitstream.getLeft();
+        String firstBitstreamStatus = accessStatusFirstBitstream.getStatus();
         assertThat("testWithNoPrimaryAndMultipleBitstreams 3", firstBitstreamStatus,
                 equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
-        LocalDate firstAvailabilityDate = accessStatusFirstBitstream.getRight();
+        LocalDate firstAvailabilityDate = accessStatusFirstBitstream.getAvailabilityDate();
         assertNull("testWithNoPrimaryAndMultipleBitstreams 4", firstAvailabilityDate);
         // getAccessStatusFromBitstream -> other
-        Pair<String, LocalDate> accessStatusOtherBitstream = helper.getAccessStatusFromBitstream(context,
+        AccessStatus accessStatusOtherBitstream = helper.getAccessStatusFromBitstream(context,
                 anotherBitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
-        String otherBitstreamStatus = accessStatusOtherBitstream.getLeft();
+        String otherBitstreamStatus = accessStatusOtherBitstream.getStatus();
         assertThat("testWithNoPrimaryAndMultipleBitstreams 5", otherBitstreamStatus,
                 equalTo(DefaultAccessStatusHelper.EMBARGO));
-        LocalDate otherAvailabilityDate = accessStatusOtherBitstream.getRight();
+        LocalDate otherAvailabilityDate = accessStatusOtherBitstream.getAvailabilityDate();
         assertThat("testWithNoPrimaryAndMultipleBitstreams 6", otherAvailabilityDate, equalTo(startDate));
     }
 
@@ -629,37 +629,37 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         assertThat("testWithEmbargoForCurrentOrAnonymousAsGuest 0", embargoDate, equalTo(startDate.toString()));
         // Configuration: current
         // getAccessStatusFromItem
-        Pair<String, LocalDate> accessStatus = helper.getAccessStatusFromItem(context,
+        AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
                 itemWithEmbargo, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
-        String status = accessStatus.getLeft();
+        String status = accessStatus.getStatus();
         assertThat("testWithEmbargoForCurrentOrAnonymousAsGuest 1", status,
                 equalTo(DefaultAccessStatusHelper.EMBARGO));
-        LocalDate availabilityDate = accessStatus.getRight();
+        LocalDate availabilityDate = accessStatus.getAvailabilityDate();
         assertThat("testWithEmbargoForCurrentOrAnonymousAsGuest 2", availabilityDate, equalTo(startDate));
         // getAccessStatusFromBitstream
-        Pair<String, LocalDate> accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
+        AccessStatus accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
                 bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
-        String bitstreamStatus = accessStatusBitstream.getLeft();
+        String bitstreamStatus = accessStatusBitstream.getStatus();
         assertThat("testWithEmbargoForCurrentOrAnonymousAsGuest 3", bitstreamStatus,
                 equalTo(DefaultAccessStatusHelper.EMBARGO));
-        LocalDate bistreamAvailabilityDate = accessStatusBitstream.getRight();
+        LocalDate bistreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
         assertThat("testWithEmbargoForCurrentOrAnonymousAsGuest 4", bistreamAvailabilityDate, equalTo(startDate));
         // Configuration: anonymous
         // getAccessStatusFromItem
         accessStatus = helper.getAccessStatusFromItem(context,
                 itemWithEmbargo, threshold, DefaultAccessStatusHelper.STATUS_FOR_ANONYMOUS);
-        status = accessStatus.getLeft();
+        status = accessStatus.getStatus();
         assertThat("testWithEmbargoForCurrentOrAnonymousAsGuest 5", status,
                 equalTo(DefaultAccessStatusHelper.EMBARGO));
-        availabilityDate = accessStatus.getRight();
+        availabilityDate = accessStatus.getAvailabilityDate();
         assertThat("testWithEmbargoForCurrentOrAnonymousAsGuest 6", availabilityDate, equalTo(startDate));
         // getAccessStatusFromBitstream
         accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
                 bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_ANONYMOUS);
-        bitstreamStatus = accessStatusBitstream.getLeft();
+        bitstreamStatus = accessStatusBitstream.getStatus();
         assertThat("testWithEmbargoForCurrentOrAnonymousAsGuest 7", bitstreamStatus,
                 equalTo(DefaultAccessStatusHelper.EMBARGO));
-        bistreamAvailabilityDate = accessStatusBitstream.getRight();
+        bistreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
         assertThat("testWithEmbargoForCurrentOrAnonymousAsGuest 8", bistreamAvailabilityDate, equalTo(startDate));
     }
 
@@ -699,36 +699,36 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         assertThat("testWithEmbargoForCurrentOrAnonymousAsAdmin 0", embargoDate, equalTo(startDate.toString()));
         // Configuration: current
         // getAccessStatusFromItem
-        Pair<String, LocalDate> accessStatus = helper.getAccessStatusFromItem(context,
+        AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
                 itemWithEmbargo, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
-        String status = accessStatus.getLeft();
+        String status = accessStatus.getStatus();
         assertThat("testWithEmbargoForCurrentOrAnonymousAsAdmin 1", status,
                 equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
-        LocalDate availabilityDate = accessStatus.getRight();
+        LocalDate availabilityDate = accessStatus.getAvailabilityDate();
         assertNull("testWithEmbargoForCurrentOrAnonymousAsAdmin 2", availabilityDate);
         // getAccessStatusFromBitstream
-        Pair<String, LocalDate> accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
+        AccessStatus accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
                 bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
-        String bitstreamStatus = accessStatusBitstream.getLeft();
+        String bitstreamStatus = accessStatusBitstream.getStatus();
         assertThat("testWithEmbargoForCurrentOrAnonymousAsAdmin 3", bitstreamStatus,
                 equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
-        LocalDate bitstreamAvailabilityDate = accessStatusBitstream.getRight();
+        LocalDate bitstreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
         assertNull("testWithEmbargoForCurrentOrAnonymousAsAdmin 4", bitstreamAvailabilityDate);
         // Configuration: anonymous
         accessStatus = helper.getAccessStatusFromItem(context,
                 itemWithEmbargo, threshold, DefaultAccessStatusHelper.STATUS_FOR_ANONYMOUS);
-        status = accessStatus.getLeft();
+        status = accessStatus.getStatus();
         assertThat("testWithEmbargoForCurrentOrAnonymousAsAdmin 5", status,
                 equalTo(DefaultAccessStatusHelper.EMBARGO));
-        availabilityDate = accessStatus.getRight();
+        availabilityDate = accessStatus.getAvailabilityDate();
         assertThat("testWithEmbargoForCurrentOrAnonymousAsAdmin 6", availabilityDate, equalTo(startDate));
         // getAccessStatusFromBitstream
         accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
                 bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_ANONYMOUS);
-        bitstreamStatus = accessStatusBitstream.getLeft();
+        bitstreamStatus = accessStatusBitstream.getStatus();
         assertThat("testWithEmbargoForCurrentOrAnonymousAsAdmin 7", bitstreamStatus,
                 equalTo(DefaultAccessStatusHelper.EMBARGO));
-        bitstreamAvailabilityDate = accessStatusBitstream.getRight();
+        bitstreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
         assertThat("testWithEmbargoForCurrentOrAnonymousAsAdmin 8", bitstreamAvailabilityDate, equalTo(startDate));
         context.setCurrentUser(currentUser);
     }

--- a/dspace-api/src/test/java/org/dspace/access/status/DefaultAccessStatusHelperTest.java
+++ b/dspace-api/src/test/java/org/dspace/access/status/DefaultAccessStatusHelperTest.java
@@ -40,8 +40,10 @@ import org.dspace.content.service.InstallItemService;
 import org.dspace.content.service.ItemService;
 import org.dspace.content.service.WorkspaceItemService;
 import org.dspace.core.Constants;
+import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
 import org.dspace.eperson.factory.EPersonServiceFactory;
+import org.dspace.eperson.service.EPersonService;
 import org.dspace.eperson.service.GroupService;
 import org.junit.After;
 import org.junit.Before;
@@ -50,6 +52,9 @@ import org.junit.Test;
 public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
 
     private static final Logger log = LogManager.getLogger(DefaultAccessStatusHelperTest.class);
+
+    private static final String ANONYMOUS_TYPE = "anonymous";
+    private static final String CURRENT_TYPE = "current";
 
     private Collection collection;
     private Community owningCommunity;
@@ -84,6 +89,8 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
             AuthorizeServiceFactory.getInstance().getResourcePolicyService();
     protected GroupService groupService =
             EPersonServiceFactory.getInstance().getGroupService();
+    protected EPersonService ePersonService =
+            EPersonServiceFactory.getInstance().getEPersonService();
 
     /**
      * This method will be run before every test as per @Before. It will
@@ -204,7 +211,7 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
      */
     @Test
     public void testWithNullItem() throws Exception {
-        String status = helper.getAccessStatusFromItem(context, null, threshold);
+        String status = helper.getAccessStatusFromItem(context, null, threshold, CURRENT_TYPE);
         assertThat("testWithNullItem 0", status, equalTo(DefaultAccessStatusHelper.UNKNOWN));
         String embargoDate = helper.getEmbargoFromItem(context, null, threshold);
         assertNull("testWithNullItem 1", embargoDate);
@@ -216,7 +223,7 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
      */
     @Test
     public void testWithoutBundle() throws Exception {
-        String status = helper.getAccessStatusFromItem(context, itemWithoutBundle, threshold);
+        String status = helper.getAccessStatusFromItem(context, itemWithoutBundle, threshold, CURRENT_TYPE);
         assertThat("testWithoutBundle 0", status, equalTo(DefaultAccessStatusHelper.METADATA_ONLY));
         String embargoDate = helper.getEmbargoFromItem(context, itemWithoutBundle, threshold);
         assertNull("testWithoutBundle 1", embargoDate);
@@ -231,11 +238,11 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         context.turnOffAuthorisationSystem();
         bundleService.create(context, itemWithoutBitstream, Constants.CONTENT_BUNDLE_NAME);
         context.restoreAuthSystemState();
-        String status = helper.getAccessStatusFromItem(context, itemWithoutBitstream, threshold);
+        String status = helper.getAccessStatusFromItem(context, itemWithoutBitstream, threshold, CURRENT_TYPE);
         assertThat("testWithoutBitstream 0", status, equalTo(DefaultAccessStatusHelper.METADATA_ONLY));
         String embargoDate = helper.getEmbargoFromItem(context, itemWithoutBitstream, threshold);
         assertNull("testWithoutBitstream 1", embargoDate);
-        LocalDate availabilityDate = helper.getAvailabilityDateFromBitstream(context, null, threshold);
+        LocalDate availabilityDate = helper.getAvailabilityDateFromBitstream(context, null, threshold, CURRENT_TYPE);
         assertNull("testWithoutBitstream 2", availabilityDate);
         String bitstreamStatus = helper.getAccessStatusFromAvailabilityDate(availabilityDate, threshold);
         assertThat("testWithoutBitstream 3", bitstreamStatus, equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
@@ -254,11 +261,12 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         bitstream.setName(context, "primary");
         bundle.setPrimaryBitstreamID(bitstream);
         context.restoreAuthSystemState();
-        String status = helper.getAccessStatusFromItem(context, itemWithBitstream, threshold);
+        String status = helper.getAccessStatusFromItem(context, itemWithBitstream, threshold, CURRENT_TYPE);
         assertThat("testWithBitstream 0", status, equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
         String embargoDate = helper.getEmbargoFromItem(context, itemWithBitstream, threshold);
         assertNull("testWithBitstream 1", embargoDate);
-        LocalDate availabilityDate = helper.getAvailabilityDateFromBitstream(context, bitstream, threshold);
+        LocalDate availabilityDate = helper.getAvailabilityDateFromBitstream(context,
+                bitstream, threshold, CURRENT_TYPE);
         assertNull("testWithBitstream 2", availabilityDate);
         String bitstreamStatus = helper.getAccessStatusFromAvailabilityDate(availabilityDate, threshold);
         assertThat("testWithBitstream 3", bitstreamStatus, equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
@@ -287,11 +295,12 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         authorizeService.removeAllPolicies(context, bitstream);
         authorizeService.addPolicies(context, policies, bitstream);
         context.restoreAuthSystemState();
-        String status = helper.getAccessStatusFromItem(context, itemWithEmbargo, threshold);
+        String status = helper.getAccessStatusFromItem(context, itemWithEmbargo, threshold, CURRENT_TYPE);
         assertThat("testWithEmbargo 0", status, equalTo(DefaultAccessStatusHelper.EMBARGO));
         String embargoDate = helper.getEmbargoFromItem(context, itemWithEmbargo, threshold);
         assertThat("testWithEmbargo 1", embargoDate, equalTo(startDate.toString()));
-        LocalDate availabilityDate = helper.getAvailabilityDateFromBitstream(context, bitstream, threshold);
+        LocalDate availabilityDate = helper.getAvailabilityDateFromBitstream(context,
+                bitstream, threshold, CURRENT_TYPE);
         assertThat("testWithEmbargo 2", availabilityDate, equalTo(startDate));
         String bitstreamStatus = helper.getAccessStatusFromAvailabilityDate(availabilityDate, threshold);
         assertThat("testWithEmbargo 3", bitstreamStatus, equalTo(DefaultAccessStatusHelper.EMBARGO));
@@ -320,11 +329,12 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         authorizeService.removeAllPolicies(context, bitstream);
         authorizeService.addPolicies(context, policies, bitstream);
         context.restoreAuthSystemState();
-        String status = helper.getAccessStatusFromItem(context, itemWithDateRestriction, threshold);
+        String status = helper.getAccessStatusFromItem(context, itemWithDateRestriction, threshold, CURRENT_TYPE);
         assertThat("testWithDateRestriction 0", status, equalTo(DefaultAccessStatusHelper.RESTRICTED));
         String embargoDate = helper.getEmbargoFromItem(context, itemWithDateRestriction, threshold);
         assertNull("testWithDateRestriction 1", embargoDate);
-        LocalDate availabilityDate = helper.getAvailabilityDateFromBitstream(context, bitstream, threshold);
+        LocalDate availabilityDate = helper.getAvailabilityDateFromBitstream(context,
+                bitstream, threshold, CURRENT_TYPE);
         assertThat("testWithDateRestriction 2", availabilityDate, equalTo(startDate));
         String bitstreamStatus = helper.getAccessStatusFromAvailabilityDate(availabilityDate, threshold);
         assertThat("testWithDateRestriction 3", bitstreamStatus, equalTo(DefaultAccessStatusHelper.RESTRICTED));
@@ -351,11 +361,12 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         authorizeService.removeAllPolicies(context, bitstream);
         authorizeService.addPolicies(context, policies, bitstream);
         context.restoreAuthSystemState();
-        String status = helper.getAccessStatusFromItem(context, itemWithGroupRestriction, threshold);
+        String status = helper.getAccessStatusFromItem(context, itemWithGroupRestriction, threshold, CURRENT_TYPE);
         assertThat("testWithGroupRestriction 0", status, equalTo(DefaultAccessStatusHelper.RESTRICTED));
         String embargoDate = helper.getEmbargoFromItem(context, itemWithGroupRestriction, threshold);
         assertNull("testWithGroupRestriction 1", embargoDate);
-        LocalDate availabilityDate = helper.getAvailabilityDateFromBitstream(context, bitstream, threshold);
+        LocalDate availabilityDate = helper.getAvailabilityDateFromBitstream(context,
+                bitstream, threshold, CURRENT_TYPE);
         assertThat("testWithGroupRestriction 2", availabilityDate, equalTo(threshold));
         String bitstreamStatus = helper.getAccessStatusFromAvailabilityDate(availabilityDate, threshold);
         assertThat("testWithGroupRestriction 3", bitstreamStatus, equalTo(DefaultAccessStatusHelper.RESTRICTED));
@@ -375,11 +386,12 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         bundle.setPrimaryBitstreamID(bitstream);
         authorizeService.removeAllPolicies(context, bitstream);
         context.restoreAuthSystemState();
-        String status = helper.getAccessStatusFromItem(context, itemWithoutPolicy, threshold);
+        String status = helper.getAccessStatusFromItem(context, itemWithoutPolicy, threshold, CURRENT_TYPE);
         assertThat("testWithoutPolicy 0", status, equalTo(DefaultAccessStatusHelper.RESTRICTED));
         String embargoDate = helper.getEmbargoFromItem(context, itemWithoutPolicy, threshold);
         assertNull("testWithoutPolicy 1", embargoDate);
-        LocalDate availabilityDate = helper.getAvailabilityDateFromBitstream(context, bitstream, threshold);
+        LocalDate availabilityDate = helper.getAvailabilityDateFromBitstream(context,
+                bitstream, threshold, CURRENT_TYPE);
         assertThat("testWithoutPolicy 2", availabilityDate, equalTo(threshold));
         String bitstreamStatus = helper.getAccessStatusFromAvailabilityDate(availabilityDate, threshold);
         assertThat("testWithoutPolicy 3", bitstreamStatus, equalTo(DefaultAccessStatusHelper.RESTRICTED));
@@ -397,11 +409,12 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
                 new ByteArrayInputStream("1".getBytes(StandardCharsets.UTF_8)));
         bitstream.setName(context, "first");
         context.restoreAuthSystemState();
-        String status = helper.getAccessStatusFromItem(context, itemWithoutPrimaryBitstream, threshold);
+        String status = helper.getAccessStatusFromItem(context, itemWithoutPrimaryBitstream, threshold, CURRENT_TYPE);
         assertThat("testWithoutPrimaryBitstream 0", status, equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
         String embargoDate = helper.getEmbargoFromItem(context, itemWithoutPrimaryBitstream, threshold);
         assertNull("testWithoutPrimaryBitstream 1", embargoDate);
-        LocalDate availabilityDate = helper.getAvailabilityDateFromBitstream(context, bitstream, threshold);
+        LocalDate availabilityDate = helper.getAvailabilityDateFromBitstream(context,
+                bitstream, threshold, CURRENT_TYPE);
         assertNull("testWithoutPrimaryBitstream 2", availabilityDate);
         String bitstreamStatus = helper.getAccessStatusFromAvailabilityDate(availabilityDate, threshold);
         assertThat("testWithoutPrimaryBitstream 3", bitstreamStatus, equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
@@ -433,16 +446,19 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         authorizeService.removeAllPolicies(context, primaryBitstream);
         authorizeService.addPolicies(context, policies, primaryBitstream);
         context.restoreAuthSystemState();
-        String status = helper.getAccessStatusFromItem(context, itemWithPrimaryAndMultipleBitstreams, threshold);
+        String status = helper.getAccessStatusFromItem(context,
+                itemWithPrimaryAndMultipleBitstreams, threshold, CURRENT_TYPE);
         assertThat("testWithPrimaryAndMultipleBitstreams 0", status, equalTo(DefaultAccessStatusHelper.EMBARGO));
         String embargoDate = helper.getEmbargoFromItem(context, itemWithPrimaryAndMultipleBitstreams, threshold);
         assertThat("testWithPrimaryAndMultipleBitstreams 1", embargoDate, equalTo(startDate.toString()));
-        LocalDate primaryAvailabilityDate = helper.getAvailabilityDateFromBitstream(context, primaryBitstream, threshold);
+        LocalDate primaryAvailabilityDate = helper.getAvailabilityDateFromBitstream(context,
+                primaryBitstream, threshold, CURRENT_TYPE);
         assertThat("testWithPrimaryAndMultipleBitstreams 2", primaryAvailabilityDate, equalTo(startDate));
         String primaryBitstreamStatus = helper.getAccessStatusFromAvailabilityDate(primaryAvailabilityDate, threshold);
         assertThat("testWithPrimaryAndMultipleBitstreams 3", primaryBitstreamStatus,
                 equalTo(DefaultAccessStatusHelper.EMBARGO));
-        LocalDate otherAvailabilityDate = helper.getAvailabilityDateFromBitstream(context, otherBitstream, threshold);
+        LocalDate otherAvailabilityDate = helper.getAvailabilityDateFromBitstream(context,
+                otherBitstream, threshold, CURRENT_TYPE);
         assertNull("testWithPrimaryAndMultipleBitstreams 4", otherAvailabilityDate);
         String otherBitstreamStatus = helper.getAccessStatusFromAvailabilityDate(otherAvailabilityDate, threshold);
         assertThat("testWithPrimaryAndMultipleBitstreams 5", otherBitstreamStatus,
@@ -474,20 +490,73 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         authorizeService.removeAllPolicies(context, anotherBitstream);
         authorizeService.addPolicies(context, policies, anotherBitstream);
         context.restoreAuthSystemState();
-        String status = helper.getAccessStatusFromItem(context, itemWithoutPrimaryAndMultipleBitstreams, threshold);
+        String status = helper.getAccessStatusFromItem(context,
+                itemWithoutPrimaryAndMultipleBitstreams, threshold, CURRENT_TYPE);
         assertThat("testWithNoPrimaryAndMultipleBitstreams 0", status,
                 equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
         String embargoDate = helper.getEmbargoFromItem(context, itemWithEmbargo, threshold);
         assertNull("testWithNoPrimaryAndMultipleBitstreams 1", embargoDate);
-        LocalDate firstAvailabilityDate = helper.getAvailabilityDateFromBitstream(context, firstBitstream, threshold);
+        LocalDate firstAvailabilityDate = helper.getAvailabilityDateFromBitstream(context,
+                firstBitstream, threshold, CURRENT_TYPE);
         assertNull("testWithNoPrimaryAndMultipleBitstreams 2", firstAvailabilityDate);
         String firstBitstreamStatus = helper.getAccessStatusFromAvailabilityDate(firstAvailabilityDate, threshold);
         assertThat("testWithNoPrimaryAndMultipleBitstreams 3", firstBitstreamStatus,
                 equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
-        LocalDate otherAvailabilityDate = helper.getAvailabilityDateFromBitstream(context, anotherBitstream, threshold);
+        LocalDate otherAvailabilityDate = helper.getAvailabilityDateFromBitstream(context,
+                anotherBitstream, threshold, CURRENT_TYPE);
         assertThat("testWithNoPrimaryAndMultipleBitstreams 4", otherAvailabilityDate, equalTo(startDate));
         String otherBitstreamStatus = helper.getAccessStatusFromAvailabilityDate(otherAvailabilityDate, threshold);
         assertThat("testWithNoPrimaryAndMultipleBitstreams 5", otherBitstreamStatus,
                 equalTo(DefaultAccessStatusHelper.EMBARGO));
+    }
+
+    /**
+     * Test for an item with an embargo
+     * @throws java.lang.Exception passed through.
+     */
+    @Test
+    public void testWithEmbargoForAnonymousOrAdminUser() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Bundle bundle = bundleService.create(context, itemWithEmbargo, Constants.CONTENT_BUNDLE_NAME);
+        Bitstream bitstream = bitstreamService.create(context, bundle,
+                new ByteArrayInputStream("1".getBytes(StandardCharsets.UTF_8)));
+        bitstream.setName(context, "primary");
+        bundle.setPrimaryBitstreamID(bitstream);
+        List<ResourcePolicy> policies = new ArrayList<>();
+        Group group = groupService.findByName(context, Group.ANONYMOUS);
+        ResourcePolicy policy = resourcePolicyService.create(context, null, group);
+        policy.setRpName("Embargo");
+        policy.setAction(Constants.READ);
+        LocalDate startDate = LocalDate.of(9999, 12, 31);
+        policy.setStartDate(startDate);
+        policies.add(policy);
+        EPerson admin = ePersonService.create(context);
+        Group adminGroup = groupService.findByName(context, Group.ADMIN);
+        ResourcePolicy adminPolicy = resourcePolicyService.create(context, admin, adminGroup);
+        adminPolicy.setRpName("Open Access For Admin");
+        adminPolicy.setAction(Constants.READ);
+        policies.add(adminPolicy);
+        authorizeService.removeAllPolicies(context, bitstream);
+        authorizeService.addPolicies(context, policies, bitstream);
+        context.restoreAuthSystemState();
+        String status = helper.getAccessStatusFromItem(context, itemWithEmbargo, threshold, CURRENT_TYPE);
+        assertThat("testWithEmbargoForAnonymousOrAdminUser 0", status, equalTo(DefaultAccessStatusHelper.EMBARGO));
+        String embargoDate = helper.getEmbargoFromItem(context, itemWithEmbargo, threshold);
+        assertThat("testWithEmbargoForAnonymousOrAdminUser 1", embargoDate, equalTo(startDate.toString()));
+        LocalDate availabilityDate = helper.getAvailabilityDateFromBitstream(context,
+                bitstream, threshold, CURRENT_TYPE);
+        assertThat("testWithEmbargoForAnonymousOrAdminUser 2", availabilityDate, equalTo(startDate));
+        String bitstreamStatus = helper.getAccessStatusFromAvailabilityDate(availabilityDate, threshold);
+        assertThat("testWithEmbargoForAnonymousOrAdminUser 3", bitstreamStatus,
+                equalTo(DefaultAccessStatusHelper.EMBARGO));
+        EPerson currentUser = context.getCurrentUser();
+        context.setCurrentUser(admin);
+        String statusAdmin = helper.getAccessStatusFromItem(context, itemWithEmbargo, threshold, CURRENT_TYPE);
+        assertThat("testWithEmbargoForAnonymousOrAdminUser 4", statusAdmin,
+                equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
+        String statusAnonymous = helper.getAccessStatusFromItem(context, itemWithEmbargo, threshold, ANONYMOUS_TYPE);
+        assertThat("testWithEmbargoForAnonymousOrAdminUser 5", statusAnonymous,
+                equalTo(DefaultAccessStatusHelper.EMBARGO));
+        context.setCurrentUser(currentUser);
     }
 }

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/plugins/AccessStatusElementItemCompilePlugin.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/plugins/AccessStatusElementItemCompilePlugin.java
@@ -8,15 +8,14 @@
 package org.dspace.xoai.app.plugins;
 
 import java.sql.SQLException;
-import java.time.LocalDate;
 import java.util.List;
 
 import com.lyncode.xoai.dataprovider.xml.xoai.Element;
 import com.lyncode.xoai.dataprovider.xml.xoai.Metadata;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.dspace.access.status.factory.AccessStatusServiceFactory;
 import org.dspace.access.status.service.AccessStatusService;
+import org.dspace.content.AccessStatus;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
 import org.dspace.xoai.app.XOAIExtensionItemCompilePlugin;
@@ -53,8 +52,8 @@ public class AccessStatusElementItemCompilePlugin implements XOAIExtensionItemCo
         AccessStatusService accessStatusService = AccessStatusServiceFactory.getInstance().getAccessStatusService();
 
         try {
-            Pair<String, LocalDate> accessStatusResult = accessStatusService.getAccessStatus(context, item);
-            String accessStatusType = accessStatusResult.getLeft();
+            AccessStatus accessStatusResult = accessStatusService.getAccessStatus(context, item);
+            String accessStatusType = accessStatusResult.getStatus();
 
             String embargoFromItem = accessStatusService.getEmbargoFromItem(context, item);
 

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/plugins/AccessStatusElementItemCompilePlugin.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/plugins/AccessStatusElementItemCompilePlugin.java
@@ -8,11 +8,13 @@
 package org.dspace.xoai.app.plugins;
 
 import java.sql.SQLException;
+import java.time.LocalDate;
 import java.util.List;
 
 import com.lyncode.xoai.dataprovider.xml.xoai.Element;
 import com.lyncode.xoai.dataprovider.xml.xoai.Metadata;
 import org.apache.commons.lang3.StringUtils;
+import org.dspace.access.status.DefaultAccessStatusHelper;
 import org.dspace.access.status.factory.AccessStatusServiceFactory;
 import org.dspace.access.status.service.AccessStatusService;
 import org.dspace.content.AccessStatus;
@@ -52,10 +54,13 @@ public class AccessStatusElementItemCompilePlugin implements XOAIExtensionItemCo
         AccessStatusService accessStatusService = AccessStatusServiceFactory.getInstance().getAccessStatusService();
 
         try {
-            AccessStatus accessStatusResult = accessStatusService.getAccessStatus(context, item);
+            AccessStatus accessStatusResult = accessStatusService.getAnonymousAccessStatus(context, item);
             String accessStatusType = accessStatusResult.getStatus();
-
-            String embargoFromItem = accessStatusService.getEmbargoFromItem(context, item);
+            LocalDate availabilityDate = accessStatusResult.getAvailabilityDate();
+            String embargoFromItem = null;
+            if (accessStatusType == DefaultAccessStatusHelper.EMBARGO && availabilityDate != null) {
+                embargoFromItem = availabilityDate.toString();
+            }
 
             Element accessStatus = ItemUtils.create("access-status");
             accessStatus.getField().add(ItemUtils.createValue("value", accessStatusType));

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/plugins/AccessStatusElementItemCompilePlugin.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/plugins/AccessStatusElementItemCompilePlugin.java
@@ -8,11 +8,13 @@
 package org.dspace.xoai.app.plugins;
 
 import java.sql.SQLException;
+import java.time.LocalDate;
 import java.util.List;
 
 import com.lyncode.xoai.dataprovider.xml.xoai.Element;
 import com.lyncode.xoai.dataprovider.xml.xoai.Metadata;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.dspace.access.status.factory.AccessStatusServiceFactory;
 import org.dspace.access.status.service.AccessStatusService;
 import org.dspace.content.Item;
@@ -51,8 +53,8 @@ public class AccessStatusElementItemCompilePlugin implements XOAIExtensionItemCo
         AccessStatusService accessStatusService = AccessStatusServiceFactory.getInstance().getAccessStatusService();
 
         try {
-            String accessStatusType;
-            accessStatusType = accessStatusService.getAccessStatus(context, item);
+            Pair<String, LocalDate> accessStatusResult = accessStatusService.getAccessStatus(context, item);
+            String accessStatusType = accessStatusResult.getLeft();
 
             String embargoFromItem = accessStatusService.getEmbargoFromItem(context, item);
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/AccessStatusRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/AccessStatusRest.java
@@ -18,6 +18,7 @@ public class AccessStatusRest implements RestModel {
     public static final String PLURAL_NAME = NAME;
 
     String status;
+    String embargoDate;
 
     @Override
     @JsonProperty(access = Access.READ_ONLY)
@@ -35,10 +36,12 @@ public class AccessStatusRest implements RestModel {
 
     public AccessStatusRest() {
         setStatus(null);
+        setEmbargoDate(null);
     }
 
     public AccessStatusRest(String status) {
         setStatus(status);
+        setEmbargoDate(null);
     }
 
     public String getStatus() {
@@ -47,5 +50,13 @@ public class AccessStatusRest implements RestModel {
 
     public void setStatus(String status) {
         this.status = status;
+    }
+
+    public String getEmbargoDate() {
+        return embargoDate;
+    }
+
+    public void setEmbargoDate(String embargoDate) {
+        this.embargoDate = embargoDate;
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/BitstreamRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/BitstreamRest.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.annotation.JsonProperty.Access;
  */
 @LinksRest(links = {
     @LinkRest(name = BitstreamRest.BUNDLE, method = "getBundle"),
+    @LinkRest(name = BitstreamRest.ACCESS_STATUS, method = "getAccessStatus"),
     @LinkRest(name = BitstreamRest.FORMAT, method = "getFormat"),
     @LinkRest(name = BitstreamRest.THUMBNAIL, method = "getThumbnail")
 })
@@ -26,6 +27,7 @@ public class BitstreamRest extends DSpaceObjectRest {
     public static final String CATEGORY = RestAddressableModel.CORE;
 
     public static final String BUNDLE = "bundle";
+    public static final String ACCESS_STATUS = "accessStatus";
     public static final String FORMAT = "format";
     public static final String THUMBNAIL = "thumbnail";
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamAccessStatusLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamAccessStatusLinkRepository.java
@@ -9,7 +9,7 @@
 package org.dspace.app.rest.repository;
 
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.UUID;
 
 import jakarta.annotation.Nullable;
@@ -54,7 +54,7 @@ public class BitstreamAccessStatusLinkRepository extends AbstractDSpaceRestRepos
                 throw new ResourceNotFoundException("No such bitstream: " + bitstreamId);
             }
             AccessStatusRest accessStatusRest = new AccessStatusRest();
-            Date availabilityDate = accessStatusService.getAvailabilityDateFromBitstream(context, bitstream);
+            LocalDate availabilityDate = accessStatusService.getAvailabilityDateFromBitstream(context, bitstream);
             String status = accessStatusService.getAccessStatusFromAvailabilityDate(availabilityDate);
             if (status == DefaultAccessStatusHelper.EMBARGO) {
                 String embargoDate = availabilityDate.toString();

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamAccessStatusLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamAccessStatusLinkRepository.java
@@ -14,6 +14,7 @@ import java.util.UUID;
 
 import jakarta.annotation.Nullable;
 import jakarta.servlet.http.HttpServletRequest;
+import org.apache.commons.lang3.tuple.Pair;
 import org.dspace.access.status.DefaultAccessStatusHelper;
 import org.dspace.access.status.service.AccessStatusService;
 import org.dspace.app.rest.model.AccessStatusRest;
@@ -54,9 +55,10 @@ public class BitstreamAccessStatusLinkRepository extends AbstractDSpaceRestRepos
                 throw new ResourceNotFoundException("No such bitstream: " + bitstreamId);
             }
             AccessStatusRest accessStatusRest = new AccessStatusRest();
-            LocalDate availabilityDate = accessStatusService.getAvailabilityDateFromBitstream(context, bitstream);
-            String status = accessStatusService.getAccessStatusFromAvailabilityDate(availabilityDate);
+            Pair<String, LocalDate> accessStatus = accessStatusService.getAccessStatus(context, bitstream);
+            String status = accessStatus.getLeft();
             if (status == DefaultAccessStatusHelper.EMBARGO) {
+                LocalDate availabilityDate = accessStatus.getRight();
                 String embargoDate = availabilityDate.toString();
                 accessStatusRest.setEmbargoDate(embargoDate);
             }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamAccessStatusLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamAccessStatusLinkRepository.java
@@ -14,12 +14,12 @@ import java.util.UUID;
 
 import jakarta.annotation.Nullable;
 import jakarta.servlet.http.HttpServletRequest;
-import org.apache.commons.lang3.tuple.Pair;
 import org.dspace.access.status.DefaultAccessStatusHelper;
 import org.dspace.access.status.service.AccessStatusService;
 import org.dspace.app.rest.model.AccessStatusRest;
 import org.dspace.app.rest.model.BitstreamRest;
 import org.dspace.app.rest.projection.Projection;
+import org.dspace.content.AccessStatus;
 import org.dspace.content.Bitstream;
 import org.dspace.content.service.BitstreamService;
 import org.dspace.core.Context;
@@ -55,10 +55,10 @@ public class BitstreamAccessStatusLinkRepository extends AbstractDSpaceRestRepos
                 throw new ResourceNotFoundException("No such bitstream: " + bitstreamId);
             }
             AccessStatusRest accessStatusRest = new AccessStatusRest();
-            Pair<String, LocalDate> accessStatus = accessStatusService.getAccessStatus(context, bitstream);
-            String status = accessStatus.getLeft();
+            AccessStatus accessStatus = accessStatusService.getAccessStatus(context, bitstream);
+            String status = accessStatus.getStatus();
             if (status == DefaultAccessStatusHelper.EMBARGO) {
-                LocalDate availabilityDate = accessStatus.getRight();
+                LocalDate availabilityDate = accessStatus.getAvailabilityDate();
                 String embargoDate = availabilityDate.toString();
                 accessStatusRest.setEmbargoDate(embargoDate);
             }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamAccessStatusLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamAccessStatusLinkRepository.java
@@ -1,0 +1,69 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+
+package org.dspace.app.rest.repository;
+
+import java.sql.SQLException;
+import java.util.Date;
+import java.util.UUID;
+
+import jakarta.annotation.Nullable;
+import jakarta.servlet.http.HttpServletRequest;
+import org.dspace.access.status.DefaultAccessStatusHelper;
+import org.dspace.access.status.service.AccessStatusService;
+import org.dspace.app.rest.model.AccessStatusRest;
+import org.dspace.app.rest.model.BitstreamRest;
+import org.dspace.app.rest.projection.Projection;
+import org.dspace.content.Bitstream;
+import org.dspace.content.service.BitstreamService;
+import org.dspace.core.Context;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.rest.webmvc.ResourceNotFoundException;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Component;
+
+/**
+ * Link repository for calculating the access status of a Bitstream,
+ * including the embargo date
+ */
+@Component(BitstreamRest.CATEGORY + "." + BitstreamRest.PLURAL_NAME + "." + BitstreamRest.ACCESS_STATUS)
+public class BitstreamAccessStatusLinkRepository extends AbstractDSpaceRestRepository
+    implements LinkRestRepository {
+
+    @Autowired
+    BitstreamService bitstreamService;
+
+    @Autowired
+    AccessStatusService accessStatusService;
+
+    @PreAuthorize("hasPermission(#bitstreamId, 'BITSTREAM', 'METADATA_READ')")
+    public AccessStatusRest getAccessStatus(@Nullable HttpServletRequest request,
+                                            UUID bitstreamId,
+                                            @Nullable Pageable optionalPageable,
+                                            Projection projection) {
+        try {
+            Context context = obtainContext();
+            Bitstream bitstream = bitstreamService.find(context, bitstreamId);
+            if (bitstream == null) {
+                throw new ResourceNotFoundException("No such bitstream: " + bitstreamId);
+            }
+            AccessStatusRest accessStatusRest = new AccessStatusRest();
+            Date availabilityDate = accessStatusService.getAvailabilityDateFromBitstream(context, bitstream);
+            String status = accessStatusService.getAccessStatusFromAvailabilityDate(availabilityDate);
+            if (status == DefaultAccessStatusHelper.EMBARGO) {
+                String embargoDate = availabilityDate.toString();
+                accessStatusRest.setEmbargoDate(embargoDate);
+            }
+            accessStatusRest.setStatus(status);
+            return accessStatusRest;
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ItemAccessStatusLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ItemAccessStatusLinkRepository.java
@@ -9,10 +9,13 @@
 package org.dspace.app.rest.repository;
 
 import java.sql.SQLException;
+import java.time.LocalDate;
 import java.util.UUID;
 
 import jakarta.annotation.Nullable;
 import jakarta.servlet.http.HttpServletRequest;
+import org.apache.commons.lang3.tuple.Pair;
+import org.dspace.access.status.DefaultAccessStatusHelper;
 import org.dspace.access.status.service.AccessStatusService;
 import org.dspace.app.rest.model.AccessStatusRest;
 import org.dspace.app.rest.model.ItemRest;
@@ -51,8 +54,14 @@ public class ItemAccessStatusLinkRepository extends AbstractDSpaceRestRepository
                 throw new ResourceNotFoundException("No such item: " + itemId);
             }
             AccessStatusRest accessStatusRest = new AccessStatusRest();
-            String accessStatus = accessStatusService.getAccessStatus(context, item);
-            accessStatusRest.setStatus(accessStatus);
+            Pair<String, LocalDate> accessStatus = accessStatusService.getAccessStatus(context, item);
+            String status = accessStatus.getLeft();
+            if (status == DefaultAccessStatusHelper.EMBARGO) {
+                LocalDate availabilityDate = accessStatus.getRight();
+                String embargoDate = availabilityDate.toString();
+                accessStatusRest.setEmbargoDate(embargoDate);
+            }
+            accessStatusRest.setStatus(status);
             return accessStatusRest;
         } catch (SQLException e) {
             throw new RuntimeException(e);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ItemAccessStatusLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ItemAccessStatusLinkRepository.java
@@ -14,12 +14,12 @@ import java.util.UUID;
 
 import jakarta.annotation.Nullable;
 import jakarta.servlet.http.HttpServletRequest;
-import org.apache.commons.lang3.tuple.Pair;
 import org.dspace.access.status.DefaultAccessStatusHelper;
 import org.dspace.access.status.service.AccessStatusService;
 import org.dspace.app.rest.model.AccessStatusRest;
 import org.dspace.app.rest.model.ItemRest;
 import org.dspace.app.rest.projection.Projection;
+import org.dspace.content.AccessStatus;
 import org.dspace.content.Item;
 import org.dspace.content.service.ItemService;
 import org.dspace.core.Context;
@@ -54,10 +54,10 @@ public class ItemAccessStatusLinkRepository extends AbstractDSpaceRestRepository
                 throw new ResourceNotFoundException("No such item: " + itemId);
             }
             AccessStatusRest accessStatusRest = new AccessStatusRest();
-            Pair<String, LocalDate> accessStatus = accessStatusService.getAccessStatus(context, item);
-            String status = accessStatus.getLeft();
+            AccessStatus accessStatus = accessStatusService.getAccessStatus(context, item);
+            String status = accessStatus.getStatus();
             if (status == DefaultAccessStatusHelper.EMBARGO) {
-                LocalDate availabilityDate = accessStatus.getRight();
+                LocalDate availabilityDate = accessStatus.getAvailabilityDate();
                 String embargoDate = availabilityDate.toString();
                 accessStatusRest.setEmbargoDate(embargoDate);
             }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestRepositoryIT.java
@@ -16,6 +16,8 @@ import static org.dspace.core.Constants.WRITE;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -2972,7 +2974,41 @@ public class BitstreamRestRepositoryIT extends AbstractControllerIntegrationTest
         // Bitstream access status should still be accessible by anonymous request
         getClient().perform(get("/api/core/bitstreams/" + bitstream.getID() + "/accessStatus"))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$", HalMatcher.matchNoEmbeds()));
+            .andExpect(jsonPath("$", HalMatcher.matchNoEmbeds()))
+            .andExpect(jsonPath("$.status", notNullValue()))
+            .andExpect(jsonPath("$.embargoDate", nullValue()));
+    }
+
+    @Test
+    public void findAccessStatusWithEmbargoDateForBitstreamTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+        Collection col1 = CollectionBuilder.createCollection(context, parentCommunity)
+                                           .withName("Collection 1")
+                                           .build();
+        Item publicItem1 = ItemBuilder.createItem(context, col1)
+                                           .withTitle("Test item 1")
+                                           .build();
+        String bitstreamContent = "ThisIsSomeDummyText";
+        Bitstream bitstream = null;
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
+            bitstream = BitstreamBuilder.createBitstream(context, publicItem1, is)
+                                        .withName("Bitstream")
+                                        .withDescription("Description")
+                                        .withMimeType("text/plain")
+                                        .withEmbargoPeriod(Period.ofMonths(6))
+                                        .build();
+        }
+        context.restoreAuthSystemState();
+
+        // Bitstream access status should still be accessible by anonymous request
+        getClient().perform(get("/api/core/bitstreams/" + bitstream.getID() + "/accessStatus"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", HalMatcher.matchNoEmbeds()))
+            .andExpect(jsonPath("$.status", notNullValue()))
+            .andExpect(jsonPath("$.embargoDate", notNullValue()));
     }
 
     public boolean bitstreamExists(String token, Bitstream ...bitstreams) throws Exception {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
@@ -4688,7 +4688,36 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.restoreAuthSystemState();
         getClient().perform(get("/api/core/items/{uuid}/accessStatus", item.getID()))
                    .andExpect(status().isOk())
-                   .andExpect(jsonPath("$.status", notNullValue()));
+                   .andExpect(jsonPath("$.status", notNullValue()))
+                   .andExpect(jsonPath("$.embargoDate", nullValue()));
+    }
+
+    @Test
+    public void findAccessStatusWithEmbargoDateForItemTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+        Collection owningCollection = CollectionBuilder.createCollection(context, parentCommunity)
+                                                       .withName("Owning Collection")
+                                                       .build();
+        Item item = ItemBuilder.createItem(context, owningCollection)
+                               .withTitle("Test item")
+                               .build();
+        Bundle originalBundle = BundleBuilder.createBundle(context, item)
+                                             .withName(Constants.DEFAULT_BUNDLE_NAME)
+                                             .build();
+        InputStream is = IOUtils.toInputStream("dummy", "utf-8");
+        Bitstream bitstream = BitstreamBuilder.createBitstream(context, originalBundle, is)
+                                              .withName("test.pdf")
+                                              .withMimeType("application/pdf")
+                                              .withEmbargoPeriod(Period.ofMonths(6))
+                                              .build();
+        context.restoreAuthSystemState();
+        getClient().perform(get("/api/core/items/{uuid}/accessStatus", item.getID()))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.status", notNullValue()))
+                   .andExpect(jsonPath("$.embargoDate", notNullValue()));
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/BitstreamMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/BitstreamMatcher.java
@@ -102,7 +102,8 @@ public class BitstreamMatcher {
         return matchEmbeds(
                 "bundle",
                 "format",
-                "thumbnail"
+                "thumbnail",
+                "accessStatus"
         );
     }
 
@@ -115,7 +116,8 @@ public class BitstreamMatcher {
                 "content",
                 "format",
                 "self",
-                "thumbnail"
+                "thumbnail",
+                "accessStatus"
         );
     }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/model/AccessStatusRestTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/model/AccessStatusRestTest.java
@@ -15,7 +15,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
- * Test the AccessStatusRestTest class
+ * Test the AccessStatusRest class
  */
 public class AccessStatusRestTest {
 
@@ -35,5 +35,16 @@ public class AccessStatusRestTest {
     public void testAccessStatusIsNotNullAfterStatusSet() throws Exception {
         accessStatusRest.setStatus(DefaultAccessStatusHelper.UNKNOWN);
         assertNotNull(accessStatusRest.getStatus());
+    }
+
+    @Test
+    public void testEmbargoDateIsNullBeforeEmbargoDateSet() throws Exception {
+        assertNull(accessStatusRest.getEmbargoDate());
+    }
+
+    @Test
+    public void testEmbargoDateIsNotNullAfterEmbargoDateSet() throws Exception {
+        accessStatusRest.setEmbargoDate("2050-01-01");
+        assertNotNull(accessStatusRest.getEmbargoDate());
     }
 }

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -878,9 +878,16 @@ access.status.embargo.forever.year = 10000
 access.status.embargo.forever.month = 1
 access.status.embargo.forever.day = 1
 
-# How to determine the access status
+# How to determine the access status:
 # anonymous - Only consider the anonymous group
 # current - Consider the current user
+#
+# For example, if an object is embargoed, "anonymous" will ensure the embargo status is displayed
+# for everyone (regardless of permissions). But, "current" will only display the embargo status
+# if the current user does not have read permissions on the object.
+#
+# This configuration doesn't impact the calculation for OAI-PMH. The XOAI plugin will always
+# calculate the status with the "anonymous" type.
 access.status.for-user.item = anonymous
 access.status.for-user.bitstream = current
 

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -878,6 +878,12 @@ access.status.embargo.forever.year = 10000
 access.status.embargo.forever.month = 1
 access.status.embargo.forever.day = 1
 
+# How to determine the access status
+# anonymous - Only consider the anonymous group
+# current - Consider the current user
+access.status.for-user.item = anonymous
+access.status.for-user.bitstream = current
+
 # implementation of access status helper plugin - replace with local implementation if applicable
 # This default access status helper provides an item status based on the policies of the primary
 # bitstream (or first bitstream in the original bundles if no primary file is specified).


### PR DESCRIPTION
## References
* Fixes DSpace/dspace-angular#2413
* Related to DSpace/RestContract#300
* Requires https://github.com/DSpace/dspace-angular/pull/3882

## Description
Added a new endpoint on the bitstream to get the access status and the embargo date. This status is based on the current user and not only for the anonymous group, as this was requested in the referenced ticket.

For now, the access status on the item is still calculated for the anonymous group only.

## Instructions for Reviewers
* Ensure the behavior for the access status on the item is not impacted
* The new endpoint should be present for the bitstreams
* More tests are described in the dspace-angular PR

List of changes in this PR:
* Added the /accessStatus endpoint for bitstreams
* Added a new property called embargoDate in the AccessStatusRest object
* Added new methods on the AccessStatusHelper to populate the AccessStatusRest object
* Added new unit/integration tests and adapted existing ones

## Checklist

- [X] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [X] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [X] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [X] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
