### PR TITLE
Remove outdated, unused Google Analytics APIs. 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -85,17 +85,6 @@ updates:
         update-types:
         - "minor"
         - "patch"
-      # Group together all Google deps in a single PR
-      google-apis:
-        applies-to: version-updates
-        patterns:
-        - "com.google.apis:*"
-        - "com.google.api-client:*"
-        - "com.google.http-client:*"
-        - "com.google.oauth-client:*"
-        update-types:
-        - "minor"
-        - "patch"
       # Group together all Spring deps in a single PR
       spring:
         applies-to: version-updates
@@ -198,17 +187,6 @@ updates:
           - "jakarta.*:*"
           - "org.eclipse.angus:jakarta.mail"
           - "org.glassfish.jaxb:jaxb-runtime"
-        update-types:
-          - "minor"
-          - "patch"
-      # Group together all Google deps in a single PR
-      google-apis:
-        applies-to: version-updates
-        patterns:
-          - "com.google.apis:*"
-          - "com.google.api-client:*"
-          - "com.google.http-client:*"
-          - "com.google.oauth-client:*"
         update-types:
           - "minor"
           - "patch"
@@ -318,6 +296,7 @@ updates:
           - "minor"
           - "patch"
       # Group together all Google deps in a single PR
+      # NOTE: These Google deps are only used in 7.x and have been removed in 8.x and later
       google-apis:
         applies-to: version-updates
         patterns:

--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -692,12 +692,6 @@
             <version>${flyway.version}</version>
         </dependency>
 
-        <!-- Google Analytics -->
-        <dependency>
-            <groupId>com.google.apis</groupId>
-            <artifactId>google-api-services-analytics</artifactId>
-        </dependency>
-
         <!-- FindBugs -->
         <dependency>
             <groupId>com.google.code.findbugs</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1713,12 +1713,6 @@
                 <version>2.3.232</version>
                 <scope>test</scope>
             </dependency>
-            <!-- Google Analytics -->
-            <dependency>
-                <groupId>com.google.apis</groupId>
-                <artifactId>google-api-services-analytics</artifactId>
-                <version>v3-rev145-1.23.0</version>
-            </dependency>
 
             <!-- Findbugs annotations -->
             <dependency>


### PR DESCRIPTION
## References
* Related to https://github.com/DSpace/DSpace/pull/10286 and https://github.com/DSpace/DSpace/pull/10095

## Description
Removes unused `google-api-services-analytics` dependency, as this was an old artifact from 6.x and 7.x  It's related code was removed in #9999 , but this dependency was accidently left around.  Dependabot keeps trying to upgrade this dependency (see links above) which is unnecessary, as it's unused.

Also updated our `dependabot` rules to remove rules specific to Google dependencies, as these dependencies were all removed in this PR and #9999

This should be ported to 8.x as well.  It may not be possible to port to 7.x, because #9999 was not ported to 7.x

## Instructions for Reviewers
* Ensure all tests pass.  These dependencies are unused