### PR TITLE
Remove unused configuration `csvexport.dir`

### DIFF
--- a/dspace-api/src/test/data/dspaceFolder/config/local.cfg
+++ b/dspace-api/src/test/data/dspaceFolder/config/local.cfg
@@ -156,8 +156,6 @@ useProxies = true
 proxies.trusted.ipranges = 7.7.7.7
 proxies.trusted.include_ui_ip = true
 
-csvexport.dir = dspace-server-webapp/src/test/data/dspaceFolder/exports
-
 # For the tests we have to disable this health indicator because there isn't a mock server and the calculated status was DOWN
 management.health.solrOai.enabled = false
 

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -19,8 +19,6 @@
 # Windows note: Please remember to use forward slashes for all paths (e.g. C:/dspace)
 dspace.dir = /dspace
 
-csvexport.dir = ${dspace.dir}/exports
-
 # Public URL of DSpace backend ('server' webapp). May require a port number if not using standard ports (80 or 443)
 # DO NOT end it with '/'.
 # This is where REST API and all enabled server modules (OAI-PMH, SWORD, SWORDv2, RDF, etc) will respond.


### PR DESCRIPTION
## Description

While reviewing other PRs, I stumbled on this "out of place" configuration in `dspace.cfg`.  On further investigation, I realized it's not referenced from any of our Java code.

This PR simply removes the `csvexport.dir` configuration from both `dspace.cfg` and our `local.cfg` used by Unit/Integration tests

## Instructions for Reviewers
* Simply config removal.  Also removes the corresponding config from our tests.  So, assuming all tests still succeed, this is a good indication that the config is safe to remove.