### PR TITLE
DataCite should not use "unknown" for missing required metadata

### DIFF
--- a/dspace-api/src/main/java/org/dspace/identifier/doi/DOIIdentifierException.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/doi/DOIIdentifierException.java
@@ -112,6 +112,8 @@ public class DOIIdentifierException extends IdentifierException {
                 return "UNAUTHORIZED_METADATA_MANIPULATION";
             case DOI_IS_DELETED:
                 return "DELETED";
+            case BAD_REQUEST:
+                return "BAD_REQUEST (Malformed request)";
             default:
                 return "UNKNOWN";
         }

--- a/dspace-api/src/main/java/org/dspace/identifier/doi/DataCiteConnector.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/doi/DataCiteConnector.java
@@ -456,6 +456,17 @@ public class DataCiteConnector
                                                      + ". Please inform your administrator or take a look "
                                                      + " into the log files.", DOIIdentifierException.BAD_REQUEST);
             }
+            // 422 -> likely invalid metadata
+            case (422): {
+                log.warn("DataCite returned 422, it understood the XML we send, but it was invalid. " +
+                        "Most likely metadata required by DataCite is missing. " +
+                        "(https://datacite-metadata-schema.readthedocs.io/en/4.5/properties/" +
+                        "overview/#mandatory-properties) " +
+                        "Resolve this in the crosswalk configuration as needed.");
+                throw new DOIIdentifierException("Unable to reserve DOI " + doi
+                        + ". Please inform your administrator or take a look "
+                        + " into the log files.", DOIIdentifierException.BAD_REQUEST);
+            }
             // Catch all other http status code in case we forgot one.
             default: {
                 log.warn("While reserving the DOI {}, we got a http status code "

--- a/dspace/config/crosswalks/DIM2DataCite.xsl
+++ b/dspace/config/crosswalks/DIM2DataCite.xsl
@@ -89,11 +89,6 @@
                     <xsl:when test="//dspace:field[@mdschema='dc' and @element='contributor' and @qualifier='author']">
                         <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='contributor' and @qualifier='author']" />
                     </xsl:when>
-                    <xsl:otherwise>
-                        <creator>
-                            <creatorName>(:unkn) unknown</creatorName>
-                        </creator>
-                    </xsl:otherwise>
                 </xsl:choose>
             </creators>
 

--- a/dspace/config/crosswalks/DIM2DataCite.xsl
+++ b/dspace/config/crosswalks/DIM2DataCite.xsl
@@ -89,6 +89,13 @@
                     <xsl:when test="//dspace:field[@mdschema='dc' and @element='contributor' and @qualifier='author']">
                         <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='contributor' and @qualifier='author']" />
                     </xsl:when>
+<!-- If your repository does not have any creator/author metadata included, but you still wish to register items in
+     DataCite You may uncomment the block below which will provide "unknown" for the required field. -->
+<!--                    <xsl:otherwise>-->
+<!--                        <creator>-->
+<!--                            <creatorName>(:unkn) unknown</creatorName>-->
+<!--                        </creator>-->
+<!--                    </xsl:otherwise>-->
                 </xsl:choose>
             </creators>
 


### PR DESCRIPTION
## References
* Fixes #9640 

## Description

This PR removes the fallback values of required DataCite metadata, it instead logs an error with the explanation of the issue, and sends out an email (sadly enough DataCite does not return the missing mandatory field in their response so we can not log that).

## Instructions for Reviewers
Verify expected behavior of linked issue is now present

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
