### PR TITLE
Fix updateMissingBitstreams to use single database operation instead of o-o operations [DS-3975] with logging

### DIFF
--- a/dspace-api/src/main/java/org/dspace/checker/MostRecentChecksumServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/checker/MostRecentChecksumServiceImpl.java
@@ -92,61 +92,16 @@ public class MostRecentChecksumServiceImpl implements MostRecentChecksumService 
     /**
      * Queries the bitstream table for bitstream IDs that are not yet in the
      * most_recent_checksum table, and inserts them into the
-     * most_recent_checksum and checksum_history tables.
-     *
+     * most_recent_checksum table.
      * @param context Context
      * @throws SQLException if database error
      */
     @Override
     public void updateMissingBitstreams(Context context) throws SQLException {
-//                "insert into most_recent_checksum ( "
-//                + "bitstream_id, to_be_processed, expected_checksum, current_checksum, "
-//                + "last_process_start_date, last_process_end_date, "
-//                + "checksum_algorithm, matched_prev_checksum, result ) "
-//                + "select bitstream.bitstream_id, "
-//                + "CASE WHEN bitstream.deleted = false THEN true ELSE false END, "
-//                + "CASE WHEN bitstream.checksum IS NULL THEN '' ELSE bitstream.checksum END, "
-//                + "CASE WHEN bitstream.checksum IS NULL THEN '' ELSE bitstream.checksum END, "
-//                + "?, ?, CASE WHEN bitstream.checksum_algorithm IS NULL "
-//                + "THEN 'MD5' ELSE bitstream.checksum_algorithm END, true, "
-//                + "CASE WHEN bitstream.deleted = true THEN 'BITSTREAM_MARKED_DELETED' else 'CHECKSUM_MATCH' END "
-//                + "from bitstream where not exists( "
-//                + "select 'x' from most_recent_checksum "
-//                + "where most_recent_checksum.bitstream_id = bitstream.bitstream_id )";
-
-        List<Bitstream> unknownBitstreams = bitstreamService.findBitstreamsWithNoRecentChecksum(context);
-        for (Bitstream bitstream : unknownBitstreams) {
-            log.info(bitstream + " " + bitstream.getID().toString() + " " + bitstream.getName());
-
-            MostRecentChecksum mostRecentChecksum = new MostRecentChecksum();
-            mostRecentChecksum.setBitstream(bitstream);
-            //Only process if our bitstream isn't deleted
-            mostRecentChecksum.setToBeProcessed(!bitstream.isDeleted());
-            if (bitstream.getChecksum() == null) {
-                mostRecentChecksum.setCurrentChecksum("");
-                mostRecentChecksum.setExpectedChecksum("");
-            } else {
-                mostRecentChecksum.setCurrentChecksum(bitstream.getChecksum());
-                mostRecentChecksum.setExpectedChecksum(bitstream.getChecksum());
-            }
-            mostRecentChecksum.setProcessStartDate(Instant.now());
-            mostRecentChecksum.setProcessEndDate(Instant.now());
-            if (bitstream.getChecksumAlgorithm() == null) {
-                mostRecentChecksum.setChecksumAlgorithm("MD5");
-            } else {
-                mostRecentChecksum.setChecksumAlgorithm(bitstream.getChecksumAlgorithm());
-            }
-            mostRecentChecksum.setMatchedPrevChecksum(true);
-            ChecksumResult checksumResult;
-            if (bitstream.isDeleted()) {
-                checksumResult = checksumResultService.findByCode(context, ChecksumResultCode.BITSTREAM_MARKED_DELETED);
-            } else {
-                checksumResult = checksumResultService.findByCode(context, ChecksumResultCode.CHECKSUM_MATCH);
-            }
-            mostRecentChecksum.setChecksumResult(checksumResult);
-            mostRecentChecksumDAO.create(context, mostRecentChecksum);
-            mostRecentChecksumDAO.save(context, mostRecentChecksum);
-        }
+        log.info("Retrieving missing bitsreams (bitstream IDs that are not yet in most_recent_checksum table)...");
+        int updated = mostRecentChecksumDAO.updateMissingBitstreams(context);
+        log.info("Updated most_recent_checksum for " + updated + " bitstreams.");
+        log.info("Missing bitsreams processing done.");
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/checker/dao/MostRecentChecksumDAO.java
+++ b/dspace-api/src/main/java/org/dspace/checker/dao/MostRecentChecksumDAO.java
@@ -33,6 +33,8 @@ public interface MostRecentChecksumDAO extends GenericDAO<MostRecentChecksum> {
     public List<MostRecentChecksum> findByResultTypeInDateRange(Context context, Instant startDate, Instant endDate,
                                                                 ChecksumResultCode resultCode) throws SQLException;
 
+    public int updateMissingBitstreams(Context context) throws SQLException;
+
     public void deleteByBitstream(Context context, Bitstream bitstream) throws SQLException;
 
     public MostRecentChecksum getOldestRecord(Context context) throws SQLException;

--- a/dspace-api/src/main/java/org/dspace/checker/dao/impl/MostRecentChecksumDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/checker/dao/impl/MostRecentChecksumDAOImpl.java
@@ -74,13 +74,13 @@ public class MostRecentChecksumDAOImpl extends AbstractHibernateDAO<MostRecentCh
                 "CASE WHEN deleted = false THEN true ELSE false END, " +
                 "CASE WHEN checksum IS NULL THEN '' ELSE checksum END, " +
                 "CASE WHEN checksum IS NULL THEN '' ELSE checksum END, " +
-                "current_date(), current_date(), " +
+                "current_timestamp(), current_timestamp(), " +
                 "CASE WHEN checksumAlgorithm IS NULL THEN 'MD5' ELSE checksumAlgorithm END, " +
                 "CAST(1 AS boolean), " +
                 "(SELECT cr FROM ChecksumResult AS cr WHERE " +
-                "(resultCode='BITSTREAM_MARKED_DELETED' AND b.deleted = true) " +
-                "OR (resultCode='CHECKSUM_MATCH' AND b.deleted = false)) " +
-                "FROM Bitstream AS b WHERE NOT EXISTS(SELECT 'x' FROM MostRecentChecksum WHERE id=b.id)";
+                "(resultCode = 'BITSTREAM_MARKED_DELETED' AND b.deleted = true) " +
+                "OR (resultCode = 'CHECKSUM_MATCH' AND b.deleted = false)) " +
+                "FROM Bitstream AS b WHERE NOT EXISTS(SELECT 'x' FROM MostRecentChecksum AS c WHERE c.bitstream = b)";
         Query query = createQuery(context, hql);
         return query.executeUpdate();
     }

--- a/dspace-api/src/main/java/org/dspace/checker/dao/impl/MostRecentChecksumDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/checker/dao/impl/MostRecentChecksumDAOImpl.java
@@ -66,6 +66,24 @@ public class MostRecentChecksumDAOImpl extends AbstractHibernateDAO<MostRecentCh
         return list(context, criteriaQuery, false, MostRecentChecksum.class, -1, -1);
     }
 
+    @Override
+    public int updateMissingBitstreams(Context context) throws SQLException {
+        String hql = "INSERT INTO MostRecentChecksum(bitstream, toBeProcessed, expectedChecksum, currentChecksum, " +
+                "processStartDate, processEndDate, checksumAlgorithm, matchedPrevChecksum, checksumResult) " +
+                "SELECT b, " +
+                "CASE WHEN deleted = false THEN true ELSE false END, " +
+                "CASE WHEN checksum IS NULL THEN '' ELSE checksum END, " +
+                "CASE WHEN checksum IS NULL THEN '' ELSE checksum END, " +
+                "current_date(), current_date(), " +
+                "CASE WHEN checksumAlgorithm IS NULL THEN 'MD5' ELSE checksumAlgorithm END, " +
+                "CAST(1 AS boolean), " +
+                "(SELECT cr FROM ChecksumResult AS cr WHERE " +
+                "(resultCode='BITSTREAM_MARKED_DELETED' AND b.deleted = true) " +
+                "OR (resultCode='CHECKSUM_MATCH' AND b.deleted = false)) " +
+                "FROM Bitstream AS b WHERE NOT EXISTS(SELECT 'x' FROM MostRecentChecksum WHERE id=b.id)";
+        Query query = createQuery(context, hql);
+        return query.executeUpdate();
+    }
 
     @Override
     public MostRecentChecksum findByBitstream(Context context, Bitstream bitstream) throws SQLException {


### PR DESCRIPTION
## References

* Fixes #7322
* Replaces #2169
* Related to #10008 (adds logging about checking missing bitstreams)

## Description

This is a replacement patch for checker performance fix by @KingKrimmson applied to main branch. In addition, includes fix to HQL suggested by @toniprieto in original PR discussion and additional logging.

Original description from #2169 

> Currently, checksum checker fails to complete on large repositories. This is because of the large O-O operation done within updateMissingBitstream initializing objects just to insert into the database, instead of performing a single database operation.
> 
> While the HQL syntax was difficult to come up with, the query performed in this commit accomplishes the same thing as the Java code did previously (and the PSQL command before it).
> 
> Tested this on a large client repository and performance is exponentially improved.

## Instructions for Reviewers

List of changes in this PR:
* Java-based implementation introduced in DSpace 6.x has been replaced with HQL, placed in a new method in [MostRecentChecksumDAOImpl.java](https://github.com/minurmin/DSpace/blob/b6bc6657f6b16e236e08c7cf528579f36f833f94/dspace-api/src/main/java/org/dspace/checker/dao/impl/MostRecentChecksumDAOImpl.java#L70) that essentially reintroduces (SQL-based) functionality used in Dspace 5.x, (see [BitstreamInfoDAO.java](https://github.com/DSpace/DSpace/blob/dspace-5_x/dspace-api/src/main/java/org/dspace/checker/BitstreamInfoDAO.java#L63)) before the present Service API
* Added logging on start and end of detecting missing bitstreams, including the number of rows added to most_recent_checksum table

Testing the PR could be done with e.g. adding new (preferably many) bitstreams to repository and running checker, or utilizing a database dump of a working repository that has not been run with checker for a long time. The change should not affect the functionality of dispatchers (=what checker does after checksumService.updateMissingBitstreams call, see https://github.com/DSpace/DSpace/blob/main/dspace-api/src/main/java/org/dspace/checker/CheckerCommand.java#L121), but to ensure that updateMissingBitstreams-related functionality remains identical, it might be a good idea to make comparisons (based on similar db baseline) of most_recent_checksum table values with the original implementation and HQL-based one.

The change substantially improves performance on checker startup in the case where large (e.g. >100000) amount of bitstreams have been added to the repository after the last checker run. As a consequence, running checker becomes more intuitive because of the faster response time on initial run. Because checking missing bitstreams takes place regardless of selected dispatcher (like `-c 1` option to check just a single bitstream), running the script with original Java-based implementation and large number of added bitstreams may take considerable time or not finish at all _without intuitive note on progress to the end user_, just bitstream names on the log (the confusion related to this behaviour was one motivation to #10412 as it was not initially clear why the script run for unexpectedly long time span).

The PR has been tested with a DSpace 7 -based repository (apparently no substantial changes related to this part of checker are present in newer codebase) that had over 180000 missing bitstreams after migration from DSpace 6 where checker had not been run regularly). Assuming that with original Java code one insertion would take c. 1 seconds (based on observation of checker log) running _any_ checker operation the first time it would take over two days ( 180000 / (60 * 60 * 24) ). However, with HQL-based implementation update takes only less than a minute! After this initial run (i.e. most_recent_checksum more or less up-to-date) running the script either with Java or HQL -based implementation makes no difference as the bitsreams are more in line with checker status.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
