### PR TITLE
Fix #10405 bug in log4j-cli

### DIFF
--- a/dspace/config/log4j2-cli.xml
+++ b/dspace/config/log4j2-cli.xml
@@ -25,6 +25,7 @@
         <Appender name='A1'
                   filePattern="${log.dir}/dspace-cli.log-%d{yyyy-MM-dd}"
                   type='RollingFile'
+                  fileName='${log.dir}/dspace-cli.log'
         >
             <!-- NOTE: The %equals patterns are providing a default value of "unknown" if "correlationID" or
                  "requestID" are not currently set in the ThreadContext. -->


### PR DESCRIPTION
## References
* Fixes #10405

## Description
Adds `fileName='${log.dir}/dspace-cli.log’` to "A1 Appender" to fix bug that occurs when DefaultRolloverStrategy is uncommented.

## Instructions for Reviewers
- In log4j2-cli.xml uncomment the DefaultRolloverStrategy
- Build and deploy DSpace
- Call a command like for example `dspace database info`
- You should see no error messages concerning the logging.

List of changes in this PR:
* Adds `fileName='${log.dir}/dspace-cli.log’` to "A1 Appender"

## Checklist
- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
