### PR TITLE
Update stat. log extractor to DSpace 7+

### DIFF
--- a/dspace-api/src/main/java/org/dspace/statistics/util/ClassicDSpaceLogConverter.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/util/ClassicDSpaceLogConverter.java
@@ -37,15 +37,15 @@ import org.dspace.core.Context;
 import org.dspace.handle.factory.HandleServiceFactory;
 
 /**
- * A utility class to convert the classic dspace.log (as generated
- * by log4j) files into an intermediate format for ingestion into
- * the new solr stats.
+ * A utility class to convert the classic {@code dspace.log} (as generated
+ * by {@code log4j}) files into an intermediate format for ingestion into
+ * the new Solr stats.
  *
  * @author Stuart Lewis
  * @see StatisticsImporter
  */
 public class ClassicDSpaceLogConverter {
-    private final Logger log = org.apache.logging.log4j.LogManager.getLogger(ClassicDSpaceLogConverter.class);
+    private final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
     /**
      * A DSpace context
@@ -58,7 +58,8 @@ public class ClassicDSpaceLogConverter {
     private boolean verbose = false;
 
     /**
-     * Whether to include actions logged by org.dspace.usage.LoggerUsageEventListener
+     * Whether to include actions logged by
+     * {@link org.dspace.usage.LoggerUsageEventListener}.
      */
     private boolean newEvents = false;
 
@@ -93,7 +94,8 @@ public class ClassicDSpaceLogConverter {
      *
      * @param c  The context
      * @param v  Whether or not to provide verbose output
-     * @param nE Whether to include actions logged by org.dspace.usage.LoggerUsageEventListener
+     * @param nE Whether to include actions logged by
+     *           {@link org.dspace.usage.LoggerUsageEventListener}.
      */
     public ClassicDSpaceLogConverter(Context c, boolean v, boolean nE) {
         // Set up some variables
@@ -203,6 +205,10 @@ public class ClassicDSpaceLogConverter {
                         ((!line.contains("org.dspace.usage.LoggerUsageEventListener")) || newEvents)) {
                         handle = lline.getParams().substring(7);
                         dso = HandleServiceFactory.getInstance().getHandleService().resolveToObject(context, handle);
+                        if (null == dso) {
+                            log.warn("Unknown Handle {}", handle);
+                            continue;
+                        }
                         id = "" + dso.getID();
                     } else if ((lline.getAction().equals("view_collection")) &&
                         ((!line.contains("org.dspace.usage.LoggerUsageEventListener")) || newEvents)) {
@@ -334,6 +340,7 @@ public class ClassicDSpaceLogConverter {
             newEvents);
 
         // Set up the log analyser
+        LogAnalyser.setParameters(null, null, null, null, null, null, false);
         try {
             LogAnalyser.readConfig();
         } catch (IOException ioe) {


### PR DESCRIPTION
## Description
The tool to extract usage events from DSpace logs has not been updated for recent changes in the log format.  Add a regular expression that matches DSpace 7+ log lines, and code to use it.

## Instructions for Reviewers
List of changes in this PR:
* Properly initialize the LogAnalyser.
* New regex to match current log format.
* Add code using the new regex to the sequence of attempts to interpret a log line.

To test:  run the extractor over a recent log file and check that the output is what you expect.

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).