### PR TITLE
CurationTaskConsumer

### DIFF
--- a/dspace-api/src/main/java/org/dspace/curate/Curation.java
+++ b/dspace-api/src/main/java/org/dspace/curate/Curation.java
@@ -24,6 +24,8 @@ import java.util.UUID;
 
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.io.output.NullOutputStream;
+import org.dspace.app.util.DSpaceObjectUtilsImpl;
+import org.dspace.app.util.service.DSpaceObjectUtils;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.factory.ContentServiceFactory;
@@ -35,6 +37,7 @@ import org.dspace.eperson.service.EPersonService;
 import org.dspace.handle.factory.HandleServiceFactory;
 import org.dspace.handle.service.HandleService;
 import org.dspace.scripts.DSpaceRunnable;
+import org.dspace.util.UUIDUtils;
 import org.dspace.utils.DSpace;
 
 /**
@@ -354,6 +357,24 @@ public class Curation extends DSpaceRunnable<CurationScriptConfiguration> {
                     super.handler.logError("SQLException trying to resolve handle " + id + " to a valid dso");
                     throw new IllegalArgumentException(
                         "SQLException trying to resolve handle " + id + " to a valid dso");
+                }
+                if (dso == null) {
+                    UUID uuid = null;
+                    try {
+                        uuid = UUIDUtils.fromString(id);
+                    } catch (IllegalArgumentException ex) {
+                        // couldn't parse uuid, setting it null
+                        uuid = null;
+                    }
+                    if (uuid != null) {
+                        DSpaceObjectUtils dSpaceObjectUtils = new DSpace().getServiceManager()
+                                .getServiceByName(DSpaceObjectUtilsImpl.class.getName(), DSpaceObjectUtilsImpl.class);
+                        try {
+                            dso = dSpaceObjectUtils.findDSpaceObject(context, uuid);
+                        } catch (SQLException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
                 }
                 if (dso == null) {
                     super.handler.logError("Id must be specified: a valid dso handle or 'all'; " + this.id + " could " +

--- a/dspace-api/src/main/java/org/dspace/curate/CurationTaskConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/curate/CurationTaskConsumer.java
@@ -1,0 +1,107 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.curate;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+
+import org.apache.commons.cli.ParseException;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.dspace.core.Context;
+import org.dspace.event.Event;
+import org.dspace.event.NamedConsumer;
+import org.dspace.scripts.DSpaceCommandLineParameter;
+import org.dspace.scripts.DSpaceRunnable;
+import org.dspace.scripts.ProcessDSpaceRunnableHandler;
+import org.dspace.scripts.configuration.ScriptConfiguration;
+import org.dspace.scripts.factory.ScriptServiceFactory;
+import org.dspace.scripts.service.ScriptService;
+import org.dspace.services.factory.DSpaceServicesFactory;
+
+public class CurationTaskConsumer extends NamedConsumer {
+
+    ScriptService scriptService;
+
+    Logger log = LogManager.getLogger();
+
+    private String curationTaskName;
+
+    @Override
+    public void initialize() throws Exception {
+        this.scriptService = ScriptServiceFactory.getInstance().getScriptService();
+        this.curationTaskName = DSpaceServicesFactory.getInstance().getConfigurationService()
+                .getProperty("event.consumer.curationtask.taskname");
+    }
+
+    @Override
+    public void consume(Context ctx, Event event) throws Exception {
+        log.debug("Consumer Event " + event.toString());
+        ScriptConfiguration scriptToExecute = scriptService.getScriptConfiguration("curate");
+        DSpaceRunnable dSpaceRunnable = scriptService.createDSpaceRunnableForScriptConfiguration(scriptToExecute);
+        List<DSpaceCommandLineParameter> parameters = Arrays.asList(new DSpaceCommandLineParameter[] {
+            new DSpaceCommandLineParameter("-t", this.curationTaskName),
+            new DSpaceCommandLineParameter("-i", event.getSubjectID().toString())
+        });
+        List<String> args = new ArrayList<>(2 * parameters.size());
+        for (DSpaceCommandLineParameter parameter : parameters) {
+            args.add(parameter.getName());
+            if (parameter.getValue() != null) {
+                args.add(parameter.getValue());
+            }
+        }
+
+        if (scriptToExecute == null) {
+            log.error("Unable to find script curate");
+            throw new RuntimeException("The script for name: curate wasn't found");
+        }
+        try {
+            if (!scriptToExecute.isAllowedToExecute(ctx, parameters)) {
+                log.error("Current user is not eligible to execute script with name: curate and the specified " +
+                        "parameters " + StringUtils.join(parameters, ", "));
+                return;
+            }
+        } catch (IllegalArgumentException e) {
+            log.error("Illegal argument " + e.getMessage(), e);
+        }
+        log.debug("Initializing process " + scriptToExecute.getName() + " for user " + ctx.getCurrentUser().getID() +
+                "with parameters: " + StringUtils.join(parameters, " ") + ".");
+        ProcessDSpaceRunnableHandler processDSpaceRunnableHandler = new ProcessDSpaceRunnableHandler(
+                ctx.getCurrentUser(), scriptToExecute.getName(), parameters,
+                new HashSet<>(ctx.getSpecialGroups()));
+        try {
+            dSpaceRunnable.initialize(args.toArray(new String[0]), processDSpaceRunnableHandler, ctx.getCurrentUser());
+            processDSpaceRunnableHandler.schedule(dSpaceRunnable);
+        } catch (ParseException e) {
+            dSpaceRunnable.printHelp();
+            try {
+                processDSpaceRunnableHandler.handleException(
+                        "Failed to parse the arguments given to the script with name: " + scriptToExecute.getName()
+                                + " and args: " + StringUtils.join(parameters, " "), e
+                );
+            } catch (Exception re) {
+                // ignore re-thrown exception
+            }
+        }
+        log.debug("Process scheduled.");
+    }
+
+    @Override
+    public void end(Context ctx) throws Exception {
+
+    }
+
+    @Override
+    public void finish(Context ctx) throws Exception {
+
+    }
+
+}

--- a/dspace-api/src/main/java/org/dspace/curate/CurationTaskConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/curate/CurationTaskConsumer.java
@@ -30,18 +30,32 @@ import org.dspace.services.factory.DSpaceServicesFactory;
 public class CurationTaskConsumer extends NamedConsumer {
 
     ScriptService scriptService;
-
     Logger log = LogManager.getLogger();
-
+    /**
+     * Name of the curation task which this consumer will execute
+     */
     private String curationTaskName;
 
+    /**
+     * Iniitalize the consumer, getting curation task details from named consumer configuration
+     * @throws Exception
+     */
     @Override
     public void initialize() throws Exception {
         this.scriptService = ScriptServiceFactory.getInstance().getScriptService();
         this.curationTaskName = DSpaceServicesFactory.getInstance().getConfigurationService()
-                .getProperty("event.consumer.curationtask.taskname");
+                .getProperty("event.consumer." + name + ".taskname");
+        if (this.curationTaskName == null) {
+            throw new Exception("No curation task name configured for consumer " + name);
+        }
     }
 
+    /**
+     * Resolve and execute the configured curation task for this event's subject
+     * @param ctx   the current DSpace session
+     * @param event the content event
+     * @throws Exception
+     */
     @Override
     public void consume(Context ctx, Event event) throws Exception {
         log.debug("Consumer Event " + event.toString());

--- a/dspace-api/src/main/java/org/dspace/curate/Curator.java
+++ b/dspace-api/src/main/java/org/dspace/curate/Curator.java
@@ -15,9 +15,12 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.dspace.app.util.DSpaceObjectUtilsImpl;
+import org.dspace.app.util.service.DSpaceObjectUtils;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.DSpaceObject;
@@ -32,6 +35,8 @@ import org.dspace.core.factory.CoreServiceFactory;
 import org.dspace.handle.factory.HandleServiceFactory;
 import org.dspace.handle.service.HandleService;
 import org.dspace.scripts.handler.DSpaceRunnableHandler;
+import org.dspace.util.UUIDUtils;
+import org.dspace.utils.DSpace;
 
 /**
  * Curator orchestrates and manages the application of a one or more curation
@@ -249,6 +254,20 @@ public class Curator {
             curationCtx.set(c);
 
             DSpaceObject dso = handleService.resolveToObject(c, id);
+            if (dso == null) {
+                UUID uuid = null;
+                try {
+                    uuid = UUIDUtils.fromString(id);
+                } catch (IllegalArgumentException ex) {
+                    // couldn't parse uuid, setting it null
+                    uuid = null;
+                }
+                if (uuid != null) {
+                    DSpaceObjectUtils dSpaceObjectUtils = new DSpace().getServiceManager()
+                            .getServiceByName(DSpaceObjectUtilsImpl.class.getName(), DSpaceObjectUtilsImpl.class);
+                    dso = dSpaceObjectUtils.findDSpaceObject(c, uuid);
+                }
+            }
             if (dso != null) {
                 curate(dso);
             } else {

--- a/dspace-api/src/main/java/org/dspace/event/ConsumerProfile.java
+++ b/dspace-api/src/main/java/org/dspace/event/ConsumerProfile.java
@@ -108,6 +108,10 @@ public class ConsumerProfile {
                 .asSubclass(Consumer.class)
                 .getDeclaredConstructor().newInstance();
 
+        if (consumer instanceof NamedConsumer) {
+            ((NamedConsumer) consumer).setName(name);
+        }
+
         // Each "filter" is <objectTypes> + <eventTypes> : ...
         filters = new ArrayList<>();
         String part[] = filterString.trim().split(":");

--- a/dspace-api/src/main/java/org/dspace/event/NamedConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/event/NamedConsumer.java
@@ -1,0 +1,20 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.event;
+
+public abstract class NamedConsumer implements Consumer {
+    protected String name;
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/scripts/ProcessDSpaceRunnableHandler.java
+++ b/dspace-api/src/main/java/org/dspace/scripts/ProcessDSpaceRunnableHandler.java
@@ -5,7 +5,7 @@
  *
  * http://www.dspace.org/license/
  */
-package org.dspace.app.rest.scripts.handler.impl;
+package org.dspace.scripts;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -32,10 +32,6 @@ import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
 import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.eperson.service.EPersonService;
-import org.dspace.scripts.DSpaceCommandLineParameter;
-import org.dspace.scripts.DSpaceRunnable;
-import org.dspace.scripts.Process;
-import org.dspace.scripts.ProcessLogLevel;
 import org.dspace.scripts.factory.ScriptServiceFactory;
 import org.dspace.scripts.handler.DSpaceRunnableHandler;
 import org.dspace.scripts.service.ProcessService;
@@ -43,11 +39,11 @@ import org.dspace.utils.DSpace;
 import org.springframework.core.task.TaskExecutor;
 
 /**
- * The {@link DSpaceRunnableHandler} dealing with Scripts started from the REST api
+ * The {@link DSpaceRunnableHandler} starting Scripts as {@link Process}
  */
-public class RestDSpaceRunnableHandler implements DSpaceRunnableHandler {
+public class ProcessDSpaceRunnableHandler implements DSpaceRunnableHandler {
     private static final Logger log = org.apache.logging.log4j.LogManager
-        .getLogger(RestDSpaceRunnableHandler.class);
+        .getLogger(ProcessDSpaceRunnableHandler.class);
 
     private BitstreamService bitstreamService = ContentServiceFactory.getInstance().getBitstreamService();
     private ProcessService processService = ScriptServiceFactory.getInstance().getProcessService();
@@ -65,8 +61,8 @@ public class RestDSpaceRunnableHandler implements DSpaceRunnableHandler {
      * @param specialGroups specialGroups The list of special groups related to eperson
      *                      creating process at process creation time
      */
-    public RestDSpaceRunnableHandler(EPerson ePerson, String scriptName, List<DSpaceCommandLineParameter> parameters,
-                                     final Set<Group> specialGroups) {
+    public ProcessDSpaceRunnableHandler(EPerson ePerson, String scriptName, List<DSpaceCommandLineParameter> parameters,
+                                        final Set<Group> specialGroups) {
         Context context = new Context();
         try {
             ePersonId = ePerson.getID();

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ScriptRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ScriptRestRepository.java
@@ -27,11 +27,11 @@ import org.dspace.app.rest.exception.UnprocessableEntityException;
 import org.dspace.app.rest.model.ParameterValueRest;
 import org.dspace.app.rest.model.ProcessRest;
 import org.dspace.app.rest.model.ScriptRest;
-import org.dspace.app.rest.scripts.handler.impl.RestDSpaceRunnableHandler;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.core.Context;
 import org.dspace.scripts.DSpaceCommandLineParameter;
 import org.dspace.scripts.DSpaceRunnable;
+import org.dspace.scripts.ProcessDSpaceRunnableHandler;
 import org.dspace.scripts.configuration.ScriptConfiguration;
 import org.dspace.scripts.service.ScriptService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -112,12 +112,12 @@ public class ScriptRestRepository extends DSpaceRestRepository<ScriptRest, Strin
         } catch (IllegalArgumentException e) {
             throw new DSpaceBadRequestException("Illegal argoument " + e.getMessage(), e);
         }
-        RestDSpaceRunnableHandler restDSpaceRunnableHandler = new RestDSpaceRunnableHandler(
+        ProcessDSpaceRunnableHandler processDSpaceRunnableHandler = new ProcessDSpaceRunnableHandler(
             context.getCurrentUser(), scriptToExecute.getName(), dSpaceCommandLineParameters,
             new HashSet<>(context.getSpecialGroups()));
         List<String> args = constructArgs(dSpaceCommandLineParameters);
-        runDSpaceScript(files, context, scriptToExecute, restDSpaceRunnableHandler, args);
-        return converter.toRest(restDSpaceRunnableHandler.getProcess(context), utils.obtainProjection());
+        runDSpaceScript(files, context, scriptToExecute, processDSpaceRunnableHandler, args);
+        return converter.toRest(processDSpaceRunnableHandler.getProcess(context), utils.obtainProjection());
     }
 
     private List<DSpaceCommandLineParameter> processPropertiesToDSpaceCommandLineParameters(String propertiesJson)
@@ -147,20 +147,21 @@ public class ScriptRestRepository extends DSpaceRestRepository<ScriptRest, Strin
     }
 
     private void runDSpaceScript(List<MultipartFile> files, Context context, ScriptConfiguration scriptToExecute,
-                                 RestDSpaceRunnableHandler restDSpaceRunnableHandler, List<String> args)
+                                 ProcessDSpaceRunnableHandler processDSpaceRunnableHandler, List<String> args)
         throws IOException, SQLException, AuthorizeException, InstantiationException, IllegalAccessException {
         DSpaceRunnable dSpaceRunnable = scriptService.createDSpaceRunnableForScriptConfiguration(scriptToExecute);
         try {
-            dSpaceRunnable.initialize(args.toArray(new String[0]), restDSpaceRunnableHandler, context.getCurrentUser());
+            dSpaceRunnable.initialize(args.toArray(new String[0]), processDSpaceRunnableHandler,
+                    context.getCurrentUser());
             if (files != null && !files.isEmpty()) {
                 checkFileNames(dSpaceRunnable, files);
-                processFiles(context, restDSpaceRunnableHandler, files);
+                processFiles(context, processDSpaceRunnableHandler, files);
             }
-            restDSpaceRunnableHandler.schedule(dSpaceRunnable);
+            processDSpaceRunnableHandler.schedule(dSpaceRunnable);
         } catch (ParseException e) {
             dSpaceRunnable.printHelp();
             try {
-                restDSpaceRunnableHandler.handleException(
+                processDSpaceRunnableHandler.handleException(
                     "Failed to parse the arguments given to the script with name: "
                         + scriptToExecute.getName() + " and args: " + args, e
                 );
@@ -170,11 +171,11 @@ public class ScriptRestRepository extends DSpaceRestRepository<ScriptRest, Strin
         }
     }
 
-    private void processFiles(Context context, RestDSpaceRunnableHandler restDSpaceRunnableHandler,
+    private void processFiles(Context context, ProcessDSpaceRunnableHandler processDSpaceRunnableHandler,
                               List<MultipartFile> files)
         throws IOException, SQLException, AuthorizeException {
         for (MultipartFile file : files) {
-            restDSpaceRunnableHandler
+            processDSpaceRunnableHandler
                 .writeFilestream(context, file.getOriginalFilename(), file.getInputStream(), "inputfile");
         }
     }

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -787,7 +787,7 @@ event.dispatcher.default.class = org.dspace.event.BasicDispatcher
 # Add rdf here, if you are using dspace-rdf to export your repository content as RDF.
 # Add iiif here, if you are using dspace-iiif.
 # Add orcidqueue here, if the integration with ORCID is configured and wish to enable the synchronization queue functionality
-event.dispatcher.default.consumers = versioning, discovery, eperson, qaeventsdelete, ldnmessage, curationtask, curateContributors
+event.dispatcher.default.consumers = versioning, discovery, eperson, qaeventsdelete, ldnmessage
 
 # The noindex dispatcher will not create search or browse indexes (useful for batch item imports)
 event.dispatcher.noindex.class = org.dspace.event.BasicDispatcher
@@ -846,13 +846,25 @@ event.consumer.ldnmessage.filters = Item+Install
 event.consumer.submissionconfig.class = org.dspace.submit.consumer.SubmissionConfigConsumer
 event.consumer.submissionconfig.filters = Collection+Modify_Metadata
 
-event.consumer.curationtask.class = org.dspace.curate.CurationTaskConsumer
-event.consumer.curationtask.filters = Item+Install
-event.consumer.curationtask.taskname = copySeriesCT
-
-event.consumer.curateContributors.class = org.dspace.curate.CurationTaskConsumer
-event.consumer.curateContributors.filters = Item+Install
-event.consumer.curateContributors.taskname = curateContributors
+# The CurationTaskConsumer starts a curation task as a process in DSpace.
+# The curation task runs as its own process and therefore is not depending
+# on the session of the current user.
+# If shows up in the list of processes in the admin process panel in the web ui.
+# It runs on the subject of the DSpace Event that was fired and can be used
+# on any dspace object type that is used as subject of an event (like items,
+# collections and communities).
+# To configure it, give it a name, reference the class and configure the
+# name of the curation task you want it to schedule and start:
+#
+# event.consumer.noopCurator.class = org.dspace.curate.CurationTaskConsumer
+# event.consumer.noopCurator.filters = Item+Install|Item+Modify_Metadata
+# event.consumer.noopCurator.taskname = noop
+# 
+# Please ensure, that a curation task with this name exists.
+# For DSpace to use this consumer, you must add it to a dispatcher, most likely the
+# default dispatcher:
+# event.dispatcher.default.consumers = ..., noopCurator
+# look above for this configuration and add it there.
 
 # ...set to true to enable testConsumer messages to standard output
 #testConsumer.verbose = true

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -787,7 +787,7 @@ event.dispatcher.default.class = org.dspace.event.BasicDispatcher
 # Add rdf here, if you are using dspace-rdf to export your repository content as RDF.
 # Add iiif here, if you are using dspace-iiif.
 # Add orcidqueue here, if the integration with ORCID is configured and wish to enable the synchronization queue functionality
-event.dispatcher.default.consumers = versioning, discovery, eperson, qaeventsdelete, ldnmessage
+event.dispatcher.default.consumers = versioning, discovery, eperson, qaeventsdelete, ldnmessage, curationtask, curateContributors
 
 # The noindex dispatcher will not create search or browse indexes (useful for batch item imports)
 event.dispatcher.noindex.class = org.dspace.event.BasicDispatcher
@@ -845,6 +845,14 @@ event.consumer.ldnmessage.filters = Item+Install
 # activated consumers (event.dispatcher.default.consumers).
 event.consumer.submissionconfig.class = org.dspace.submit.consumer.SubmissionConfigConsumer
 event.consumer.submissionconfig.filters = Collection+Modify_Metadata
+
+event.consumer.curationtask.class = org.dspace.curate.CurationTaskConsumer
+event.consumer.curationtask.filters = Item+Install
+event.consumer.curationtask.taskname = copySeriesCT
+
+event.consumer.curateContributors.class = org.dspace.curate.CurationTaskConsumer
+event.consumer.curateContributors.filters = Item+Install
+event.consumer.curateContributors.taskname = curateContributors
 
 # ...set to true to enable testConsumer messages to standard output
 #testConsumer.verbose = true


### PR DESCRIPTION
## Description
This adds a consumer that can start curation tasks as DSpace processes. This allows us to use the event system to trigger consumers that then run separate from the session they were triggerd in and show up in the admin's process pannel in the web ui.

## Instructions for Reviewers
To test this, please do:
1. edit dspace.cfg. It contains an example to trigger the noop curation task with this consumer (search for event.consumer.noopCurator.class).
2. Activate the example configuration
3. add an item to the repository
4. check for the noop Curation task to show up in admin process panel.

List of changes in this PR:
* This PR adds an abstract class `NamedConsumer` that knows the name that is used for this consumer in the configuration. This can then be used to load further configuration while being able to reuse the same class multiple times.
* The PR enhances the curate command line script of dspace by letting us use UUIDs and handles when referencing an object with the parameter `-i <handle|uuid>`
* This PR adds a CurationTaskConsumer that start curations tasks on DSpace events
* This PR moves RestDSpaceRunnableHandler from dspace-rest to dspace-api and renames it. The `RestDSpaceRunnableHandler` has less to do with the REST-API of DSpace and more with the DSpace's support for processes. Therefore I renamed it to `ProcessDSpaceRunnableHandler`. It was necessary to move it as dspace-rest depends on dspace-api and I couldn't use it without creating a circular dependency.

This PR does not contain unit or integration tests. It would be very hard to test that the consumer triggers the processes. My first though was to work with java reflections and Mockito Spy to see if the right methods were called to create the processes. But because of the structure and Spring Dependency Injection this would have bin very hard and probably taking more code changes than the actual Consumer itself.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
