### PR TITLE
Remove unused/unnecessary dependencies : `byte-buddy` and `joda-time`

### DIFF
--- a/dspace-api/src/main/java/org/dspace/access/status/DefaultAccessStatusHelper.java
+++ b/dspace-api/src/main/java/org/dspace/access/status/DefaultAccessStatusHelper.java
@@ -8,6 +8,7 @@
 package org.dspace.access.status;
 
 import java.sql.SQLException;
+import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
@@ -26,7 +27,6 @@ import org.dspace.content.service.ItemService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.eperson.Group;
-import org.joda.time.LocalDate;
 
 /**
  * Default plugin implementation of the access status helper.
@@ -230,7 +230,7 @@ public class DefaultAccessStatusHelper implements AccessStatusHelper {
                     // If the policy is not valid there is an active embargo
                     Date startDate = policy.getStartDate();
 
-                    if (startDate != null && !startDate.before(LocalDate.now().toDate())) {
+                    if (startDate != null && !startDate.before(Date.from(Instant.now()))) {
                         // There is an active embargo: aim to take the shortest embargo (account for rare cases where
                         // more than one resource policy exists)
                         if (embargoDate == null) {

--- a/pom.xml
+++ b/pom.xml
@@ -1540,11 +1540,6 @@
                 <version>1.9.0</version>
             </dependency>
             <dependency>
-                <groupId>joda-time</groupId>
-                <artifactId>joda-time</artifactId>
-                <version>2.13.0</version>
-            </dependency>
-            <dependency>
                 <groupId>jakarta.activation</groupId>
                 <artifactId>jakarta.activation-api</artifactId>
                 <version>2.1.3</version>

--- a/pom.xml
+++ b/pom.xml
@@ -1804,13 +1804,6 @@
                 <artifactId>jakarta.annotation-api</artifactId>
                 <version>${jakarta-annotation.version}</version>
             </dependency>
-            <!-- mockito-inline and hibernate-ehcache pull in different versions of byte-buddy. Specify which we want. -->
-            <!-- TODO: We might be able to remove this after hibernate-ehcache is replaced by hibernate-jcache -->
-            <dependency>
-                <groupId>net.bytebuddy</groupId>
-                <artifactId>byte-buddy</artifactId>
-                <version>1.16.1</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
## References
Replaces several PRs created by `dependabot` to update these unused/unnecessary dependencies, including:
* #10371 (and similar PR for 7.x and 8.x branches)
* #10369 (and similar PR for 7.x and 8.x branches)
* Fixes #10015

## Description
* Removes `byte-buddy` dependency which is unused.
* Removes `joda-time` dependency which is only used in one place. Fixes the code to use `java.time.*` instead.  This fixes #10015

## Instructions for Reviewers
* Assuming this passes build & tests, it can be merged.  The one code change to `DefaultAccessStatusHelper` has code coverage in `DefaultAccessStatusHelperTest`
