### PR TITLE
Migrate from legacy `java.util.Date` and `java.util.Calendar` to `java.time.*` Date classes

### DIFF
--- a/dspace-api/src/main/java/org/dspace/access/status/AccessStatusHelper.java
+++ b/dspace-api/src/main/java/org/dspace/access/status/AccessStatusHelper.java
@@ -8,7 +8,7 @@
 package org.dspace.access.status;
 
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.LocalDate;
 
 import org.dspace.content.Item;
 import org.dspace.core.Context;
@@ -26,7 +26,7 @@ public interface AccessStatusHelper {
      * @return an access status value
      * @throws SQLException An exception that provides information on a database access error or other errors.
      */
-    public String getAccessStatusFromItem(Context context, Item item, Date threshold)
+    public String getAccessStatusFromItem(Context context, Item item, LocalDate threshold)
         throws SQLException;
 
     /**
@@ -38,5 +38,5 @@ public interface AccessStatusHelper {
      * @return an embargo date
      * @throws SQLException An exception that provides information on a database access error or other errors.
      */
-    public String getEmbargoFromItem(Context context, Item item, Date threshold) throws SQLException;
+    public String getEmbargoFromItem(Context context, Item item, LocalDate threshold) throws SQLException;
 }

--- a/dspace-api/src/main/java/org/dspace/access/status/AccessStatusServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/access/status/AccessStatusServiceImpl.java
@@ -10,7 +10,6 @@ package org.dspace.access.status;
 import java.sql.SQLException;
 import java.time.LocalDate;
 import java.time.ZoneId;
-import java.util.Date;
 
 import org.dspace.access.status.service.AccessStatusService;
 import org.dspace.content.Item;
@@ -26,7 +25,7 @@ public class AccessStatusServiceImpl implements AccessStatusService {
     // Plugin implementation, set from the DSpace configuration by init().
     protected AccessStatusHelper helper = null;
 
-    protected Date forever_date = null;
+    protected LocalDate forever_date = null;
 
     @Autowired(required = true)
     protected ConfigurationService configurationService;
@@ -56,10 +55,10 @@ public class AccessStatusServiceImpl implements AccessStatusService {
             int month = configurationService.getIntProperty("access.status.embargo.forever.month");
             int day = configurationService.getIntProperty("access.status.embargo.forever.day");
 
-            forever_date = Date.from(LocalDate.of(year, month, day)
+            forever_date = LocalDate.of(year, month, day)
                     .atStartOfDay()
                     .atZone(ZoneId.systemDefault())
-                    .toInstant());
+                    .toLocalDate();
         }
     }
 

--- a/dspace-api/src/main/java/org/dspace/access/status/DefaultAccessStatusHelper.java
+++ b/dspace-api/src/main/java/org/dspace/access/status/DefaultAccessStatusHelper.java
@@ -8,8 +8,7 @@
 package org.dspace.access.status;
 
 import java.sql.SQLException;
-import java.time.Instant;
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Objects;
 
@@ -70,7 +69,7 @@ public class DefaultAccessStatusHelper implements AccessStatusHelper {
      * @return an access status value
      */
     @Override
-    public String getAccessStatusFromItem(Context context, Item item, Date threshold)
+    public String getAccessStatusFromItem(Context context, Item item, LocalDate threshold)
             throws SQLException {
         if (item == null) {
             return UNKNOWN;
@@ -110,7 +109,7 @@ public class DefaultAccessStatusHelper implements AccessStatusHelper {
      * @param threshold   the embargo threshold date
      * @return an access status value
      */
-    private String calculateAccessStatusForDso(Context context, DSpaceObject dso, Date threshold)
+    private String calculateAccessStatusForDso(Context context, DSpaceObject dso, LocalDate threshold)
             throws SQLException {
         if (dso == null) {
             return METADATA_ONLY;
@@ -137,8 +136,8 @@ public class DefaultAccessStatusHelper implements AccessStatusHelper {
                     // to the bitstream.
                     openAccessCount++;
                 } else {
-                    Date startDate = policy.getStartDate();
-                    if (startDate != null && !startDate.before(threshold)) {
+                    LocalDate startDate = policy.getStartDate();
+                    if (startDate != null && !startDate.isBefore(threshold)) {
                         // If the policy start date have a value and if this value
                         // is equal or superior to the configured forever date, the
                         // access status is also restricted.
@@ -173,9 +172,9 @@ public class DefaultAccessStatusHelper implements AccessStatusHelper {
      * @return an access status value
      */
     @Override
-    public String getEmbargoFromItem(Context context, Item item, Date threshold)
+    public String getEmbargoFromItem(Context context, Item item, LocalDate threshold)
             throws SQLException {
-        Date embargoDate;
+        LocalDate embargoDate;
 
         // If Item status is not "embargo" then return a null embargo date.
         String accessStatus = getAccessStatusFromItem(context, item, threshold);
@@ -213,8 +212,8 @@ public class DefaultAccessStatusHelper implements AccessStatusHelper {
     /**
      *
      */
-    private Date retrieveShortestEmbargo(Context context, Bitstream bitstream) throws SQLException {
-        Date embargoDate = null;
+    private LocalDate retrieveShortestEmbargo(Context context, Bitstream bitstream) throws SQLException {
+        LocalDate embargoDate = null;
         // Only consider read policies.
         List<ResourcePolicy> policies = authorizeService
                 .getPoliciesActionFilter(context, bitstream, Constants.READ);
@@ -228,15 +227,15 @@ public class DefaultAccessStatusHelper implements AccessStatusHelper {
                 // Only calculate the status for the anonymous group.
                 if (!isValid) {
                     // If the policy is not valid there is an active embargo
-                    Date startDate = policy.getStartDate();
+                    LocalDate startDate = policy.getStartDate();
 
-                    if (startDate != null && !startDate.before(Date.from(Instant.now()))) {
+                    if (startDate != null && !startDate.isBefore(LocalDate.now())) {
                         // There is an active embargo: aim to take the shortest embargo (account for rare cases where
                         // more than one resource policy exists)
                         if (embargoDate == null) {
                             embargoDate = startDate;
                         } else {
-                            embargoDate = startDate.before(embargoDate) ? startDate : embargoDate;
+                            embargoDate = startDate.isBefore(embargoDate) ? startDate : embargoDate;
                         }
                     }
                 }

--- a/dspace-api/src/main/java/org/dspace/administer/ProcessCleaner.java
+++ b/dspace-api/src/main/java/org/dspace/administer/ProcessCleaner.java
@@ -9,12 +9,12 @@ package org.dspace.administer;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.lang.time.DateUtils;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.ProcessStatus;
 import org.dspace.core.Context;
@@ -96,7 +96,7 @@ public class ProcessCleaner extends DSpaceRunnable<ProcessCleanerConfiguration<P
     private void performDeletion(Context context) throws SQLException, IOException, AuthorizeException {
 
         List<ProcessStatus> statuses = getProcessToDeleteStatuses();
-        Date creationDate = calculateCreationDate();
+        Instant creationDate = calculateCreationDate();
 
         handler.logInfo("Searching for processes with status: " + statuses);
         List<Process> processes = processService.findByStatusAndCreationTimeOlderThan(context, statuses, creationDate);
@@ -126,8 +126,8 @@ public class ProcessCleaner extends DSpaceRunnable<ProcessCleanerConfiguration<P
         return statuses;
     }
 
-    private Date calculateCreationDate() {
-        return DateUtils.addDays(new Date(), -days);
+    private Instant calculateCreationDate() {
+        return Instant.now().minus(days, ChronoUnit.DAYS);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/alerts/SystemWideAlert.java
+++ b/dspace-api/src/main/java/org/dspace/alerts/SystemWideAlert.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.alerts;
 
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 
 import jakarta.persistence.Cacheable;
 import jakarta.persistence.Column;
@@ -44,7 +44,7 @@ public class SystemWideAlert implements ReloadableEntity<Integer> {
     private String allowSessions;
 
     @Column(name = "countdown_to")
-    private LocalDateTime countdownTo;
+    private ZonedDateTime countdownTo;
 
     @Column(name = "active")
     private boolean active;
@@ -112,7 +112,7 @@ public class SystemWideAlert implements ReloadableEntity<Integer> {
      *
      * @return the date to which will be count down when the system-wide alert is active
      */
-    public LocalDateTime getCountdownTo() {
+    public ZonedDateTime getCountdownTo() {
         return countdownTo;
     }
 
@@ -121,7 +121,7 @@ public class SystemWideAlert implements ReloadableEntity<Integer> {
      *
      * @param countdownTo The date to which will be count down
      */
-    public void setCountdownTo(final LocalDateTime countdownTo) {
+    public void setCountdownTo(final ZonedDateTime countdownTo) {
         this.countdownTo = countdownTo;
     }
 

--- a/dspace-api/src/main/java/org/dspace/alerts/SystemWideAlert.java
+++ b/dspace-api/src/main/java/org/dspace/alerts/SystemWideAlert.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.alerts;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import jakarta.persistence.Cacheable;
 import jakarta.persistence.Column;
@@ -17,8 +17,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
-import jakarta.persistence.Temporal;
-import jakarta.persistence.TemporalType;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.dspace.core.ReloadableEntity;
@@ -46,8 +44,7 @@ public class SystemWideAlert implements ReloadableEntity<Integer> {
     private String allowSessions;
 
     @Column(name = "countdown_to")
-    @Temporal(TemporalType.TIMESTAMP)
-    private Date countdownTo;
+    private LocalDateTime countdownTo;
 
     @Column(name = "active")
     private boolean active;
@@ -115,7 +112,7 @@ public class SystemWideAlert implements ReloadableEntity<Integer> {
      *
      * @return the date to which will be count down when the system-wide alert is active
      */
-    public Date getCountdownTo() {
+    public LocalDateTime getCountdownTo() {
         return countdownTo;
     }
 
@@ -124,7 +121,7 @@ public class SystemWideAlert implements ReloadableEntity<Integer> {
      *
      * @param countdownTo The date to which will be count down
      */
-    public void setCountdownTo(final Date countdownTo) {
+    public void setCountdownTo(final LocalDateTime countdownTo) {
         this.countdownTo = countdownTo;
     }
 

--- a/dspace-api/src/main/java/org/dspace/alerts/SystemWideAlertServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/alerts/SystemWideAlertServiceImpl.java
@@ -9,7 +9,7 @@ package org.dspace.alerts;
 
 import java.io.IOException;
 import java.sql.SQLException;
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 import org.apache.logging.log4j.Logger;
@@ -39,7 +39,7 @@ public class SystemWideAlertServiceImpl implements SystemWideAlertService {
     @Override
     public SystemWideAlert create(final Context context, final String message,
                                   final AllowSessionsEnum allowSessionsType,
-                                  final LocalDateTime countdownTo, final boolean active) throws SQLException,
+                                  final ZonedDateTime countdownTo, final boolean active) throws SQLException,
             AuthorizeException {
         if (!authorizeService.isAdmin(context)) {
             throw new AuthorizeException(

--- a/dspace-api/src/main/java/org/dspace/alerts/SystemWideAlertServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/alerts/SystemWideAlertServiceImpl.java
@@ -9,7 +9,7 @@ package org.dspace.alerts;
 
 import java.io.IOException;
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.apache.logging.log4j.Logger;
@@ -39,7 +39,7 @@ public class SystemWideAlertServiceImpl implements SystemWideAlertService {
     @Override
     public SystemWideAlert create(final Context context, final String message,
                                   final AllowSessionsEnum allowSessionsType,
-                                  final Date countdownTo, final boolean active) throws SQLException,
+                                  final LocalDateTime countdownTo, final boolean active) throws SQLException,
             AuthorizeException {
         if (!authorizeService.isAdmin(context)) {
             throw new AuthorizeException(

--- a/dspace-api/src/main/java/org/dspace/alerts/service/SystemWideAlertService.java
+++ b/dspace-api/src/main/java/org/dspace/alerts/service/SystemWideAlertService.java
@@ -9,7 +9,7 @@ package org.dspace.alerts.service;
 
 import java.io.IOException;
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.dspace.alerts.AllowSessionsEnum;
@@ -35,7 +35,7 @@ public interface SystemWideAlertService {
      * @throws SQLException If something goes wrong
      */
     SystemWideAlert create(Context context, String message, AllowSessionsEnum allowSessionsType,
-                           Date countdownTo, boolean active
+                           LocalDateTime countdownTo, boolean active
     ) throws SQLException, AuthorizeException;
 
     /**

--- a/dspace-api/src/main/java/org/dspace/alerts/service/SystemWideAlertService.java
+++ b/dspace-api/src/main/java/org/dspace/alerts/service/SystemWideAlertService.java
@@ -9,7 +9,7 @@ package org.dspace.alerts.service;
 
 import java.io.IOException;
 import java.sql.SQLException;
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 import org.dspace.alerts.AllowSessionsEnum;
@@ -35,7 +35,7 @@ public interface SystemWideAlertService {
      * @throws SQLException If something goes wrong
      */
     SystemWideAlert create(Context context, String message, AllowSessionsEnum allowSessionsType,
-                           LocalDateTime countdownTo, boolean active
+                           ZonedDateTime countdownTo, boolean active
     ) throws SQLException, AuthorizeException;
 
     /**

--- a/dspace-api/src/main/java/org/dspace/app/bulkaccesscontrol/BulkAccessControl.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkaccesscontrol/BulkAccessControl.java
@@ -16,10 +16,9 @@ import static org.dspace.core.Constants.CONTENT_BUNDLE_NAME;
 import java.io.IOException;
 import java.io.InputStream;
 import java.sql.SQLException;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -312,7 +311,7 @@ public class BulkAccessControl extends DSpaceRunnable<BulkAccessControlScriptCon
      * check the validation of access condition,
      * the access condition name must equal to one of configured access conditions,
      * then call {@link AccessConditionOption#validateResourcePolicy(
-     * Context, String, Date, Date)} if exception happens so, it's invalid.
+     * Context, String, LocalDate, LocalDate)} if exception happens so, it's invalid.
      *
      * @param accessCondition the accessCondition
      * @throws BulkAccessControlException if the accessCondition is invalid
@@ -596,8 +595,8 @@ public class BulkAccessControl extends DSpaceRunnable<BulkAccessControlScriptCon
 
         String name = accessCondition.getName();
         String description = accessCondition.getDescription();
-        Date startDate = accessCondition.getStartDate();
-        Date endDate = accessCondition.getEndDate();
+        LocalDate startDate = accessCondition.getStartDate();
+        LocalDate endDate = accessCondition.getEndDate();
 
         try {
             accessConditionOption.createResourcePolicy(context, obj, name, description, startDate, endDate);
@@ -651,7 +650,7 @@ public class BulkAccessControl extends DSpaceRunnable<BulkAccessControlScriptCon
     }
 
     private void AppendAccessConditionsInfo(StringBuilder message, List<AccessCondition> accessConditions) {
-        DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+        DateTimeFormatter dateFormat = DateTimeFormatter.ISO_LOCAL_DATE;
         message.append("{");
 
         for (int i = 0; i <  accessConditions.size(); i++) {

--- a/dspace-api/src/main/java/org/dspace/app/bulkaccesscontrol/BulkAccessControl.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkaccesscontrol/BulkAccessControl.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.sql.SQLException;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -153,7 +154,7 @@ public class BulkAccessControl extends DSpaceRunnable<BulkAccessControlScriptCon
         }
 
         ObjectMapper mapper = new ObjectMapper();
-        mapper.setTimeZone(TimeZone.getTimeZone("UTC"));
+        mapper.setTimeZone(TimeZone.getTimeZone(ZoneOffset.UTC));
         BulkAccessControlInput accessControl;
         context = new Context(Context.Mode.BATCH_EDIT);
         setEPerson(context);

--- a/dspace-api/src/main/java/org/dspace/app/bulkaccesscontrol/model/AccessCondition.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkaccesscontrol/model/AccessCondition.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.app.bulkaccesscontrol.model;
 
-import java.util.Date;
+import java.time.LocalDate;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.dspace.app.bulkaccesscontrol.BulkAccessControl;
@@ -25,15 +25,15 @@ public class AccessCondition {
     private  String description;
 
     @JsonDeserialize(using = MultiFormatDateDeserializer.class)
-    private  Date startDate;
+    private LocalDate startDate;
 
     @JsonDeserialize(using = MultiFormatDateDeserializer.class)
-    private  Date endDate;
+    private LocalDate endDate;
 
     public AccessCondition() {
     }
 
-    public AccessCondition(String name, String description, Date startDate, Date endDate) {
+    public AccessCondition(String name, String description, LocalDate startDate, LocalDate endDate) {
         this.name = name;
         this.description = description;
         this.startDate = startDate;
@@ -48,11 +48,11 @@ public class AccessCondition {
         return description;
     }
 
-    public Date getStartDate() {
+    public LocalDate getStartDate() {
         return startDate;
     }
 
-    public Date getEndDate() {
+    public LocalDate getEndDate() {
         return endDate;
     }
 

--- a/dspace-api/src/main/java/org/dspace/app/checker/ChecksumChecker.java
+++ b/dspace-api/src/main/java/org/dspace/app/checker/ChecksumChecker.java
@@ -9,9 +9,8 @@ package org.dspace.app.checker;
 
 import java.io.FileNotFoundException;
 import java.sql.SQLException;
+import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
@@ -149,7 +148,7 @@ public final class ChecksumChecker {
                                        + " old results from the database.");
             }
 
-            Date processStart = Calendar.getInstance().getTime();
+            Instant processStart = Instant.now();
 
             BitstreamDispatcher dispatcher = null;
 
@@ -180,10 +179,8 @@ public final class ChecksumChecker {
                 // run checker process for specified duration
                 try {
                     dispatcher = new LimitedDurationDispatcher(
-                        new SimpleDispatcher(context, processStart, true), new Date(
-                        System.currentTimeMillis()
-                            + Utils.parseDuration(line
-                                                      .getOptionValue('d'))));
+                        new SimpleDispatcher(context, processStart, true), Instant.ofEpochMilli(
+                        Instant.now().toEpochMilli() + Utils.parseDuration(line.getOptionValue('d'))));
                 } catch (Exception e) {
                     LOG.fatal("Couldn't parse " + line.getOptionValue('d')
                                   + " as a duration: ", e);

--- a/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExportServiceImpl.java
@@ -19,6 +19,7 @@ import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -678,7 +679,7 @@ public class ItemExportServiceImpl implements ItemExportService {
                         context.turnOffAuthorisationSystem();
 
                         String fileName = assembleFileName("item", eperson,
-                                                           Instant.now());
+                                                           LocalDate.now());
                         String workParentDir = getExportWorkDirectory()
                             + System.getProperty("file.separator")
                             + fileName;
@@ -750,7 +751,7 @@ public class ItemExportServiceImpl implements ItemExportService {
 
     @Override
     public String assembleFileName(String type, EPerson eperson,
-                                   Instant date) throws Exception {
+                                   LocalDate date) throws Exception {
         // to format the date
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy_MMM_dd");
         String downloadDir = getExportDownloadDirectory(eperson);

--- a/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExportServiceImpl.java
@@ -18,10 +18,10 @@ import java.io.InputStream;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -678,7 +678,7 @@ public class ItemExportServiceImpl implements ItemExportService {
                         context.turnOffAuthorisationSystem();
 
                         String fileName = assembleFileName("item", eperson,
-                                                           new Date());
+                                                           Instant.now());
                         String workParentDir = getExportWorkDirectory()
                             + System.getProperty("file.separator")
                             + fileName;
@@ -750,16 +750,16 @@ public class ItemExportServiceImpl implements ItemExportService {
 
     @Override
     public String assembleFileName(String type, EPerson eperson,
-                                   Date date) throws Exception {
+                                   Instant date) throws Exception {
         // to format the date
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy_MMM_dd");
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy_MMM_dd");
         String downloadDir = getExportDownloadDirectory(eperson);
         // used to avoid name collision
         int count = 1;
         boolean exists = true;
         String fileName = null;
         while (exists) {
-            fileName = type + "_export_" + sdf.format(date) + "_" + count + "_"
+            fileName = type + "_export_" + formatter.format(date) + "_" + count + "_"
                 + eperson.getID();
             exists = new File(downloadDir
                                   + System.getProperty("file.separator") + fileName + ".zip")
@@ -915,14 +915,12 @@ public class ItemExportServiceImpl implements ItemExportService {
     public void deleteOldExportArchives(EPerson eperson) throws Exception {
         int hours = configurationService
             .getIntProperty("org.dspace.app.itemexport.life.span.hours");
-        Calendar now = Calendar.getInstance();
-        now.setTime(new Date());
-        now.add(Calendar.HOUR, -hours);
+        Instant modifiedTime = Instant.now().minus(hours, ChronoUnit.HOURS);
         File downloadDir = new File(getExportDownloadDirectory(eperson));
         if (downloadDir.exists()) {
             File[] files = downloadDir.listFiles();
             for (File file : files) {
-                if (file.lastModified() < now.getTimeInMillis()) {
+                if (file.lastModified() < modifiedTime.toEpochMilli()) {
                     if (!file.delete()) {
                         logError("Unable to delete export file");
                     }
@@ -935,9 +933,7 @@ public class ItemExportServiceImpl implements ItemExportService {
     @Override
     public void deleteOldExportArchives() throws Exception {
         int hours = configurationService.getIntProperty("org.dspace.app.itemexport.life.span.hours");
-        Calendar now = Calendar.getInstance();
-        now.setTime(new Date());
-        now.add(Calendar.HOUR, -hours);
+        Instant modifiedTime = Instant.now().minus(hours, ChronoUnit.HOURS);
         File downloadDir = new File(configurationService.getProperty("org.dspace.app.itemexport.download.dir"));
         if (downloadDir.exists()) {
             // Get a list of all the sub-directories, potentially one for each ePerson.
@@ -946,7 +942,7 @@ public class ItemExportServiceImpl implements ItemExportService {
                 // For each sub-directory delete any old files.
                 File[] files = dir.listFiles();
                 for (File file : files) {
-                    if (file.lastModified() < now.getTimeInMillis()) {
+                    if (file.lastModified() < modifiedTime.toEpochMilli()) {
                         if (!file.delete()) {
                             logError("Unable to delete old files");
                         }

--- a/dspace-api/src/main/java/org/dspace/app/itemexport/service/ItemExportService.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemexport/service/ItemExportService.java
@@ -8,7 +8,7 @@
 package org.dspace.app.itemexport.service;
 
 import java.io.InputStream;
-import java.time.Instant;
+import java.time.LocalDate;
 import java.util.Iterator;
 import java.util.List;
 
@@ -130,7 +130,7 @@ public interface ItemExportService {
      * @throws Exception if error
      */
     public String assembleFileName(String type, EPerson eperson,
-                                   Instant date) throws Exception;
+                                   LocalDate date) throws Exception;
 
 
     /**

--- a/dspace-api/src/main/java/org/dspace/app/itemexport/service/ItemExportService.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemexport/service/ItemExportService.java
@@ -8,7 +8,7 @@
 package org.dspace.app.itemexport.service;
 
 import java.io.InputStream;
-import java.util.Date;
+import java.time.Instant;
 import java.util.Iterator;
 import java.util.List;
 
@@ -130,7 +130,7 @@ public interface ItemExportService {
      * @throws Exception if error
      */
     public String assembleFileName(String type, EPerson eperson,
-                                   Date date) throws Exception;
+                                   Instant date) throws Exception;
 
 
     /**

--- a/dspace-api/src/main/java/org/dspace/app/itemimport/BatchUpload.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/BatchUpload.java
@@ -11,11 +11,9 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.LineNumberReader;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.GregorianCalendar;
 import java.util.List;
 
 /**
@@ -23,7 +21,7 @@ import java.util.List;
  */
 public class BatchUpload {
 
-    private Date date;
+    private Instant date;
     private File dir;
     private boolean successful;
     private int itemsImported;
@@ -65,9 +63,7 @@ public class BatchUpload {
 
         String dirName = dir.getName();
         long timeMillis = Long.parseLong(dirName);
-        Calendar calendar = new GregorianCalendar();
-        calendar.setTimeInMillis(timeMillis);
-        this.date = calendar.getTime();
+        this.date = Instant.ofEpochMilli(timeMillis);
 
         try {
             this.itemsImported = countLines(dir + File.separator + "mapfile");
@@ -149,7 +145,7 @@ public class BatchUpload {
      *
      * @return Date
      */
-    public Date getDate() {
+    public Instant getDate() {
         return date;
     }
 
@@ -190,14 +186,12 @@ public class BatchUpload {
     }
 
     /**
-     * Get formatted date (DD/MM/YY)
+     * Get formatted date (YYYY-MM-DDThh:mm:ssZ)
      *
      * @return date as string
      */
     public String getDateFormatted() {
-        SimpleDateFormat df = new SimpleDateFormat("dd/MM/yyyy - HH:mm");
-
-        return df.format(date);
+        return DateTimeFormatter.ISO_INSTANT.format(date);
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
@@ -14,8 +14,9 @@ import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Files;
 import java.sql.SQLException;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -156,7 +157,7 @@ public class ItemImport extends DSpaceRunnable<ItemImportScriptConfiguration> {
             return;
         }
 
-        Date startTime = new Date();
+        Instant startTime = Instant.now();
         Context context = new Context(Context.Mode.BATCH_EDIT);
 
         setMapFile();
@@ -254,12 +255,12 @@ public class ItemImport extends DSpaceRunnable<ItemImportScriptConfiguration> {
                 }
             }
 
-            Date endTime = new Date();
-            handler.logInfo("Started: " + startTime.getTime());
-            handler.logInfo("Ended: " + endTime.getTime());
+            Instant endTime = Instant.now();
+            handler.logInfo("Started: " + DateTimeFormatter.ISO_INSTANT.format(startTime));
+            handler.logInfo("Ended: " + DateTimeFormatter.ISO_INSTANT.format(endTime));
             handler.logInfo(
-                "Elapsed time: " + ((endTime.getTime() - startTime.getTime()) / 1000) + " secs (" + (endTime
-                    .getTime() - startTime.getTime()) + " msecs)");
+                "Elapsed time: " + ((endTime.toEpochMilli() - startTime.toEpochMilli()) / 1000) + " secs (" +
+                    (endTime.toEpochMilli() - startTime.toEpochMilli()) + " msecs)");
         }
     }
 

--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
@@ -30,12 +30,11 @@ import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.net.URL;
 import java.sql.SQLException;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.Enumeration;
-import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -2039,8 +2038,8 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
      */
     protected String generateRandomFilename(boolean hidden) {
         String filename = String.format("%s", RandomStringUtils.randomAlphanumeric(8));
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd_HHmm");
-        String datePart = sdf.format(new Date());
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd_HHmm");
+        String datePart = formatter.format(Instant.now());
         filename = datePart + "_" + filename;
 
         return filename;
@@ -2102,8 +2101,7 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
                         "org.dspace.app.batchitemimport.work.dir") + File.separator + "batchuploads" + File.separator
                         + context
                         .getCurrentUser()
-                        .getID() + File.separator + (isResume ? theResumeDir : (new GregorianCalendar())
-                        .getTimeInMillis());
+                        .getID() + File.separator + (isResume ? theResumeDir : Instant.now().toEpochMilli());
                     File importDirFile = new File(importDir);
                     if (!importDirFile.exists()) {
                         boolean success = importDirFile.mkdirs();

--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
@@ -31,6 +31,8 @@ import java.io.PrintWriter;
 import java.net.URL;
 import java.sql.SQLException;
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -2039,7 +2041,7 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
     protected String generateRandomFilename(boolean hidden) {
         String filename = String.format("%s", RandomStringUtils.randomAlphanumeric(8));
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd_HHmm");
-        String datePart = formatter.format(Instant.now());
+        String datePart = formatter.format(LocalDateTime.now(ZoneOffset.UTC));
         filename = datePart + "_" + filename;
 
         return filename;

--- a/dspace-api/src/main/java/org/dspace/app/itemupdate/ItemUpdate.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemupdate/ItemUpdate.java
@@ -14,9 +14,9 @@ import java.io.FileWriter;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -332,7 +332,7 @@ public class ItemUpdate {
                 }
             }
 
-            pr("ItemUpdate - initializing run on " + (new Date()).toString());
+            pr("ItemUpdate - initializing run on " + (Instant.now()).toString());
 
             context = new Context(Context.Mode.BATCH_EDIT);
             iu.setEPerson(context, iu.eperson);

--- a/dspace-api/src/main/java/org/dspace/app/ldn/LDNMessageConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/app/ldn/LDNMessageConsumer.java
@@ -11,9 +11,9 @@ import static java.lang.String.format;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -126,7 +126,7 @@ public class LDNMessageConsumer implements Consumer {
         ldnMessage.setObject(item);
         ldnMessage.setTarget(service);
         ldnMessage.setQueueStatus(LDNMessageEntity.QUEUE_STATUS_QUEUED);
-        ldnMessage.setQueueTimeout(new Date());
+        ldnMessage.setQueueTimeout(Instant.now());
 
         appendGeneratedMessage(ldn, ldnMessage, pattern);
 

--- a/dspace-api/src/main/java/org/dspace/app/ldn/LDNMessageEntity.java
+++ b/dspace-api/src/main/java/org/dspace/app/ldn/LDNMessageEntity.java
@@ -8,7 +8,7 @@
 package org.dspace.app.ldn;
 
 import java.lang.reflect.Field;
-import java.util.Date;
+import java.time.Instant;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -16,8 +16,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import jakarta.persistence.Temporal;
-import jakarta.persistence.TemporalType;
 import org.dspace.content.DSpaceObject;
 import org.dspace.core.ReloadableEntity;
 
@@ -100,13 +98,11 @@ public class LDNMessageEntity implements ReloadableEntity<String> {
     @Column(name = "queue_attempts")
     private Integer queueAttempts = 0;
 
-    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "queue_last_start_time")
-    private Date queueLastStartTime = null;
+    private Instant queueLastStartTime = null;
 
-    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "queue_timeout")
-    private Date queueTimeout = null;
+    private Instant queueTimeout = null;
 
     @ManyToOne
     @JoinColumn(name = "origin", referencedColumnName = "id")
@@ -259,19 +255,19 @@ public class LDNMessageEntity implements ReloadableEntity<String> {
         this.queueAttempts = queueAttempts;
     }
 
-    public Date getQueueLastStartTime() {
+    public Instant getQueueLastStartTime() {
         return queueLastStartTime;
     }
 
-    public void setQueueLastStartTime(Date queueLastStartTime) {
+    public void setQueueLastStartTime(Instant queueLastStartTime) {
         this.queueLastStartTime = queueLastStartTime;
     }
 
-    public Date getQueueTimeout() {
+    public Instant getQueueTimeout() {
         return queueTimeout;
     }
 
-    public void setQueueTimeout(Date queueTimeout) {
+    public void setQueueTimeout(Instant queueTimeout) {
         this.queueTimeout = queueTimeout;
     }
 

--- a/dspace-api/src/main/java/org/dspace/app/ldn/action/LDNCorrectionAction.java
+++ b/dspace-api/src/main/java/org/dspace/app/ldn/action/LDNCorrectionAction.java
@@ -9,7 +9,7 @@ package org.dspace.app.ldn.action;
 
 import java.math.BigDecimal;
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.LogManager;
@@ -73,8 +73,7 @@ public class LDNCorrectionAction implements LDNAction {
             qaEvent = new QAEvent(QAEvent.COAR_NOTIFY_SOURCE,
                 handleService.findHandle(context, item), item.getID().toString(), itemName,
                 this.getQaEventTopic(), doubleScoreValue,
-                mapper.writeValueAsString(message),
-                new Date());
+                mapper.writeValueAsString(message), Instant.now());
             qaEventService.store(context, qaEvent);
             result = LDNActionStatus.CONTINUE;
         }

--- a/dspace-api/src/main/java/org/dspace/app/ldn/action/LDNEmailAction.java
+++ b/dspace-api/src/main/java/org/dspace/app/ldn/action/LDNEmailAction.java
@@ -9,9 +9,9 @@ package org.dspace.app.ldn.action;
 
 import static java.lang.String.format;
 
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
-import java.util.Calendar;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
@@ -80,7 +80,7 @@ public class LDNEmailAction implements LDNAction {
                 email.addRecipient(recipient);
             }
 
-            String date = new SimpleDateFormat(DATE_PATTERN).format(Calendar.getInstance().getTime());
+            String date = DateTimeFormatter.ofPattern(DATE_PATTERN).format(Instant.now());
 
             email.addArgument(notification.getActor().getName());
             email.addArgument(item.getName());

--- a/dspace-api/src/main/java/org/dspace/app/ldn/action/LDNEmailAction.java
+++ b/dspace-api/src/main/java/org/dspace/app/ldn/action/LDNEmailAction.java
@@ -10,7 +10,6 @@ package org.dspace.app.ldn.action;
 import static java.lang.String.format;
 
 import java.time.Instant;
-import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
@@ -33,8 +32,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 public class LDNEmailAction implements LDNAction {
 
     private static final Logger log = LogManager.getLogger(LDNEmailAction.class);
-
-    private final static String DATE_PATTERN = "dd-MM-yyyy HH:mm:ss";
 
     @Autowired
     private ConfigurationService configurationService;
@@ -80,7 +77,7 @@ public class LDNEmailAction implements LDNAction {
                 email.addRecipient(recipient);
             }
 
-            String date = DateTimeFormatter.ofPattern(DATE_PATTERN).format(Instant.now());
+            String date = Instant.now().toString();
 
             email.addArgument(notification.getActor().getName());
             email.addArgument(item.getName());

--- a/dspace-api/src/main/java/org/dspace/app/ldn/action/LDNRelationCorrectionAction.java
+++ b/dspace-api/src/main/java/org/dspace/app/ldn/action/LDNRelationCorrectionAction.java
@@ -9,7 +9,7 @@ package org.dspace.app.ldn.action;
 
 import java.math.BigDecimal;
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.Set;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -75,8 +75,7 @@ public class LDNRelationCorrectionAction implements LDNAction {
             qaEvent = new QAEvent(QAEvent.COAR_NOTIFY_SOURCE,
                 handleService.findHandle(context, item), item.getID().toString(), itemName,
                 this.getQaEventTopic(), doubleScoreValue,
-                mapper.writeValueAsString(message),
-                new Date());
+                mapper.writeValueAsString(message), Instant.now());
             qaEventService.store(context, qaEvent);
             result = LDNActionStatus.CONTINUE;
         }

--- a/dspace-api/src/main/java/org/dspace/app/ldn/dao/impl/LDNMessageDaoImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/ldn/dao/impl/LDNMessageDaoImpl.java
@@ -8,8 +8,8 @@
 package org.dspace.app.ldn.dao.impl;
 
 import java.sql.SQLException;
+import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -47,7 +47,7 @@ public class LDNMessageDaoImpl extends AbstractHibernateDAO<LDNMessageEntity> im
         andPredicates
             .add(criteriaBuilder.equal(root.get(LDNMessageEntity_.queueStatus), LDNMessageEntity.QUEUE_STATUS_QUEUED));
         andPredicates.add(criteriaBuilder.lessThan(root.get(LDNMessageEntity_.queueAttempts), max_attempts));
-        andPredicates.add(criteriaBuilder.lessThan(root.get(LDNMessageEntity_.queueTimeout), new Date()));
+        andPredicates.add(criteriaBuilder.lessThan(root.get(LDNMessageEntity_.queueTimeout), Instant.now()));
         criteriaQuery.where(criteriaBuilder.and(andPredicates.toArray(new Predicate[] {})));
         List<Order> orderList = new LinkedList<>();
         orderList.add(criteriaBuilder.desc(root.get(LDNMessageEntity_.queueAttempts)));
@@ -94,7 +94,7 @@ public class LDNMessageDaoImpl extends AbstractHibernateDAO<LDNMessageEntity> im
         andPredicates.add(
             criteriaBuilder.equal(root.get(LDNMessageEntity_.queueStatus), LDNMessageEntity.QUEUE_STATUS_PROCESSING));
         andPredicates.add(criteriaBuilder.lessThanOrEqualTo(root.get(LDNMessageEntity_.queueAttempts), max_attempts));
-        andPredicates.add(criteriaBuilder.lessThan(root.get(LDNMessageEntity_.queueTimeout), new Date()));
+        andPredicates.add(criteriaBuilder.lessThan(root.get(LDNMessageEntity_.queueTimeout), Instant.now()));
         criteriaQuery.where(criteriaBuilder.and(andPredicates.toArray(new Predicate[] {})));
         List<Order> orderList = new LinkedList<>();
         orderList.add(criteriaBuilder.desc(root.get(LDNMessageEntity_.queueAttempts)));

--- a/dspace-api/src/main/java/org/dspace/app/ldn/service/impl/LDNMessageServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/ldn/service/impl/LDNMessageServiceImpl.java
@@ -10,10 +10,11 @@ package org.dspace.app.ldn.service.impl;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.sql.SQLException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -22,7 +23,6 @@ import java.util.UUID;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.JsonSyntaxException;
-import org.apache.commons.lang.time.DateUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.ldn.LDNMessageEntity;
@@ -157,7 +157,7 @@ public class LDNMessageServiceImpl implements LDNMessageService {
                 ldnMessage.setQueueStatus(LDNMessageEntity.QUEUE_STATUS_UNTRUSTED_IP);
             }
         }
-        ldnMessage.setQueueTimeout(new Date());
+        ldnMessage.setQueueTimeout(Instant.now());
 
         update(context, ldnMessage);
         return ldnMessage;
@@ -282,9 +282,9 @@ public class LDNMessageServiceImpl implements LDNMessageService {
                     msg.setQueueAttempts(msg.getQueueAttempts() + 1);
                     update(context, msg);
                 } else {
-                    msg.setQueueLastStartTime(new Date());
+                    msg.setQueueLastStartTime(Instant.now());
                     msg.setQueueStatus(LDNMessageEntity.QUEUE_STATUS_PROCESSING);
-                    msg.setQueueTimeout(DateUtils.addMinutes(new Date(), timeoutInMinutes));
+                    msg.setQueueTimeout(Instant.now().plus(timeoutInMinutes, ChronoUnit.MINUTES));
                     update(context, msg);
                     ObjectMapper mapper = new ObjectMapper();
                     Notification notification = mapper.readValue(msg.getMessage(), Notification.class);

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
@@ -13,7 +13,6 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -128,7 +127,7 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
             Iterator<Item> itemIterator =
                     itemService.findByLastModifiedSince(
                             context,
-                            Date.from(fromDate.atStartOfDay(ZoneId.systemDefault()).toInstant())
+                            fromDate.atStartOfDay(ZoneId.systemDefault()).toInstant()
                     );
             while (itemIterator.hasNext() && processed < max2Process) {
                 applyFiltersItem(context, itemIterator.next());

--- a/dspace-api/src/main/java/org/dspace/app/requestitem/RequestItem.java
+++ b/dspace-api/src/main/java/org/dspace/app/requestitem/RequestItem.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.app.requestitem;
 
-import java.util.Date;
+import java.time.Instant;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -19,8 +19,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
-import jakarta.persistence.Temporal;
-import jakarta.persistence.TemporalType;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
@@ -63,16 +61,13 @@ public class RequestItem implements ReloadableEntity<Integer> {
     private boolean allfiles;
 
     @Column(name = "decision_date")
-    @Temporal(TemporalType.TIMESTAMP)
-    private Date decision_date = null;
+    private Instant decision_date = null;
 
     @Column(name = "expires")
-    @Temporal(TemporalType.TIMESTAMP)
-    private Date expires = null;
+    private Instant expires = null;
 
     @Column(name = "request_date")
-    @Temporal(TemporalType.TIMESTAMP)
-    private Date request_date = null;
+    private Instant request_date = null;
 
     @Column(name = "accept_request")
     private boolean accept_request;
@@ -161,11 +156,11 @@ public class RequestItem implements ReloadableEntity<Integer> {
         return bitstream;
     }
 
-    public Date getDecision_date() {
+    public Instant getDecision_date() {
         return decision_date;
     }
 
-    public void setDecision_date(Date decision_date) {
+    public void setDecision_date(Instant decision_date) {
         this.decision_date = decision_date;
     }
 
@@ -177,19 +172,19 @@ public class RequestItem implements ReloadableEntity<Integer> {
         this.accept_request = accept_request;
     }
 
-    public Date getExpires() {
+    public Instant getExpires() {
         return expires;
     }
 
-    void setExpires(Date expires) {
+    void setExpires(Instant expires) {
         this.expires = expires;
     }
 
-    public Date getRequest_date() {
+    public Instant getRequest_date() {
         return request_date;
     }
 
-    void setRequest_date(Date request_date) {
+    void setRequest_date(Instant request_date) {
         this.request_date = request_date;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/app/requestitem/RequestItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/requestitem/RequestItemServiceImpl.java
@@ -8,7 +8,7 @@
 package org.dspace.app.requestitem;
 
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.Iterator;
 import java.util.List;
 
@@ -66,7 +66,7 @@ public class RequestItemServiceImpl implements RequestItemService {
         requestItem.setReqEmail(reqEmail);
         requestItem.setReqName(reqName);
         requestItem.setReqMessage(reqMessage);
-        requestItem.setRequest_date(new Date());
+        requestItem.setRequest_date(Instant.now());
 
         requestItemDAO.save(context, requestItem);
 

--- a/dspace-api/src/main/java/org/dspace/app/sherpa/v2/SHERPAResponse.java
+++ b/dspace-api/src/main/java/org/dspace/app/sherpa/v2/SHERPAResponse.java
@@ -12,8 +12,8 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -59,7 +59,7 @@ public class SHERPAResponse implements Serializable {
     private String uri;
 
     @JsonIgnore
-    private Date retrievalTime = new Date();
+    private Instant retrievalTime = Instant.now();
 
     // Format enum - currently only JSON is supported
     public enum SHERPAFormat {
@@ -563,7 +563,7 @@ public class SHERPAResponse implements Serializable {
         return metadata;
     }
 
-    public Date getRetrievalTime() {
+    public Instant getRetrievalTime() {
         return retrievalTime;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/app/sitemap/AbstractGenerator.java
+++ b/dspace-api/src/main/java/org/dspace/app/sitemap/AbstractGenerator.java
@@ -12,7 +12,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
-import java.util.Date;
+import java.time.Instant;
 import java.util.zip.GZIPOutputStream;
 
 /**
@@ -110,7 +110,7 @@ public abstract class AbstractGenerator {
      * @throws IOException if IO error
      *                     if an error occurs writing
      */
-    public void addURL(String url, Date lastMod) throws IOException {
+    public void addURL(String url, Instant lastMod) throws IOException {
         // Kick things off if this is the first call
         if (currentOutput == null) {
             startNewFile();
@@ -143,7 +143,7 @@ public abstract class AbstractGenerator {
 
     /**
      * Complete writing sitemap files and write the index files. This is invoked
-     * when all calls to {@link AbstractGenerator#addURL(String, Date)} have
+     * when all calls to {@link AbstractGenerator#addURL(String, Instant)} have
      * been completed, and invalidates the generator.
      *
      * @return number of sitemap files written.
@@ -177,7 +177,7 @@ public abstract class AbstractGenerator {
      *                applicable
      * @return the mark-up to include
      */
-    public abstract String getURLText(String url, Date lastMod);
+    public abstract String getURLText(String url, Instant lastMod);
 
     /**
      * Return the boilerplate at the top of a sitemap file.

--- a/dspace-api/src/main/java/org/dspace/app/sitemap/GenerateSitemaps.java
+++ b/dspace-api/src/main/java/org/dspace/app/sitemap/GenerateSitemaps.java
@@ -10,7 +10,6 @@ package org.dspace.app.sitemap;
 import java.io.File;
 import java.io.IOException;
 import java.sql.SQLException;
-import java.util.Date;
 import java.util.List;
 
 import org.apache.commons.cli.CommandLine;
@@ -256,7 +255,6 @@ public class GenerateSitemaps {
                     } else {
                         url = uiURLStem + "items/" + doc.getID();
                     }
-                    Date lastMod = doc.getLastModified();
                     c.uncacheEntity(doc.getIndexedObject());
 
                     if (makeHTMLMap) {

--- a/dspace-api/src/main/java/org/dspace/app/sitemap/HTMLSitemapGenerator.java
+++ b/dspace-api/src/main/java/org/dspace/app/sitemap/HTMLSitemapGenerator.java
@@ -10,7 +10,7 @@ package org.dspace.app.sitemap;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.util.Date;
+import java.time.Instant;
 
 /**
  * Class for generating HTML "sitemaps" which contain links to various pages in
@@ -77,7 +77,7 @@ public class HTMLSitemapGenerator extends AbstractGenerator {
     }
 
     @Override
-    public String getURLText(String url, Date lastMod) {
+    public String getURLText(String url, Instant lastMod) {
         StringBuffer urlText = new StringBuffer();
 
         urlText.append("<li><a href=\"").append(url).append("\">").append(url)

--- a/dspace-api/src/main/java/org/dspace/app/sitemap/SitemapsOrgGenerator.java
+++ b/dspace-api/src/main/java/org/dspace/app/sitemap/SitemapsOrgGenerator.java
@@ -10,9 +10,8 @@ package org.dspace.app.sitemap;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 
 /**
  * Class for generating <a href="http://sitemaps.org/">Sitemaps</a> to improve
@@ -36,8 +35,7 @@ public class SitemapsOrgGenerator extends AbstractGenerator {
     /**
      * The correct date format
      */
-    protected DateFormat w3dtfFormat = new SimpleDateFormat(
-        "yyyy-MM-dd'T'HH:mm:ss'Z'");
+    protected DateTimeFormatter w3dtfFormat = DateTimeFormatter.ISO_INSTANT;
 
     /**
      * Construct a sitemaps.org protocol sitemap generator, writing files to the
@@ -85,7 +83,7 @@ public class SitemapsOrgGenerator extends AbstractGenerator {
     }
 
     @Override
-    public String getURLText(String url, Date lastMod) {
+    public String getURLText(String url, Instant lastMod) {
         StringBuilder urlText = new StringBuilder();
 
         urlText.append("<url><loc>").append(url).append("</loc>");
@@ -111,7 +109,7 @@ public class SitemapsOrgGenerator extends AbstractGenerator {
     @Override
     public void writeIndex(PrintStream output, int sitemapCount)
         throws IOException {
-        String now = w3dtfFormat.format(new Date());
+        String now = w3dtfFormat.format(Instant.now());
 
         output.println("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
         output

--- a/dspace-api/src/main/java/org/dspace/app/solrdatabaseresync/SolrDatabaseResyncCli.java
+++ b/dspace-api/src/main/java/org/dspace/app/solrdatabaseresync/SolrDatabaseResyncCli.java
@@ -12,7 +12,8 @@ import static org.dspace.discovery.indexobject.ItemIndexFactoryImpl.STATUS_FIELD
 
 import java.io.IOException;
 import java.sql.SQLException;
-import java.util.Calendar;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -166,11 +167,11 @@ public class SolrDatabaseResyncCli extends DSpaceRunnable<SolrDatabaseResyncCliS
     }
 
     private String getMaxTime() {
-        Calendar cal = Calendar.getInstance();
+        Instant now = Instant.now();
         if (timeUntilReindex > 0) {
-            cal.add(Calendar.MILLISECOND, -timeUntilReindex);
+            now = now.minus(timeUntilReindex, ChronoUnit.MILLIS);
         }
-        return SolrUtils.getDateFormatter().format(cal.getTime());
+        return SolrUtils.getDateFormatter().format(now);
     }
 
     private int getTimeUntilReindex() {

--- a/dspace-api/src/main/java/org/dspace/app/statistics/HTMLReport.java
+++ b/dspace-api/src/main/java/org/dspace/app/statistics/HTMLReport.java
@@ -13,8 +13,8 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.text.DateFormat;
+import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -50,12 +50,12 @@ public class HTMLReport implements Report {
     /**
      * start date for report
      */
-    private Date start = null;
+    private LocalDate start = null;
 
     /**
      * end date for report
      */
-    private Date end = null;
+    private LocalDate end = null;
 
     /**
      * the output file to which to write aggregation data
@@ -190,8 +190,8 @@ public class HTMLReport implements Report {
      * @param start the start date for the report
      */
     @Override
-    public void setStartDate(Date start) {
-        this.start = (start == null ? null : new Date(start.getTime()));
+    public void setStartDate(LocalDate start) {
+        this.start = start;
     }
 
 
@@ -201,8 +201,8 @@ public class HTMLReport implements Report {
      * @param end the end date for the report
      */
     @Override
-    public void setEndDate(Date end) {
-        this.end = (end == null ? null : new Date(end.getTime()));
+    public void setEndDate(LocalDate end) {
+        this.end = end;
     }
 
 

--- a/dspace-api/src/main/java/org/dspace/app/statistics/LogAnalyser.java
+++ b/dspace-api/src/main/java/org/dspace/app/statistics/LogAnalyser.java
@@ -14,18 +14,16 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.sql.SQLException;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
-import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -265,7 +263,7 @@ public class LogAnalyser {
     /**
      * process timing clock
      */
-    private static Calendar startTime = null;
+    private static Instant startTime = null;
 
     /////////////////////////
     // command line options
@@ -298,22 +296,22 @@ public class LogAnalyser {
     /**
      * the starting date of the report
      */
-    private static Date startDate = null;
+    private static LocalDate startDate = null;
 
     /**
      * the end date of the report
      */
-    private static Date endDate = null;
+    private static LocalDate endDate = null;
 
     /**
      * the starting date of the report as obtained from the log files
      */
-    private static Date logStartDate = null;
+    private static LocalDate logStartDate = null;
 
     /**
      * the end date of the report as obtained from the log files
      */
-    private static Date logEndDate = null;
+    private static LocalDate logEndDate = null;
 
     /**
      * Default constructor
@@ -331,7 +329,7 @@ public class LogAnalyser {
     public static void main(String[] argv)
         throws Exception, SQLException {
         // first, start the processing clock
-        startTime = new GregorianCalendar();
+        startTime = Instant.now();
 
         // create context as super user
         Context context = new Context();
@@ -342,8 +340,8 @@ public class LogAnalyser {
         String myFileTemplate = null;
         String myConfigFile = null;
         String myOutFile = null;
-        Date myStartDate = null;
-        Date myEndDate = null;
+        LocalDate myStartDate = null;
+        LocalDate myEndDate = null;
         boolean myLookUp = false;
 
         // Define command line options.
@@ -434,14 +432,14 @@ public class LogAnalyser {
      */
     public static String processLogs(Context context, String myLogDir,
                                      String myFileTemplate, String myConfigFile,
-                                     String myOutFile, Date myStartDate,
-                                     Date myEndDate, boolean myLookUp)
+                                     String myOutFile, LocalDate myStartDate,
+                                     LocalDate myEndDate, boolean myLookUp)
         throws IOException, SQLException, SearchServiceException {
         // FIXME: perhaps we should have all parameters and aggregators put
         // together in a single aggregating object
 
         // if the timer has not yet been started, then start it
-        startTime = new GregorianCalendar();
+        startTime = Instant.now();
 
         //instantiate aggregators
         actionAggregator = new HashMap<>();
@@ -658,7 +656,7 @@ public class LogAnalyser {
      */
     public static void setParameters(String myLogDir, String myFileTemplate,
                                      String myConfigFile, String myOutFile,
-                                     Date myStartDate, Date myEndDate,
+                                     LocalDate myStartDate, LocalDate myEndDate,
                                      boolean myLookUp) {
 
         if (myLogDir != null) {
@@ -676,11 +674,11 @@ public class LogAnalyser {
         }
 
         if (myStartDate != null) {
-            startDate = new Date(myStartDate.getTime());
+            startDate = myStartDate;
         }
 
         if (myEndDate != null) {
-            endDate = new Date(myEndDate.getTime());
+            endDate = myEndDate;
         }
 
         if (myOutFile != null) {
@@ -722,18 +720,17 @@ public class LogAnalyser {
         summary.append("service_name=").append(name).append("\n");
 
         // output the date information if necessary
-        SimpleDateFormat sdf = new SimpleDateFormat("dd'/'MM'/'yyyy");
-
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd'/'MM'/'yyyy");
         if (startDate != null) {
-            summary.append("start_date=").append(sdf.format(startDate)).append("\n");
+            summary.append("start_date=").append(formatter.format(startDate)).append("\n");
         } else if (logStartDate != null) {
-            summary.append("start_date=").append(sdf.format(logStartDate)).append("\n");
+            summary.append("start_date=").append(formatter.format(logStartDate)).append("\n");
         }
 
         if (endDate != null) {
-            summary.append("end_date=").append(sdf.format(endDate)).append("\n");
+            summary.append("end_date=").append(formatter.format(endDate)).append("\n");
         } else if (logEndDate != null) {
-            summary.append("end_date=").append(sdf.format(logEndDate)).append("\n");
+            summary.append("end_date=").append(formatter.format(logEndDate)).append("\n");
         }
 
         // write out the archive stats
@@ -813,8 +810,7 @@ public class LogAnalyser {
         }
 
         // insert the analysis processing time information
-        Calendar endTime = new GregorianCalendar();
-        long timeInMillis = (endTime.getTimeInMillis() - startTime.getTimeInMillis());
+        long timeInMillis = Instant.now().toEpochMilli() - startTime.toEpochMilli();
         summary.append("analysis_process_time=")
                 .append(Long.toString(timeInMillis / 1000)).append("\n");
 
@@ -1072,13 +1068,13 @@ public class LogAnalyser {
      * @return a date object containing the date, with the time set to
      * 00:00:00
      */
-    public static Date parseDate(String date) {
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy'-'MM'-'dd");
-        Date parsedDate = null;
+    public static LocalDate parseDate(String date) {
+        DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE;
+        LocalDate parsedDate = null;
 
         try {
-            parsedDate = sdf.parse(date);
-        } catch (ParseException e) {
+            parsedDate = LocalDate.parse(date, formatter);
+        } catch (DateTimeParseException e) {
             System.out.println("The date is not in the correct format");
             System.exit(0);
         }
@@ -1092,11 +1088,8 @@ public class LogAnalyser {
      * @param date the date to be converted
      * @return A string of the form YYYY-MM-DD
      */
-    public static String unParseDate(Date date) {
-        // Use SimpleDateFormat
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy'-'MM'-'dd'T'hh:mm:ss'Z'");
-        sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
-        return sdf.format(date);
+    public static String unParseDate(LocalDate date) {
+        return DateTimeFormatter.ISO_INSTANT.format(date);
     }
 
 

--- a/dspace-api/src/main/java/org/dspace/app/statistics/LogAnalyser.java
+++ b/dspace-api/src/main/java/org/dspace/app/statistics/LogAnalyser.java
@@ -1089,7 +1089,7 @@ public class LogAnalyser {
      * @return A string of the form YYYY-MM-DD
      */
     public static String unParseDate(LocalDate date) {
-        return DateTimeFormatter.ISO_INSTANT.format(date);
+        return DateTimeFormatter.ISO_LOCAL_DATE.format(date);
     }
 
 

--- a/dspace-api/src/main/java/org/dspace/app/statistics/LogLine.java
+++ b/dspace-api/src/main/java/org/dspace/app/statistics/LogLine.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.app.statistics;
 
-import java.util.Date;
+import java.time.LocalDate;
 
 /**
  * This class represents a single log file line and the operations that can be
@@ -22,7 +22,7 @@ public class LogLine {
     /**
      * the date of the log file line
      */
-    private Date date = null;
+    private LocalDate date = null;
 
     /**
      * the level of the log line type
@@ -47,7 +47,7 @@ public class LogLine {
     /**
      * constructor to create new statistic
      */
-    LogLine(Date date, String level, String user, String action, String params) {
+    LogLine(LocalDate date, String level, String user, String action, String params) {
         this.date = date;
         this.level = level;
         this.user = user;
@@ -60,8 +60,8 @@ public class LogLine {
      *
      * @return the date of this log line
      */
-    public Date getDate() {
-        return this.date == null ? null : new Date(this.date.getTime());
+    public LocalDate getDate() {
+        return this.date;
     }
 
 
@@ -108,12 +108,12 @@ public class LogLine {
     /**
      * find out if this log file line is before the given date
      *
-     * @param date the date to be compared to
+     * @param compareDate the date to be compared to
      * @return true if the line is before the given date, false if not
      */
-    public boolean beforeDate(Date date) {
-        if (date != null) {
-            return (date.compareTo(this.date) >= 0);
+    public boolean beforeDate(LocalDate compareDate) {
+        if (compareDate != null) {
+            return this.date.isBefore(compareDate);
         }
         return false;
     }
@@ -122,12 +122,12 @@ public class LogLine {
     /**
      * find out if this log file line is after the given date
      *
-     * @param date the date to be compared to
+     * @param compareDate the date to be compared to
      * @return true if the line is after the given date, false if not
      */
-    public boolean afterDate(Date date) {
-        if (date != null) {
-            return (date.compareTo(this.date) <= 0);
+    public boolean afterDate(LocalDate compareDate) {
+        if (compareDate != null) {
+            return this.date.isAfter(compareDate);
         }
         return false;
     }

--- a/dspace-api/src/main/java/org/dspace/app/statistics/Report.java
+++ b/dspace-api/src/main/java/org/dspace/app/statistics/Report.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.app.statistics;
 
-import java.util.Date;
+import java.time.LocalDate;
 
 /**
  * Sn interface to a generic report generating
@@ -120,12 +120,12 @@ public interface Report {
      *
      * @param start the start date for the report
      */
-    public abstract void setStartDate(Date start);
+    public abstract void setStartDate(LocalDate start);
 
     /**
      * set the end date for the report
      *
      * @param end the end date for the report
      */
-    public abstract void setEndDate(Date end);
+    public abstract void setEndDate(LocalDate end);
 }

--- a/dspace-api/src/main/java/org/dspace/app/statistics/ReportGenerator.java
+++ b/dspace-api/src/main/java/org/dspace/app/statistics/ReportGenerator.java
@@ -13,12 +13,11 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -132,12 +131,12 @@ public class ReportGenerator {
     /**
      * start date of this report
      */
-    private static Date startDate = null;
+    private static LocalDate startDate = null;
 
     /**
      * end date of this report
      */
-    private static Date endDate = null;
+    private static LocalDate endDate = null;
 
     /**
      * the time taken to build the aggregation file from the log
@@ -175,7 +174,7 @@ public class ReportGenerator {
     /**
      * process timing clock
      */
-    private static Calendar startTime = null;
+    private static Instant startTime = null;
 
     /**
      * a map from log file action to human readable action
@@ -326,7 +325,7 @@ public class ReportGenerator {
     public static void processReport(Context context, Report report,
                                      String myInput)
         throws Exception, SQLException {
-        startTime = new GregorianCalendar();
+        startTime = Instant.now();
 
         /** instantiate aggregators */
         actionAggregator = new HashMap<>();
@@ -492,8 +491,7 @@ public class ReportGenerator {
         report.addBlock(levels);
 
         // get the display processing time information
-        Calendar endTime = new GregorianCalendar();
-        long timeInMillis = (endTime.getTimeInMillis() - startTime.getTimeInMillis());
+        long timeInMillis = Instant.now().toEpochMilli() - startTime.toEpochMilli();
         int outputProcessTime = (int) (timeInMillis / 1000);
 
         // prepare the processing information statistics
@@ -666,7 +664,7 @@ public class ReportGenerator {
 
         // first initialise a date format object to do our date processing
         // if necessary
-        SimpleDateFormat sdf = new SimpleDateFormat("dd'/'MM'/'yyyy");
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd'/'MM'/'yyyy");
 
         // FIXME: although this works, it is not very elegant
         // loop through the aggregator file and read in the values
@@ -738,9 +736,9 @@ public class ReportGenerator {
             } else if ("service_name".equals(section)) {
                 name = value;
             } else if ("start_date".equals(section)) {
-                startDate = sdf.parse(value);
+                startDate = LocalDate.parse(value, formatter);
             } else if ("end_date".equals(section)) {
-                endDate = sdf.parse(value);
+                endDate = LocalDate.parse(value, formatter);
             } else if ("analysis_process_time".equals(section)) {
                 processTime = Integer.parseInt(value);
             } else if ("general_summary".equals(section)) {

--- a/dspace-api/src/main/java/org/dspace/app/statistics/StatisticsLoader.java
+++ b/dspace-api/src/main/java/org/dspace/app/statistics/StatisticsLoader.java
@@ -11,6 +11,7 @@ import java.io.File;
 import java.io.FilenameFilter;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
@@ -103,7 +104,7 @@ public class StatisticsLoader {
         int i = 0;
         for (String date : keys) {
             try {
-                dates[i] = LocalDate.parse(date, monthlySDF.get());
+                dates[i] = YearMonth.parse(date, monthlySDF.get()).atDay(1);
             } catch (DateTimeParseException pe) {
                 //ignore
             }

--- a/dspace-api/src/main/java/org/dspace/app/statistics/StatisticsLoader.java
+++ b/dspace-api/src/main/java/org/dspace/app/statistics/StatisticsLoader.java
@@ -9,19 +9,19 @@ package org.dspace.app.statistics;
 
 import java.io.File;
 import java.io.FilenameFilter;
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Comparator;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.lang3.time.DateUtils;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 
@@ -35,7 +35,7 @@ public class StatisticsLoader {
     private static StatsFile generalAnalysis = null;
     private static StatsFile generalReport = null;
 
-    private static Date lastLoaded = null;
+    private static Instant lastLoaded = null;
     private static int fileCount = 0;
 
     private static Pattern analysisMonthlyPattern;
@@ -43,8 +43,8 @@ public class StatisticsLoader {
     private static Pattern reportMonthlyPattern;
     private static Pattern reportGeneralPattern;
 
-    private static ThreadLocal<DateFormat> monthlySDF;
-    private static ThreadLocal<DateFormat> generalSDF;
+    private static ThreadLocal<DateTimeFormatter> monthlySDF;
+    private static ThreadLocal<DateTimeFormatter> generalSDF;
 
     // one time initialisation of the regex patterns and formatters we will use
     static {
@@ -53,17 +53,17 @@ public class StatisticsLoader {
         reportMonthlyPattern = Pattern.compile("report-([0-9][0-9][0-9][0-9]-[0-9]+)\\.html");
         reportGeneralPattern = Pattern.compile("report-general-([0-9]+-[0-9]+-[0-9]+)\\.html");
 
-        monthlySDF = new ThreadLocal<DateFormat>() {
+        monthlySDF = new ThreadLocal<DateTimeFormatter>() {
             @Override
-            protected DateFormat initialValue() {
-                return new SimpleDateFormat("yyyy'-'M");
+            protected DateTimeFormatter initialValue() {
+                return DateTimeFormatter.ofPattern("yyyy'-'M");
             }
         };
 
-        generalSDF = new ThreadLocal<DateFormat>() {
+        generalSDF = new ThreadLocal<DateTimeFormatter>() {
             @Override
-            protected DateFormat initialValue() {
-                return new SimpleDateFormat("yyyy'-'M'-'dd");
+            protected DateTimeFormatter initialValue() {
+                return DateTimeFormatter.ofPattern("yyyy'-'M'-'dd");
             }
         };
     }
@@ -78,7 +78,7 @@ public class StatisticsLoader {
      *
      * @return array of dates
      */
-    public static Date[] getMonthlyReportDates() {
+    public static LocalDate[] getMonthlyReportDates() {
         return sortDatesDescending(getDatesFromMap(monthlyReports));
     }
 
@@ -87,7 +87,7 @@ public class StatisticsLoader {
      *
      * @return array of dates
      */
-    public static Date[] getMonthlyAnalysisDates() {
+    public static LocalDate[] getMonthlyAnalysisDates() {
         return sortDatesDescending(getDatesFromMap(monthlyAnalysis));
     }
 
@@ -97,15 +97,15 @@ public class StatisticsLoader {
      * @param monthlyMap map
      * @return array of dates
      */
-    protected static Date[] getDatesFromMap(Map<String, StatsFile> monthlyMap) {
+    protected static LocalDate[] getDatesFromMap(Map<String, StatsFile> monthlyMap) {
         Set<String> keys = monthlyMap.keySet();
-        Date[] dates = new Date[keys.size()];
+        LocalDate[] dates = new LocalDate[keys.size()];
         int i = 0;
         for (String date : keys) {
             try {
-                dates[i] = monthlySDF.get().parse(date);
-            } catch (ParseException pe) {
-                // ignore
+                dates[i] = LocalDate.parse(date, monthlySDF.get());
+            } catch (DateTimeParseException pe) {
+                //ignore
             }
 
             i++;
@@ -120,19 +120,19 @@ public class StatisticsLoader {
      * @param dates array of dates
      * @return sorted dates.
      */
-    protected static Date[] sortDatesDescending(Date[] dates) {
-        Arrays.sort(dates, new Comparator<Date>() {
+    protected static LocalDate[] sortDatesDescending(LocalDate[] dates) {
+        Arrays.sort(dates, new Comparator<LocalDate>() {
             @Override
-            public int compare(Date d1, Date d2) {
+            public int compare(LocalDate d1, LocalDate d2) {
                 if (d1 == null && d2 == null) {
                     return 0;
                 } else if (d1 == null) {
                     return -1;
                 } else if (d2 == null) {
                     return 1;
-                } else if (d1.before(d2)) {
+                } else if (d1.isBefore(d2)) {
                     return 1;
-                } else if (d2.before(d1)) {
+                } else if (d2.isBefore(d1)) {
                     return -1;
                 }
 
@@ -203,7 +203,7 @@ public class StatisticsLoader {
             StatisticsLoader.loadFileList(fileList);
         } else if (lastLoaded == null) {
             StatisticsLoader.loadFileList(fileList);
-        } else if (DateUtils.addHours(lastLoaded, 1).before(new Date())) {
+        } else if (Instant.now().isAfter(lastLoaded.plus(1, ChronoUnit.HOURS))) {
             StatisticsLoader.loadFileList(fileList);
         }
     }
@@ -256,7 +256,7 @@ public class StatisticsLoader {
                     statsFile = makeStatsFile(thisFile, analysisGeneralPattern, generalSDF.get());
                     if (statsFile != null) {
                         // If it is, ensure that we are pointing to the most recent file
-                        if (newGeneralAnalysis == null || statsFile.date.after(newGeneralAnalysis.date)) {
+                        if (newGeneralAnalysis == null || statsFile.date.isAfter(newGeneralAnalysis.date)) {
                             newGeneralAnalysis = statsFile;
                         }
                     }
@@ -268,7 +268,7 @@ public class StatisticsLoader {
                     statsFile = makeStatsFile(thisFile, reportGeneralPattern, generalSDF.get());
                     if (statsFile != null) {
                         // If it is, ensure that we are pointing to the most recent file
-                        if (newGeneralReport == null || statsFile.date.after(newGeneralReport.date)) {
+                        if (newGeneralReport == null || statsFile.date.isAfter(newGeneralReport.date)) {
                             newGeneralReport = statsFile;
                         }
                     }
@@ -281,7 +281,7 @@ public class StatisticsLoader {
         monthlyReports = newMonthlyReports;
         generalAnalysis = newGeneralAnalysis;
         generalReport = newGeneralReport;
-        lastLoaded = new Date();
+        lastLoaded = Instant.now();
     }
 
     /**
@@ -292,10 +292,10 @@ public class StatisticsLoader {
      *
      * @param thisFile    file
      * @param thisPattern pattern
-     * @param sdf         date format
+     * @param formatter   date formatter
      * @return StatsFile
      */
-    private static StatsFile makeStatsFile(File thisFile, Pattern thisPattern, DateFormat sdf) {
+    private static StatsFile makeStatsFile(File thisFile, Pattern thisPattern, DateTimeFormatter formatter) {
         Matcher matcher = thisPattern.matcher(thisFile.getName());
         if (matcher.matches()) {
             StatsFile sf = new StatsFile();
@@ -304,8 +304,8 @@ public class StatisticsLoader {
             sf.dateStr = matcher.group(1).trim();
 
             try {
-                sf.date = sdf.parse(sf.dateStr);
-            } catch (ParseException e) {
+                sf.date = LocalDate.parse(sf.dateStr, formatter);
+            } catch (DateTimeParseException e) {
                 // ignore
             }
 
@@ -333,7 +333,7 @@ public class StatisticsLoader {
     private static class StatsFile {
         File file;
         String path;
-        Date date;
+        LocalDate date;
         String dateStr;
     }
 

--- a/dspace-api/src/main/java/org/dspace/app/suggestion/openaire/DateScorer.java
+++ b/dspace-api/src/main/java/org/dspace/app/suggestion/openaire/DateScorer.java
@@ -7,10 +7,8 @@
  */
 package org.dspace.app.suggestion.openaire;
 
-import java.util.Calendar;
+import java.time.LocalDateTime;
 import java.util.Collections;
-import java.util.Date;
-import java.util.GregorianCalendar;
 import java.util.List;
 
 import org.dspace.app.suggestion.SuggestionEvidence;
@@ -202,11 +200,9 @@ public class DateScorer implements EvidenceScorer {
     private int getYear(String birthDateStr) {
         int birthDateYear = -1;
         if (birthDateStr != null) {
-            Date birthDate = MultiFormatDateParser.parse(birthDateStr);
+            LocalDateTime birthDate = MultiFormatDateParser.parse(birthDateStr).toLocalDateTime();
             if (birthDate != null) {
-                Calendar calendar = new GregorianCalendar();
-                calendar.setTime(birthDate);
-                birthDateYear = calendar.get(Calendar.YEAR);
+                birthDateYear = birthDate.getYear();
             }
         }
         return birthDateYear;

--- a/dspace-api/src/main/java/org/dspace/app/util/AbstractDSpaceWebapp.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/AbstractDSpaceWebapp.java
@@ -9,8 +9,7 @@
 package org.dspace.app.util;
 
 import java.sql.SQLException;
-import java.sql.Timestamp;
-import java.util.Date;
+import java.time.Instant;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -35,7 +34,7 @@ abstract public class AbstractDSpaceWebapp
 
     protected String kind;
 
-    protected Date started;
+    protected Instant started;
 
     protected String url;
 
@@ -55,7 +54,7 @@ abstract public class AbstractDSpaceWebapp
     public AbstractDSpaceWebapp(String kind) {
         this.kind = kind;
 
-        started = new Date();
+        started = Instant.now();
 
         ConfigurationService configurationService
                 = DSpaceServicesFactory.getInstance().getConfigurationService();
@@ -70,10 +69,9 @@ abstract public class AbstractDSpaceWebapp
      */
     public void register() {
         // Create the database entry
-        Timestamp now = new Timestamp(started.getTime());
         try {
             Context context = new Context();
-            webApp = webAppService.create(context, kind, url, now, isUI() ? 1 : 0);
+            webApp = webAppService.create(context, kind, url, started, isUI() ? 1 : 0);
             context.complete();
         } catch (SQLException e) {
             log.error("Failed to record startup in Webapp table.", e);

--- a/dspace-api/src/main/java/org/dspace/app/util/SyndicationFeed.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/SyndicationFeed.java
@@ -9,8 +9,9 @@ package org.dspace.app.util;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -215,7 +216,7 @@ public class SyndicationFeed {
 
         feed.setDescription(defaultDescriptionField);
         feed.setLink(objectURL);
-        feed.setPublishedDate(new Date());
+        feed.setPublishedDate(java.util.Date.from(Instant.now()));
         feed.setUri(objectURL);
 
         // add logo if we found one:
@@ -253,13 +254,14 @@ public class SyndicationFeed {
                 entry.setTitle(title == null ? localize(labels, MSG_UNTITLED) : title);
 
                 // "published" date -- should be dc.date.issued
-                String pubDate = getOneDC(item, dateField);
-                if (pubDate != null) {
-                    entry.setPublishedDate((new DCDate(pubDate)).toDate());
+                String pubDateString = getOneDC(item, dateField);
+                if (pubDateString != null) {
+                    ZonedDateTime pubDate = new DCDate(pubDateString).toDate();
+                    entry.setPublishedDate(java.util.Date.from(pubDate.toInstant()));
                     hasDate = true;
                 }
                 // date of last change to Item
-                entry.setUpdatedDate(item.getLastModified());
+                entry.setUpdatedDate(java.util.Date.from(item.getLastModified()));
 
                 StringBuilder db = new StringBuilder();
                 for (String df : descriptionFields) {
@@ -324,7 +326,8 @@ public class SyndicationFeed {
                     if (dcDateField != null && !hasDate) {
                         List<MetadataValue> v = itemService.getMetadataByMetadataString(item, dcDateField);
                         if (v.size() > 0) {
-                            dc.setDate((new DCDate(v.get(0).getValue())).toDate());
+                            ZonedDateTime dateTime = (new DCDate(v.get(0).getValue())).toDate();
+                            dc.setDate(java.util.Date.from(dateTime.toInstant()));
                         }
                     }
                     if (dcDescriptionField != null) {

--- a/dspace-api/src/main/java/org/dspace/app/util/WebApp.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/WebApp.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.app.util;
 
-import java.util.Date;
+import java.time.Instant;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -16,8 +16,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
-import jakarta.persistence.Temporal;
-import jakarta.persistence.TemporalType;
 import org.dspace.core.Context;
 import org.dspace.core.ReloadableEntity;
 
@@ -43,16 +41,15 @@ public class WebApp implements ReloadableEntity<Integer> {
     @Column(name = "url")
     private String url;
 
-    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "started")
-    private Date started;
+    private Instant started;
 
     @Column(name = "isui")
     private Integer isui;
 
     /**
      * Protected constructor, create object using:
-     * {@link org.dspace.app.util.service.WebAppService#create(Context, String, String, Date, int)}
+     * {@link org.dspace.app.util.service.WebAppService#create(Context, String, String, Instant, int)}
      */
     protected WebApp() {
 
@@ -79,11 +76,11 @@ public class WebApp implements ReloadableEntity<Integer> {
         this.url = url;
     }
 
-    public Date getStarted() {
+    public Instant getStarted() {
         return started;
     }
 
-    public void setStarted(Date started) {
+    public void setStarted(Instant started) {
         this.started = started;
     }
 

--- a/dspace-api/src/main/java/org/dspace/app/util/WebAppServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/WebAppServiceImpl.java
@@ -9,8 +9,8 @@ package org.dspace.app.util;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 import org.apache.http.HttpResponse;
@@ -44,7 +44,7 @@ public class WebAppServiceImpl implements WebAppService {
     }
 
     @Override
-    public WebApp create(Context context, String appName, String url, Date started, int isUI) throws SQLException {
+    public WebApp create(Context context, String appName, String url, Instant started, int isUI) throws SQLException {
         WebApp webApp = webAppDAO.create(context, new WebApp());
         webApp.setAppName(appName);
         webApp.setUrl(url);

--- a/dspace-api/src/main/java/org/dspace/app/util/service/WebAppService.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/service/WebAppService.java
@@ -8,7 +8,7 @@
 package org.dspace.app.util.service;
 
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 
 import org.dspace.app.util.WebApp;
@@ -23,7 +23,7 @@ import org.dspace.core.Context;
  */
 public interface WebAppService {
 
-    public WebApp create(Context context, String appName, String url, Date started, int isUI) throws SQLException;
+    public WebApp create(Context context, String appName, String url, Instant started, int isUI) throws SQLException;
 
     public List<WebApp> findAll(Context context) throws SQLException;
 

--- a/dspace-api/src/main/java/org/dspace/authenticate/AuthenticationServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/AuthenticationServiceImpl.java
@@ -8,9 +8,9 @@
 package org.dspace.authenticate;
 
 import java.sql.SQLException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 
@@ -124,7 +124,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
     public void updateLastActiveDate(Context context) {
         EPerson me = context.getCurrentUser();
         if (me != null) {
-            me.setLastActive(new Date());
+            me.setLastActive(Instant.now());
             try {
                 ePersonService.update(context, me);
             } catch (SQLException ex) {

--- a/dspace-api/src/main/java/org/dspace/authority/AuthorityValue.java
+++ b/dspace-api/src/main/java/org/dspace/authority/AuthorityValue.java
@@ -172,8 +172,8 @@ public class AuthorityValue {
         this.field = String.valueOf(document.getFieldValue("field"));
         this.value = String.valueOf(document.getFieldValue("value"));
         this.deleted = (Boolean) document.getFieldValue("deleted");
-        this.creationDate = Instant.parse((String) document.getFieldValue("creation_date"));
-        this.lastModified = Instant.parse((String) document.getFieldValue("last_modified_date"));
+        this.creationDate = ((java.util.Date) document.getFieldValue("creation_date")).toInstant();
+        this.lastModified = ((java.util.Date) document.getFieldValue("last_modified_date")).toInstant();
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/authority/AuthorityValue.java
+++ b/dspace-api/src/main/java/org/dspace/authority/AuthorityValue.java
@@ -8,13 +8,12 @@
 package org.dspace.authority;
 
 import java.sql.SQLException;
-import java.text.DateFormat;
 import java.time.DateTimeException;
+import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -56,7 +55,7 @@ public class AuthorityValue {
     /**
      * When this authority record has been created
      */
-    private Date creationDate;
+    private Instant creationDate;
 
     /**
      * If this authority has been removed
@@ -66,7 +65,7 @@ public class AuthorityValue {
     /**
      * represents the last time that DSpace got updated information from its external source
      */
-    private Date lastModified;
+    private Instant lastModified;
 
     public AuthorityValue() {
     }
@@ -99,11 +98,11 @@ public class AuthorityValue {
         this.value = value;
     }
 
-    public Date getCreationDate() {
+    public Instant getCreationDate() {
         return creationDate;
     }
 
-    public void setCreationDate(Date creationDate) {
+    public void setCreationDate(Instant creationDate) {
         this.creationDate = creationDate;
     }
 
@@ -111,7 +110,7 @@ public class AuthorityValue {
         this.creationDate = stringToDate(creationDate);
     }
 
-    public Date getLastModified() {
+    public Instant getLastModified() {
         return lastModified;
     }
 
@@ -119,7 +118,7 @@ public class AuthorityValue {
         this.lastModified = stringToDate(lastModified);
     }
 
-    public void setLastModified(Date lastModified) {
+    public void setLastModified(Instant lastModified) {
         this.lastModified = lastModified;
     }
 
@@ -132,7 +131,7 @@ public class AuthorityValue {
     }
 
     protected void updateLastModifiedDate() {
-        this.lastModified = new Date();
+        this.lastModified = Instant.now();
     }
 
     public void update() {
@@ -152,7 +151,7 @@ public class AuthorityValue {
     public SolrInputDocument getSolrInputDocument() {
 
         SolrInputDocument doc = new SolrInputDocument();
-        DateFormat solrDateFormatter = SolrUtils.getDateFormatter();
+        DateTimeFormatter solrDateFormatter = SolrUtils.getDateFormatter();
         doc.addField("id", getId());
         doc.addField("field", getField());
         doc.addField("value", getValue());
@@ -173,8 +172,8 @@ public class AuthorityValue {
         this.field = String.valueOf(document.getFieldValue("field"));
         this.value = String.valueOf(document.getFieldValue("value"));
         this.deleted = (Boolean) document.getFieldValue("deleted");
-        this.creationDate = (Date) document.getFieldValue("creation_date");
-        this.lastModified = (Date) document.getFieldValue("last_modified_date");
+        this.creationDate = Instant.parse((String) document.getFieldValue("creation_date"));
+        this.lastModified = Instant.parse((String) document.getFieldValue("last_modified_date"));
     }
 
     /**
@@ -206,7 +205,7 @@ public class AuthorityValue {
      * Build a list of ISO date formatters to parse various forms.
      *
      * <p><strong>Note:</strong>  any formatter which does not parse a zone or
-     * offset must have a default zone set.  See {@link stringToDate}.
+     * offset must have a default zone set.  See {@link #stringToDate(String)}.
      *
      * @return the formatters.
      */
@@ -224,13 +223,13 @@ public class AuthorityValue {
      * @param date serialized date to be converted.
      * @return converted date, or null if no parser accepted the input.
      */
-    static public Date stringToDate(String date) {
-        Date result = null;
+    static public Instant stringToDate(String date) {
+        Instant result = null;
         if (StringUtils.isNotBlank(date)) {
             for (DateTimeFormatter formatter : getDateFormatters()) {
                 try {
                     ZonedDateTime dateTime = ZonedDateTime.parse(date, formatter);
-                    result = Date.from(dateTime.toInstant());
+                    result = dateTime.toInstant();
                     break;
                 } catch (DateTimeException e) {
                     log.debug("Input '{}' did not match {}", date, formatter);

--- a/dspace-api/src/main/java/org/dspace/authority/AuthorityValueServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authority/AuthorityValueServiceImpl.java
@@ -7,8 +7,8 @@
  */
 package org.dspace.authority;
 
+import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -67,7 +67,7 @@ public class AuthorityValueServiceImpl implements AuthorityValueService {
 
             nextValue.setId(authorityKey);
             nextValue.updateLastModifiedDate();
-            nextValue.setCreationDate(new Date());
+            nextValue.setCreationDate(Instant.now());
             nextValue.setField(field);
         }
 

--- a/dspace-api/src/main/java/org/dspace/authority/orcid/Orcidv3AuthorityValue.java
+++ b/dspace-api/src/main/java/org/dspace/authority/orcid/Orcidv3AuthorityValue.java
@@ -7,9 +7,9 @@
  */
 package org.dspace.authority.orcid;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -84,7 +84,7 @@ public class Orcidv3AuthorityValue extends PersonAuthorityValue {
         Orcidv3AuthorityValue orcidAuthorityValue = new Orcidv3AuthorityValue();
         orcidAuthorityValue.setId(UUID.randomUUID().toString());
         orcidAuthorityValue.updateLastModifiedDate();
-        orcidAuthorityValue.setCreationDate(new Date());
+        orcidAuthorityValue.setCreationDate(Instant.now());
         return orcidAuthorityValue;
     }
 

--- a/dspace-api/src/main/java/org/dspace/authorize/AuthorizeServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/AuthorizeServiceImpl.java
@@ -11,9 +11,9 @@ import static org.dspace.app.util.AuthorizeUtil.canCollectionAdminManageAccounts
 import static org.dspace.app.util.AuthorizeUtil.canCommunityAdminManageAccounts;
 
 import java.sql.SQLException;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
@@ -662,7 +662,8 @@ public class AuthorizeServiceImpl implements AuthorizeService {
     @Override
     public ResourcePolicy createResourcePolicy(Context context, DSpaceObject dso, Group group, EPerson eperson,
                                                int type, String rpType, String rpName, String rpDescription,
-                                               Date startDate, Date endDate) throws SQLException, AuthorizeException {
+                                               LocalDate startDate, LocalDate endDate)
+        throws SQLException, AuthorizeException {
         if (group == null && eperson == null) {
             throw new IllegalArgumentException(
                 "We need at least an eperson or a group in order to create a resource policy.");
@@ -684,7 +685,7 @@ public class AuthorizeServiceImpl implements AuthorizeService {
     @Override
     public ResourcePolicy createOrModifyPolicy(ResourcePolicy policy, Context context, String name, Group group,
                                                EPerson ePerson,
-                                               Date embargoDate, int action, String reason, DSpaceObject dso)
+                                               LocalDate embargoDate, int action, String reason, DSpaceObject dso)
         throws AuthorizeException, SQLException {
         ResourcePolicy policyTemp = null;
         if (policy != null) {

--- a/dspace-api/src/main/java/org/dspace/authorize/PolicySet.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/PolicySet.java
@@ -8,7 +8,7 @@
 package org.dspace.authorize;
 
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
@@ -146,7 +146,7 @@ public class PolicySet {
     public static void setPolicies(Context c, int containerType,
                                    UUID containerID, int contentType, int actionID, UUID groupID,
                                    boolean isReplace, boolean clearOnly,
-                                   String name, String description, Date startDate, Date endDate)
+                                   String name, String description, LocalDate startDate, LocalDate endDate)
         throws SQLException, AuthorizeException {
         setPoliciesFilter(c, containerType, containerID, contentType,
                           actionID, groupID, isReplace, clearOnly, null, name, description, startDate, endDate);
@@ -207,7 +207,7 @@ public class PolicySet {
     public static void setPoliciesFilter(Context c, int containerType,
                                          UUID containerID, int contentType, int actionID, UUID groupID,
                                          boolean isReplace, boolean clearOnly, String filter,
-                                         String name, String description, Date startDate, Date endDate)
+                                         String name, String description, LocalDate startDate, LocalDate endDate)
         throws SQLException, AuthorizeException {
         if (containerType == Constants.COLLECTION) {
             Collection collection = collectionService.find(c, containerID);

--- a/dspace-api/src/main/java/org/dspace/authorize/ResourcePolicy.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/ResourcePolicy.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.authorize;
 
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.Objects;
 
 import jakarta.persistence.CascadeType;
@@ -21,8 +21,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
-import jakarta.persistence.Temporal;
-import jakarta.persistence.TemporalType;
 import org.apache.solr.common.StringUtils;
 import org.dspace.content.DSpaceObject;
 import org.dspace.core.Context;
@@ -84,12 +82,10 @@ public class ResourcePolicy implements ReloadableEntity<Integer> {
     private Group epersonGroup;
 
     @Column(name = "start_date")
-    @Temporal(TemporalType.DATE)
-    private Date startDate;
+    private LocalDate startDate;
 
     @Column(name = "end_date")
-    @Temporal(TemporalType.DATE)
-    private Date endDate;
+    private LocalDate endDate;
 
     @Column(name = "rpname", length = 30)
     private String rpname;
@@ -247,7 +243,7 @@ public class ResourcePolicy implements ReloadableEntity<Integer> {
      * @return start date, or null if there is no start date set (probably most
      * common case)
      */
-    public java.util.Date getStartDate() {
+    public LocalDate getStartDate() {
         return startDate;
     }
 
@@ -256,7 +252,7 @@ public class ResourcePolicy implements ReloadableEntity<Integer> {
      *
      * @param d date, or null for no start date
      */
-    public void setStartDate(java.util.Date d) {
+    public void setStartDate(LocalDate d) {
         startDate = d;
     }
 
@@ -265,7 +261,7 @@ public class ResourcePolicy implements ReloadableEntity<Integer> {
      *
      * @return end date or null for no end date
      */
-    public java.util.Date getEndDate() {
+    public LocalDate getEndDate() {
         return endDate;
     }
 
@@ -274,7 +270,7 @@ public class ResourcePolicy implements ReloadableEntity<Integer> {
      *
      * @param d end date, or null
      */
-    public void setEndDate(java.util.Date d) {
+    public void setEndDate(LocalDate d) {
         this.endDate = d;
     }
 

--- a/dspace-api/src/main/java/org/dspace/authorize/ResourcePolicy.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/ResourcePolicy.java
@@ -306,6 +306,7 @@ public class ResourcePolicy implements ReloadableEntity<Integer> {
     public String toString() {
         return "ResourcePolicy{" +
             "id='" + id + '\'' +
+            ", action_id='" + actionId + '\'' +
             ", eperson='" + eperson + '\'' +
             ", group='" + epersonGroup + '\'' +
             ", type='" + rptype + '\'' +

--- a/dspace-api/src/main/java/org/dspace/authorize/ResourcePolicy.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/ResourcePolicy.java
@@ -297,4 +297,22 @@ public class ResourcePolicy implements ReloadableEntity<Integer> {
     public void setRpDescription(String description) {
         this.rpdescription = description;
     }
+
+    /**
+     * Describe the ResourcePolicy in String form. Useful for debugging ResourcePolicy issues in tests or similar.
+     * @return String representation of ResourcePolicy object
+     */
+    @Override
+    public String toString() {
+        return "ResourcePolicy{" +
+            "id='" + id + '\'' +
+            ", eperson='" + eperson + '\'' +
+            ", group='" + epersonGroup + '\'' +
+            ", type='" + rptype + '\'' +
+            ", name='" + rpname + '\'' +
+            ", description='" + rpdescription + '\'' +
+            ", start_date='" + startDate + '\'' +
+            ", end_date='" + endDate + '\'' +
+            '}';
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/authorize/ResourcePolicyServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/ResourcePolicyServiceImpl.java
@@ -8,8 +8,8 @@
 package org.dspace.authorize;
 
 import java.sql.SQLException;
+import java.time.LocalDate;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -183,8 +183,8 @@ public class ResourcePolicyServiceImpl implements ResourcePolicyService {
      */
     @Override
     public boolean isDateValid(ResourcePolicy resourcePolicy) {
-        Date sd = resourcePolicy.getStartDate();
-        Date ed = resourcePolicy.getEndDate();
+        LocalDate sd = resourcePolicy.getStartDate();
+        LocalDate ed = resourcePolicy.getEndDate();
 
         // if no dates set, return true (most common case)
         if ((sd == null) && (ed == null)) {
@@ -192,16 +192,16 @@ public class ResourcePolicyServiceImpl implements ResourcePolicyService {
         }
 
         // one is set, now need to do some date math
-        Date now = new Date();
+        LocalDate now = LocalDate.now();
 
         // check start date first
-        if (sd != null && now.before(sd)) {
+        if (sd != null && now.isBefore(sd)) {
             // start date is set, return false if we're before it
             return false;
         }
 
         // now expiration date
-        if (ed != null && now.after(ed)) {
+        if (ed != null && now.isAfter(ed)) {
             // end date is set, return false if we're after it
             return false;
         }
@@ -214,10 +214,10 @@ public class ResourcePolicyServiceImpl implements ResourcePolicyService {
     public ResourcePolicy clone(Context context, ResourcePolicy resourcePolicy)
         throws SQLException, AuthorizeException {
         ResourcePolicy clone = create(context, resourcePolicy.getEPerson(), resourcePolicy.getGroup());
-        clone.setStartDate((Date) ObjectUtils.clone(resourcePolicy.getStartDate()));
-        clone.setEndDate((Date) ObjectUtils.clone(resourcePolicy.getEndDate()));
-        clone.setRpType((String) ObjectUtils.clone(resourcePolicy.getRpType()));
-        clone.setRpDescription((String) ObjectUtils.clone(resourcePolicy.getRpDescription()));
+        clone.setStartDate(ObjectUtils.clone(resourcePolicy.getStartDate()));
+        clone.setEndDate(ObjectUtils.clone(resourcePolicy.getEndDate()));
+        clone.setRpType(ObjectUtils.clone(resourcePolicy.getRpType()));
+        clone.setRpDescription(ObjectUtils.clone(resourcePolicy.getRpDescription()));
         update(context, clone);
         return clone;
     }

--- a/dspace-api/src/main/java/org/dspace/authorize/service/AuthorizeService.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/service/AuthorizeService.java
@@ -8,7 +8,7 @@
 package org.dspace.authorize.service;
 
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.List;
 
 import org.dspace.authorize.AuthorizeException;
@@ -475,10 +475,11 @@ public interface AuthorizeService {
 
     public ResourcePolicy createResourcePolicy(Context context, DSpaceObject dso, Group group, EPerson eperson,
                                                int type, String rpType, String rpName, String rpDescription,
-                                               Date startDate, Date endDate) throws SQLException, AuthorizeException;
+                                               LocalDate startDate, LocalDate endDate)
+        throws SQLException, AuthorizeException;
 
     public ResourcePolicy createOrModifyPolicy(ResourcePolicy policy, Context context, String name, Group group,
-                                               EPerson ePerson, Date embargoDate, int action, String reason,
+                                               EPerson ePerson, LocalDate embargoDate, int action, String reason,
                                                DSpaceObject dso) throws AuthorizeException, SQLException;
 
     /**

--- a/dspace-api/src/main/java/org/dspace/checker/CheckerCommand.java
+++ b/dspace-api/src/main/java/org/dspace/checker/CheckerCommand.java
@@ -9,7 +9,7 @@ package org.dspace.checker;
 
 import java.io.IOException;
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.Map;
 
 import org.apache.commons.collections4.MapUtils;
@@ -61,7 +61,7 @@ public final class CheckerCommand {
     /**
      * start time for current process.
      */
-    private Date processStartDate = null;
+    private Instant processStartDate = null;
 
     /**
      * Dispatcher to be used for processing run.
@@ -201,9 +201,9 @@ public final class CheckerCommand {
      * @throws SQLException if database error
      */
     protected void processDeletedBitstream(MostRecentChecksum info) throws SQLException {
-        info.setProcessStartDate(new Date());
+        info.setProcessStartDate(Instant.now());
         info.setChecksumResult(getChecksumResultByCode(ChecksumResultCode.BITSTREAM_MARKED_DELETED));
-        info.setProcessEndDate(new Date());
+        info.setProcessEndDate(Instant.now());
         info.setToBeProcessed(false);
         checksumService.update(context, info);
         checksumHistoryService.addHistory(context, info);
@@ -220,8 +220,8 @@ public final class CheckerCommand {
      */
     protected void processNullInfoBitstream(MostRecentChecksum info) throws SQLException {
         info.setInfoFound(false);
-        info.setProcessStartDate(new Date());
-        info.setProcessEndDate(new Date());
+        info.setProcessStartDate(Instant.now());
+        info.setProcessEndDate(Instant.now());
         info.setChecksumResult(getChecksumResultByCode(ChecksumResultCode.BITSTREAM_INFO_NOT_FOUND));
     }
 
@@ -242,7 +242,7 @@ public final class CheckerCommand {
      * @throws SQLException if database error
      */
     protected void processBitstream(MostRecentChecksum info) throws SQLException {
-        info.setProcessStartDate(new Date());
+        info.setProcessStartDate(Instant.now());
 
         try {
             Map<String, Object> checksumMap = bitstreamStorageService.computeChecksum(context, info.getBitstream());
@@ -279,7 +279,7 @@ public final class CheckerCommand {
             LOG.error("Error retrieving metadata for bitstream ID "
                           + info.getBitstream().getID(), e);
         } finally {
-            info.setProcessEndDate(new Date());
+            info.setProcessEndDate(Instant.now());
 
             // record new checksum and comparison result in db
             checksumService.update(context, info);
@@ -332,8 +332,8 @@ public final class CheckerCommand {
      *
      * @return start time
      */
-    public Date getProcessStartDate() {
-        return processStartDate == null ? null : new Date(processStartDate.getTime());
+    public Instant getProcessStartDate() {
+        return processStartDate;
     }
 
     /**
@@ -341,8 +341,8 @@ public final class CheckerCommand {
      *
      * @param startDate start time
      */
-    public void setProcessStartDate(Date startDate) {
-        processStartDate = startDate == null ? null : new Date(startDate.getTime());
+    public void setProcessStartDate(Instant startDate) {
+        processStartDate = startDate;
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/checker/ChecksumHistory.java
+++ b/dspace-api/src/main/java/org/dspace/checker/ChecksumHistory.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.checker;
 
-import java.util.Date;
+import java.time.Instant;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -19,8 +19,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
-import jakarta.persistence.Temporal;
-import jakarta.persistence.TemporalType;
 import org.dspace.content.Bitstream;
 import org.dspace.core.Context;
 import org.dspace.core.ReloadableEntity;
@@ -50,13 +48,11 @@ public class ChecksumHistory implements ReloadableEntity<Long> {
     @JoinColumn(name = "bitstream_id")
     private Bitstream bitstream;
 
-    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "process_start_date", nullable = false)
-    private Date processStartDate;
+    private Instant processStartDate;
 
-    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "process_end_date", nullable = false)
-    private Date processEndDate;
+    private Instant processEndDate;
 
     @Column(name = "checksum_expected", nullable = false)
     private String checksumExpected;
@@ -130,8 +126,8 @@ public class ChecksumHistory implements ReloadableEntity<Long> {
      *
      * @return Returns the processEndDate.
      */
-    public Date getProcessEndDate() {
-        return processEndDate == null ? null : new Date(processEndDate.getTime());
+    public Instant getProcessEndDate() {
+        return processEndDate;
     }
 
     /**
@@ -139,8 +135,8 @@ public class ChecksumHistory implements ReloadableEntity<Long> {
      *
      * @param processEndDate The processEndDate to set.
      */
-    public void setProcessEndDate(Date processEndDate) {
-        this.processEndDate = (processEndDate == null ? null : new Date(processEndDate.getTime()));
+    public void setProcessEndDate(Instant processEndDate) {
+        this.processEndDate = processEndDate;
     }
 
     /**
@@ -149,8 +145,8 @@ public class ChecksumHistory implements ReloadableEntity<Long> {
      *
      * @return Returns the processStartDate.
      */
-    public Date getProcessStartDate() {
-        return processStartDate == null ? null : new Date(processStartDate.getTime());
+    public Instant getProcessStartDate() {
+        return processStartDate;
     }
 
     /**
@@ -159,8 +155,8 @@ public class ChecksumHistory implements ReloadableEntity<Long> {
      *
      * @param processStartDate The processStartDate to set.
      */
-    public void setProcessStartDate(Date processStartDate) {
-        this.processStartDate = (processStartDate == null ? null : new Date(processStartDate.getTime()));
+    public void setProcessStartDate(Instant processStartDate) {
+        this.processStartDate = processStartDate;
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/checker/ChecksumHistoryServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/checker/ChecksumHistoryServiceImpl.java
@@ -8,7 +8,7 @@
 package org.dspace.checker;
 
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
@@ -94,7 +94,7 @@ public class ChecksumHistoryServiceImpl implements ChecksumHistoryService {
      * @throws SQLException if database error occurs.
      */
     @Override
-    public int deleteByDateAndCode(Context context, Date retentionDate, ChecksumResultCode checksumResultCode)
+    public int deleteByDateAndCode(Context context, Instant retentionDate, ChecksumResultCode checksumResultCode)
         throws SQLException {
         return checksumHistoryDAO.deleteByDateAndCode(context, retentionDate, checksumResultCode);
     }
@@ -109,10 +109,10 @@ public class ChecksumHistoryServiceImpl implements ChecksumHistoryService {
 
     @Override
     public int prune(Context context, Map<ChecksumResultCode, Long> interests) throws SQLException {
-        long now = System.currentTimeMillis();
+        long now = Instant.now().toEpochMilli();
         int count = 0;
         for (Map.Entry<ChecksumResultCode, Long> interest : interests.entrySet()) {
-            count += deleteByDateAndCode(context, new Date(now - interest.getValue().longValue()),
+            count += deleteByDateAndCode(context, Instant.ofEpochMilli(now - interest.getValue().longValue()),
                                          interest.getKey());
         }
         return count;

--- a/dspace-api/src/main/java/org/dspace/checker/DailyReportEmailer.java
+++ b/dspace-api/src/main/java/org/dspace/checker/DailyReportEmailer.java
@@ -11,8 +11,8 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.sql.SQLException;
-import java.util.Date;
-import java.util.GregorianCalendar;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 
 import jakarta.mail.MessagingException;
 import org.apache.commons.cli.CommandLine;
@@ -148,14 +148,9 @@ public class DailyReportEmailer {
 
         DailyReportEmailer emailer = new DailyReportEmailer();
 
-        // get dates for yesterday and tomorrow
-        GregorianCalendar calendar = new GregorianCalendar();
-        calendar.add(GregorianCalendar.DAY_OF_YEAR, -1);
-
-        Date yesterday = calendar.getTime();
-        calendar.add(GregorianCalendar.DAY_OF_YEAR, 2);
-
-        Date tomorrow = calendar.getTime();
+        // get dates for yesterday and tomorrow (start of day for both)
+        Instant yesterday = Instant.now().minus(1, ChronoUnit.DAYS).truncatedTo(ChronoUnit.DAYS);
+        Instant tomorrow = Instant.now().plus(1, ChronoUnit.DAYS).truncatedTo(ChronoUnit.DAYS);
 
         File report = null;
         FileWriter writer = null;

--- a/dspace-api/src/main/java/org/dspace/checker/LimitedDurationDispatcher.java
+++ b/dspace-api/src/main/java/org/dspace/checker/LimitedDurationDispatcher.java
@@ -8,7 +8,7 @@
 package org.dspace.checker;
 
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
 
 import org.dspace.content.Bitstream;
 
@@ -55,9 +55,9 @@ public class LimitedDurationDispatcher implements BitstreamDispatcher {
      * @param endTime    when this dispatcher will stop returning valid bitstream ids.
      */
     public LimitedDurationDispatcher(BitstreamDispatcher dispatcher,
-                                     Date endTime) {
+                                     Instant endTime) {
         delegate = dispatcher;
-        end = endTime.getTime();
+        end = endTime.toEpochMilli();
     }
 
     /**
@@ -66,6 +66,6 @@ public class LimitedDurationDispatcher implements BitstreamDispatcher {
      */
     @Override
     public Bitstream next() throws SQLException {
-        return (System.currentTimeMillis() > end) ? null : delegate.next();
+        return (Instant.now().toEpochMilli() > end) ? null : delegate.next();
     }
 }

--- a/dspace-api/src/main/java/org/dspace/checker/MostRecentChecksum.java
+++ b/dspace-api/src/main/java/org/dspace/checker/MostRecentChecksum.java
@@ -8,7 +8,7 @@
 package org.dspace.checker;
 
 import java.io.Serializable;
-import java.util.Date;
+import java.time.Instant;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -16,8 +16,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
-import jakarta.persistence.Temporal;
-import jakarta.persistence.TemporalType;
 import jakarta.persistence.Transient;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -45,13 +43,11 @@ public class MostRecentChecksum implements Serializable {
     @Column(name = "current_checksum", nullable = false)
     private String currentChecksum;
 
-    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "last_process_start_date", nullable = false)
-    private Date processStartDate;
+    private Instant processStartDate;
 
-    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "last_process_end_date", nullable = false)
-    private Date processEndDate;
+    private Instant processEndDate;
 
     @Column(name = "checksum_algorithm", nullable = false)
     private String checksumAlgorithm;
@@ -108,19 +104,19 @@ public class MostRecentChecksum implements Serializable {
         this.currentChecksum = currentChecksum;
     }
 
-    public Date getProcessStartDate() {
+    public Instant getProcessStartDate() {
         return processStartDate;
     }
 
-    public void setProcessStartDate(Date processStartDate) {
+    public void setProcessStartDate(Instant processStartDate) {
         this.processStartDate = processStartDate;
     }
 
-    public Date getProcessEndDate() {
+    public Instant getProcessEndDate() {
         return processEndDate;
     }
 
-    public void setProcessEndDate(Date processEndDate) {
+    public void setProcessEndDate(Instant processEndDate) {
         this.processEndDate = processEndDate;
     }
 

--- a/dspace-api/src/main/java/org/dspace/checker/MostRecentChecksumServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/checker/MostRecentChecksumServiceImpl.java
@@ -8,7 +8,7 @@
 package org.dspace.checker;
 
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 
 import org.apache.logging.log4j.Logger;
@@ -65,7 +65,8 @@ public class MostRecentChecksumServiceImpl implements MostRecentChecksumService 
      * @throws SQLException if database error
      */
     @Override
-    public List<MostRecentChecksum> findNotProcessedBitstreamsReport(Context context, Date startDate, Date endDate)
+    public List<MostRecentChecksum> findNotProcessedBitstreamsReport(Context context, Instant startDate,
+                                                                     Instant endDate)
         throws SQLException {
         return mostRecentChecksumDAO.findByNotProcessedInDateRange(context, startDate, endDate);
     }
@@ -82,7 +83,8 @@ public class MostRecentChecksumServiceImpl implements MostRecentChecksumService 
      * @throws SQLException if database error
      */
     @Override
-    public List<MostRecentChecksum> findBitstreamResultTypeReport(Context context, Date startDate, Date endDate,
+    public List<MostRecentChecksum> findBitstreamResultTypeReport(Context context, Instant startDate,
+                                                                  Instant endDate,
                                                                   ChecksumResultCode resultCode) throws SQLException {
         return mostRecentChecksumDAO.findByResultTypeInDateRange(context, startDate, endDate, resultCode);
     }
@@ -127,8 +129,8 @@ public class MostRecentChecksumServiceImpl implements MostRecentChecksumService 
                 mostRecentChecksum.setCurrentChecksum(bitstream.getChecksum());
                 mostRecentChecksum.setExpectedChecksum(bitstream.getChecksum());
             }
-            mostRecentChecksum.setProcessStartDate(new Date());
-            mostRecentChecksum.setProcessEndDate(new Date());
+            mostRecentChecksum.setProcessStartDate(Instant.now());
+            mostRecentChecksum.setProcessEndDate(Instant.now());
             if (bitstream.getChecksumAlgorithm() == null) {
                 mostRecentChecksum.setChecksumAlgorithm("MD5");
             } else {
@@ -175,7 +177,7 @@ public class MostRecentChecksumServiceImpl implements MostRecentChecksumService 
      * @throws SQLException if database error
      */
     @Override
-    public MostRecentChecksum findOldestRecord(Context context, Date lessThanDate) throws SQLException {
+    public MostRecentChecksum findOldestRecord(Context context, Instant lessThanDate) throws SQLException {
         return mostRecentChecksumDAO.getOldestRecord(context, lessThanDate);
     }
 

--- a/dspace-api/src/main/java/org/dspace/checker/ResultsLogger.java
+++ b/dspace-api/src/main/java/org/dspace/checker/ResultsLogger.java
@@ -8,9 +8,8 @@
 package org.dspace.checker;
 
 import java.sql.SQLException;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 
 import org.apache.logging.log4j.Logger;
 import org.dspace.content.Bitstream;
@@ -33,20 +32,6 @@ public class ResultsLogger implements ChecksumResultsCollector {
     private static final Logger LOG = org.apache.logging.log4j.LogManager.getLogger(ResultsLogger.class);
 
     /**
-     * Utility date format.
-     */
-    private static final ThreadLocal<DateFormat> DATE_FORMAT = new ThreadLocal<DateFormat>() {
-        @Override
-        protected DateFormat initialValue() {
-            return new SimpleDateFormat("MM/dd/yyyy hh:mm:ss");
-        }
-    };
-    /**
-     * Date the current checking run started.
-     */
-    Date startDate = null;
-
-    /**
      * Blanked off, no-op constructor. Do not use.
      */
     private ResultsLogger() {
@@ -57,8 +42,8 @@ public class ResultsLogger implements ChecksumResultsCollector {
      *
      * @param startDt Date the checking run started.
      */
-    public ResultsLogger(Date startDt) {
-        LOG.info(msg("run-start-time") + ": " + DATE_FORMAT.get().format(startDt));
+    public ResultsLogger(Instant startDt) {
+        LOG.info(msg("run-start-time") + ": " + DateTimeFormatter.ISO_INSTANT.format(startDt));
     }
 
     /**
@@ -104,7 +89,7 @@ public class ResultsLogger implements ChecksumResultsCollector {
         LOG.info(msg("previous-checksum") + ": " + info.getExpectedChecksum());
         LOG.info(msg("previous-checksum-date")
                      + ": "
-                     + ((info.getProcessEndDate() != null) ? DATE_FORMAT.get().format(info
+                     + ((info.getProcessEndDate() != null) ? DateTimeFormatter.ISO_INSTANT.format(info
                                                                                           .getProcessEndDate()) :
             "unknown"));
         LOG.info(msg("new-checksum") + ": " + info.getCurrentChecksum());

--- a/dspace-api/src/main/java/org/dspace/checker/SimpleDispatcher.java
+++ b/dspace-api/src/main/java/org/dspace/checker/SimpleDispatcher.java
@@ -8,7 +8,7 @@
 package org.dspace.checker;
 
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
 
 import org.dspace.checker.factory.CheckerServiceFactory;
 import org.dspace.checker.service.MostRecentChecksumService;
@@ -33,7 +33,7 @@ public class SimpleDispatcher implements BitstreamDispatcher {
     /**
      * Date this dispatcher started dispatching.
      */
-    protected Date processStartTime = null;
+    protected Instant processStartTime = null;
 
     /**
      * Access for bitstream information
@@ -50,10 +50,10 @@ public class SimpleDispatcher implements BitstreamDispatcher {
      * @param looping   indicates whether checker should loop infinitely through
      *                  most_recent_checksum table
      */
-    public SimpleDispatcher(Context context, Date startTime, boolean looping) {
+    public SimpleDispatcher(Context context, Instant startTime, boolean looping) {
         checksumService = CheckerServiceFactory.getInstance().getMostRecentChecksumService();
         this.context = context;
-        this.processStartTime = (startTime == null ? null : new Date(startTime.getTime()));
+        this.processStartTime = startTime;
         this.loopContinuously = looping;
     }
 

--- a/dspace-api/src/main/java/org/dspace/checker/SimpleReporterServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/checker/SimpleReporterServiceImpl.java
@@ -10,8 +10,8 @@ package org.dspace.checker;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.sql.SQLException;
-import java.text.DateFormat;
-import java.util.Date;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import org.dspace.checker.service.MostRecentChecksumService;
@@ -61,7 +61,7 @@ public class SimpleReporterServiceImpl implements SimpleReporterService {
      * @throws SQLException if database error
      */
     @Override
-    public int getDeletedBitstreamReport(Context context, Date startDate, Date endDate,
+    public int getDeletedBitstreamReport(Context context, Instant startDate, Instant endDate,
                                          OutputStreamWriter osw) throws IOException, SQLException {
         // get all the bitstreams marked deleted for today
         List<MostRecentChecksum> recentChecksums = mostRecentChecksumService
@@ -101,7 +101,7 @@ public class SimpleReporterServiceImpl implements SimpleReporterService {
      * @throws SQLException if database error
      */
     @Override
-    public int getChangedChecksumReport(Context context, Date startDate, Date endDate,
+    public int getChangedChecksumReport(Context context, Instant startDate, Instant endDate,
                                         OutputStreamWriter osw) throws IOException, SQLException {
         // get all the bitstreams marked deleted for today
         List<MostRecentChecksum> history =
@@ -143,7 +143,7 @@ public class SimpleReporterServiceImpl implements SimpleReporterService {
      * @throws SQLException if database error
      */
     @Override
-    public int getBitstreamNotFoundReport(Context context, Date startDate, Date endDate,
+    public int getBitstreamNotFoundReport(Context context, Instant startDate, Instant endDate,
                                           OutputStreamWriter osw) throws IOException, SQLException {
         // get all the bitstreams marked deleted for today
         List<MostRecentChecksum> history =
@@ -185,7 +185,7 @@ public class SimpleReporterServiceImpl implements SimpleReporterService {
      * @throws SQLException if database error
      */
     @Override
-    public int getNotToBeProcessedReport(Context context, Date startDate, Date endDate,
+    public int getNotToBeProcessedReport(Context context, Instant startDate, Instant endDate,
                                          OutputStreamWriter osw) throws IOException, SQLException {
         // get all the bitstreams marked deleted for today
         List<MostRecentChecksum> mostRecentChecksums = mostRecentChecksumService
@@ -232,7 +232,7 @@ public class SimpleReporterServiceImpl implements SimpleReporterService {
         osw.write("\n");
         osw.write(msg("unchecked-bitstream-report"));
         osw.write(" ");
-        osw.write(applyDateFormatShort(new Date()));
+        osw.write(applyDateFormatShort(Instant.now()));
         osw.write("\n\n\n");
 
         if (bitstreams.isEmpty()) {
@@ -323,11 +323,11 @@ public class SimpleReporterServiceImpl implements SimpleReporterService {
         }
     }
 
-    protected String applyDateFormatLong(Date thisDate) {
-        return DateFormat.getDateInstance(DateFormat.MEDIUM).format(thisDate);
+    protected String applyDateFormatLong(Instant thisDate) {
+        return DateTimeFormatter.ISO_INSTANT.format(thisDate);
     }
 
-    protected String applyDateFormatShort(Date thisDate) {
-        return DateFormat.getDateInstance(DateFormat.SHORT).format(thisDate);
+    protected String applyDateFormatShort(Instant thisDate) {
+        return DateTimeFormatter.ISO_LOCAL_DATE.format(thisDate);
     }
 }

--- a/dspace-api/src/main/java/org/dspace/checker/SimpleReporterServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/checker/SimpleReporterServiceImpl.java
@@ -11,6 +11,8 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.sql.SQLException;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
@@ -328,6 +330,6 @@ public class SimpleReporterServiceImpl implements SimpleReporterService {
     }
 
     protected String applyDateFormatShort(Instant thisDate) {
-        return DateTimeFormatter.ISO_LOCAL_DATE.format(thisDate);
+        return DateTimeFormatter.ISO_LOCAL_DATE.format(LocalDate.ofInstant(thisDate, ZoneOffset.UTC));
     }
 }

--- a/dspace-api/src/main/java/org/dspace/checker/dao/ChecksumHistoryDAO.java
+++ b/dspace-api/src/main/java/org/dspace/checker/dao/ChecksumHistoryDAO.java
@@ -8,7 +8,7 @@
 package org.dspace.checker.dao;
 
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
 
 import org.dspace.checker.ChecksumHistory;
 import org.dspace.checker.ChecksumResultCode;
@@ -36,7 +36,7 @@ public interface ChecksumHistoryDAO extends GenericDAO<ChecksumHistory> {
      * @return number of rows deleted.
      * @throws SQLException if database error
      */
-    public int deleteByDateAndCode(Context context, Date retentionDate, ChecksumResultCode checksumResultCode)
+    public int deleteByDateAndCode(Context context, Instant retentionDate, ChecksumResultCode checksumResultCode)
         throws SQLException;
 
     /**

--- a/dspace-api/src/main/java/org/dspace/checker/dao/MostRecentChecksumDAO.java
+++ b/dspace-api/src/main/java/org/dspace/checker/dao/MostRecentChecksumDAO.java
@@ -8,7 +8,7 @@
 package org.dspace.checker.dao;
 
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 
 import org.dspace.checker.ChecksumResultCode;
@@ -27,17 +27,17 @@ import org.dspace.core.GenericDAO;
  */
 public interface MostRecentChecksumDAO extends GenericDAO<MostRecentChecksum> {
 
-    public List<MostRecentChecksum> findByNotProcessedInDateRange(Context context, Date startDate, Date endDate)
+    public List<MostRecentChecksum> findByNotProcessedInDateRange(Context context, Instant startDate, Instant endDate)
         throws SQLException;
 
-    public List<MostRecentChecksum> findByResultTypeInDateRange(Context context, Date startDate, Date endDate,
+    public List<MostRecentChecksum> findByResultTypeInDateRange(Context context, Instant startDate, Instant endDate,
                                                                 ChecksumResultCode resultCode) throws SQLException;
 
     public void deleteByBitstream(Context context, Bitstream bitstream) throws SQLException;
 
     public MostRecentChecksum getOldestRecord(Context context) throws SQLException;
 
-    public MostRecentChecksum getOldestRecord(Context context, Date lessThanDate) throws SQLException;
+    public MostRecentChecksum getOldestRecord(Context context, Instant lessThanDate) throws SQLException;
 
     public List<MostRecentChecksum> findNotInHistory(Context context) throws SQLException;
 

--- a/dspace-api/src/main/java/org/dspace/checker/dao/impl/ChecksumHistoryDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/checker/dao/impl/ChecksumHistoryDAOImpl.java
@@ -8,10 +8,9 @@
 package org.dspace.checker.dao.impl;
 
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
 
 import jakarta.persistence.Query;
-import jakarta.persistence.TemporalType;
 import org.dspace.checker.ChecksumHistory;
 import org.dspace.checker.ChecksumResultCode;
 import org.dspace.checker.dao.ChecksumHistoryDAO;
@@ -40,12 +39,12 @@ public class ChecksumHistoryDAOImpl extends AbstractHibernateDAO<ChecksumHistory
     }
 
     @Override
-    public int deleteByDateAndCode(Context context, Date retentionDate, ChecksumResultCode resultCode)
+    public int deleteByDateAndCode(Context context, Instant retentionDate, ChecksumResultCode resultCode)
         throws SQLException {
         String hql = "delete from ChecksumHistory where processEndDate < :processEndDate AND checksumResult" +
             ".resultCode=:resultCode";
         Query query = createQuery(context, hql);
-        query.setParameter("processEndDate", retentionDate, TemporalType.TIMESTAMP);
+        query.setParameter("processEndDate", retentionDate);
         query.setParameter("resultCode", resultCode);
         return query.executeUpdate();
     }

--- a/dspace-api/src/main/java/org/dspace/checker/dao/impl/MostRecentChecksumDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/checker/dao/impl/MostRecentChecksumDAOImpl.java
@@ -8,7 +8,7 @@
 package org.dspace.checker.dao.impl;
 
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -46,7 +46,7 @@ public class MostRecentChecksumDAOImpl extends AbstractHibernateDAO<MostRecentCh
 
 
     @Override
-    public List<MostRecentChecksum> findByNotProcessedInDateRange(Context context, Date startDate, Date endDate)
+    public List<MostRecentChecksum> findByNotProcessedInDateRange(Context context, Instant startDate, Instant endDate)
         throws SQLException {
 
         CriteriaBuilder criteriaBuilder = getCriteriaBuilder(context);
@@ -80,7 +80,7 @@ public class MostRecentChecksumDAOImpl extends AbstractHibernateDAO<MostRecentCh
 
 
     @Override
-    public List<MostRecentChecksum> findByResultTypeInDateRange(Context context, Date startDate, Date endDate,
+    public List<MostRecentChecksum> findByResultTypeInDateRange(Context context, Instant startDate, Instant endDate,
                                                                 ChecksumResultCode resultCode) throws SQLException {
         CriteriaBuilder criteriaBuilder = getCriteriaBuilder(context);
         CriteriaQuery<MostRecentChecksum> criteriaQuery = getCriteriaQuery(criteriaBuilder, MostRecentChecksum.class);
@@ -126,7 +126,7 @@ public class MostRecentChecksumDAOImpl extends AbstractHibernateDAO<MostRecentCh
     }
 
     @Override
-    public MostRecentChecksum getOldestRecord(Context context, Date lessThanDate) throws SQLException {
+    public MostRecentChecksum getOldestRecord(Context context, Instant lessThanDate) throws SQLException {
         CriteriaBuilder criteriaBuilder = getCriteriaBuilder(context);
         CriteriaQuery<MostRecentChecksum> criteriaQuery = getCriteriaQuery(criteriaBuilder, MostRecentChecksum.class);
         Root<MostRecentChecksum> mostRecentChecksumRoot = criteriaQuery.from(MostRecentChecksum.class);

--- a/dspace-api/src/main/java/org/dspace/checker/service/ChecksumHistoryService.java
+++ b/dspace-api/src/main/java/org/dspace/checker/service/ChecksumHistoryService.java
@@ -8,7 +8,7 @@
 package org.dspace.checker.service;
 
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.Map;
 
 import org.dspace.checker.ChecksumResultCode;
@@ -29,7 +29,8 @@ public interface ChecksumHistoryService {
 
     public void addHistory(Context context, MostRecentChecksum mostRecentChecksum) throws SQLException;
 
-    public int deleteByDateAndCode(Context context, Date retentionDate, ChecksumResultCode result) throws SQLException;
+    public int deleteByDateAndCode(Context context, Instant retentionDate, ChecksumResultCode result)
+        throws SQLException;
 
     public void deleteByBitstream(Context context, Bitstream bitstream) throws SQLException;
 

--- a/dspace-api/src/main/java/org/dspace/checker/service/MostRecentChecksumService.java
+++ b/dspace-api/src/main/java/org/dspace/checker/service/MostRecentChecksumService.java
@@ -8,7 +8,7 @@
 package org.dspace.checker.service;
 
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 
 import org.dspace.checker.ChecksumResultCode;
@@ -29,10 +29,12 @@ public interface MostRecentChecksumService {
 
     public MostRecentChecksum findByBitstream(Context context, Bitstream bitstream) throws SQLException;
 
-    public List<MostRecentChecksum> findNotProcessedBitstreamsReport(Context context, Date startDate, Date endDate)
+    public List<MostRecentChecksum> findNotProcessedBitstreamsReport(Context context, Instant startDate,
+                                                                     Instant endDate)
         throws SQLException;
 
-    public List<MostRecentChecksum> findBitstreamResultTypeReport(Context context, Date startDate, Date endDate,
+    public List<MostRecentChecksum> findBitstreamResultTypeReport(Context context, Instant startDate,
+                                                                  Instant endDate,
                                                                   ChecksumResultCode resultCode) throws SQLException;
 
     public void updateMissingBitstreams(Context context) throws SQLException;
@@ -41,7 +43,7 @@ public interface MostRecentChecksumService {
 
     public MostRecentChecksum findOldestRecord(Context context) throws SQLException;
 
-    public MostRecentChecksum findOldestRecord(Context context, Date lessThanDate) throws SQLException;
+    public MostRecentChecksum findOldestRecord(Context context, Instant lessThanDate) throws SQLException;
 
     public List<MostRecentChecksum> findNotInHistory(Context context) throws SQLException;
 

--- a/dspace-api/src/main/java/org/dspace/checker/service/SimpleReporterService.java
+++ b/dspace-api/src/main/java/org/dspace/checker/service/SimpleReporterService.java
@@ -10,7 +10,7 @@ package org.dspace.checker.service;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
 
 import org.dspace.core.Context;
 
@@ -35,7 +35,7 @@ public interface SimpleReporterService {
      *                      if io error occurs
      * @throws SQLException if database error
      */
-    public int getDeletedBitstreamReport(Context context, Date startDate, Date endDate,
+    public int getDeletedBitstreamReport(Context context, Instant startDate, Instant endDate,
                                          OutputStreamWriter osw) throws IOException, SQLException;
 
     /**
@@ -51,7 +51,7 @@ public interface SimpleReporterService {
      *                      if io error occurs
      * @throws SQLException if database error
      */
-    public int getChangedChecksumReport(Context context, Date startDate, Date endDate,
+    public int getChangedChecksumReport(Context context, Instant startDate, Instant endDate,
                                         OutputStreamWriter osw) throws IOException, SQLException;
 
     /**
@@ -67,7 +67,7 @@ public interface SimpleReporterService {
      *                      if io error occurs
      * @throws SQLException if database error
      */
-    public int getBitstreamNotFoundReport(Context context, Date startDate, Date endDate,
+    public int getBitstreamNotFoundReport(Context context, Instant startDate, Instant endDate,
                                           OutputStreamWriter osw) throws IOException, SQLException;
 
     /**
@@ -83,7 +83,7 @@ public interface SimpleReporterService {
      *                      if io error occurs
      * @throws SQLException if database error
      */
-    public int getNotToBeProcessedReport(Context context, Date startDate, Date endDate,
+    public int getNotToBeProcessedReport(Context context, Instant startDate, Instant endDate,
                                          OutputStreamWriter osw) throws IOException, SQLException;
 
     /**

--- a/dspace-api/src/main/java/org/dspace/content/DCDate.java
+++ b/dspace-api/src/main/java/org/dspace/content/DCDate.java
@@ -19,7 +19,6 @@ import java.time.format.DateTimeParseException;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
-import java.util.TimeZone;
 
 import org.apache.logging.log4j.Logger;
 
@@ -48,9 +47,6 @@ public class DCDate {
      * Logger
      */
     private static Logger log = org.apache.logging.log4j.LogManager.getLogger(DCDate.class);
-
-    // UTC timezone
-    private static final TimeZone utcZone = TimeZone.getTimeZone("UTC");
 
     // components of time in UTC
     private ZonedDateTime calendar = null;

--- a/dspace-api/src/main/java/org/dspace/content/DCDate.java
+++ b/dspace-api/src/main/java/org/dspace/content/DCDate.java
@@ -8,11 +8,12 @@
 package org.dspace.content;
 
 import java.text.DateFormatSymbols;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.GregorianCalendar;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -50,49 +51,55 @@ public class DCDate {
     private static final TimeZone utcZone = TimeZone.getTimeZone("UTC");
 
     // components of time in UTC
-    private GregorianCalendar calendar = null;
+    private ZonedDateTime calendar = null;
 
     // components of time in local zone
-    private GregorianCalendar localCalendar = null;
+    private LocalDateTime localCalendar = null;
 
     private enum DateGran { YEAR, MONTH, DAY, TIME }
 
     DateGran granularity = null;
 
     // Full ISO 8601 is e.g. "2009-07-16T13:59:21Z"
-    private final SimpleDateFormat fullIso = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+    private final DateTimeFormatter fullIso = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'")
+                                                               .withZone(ZoneOffset.UTC);
 
     // without Z
-    private final SimpleDateFormat fullIso2 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+    private final DateTimeFormatter fullIso2 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")
+                                                                .withZone(ZoneOffset.UTC);
 
     // without seconds
-    private final SimpleDateFormat fullIso3 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm");
+    private final DateTimeFormatter fullIso3 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm")
+                                                                .withZone(ZoneOffset.UTC);
 
     // without minutes
-    private final SimpleDateFormat fullIso4 = new SimpleDateFormat("yyyy-MM-dd'T'HH");
+    private final DateTimeFormatter fullIso4 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH")
+                                                                .withZone(ZoneOffset.UTC);
 
     // Date-only ISO 8601 is e.g. "2009-07-16"
-    private final SimpleDateFormat dateIso = new SimpleDateFormat("yyyy-MM-dd");
+    private final DateTimeFormatter dateIso = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+                                                               .withZone(ZoneOffset.UTC);
 
     // Year-Month-only ISO 8601 is e.g. "2009-07"
-    private final SimpleDateFormat yearMonthIso = new SimpleDateFormat("yyyy-MM");
+    private final DateTimeFormatter yearMonthIso = DateTimeFormatter.ofPattern("yyyy-MM")
+                                                                    .withZone(ZoneOffset.UTC);
 
     // just year, "2009"
-    private final SimpleDateFormat yearIso = new SimpleDateFormat("yyyy");
+    private final DateTimeFormatter yearIso = DateTimeFormatter.ofPattern("yyyy")
+                                                               .withZone(ZoneOffset.UTC);
 
     // Additional iso-like format which contains milliseconds
-    private final SimpleDateFormat fullIsoWithMs = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'.000'");
+    private final DateTimeFormatter fullIsoWithMs = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'.000'")
+                                                                     .withZone(ZoneOffset.UTC);
 
-    private static Map<Locale, DateFormatSymbols> dfsLocaleMap = new HashMap<Locale, DateFormatSymbols>();
+    private static Map<Locale, DateFormatSymbols> dfsLocaleMap = new HashMap<>();
 
     /**
-     * Construct a date object from a Java <code>Date</code> object.
+     * Construct a date object from a Java <code>Instant</code> object.
      *
-     * @param date the Java <code>Date</code> object.
+     * @param date the Java <code>Instant</code> object.
      */
-    public DCDate(Date date) {
-        setUTCForFormatting();
-
+    public DCDate(LocalDateTime date) {
         if (date == null) {
             return;
         }
@@ -101,12 +108,10 @@ public class DCDate {
         granularity = DateGran.TIME;
 
         // Set the local calendar.
-        localCalendar = new GregorianCalendar();
-        localCalendar.setTime(date);
+        localCalendar = date;
 
-        // Now set the UTC equivalent.
-        calendar = new GregorianCalendar(utcZone);
-        calendar.setTime(date);
+        // Now set the UTC equivalent. This converts local system default to UTC time.
+        calendar = date.atZone(ZoneId.systemDefault()).withZoneSameInstant(ZoneOffset.UTC);
     }
 
     /**
@@ -121,8 +126,6 @@ public class DCDate {
      * @param ss   the seconds
      */
     public DCDate(int yyyy, int mm, int dd, int hh, int mn, int ss) {
-        setUTCForFormatting();
-
         // default values
         int lyear = 0;
         int lhours = 0;
@@ -157,17 +160,18 @@ public class DCDate {
         }
 
         // Set the local calendar.
-        localCalendar = new GregorianCalendar(lyear, lmonth - 1, lday,
-                                              lhours, lminutes, lseconds);
+        localCalendar = LocalDateTime.of(lyear, lmonth, lday, lhours, lminutes, lseconds);
 
         if (granularity == DateGran.TIME) {
             // Now set the UTC equivalent.
-            calendar = new GregorianCalendar(utcZone);
-            calendar.setTime(localCalendar.getTime());
+            calendar = localCalendar.atZone(ZoneId.systemDefault())
+                                    .withZoneSameInstant(ZoneOffset.UTC);
         } else {
             // No Time component so just set the UTC date to be the same as the local Year, Month, and Day.
-            calendar = new GregorianCalendar(localCalendar.get(Calendar.YEAR), localCalendar.get(Calendar.MONTH),
-                                             localCalendar.get(Calendar.DAY_OF_MONTH));
+            calendar = ZonedDateTime.of(localCalendar.getYear(),
+                                        localCalendar.getMonthValue(),
+                                        localCalendar.getDayOfMonth(), 0, 0, 0, 0,
+                                        ZoneOffset.UTC);
         }
     }
 
@@ -177,8 +181,6 @@ public class DCDate {
      * @param fromDC the date string, in ISO 8601 (no timezone, always use UTC)
      */
     public DCDate(String fromDC) {
-        setUTCForFormatting();
-
         // An empty date is OK
         if ((fromDC == null) || fromDC.equals("")) {
             return;
@@ -186,7 +188,7 @@ public class DCDate {
 
         // default granularity
         granularity = DateGran.TIME;
-        Date date = tryParse(fullIso, fromDC);
+        LocalDateTime date = tryParse(fullIso, fromDC);
         if (date == null) {
             date = tryParse(fullIso2, fromDC);
         }
@@ -223,41 +225,26 @@ public class DCDate {
             log.warn("Mangled date: " + fromDC + "  ..failed all attempts to parse as date.");
         } else {
             // Set the UTC time.
-            calendar = new GregorianCalendar(utcZone);
-            calendar.setTime(date);
+            calendar = date.atZone(ZoneId.systemDefault())
+                           .withZoneSameInstant(ZoneOffset.UTC);
 
             // Now set the local equivalent.
             if (granularity == DateGran.TIME) {
-                localCalendar = new GregorianCalendar();
-                localCalendar.setTime(date);
+                localCalendar = date;
             } else {
                 // No Time component so just set the local date to be the same as the UTC  Year, Month, and Day.
-                localCalendar = new GregorianCalendar(calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH),
-                                                      calendar.get(Calendar.DAY_OF_MONTH));
+                localCalendar = LocalDateTime.of(calendar.getYear(),
+                                                 calendar.getMonth(),
+                                                 calendar.getDayOfMonth(), 0, 0);
             }
         }
     }
 
-    /**
-     * Set all the formatters to use UTC. SimpleDateFormat is not thread-safe which
-     * is why they are not static variables initialised once.
-     */
-    private void setUTCForFormatting() {
-        fullIso.setTimeZone(utcZone);
-        fullIso2.setTimeZone(utcZone);
-        fullIso3.setTimeZone(utcZone);
-        fullIso4.setTimeZone(utcZone);
-        dateIso.setTimeZone(utcZone);
-        yearMonthIso.setTimeZone(utcZone);
-        yearIso.setTimeZone(utcZone);
-        fullIsoWithMs.setTimeZone(utcZone);
-    }
-
     // Attempt to parse, swallowing errors; return null for failure.
-    private synchronized Date tryParse(SimpleDateFormat sdf, String source) {
+    private synchronized LocalDateTime tryParse(DateTimeFormatter formatter, String source) {
         try {
-            return sdf.parse(source);
-        } catch (ParseException pe) {
+            return LocalDateTime.parse(source, formatter);
+        } catch (DateTimeParseException e) {
             return null;
         }
     }
@@ -268,7 +255,7 @@ public class DCDate {
      * @return the year
      */
     public int getYear() {
-        return !withinGranularity(DateGran.YEAR) ? -1 : localCalendar.get(Calendar.YEAR);
+        return !withinGranularity(DateGran.YEAR) ? -1 : localCalendar.getYear();
     }
 
     /**
@@ -277,7 +264,7 @@ public class DCDate {
      * @return the month
      */
     public int getMonth() {
-        return !withinGranularity(DateGran.MONTH) ? -1 : localCalendar.get(Calendar.MONTH) + 1;
+        return !withinGranularity(DateGran.MONTH) ? -1 : localCalendar.getMonthValue();
     }
 
     /**
@@ -286,7 +273,7 @@ public class DCDate {
      * @return the day
      */
     public int getDay() {
-        return !withinGranularity(DateGran.DAY) ? -1 : localCalendar.get(Calendar.DAY_OF_MONTH);
+        return !withinGranularity(DateGran.DAY) ? -1 : localCalendar.getDayOfMonth();
     }
 
     /**
@@ -295,7 +282,7 @@ public class DCDate {
      * @return the hour
      */
     public int getHour() {
-        return !withinGranularity(DateGran.TIME) ? -1 : localCalendar.get(Calendar.HOUR_OF_DAY);
+        return !withinGranularity(DateGran.TIME) ? -1 : localCalendar.getHour();
     }
 
     /**
@@ -304,7 +291,7 @@ public class DCDate {
      * @return the minute
      */
     public int getMinute() {
-        return !withinGranularity(DateGran.TIME) ? -1 : localCalendar.get(Calendar.MINUTE);
+        return !withinGranularity(DateGran.TIME) ? -1 : localCalendar.getMinute();
     }
 
     /**
@@ -313,7 +300,7 @@ public class DCDate {
      * @return the second
      */
     public int getSecond() {
-        return !withinGranularity(DateGran.TIME) ? -1 : localCalendar.get(Calendar.SECOND);
+        return !withinGranularity(DateGran.TIME) ? -1 : localCalendar.getSecond();
     }
 
     /**
@@ -322,7 +309,7 @@ public class DCDate {
      * @return the year
      */
     public int getYearUTC() {
-        return !withinGranularity(DateGran.YEAR) ? -1 : calendar.get(Calendar.YEAR);
+        return !withinGranularity(DateGran.YEAR) ? -1 : calendar.getYear();
     }
 
     /**
@@ -331,7 +318,7 @@ public class DCDate {
      * @return the month
      */
     public int getMonthUTC() {
-        return !withinGranularity(DateGran.MONTH) ? -1 : calendar.get(Calendar.MONTH) + 1;
+        return !withinGranularity(DateGran.MONTH) ? -1 : calendar.getMonthValue();
     }
 
     /**
@@ -340,7 +327,7 @@ public class DCDate {
      * @return the day
      */
     public int getDayUTC() {
-        return !withinGranularity(DateGran.DAY) ? -1 : calendar.get(Calendar.DAY_OF_MONTH);
+        return !withinGranularity(DateGran.DAY) ? -1 : calendar.getDayOfMonth();
     }
 
     /**
@@ -349,7 +336,7 @@ public class DCDate {
      * @return the hour
      */
     public int getHourUTC() {
-        return !withinGranularity(DateGran.TIME) ? -1 : calendar.get(Calendar.HOUR_OF_DAY);
+        return !withinGranularity(DateGran.TIME) ? -1 : calendar.getHour();
     }
 
     /**
@@ -358,7 +345,7 @@ public class DCDate {
      * @return the minute
      */
     public int getMinuteUTC() {
-        return !withinGranularity(DateGran.TIME) ? -1 : calendar.get(Calendar.MINUTE);
+        return !withinGranularity(DateGran.TIME) ? -1 : calendar.getMinute();
     }
 
     /**
@@ -367,7 +354,7 @@ public class DCDate {
      * @return the second
      */
     public int getSecondUTC() {
-        return !withinGranularity(DateGran.TIME) ? -1 : calendar.get(Calendar.SECOND);
+        return !withinGranularity(DateGran.TIME) ? -1 : calendar.getSecond();
     }
 
     /**
@@ -391,20 +378,20 @@ public class DCDate {
         } else if (granularity == DateGran.DAY) {
             return String.format("%4d-%02d-%02d", getYearUTC(), getMonthUTC(), getDayUTC());
         } else {
-            return fullIso.format(calendar.getTime());
+            return fullIso.format(calendar);
         }
     }
 
     /**
-     * Get the date as a Java Date object.
+     * Get the date as a Java ZonedDateTime object in UTC timezone.
      *
-     * @return a Date object
+     * @return a ZonedDateTime object
      */
-    public Date toDate() {
+    public ZonedDateTime toDate() {
         if (calendar == null) {
             return null;
         } else {
-            return calendar.getTime();
+            return calendar;
         }
     }
 
@@ -512,7 +499,7 @@ public class DCDate {
      * @return a DSpaceDate object representing the current instant.
      */
     public static DCDate getCurrent() {
-        return (new DCDate(new Date()));
+        return (new DCDate(LocalDateTime.now()));
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/content/FeedbackServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/FeedbackServiceImpl.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.content;
 import java.io.IOException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.Objects;
 
 import jakarta.mail.MessagingException;
@@ -37,7 +37,7 @@ public class FeedbackServiceImpl implements FeedbackService {
         }
         Email email = Email.getEmail(I18nUtil.getEmailFilename(context.getCurrentLocale(), "feedback"));
         email.addRecipient(recipientEmail);
-        email.addArgument(new Date());         // Date
+        email.addArgument(Instant.now());      // Date
         email.addArgument(senderEmail);       // Email
         email.addArgument(currentUserEmail); // Logged in as
         email.addArgument(page);            // Referring page

--- a/dspace-api/src/main/java/org/dspace/content/Item.java
+++ b/dspace-api/src/main/java/org/dspace/content/Item.java
@@ -7,9 +7,9 @@
  */
 package org.dspace.content;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -25,8 +25,6 @@ import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
-import jakarta.persistence.Temporal;
-import jakarta.persistence.TemporalType;
 import jakarta.persistence.Transient;
 import org.dspace.content.comparator.NameAscendingComparator;
 import org.dspace.content.factory.ContentServiceFactory;
@@ -71,8 +69,7 @@ public class Item extends DSpaceObject implements DSpaceObjectLegacySupport {
     private boolean withdrawn = false;
 
     @Column(name = "last_modified", columnDefinition = "timestamp with time zone")
-    @Temporal(TemporalType.TIMESTAMP)
-    private Date lastModified = new Date();
+    private Instant lastModified = Instant.now();
 
     @ManyToOne(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST})
     @JoinColumn(name = "owning_collection")
@@ -178,11 +175,11 @@ public class Item extends DSpaceObject implements DSpaceObjectLegacySupport {
      * @return the date the item was last modified, or the current date if the
      * column is null.
      */
-    public Date getLastModified() {
+    public Instant getLastModified() {
         return lastModified;
     }
 
-    public void setLastModified(Date lastModified) {
+    public void setLastModified(Instant lastModified) {
         this.lastModified = lastModified;
     }
 

--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -10,9 +10,9 @@ package org.dspace.content;
 import java.io.IOException;
 import java.io.InputStream;
 import java.sql.SQLException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -415,20 +415,20 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
     }
 
     @Override
-    public Iterator<Item> findInArchiveOrWithdrawnDiscoverableModifiedSince(Context context, Date since)
+    public Iterator<Item> findInArchiveOrWithdrawnDiscoverableModifiedSince(Context context, Instant since)
         throws SQLException {
         return itemDAO.findAll(context, true, true, true, since);
     }
 
     @Override
-    public Iterator<Item> findInArchiveOrWithdrawnNonDiscoverableModifiedSince(Context context, Date since)
+    public Iterator<Item> findInArchiveOrWithdrawnNonDiscoverableModifiedSince(Context context, Instant since)
         throws SQLException {
         return itemDAO.findAll(context, true, true, false, since);
     }
 
     @Override
     public void updateLastModified(Context context, Item item) throws SQLException, AuthorizeException {
-        item.setLastModified(new Date());
+        item.setLastModified(Instant.now());
         update(context, item);
         //Also fire a modified event since the item HAS been modified
         context.addEvent(new Event(Event.MODIFY, Constants.ITEM, item.getID(), null, getIdentifiers(context, item)));
@@ -681,7 +681,7 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
 
         if (item.isMetadataModified() || item.isModified()) {
             // Set the last modified date
-            item.setLastModified(new Date());
+            item.setLastModified(Instant.now());
 
             itemDAO.save(context, item);
 
@@ -1694,7 +1694,7 @@ prevent the generation of resource policy entry values with null dspace_object a
     }
 
     @Override
-    public Iterator<Item> findByLastModifiedSince(Context context, Date last)
+    public Iterator<Item> findByLastModifiedSince(Context context, Instant last)
         throws SQLException {
         return itemDAO.findByLastModifiedSince(context, last);
     }

--- a/dspace-api/src/main/java/org/dspace/content/LicenseUtils.java
+++ b/dspace-api/src/main/java/org/dspace/content/LicenseUtils.java
@@ -10,6 +10,7 @@ package org.dspace.content;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.sql.SQLException;
+import java.time.Instant;
 import java.util.Formatter;
 import java.util.Locale;
 import java.util.Map;
@@ -82,7 +83,7 @@ public class LicenseUtils {
         args[0] = eperson.getFirstName();
         args[1] = eperson.getLastName();
         args[2] = eperson.getEmail();
-        args[3] = new java.util.Date();
+        args[3] = Instant.now();
         args[4] = new FormattableArgument("collection", collection);
         args[5] = new FormattableArgument("item", item);
         args[6] = new FormattableArgument("eperson", eperson);

--- a/dspace-api/src/main/java/org/dspace/content/QAEvent.java
+++ b/dspace-api/src/main/java/org/dspace/content/QAEvent.java
@@ -10,7 +10,7 @@ package org.dspace.content;
 import java.io.UnsupportedEncodingException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.Date;
+import java.time.Instant;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.dspace.qaevent.service.dto.CorrectionTypeMessageDTO;
@@ -63,14 +63,14 @@ public class QAEvent {
     @JsonDeserialize(using = RawJsonDeserializer.class)
     private String message;
 
-    private Date lastUpdate;
+    private Instant lastUpdate;
 
     private String status = "PENDING";
 
     public QAEvent() {}
 
     public QAEvent(String source, String originalId, String target, String title,
-        String topic, double trust, String message, Date lastUpdate) {
+        String topic, double trust, String message, Instant lastUpdate) {
         super();
         this.source = source;
         this.originalId = originalId;
@@ -150,11 +150,11 @@ public class QAEvent {
         this.target = target;
     }
 
-    public Date getLastUpdate() {
+    public Instant getLastUpdate() {
         return lastUpdate;
     }
 
-    public void setLastUpdate(Date lastUpdate) {
+    public void setLastUpdate(Instant lastUpdate) {
         this.lastUpdate = lastUpdate;
     }
 

--- a/dspace-api/src/main/java/org/dspace/content/QAEventProcessed.java
+++ b/dspace-api/src/main/java/org/dspace/content/QAEventProcessed.java
@@ -8,7 +8,7 @@
 package org.dspace.content;
 
 import java.io.Serializable;
-import java.util.Date;
+import java.time.Instant;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -16,8 +16,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import jakarta.persistence.Temporal;
-import jakarta.persistence.TemporalType;
 import org.dspace.eperson.EPerson;
 
 /**
@@ -35,9 +33,8 @@ public class QAEventProcessed implements Serializable {
     @Column(name = "qaevent_id")
     private String eventId;
 
-    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "qaevent_timestamp")
-    private Date eventTimestamp;
+    private Instant eventTimestamp;
 
     @JoinColumn(name = "eperson_uuid")
     @ManyToOne
@@ -55,11 +52,11 @@ public class QAEventProcessed implements Serializable {
         this.eventId = eventId;
     }
 
-    public Date getEventTimestamp() {
+    public Instant getEventTimestamp() {
         return eventTimestamp;
     }
 
-    public void setEventTimestamp(Date eventTimestamp) {
+    public void setEventTimestamp(Instant eventTimestamp) {
         this.eventTimestamp = eventTimestamp;
     }
 

--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/CrosswalkMetadataValidator.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/CrosswalkMetadataValidator.java
@@ -8,7 +8,7 @@
 package org.dspace.content.crosswalk;
 
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -82,7 +82,8 @@ public class CrosswalkMetadataValidator {
                 // add a new schema, giving it a namespace of "unknown". Possibly a very bad idea.
                 if (forceCreate && schemaChoice.equals("add")) {
                     try {
-                        mdSchema = metadataSchemaService.create(context, schema, String.valueOf(new Date().getTime()));
+                        mdSchema = metadataSchemaService.create(context, schema,
+                                                                String.valueOf(Instant.now().toEpochMilli()));
                         mdSchema.setNamespace("unknown" + mdSchema.getID());
                         metadataSchemaService.update(context, mdSchema);
                     } catch (NonUniqueMetadataException e) {

--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/METSRightsCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/METSRightsCrosswalk.java
@@ -9,10 +9,10 @@ package org.dspace.content.crosswalk;
 
 import java.io.IOException;
 import java.sql.SQLException;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -180,18 +180,18 @@ public class METSRightsCrosswalk
 
             // As of DSpace 3.0, policies may have an effective date range, check if a policy is effective
             rightsContext.setAttribute("in-effect", "true");
-            Date now = new Date();
-            SimpleDateFormat iso8601 = new SimpleDateFormat("yyyy-MM-dd");
+            LocalDate now = LocalDate.now();
+            DateTimeFormatter iso8601 = DateTimeFormatter.ISO_LOCAL_DATE;
             if (policy.getStartDate() != null) {
                 rightsContext.setAttribute("start-date", iso8601.format(policy.getStartDate()));
-                if (policy.getStartDate().after(now)) {
+                if (policy.getStartDate().isAfter(now)) {
                     rightsContext.setAttribute("in-effect", "false");
                 }
             }
 
             if (policy.getEndDate() != null) {
                 rightsContext.setAttribute("end-date", iso8601.format(policy.getEndDate()));
-                if (policy.getEndDate().before(now)) {
+                if (policy.getEndDate().isBefore(now)) {
                     rightsContext.setAttribute("in-effect", "false");
                 }
             }
@@ -526,7 +526,7 @@ public class METSRightsCrosswalk
                         log.error("Unrecognized CONTEXTCLASS:  " + contextClass);
                     }
                     if (rp != null) {
-                        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+                        DateTimeFormatter iso8601 = DateTimeFormatter.ISO_LOCAL_DATE;
 
                         // get reference to the <Permissions> element
                         // Note: we are assuming here that there will only ever be ONE <Permissions>
@@ -542,12 +542,12 @@ public class METSRightsCrosswalk
                         }
                         try {
                             if (element.getAttributeValue("start-date") != null) {
-                                rp.setStartDate(sdf.parse(element.getAttributeValue("start-date")));
+                                rp.setStartDate(LocalDate.parse(element.getAttributeValue("start-date"), iso8601));
                             }
                             if (element.getAttributeValue("end-date") != null) {
-                                rp.setEndDate(sdf.parse(element.getAttributeValue("end-date")));
+                                rp.setEndDate(LocalDate.parse(element.getAttributeValue("end-date"), iso8601));
                             }
-                        } catch (ParseException ex) {
+                        } catch (DateTimeParseException ex) {
                             log.error("Failed to parse embargo date. The date needs to be in the format 'yyyy-MM-dd'.",
                                       ex);
                         }

--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/OREDisseminationCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/OREDisseminationCrosswalk.java
@@ -9,9 +9,9 @@ package org.dspace.content.crosswalk;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -141,9 +141,9 @@ public class OREDisseminationCrosswalk
         uriRLink.setAttribute("type", "application/atom+xml");
 
         Element remPublished = new Element("published", ATOM_NS);
-        remPublished.addContent(Utils.formatISO8601Date(new Date()));
+        remPublished.addContent(Utils.formatISO8601Date(LocalDateTime.now()));
         Element remUpdated = new Element("updated", ATOM_NS);
-        remUpdated.addContent(Utils.formatISO8601Date(new Date()));
+        remUpdated.addContent(Utils.formatISO8601Date(LocalDateTime.now()));
 
         Element remCreator = new Element("source", ATOM_NS);
         Element remGenerator = new Element("generator", ATOM_NS);

--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/OREIngestionCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/OREIngestionCrosswalk.java
@@ -14,8 +14,8 @@ import java.net.ConnectException;
 import java.net.URL;
 import java.sql.SQLException;
 import java.text.NumberFormat;
+import java.time.Instant;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -99,7 +99,7 @@ public class OREIngestionCrosswalk
     public void ingest(Context context, DSpaceObject dso, Element root, boolean createMissingMetadataFields)
         throws CrosswalkException, IOException, SQLException, AuthorizeException {
 
-        Date timeStart = new Date();
+        Instant timeStart = Instant.now();
 
         if (dso.getType() != Constants.ITEM) {
             throw new CrosswalkObjectNotSupported("OREIngestionCrosswalk can only crosswalk an Item.");
@@ -209,7 +209,8 @@ public class OREIngestionCrosswalk
 
         }
         log.info(
-            "OREIngest for Item " + item.getID() + " took: " + (new Date().getTime() - timeStart.getTime()) + "ms.");
+            "OREIngest for Item " + item.getID() + " took: " +
+                (Instant.now().toEpochMilli() - timeStart.toEpochMilli()) + "ms.");
     }
 
 

--- a/dspace-api/src/main/java/org/dspace/content/dao/ItemDAO.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/ItemDAO.java
@@ -8,7 +8,7 @@
 package org.dspace.content.dao;
 
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
@@ -56,7 +56,7 @@ public interface ItemDAO extends DSpaceObjectLegacySupportDAO<Item> {
      * @return iterator over items
      * @throws SQLException if database error
      */
-    Iterator<Item> findByLastModifiedSince(Context context, Date since)
+    Iterator<Item> findByLastModifiedSince(Context context, Instant since)
         throws SQLException;
 
     Iterator<Item> findBySubmitter(Context context, EPerson eperson) throws SQLException;
@@ -177,7 +177,7 @@ public interface ItemDAO extends DSpaceObjectLegacySupportDAO<Item> {
      * @throws SQLException if database error
      */
     Iterator<Item> findAll(Context context, boolean archived,
-                                  boolean withdrawn, boolean discoverable, Date lastModified)
+                                  boolean withdrawn, boolean discoverable, Instant lastModified)
         throws SQLException;
 
     /**

--- a/dspace-api/src/main/java/org/dspace/content/dao/ProcessDAO.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/ProcessDAO.java
@@ -8,7 +8,7 @@
 package org.dspace.content.dao;
 
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 
 import org.dspace.content.ProcessStatus;
@@ -95,7 +95,7 @@ public interface ProcessDAO extends GenericDAO<Process> {
      * @return              The list of all Processes which match requirements
      * @throws SQLException If something goes wrong
      */
-    List<Process> findByStatusAndCreationTimeOlderThan(Context context, List<ProcessStatus> statuses, Date date)
+    List<Process> findByStatusAndCreationTimeOlderThan(Context context, List<ProcessStatus> statuses, Instant date)
         throws SQLException;
 
     /**

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/ItemDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/ItemDAOImpl.java
@@ -8,15 +8,14 @@
 package org.dspace.content.dao.impl;
 
 import java.sql.SQLException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
 
 import jakarta.persistence.Query;
-import jakarta.persistence.TemporalType;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaBuilder.In;
 import jakarta.persistence.criteria.CriteriaQuery;
@@ -103,7 +102,7 @@ public class ItemDAOImpl extends AbstractHibernateDSODAO<Item> implements ItemDA
 
     @Override
     public Iterator<Item> findAll(Context context, boolean archived,
-                                  boolean withdrawn, boolean discoverable, Date lastModified)
+                                  boolean withdrawn, boolean discoverable, Instant lastModified)
         throws SQLException {
         StringBuilder queryStr = new StringBuilder();
         queryStr.append("SELECT i.id FROM Item i");
@@ -120,7 +119,7 @@ public class ItemDAOImpl extends AbstractHibernateDSODAO<Item> implements ItemDA
         query.setParameter("withdrawn", withdrawn);
         query.setParameter("discoverable", discoverable);
         if (lastModified != null) {
-            query.setParameter("last_modified", lastModified, TemporalType.TIMESTAMP);
+            query.setParameter("last_modified", lastModified);
         }
         @SuppressWarnings("unchecked")
         List<UUID> uuids = query.getResultList();
@@ -438,11 +437,11 @@ public class ItemDAOImpl extends AbstractHibernateDSODAO<Item> implements ItemDA
     }
 
     @Override
-    public Iterator<Item> findByLastModifiedSince(Context context, Date since)
+    public Iterator<Item> findByLastModifiedSince(Context context, Instant since)
         throws SQLException {
         Query query = createQuery(context,
                 "SELECT i.id FROM Item i WHERE lastModified > :last_modified ORDER BY id");
-        query.setParameter("last_modified", since, TemporalType.TIMESTAMP);
+        query.setParameter("last_modified", since);
         @SuppressWarnings("unchecked")
         List<UUID> uuids = query.getResultList();
         return new UUIDIterator<Item>(context, uuids, Item.class, this);

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/ProcessDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/ProcessDAOImpl.java
@@ -10,7 +10,7 @@ package org.dspace.content.dao.impl;
 import static org.dspace.scripts.Process_.CREATION_TIME;
 
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -154,7 +154,7 @@ public class ProcessDAOImpl extends AbstractHibernateDAO<Process> implements Pro
 
     @Override
     public List<Process> findByStatusAndCreationTimeOlderThan(Context context, List<ProcessStatus> statuses,
-        Date date) throws SQLException {
+        Instant date) throws SQLException {
 
         CriteriaBuilder criteriaBuilder = getCriteriaBuilder(context);
         CriteriaQuery<Process> criteriaQuery = getCriteriaQuery(criteriaBuilder, Process.class);

--- a/dspace-api/src/main/java/org/dspace/content/packager/AbstractMETSDisseminator.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/AbstractMETSDisseminator.java
@@ -316,7 +316,7 @@ public abstract class AbstractMETSDisseminator
             IllegalArgumentException, InvocationTargetException {
         long lmTime = 0;
         if (dso.getType() == Constants.ITEM) {
-            lmTime = ((Item) dso).getLastModified().getTime();
+            lmTime = ((Item) dso).getLastModified().toEpochMilli();
         }
 
         // map of extra streams to put in Zip (these are located during makeManifest())
@@ -417,7 +417,7 @@ public abstract class AbstractMETSDisseminator
             Item item = (Item) dso;
 
             //get last modified time
-            long lmTime = ((Item) dso).getLastModified().getTime();
+            long lmTime = ((Item) dso).getLastModified().toEpochMilli();
 
             List<Bundle> bundles = item.getBundles();
             for (Bundle bundle : bundles) {

--- a/dspace-api/src/main/java/org/dspace/content/packager/DSpaceAIPDisseminator.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/DSpaceAIPDisseminator.java
@@ -10,9 +10,9 @@ package org.dspace.content.packager;
 import java.io.File;
 import java.io.IOException;
 import java.sql.SQLException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 
 import edu.harvard.hul.ois.mets.Agent;
@@ -137,7 +137,7 @@ public class DSpaceAIPDisseminator extends AbstractMETSDisseminator {
         // (Note: this only works for Items right now, as DSpace doesn't store a
         //  last modified date for Collections or Communities)
         if (disseminateParams.containsKey("updatedAfter") && dso.getType() == Constants.ITEM) {
-            Date afterDate = Utils.parseISO8601Date(disseminateParams.getProperty("updatedAfter"));
+            Instant afterDate = Utils.parseISO8601Date(disseminateParams.getProperty("updatedAfter"));
 
             //if null is returned, we couldn't parse the date!
             if (afterDate == null) {
@@ -148,7 +148,7 @@ public class DSpaceAIPDisseminator extends AbstractMETSDisseminator {
 
             //check when this item was last modified.
             Item i = (Item) dso;
-            if (i.getLastModified().after(afterDate)) {
+            if (i.getLastModified().isAfter(afterDate)) {
                 disseminate = true;
             } else {
                 disseminate = false;
@@ -207,7 +207,7 @@ public class DSpaceAIPDisseminator extends AbstractMETSDisseminator {
 
         // Add a LASTMODDATE for items
         if (dso.getType() == Constants.ITEM) {
-            metsHdr.setLASTMODDATE(((Item) dso).getLastModified());
+            metsHdr.setLASTMODDATE(java.util.Date.from(((Item) dso).getLastModified()));
         }
 
         // Agent Custodian - name custodian, the DSpace Archive, by handle.

--- a/dspace-api/src/main/java/org/dspace/content/packager/DSpaceMETSDisseminator.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/DSpaceMETSDisseminator.java
@@ -9,8 +9,8 @@ package org.dspace.content.packager;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 import edu.harvard.hul.ois.mets.Agent;
@@ -105,7 +105,7 @@ public class DSpaceMETSDisseminator
         MetsHdr metsHdr = new MetsHdr();
 
         // FIXME: CREATEDATE is now: maybe should be item create?
-        metsHdr.setCREATEDATE(new Date());
+        metsHdr.setCREATEDATE(java.util.Date.from(Instant.now()));
 
         // Agent
         Agent agent = new Agent();

--- a/dspace-api/src/main/java/org/dspace/content/packager/PDFPackager.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/PDFPackager.java
@@ -13,8 +13,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.sql.SQLException;
-import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 import org.apache.commons.lang3.ArrayUtils;
@@ -425,7 +425,7 @@ public class PDFPackager
             if (calValue != null) {
                 itemService.addMetadata(context, item, MetadataSchemaEnum.DC.getName(), "date", "created", null,
                                         new DCDate(
-                                            LocalDateTime.ofInstant(calValue.toInstant(), ZoneOffset.UTC)
+                                            ZonedDateTime.ofInstant(calValue.toInstant(), ZoneOffset.UTC)
                                         ).toString());
             }
             itemService.update(context, item);

--- a/dspace-api/src/main/java/org/dspace/content/packager/PDFPackager.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/PDFPackager.java
@@ -13,7 +13,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.sql.SQLException;
-import java.util.Calendar;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 
 import org.apache.commons.lang3.ArrayUtils;
@@ -416,14 +417,16 @@ public class PDFPackager
 
             // Take either CreationDate or ModDate as "date.created",
             // Too bad there's no place to put "last modified" in the DC.
-            Calendar calValue = docinfo.getCreationDate();
+            java.util.Calendar calValue = docinfo.getCreationDate();
             if (calValue == null) {
                 calValue = docinfo.getModificationDate();
             }
 
             if (calValue != null) {
                 itemService.addMetadata(context, item, MetadataSchemaEnum.DC.getName(), "date", "created", null,
-                                        (new DCDate(calValue.getTime())).toString());
+                                        new DCDate(
+                                            LocalDateTime.ofInstant(calValue.toInstant(), ZoneOffset.UTC)
+                                        ).toString());
             }
             itemService.update(context, item);
         } finally {

--- a/dspace-api/src/main/java/org/dspace/content/service/ItemService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/ItemService.java
@@ -10,7 +10,7 @@ package org.dspace.content.service;
 import java.io.IOException;
 import java.io.InputStream;
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
@@ -246,7 +246,7 @@ public interface ItemService
      * @return an iterator over the items in the collection.
      * @throws SQLException if database error
      */
-    Iterator<Item> findInArchiveOrWithdrawnDiscoverableModifiedSince(Context context, Date since)
+    Iterator<Item> findInArchiveOrWithdrawnDiscoverableModifiedSince(Context context, Instant since)
         throws SQLException;
 
     /**
@@ -256,7 +256,7 @@ public interface ItemService
      * @return an iterator over the items in the collection.
      * @throws SQLException if database error
      */
-    Iterator<Item> findInArchiveOrWithdrawnNonDiscoverableModifiedSince(Context context, Date since)
+    Iterator<Item> findInArchiveOrWithdrawnNonDiscoverableModifiedSince(Context context, Instant since)
         throws SQLException;
 
     /**
@@ -853,7 +853,7 @@ public interface ItemService
      * @return iterator over items
      * @throws SQLException if database error
      */
-    Iterator<Item> findByLastModifiedSince(Context context, Date last)
+    Iterator<Item> findByLastModifiedSince(Context context, Instant last)
         throws SQLException;
 
     /**

--- a/dspace-api/src/main/java/org/dspace/contentreport/ItemFilterUtil.java
+++ b/dspace-api/src/main/java/org/dspace/contentreport/ItemFilterUtil.java
@@ -10,8 +10,9 @@ package org.dspace.contentreport;
 import static org.dspace.content.Item.ANY;
 
 import java.sql.SQLException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
-import java.util.Calendar;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -345,9 +346,8 @@ public class ItemFilterUtil {
     }
 
     static boolean recentlyModified(Item item, int days) {
-        Calendar cal = Calendar.getInstance();
-        cal.add(Calendar.DATE, -days);
-        return cal.getTime().before(item.getLastModified());
+        Instant compareDate = Instant.now().minus(days, ChronoUnit.DAYS);
+        return compareDate.isBefore(item.getLastModified());
     }
 
 }

--- a/dspace-api/src/main/java/org/dspace/core/Email.java
+++ b/dspace-api/src/main/java/org/dspace/core/Email.java
@@ -17,9 +17,9 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.StringWriter;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Properties;
@@ -388,8 +388,8 @@ public class Email {
         String fullMessage = writer.toString();
 
         // Set some message header fields
-        Date date = new Date();
-        message.setSentDate(date);
+        Instant date = Instant.now();
+        message.setSentDate(java.util.Date.from(date));
         message.setFrom(new InternetAddress(from));
 
         for (String headerName : templateHeaders) {

--- a/dspace-api/src/main/java/org/dspace/core/Utils.java
+++ b/dspace-api/src/main/java/org/dspace/core/Utils.java
@@ -23,12 +23,12 @@ import java.rmi.dgc.VMID;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.TemporalAccessor;
 import java.util.Arrays;
-import java.util.Calendar;
 import java.util.Collections;
-import java.util.Date;
-import java.util.GregorianCalendar;
 import java.util.Random;
 import java.util.StringTokenizer;
 import java.util.regex.Matcher;
@@ -75,31 +75,27 @@ public final class Utils {
     private static final VMID vmid = new VMID();
 
     // for parseISO8601Date
-    private static final SimpleDateFormat[] parseFmt = {
-        // first try at parsing, has milliseconds (note General time zone)
-        new SimpleDateFormat("yyyy'-'MM'-'dd'T'HH':'mm':'ss.SSSz"),
+    private static final DateTimeFormatter[] parseFmt = {
+        // First try a standard Instant format
+        DateTimeFormatter.ISO_INSTANT,
 
-        // second try at parsing, no milliseconds (note General time zone)
-        new SimpleDateFormat("yyyy'-'MM'-'dd'T'HH':'mm':'ssz"),
+        // then try at parsing, has milliseconds (note General time zone)
+        DateTimeFormatter.ofPattern("yyyy'-'MM'-'dd'T'HH':'mm':'ss.SSSz"),
+
+        // then try at parsing, no milliseconds (note General time zone)
+        DateTimeFormatter.ofPattern("yyyy'-'MM'-'dd'T'HH':'mm':'ssz"),
 
         // finally, try without any timezone (defaults to current TZ)
-        new SimpleDateFormat("yyyy'-'MM'-'dd'T'HH':'mm':'ss.SSS"),
+        DateTimeFormatter.ofPattern("yyyy'-'MM'-'dd'T'HH':'mm':'ss.SSS"),
 
-        new SimpleDateFormat("yyyy'-'MM'-'dd'T'HH':'mm':'ss"),
+        DateTimeFormatter.ofPattern("yyyy'-'MM'-'dd'T'HH':'mm':'ss"),
 
-        new SimpleDateFormat("yyyy'-'MM'-'dd")
+        DateTimeFormatter.ofPattern("yyyy'-'MM'-'dd")
     };
 
     // for formatISO8601Date
-    // output canonical format (note RFC22 time zone, easier to hack)
-    private static final SimpleDateFormat outFmtSecond
-            = new SimpleDateFormat("yyyy'-'MM'-'dd'T'HH':'mm':'ssZ");
-
-    // output format with millisecond precision
-    private static final SimpleDateFormat outFmtMillisec
-            = new SimpleDateFormat("yyyy'-'MM'-'dd'T'HH':'mm':'ss.SSSZ");
-
-    private static final Calendar outCal = GregorianCalendar.getInstance();
+    // output canonical format
+    private static final DateTimeFormatter outFmt = DateTimeFormatter.ISO_INSTANT;
 
     /**
      * Private constructor
@@ -199,7 +195,7 @@ public final class Utils {
         byte[] junk = new byte[16];
 
         random.nextBytes(junk);
-        String input = String.valueOf(vmid) + new Date() + Arrays.toString(junk) + counter++;
+        String input = String.valueOf(vmid) + Instant.now().toEpochMilli() + Arrays.toString(junk) + counter++;
 
         return getMD5Bytes(input.getBytes(StandardCharsets.UTF_8));
     }
@@ -316,29 +312,16 @@ public final class Utils {
     /**
      * Translates timestamp from an ISO 8601-standard format, which
      * is commonly used in XML and RDF documents.
-     * This method is synchronized because it depends on a non-reentrant
-     * static DateFormat (more efficient than creating a new one each call).
      *
      * @param s the input string
-     * @return Date object, or null if there is a problem translating.
+     * @return Instant object, or null if there is a problem translating.
      */
-    public static synchronized Date parseISO8601Date(String s) {
-        // attempt to normalize the timezone to something we can parse;
-        // SimpleDateFormat can't handle "Z"
-        char tzSign = s.charAt(s.length() - 6);
-        if (s.endsWith("Z")) {
-            s = s.substring(0, s.length() - 1) + "GMT+00:00";
-        } else if ((tzSign == '-' || tzSign == '+') && s.length() > 10) {
-            // check for trailing timezone
-            s = s.substring(0, s.length() - 6) + "GMT" + s.substring(s.length() - 6);
-        }
-
-        // try to parse without milliseconds
-        ParseException lastError = null;
-        for (SimpleDateFormat simpleDateFormat : parseFmt) {
+    public static Instant parseISO8601Date(String s) {
+        DateTimeParseException lastError = null;
+        for (DateTimeFormatter formatter : parseFmt) {
             try {
-                return simpleDateFormat.parse(s);
-            } catch (ParseException e) {
+                return formatter.parse(s, Instant::from);
+            } catch (DateTimeParseException e) {
                 lastError = e;
             }
         }
@@ -349,24 +332,13 @@ public final class Utils {
     }
 
     /**
-     * Convert a Date to String in the ISO 8601 standard format.
-     * The RFC822 timezone is almost right, still need to insert ":".
-     * This method is synchronized because it depends on a non-reentrant
-     * static DateFormat (more efficient than creating a new one each call).
+     * Convert a date to String in the ISO 8601 standard format.
      *
-     * @param d the input Date
+     * @param date the input TemporalAccessor (e.g. LocalDate, LocalDateTime, Instant)
      * @return String containing formatted date.
      */
-    public static synchronized String formatISO8601Date(Date d) {
-        String result;
-        outCal.setTime(d);
-        if (outCal.get(Calendar.MILLISECOND) == 0) {
-            result = outFmtSecond.format(d);
-        } else {
-            result = outFmtMillisec.format(d);
-        }
-        int rl = result.length();
-        return result.substring(0, rl - 2) + ":" + result.substring(rl - 2);
+    public static String formatISO8601Date(TemporalAccessor date) {
+        return outFmt.format(date);
     }
 
     public static <E> java.util.Collection<E> emptyIfNull(java.util.Collection<E> collection) {

--- a/dspace-api/src/main/java/org/dspace/correctiontype/ReinstateCorrectionType.java
+++ b/dspace-api/src/main/java/org/dspace/correctiontype/ReinstateCorrectionType.java
@@ -11,7 +11,7 @@ import static org.dspace.content.QAEvent.DSPACE_USERS_SOURCE;
 import static org.dspace.correctiontype.WithdrawnCorrectionType.WITHDRAWAL_REINSTATE_GROUP;
 
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -89,7 +89,7 @@ public class ReinstateCorrectionType implements CorrectionType, InitializingBean
                                       this.getTopic(),
                                       1.0,
                                       reasonJson.toString(),
-                                      new Date()
+                                      Instant.now()
                                       );
 
         qaEventService.store(context, qaEvent);

--- a/dspace-api/src/main/java/org/dspace/correctiontype/WithdrawnCorrectionType.java
+++ b/dspace-api/src/main/java/org/dspace/correctiontype/WithdrawnCorrectionType.java
@@ -11,7 +11,7 @@ import static org.dspace.content.QAEvent.DSPACE_USERS_SOURCE;
 import static org.dspace.core.Constants.READ;
 
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -91,7 +91,7 @@ public class WithdrawnCorrectionType implements CorrectionType, InitializingBean
                                       this.getTopic(),
                                       1.0,
                                       reasonJson.toString(),
-                                      new Date()
+                                      Instant.now()
                                       );
 
         qaEventService.store(context, qaEvent);

--- a/dspace-api/src/main/java/org/dspace/curate/Curation.java
+++ b/dspace-api/src/main/java/org/dspace/curate/Curation.java
@@ -17,6 +17,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.io.Writer;
 import java.sql.SQLException;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -69,7 +70,7 @@ public class Curation extends DSpaceRunnable<CurationScriptConfiguration> {
 
         // load curation tasks
         if (curationClientOptions == CurationClientOptions.TASK) {
-            long start = System.currentTimeMillis();
+            long start = Instant.now().toEpochMilli();
             handleCurationTask(curator);
             this.endScript(start);
         }
@@ -144,7 +145,7 @@ public class Curation extends DSpaceRunnable<CurationScriptConfiguration> {
      */
     private long runQueue(TaskQueue queue, Curator curator) throws SQLException, AuthorizeException, IOException {
         // use current time as our reader 'ticket'
-        long ticket = System.currentTimeMillis();
+        long ticket = Instant.now().toEpochMilli();
         Iterator<TaskQueueEntry> entryIter = queue.dequeue(this.queue, ticket).iterator();
         while (entryIter.hasNext()) {
             TaskQueueEntry entry = entryIter.next();
@@ -170,7 +171,7 @@ public class Curation extends DSpaceRunnable<CurationScriptConfiguration> {
     private void endScript(long timeRun) throws SQLException {
         context.complete();
         if (verbose) {
-            long elapsed = System.currentTimeMillis() - timeRun;
+            long elapsed = Instant.now().toEpochMilli() - timeRun;
             this.handler.logInfo("Ending curation. Elapsed time: " + elapsed);
         }
     }

--- a/dspace-api/src/main/java/org/dspace/curate/Curator.java
+++ b/dspace-api/src/main/java/org/dspace/curate/Curator.java
@@ -10,6 +10,7 @@ package org.dspace.curate;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.text.MessageFormat;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -330,7 +331,7 @@ public class Curator {
         }
         if (taskQ != null) {
             taskQ.enqueue(queueId, new TaskQueueEntry(c.getCurrentUser().getName(),
-                                                      System.currentTimeMillis(), perfList, id));
+                                                      Instant.now().toEpochMilli(), perfList, id));
         } else {
             System.out.println("curate - no TaskQueue implemented");
         }

--- a/dspace-api/src/main/java/org/dspace/curate/FileReporter.java
+++ b/dspace-api/src/main/java/org/dspace/curate/FileReporter.java
@@ -13,9 +13,8 @@ import java.io.IOException;
 import java.io.Writer;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.GregorianCalendar;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 
 import org.dspace.services.ConfigurationService;
 import org.dspace.utils.DSpace;
@@ -41,9 +40,8 @@ public class FileReporter
     public FileReporter()
             throws IOException {
         // Calculate a unique(?) file name.
-        Date now = GregorianCalendar.getInstance().getTime();
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd'T'hhmmssSSS");
-        String filename = String.format("curation-%s.report", sdf.format(now));
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd'T'hhmmssSSS");
+        String filename = String.format("curation-%s.report", formatter.format(Instant.now()));
 
         // Build a path to the directory which is to receive the file.
         ConfigurationService cfg = new DSpace().getConfigurationService();

--- a/dspace-api/src/main/java/org/dspace/curate/FileReporter.java
+++ b/dspace-api/src/main/java/org/dspace/curate/FileReporter.java
@@ -13,7 +13,8 @@ import java.io.IOException;
 import java.io.Writer;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 
 import org.dspace.services.ConfigurationService;
@@ -41,7 +42,7 @@ public class FileReporter
             throws IOException {
         // Calculate a unique(?) file name.
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd'T'hhmmssSSS");
-        String filename = String.format("curation-%s.report", formatter.format(Instant.now()));
+        String filename = String.format("curation-%s.report", formatter.format(LocalDateTime.now(ZoneOffset.UTC)));
 
         // Build a path to the directory which is to receive the file.
         ConfigurationService cfg = new DSpace().getConfigurationService();

--- a/dspace-api/src/main/java/org/dspace/curate/TaskQueueEntry.java
+++ b/dspace-api/src/main/java/org/dspace/curate/TaskQueueEntry.java
@@ -26,7 +26,7 @@ public final class TaskQueueEntry {
      * TaskQueueEntry constructor with enumerated field values.
      *
      * @param epersonId  task owner
-     * @param submitTime time the task was submitted (System.currentTimeMillis())
+     * @param submitTime time the task was submitted (Instant.now().toEpochMilli())
      * @param taskNames  list of task names
      * @param objId      usually a handle or workflow id
      */

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexClient.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexClient.java
@@ -11,6 +11,7 @@ import static org.dspace.discovery.IndexClientOptions.TYPE_OPTION;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -116,10 +117,10 @@ public class IndexClient extends DSpaceRunnable<IndexDiscoveryScriptConfiguratio
                 break;
             case INDEX:
                 handler.logInfo("Indexing " + commandLine.getOptionValue('i') + " force " + commandLine.hasOption("f"));
-                final long startTimeMillis = System.currentTimeMillis();
+                final long startTimeMillis = Instant.now().toEpochMilli();
                 final long count = indexAll(indexer, ContentServiceFactory.getInstance().getItemService(), context,
                     indexableObject.get());
-                final long seconds = (System.currentTimeMillis() - startTimeMillis) / 1000;
+                final long seconds = (Instant.now().toEpochMilli() - startTimeMillis) / 1000;
                 handler.logInfo("Indexed " + count + " object" + (count > 1 ? "s" : "") +
                                 " in " + seconds + " seconds");
                 break;

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexableObject.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexableObject.java
@@ -8,7 +8,7 @@
 package org.dspace.discovery;
 
 import java.io.Serializable;
-import java.util.Date;
+import java.time.Instant;
 
 import org.dspace.core.Constants;
 import org.dspace.core.ReloadableEntity;
@@ -62,10 +62,10 @@ public interface IndexableObject<T extends ReloadableEntity<PK>, PK extends Seri
     String getTypeText();
 
     /**
-     * Return the last modified date of an of an object, or if no modification dates are stored, return NUll
+     * Return the last modified date of an object, or if no modification dates are stored, return NUll
      * @return the last modified date
      */
-    default Date getLastModified() {
+    default Instant getLastModified() {
         return null;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -15,12 +15,9 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.sql.SQLException;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -28,7 +25,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
-import java.util.TimeZone;
 import java.util.UUID;
 
 import jakarta.mail.MessagingException;
@@ -454,10 +450,10 @@ public class SolrServiceImpl implements SearchService, IndexingService {
             if (solrSearchCore.getSolr() == null) {
                 return;
             }
-            long start = System.currentTimeMillis();
+            long start = Instant.now().toEpochMilli();
             System.out.println("SOLR Search Optimize -- Process Started:" + start);
             solrSearchCore.getSolr().optimize();
-            long finish = System.currentTimeMillis();
+            long finish = Instant.now().toEpochMilli();
             System.out.println("SOLR Search Optimize -- Process Finished:" + finish);
             System.out.println("SOLR Search Optimize -- Total time taken:" + (finish - start) + " (ms).");
         } catch (SolrServerException | IOException e) {
@@ -508,7 +504,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
                         Locale.getDefault(), "internal_error"));
                 email.addRecipient(recipient);
                 email.addArgument(configurationService.getProperty("dspace.ui.url"));
-                email.addArgument(new Date());
+                email.addArgument(Instant.now());
 
                 String stackTrace;
 
@@ -544,7 +540,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
      * @throws IOException            io exception
      * @throws SearchServiceException if something went wrong with querying the solr server
      */
-    protected boolean requiresIndexing(String uniqueId, Date lastModified)
+    protected boolean requiresIndexing(String uniqueId, Instant lastModified)
         throws SQLException, IOException, SearchServiceException {
 
         // Check if we even have a last modified date
@@ -576,11 +572,13 @@ public class SolrServiceImpl implements SearchService, IndexingService {
 
             Object value = doc.getFieldValue(SearchUtils.LAST_INDEXED_FIELD);
 
-            if (value instanceof Date) {
-                Date lastIndexed = (Date) value;
+            // If it's a java.util.Date, convert to an Instant
+            if (value instanceof java.util.Date) {
+                value = ((java.util.Date) value).toInstant();
+            }
 
-                if (lastIndexed.before(lastModified)) {
-
+            if (value instanceof Instant lastIndexed) {
+                if (lastIndexed.isBefore(lastModified)) {
                     reindexItem = true;
                 }
             }
@@ -653,73 +651,6 @@ public class SolrServiceImpl implements SearchService, IndexingService {
             }
         }
         return locationQuery.toString();
-    }
-
-    /**
-     * Helper function to retrieve a date using a best guess of the potential
-     * date encodings on a field
-     *
-     * @param t the string to be transformed to a date
-     * @return a date if the formatting was successful, null if not able to transform to a date
-     */
-    public Date toDate(String t) {
-        SimpleDateFormat[] dfArr;
-
-        // Choose the likely date formats based on string length
-        switch (t.length()) {
-            // case from 1 to 3 go through adding anyone a single 0. Case 4 define
-            // for all the SimpleDateFormat
-            case 1:
-                t = "0" + t;
-                // fall through
-            case 2:
-                t = "0" + t;
-                // fall through
-            case 3:
-                t = "0" + t;
-                // fall through
-            case 4:
-                dfArr = new SimpleDateFormat[] {new SimpleDateFormat("yyyy")};
-                break;
-            case 6:
-                dfArr = new SimpleDateFormat[] {new SimpleDateFormat("yyyyMM")};
-                break;
-            case 7:
-                dfArr = new SimpleDateFormat[] {new SimpleDateFormat("yyyy-MM")};
-                break;
-            case 8:
-                dfArr = new SimpleDateFormat[] {new SimpleDateFormat("yyyyMMdd"),
-                    new SimpleDateFormat("yyyy MMM")};
-                break;
-            case 10:
-                dfArr = new SimpleDateFormat[] {new SimpleDateFormat("yyyy-MM-dd")};
-                break;
-            case 11:
-                dfArr = new SimpleDateFormat[] {new SimpleDateFormat("yyyy MMM dd")};
-                break;
-            case 20:
-                dfArr = new SimpleDateFormat[] {new SimpleDateFormat(
-                    "yyyy-MM-dd'T'HH:mm:ss'Z'")};
-                break;
-            default:
-                dfArr = new SimpleDateFormat[] {new SimpleDateFormat(
-                    "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")};
-                break;
-        }
-
-        for (SimpleDateFormat df : dfArr) {
-            try {
-                // Parse the date
-                df.setCalendar(Calendar
-                                   .getInstance(TimeZone.getTimeZone("UTC")));
-                df.setLenient(false);
-                return df.parse(t);
-            } catch (ParseException pe) {
-                log.error("Unable to parse date format", pe);
-            }
-        }
-
-        return null;
     }
 
     public String locationToName(Context context, String field, String value) throws SQLException {

--- a/dspace-api/src/main/java/org/dspace/discovery/indexobject/IndexFactoryImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/indexobject/IndexFactoryImpl.java
@@ -10,7 +10,7 @@ package org.dspace.discovery.indexobject;
 import java.io.IOException;
 import java.io.InputStream;
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 
 import org.apache.commons.collections4.ListUtils;
@@ -54,7 +54,7 @@ public abstract class IndexFactoryImpl<T extends IndexableObject, S> implements 
         SolrInputDocument doc = new SolrInputDocument();
         // want to be able to check when last updated
         // (not tokenized, but it is indexed)
-        doc.addField(SearchUtils.LAST_INDEXED_FIELD, SolrUtils.getDateFormatter().format(new Date()));
+        doc.addField(SearchUtils.LAST_INDEXED_FIELD, SolrUtils.getDateFormatter().format(Instant.now()));
 
         // New fields to weaken the dependence on handles, and allow for faster
         // list display

--- a/dspace-api/src/main/java/org/dspace/discovery/indexobject/IndexableItem.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/indexobject/IndexableItem.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.discovery.indexobject;
 
-import java.util.Date;
+import java.time.Instant;
 
 import org.dspace.content.Item;
 import org.dspace.core.Constants;
@@ -25,7 +25,7 @@ public class IndexableItem extends IndexableDSpaceObject<Item> {
     }
 
     @Override
-    public Date getLastModified() {
+    public Instant getLastModified() {
         return getIndexedObject().getLastModified();
     }
 

--- a/dspace-api/src/main/java/org/dspace/discovery/indexobject/ItemIndexFactoryImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/indexobject/ItemIndexFactoryImpl.java
@@ -11,8 +11,9 @@ import static org.dspace.discovery.SolrServiceImpl.SOLR_FIELD_SUFFIX_FACET_PREFI
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -27,7 +28,6 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.time.DateFormatUtils;
 import org.apache.logging.log4j.Logger;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.common.SolrInputDocument;
@@ -413,7 +413,7 @@ public class ItemIndexFactoryImpl extends DSpaceObjectIndexFactoryImpl<Indexable
                     }
 
                     for (DiscoverySearchFilter searchFilter : searchFilterConfigs) {
-                        Date date = null;
+                        ZonedDateTime date = null;
                         String separator = DSpaceServicesFactory.getInstance().getConfigurationService()
                                 .getProperty("discovery.solr.facets.split.char");
                         if (separator == null) {
@@ -424,7 +424,7 @@ public class ItemIndexFactoryImpl extends DSpaceObjectIndexFactoryImpl<Indexable
                             date = MultiFormatDateParser.parse(value);
                             if (date != null) {
                                 //TODO: make this date format configurable !
-                                value = DateFormatUtils.formatUTC(date, "yyyy-MM-dd");
+                                value = DateTimeFormatter.ISO_LOCAL_DATE.format(date);
                             }
                         }
                         doc.addField(searchFilter.getIndexFieldName(), value);
@@ -501,7 +501,7 @@ public class ItemIndexFactoryImpl extends DSpaceObjectIndexFactoryImpl<Indexable
                     }
 
                     if (type.equals(DiscoveryConfigurationParameters.TYPE_DATE)) {
-                        Date date = MultiFormatDateParser.parse(value);
+                        ZonedDateTime date = MultiFormatDateParser.parse(value);
                         if (date != null) {
                             String stringDate = SolrUtils.getDateFormatter().format(date);
                             doc.addField(field + "_dt", stringDate);
@@ -688,13 +688,13 @@ public class ItemIndexFactoryImpl extends DSpaceObjectIndexFactoryImpl<Indexable
      * @param doc the solr document
      * @param searchFilter the discoverySearchFilter
      * @param value the metadata value
-     * @param date Date object
+     * @param date ZonedDateTime object
      * @param authority the authority key
      * @param preferedLabel the preferred label for metadata field
      * @param separator the separator being used to separate lowercase and regular case
      */
     private void indexIfFilterTypeFacet(SolrInputDocument doc, DiscoverySearchFilter searchFilter, String value,
-                                   Date date, String authority, String preferedLabel, String separator) {
+                                   ZonedDateTime date, String authority, String preferedLabel, String separator) {
         if (searchFilter.getType().equals(DiscoveryConfigurationParameters.TYPE_TEXT)) {
             //Add a special filter
             //We use a separator to split up the lowercase and regular case, this is needed to
@@ -714,7 +714,7 @@ public class ItemIndexFactoryImpl extends DSpaceObjectIndexFactoryImpl<Indexable
         } else if (searchFilter.getType().equals(DiscoveryConfigurationParameters.TYPE_DATE)) {
             if (date != null) {
                 String indexField = searchFilter.getIndexFieldName() + ".year";
-                String yearUTC = DateFormatUtils.formatUTC(date, "yyyy");
+                String yearUTC = DateTimeFormatter.ofPattern("yyyy").format(date);
                 doc.addField(searchFilter.getIndexFieldName() + "_keyword", yearUTC);
                 // add the year to the autocomplete index
                 doc.addField(searchFilter.getIndexFieldName() + "_ac", yearUTC);

--- a/dspace-api/src/main/java/org/dspace/discovery/indexobject/ItemIndexFactoryImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/indexobject/ItemIndexFactoryImpl.java
@@ -424,7 +424,7 @@ public class ItemIndexFactoryImpl extends DSpaceObjectIndexFactoryImpl<Indexable
                             date = MultiFormatDateParser.parse(value);
                             if (date != null) {
                                 //TODO: make this date format configurable !
-                                value = DateTimeFormatter.ISO_LOCAL_DATE.format(date);
+                                value = DateTimeFormatter.ISO_LOCAL_DATE.format(date.toLocalDateTime().toLocalDate());
                             }
                         }
                         doc.addField(searchFilter.getIndexFieldName(), value);
@@ -714,7 +714,7 @@ public class ItemIndexFactoryImpl extends DSpaceObjectIndexFactoryImpl<Indexable
         } else if (searchFilter.getType().equals(DiscoveryConfigurationParameters.TYPE_DATE)) {
             if (date != null) {
                 String indexField = searchFilter.getIndexFieldName() + ".year";
-                String yearUTC = DateTimeFormatter.ofPattern("yyyy").format(date);
+                String yearUTC = String.valueOf(date.getYear());
                 doc.addField(searchFilter.getIndexFieldName() + "_keyword", yearUTC);
                 // add the year to the autocomplete index
                 doc.addField(searchFilter.getIndexFieldName() + "_ac", yearUTC);

--- a/dspace-api/src/main/java/org/dspace/discovery/indexobject/LDNMessageEntityIndexFactoryImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/indexobject/LDNMessageEntityIndexFactoryImpl.java
@@ -7,12 +7,12 @@
  */
 package org.dspace.discovery.indexobject;
 
-import static org.apache.commons.lang3.time.DateFormatUtils.format;
-
 import java.io.IOException;
 import java.sql.SQLException;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -137,9 +137,9 @@ public class LDNMessageEntityIndexFactoryImpl extends IndexFactoryImpl<Indexable
         return doc;
     }
 
-    private void indexDateFieldForFacet(SolrInputDocument doc, Date queueLastStartTime) {
+    private void indexDateFieldForFacet(SolrInputDocument doc, Instant queueLastStartTime) {
         if (queueLastStartTime != null) {
-            String value = format(queueLastStartTime, "yyyy-MM-dd");
+            String value = DateTimeFormatter.ISO_LOCAL_DATE.format(queueLastStartTime);
             addFacetIndex(doc, "queue_last_start_time", value, value);
             doc.addField("queue_last_start_time", value);
             doc.addField("queue_last_start_time_dt", queueLastStartTime);
@@ -147,10 +147,8 @@ public class LDNMessageEntityIndexFactoryImpl extends IndexFactoryImpl<Indexable
             doc.addField("queue_last_start_time_min_sort", value);
             doc.addField("queue_last_start_time_max", value);
             doc.addField("queue_last_start_time_max_sort", value);
-            doc.addField("queue_last_start_time.year",
-                Integer.parseInt(format(queueLastStartTime, "yyyy")));
-            doc.addField("queue_last_start_time.year_sort",
-                Integer.parseInt(format(queueLastStartTime, "yyyy")));
+            doc.addField("queue_last_start_time.year", queueLastStartTime.atZone(ZoneOffset.UTC).getYear());
+            doc.addField("queue_last_start_time.year_sort", queueLastStartTime.atZone(ZoneOffset.UTC).getYear());
         }
     }
 

--- a/dspace-api/src/main/java/org/dspace/discovery/indexobject/LDNMessageEntityIndexFactoryImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/indexobject/LDNMessageEntityIndexFactoryImpl.java
@@ -10,6 +10,7 @@ package org.dspace.discovery.indexobject;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
@@ -139,7 +140,8 @@ public class LDNMessageEntityIndexFactoryImpl extends IndexFactoryImpl<Indexable
 
     private void indexDateFieldForFacet(SolrInputDocument doc, Instant queueLastStartTime) {
         if (queueLastStartTime != null) {
-            String value = DateTimeFormatter.ISO_LOCAL_DATE.format(queueLastStartTime);
+            String value = DateTimeFormatter.ISO_LOCAL_DATE.format(LocalDate.ofInstant(queueLastStartTime,
+                                                                                       ZoneOffset.UTC));
             addFacetIndex(doc, "queue_last_start_time", value, value);
             doc.addField("queue_last_start_time", value);
             doc.addField("queue_last_start_time_dt", queueLastStartTime);

--- a/dspace-api/src/main/java/org/dspace/embargo/DayTableEmbargoSetter.java
+++ b/dspace-api/src/main/java/org/dspace/embargo/DayTableEmbargoSetter.java
@@ -9,8 +9,8 @@ package org.dspace.embargo;
 
 import java.sql.SQLException;
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Properties;
 
 import org.dspace.authorize.AuthorizeException;
@@ -65,7 +65,7 @@ public class DayTableEmbargoSetter extends DefaultEmbargoSetter {
             if (days != null && days.length() > 0) {
                 long lift = Instant.now().toEpochMilli() +
                     (Long.parseLong(days) * 24 * 60 * 60 * 1000);
-                return new DCDate(LocalDateTime.ofEpochSecond(lift, 0, ZoneOffset.UTC));
+                return new DCDate(ZonedDateTime.ofInstant(Instant.ofEpochSecond(lift), ZoneOffset.UTC));
             }
         }
         return null;

--- a/dspace-api/src/main/java/org/dspace/embargo/DayTableEmbargoSetter.java
+++ b/dspace-api/src/main/java/org/dspace/embargo/DayTableEmbargoSetter.java
@@ -8,7 +8,9 @@
 package org.dspace.embargo;
 
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.Properties;
 
 import org.dspace.authorize.AuthorizeException;
@@ -61,9 +63,9 @@ public class DayTableEmbargoSetter extends DefaultEmbargoSetter {
             }
             String days = termProps.getProperty(terms);
             if (days != null && days.length() > 0) {
-                long lift = System.currentTimeMillis() +
+                long lift = Instant.now().toEpochMilli() +
                     (Long.parseLong(days) * 24 * 60 * 60 * 1000);
-                return new DCDate(new Date(lift));
+                return new DCDate(LocalDateTime.ofEpochSecond(lift, 0, ZoneOffset.UTC));
             }
         }
         return null;

--- a/dspace-api/src/main/java/org/dspace/embargo/DefaultEmbargoSetter.java
+++ b/dspace-api/src/main/java/org/dspace/embargo/DefaultEmbargoSetter.java
@@ -9,7 +9,7 @@ package org.dspace.embargo;
 
 import java.io.IOException;
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
@@ -94,16 +94,16 @@ public class DefaultEmbargoSetter implements EmbargoSetter {
             if (!(bnn.equals(Constants.LICENSE_BUNDLE_NAME) || bnn.equals(Constants.METADATA_BUNDLE_NAME) || bnn
                 .equals(CreativeCommonsServiceImpl.CC_BUNDLE_NAME))) {
                 //AuthorizeManager.removePoliciesActionFilter(context, bn, Constants.READ);
-                generatePolicies(context, liftDate.toDate(), null, bn, item.getOwningCollection());
+                generatePolicies(context, liftDate.toDate().toLocalDate(), null, bn, item.getOwningCollection());
                 for (Bitstream bs : bn.getBitstreams()) {
                     //AuthorizeManager.removePoliciesActionFilter(context, bs, Constants.READ);
-                    generatePolicies(context, liftDate.toDate(), null, bs, item.getOwningCollection());
+                    generatePolicies(context, liftDate.toDate().toLocalDate(), null, bs, item.getOwningCollection());
                 }
             }
         }
     }
 
-    protected void generatePolicies(Context context, Date embargoDate,
+    protected void generatePolicies(Context context, LocalDate embargoDate,
                                     String reason, DSpaceObject dso, Collection owningCollection)
         throws SQLException, AuthorizeException {
 

--- a/dspace-api/src/main/java/org/dspace/embargo/EmbargoCLITool.java
+++ b/dspace-api/src/main/java/org/dspace/embargo/EmbargoCLITool.java
@@ -9,6 +9,7 @@ package org.dspace.embargo;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Iterator;
 import java.util.List;
@@ -123,7 +124,7 @@ public class EmbargoCLITool {
         try {
             context = new Context(Context.Mode.BATCH_EDIT);
             context.turnOffAuthorisationSystem();
-            ZonedDateTime now = ZonedDateTime.now();
+            ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
 
             // scan items under embargo
             if (line.hasOption('i')) {

--- a/dspace-api/src/main/java/org/dspace/embargo/EmbargoCLITool.java
+++ b/dspace-api/src/main/java/org/dspace/embargo/EmbargoCLITool.java
@@ -9,7 +9,7 @@ package org.dspace.embargo;
 
 import java.io.IOException;
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.ZonedDateTime;
 import java.util.Iterator;
 import java.util.List;
 
@@ -123,7 +123,7 @@ public class EmbargoCLITool {
         try {
             context = new Context(Context.Mode.BATCH_EDIT);
             context.turnOffAuthorisationSystem();
-            Date now = new Date();
+            ZonedDateTime now = ZonedDateTime.now();
 
             // scan items under embargo
             if (line.hasOption('i')) {
@@ -173,7 +173,7 @@ public class EmbargoCLITool {
 
     // lift or check embargo on one Item, handle exceptions
     // return false on success, true if there was fatal exception.
-    protected static boolean processOneItem(Context context, Item item, CommandLine line, Date now)
+    protected static boolean processOneItem(Context context, Item item, CommandLine line, ZonedDateTime now)
         throws Exception {
         boolean status = false;
         List<MetadataValue> lift = embargoService.getLiftMetadata(context, item);
@@ -186,7 +186,7 @@ public class EmbargoCLITool {
                     embargoService.setEmbargo(context, item);
                 } else {
                     log.debug("Testing embargo on item=" + item.getHandle() + ", date=" + liftDate.toString());
-                    if (liftDate.toDate().before(now)) {
+                    if (liftDate.toDate().isBefore(now)) {
                         if (line.hasOption('v')) {
                             System.err.println(
                                 "Lifting embargo from Item handle=" + item.getHandle() + ", lift date=" +

--- a/dspace-api/src/main/java/org/dspace/embargo/EmbargoServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/embargo/EmbargoServiceImpl.java
@@ -9,7 +9,7 @@ package org.dspace.embargo;
 
 import java.io.IOException;
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.ZonedDateTime;
 import java.util.Iterator;
 import java.util.List;
 
@@ -129,7 +129,7 @@ public class EmbargoServiceImpl implements EmbargoService {
         }
 
         // new DCDate(non-date String) means toDate() will return null
-        Date liftDate = result.toDate();
+        ZonedDateTime liftDate = result.toDate();
         if (liftDate == null) {
             throw new IllegalArgumentException(
                 "Embargo lift date is uninterpretable:  "
@@ -223,7 +223,7 @@ public class EmbargoServiceImpl implements EmbargoService {
         if (lift.size() > 0) {
             liftDate = new DCDate(lift.get(0).getValue());
             // sanity check: do not allow an embargo lift date in the past.
-            if (liftDate.toDate().before(new Date())) {
+            if (liftDate.toDate().isBefore(ZonedDateTime.now())) {
                 liftDate = null;
             }
         }

--- a/dspace-api/src/main/java/org/dspace/eperson/AccountServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/AccountServiceImpl.java
@@ -163,11 +163,6 @@ public class AccountServiceImpl implements AccountService {
             return null;
         }
 
-        /*
-         * ignore the expiration date on tokens Date expires =
-         * rd.getDateColumn("expires"); if (expires != null) { if ((new
-         * java.util.Date()).after(expires)) return null; }
-         */
         return registrationData.getEmail();
     }
 

--- a/dspace-api/src/main/java/org/dspace/eperson/EPerson.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/EPerson.java
@@ -8,8 +8,8 @@
 package org.dspace.eperson;
 
 import java.sql.SQLException;
+import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 import jakarta.persistence.Column;
@@ -17,8 +17,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.Table;
-import jakarta.persistence.Temporal;
-import jakarta.persistence.TemporalType;
 import jakarta.persistence.Transient;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -46,8 +44,7 @@ public class EPerson extends CacheableDSpaceObject implements DSpaceObjectLegacy
     private String netid;
 
     @Column(name = "last_active")
-    @Temporal(TemporalType.TIMESTAMP)
-    private Date lastActive;
+    private Instant lastActive;
 
     @Column(name = "can_log_in", nullable = true)
     private Boolean canLogIn;
@@ -105,7 +102,7 @@ public class EPerson extends CacheableDSpaceObject implements DSpaceObjectLegacy
     protected transient EPersonService ePersonService;
 
     @Transient
-    private Date previousActive;
+    private Instant previousActive;
 
     /**
      * Protected constructor, create object using:
@@ -345,7 +342,7 @@ public class EPerson extends CacheableDSpaceObject implements DSpaceObjectLegacy
      *
      * @param when latest activity timestamp, or null to clear.
      */
-    public void setLastActive(Date when) {
+    public void setLastActive(Instant when) {
         this.previousActive = lastActive;
         this.lastActive = when;
     }
@@ -355,7 +352,7 @@ public class EPerson extends CacheableDSpaceObject implements DSpaceObjectLegacy
      *
      * @return date when last logged on, or null.
      */
-    public Date getLastActive() {
+    public Instant getLastActive() {
         return lastActive;
     }
 
@@ -435,9 +432,9 @@ public class EPerson extends CacheableDSpaceObject implements DSpaceObjectLegacy
         this.sessionSalt = sessionSalt;
     }
 
-    public Date getPreviousActive() {
+    public Instant getPreviousActive() {
         if (previousActive == null) {
-            return new Date(0);
+            return Instant.now();
         }
         return previousActive;
     }

--- a/dspace-api/src/main/java/org/dspace/eperson/EPersonConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/EPersonConsumer.java
@@ -8,7 +8,7 @@
 package org.dspace.eperson;
 
 import java.io.IOException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.UUID;
 
 import jakarta.mail.MessagingException;
@@ -93,7 +93,7 @@ public class EPersonConsumer implements Consumer {
                             adminEmail.addArgument(configurationService.getProperty("dspace.ui.url"));
                             adminEmail.addArgument(eperson.getFirstName() + " " + eperson.getLastName()); // Name
                             adminEmail.addArgument(eperson.getEmail());
-                            adminEmail.addArgument(new Date());
+                            adminEmail.addArgument(Instant.now());
 
                             adminEmail.setReplyTo(eperson.getEmail());
 

--- a/dspace-api/src/main/java/org/dspace/eperson/EPersonServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/EPersonServiceImpl.java
@@ -11,10 +11,10 @@ import static org.dspace.content.Item.ANY;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -695,7 +695,7 @@ public class EPersonServiceImpl extends DSpaceObjectServiceImpl<EPerson> impleme
     }
 
     @Override
-    public List<EPerson> findNotActiveSince(Context context, Date date) throws SQLException {
+    public List<EPerson> findNotActiveSince(Context context, Instant date) throws SQLException {
         return ePersonDAO.findNotActiveSince(context, date);
     }
 

--- a/dspace-api/src/main/java/org/dspace/eperson/FrequencyType.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/FrequencyType.java
@@ -7,9 +7,18 @@
  */
 package org.dspace.eperson;
 
-import java.text.SimpleDateFormat;
+import static java.time.temporal.TemporalAdjusters.nextOrSame;
+import static java.time.temporal.TemporalAdjusters.previousOrSame;
+
+import java.time.DayOfWeek;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.YearMonth;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
-import java.util.Calendar;
 
 import org.apache.commons.codec.binary.StringUtils;
 
@@ -33,31 +42,54 @@ public enum FrequencyType {
     public static String findLastFrequency(String frequency) {
         String startDate = "";
         String endDate = "";
-        Calendar cal = Calendar.getInstance();
-        // Full ISO 8601 is e.g.
-        SimpleDateFormat fullIsoStart = new SimpleDateFormat("yyyy-MM-dd'T'00:00:00'Z'");
-        SimpleDateFormat fullIsoEnd = new SimpleDateFormat("yyyy-MM-dd'T'23:59:59'Z'");
         switch (frequency) {
             case "D":
-                cal.add(Calendar.DAY_OF_MONTH, -1);
-                endDate = fullIsoEnd.format(cal.getTime());
-                startDate = fullIsoStart.format(cal.getTime());
+                // Frequency is anything updated yesterday.
+                // startDate is beginning of day yesterday
+                Instant startOfYesterday = ZonedDateTime.now(ZoneOffset.UTC)
+                                                        .minus(1, ChronoUnit.DAYS)
+                                                        .with(LocalDateTime.MIN)
+                                                        .toInstant();
+                startDate = startOfYesterday.toString();
+                // endDate is end of day yesterday
+                Instant endOfYesterday = ZonedDateTime.now(ZoneOffset.UTC)
+                                                      .minus(1, ChronoUnit.DAYS)
+                                                      .with(LocalDateTime.MAX)
+                                                      .toInstant();
+                endDate = endOfYesterday.toString();
                 break;
             case "M":
-                int dayOfMonth = cal.get(Calendar.DAY_OF_MONTH);
-                cal.add(Calendar.DAY_OF_MONTH, -dayOfMonth);
-                endDate = fullIsoEnd.format(cal.getTime());
-                cal.add(Calendar.MONTH, -1);
-                cal.add(Calendar.DAY_OF_MONTH, 1);
-                startDate = fullIsoStart.format(cal.getTime());
+                // Frequency is anything updated last month.
+                // startDate is beginning of last month (first day of month at start of day)
+                Instant startOfLastMonth = YearMonth.now(ZoneOffset.UTC)
+                                                    .minusMonths(1)
+                                                    .atDay(1)
+                                                    .atStartOfDay().toInstant(ZoneOffset.UTC);
+                startDate = startOfLastMonth.toString();
+                // endDate is end of last month (last day of month at end of day)
+                Instant endOfLastMonth = YearMonth.now(ZoneOffset.UTC)
+                                                  .minusMonths(1)
+                                                  .atEndOfMonth()
+                                                  .atTime(LocalTime.MAX).toInstant(ZoneOffset.UTC);
+
+                endDate = endOfLastMonth.toString();
                 break;
             case "W":
-                cal.add(Calendar.DAY_OF_WEEK, -1);
-                int dayOfWeek = cal.get(Calendar.DAY_OF_WEEK) - 1;
-                cal.add(Calendar.DAY_OF_WEEK, -dayOfWeek);
-                endDate = fullIsoEnd.format(cal.getTime());
-                cal.add(Calendar.DAY_OF_WEEK, -6);
-                startDate = fullIsoStart.format(cal.getTime());
+                // Frequency is anything updated last week
+                // startDate is beginning of last week (Sunday, beginning of the day)
+                Instant startOfLastWeek = ZonedDateTime.now(ZoneOffset.UTC)
+                                                       .minus(1, ChronoUnit.WEEKS)
+                                                       .with(previousOrSame(DayOfWeek.SUNDAY))
+                                                       .with(LocalDateTime.MIN)
+                                                       .toInstant();
+                startDate = startOfLastWeek.toString();
+                // End date is end of last week (Saturday, end of day)
+                Instant endOfLastWeek = ZonedDateTime.now(ZoneOffset.UTC)
+                                                     .minus(1, ChronoUnit.WEEKS)
+                                                     .with(nextOrSame(DayOfWeek.SATURDAY))
+                                                     .with(LocalDateTime.MAX)
+                                                     .toInstant();
+                endDate = endOfLastWeek.toString();
                 break;
             default:
                 return null;

--- a/dspace-api/src/main/java/org/dspace/eperson/Groomer.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/Groomer.java
@@ -10,9 +10,9 @@ package org.dspace.eperson;
 
 import java.io.IOException;
 import java.sql.SQLException;
-import java.text.DateFormat;
-import java.util.Calendar;
-import java.util.Date;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.List;
 
 import org.apache.commons.cli.CommandLine;
@@ -35,13 +35,6 @@ import org.dspace.eperson.service.EPersonService;
  * @author mwood
  */
 public class Groomer {
-    private static final ThreadLocal<DateFormat> dateFormat = new ThreadLocal<DateFormat>() {
-        @Override
-        protected DateFormat initialValue() {
-            return DateFormat.getDateInstance(DateFormat.SHORT);
-        }
-    };
-
     private static final EPersonService ePersonService = EPersonServiceFactory.getInstance().getEPersonService();
 
     /**
@@ -70,7 +63,7 @@ public class Groomer {
 
         options.addOption("b", "last-used-before", true,
                           "date of last login was before this (for example:  "
-                              + dateFormat.get().format(Calendar.getInstance().getTime())
+                              + DateTimeFormatter.ISO_LOCAL_DATE.format(Instant.now())
                               + ')');
         options.addOption("d", "delete", false, "delete matching epersons");
 
@@ -114,10 +107,10 @@ public class Groomer {
             System.exit(1);
         }
 
-        Date before = null;
+        Instant before = null;
         try {
-            before = dateFormat.get().parse(command.getOptionValue('b'));
-        } catch (java.text.ParseException ex) {
+            before = DateTimeFormatter.ISO_LOCAL_DATE.parse(command.getOptionValue('b'), Instant::from);
+        } catch (DateTimeParseException ex) {
             System.err.println(ex.getMessage());
             System.exit(1);
         }

--- a/dspace-api/src/main/java/org/dspace/eperson/Groomer.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/Groomer.java
@@ -10,7 +10,8 @@ package org.dspace.eperson;
 
 import java.io.IOException;
 import java.sql.SQLException;
-import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.List;
@@ -63,7 +64,7 @@ public class Groomer {
 
         options.addOption("b", "last-used-before", true,
                           "date of last login was before this (for example:  "
-                              + DateTimeFormatter.ISO_LOCAL_DATE.format(Instant.now())
+                              + DateTimeFormatter.ISO_LOCAL_DATE.format(LocalDate.now(ZoneOffset.UTC))
                               + ')');
         options.addOption("d", "delete", false, "delete matching epersons");
 
@@ -107,9 +108,9 @@ public class Groomer {
             System.exit(1);
         }
 
-        Instant before = null;
+        LocalDate before = null;
         try {
-            before = DateTimeFormatter.ISO_LOCAL_DATE.parse(command.getOptionValue('b'), Instant::from);
+            before = LocalDate.parse(command.getOptionValue('b'));
         } catch (DateTimeParseException ex) {
             System.err.println(ex.getMessage());
             System.exit(1);
@@ -118,7 +119,8 @@ public class Groomer {
         boolean delete = command.hasOption('d');
 
         Context myContext = new Context();
-        List<EPerson> epeople = ePersonService.findNotActiveSince(myContext, before);
+        List<EPerson> epeople = ePersonService.findNotActiveSince(myContext,
+                                                                  before.atStartOfDay().toInstant(ZoneOffset.UTC));
 
         myContext.turnOffAuthorisationSystem();
         for (EPerson account : epeople) {

--- a/dspace-api/src/main/java/org/dspace/eperson/LoadLastLogin.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/LoadLastLogin.java
@@ -13,9 +13,9 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -106,7 +106,7 @@ public class LoadLastLogin {
 
         // Scan log files looking for login records
         final Pattern loginCracker = Pattern.compile(loginRE);
-        final SimpleDateFormat dateEncoder = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        final DateTimeFormatter dateEncoder = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
         for (String logName : args) {
             BufferedReader logReader = new BufferedReader(new FileReader(logName, StandardCharsets.UTF_8));
@@ -133,15 +133,15 @@ public class LoadLastLogin {
                 String user = loginMatcher.group(3);
 
                 String logDateTime = date + ' ' + time;
-                Date stamp;
+                Instant stamp;
                 try {
-                    stamp = dateEncoder.parse(logDateTime);
-                } catch (ParseException ex) {
+                    stamp = dateEncoder.parse(logDateTime, Instant::from);
+                } catch (DateTimeParseException ex) {
                     System.err.println("Skipping log record:  " + ex.getMessage());
                     continue;
                 }
-                Date previous = (Date) stampDb.find(user);
-                if (null == previous || stamp.after(previous)) {
+                Instant previous = Instant.parse((String) stampDb.find(user));
+                if (null == previous || stamp.isAfter(previous)) {
                     stampDb.insert(user, stamp, true); // Record this user's newest login so far
                 }
             }
@@ -159,7 +159,7 @@ public class LoadLastLogin {
         while (walker.getNext(stamp)) {
             // Update an EPerson's last login
             String name = (String) stamp.getKey();
-            Date date = (Date) stamp.getValue();
+            Instant date = Instant.parse((String) stamp.getValue());
             EPerson ePerson;
             ePerson = ePersonService.findByEmail(ctx, name);
             if (null == ePerson) {
@@ -169,8 +169,8 @@ public class LoadLastLogin {
                 System.err.println("Skipping unknown user:  " + name);
                 continue;
             }
-            Date previous = ePerson.getLastActive();
-            if ((null == previous) || date.after(previous)) {
+            Instant previous = ePerson.getLastActive();
+            if ((null == previous) || date.isAfter(previous)) {
                 if (PRETEND) {
                     System.out.printf("%s\t%s\t%s\t%s\t%s\n",
                                       ePerson.getID().toString(),

--- a/dspace-api/src/main/java/org/dspace/eperson/LoadLastLogin.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/LoadLastLogin.java
@@ -14,6 +14,8 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Properties;
@@ -135,12 +137,12 @@ public class LoadLastLogin {
                 String logDateTime = date + ' ' + time;
                 Instant stamp;
                 try {
-                    stamp = dateEncoder.parse(logDateTime, Instant::from);
+                    stamp = LocalDateTime.parse(logDateTime, dateEncoder).atZone(ZoneOffset.UTC).toInstant();
                 } catch (DateTimeParseException ex) {
                     System.err.println("Skipping log record:  " + ex.getMessage());
                     continue;
                 }
-                Instant previous = Instant.parse((String) stampDb.find(user));
+                Instant previous = ((java.util.Date) stampDb.find(user)).toInstant();
                 if (null == previous || stamp.isAfter(previous)) {
                     stampDb.insert(user, stamp, true); // Record this user's newest login so far
                 }
@@ -159,7 +161,7 @@ public class LoadLastLogin {
         while (walker.getNext(stamp)) {
             // Update an EPerson's last login
             String name = (String) stamp.getKey();
-            Instant date = Instant.parse((String) stamp.getValue());
+            Instant date = ((java.util.Date) stamp.getValue()).toInstant();
             EPerson ePerson;
             ePerson = ePersonService.findByEmail(ctx, name);
             if (null == ePerson) {

--- a/dspace-api/src/main/java/org/dspace/eperson/RegistrationData.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/RegistrationData.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.eperson;
 
-import java.util.Date;
+import java.time.Instant;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -16,8 +16,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
-import jakarta.persistence.Temporal;
-import jakarta.persistence.TemporalType;
 import org.dspace.core.Context;
 import org.dspace.core.ReloadableEntity;
 
@@ -43,8 +41,7 @@ public class RegistrationData implements ReloadableEntity<Integer> {
     private String token;
 
     @Column(name = "expires")
-    @Temporal(TemporalType.TIMESTAMP)
-    private Date expires;
+    private Instant expires;
 
     /**
      * Protected constructor, create object using:
@@ -74,11 +71,11 @@ public class RegistrationData implements ReloadableEntity<Integer> {
         this.token = token;
     }
 
-    public Date getExpires() {
+    public Instant getExpires() {
         return expires;
     }
 
-    void setExpires(Date expires) {
+    void setExpires(Instant expires) {
         this.expires = expires;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/eperson/dao/EPersonDAO.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/dao/EPersonDAO.java
@@ -8,7 +8,7 @@
 package org.dspace.eperson.dao;
 
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 
@@ -121,7 +121,7 @@ public interface EPersonDAO extends DSpaceObjectDAO<EPerson>, DSpaceObjectLegacy
 
     public List<EPerson> findWithPasswordWithoutDigestAlgorithm(Context context) throws SQLException;
 
-    public List<EPerson> findNotActiveSince(Context context, Date date) throws SQLException;
+    public List<EPerson> findNotActiveSince(Context context, Instant date) throws SQLException;
 
     public List<EPerson> findAll(Context context, MetadataField metadataFieldSort, String sortColumn, int pageSize,
                                  int offset) throws SQLException;

--- a/dspace-api/src/main/java/org/dspace/eperson/dao/impl/EPersonDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/dao/impl/EPersonDAOImpl.java
@@ -8,9 +8,9 @@
 package org.dspace.eperson.dao.impl;
 
 import java.sql.SQLException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -180,7 +180,7 @@ public class EPersonDAOImpl extends AbstractHibernateDSODAO<EPerson> implements 
     }
 
     @Override
-    public List<EPerson> findNotActiveSince(Context context, Date date) throws SQLException {
+    public List<EPerson> findNotActiveSince(Context context, Instant date) throws SQLException {
         CriteriaBuilder criteriaBuilder = getCriteriaBuilder(context);
         CriteriaQuery criteriaQuery = getCriteriaQuery(criteriaBuilder, EPerson.class);
         Root<EPerson> ePersonRoot = criteriaQuery.from(EPerson.class);

--- a/dspace-api/src/main/java/org/dspace/eperson/service/EPersonService.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/service/EPersonService.java
@@ -10,7 +10,7 @@ package org.dspace.eperson.service;
 import static org.dspace.content.MetadataSchemaEnum.EPERSON;
 
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 
@@ -263,7 +263,7 @@ public interface EPersonService extends DSpaceObjectService<EPerson>, DSpaceObje
      * @return a list of epeople
      * @throws SQLException An exception that provides information on a database access error or other errors.
      */
-    public List<EPerson> findNotActiveSince(Context context, Date date) throws SQLException;
+    public List<EPerson> findNotActiveSince(Context context, Instant date) throws SQLException;
 
     /**
      * Check for presence of EPerson in tables that have constraints on

--- a/dspace-api/src/main/java/org/dspace/event/Event.java
+++ b/dspace-api/src/main/java/org/dspace/event/Event.java
@@ -9,6 +9,7 @@ package org.dspace.event;
 
 import java.io.Serializable;
 import java.sql.SQLException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.HashMap;
@@ -257,7 +258,7 @@ public class Event implements Serializable {
         this.eventType = eventType;
         this.subjectType = coreTypeToMask(subjectType);
         this.subjectID = subjectID;
-        timeStamp = System.currentTimeMillis();
+        timeStamp = Instant.now().toEpochMilli();
         this.detail = detail;
         this.identifiers = (ArrayList<String>) identifiers.clone();
     }
@@ -299,7 +300,7 @@ public class Event implements Serializable {
         this.subjectID = subjectID;
         this.objectType = coreTypeToMask(objectType);
         this.objectID = objectID;
-        timeStamp = System.currentTimeMillis();
+        timeStamp = Instant.now().toEpochMilli();
         this.detail = detail;
         this.identifiers = (ArrayList<String>) identifiers.clone();
     }

--- a/dspace-api/src/main/java/org/dspace/event/TestConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/event/TestConsumer.java
@@ -8,8 +8,8 @@
 package org.dspace.event;
 
 import java.io.PrintStream;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.logging.log4j.LogManager;
@@ -71,7 +71,7 @@ public class TestConsumer implements Consumer {
             + ", Identifiers="
             + ArrayUtils.toString(event.getIdentifiers())
             + ", TimeStamp="
-            + applyDateFormat(new Date(event.getTimeStamp()))
+            + DateTimeFormatter.ISO_INSTANT.format(Instant.ofEpochMilli(event.getTimeStamp()))
             + ", user=\""
             + user
             + "\""
@@ -109,10 +109,4 @@ public class TestConsumer implements Consumer {
         }
 
     }
-
-    private String applyDateFormat(Date thisDate) {
-        return new SimpleDateFormat("dd-MMM-yyyy HH:mm:ss.SSS Z").format(thisDate);
-    }
-
-
 }

--- a/dspace-api/src/main/java/org/dspace/external/OpenaireRestToken.java
+++ b/dspace-api/src/main/java/org/dspace/external/OpenaireRestToken.java
@@ -7,6 +7,8 @@
  */
 package org.dspace.external;
 
+import java.time.Instant;
+
 /**
  * Openaire rest API token to be used when grabbing an accessToken.<br/>
  * Based on https://develop.openaire.eu/basic.html
@@ -57,10 +59,10 @@ public class OpenaireRestToken {
             return false;
         }
 
-        return ((accessTokenExpiration - (60 * 1000)) > System.currentTimeMillis());
+        return ((accessTokenExpiration - (60 * 1000)) > Instant.now().toEpochMilli());
     }
 
     private void setExpirationDate(Long expiresIn) {
-        accessTokenExpiration = System.currentTimeMillis() + (expiresIn * 1000L);
+        accessTokenExpiration = Instant.now().toEpochMilli() + (expiresIn * 1000L);
     }
 }

--- a/dspace-api/src/main/java/org/dspace/google/GoogleAnalyticsEvent.java
+++ b/dspace-api/src/main/java/org/dspace/google/GoogleAnalyticsEvent.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.google;
 
+import java.time.Instant;
 import java.util.Objects;
 
 import org.springframework.util.Assert;
@@ -35,7 +36,7 @@ public final class GoogleAnalyticsEvent {
         this.documentReferrer = documentReferrer;
         this.documentPath = documentPath;
         this.documentTitle = documentTitle;
-        this.time = System.currentTimeMillis();
+        this.time = Instant.now().toEpochMilli();
     }
 
     public String getClientId() {

--- a/dspace-api/src/main/java/org/dspace/google/GoogleAsyncEventListener.java
+++ b/dspace-api/src/main/java/org/dspace/google/GoogleAsyncEventListener.java
@@ -8,6 +8,7 @@
 package org.dspace.google;
 
 import java.sql.SQLException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -265,7 +266,7 @@ public class GoogleAsyncEventListener extends AbstractUsageEventListener {
             GoogleAnalyticsEvent event = (GoogleAnalyticsEvent) iterator.next();
             eventsBuffer.remove(event);
 
-            if ((System.currentTimeMillis() - event.getTime()) < MAX_TIME_SINCE_EVENT) {
+            if ((Instant.now().toEpochMilli() - event.getTime()) < MAX_TIME_SINCE_EVENT) {
                 events.add(event);
             }
 

--- a/dspace-api/src/main/java/org/dspace/google/client/UniversalAnalyticsClientRequestBuilder.java
+++ b/dspace-api/src/main/java/org/dspace/google/client/UniversalAnalyticsClientRequestBuilder.java
@@ -12,6 +12,7 @@ import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -61,7 +62,7 @@ public class UniversalAnalyticsClientRequestBuilder implements GoogleAnalyticsCl
             "&dr=" + encodeParameter(event.getDocumentReferrer()) +
             "&dp=" + encodeParameter(event.getDocumentPath()) +
             "&dt=" + encodeParameter(event.getDocumentTitle()) +
-            "&qt=" + (System.currentTimeMillis() - event.getTime()) +
+            "&qt=" + (Instant.now().toEpochMilli() - event.getTime()) +
             "&ec=bitstream" +
             "&ea=download" +
             "&el=item";

--- a/dspace-api/src/main/java/org/dspace/harvest/HarvestScheduler.java
+++ b/dspace-api/src/main/java/org/dspace/harvest/HarvestScheduler.java
@@ -9,8 +9,8 @@ package org.dspace.harvest;
 
 import java.io.IOException;
 import java.sql.SQLException;
-import java.util.Calendar;
-import java.util.Date;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Stack;
 import java.util.UUID;
@@ -254,14 +254,11 @@ public class HarvestScheduler implements Runnable {
                     harvestInterval = 720;
                 }
 
-                Date nextTime;
+                Instant nextTime;
                 long nextHarvest = 0;
                 if (hc != null) {
-                    Calendar calendar = Calendar.getInstance();
-                    calendar.setTime(hc.getHarvestDate());
-                    calendar.add(Calendar.MINUTE, harvestInterval);
-                    nextTime = calendar.getTime();
-                    nextHarvest = nextTime.getTime() + -new Date().getTime();
+                    nextTime = hc.getHarvestDate().plus(harvestInterval, ChronoUnit.MINUTES);
+                    nextHarvest = nextTime.toEpochMilli() - Instant.now().toEpochMilli();
                 }
 
                 long upperBound = Math.min(nextHarvest, maxHeartbeat);

--- a/dspace-api/src/main/java/org/dspace/harvest/HarvestedCollection.java
+++ b/dspace-api/src/main/java/org/dspace/harvest/HarvestedCollection.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.harvest;
 
-import java.util.Date;
+import java.time.Instant;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -19,8 +19,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
-import jakarta.persistence.Temporal;
-import jakarta.persistence.TemporalType;
 import jakarta.persistence.Transient;
 import org.dspace.content.Collection;
 import org.dspace.core.Context;
@@ -62,12 +60,10 @@ public class HarvestedCollection implements ReloadableEntity<Integer> {
     private int harvestStatus;
 
     @Column(name = "harvest_start_time", columnDefinition = "timestamp with time zone")
-    @Temporal(TemporalType.TIMESTAMP)
-    private Date harvestStartTime;
+    private Instant harvestStartTime;
 
     @Column(name = "last_harvested", columnDefinition = "timestamp with time zone")
-    @Temporal(TemporalType.TIMESTAMP)
-    private Date lastHarvested;
+    private Instant lastHarvested;
 
     @Transient
     public static final int TYPE_NONE = 0;
@@ -157,7 +153,7 @@ public class HarvestedCollection implements ReloadableEntity<Integer> {
         this.metadataConfigId = mdConfigId;
     }
 
-    public void setLastHarvested(Date lastHarvested) {
+    public void setLastHarvested(Instant lastHarvested) {
         this.lastHarvested = lastHarvested;
     }
 
@@ -165,7 +161,7 @@ public class HarvestedCollection implements ReloadableEntity<Integer> {
         this.harvestMessage = message;
     }
 
-    public void setHarvestStartTime(Date date) {
+    public void setHarvestStartTime(Instant date) {
         this.harvestStartTime = date;
     }
 
@@ -203,11 +199,11 @@ public class HarvestedCollection implements ReloadableEntity<Integer> {
         return harvestMessage;
     }
 
-    public Date getHarvestDate() {
+    public Instant getHarvestDate() {
         return lastHarvested;
     }
 
-    public Date getHarvestStartTime() {
+    public Instant getHarvestStartTime() {
         return harvestStartTime;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/harvest/HarvestedCollectionServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/harvest/HarvestedCollectionServiceImpl.java
@@ -14,9 +14,9 @@ import static org.dspace.harvest.OAIHarvester.OAI_SET_ERROR;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
 import java.util.List;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPathExpressionException;
@@ -126,17 +126,8 @@ public class HarvestedCollectionServiceImpl implements HarvestedCollectionServic
             expirationInterval = 24;
         }
 
-        Date startTime;
-        Date expirationTime;
-
-        Calendar calendar = Calendar.getInstance();
-        calendar.setTime(new Date());
-        calendar.add(Calendar.MINUTE, -1 * harvestInterval);
-        startTime = calendar.getTime();
-
-        calendar.setTime(startTime);
-        calendar.add(Calendar.HOUR, -2 * expirationInterval);
-        expirationTime = calendar.getTime();
+        Instant startTime = Instant.now().minus(harvestInterval, ChronoUnit.MINUTES);
+        Instant expirationTime = startTime.minus(2L * expirationInterval, ChronoUnit.HOURS);
 
         int[] statuses = new int[] {HarvestedCollection.STATUS_READY, HarvestedCollection.STATUS_OAI_ERROR};
         return harvestedCollectionDAO

--- a/dspace-api/src/main/java/org/dspace/harvest/HarvestedItem.java
+++ b/dspace-api/src/main/java/org/dspace/harvest/HarvestedItem.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.harvest;
 
-import java.util.Date;
+import java.time.Instant;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -19,8 +19,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
-import jakarta.persistence.Temporal;
-import jakarta.persistence.TemporalType;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
 import org.dspace.core.ReloadableEntity;
@@ -42,8 +40,7 @@ public class HarvestedItem implements ReloadableEntity<Integer> {
     private Item item;
 
     @Column(name = "last_harvested", columnDefinition = "timestamp with time zone")
-    @Temporal(TemporalType.TIMESTAMP)
-    private Date lastHarvested;
+    private Instant lastHarvested;
 
     @Column(name = "oai_id")
     private String oaiId;
@@ -93,14 +90,14 @@ public class HarvestedItem implements ReloadableEntity<Integer> {
     }
 
 
-    public void setHarvestDate(Date date) {
+    public void setHarvestDate(Instant date) {
         if (date == null) {
-            date = new Date();
+            date = Instant.now();
         }
         lastHarvested = date;
     }
 
-    public Date getHarvestDate() {
+    public Instant getHarvestDate() {
         return lastHarvested;
     }
 

--- a/dspace-api/src/main/java/org/dspace/harvest/OAIHarvester.java
+++ b/dspace-api/src/main/java/org/dspace/harvest/OAIHarvester.java
@@ -14,12 +14,12 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.ConnectException;
 import java.sql.SQLException;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Calendar;
 import java.util.Collections;
-import java.util.Date;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import java.util.TimeZone;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPathExpressionException;
 
@@ -39,7 +38,6 @@ import org.dspace.content.Bitstream;
 import org.dspace.content.BitstreamFormat;
 import org.dspace.content.Bundle;
 import org.dspace.content.Collection;
-import org.dspace.content.DCDate;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataValue;
@@ -79,16 +77,12 @@ import org.oclc.oai.harvester2.verb.ListMetadataFormats;
 import org.oclc.oai.harvester2.verb.ListRecords;
 import org.xml.sax.SAXException;
 
-
 /**
  * This class handles OAI harvesting of externally located records into this repository.
  *
  * @author Alexey Maslov
  */
-
-
 public class OAIHarvester {
-
 
     /**
      * log4j category
@@ -263,7 +257,7 @@ public class OAIHarvester {
             oaiSetId = null;
         }
 
-        Date lastHarvestDate = harvestRow.getHarvestDate();
+        Instant lastHarvestDate = harvestRow.getHarvestDate();
         String fromDate = null;
         if (lastHarvestDate != null) {
             fromDate = processDate(harvestRow.getHarvestDate());
@@ -271,7 +265,7 @@ public class OAIHarvester {
 
         long totalListSize = 0;
         long currentRecord = 0;
-        Date startTime = new Date();
+        Instant startTime = Instant.now();
         String toDate = processDate(startTime, 0);
 
         String dateGranularity;
@@ -326,10 +320,7 @@ public class OAIHarvester {
                 expirationInterval = 24;
             }
 
-            Calendar calendar = Calendar.getInstance();
-            calendar.setTime(startTime);
-            calendar.add(Calendar.HOUR, expirationInterval);
-            Date expirationTime = calendar.getTime();
+            Instant expirationTime = startTime.plus(expirationInterval, ChronoUnit.HOURS);
 
             // main loop to keep requesting more objects until we're done
             List<Element> records;
@@ -353,7 +344,7 @@ public class OAIHarvester {
                     }
                     if (errorSet.contains("noRecordsMatch")) {
                         log.info("noRecordsMatch: OAI server did not contain any updates");
-                        harvestRow.setHarvestStartTime(new Date());
+                        harvestRow.setHarvestStartTime(Instant.now());
                         harvestRow.setHarvestMessage("OAI server did not contain any updates");
                         harvestRow.setHarvestStatus(HarvestedCollection.STATUS_READY);
                         harvestedCollectionService.update(ourContext, harvestRow);
@@ -385,7 +376,7 @@ public class OAIHarvester {
                                 .getID() + " interrupted by stopping the scheduler.");
                         }
                         // check for timeout
-                        if (expirationTime.before(new Date())) {
+                        if (expirationTime.isBefore(Instant.now())) {
                             throw new HarvestingException(
                                 "runHarvest method timed out for collection " + targetCollection.getID());
                         }
@@ -451,8 +442,8 @@ public class OAIHarvester {
         }
 
         // If we got to this point, it means the harvest was completely successful
-        Date finishTime = new Date();
-        long timeTaken = finishTime.getTime() - startTime.getTime();
+        Instant finishTime = Instant.now();
+        long timeTaken = finishTime.toEpochMilli() - startTime.toEpochMilli();
         harvestRow.setHarvestStartTime(startTime);
         harvestRow.setHarvestMessage("Harvest from " + oaiSource + " successful");
         harvestRow.setHarvestStatus(HarvestedCollection.STATUS_READY);
@@ -501,7 +492,7 @@ public class OAIHarvester {
         throws SQLException, AuthorizeException, IOException, CrosswalkException, HarvestingException,
         ParserConfigurationException, SAXException, XPathExpressionException {
         WorkspaceItem wi = null;
-        Date timeStart = new Date();
+        Instant timeStart = Instant.now();
 
         // grab the oai identifier
         String itemOaiID = record.getChild("header", OAI_NS).getChild("identifier", OAI_NS).getText();
@@ -549,9 +540,9 @@ public class OAIHarvester {
             // Compare last-harvest on the item versus the last time the item was updated on the OAI provider side
             // If ours is more recent, forgo this item, since it's probably a left-over from a previous harvesting
             // attempt
-            Date OAIDatestamp = Utils.parseISO8601Date(header.getChildText("datestamp", OAI_NS));
-            Date itemLastHarvest = hi.getHarvestDate();
-            if (itemLastHarvest != null && OAIDatestamp.before(itemLastHarvest)) {
+            Instant oaiDatestamp = Utils.parseISO8601Date(header.getChildText("datestamp", OAI_NS));
+            Instant itemLastHarvest = hi.getHarvestDate();
+            if (itemLastHarvest != null && oaiDatestamp.isBefore(itemLastHarvest)) {
                 log.info("Item " + item
                     .getHandle() + " was harvested more recently than the last update time reported by the OAI " +
                              "server; skipping.");
@@ -648,18 +639,17 @@ public class OAIHarvester {
             bundleService.update(ourContext, OREBundle);
         }
 
-        //item.setHarvestDate(new Date());
-        hi.setHarvestDate(new Date());
+        hi.setHarvestDate(Instant.now());
 
         // Add provenance that this item was harvested via OAI
         String provenanceMsg = "Item created via OAI harvest from source: "
-            + this.harvestRow.getOaiSource() + " on " + new DCDate(hi.getHarvestDate())
-            + " (GMT).  Item's OAI Record identifier: " + hi.getOaiID();
+            + this.harvestRow.getOaiSource() + " on " + hi.getHarvestDate()
+            + ".  Item's OAI Record identifier: " + hi.getOaiID();
         itemService.addMetadata(ourContext, item, "dc", "description", "provenance", "en", provenanceMsg);
 
         itemService.update(ourContext, item);
         harvestedItemService.update(ourContext, hi);
-        long timeTaken = new Date().getTime() - timeStart.getTime();
+        long timeTaken = Instant.now().toEpochMilli() - timeStart.toEpochMilli();
         log.info(String.format("Item %s (%s) has been ingested (item %d of %d). The whole process took: %d ms.",
                                item.getHandle(), item.getID(), currentRecord, totalListSize, timeTaken));
 
@@ -719,10 +709,10 @@ public class OAIHarvester {
      * Process a date, converting it to RFC3339 format, setting the timezone to UTC and subtracting time padding
      * from the config file.
      *
-     * @param date source Date
+     * @param date source Instant
      * @return a string in the format 'yyyy-mm-ddThh:mm:ssZ' and converted to UTC timezone
      */
-    private String processDate(Date date) {
+    private String processDate(Instant date) {
         int timePad = configurationService.getIntProperty("oai.harvester.timePadding");
 
         if (timePad == 0) {
@@ -736,21 +726,13 @@ public class OAIHarvester {
      * Process a date, converting it to RFC3339 format, setting the timezone to UTC and subtracting time padding
      * from the config file.
      *
-     * @param date       source Date
+     * @param date       source Instant
      * @param secondsPad number of seconds to subtract from the date
      * @return a string in the format 'yyyy-mm-ddThh:mm:ssZ' and converted to UTC timezone
      */
-    private String processDate(Date date, int secondsPad) {
-
-        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
-        formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
-
-        Calendar calendar = Calendar.getInstance();
-        calendar.setTime(date);
-        calendar.add(Calendar.SECOND, -1 * secondsPad);
-        date = calendar.getTime();
-
-        return formatter.format(date);
+    private String processDate(Instant date, int secondsPad) {
+        date = date.minus(secondsPad, ChronoUnit.SECONDS);
+        return DateTimeFormatter.ISO_INSTANT.format(date);
     }
 
 
@@ -819,7 +801,7 @@ public class OAIHarvester {
                 Email email = Email.getEmail(I18nUtil.getEmailFilename(Locale.getDefault(), "harvesting_error"));
                 email.addRecipient(recipient);
                 email.addArgument(targetCollection.getID());
-                email.addArgument(new Date());
+                email.addArgument(Instant.now());
                 email.addArgument(status);
 
                 String stackTrace;

--- a/dspace-api/src/main/java/org/dspace/harvest/dao/HarvestedCollectionDAO.java
+++ b/dspace-api/src/main/java/org/dspace/harvest/dao/HarvestedCollectionDAO.java
@@ -8,7 +8,7 @@
 package org.dspace.harvest.dao;
 
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 
 import org.dspace.content.Collection;
@@ -37,11 +37,11 @@ public interface HarvestedCollectionDAO extends GenericDAO<HarvestedCollection> 
     public HarvestedCollection findByCollection(Context context, Collection collection) throws SQLException;
 
     List<HarvestedCollection> findByLastHarvestedAndHarvestTypeAndHarvestStatusesAndHarvestTime(Context context,
-                                                                                                Date startTime,
+                                                                                                Instant startTime,
                                                                                                 int minimalType,
                                                                                                 int[] statuses,
                                                                                                 int expirationStatus,
-                                                                                                Date expirationTime)
+                                                                                                Instant expirationTime)
         throws SQLException;
 
     public int count(Context context) throws SQLException;

--- a/dspace-api/src/main/java/org/dspace/harvest/dao/impl/HarvestedCollectionDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/harvest/dao/impl/HarvestedCollectionDAOImpl.java
@@ -8,7 +8,7 @@
 package org.dspace.harvest.dao.impl;
 
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -94,11 +94,11 @@ public class HarvestedCollectionDAOImpl extends AbstractHibernateDAO<HarvestedCo
     @Override
     public List<HarvestedCollection>
         findByLastHarvestedAndHarvestTypeAndHarvestStatusesAndHarvestTime(Context context,
-                                                                           Date startTime,
+                                                                           Instant startTime,
                                                                            int minimalType,
                                                                            int[] statuses,
                                                                            int expirationStatus,
-                                                                           Date expirationTime)
+                                                                           Instant expirationTime)
         throws SQLException {
         CriteriaBuilder criteriaBuilder = getCriteriaBuilder(context);
         CriteriaQuery criteriaQuery = getCriteriaQuery(criteriaBuilder, HarvestedCollection.class);

--- a/dspace-api/src/main/java/org/dspace/health/Check.java
+++ b/dspace-api/src/main/java/org/dspace/health/Check.java
@@ -7,6 +7,8 @@
  */
 package org.dspace.health;
 
+import java.time.Instant;
+
 import org.apache.logging.log4j.Logger;
 
 /**
@@ -26,12 +28,12 @@ public abstract class Check {
     protected abstract String run(ReportInfo ri);
 
     public void report(ReportInfo ri) {
-        took_ = System.currentTimeMillis();
+        took_ = Instant.now().toEpochMilli();
         try {
             String run_report = run(ri);
             report_ = errors_ + run_report;
         } finally {
-            took_ = System.currentTimeMillis() - took_;
+            took_ = Instant.now().toEpochMilli() - took_;
         }
     }
 

--- a/dspace-api/src/main/java/org/dspace/health/ChecksumCheck.java
+++ b/dspace-api/src/main/java/org/dspace/health/ChecksumCheck.java
@@ -8,9 +8,8 @@
 package org.dspace.health;
 
 import java.sql.SQLException;
+import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
 import java.util.List;
 
 import org.dspace.checker.CheckerCommand;
@@ -30,7 +29,7 @@ public class ChecksumCheck extends Check {
         String ret = "No md5 checks made!";
         Context context = new Context();
         CheckerCommand checker = new CheckerCommand(context);
-        Date process_start = Calendar.getInstance().getTime();
+        Instant process_start = Instant.now();
         checker.setProcessStartDate(process_start);
         checker.setDispatcher(
             new SimpleDispatcher(context, process_start, false));

--- a/dspace-api/src/main/java/org/dspace/health/InfoCheck.java
+++ b/dspace-api/src/main/java/org/dspace/health/InfoCheck.java
@@ -8,8 +8,8 @@
 package org.dspace.health;
 
 import java.io.File;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 
 import org.apache.commons.io.FileUtils;
 import org.dspace.services.ConfigurationService;
@@ -27,13 +27,13 @@ public class InfoCheck extends Check {
             = new DSpace().getConfigurationService();
         StringBuilder sb = new StringBuilder();
         sb.append("Generated: ").append(
-            new Date().toString()
+            Instant.now().toString()
         ).append("\n");
 
         sb.append("From - Till: ").append(
-            new SimpleDateFormat("yyyy-MM-dd").format(ri.from().getTime())
+            DateTimeFormatter.ISO_LOCAL_DATE.format(ri.from())
         ).append(" - ").append(
-            new SimpleDateFormat("yyyy-MM-dd").format(ri.till().getTime())
+            DateTimeFormatter.ISO_LOCAL_DATE.format(ri.till())
         ).append("\n");
 
         sb.append("Url: ").append(

--- a/dspace-api/src/main/java/org/dspace/health/LogAnalyserCheck.java
+++ b/dspace-api/src/main/java/org/dspace/health/LogAnalyserCheck.java
@@ -7,7 +7,8 @@
  */
 package org.dspace.health;
 
-import java.text.SimpleDateFormat;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -41,7 +42,8 @@ public class LogAnalyserCheck extends Check {
             Context c = new Context();
             // parse logs
             String report = LogAnalyser.processLogs(
-                c, null, null, null, null, ri.from(), ri.till(), false);
+                c, null, null, null, null,
+                ri.from().atZone(ZoneOffset.UTC).toLocalDate(), ri.till().atZone(ZoneOffset.UTC).toLocalDate(), false);
 
             // we have to deal with string report...
             for (String line : report.split("\\r?\\n")) {
@@ -56,7 +58,7 @@ public class LogAnalyserCheck extends Check {
                 sb.append(String.format("%-20s: %s\n", info[1], info_map.get(info[0])));
             }
             sb.append(String.format("Items added since [%s] (db): %s\n",
-                                    new SimpleDateFormat("yyyy-MM-dd").format(ri.from().getTime()),
+                                    DateTimeFormatter.ISO_LOCAL_DATE.format(ri.from()),
                                     LogAnalyser.getNumItems(c)));
 
             c.complete();

--- a/dspace-api/src/main/java/org/dspace/health/LogAnalyserCheck.java
+++ b/dspace-api/src/main/java/org/dspace/health/LogAnalyserCheck.java
@@ -7,7 +7,6 @@
  */
 package org.dspace.health;
 
-import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
@@ -43,7 +42,7 @@ public class LogAnalyserCheck extends Check {
             // parse logs
             String report = LogAnalyser.processLogs(
                 c, null, null, null, null,
-                ri.from().atZone(ZoneOffset.UTC).toLocalDate(), ri.till().atZone(ZoneOffset.UTC).toLocalDate(), false);
+                ri.from(), ri.till(), false);
 
             // we have to deal with string report...
             for (String line : report.split("\\r?\\n")) {

--- a/dspace-api/src/main/java/org/dspace/health/Report.java
+++ b/dspace-api/src/main/java/org/dspace/health/Report.java
@@ -8,9 +8,8 @@
 package org.dspace.health;
 
 import java.io.IOException;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map.Entry;
@@ -61,8 +60,7 @@ public class Report {
             Check check = check_entry.getValue();
 
             log.info(String.format("#%d. Processing [%s] at [%s]",
-                                   pos, check_name, new SimpleDateFormat(
-                    "yyyy-MM-dd HH:mm:ss.SSS").format(new Date())));
+                                   pos, check_name, Instant.now().toString()));
 
             try {
                 // do the stuff

--- a/dspace-api/src/main/java/org/dspace/health/ReportInfo.java
+++ b/dspace-api/src/main/java/org/dspace/health/ReportInfo.java
@@ -7,12 +7,8 @@
  */
 package org.dspace.health;
 
-import static java.util.Calendar.DAY_OF_MONTH;
-import static java.util.Calendar.MONTH;
-import static java.util.Calendar.YEAR;
-
-import java.util.Date;
-import java.util.GregorianCalendar;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 
 /**
  * Information about a report run accessible by each check.
@@ -22,17 +18,14 @@ import java.util.GregorianCalendar;
 public class ReportInfo {
 
     private boolean verbose_;
-    private GregorianCalendar from_ = null;
-    private GregorianCalendar till_ = null;
+    private Instant from_;
+    private Instant till_;
 
     public ReportInfo(int for_last_n_days) {
-        GregorianCalendar cal = new GregorianCalendar();
-        till_ = new GregorianCalendar(
-            cal.get(YEAR), cal.get(MONTH), cal.get(DAY_OF_MONTH)
-        );
+        till_ = Instant.now();
+
         // get info from the last n days
-        from_ = (GregorianCalendar) till_.clone();
-        from_.add(DAY_OF_MONTH, -for_last_n_days);
+        from_ = till_.minus(for_last_n_days, ChronoUnit.DAYS);
         // filter output
         verbose_ = false;
     }
@@ -45,11 +38,11 @@ public class ReportInfo {
         return verbose_;
     }
 
-    public Date from() {
-        return from_.getTime();
+    public Instant from() {
+        return from_;
     }
 
-    public Date till() {
-        return till_.getTime();
+    public Instant till() {
+        return till_;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/health/ReportInfo.java
+++ b/dspace-api/src/main/java/org/dspace/health/ReportInfo.java
@@ -7,7 +7,8 @@
  */
 package org.dspace.health;
 
-import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 
 /**
@@ -18,11 +19,11 @@ import java.time.temporal.ChronoUnit;
 public class ReportInfo {
 
     private boolean verbose_;
-    private Instant from_;
-    private Instant till_;
+    private LocalDate from_;
+    private LocalDate till_;
 
     public ReportInfo(int for_last_n_days) {
-        till_ = Instant.now();
+        till_ = LocalDate.now(ZoneOffset.UTC);
 
         // get info from the last n days
         from_ = till_.minus(for_last_n_days, ChronoUnit.DAYS);
@@ -38,11 +39,11 @@ public class ReportInfo {
         return verbose_;
     }
 
-    public Instant from() {
+    public LocalDate from() {
         return from_;
     }
 
-    public Instant till() {
+    public LocalDate till() {
         return till_;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/identifier/EZIDIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/EZIDIdentifierProvider.java
@@ -12,8 +12,8 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URISyntaxException;
 import java.sql.SQLException;
+import java.time.Year;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -577,7 +577,7 @@ public class EZIDIdentifierProvider
         // Supply current year as year of publication, if the Item has none.
         if (!mapped.containsKey(DATACITE_PUBLICATION_YEAR)
             && !mapped.containsKey("datacite")) {
-            String year = String.valueOf(Calendar.getInstance().get(Calendar.YEAR));
+            String year = String.valueOf(Year.now().getValue());
             log.info("Supplying default publication year:  {}", year);
             mapped.put(DATACITE_PUBLICATION_YEAR, year);
         }

--- a/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProvider.java
@@ -9,7 +9,7 @@ package org.dspace.identifier;
 
 import java.io.IOException;
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -242,7 +242,7 @@ public class VersionedHandleIdentifierProvider extends IdentifierProvider implem
         Version version = versionHistoryService.getVersion(context, vh, item);
         if (version == null) {
             version = versionService
-                .createNewVersion(context, vh, item, "Restoring from AIP Service", new Date(), versionNumber);
+                .createNewVersion(context, vh, item, "Restoring from AIP Service", Instant.now(), versionNumber);
         }
         versionHistoryService.update(context, vh);
     }

--- a/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProviderWithCanonicalHandles.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/VersionedHandleIdentifierProviderWithCanonicalHandles.java
@@ -9,7 +9,7 @@ package org.dspace.identifier;
 
 import java.io.IOException;
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
@@ -244,7 +244,7 @@ public class VersionedHandleIdentifierProviderWithCanonicalHandles extends Ident
 
         int versionNumber = Integer.parseInt(identifier.substring(identifier.lastIndexOf(".") + 1));
         versionService
-            .createNewVersion(context, history, item, "Restoring from AIP Service", new Date(), versionNumber);
+            .createNewVersion(context, history, item, "Restoring from AIP Service", Instant.now(), versionNumber);
         Version latest = versionHistoryService.getLatestVersion(context, history);
 
 
@@ -262,7 +262,7 @@ public class VersionedHandleIdentifierProviderWithCanonicalHandles extends Ident
         int versionNumber = Integer.parseInt(identifier.substring(identifier.lastIndexOf(".") + 1));
         VersionHistory history = versionHistoryService.create(context);
         versionService
-            .createNewVersion(context, history, item, "Restoring from AIP Service", new Date(), versionNumber);
+            .createNewVersion(context, history, item, "Restoring from AIP Service", Instant.now(), versionNumber);
 
         handleService.modifyHandleDSpaceObject(context, canonical, dso);
 

--- a/dspace-api/src/main/java/org/dspace/identifier/doi/DOIOrganiser.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/doi/DOIOrganiser.java
@@ -11,8 +11,8 @@ package org.dspace.identifier.doi;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.sql.SQLException;
+import java.time.Instant;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
@@ -804,7 +804,7 @@ public class DOIOrganiser {
                     I18nUtil.getEmailFilename(Locale.getDefault(), "doi_maintenance_error"));
                 email.addRecipient(recipient);
                 email.addArgument(action);
-                email.addArgument(new Date());
+                email.addArgument(Instant.now());
                 email.addArgument(ContentServiceFactory.getInstance().getDSpaceObjectService(dso).getTypeText(dso));
                 email.addArgument(dso.getID().toString());
                 email.addArgument(doi);

--- a/dspace-api/src/main/java/org/dspace/identifier/ezid/DateToYear.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/ezid/DateToYear.java
@@ -8,11 +8,9 @@
 
 package org.dspace.identifier.ezid;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.GregorianCalendar;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 /**
  * Convert a date-time string to the year thereof.
@@ -21,15 +19,13 @@ import java.util.GregorianCalendar;
  */
 public class DateToYear
     implements Transform {
-    private static final SimpleDateFormat parser
-        = new SimpleDateFormat("yyyy'-'MM'-'dd");
 
     @Override
     public synchronized String transform(String from)
-        throws ParseException {
-        Date when = parser.parse(from);
-        Calendar calendar = new GregorianCalendar();
-        calendar.setTime(when);
-        return String.valueOf(calendar.get(Calendar.YEAR));
+        throws DateTimeParseException {
+
+        DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE;
+        LocalDate parsedDate = LocalDate.parse(from, formatter);
+        return String.valueOf(parsedDate.getYear());
     }
 }

--- a/dspace-api/src/main/java/org/dspace/iiif/canvasdimension/CanvasDimensionCLI.java
+++ b/dspace-api/src/main/java/org/dspace/iiif/canvasdimension/CanvasDimensionCLI.java
@@ -7,8 +7,8 @@
  */
 package org.dspace.iiif.canvasdimension;
 
+import java.time.Instant;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.UUID;
 
 import org.apache.commons.cli.CommandLine;
@@ -49,7 +49,7 @@ public class CanvasDimensionCLI {
 
     public static void main(String[] argv) throws Exception {
 
-        Date startTime = new Date();
+        Instant startTime = Instant.now();
 
         boolean iiifEnabled = configurationService.getBooleanProperty("iiif.enabled");
         if (!iiifEnabled) {
@@ -223,12 +223,12 @@ public class CanvasDimensionCLI {
             context.commit();
         }
 
-        Date endTime = new Date();
-        System.out.println("Started: " + startTime.getTime());
-        System.out.println("Ended: " + endTime.getTime());
+        Instant endTime = Instant.now();
+        System.out.println("Started: " + startTime);
+        System.out.println("Ended: " + endTime);
         System.out.println(
-            "Elapsed time: " + ((endTime.getTime() - startTime.getTime()) / 1000) + " secs (" + (endTime
-                .getTime() - startTime.getTime()) + " msecs)");
+            "Elapsed time: " + ((endTime.toEpochMilli() - startTime.toEpochMilli()) / 1000) + " secs (" +
+                (endTime.toEpochMilli() - startTime.toEpochMilli()) + " msecs)");
 
         // Always print summary to standard out.
         System.out.println(processed + " IIIF items were processed.");

--- a/dspace-api/src/main/java/org/dspace/importer/external/metadatamapping/contributor/SimpleXpathDateFormatMetadataContributor.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/metadatamapping/contributor/SimpleXpathDateFormatMetadataContributor.java
@@ -7,9 +7,8 @@
  */
 package org.dspace.importer.external.metadatamapping.contributor;
 
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
@@ -35,15 +34,15 @@ import org.jdom2.xpath.XPathFactory;
  */
 public class SimpleXpathDateFormatMetadataContributor extends SimpleXpathMetadatumContributor {
 
-    private DateFormat dateFormatFrom;
-    private DateFormat dateFormatTo;
+    private DateTimeFormatter dateFormatFrom;
+    private DateTimeFormatter dateFormatTo;
 
     public void setDateFormatFrom(String dateFormatFrom) {
-        this.dateFormatFrom = new SimpleDateFormat(dateFormatFrom);
+        this.dateFormatFrom = DateTimeFormatter.ofPattern(dateFormatFrom);
     }
 
     public void setDateFormatTo(String dateFormatTo) {
-        this.dateFormatTo = new SimpleDateFormat(dateFormatTo);
+        this.dateFormatTo = DateTimeFormatter.ofPattern(dateFormatTo);
     }
 
     @Override
@@ -79,7 +78,7 @@ public class SimpleXpathDateFormatMetadataContributor extends SimpleXpathMetadat
         }
         try {
             dcValue.setValue(dateFormatTo.format(dateFormatFrom.parse(value)));
-        } catch (ParseException e) {
+        } catch (DateTimeParseException e) {
             dcValue.setValue(value);
         }
         dcValue.setElement(field.getElement());

--- a/dspace-api/src/main/java/org/dspace/importer/external/metadatamapping/contributor/SimpleXpathDateFormatMetadataContributor.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/metadatamapping/contributor/SimpleXpathDateFormatMetadataContributor.java
@@ -7,8 +7,9 @@
  */
 package org.dspace.importer.external.metadatamapping.contributor;
 
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
@@ -34,15 +35,15 @@ import org.jdom2.xpath.XPathFactory;
  */
 public class SimpleXpathDateFormatMetadataContributor extends SimpleXpathMetadatumContributor {
 
-    private DateTimeFormatter dateFormatFrom;
-    private DateTimeFormatter dateFormatTo;
+    private DateFormat dateFormatFrom;
+    private DateFormat dateFormatTo;
 
     public void setDateFormatFrom(String dateFormatFrom) {
-        this.dateFormatFrom = DateTimeFormatter.ofPattern(dateFormatFrom);
+        this.dateFormatFrom = new SimpleDateFormat(dateFormatFrom);
     }
 
     public void setDateFormatTo(String dateFormatTo) {
-        this.dateFormatTo = DateTimeFormatter.ofPattern(dateFormatTo);
+        this.dateFormatTo = new SimpleDateFormat(dateFormatTo);
     }
 
     @Override
@@ -78,7 +79,7 @@ public class SimpleXpathDateFormatMetadataContributor extends SimpleXpathMetadat
         }
         try {
             dcValue.setValue(dateFormatTo.format(dateFormatFrom.parse(value)));
-        } catch (DateTimeParseException e) {
+        } catch (ParseException e) {
             dcValue.setValue(value);
         }
         dcValue.setElement(field.getElement());

--- a/dspace-api/src/main/java/org/dspace/importer/external/pubmed/metadatamapping/contributor/PubmedDateMetadatumContributor.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/pubmed/metadatamapping/contributor/PubmedDateMetadatumContributor.java
@@ -8,10 +8,10 @@
 
 package org.dspace.importer.external.pubmed.metadatamapping.contributor;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.Collection;
-import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -110,17 +110,17 @@ public class PubmedDateMetadatumContributor<T> implements MetadataContributor<T>
                 String resultDateString = "";
                 String dateString = "";
 
-                SimpleDateFormat resultFormatter = null;
+                DateTimeFormatter resultFormatter;
                 if (monthList.size() > i && dayList.size() > i) {
                     dateString = yearList.get(i).getValue() + "-" + monthList.get(i).getValue() +
                         "-" + dayList.get(i).getValue();
-                    resultFormatter = new SimpleDateFormat("yyyy-MM-dd");
+                    resultFormatter = DateTimeFormatter.ISO_LOCAL_DATE;
                 } else if (monthList.size() > i) {
                     dateString = yearList.get(i).getValue() + "-" + monthList.get(i).getValue();
-                    resultFormatter = new SimpleDateFormat("yyyy-MM");
+                    resultFormatter = DateTimeFormatter.ofPattern("yyyy-MM");
                 } else {
                     dateString = yearList.get(i).getValue();
-                    resultFormatter = new SimpleDateFormat("yyyy");
+                    resultFormatter = DateTimeFormatter.ofPattern("yyyy");
                 }
 
                 int j = 0;
@@ -128,10 +128,10 @@ public class PubmedDateMetadatumContributor<T> implements MetadataContributor<T>
                 while (j < dateFormatsToAttempt.size() && StringUtils.isBlank(resultDateString)) {
                     String dateFormat = dateFormatsToAttempt.get(j);
                     try {
-                        SimpleDateFormat formatter = new SimpleDateFormat(dateFormat);
-                        Date date = formatter.parse(dateString);
+                        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(dateFormat);
+                        LocalDate date = LocalDate.parse(dateString, formatter);
                         resultDateString = resultFormatter.format(date);
-                    } catch (ParseException e) {
+                    } catch (DateTimeParseException e) {
                         // Multiple dateformats can be configured, we don't want to print the entire stacktrace every
                         // time one of those formats fails.
                         log.debug(

--- a/dspace-api/src/main/java/org/dspace/importer/external/pubmed/metadatamapping/contributor/PubmedDateMetadatumContributor.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/pubmed/metadatamapping/contributor/PubmedDateMetadatumContributor.java
@@ -9,6 +9,8 @@
 package org.dspace.importer.external.pubmed.metadatamapping.contributor;
 
 import java.time.LocalDate;
+import java.time.Year;
+import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Collection;
@@ -111,16 +113,20 @@ public class PubmedDateMetadatumContributor<T> implements MetadataContributor<T>
                 String dateString = "";
 
                 DateTimeFormatter resultFormatter;
+                String resultType;
                 if (monthList.size() > i && dayList.size() > i) {
                     dateString = yearList.get(i).getValue() + "-" + monthList.get(i).getValue() +
                         "-" + dayList.get(i).getValue();
                     resultFormatter = DateTimeFormatter.ISO_LOCAL_DATE;
+                    resultType = "DAY";
                 } else if (monthList.size() > i) {
                     dateString = yearList.get(i).getValue() + "-" + monthList.get(i).getValue();
                     resultFormatter = DateTimeFormatter.ofPattern("yyyy-MM");
+                    resultType = "MONTH";
                 } else {
                     dateString = yearList.get(i).getValue();
                     resultFormatter = DateTimeFormatter.ofPattern("yyyy");
+                    resultType = "YEAR";
                 }
 
                 int j = 0;
@@ -129,8 +135,16 @@ public class PubmedDateMetadatumContributor<T> implements MetadataContributor<T>
                     String dateFormat = dateFormatsToAttempt.get(j);
                     try {
                         DateTimeFormatter formatter = DateTimeFormatter.ofPattern(dateFormat);
-                        LocalDate date = LocalDate.parse(dateString, formatter);
-                        resultDateString = resultFormatter.format(date);
+                        if (resultType.equals("DAY")) {
+                            LocalDate parsedDate = LocalDate.parse(dateString, formatter);
+                            resultDateString = resultFormatter.format(parsedDate);
+                        } else if (resultType.equals("MONTH")) {
+                            YearMonth parsedMonth = YearMonth.parse(dateString, formatter);
+                            resultDateString = resultFormatter.format(parsedMonth);
+                        } else if (resultType.equals("YEAR")) {
+                            Year parsedYear = Year.parse(dateString, formatter);
+                            resultDateString = resultFormatter.format(parsedYear);
+                        }
                     } catch (DateTimeParseException e) {
                         // Multiple dateformats can be configured, we don't want to print the entire stacktrace every
                         // time one of those formats fails.

--- a/dspace-api/src/main/java/org/dspace/importer/external/pubmed/service/PubmedImportMetadataSourceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/pubmed/service/PubmedImportMetadataSourceServiceImpl.java
@@ -13,6 +13,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringReader;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -293,13 +294,13 @@ public class PubmedImportMetadataSourceServiceImpl extends AbstractImportMetadat
             while (StringUtils.isBlank(response) && countAttempt <= attempt) {
                 countAttempt++;
 
-                long time = System.currentTimeMillis() - lastRequest;
+                long time = Instant.now().toEpochMilli() - lastRequest;
                 if ((time) < interRequestTime) {
                     Thread.sleep(interRequestTime - time);
                 }
 
                 response = liveImportClient.executeHttpGetRequest(1000, uriBuilder.toString(), params);
-                lastRequest = System.currentTimeMillis();
+                lastRequest = Instant.now().toEpochMilli();
             }
 
             if (StringUtils.isBlank(response)) {
@@ -323,13 +324,13 @@ public class PubmedImportMetadataSourceServiceImpl extends AbstractImportMetadat
             countAttempt = 0;
             while (StringUtils.isBlank(response2) && countAttempt <= attempt) {
                 countAttempt++;
-                long time = System.currentTimeMillis() - lastRequest;
+                long time = Instant.now().toEpochMilli() - lastRequest;
                 if ((time) < interRequestTime) {
                     Thread.sleep(interRequestTime - time);
                 }
                 response2 = liveImportClient.executeHttpGetRequest(1000, uriBuilder2.toString(), params2);
 
-                lastRequest = System.currentTimeMillis();
+                lastRequest = Instant.now().toEpochMilli();
             }
 
             if (StringUtils.isBlank(response2)) {
@@ -436,13 +437,13 @@ public class PubmedImportMetadataSourceServiceImpl extends AbstractImportMetadat
             int countAttempt = 0;
             while (StringUtils.isBlank(response) && countAttempt <= attempt) {
                 countAttempt++;
-                long time = System.currentTimeMillis() - lastRequest;
+                long time = Instant.now().toEpochMilli() - lastRequest;
                 if ((time) < interRequestTime) {
                     Thread.sleep(interRequestTime - time);
                 }
 
                 response = liveImportClient.executeHttpGetRequest(1000, uriBuilder.toString(), params);
-                lastRequest = System.currentTimeMillis();
+                lastRequest = Instant.now().toEpochMilli();
             }
 
             if (StringUtils.isBlank(response)) {
@@ -465,12 +466,12 @@ public class PubmedImportMetadataSourceServiceImpl extends AbstractImportMetadat
             countAttempt = 0;
             while (StringUtils.isBlank(response2) && countAttempt <= attempt) {
                 countAttempt++;
-                long time = System.currentTimeMillis() - lastRequest;
+                long time = Instant.now().toEpochMilli() - lastRequest;
                 if ((time) < interRequestTime) {
                     Thread.sleep(interRequestTime - time);
                 }
                 response2 = liveImportClient.executeHttpGetRequest(1000, uriBuilder2.toString(), params2);
-                lastRequest = System.currentTimeMillis();
+                lastRequest = Instant.now().toEpochMilli();
             }
 
             if (StringUtils.isBlank(response2)) {

--- a/dspace-api/src/main/java/org/dspace/importer/external/service/components/AbstractRemoteMetadataSource.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/service/components/AbstractRemoteMetadataSource.java
@@ -8,6 +8,7 @@
 
 package org.dspace.importer.external.service.components;
 
+import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -158,7 +159,7 @@ public abstract class AbstractRemoteMetadataSource {
             try {
                 lock.lock();
                 this.error = null;
-                long time = System.currentTimeMillis() - lastRequest;
+                long time = Instant.now().toEpochMilli() - lastRequest;
                 if ((time) < interRequestTime) {
                     Thread.sleep(interRequestTime - time);
                 }
@@ -184,7 +185,7 @@ public abstract class AbstractRemoteMetadataSource {
                          operationId, retry, warning, e);
 
             } finally {
-                this.lastRequest = System.currentTimeMillis();
+                this.lastRequest = Instant.now().toEpochMilli();
                 lock.unlock();
             }
 

--- a/dspace-api/src/main/java/org/dspace/orcid/OrcidHistory.java
+++ b/dspace-api/src/main/java/org/dspace/orcid/OrcidHistory.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.orcid;
 
-import java.util.Date;
+import java.time.Instant;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -20,8 +20,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
-import jakarta.persistence.Temporal;
-import jakarta.persistence.TemporalType;
 import org.dspace.content.Item;
 import org.dspace.core.ReloadableEntity;
 import org.hibernate.Length;
@@ -104,9 +102,8 @@ public class OrcidHistory implements ReloadableEntity<Integer> {
     /**
      * The timestamp of the synchronization attempt.
      */
-    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "timestamp_last_attempt")
-    private Date timestamp = new Date();
+    private Instant timestamp = Instant.now();
 
     /**
      * The HTTP status incoming from ORCID.
@@ -195,11 +192,11 @@ public class OrcidHistory implements ReloadableEntity<Integer> {
         this.description = description;
     }
 
-    public Date getTimestamp() {
+    public Instant getTimestamp() {
         return timestamp;
     }
 
-    public void setTimestamp(Date timestamp) {
+    public void setTimestamp(Instant timestamp) {
         this.timestamp = timestamp;
     }
 

--- a/dspace-api/src/main/java/org/dspace/orcid/consumer/OrcidQueueConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/orcid/consumer/OrcidQueueConsumer.java
@@ -305,7 +305,7 @@ public class OrcidQueueConsumer implements Consumer {
         }
 
         return findDeletedHistoryRecordsBySignature(records, historyRecord.getMetadata())
-            .anyMatch(record -> record.getTimestamp().after(historyRecord.getTimestamp()));
+            .anyMatch(record -> record.getTimestamp().isAfter(historyRecord.getTimestamp()));
     }
 
     private Stream<OrcidHistory> findDeletedHistoryRecordsBySignature(List<OrcidHistory> records, String signature) {

--- a/dspace-api/src/main/java/org/dspace/orcid/model/factory/impl/OrcidCommonObjectFactoryImpl.java
+++ b/dspace-api/src/main/java/org/dspace/orcid/model/factory/impl/OrcidCommonObjectFactoryImpl.java
@@ -17,9 +17,7 @@ import static org.dspace.orcid.model.factory.OrcidFactoryUtils.parseConfiguratio
 import static org.orcid.jaxb.model.common.SequenceType.ADDITIONAL;
 import static org.orcid.jaxb.model.common.SequenceType.FIRST;
 
-import java.time.LocalDate;
-import java.time.ZoneId;
-import java.util.Date;
+import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -91,13 +89,11 @@ public class OrcidCommonObjectFactoryImpl implements OrcidCommonObjectFactory {
             return empty();
         }
 
-        Date date = MultiFormatDateParser.parse(metadataValue.getValue());
+        ZonedDateTime date = MultiFormatDateParser.parse(metadataValue.getValue());
         if (date == null) {
             return empty();
         }
-
-        LocalDate localDate = convertToLocalDate(date);
-        return of(FuzzyDate.valueOf(localDate.getYear(), localDate.getMonthValue(), localDate.getDayOfMonth()));
+        return of(FuzzyDate.valueOf(date.getYear(), date.getMonthValue(), date.getDayOfMonth()));
     }
 
     @Override
@@ -231,10 +227,6 @@ public class OrcidCommonObjectFactoryImpl implements OrcidCommonObjectFactory {
         } else {
             return null;
         }
-    }
-
-    private LocalDate convertToLocalDate(Date date) {
-        return date.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
     }
 
     public String getOrganizationCityField() {

--- a/dspace-api/src/main/java/org/dspace/qaevent/QASource.java
+++ b/dspace-api/src/main/java/org/dspace/qaevent/QASource.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.qaevent;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.UUID;
 
 /**
@@ -25,7 +25,7 @@ public class QASource {
      */
     private UUID focus;
     private String name;
-    private Date lastEvent;
+    private Instant lastEvent;
     private long totalEvents;
 
     public String getName() {
@@ -44,11 +44,11 @@ public class QASource {
         this.totalEvents = totalEvents;
     }
 
-    public Date getLastEvent() {
+    public Instant getLastEvent() {
         return lastEvent;
     }
 
-    public void setLastEvent(Date lastEvent) {
+    public void setLastEvent(Instant lastEvent) {
         this.lastEvent = lastEvent;
     }
 

--- a/dspace-api/src/main/java/org/dspace/qaevent/QATopic.java
+++ b/dspace-api/src/main/java/org/dspace/qaevent/QATopic.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.qaevent;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.UUID;
 
 /**
@@ -29,7 +29,7 @@ public class QATopic {
      * The source attributes contains the name of the QA source like: OpenAIRE, DSpaceUsers
      */
     private String source;
-    private Date lastEvent;
+    private Instant lastEvent;
     private long totalEvents;
 
     public String getSource() {
@@ -63,11 +63,11 @@ public class QATopic {
         this.totalEvents = totalEvents;
     }
 
-    public Date getLastEvent() {
+    public Instant getLastEvent() {
         return lastEvent;
     }
 
-    public void setLastEvent(Date lastEvent) {
+    public void setLastEvent(Instant lastEvent) {
         this.lastEvent = lastEvent;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/qaevent/dao/impl/QAEventsDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/qaevent/dao/impl/QAEventsDAOImpl.java
@@ -8,7 +8,7 @@
 package org.dspace.qaevent.dao.impl;
 
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 
 import jakarta.persistence.Query;
@@ -39,7 +39,7 @@ public class QAEventsDAOImpl extends AbstractHibernateDAO<QAEventProcessed> impl
         qaEvent.setEperson(eperson);
         qaEvent.setEventId(checksum);
         qaEvent.setItem(item);
-        qaEvent.setEventTimestamp(new Date());
+        qaEvent.setEventTimestamp(Instant.now());
         try {
             create(context, qaEvent);
             return true;

--- a/dspace-api/src/main/java/org/dspace/qaevent/service/impl/QAEventServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/qaevent/service/impl/QAEventServiceImpl.java
@@ -593,7 +593,7 @@ public class QAEventServiceImpl implements QAEventService {
         doc.addField(TOPIC, dto.getTopic());
         doc.addField(TRUST, dto.getTrust());
         doc.addField(MESSAGE, dto.getMessage());
-        doc.addField(LAST_UPDATE, Instant.now());
+        doc.addField(LAST_UPDATE, Instant.now().toString());
         String resourceUUID = getResourceUUID(context, dto.getOriginalId());
         if (resourceUUID == null) {
             resourceUUID = dto.getTarget();
@@ -635,7 +635,7 @@ public class QAEventServiceImpl implements QAEventService {
         QAEvent item = new QAEvent();
         item.setSource((String) doc.get(SOURCE));
         item.setEventId((String) doc.get(EVENT_ID));
-        item.setLastUpdate(Instant.parse((String) doc.get(LAST_UPDATE)));
+        item.setLastUpdate(((java.util.Date) doc.get(LAST_UPDATE)).toInstant());
         item.setMessage((String) doc.get(MESSAGE));
         item.setOriginalId((String) doc.get(ORIGINAL_ID));
         item.setTarget((String) doc.get(RESOURCE_UUID));

--- a/dspace-api/src/main/java/org/dspace/qaevent/service/impl/QAEventServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/qaevent/service/impl/QAEventServiceImpl.java
@@ -12,9 +12,9 @@ import static org.apache.commons.lang3.StringUtils.endsWith;
 import static org.dspace.content.QAEvent.OPENAIRE_SOURCE;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -207,7 +207,7 @@ public class QAEventServiceImpl implements QAEventService {
                     topic.setSource(sourceName);
                     topic.setKey(c.getName());
                     topic.setTotalEvents(c.getCount());
-                    topic.setLastEvent(new Date());
+                    topic.setLastEvent(Instant.now());
                     return topic;
                 }
             }
@@ -254,7 +254,7 @@ public class QAEventServiceImpl implements QAEventService {
                     QATopic topic = new QATopic();
                     topic.setKey(c.getName());
                     topic.setTotalEvents(c.getCount());
-                    topic.setLastEvent(new Date());
+                    topic.setLastEvent(Instant.now());
                     return topic;
                 }
             }
@@ -315,7 +315,7 @@ public class QAEventServiceImpl implements QAEventService {
                 topic.setKey(c.getName());
                 topic.setFocus(target);
                 topic.setTotalEvents(c.getCount());
-                topic.setLastEvent(new Date());
+                topic.setLastEvent(Instant.now());
                 topics.add(topic);
                 idx++;
             }
@@ -533,7 +533,7 @@ public class QAEventServiceImpl implements QAEventService {
                     source.setName(c.getName());
                     source.setFocus(target);
                     source.setTotalEvents(c.getCount());
-                    source.setLastEvent(new Date());
+                    source.setLastEvent(Instant.now());
                     return source;
                 }
             }
@@ -593,7 +593,7 @@ public class QAEventServiceImpl implements QAEventService {
         doc.addField(TOPIC, dto.getTopic());
         doc.addField(TRUST, dto.getTrust());
         doc.addField(MESSAGE, dto.getMessage());
-        doc.addField(LAST_UPDATE, new Date());
+        doc.addField(LAST_UPDATE, Instant.now());
         String resourceUUID = getResourceUUID(context, dto.getOriginalId());
         if (resourceUUID == null) {
             resourceUUID = dto.getTarget();
@@ -635,7 +635,7 @@ public class QAEventServiceImpl implements QAEventService {
         QAEvent item = new QAEvent();
         item.setSource((String) doc.get(SOURCE));
         item.setEventId((String) doc.get(EVENT_ID));
-        item.setLastUpdate((Date) doc.get(LAST_UPDATE));
+        item.setLastUpdate(Instant.parse((String) doc.get(LAST_UPDATE)));
         item.setMessage((String) doc.get(MESSAGE));
         item.setOriginalId((String) doc.get(ORIGINAL_ID));
         item.setTarget((String) doc.get(RESOURCE_UUID));

--- a/dspace-api/src/main/java/org/dspace/scripts/Process.java
+++ b/dspace-api/src/main/java/org/dspace/scripts/Process.java
@@ -7,8 +7,8 @@
  */
 package org.dspace.scripts;
 
+import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 import jakarta.persistence.CascadeType;
@@ -26,8 +26,6 @@ import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
-import jakarta.persistence.Temporal;
-import jakarta.persistence.TemporalType;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.dspace.content.Bitstream;
@@ -55,12 +53,10 @@ public class Process implements ReloadableEntity<Integer> {
     private EPerson ePerson;
 
     @Column(name = "start_time")
-    @Temporal(TemporalType.TIMESTAMP)
-    private Date startTime;
+    private Instant startTime;
 
     @Column(name = "finished_time")
-    @Temporal(TemporalType.TIMESTAMP)
-    private Date finishedTime;
+    private Instant finishedTime;
 
     @Column(name = "script", nullable = false)
     private String name;
@@ -92,8 +88,7 @@ public class Process implements ReloadableEntity<Integer> {
     private List<Group> groups;
 
     @Column(name = "creation_time", nullable = false)
-    @Temporal(TemporalType.TIMESTAMP)
-    private Date creationTime;
+    private Instant creationTime;
 
     public static final String BITSTREAM_TYPE_METADATAFIELD = "dspace.process.filetype";
     public static final String OUTPUT_TYPE = "script_output";
@@ -130,11 +125,11 @@ public class Process implements ReloadableEntity<Integer> {
      * This method returns the Start time for the Process. This reflects the time when the Process was actually started
      * @return  The start time for the Process
      */
-    public Date getStartTime() {
+    public Instant getStartTime() {
         return startTime;
     }
 
-    public void setStartTime(Date startTime) {
+    public void setStartTime(Instant startTime) {
         this.startTime = startTime;
     }
 
@@ -142,11 +137,11 @@ public class Process implements ReloadableEntity<Integer> {
      * This method returns the time that Process was finished
      * @return  The finished time for the Process
      */
-    public Date getFinishedTime() {
+    public Instant getFinishedTime() {
         return finishedTime;
     }
 
-    public void setFinishedTime(Date finishedTime) {
+    public void setFinishedTime(Instant finishedTime) {
         this.finishedTime = finishedTime;
     }
 
@@ -212,7 +207,7 @@ public class Process implements ReloadableEntity<Integer> {
         getBitstreams().add(bitstream);
     }
 
-    public void setCreationTime(Date creationTime) {
+    public void setCreationTime(Instant creationTime) {
         this.creationTime = creationTime;
     }
 
@@ -221,7 +216,7 @@ public class Process implements ReloadableEntity<Integer> {
      * the StartTime (for example if the Process was queued)
      * @return  The creation time of the Process
      */
-    public Date getCreationTime() {
+    public Instant getCreationTime() {
         return creationTime;
     }
 

--- a/dspace-api/src/main/java/org/dspace/scripts/ProcessServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/scripts/ProcessServiceImpl.java
@@ -14,11 +14,11 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.sql.SQLException;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -83,7 +83,7 @@ public class ProcessServiceImpl implements ProcessService {
         process.setEPerson(ePerson);
         process.setName(scriptName);
         process.setParameters(DSpaceCommandLineParameter.concatenate(parameters));
-        process.setCreationTime(new Date());
+        process.setCreationTime(Instant.now());
         Optional.ofNullable(specialGroups)
             .ifPresent(sg -> {
                 // we use a set to be sure no duplicated special groups are stored with process
@@ -144,7 +144,7 @@ public class ProcessServiceImpl implements ProcessService {
     @Override
     public void start(Context context, Process process) throws SQLException {
         process.setProcessStatus(ProcessStatus.RUNNING);
-        process.setStartTime(new Date());
+        process.setStartTime(Instant.now());
         update(context, process);
         log.info(LogHelper.getHeader(context, "process_start", "Process with ID " + process.getID()
             + " and name " + process.getName() + " has started"));
@@ -154,7 +154,7 @@ public class ProcessServiceImpl implements ProcessService {
     @Override
     public void fail(Context context, Process process) throws SQLException {
         process.setProcessStatus(ProcessStatus.FAILED);
-        process.setFinishedTime(new Date());
+        process.setFinishedTime(Instant.now());
         update(context, process);
         log.info(LogHelper.getHeader(context, "process_fail", "Process with ID " + process.getID()
             + " and name " + process.getName() + " has failed"));
@@ -164,7 +164,7 @@ public class ProcessServiceImpl implements ProcessService {
     @Override
     public void complete(Context context, Process process) throws SQLException {
         process.setProcessStatus(ProcessStatus.COMPLETED);
-        process.setFinishedTime(new Date());
+        process.setFinishedTime(Instant.now());
         update(context, process);
         log.info(LogHelper.getHeader(context, "process_complete", "Process with ID " + process.getID()
             + " and name " + process.getName() + " has been completed"));
@@ -322,7 +322,7 @@ public class ProcessServiceImpl implements ProcessService {
 
     @Override
     public List<Process> findByStatusAndCreationTimeOlderThan(Context context, List<ProcessStatus> statuses,
-        Date date) throws SQLException {
+        Instant date) throws SQLException {
         return this.processDAO.findByStatusAndCreationTimeOlderThan(context, statuses, date);
     }
 
@@ -334,7 +334,7 @@ public class ProcessServiceImpl implements ProcessService {
     @Override
     public void failRunningProcesses(Context context) throws SQLException, IOException, AuthorizeException {
         List<Process> processesToBeFailed = findByStatusAndCreationTimeOlderThan(
-                context, List.of(ProcessStatus.RUNNING, ProcessStatus.SCHEDULED), new Date());
+                context, List.of(ProcessStatus.RUNNING, ProcessStatus.SCHEDULED), Instant.now());
         for (Process process : processesToBeFailed) {
             context.setCurrentUser(process.getEPerson());
             // Fail the process.
@@ -349,9 +349,8 @@ public class ProcessServiceImpl implements ProcessService {
     }
 
     private String formatLogLine(int processId, String scriptName, String output, ProcessLogLevel processLogLevel) {
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
         StringBuilder sb = new StringBuilder();
-        sb.append(sdf.format(new Date()));
+        sb.append(DateTimeFormatter.ISO_INSTANT.format(Instant.now()));
         sb.append(" ");
         sb.append(processLogLevel);
         sb.append(" ");

--- a/dspace-api/src/main/java/org/dspace/scripts/service/ProcessService.java
+++ b/dspace-api/src/main/java/org/dspace/scripts/service/ProcessService.java
@@ -10,7 +10,7 @@ package org.dspace.scripts.service;
 import java.io.IOException;
 import java.io.InputStream;
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 
@@ -253,7 +253,7 @@ public interface ProcessService {
      * @return                    The list of all Processes which match requirements
      * @throws AuthorizeException If something goes wrong
      */
-    List<Process> findByStatusAndCreationTimeOlderThan(Context context, List<ProcessStatus> statuses, Date date)
+    List<Process> findByStatusAndCreationTimeOlderThan(Context context, List<ProcessStatus> statuses, Instant date)
         throws SQLException;
 
     /**

--- a/dspace-api/src/main/java/org/dspace/search/HarvestedItemInfo.java
+++ b/dspace-api/src/main/java/org/dspace/search/HarvestedItemInfo.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.search;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
@@ -39,7 +39,7 @@ public class HarvestedItemInfo {
     /**
      * The datestamp
      */
-    public Date datestamp;
+    public Instant datestamp;
 
     /**
      * The item. Only filled out if requested

--- a/dspace-api/src/main/java/org/dspace/statistics/AnonymizeStatistics.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/AnonymizeStatistics.java
@@ -11,19 +11,16 @@ import static java.lang.Integer.parseInt;
 import static java.lang.Thread.currentThread;
 import static java.lang.Thread.sleep;
 import static java.util.Arrays.asList;
-import static java.util.Calendar.DAY_OF_YEAR;
 import static java.util.Collections.singletonList;
 import static org.apache.commons.cli.Option.builder;
-import static org.apache.commons.lang.time.DateFormatUtils.format;
 import static org.apache.logging.log4j.LogManager.getLogger;
 import static org.dspace.core.LogHelper.getHeader;
-import static org.dspace.statistics.SolrLoggerServiceImpl.DATE_FORMAT_8601;
 
 import java.io.IOException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Collection;
-import java.util.Date;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -77,13 +74,9 @@ public class AnonymizeStatistics {
     private static final Object DNS_MASK =
             configurationService.getProperty("anonymize_statistics.dns_mask", "anonymized");
 
-    private static final String TIME_LIMIT;
-
-    static {
-        Calendar calendar = Calendar.getInstance();
-        calendar.add(DAY_OF_YEAR, -configurationService.getIntProperty("anonymize_statistics.time_threshold", 90));
-        TIME_LIMIT = format(calendar, DATE_FORMAT_8601);
-    }
+    private static final String TIME_LIMIT =
+            Instant.now().minus(configurationService.getIntProperty("anonymize_statistics.time_threshold", 90),
+                                ChronoUnit.DAYS).toString();
 
     private AnonymizeStatistics() {
 
@@ -276,7 +269,8 @@ public class AnonymizeStatistics {
                     ),
                     false
                 );
-                printInfo(updated + ": updated document with uid " + document.getFieldValue("uid") + " " + new Date());
+                printInfo(updated + ": updated document with uid " + document.getFieldValue("uid") + " " +
+                              Instant.now());
                 return true;
             } catch (Exception e) {
                 printError(e);

--- a/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java
@@ -27,6 +27,7 @@ import java.sql.SQLException;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.Year;
+import java.time.YearMonth;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -995,18 +996,18 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
             } catch (DateTimeParseException e) {
                 e.printStackTrace();
             }
-            String dateformatString = "dd-MM-yyyy";
-            if ("DAY".equals(type)) {
-                dateformatString = "dd-MM-yyyy";
-            } else if ("MONTH".equals(type)) {
-                dateformatString = "MMMM yyyy";
-
-            } else if ("YEAR".equals(type)) {
-                dateformatString = "yyyy";
-            }
-            DateTimeFormatter simpleFormat = DateTimeFormatter.ofPattern(dateformatString);
             if (date != null) {
-                name = simpleFormat.format(date);
+                String dateformatString = "dd-MM-yyyy";
+                if ("DAY".equals(type)) {
+                    DateTimeFormatter simpleFormat = DateTimeFormatter.ofPattern(dateformatString);
+                    name = simpleFormat.format(date);
+                } else if ("MONTH".equals(type)) {
+                    dateformatString = "MMMM yyyy";
+                    DateTimeFormatter simpleFormat = DateTimeFormatter.ofPattern(dateformatString);
+                    name = simpleFormat.format(YearMonth.from(date));
+                } else if ("YEAR".equals(type)) {
+                    name = String.valueOf(date.getYear());
+                }
             }
 
         }

--- a/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java
@@ -27,6 +27,7 @@ import java.sql.SQLException;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.Year;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -987,7 +988,10 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
             // Get our date
             LocalDate date = null;
             try {
-                date = LocalDate.parse(name, DateTimeFormatter.ISO_INSTANT);
+                // First parse to an instant
+                Instant instant = Instant.parse(name);
+                // Then extract the LocalDate
+                date = instant.atZone(ZoneOffset.UTC).toLocalDate();
             } catch (DateTimeParseException e) {
                 e.printStackTrace();
             }

--- a/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java
@@ -24,12 +24,14 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.sql.SQLException;
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.Year;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -47,7 +49,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.time.DateFormatUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -423,7 +424,7 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
             storeParents(doc1, dspaceObject);
         }
         // Save the current time
-        doc1.addField("time", DateFormatUtils.format(new Date(), DATE_FORMAT_8601));
+        doc1.addField("time", Instant.now().toString());
         if (currentUser != null) {
             doc1.addField("epersonid", currentUser.getID().toString());
         }
@@ -515,7 +516,7 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
             storeParents(doc1, dspaceObject);
         }
         // Save the current time
-        doc1.addField("time", DateFormatUtils.format(new Date(), DATE_FORMAT_8601));
+        doc1.addField("time", Instant.now().toString());
         if (currentUser != null) {
             doc1.addField("epersonid", currentUser.getID().toString());
         }
@@ -946,7 +947,7 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
                     RangeFacet.Count dateCount = (RangeFacet.Count) timeFacet.getCounts().get(i);
                     result[i] = new ObjectCount();
                     result[i].setCount(dateCount.getCount());
-                    result[i].setValue(getDateView(dateCount.getValue(), dateType, context));
+                    result[i].setValue(getDateView(dateCount.getValue(), dateType));
                 }
                 if (showTotal) {
                     result[result.length - 1] = new ObjectCount();
@@ -981,30 +982,14 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
         return objCount;
     }
 
-    protected String getDateView(String name, String type, Context context) {
+    protected String getDateView(String name, String type) {
         if (name != null && name.matches("^[0-9]{4}\\-[0-9]{2}.*")) {
-            /*
-             * if ("YEAR".equalsIgnoreCase(type)) return name.substring(0, 4);
-             * else if ("MONTH".equalsIgnoreCase(type)) return name.substring(0,
-             * 7); else if ("DAY".equalsIgnoreCase(type)) return
-             * name.substring(0, 10); else if ("HOUR".equalsIgnoreCase(type))
-             * return name.substring(11, 13);
-             */
             // Get our date
-            Date date = null;
+            LocalDate date = null;
             try {
-                SimpleDateFormat format = new SimpleDateFormat(DATE_FORMAT_8601, context.getCurrentLocale());
-                date = format.parse(name);
-            } catch (ParseException e) {
-                try {
-                    // We should use the dcdate (the dcdate is used when
-                    // generating random data)
-                    SimpleDateFormat format = new SimpleDateFormat(
-                        DATE_FORMAT_DCDATE, context.getCurrentLocale());
-                    date = format.parse(name);
-                } catch (ParseException e1) {
-                    e1.printStackTrace();
-                }
+                date = LocalDate.parse(name, DateTimeFormatter.ISO_INSTANT);
+            } catch (DateTimeParseException e) {
+                e.printStackTrace();
             }
             String dateformatString = "dd-MM-yyyy";
             if ("DAY".equals(type)) {
@@ -1015,8 +1000,7 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
             } else if ("YEAR".equals(type)) {
                 dateformatString = "yyyy";
             }
-            SimpleDateFormat simpleFormat = new SimpleDateFormat(
-                dateformatString, context.getCurrentLocale());
+            DateTimeFormatter simpleFormat = DateTimeFormatter.ofPattern(dateformatString);
             if (date != null) {
                 name = simpleFormat.format(date);
             }
@@ -1153,7 +1137,7 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
         //We go back to 2000 the year 2000, this is a bit overkill but this way we ensure we have everything
         //The alternative would be to sort but that isn't recommended since it would be a very costly query !
         yearRangeQuery.add(FacetParams.FACET_RANGE_START,
-                           "NOW/YEAR-" + (Calendar.getInstance().get(Calendar.YEAR) - 2000) + "YEARS");
+                           "NOW/YEAR-" + (Year.now().getValue() - 2000) + "YEARS");
         //Add the +0year to ensure that we DO NOT include the current year
         yearRangeQuery.add(FacetParams.FACET_RANGE_END, "NOW/YEAR+0YEARS");
         yearRangeQuery.add(FacetParams.FACET_RANGE_GAP, "+1YEAR");
@@ -1174,12 +1158,8 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
             //Create a range query from this !
             //We start with out current year
             DCDate dcStart = new DCDate(count.getValue());
-            Calendar endDate = Calendar.getInstance();
             //Advance one year for the start of the next one !
-            endDate.setTime(dcStart.toDate());
-            endDate.add(Calendar.YEAR, 1);
-            DCDate dcEndDate = new DCDate(endDate.getTime());
-
+            DCDate dcEndDate = new DCDate(dcStart.toDate().plus(1, ChronoUnit.YEARS).toLocalDateTime());
 
             StringBuilder filterQuery = new StringBuilder();
             filterQuery.append("time:([");
@@ -1508,7 +1488,7 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
     }
 
     protected void addDocumentsToFile(Context context, SolrDocumentList docs, File exportOutput)
-        throws SQLException, ParseException, IOException {
+        throws SQLException, DateTimeParseException, IOException {
         for (SolrDocument doc : docs) {
             String ip = doc.get("ip").toString();
             if (ip.equals("::1")) {
@@ -1529,15 +1509,13 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
             }
 
             //InputFormat: Mon May 19 07:21:27 EDT 2014
-            DateFormat inputDateFormat = new SimpleDateFormat("EEE MMM dd HH:mm:ss z yyyy");
-            Date solrDate = inputDateFormat.parse(time);
+            ZonedDateTime solrDate = ZonedDateTime.parse(time,
+                                                         DateTimeFormatter.ofPattern("EEE MMM dd HH:mm:ss z yyyy"));
 
             //OutputFormat: 2014-05-27T16:24:09
-            DateFormat outputDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-
             String out = time + "," + "view_" + contentServiceFactory.getDSpaceObjectService(dso).getTypeText(dso)
-                                                                     .toLowerCase() + "," + id + "," + outputDateFormat
-                .format(solrDate) + ",anonymous," + ip + "\n";
+                                                                     .toLowerCase() + "," + id + "," +
+                DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(solrDate) + ",anonymous," + ip + "\n";
             FileUtils.writeStringToFile(exportOutput, out, StandardCharsets.UTF_8, true);
         }
     }

--- a/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java
@@ -1159,7 +1159,7 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
             //We start with out current year
             DCDate dcStart = new DCDate(count.getValue());
             //Advance one year for the start of the next one !
-            DCDate dcEndDate = new DCDate(dcStart.toDate().plus(1, ChronoUnit.YEARS).toLocalDateTime());
+            DCDate dcEndDate = new DCDate(dcStart.toDate().plus(1, ChronoUnit.YEARS));
 
             StringBuilder filterQuery = new StringBuilder();
             filterQuery.append("time:([");

--- a/dspace-api/src/main/java/org/dspace/statistics/content/DatasetTimeGenerator.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/content/DatasetTimeGenerator.java
@@ -7,8 +7,8 @@
  */
 package org.dspace.statistics.content;
 
-import java.util.Calendar;
-import java.util.Date;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 
 /**
  * Represents a date facet for filtering.
@@ -23,8 +23,8 @@ public class DatasetTimeGenerator extends DatasetGenerator {
     private String dateType;
     private String startDate;
     private String endDate;
-    private Date actualStartDate;
-    private Date actualEndDate;
+    private LocalDateTime actualStartDate;
+    private LocalDateTime actualEndDate;
 
     //TODO: process includetotal
 
@@ -52,43 +52,34 @@ public class DatasetTimeGenerator extends DatasetGenerator {
 
     }
 
-    public void setDateInterval(String dateType, Date start, Date end)
+    public void setDateInterval(String dateType, LocalDateTime start, LocalDateTime end)
         throws IllegalArgumentException {
-        actualStartDate = (start == null ? null : new Date(start.getTime()));
-        actualEndDate = (end == null ? null : new Date(end.getTime()));
+        actualStartDate = start;
+        actualEndDate = end;
 
         this.dateType = dateType;
 
         //Check if end comes before start
-        Calendar startCal1 = Calendar.getInstance();
-        Calendar endCal1 = Calendar.getInstance();
-
-        if (startCal1 == null || endCal1 == null) {
-            throw new IllegalStateException("Unable to create calendar instances");
-        }
-
-        startCal1.setTime(start);
-        endCal1.setTime(end);
-        if (endCal1.before(startCal1)) {
-            throw new IllegalArgumentException();
+        if (end.isBefore(start)) {
+            throw new IllegalArgumentException("End date is before start date");
         }
 
         // TODO: ensure future dates are tested. Although we normally do not
         // have visits from the future.
         //Depending on our dateType check if we need to use days/months/years.
-        int type = -1;
+        ChronoUnit typeChronoUnit = ChronoUnit.DAYS;
         if ("year".equalsIgnoreCase(dateType)) {
-            type = Calendar.YEAR;
+            typeChronoUnit = ChronoUnit.YEARS;
         } else if ("month".equalsIgnoreCase(dateType)) {
-            type = Calendar.MONTH;
+            typeChronoUnit = ChronoUnit.MONTHS;
         } else if ("day".equalsIgnoreCase(dateType)) {
-            type = Calendar.DATE;
+            typeChronoUnit = ChronoUnit.DAYS;
         } else if ("hour".equalsIgnoreCase(dateType)) {
-            type = Calendar.HOUR;
+            typeChronoUnit = ChronoUnit.HOURS;
         }
 
-        int difStart = getTimeDifference(start, Calendar.getInstance().getTime(), type);
-        int difEnd = getTimeDifference(end, Calendar.getInstance().getTime(), type);
+        long difStart = typeChronoUnit.between(start, LocalDateTime.now());
+        long difEnd = typeChronoUnit.between(end, LocalDateTime.now());
 //        System.out.println(difStart + " " + difEnd);
 
         boolean endPos = false;
@@ -127,20 +118,20 @@ public class DatasetTimeGenerator extends DatasetGenerator {
         return dateType.toUpperCase();
     }
 
-    public Date getActualStartDate() {
-        return actualStartDate == null ? null : new Date(actualStartDate.getTime());
+    public LocalDateTime getActualStartDate() {
+        return actualStartDate;
     }
 
-    public void setActualStartDate(Date actualStartDate) {
-        this.actualStartDate = (actualStartDate == null ? null : new Date(actualStartDate.getTime()));
+    public void setActualStartDate(LocalDateTime actualStartDate) {
+        this.actualStartDate = actualStartDate;
     }
 
-    public Date getActualEndDate() {
-        return actualEndDate == null ? null : new Date(actualEndDate.getTime());
+    public LocalDateTime getActualEndDate() {
+        return actualEndDate;
     }
 
-    public void setActualEndDate(Date actualEndDate) {
-        this.actualEndDate = (actualEndDate == null ? null : new Date(actualEndDate.getTime()));
+    public void setActualEndDate(LocalDateTime actualEndDate) {
+        this.actualEndDate = actualEndDate;
     }
 
     public void setDateType(String dateType) {
@@ -153,74 +144,5 @@ public class DatasetTimeGenerator extends DatasetGenerator {
 
     public void setType(String type) {
         this.type = type;
-    }
-
-    /**
-     * Get the difference between two Dates in terms of a given interval.
-     * That is:  if you specify the difference in months, you get back the
-     * number of months between the dates.
-     *
-     * @param date1 the first date
-     * @param date2 the other date
-     * @param type  Calendar.HOUR or .DATE or .MONTH
-     * @return number of {@code type} intervals between {@code date1} and
-     * {@code date2}
-     */
-    private int getTimeDifference(Date date1, Date date2, int type) {
-        int toAdd;
-        int elapsed = 0;
-        //We need calendar objects to compare
-        Calendar cal1 = Calendar.getInstance();
-        Calendar cal2 = Calendar.getInstance();
-
-        cal1.setTime(date1);
-        cal2.setTime(date2);
-
-        cal1.clear(Calendar.MILLISECOND);
-        cal2.clear(Calendar.MILLISECOND);
-        cal1.clear(Calendar.SECOND);
-        cal2.clear(Calendar.SECOND);
-        cal1.clear(Calendar.MINUTE);
-        cal2.clear(Calendar.MINUTE);
-        if (type != Calendar.HOUR) {
-            cal1.clear(Calendar.HOUR);
-            cal2.clear(Calendar.HOUR);
-            cal1.clear(Calendar.HOUR_OF_DAY);
-            cal2.clear(Calendar.HOUR_OF_DAY);
-            //yet i know calendar just won't clear its hours
-            cal1.set(Calendar.HOUR_OF_DAY, 0);
-            cal2.set(Calendar.HOUR_OF_DAY, 0);
-        }
-        if (type != Calendar.DATE) {
-            cal1.set(Calendar.DATE, 1);
-            cal2.set(Calendar.DATE, 1);
-        }
-        if (type != Calendar.MONTH) {
-            cal1.clear(Calendar.MONTH);
-            cal2.clear(Calendar.MONTH);
-        }
-
-        //Switch em if needed
-        if (cal1.after(cal2) || cal1.equals(cal2)) {
-            Calendar backup = cal1;
-            cal1 = cal2;
-            cal2 = backup;
-            toAdd = 1;
-        } else {
-            toAdd = -1;
-        }
-
-
-
-        /*if(type != Calendar.YEAR){
-            cal1.clear(Calendar.YEAR);
-            cal2.clear(Calendar.YEAR);
-        }
-        */
-        while (cal1.before(cal2)) {
-            cal1.add(type, 1);
-            elapsed += toAdd;
-        }
-        return elapsed;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataWorkflow.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataWorkflow.java
@@ -13,9 +13,9 @@ import java.sql.SQLException;
 import java.text.ParseException;
 import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.Period;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -107,7 +107,7 @@ public class StatisticsDataWorkflow extends StatisticsData {
                 }
                 long monthDifference = 1;
                 if (getOldestWorkflowItemDate(facetMinCount) != null) {
-                    monthDifference = getMonthsDifference(LocalDateTime.now(),
+                    monthDifference = getMonthsDifference(ZonedDateTime.now(ZoneOffset.UTC),
                                                           getOldestWorkflowItemDate(facetMinCount));
                 }
 
@@ -160,7 +160,7 @@ public class StatisticsDataWorkflow extends StatisticsData {
         return query;
     }
 
-    private long getMonthsDifference(LocalDateTime date1, LocalDateTime date2) {
+    private long getMonthsDifference(ZonedDateTime date1, ZonedDateTime date2) {
         LocalDate earlier = date1.toLocalDate();
         LocalDate later = date2.toLocalDate();
         return Period.between(earlier, later).toTotalMonths();
@@ -187,7 +187,7 @@ public class StatisticsDataWorkflow extends StatisticsData {
         return result;
     }
 
-    protected LocalDateTime getOldestWorkflowItemDate(int facetMinCount)
+    protected ZonedDateTime getOldestWorkflowItemDate(int facetMinCount)
             throws SolrServerException, IOException {
         ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
         String workflowStartDate = configurationService.getProperty("usage-statistics.workflow-start-date");
@@ -197,8 +197,8 @@ public class StatisticsDataWorkflow extends StatisticsData {
                 .query(getQuery(), null, null, 1, 0, null, null, null, null, "time", true, facetMinCount);
             if (0 < oldestRecord.getResults().getNumFound()) {
                 SolrDocument solrDocument = oldestRecord.getResults().get(0);
-                LocalDateTime oldestDate = Instant.parse((String) solrDocument.getFieldValue("time"))
-                                                  .atZone(ZoneOffset.UTC).toLocalDateTime();
+                ZonedDateTime oldestDate = Instant.parse((String) solrDocument.getFieldValue("time"))
+                                                  .atZone(ZoneOffset.UTC);
                 //Store the date, we only need to retrieve this once !
                 try {
                     // Also store it in the solr-statics configuration file, the reason for this being that the sort
@@ -225,7 +225,7 @@ public class StatisticsDataWorkflow extends StatisticsData {
             }
 
         } else {
-            return new DCDate(workflowStartDate).toDate().toLocalDateTime();
+            return new DCDate(workflowStartDate).toDate();
         }
     }
 }

--- a/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataWorkflow.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataWorkflow.java
@@ -11,7 +11,6 @@ import java.io.File;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.text.ParseException;
-import java.time.Instant;
 import java.time.LocalDate;
 import java.time.Period;
 import java.time.ZoneOffset;
@@ -197,8 +196,8 @@ public class StatisticsDataWorkflow extends StatisticsData {
                 .query(getQuery(), null, null, 1, 0, null, null, null, null, "time", true, facetMinCount);
             if (0 < oldestRecord.getResults().getNumFound()) {
                 SolrDocument solrDocument = oldestRecord.getResults().get(0);
-                ZonedDateTime oldestDate = Instant.parse((String) solrDocument.getFieldValue("time"))
-                                                  .atZone(ZoneOffset.UTC);
+                ZonedDateTime oldestDate = ((java.util.Date) solrDocument.getFieldValue("time"))
+                    .toInstant().atZone(ZoneOffset.UTC);
                 //Store the date, we only need to retrieve this once !
                 try {
                     // Also store it in the solr-statics configuration file, the reason for this being that the sort

--- a/dspace-api/src/main/java/org/dspace/statistics/content/filter/StatisticsSolrDateFilter.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/content/filter/StatisticsSolrDateFilter.java
@@ -9,6 +9,7 @@ package org.dspace.statistics.content.filter;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 /**
@@ -124,8 +125,8 @@ public class StatisticsSolrDateFilter implements StatisticsFilter {
 
         //Parse the dates
         DateTimeFormatter formatter = DateTimeFormatter.ISO_INSTANT;
-        String startDateParsed = formatter.format(startDate);
-        String endDateParsed = formatter.format(endDate);
+        String startDateParsed = formatter.format(startDate.toInstant(ZoneOffset.UTC));
+        String endDateParsed = formatter.format(endDate.toInstant(ZoneOffset.UTC));
 
         //Create our string
         return "time:[" + startDateParsed + " TO " + endDateParsed + "]";

--- a/dspace-api/src/main/java/org/dspace/statistics/content/filter/StatisticsSolrDateFilter.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/content/filter/StatisticsSolrDateFilter.java
@@ -7,20 +7,18 @@
  */
 package org.dspace.statistics.content.filter;
 
-import java.text.SimpleDateFormat;
-import java.util.Calendar;
-import java.util.Date;
-
-import org.dspace.statistics.SolrLoggerServiceImpl;
-
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 /**
  * Encapsulate a range of dates for Solr query filtering.
  *
  * @author Kevin Van de Velde (kevin at atmire dot com)
  */
 public class StatisticsSolrDateFilter implements StatisticsFilter {
-    private Date startDate;
-    private Date endDate;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
     private String startStr;
     private String endStr;
     private String typeStr;
@@ -65,10 +63,10 @@ public class StatisticsSolrDateFilter implements StatisticsFilter {
      *
      * @param startDate statistics start date object
      *
-     *                  Must be paired with {@link #setEndDate(Date)}.
+     *                  Must be paired with {@link #setEndDate(LocalDateTime)}.
      */
-    public void setStartDate(Date startDate) {
-        this.startDate = (startDate == null ? null : new Date(startDate.getTime()));
+    public void setStartDate(LocalDateTime startDate) {
+        this.startDate = startDate;
     }
 
     /**
@@ -76,10 +74,10 @@ public class StatisticsSolrDateFilter implements StatisticsFilter {
      *
      * @param endDate statistics end date object
      *
-     *                Must be paired with {@link #setStartDate(Date)}.
+     *                Must be paired with {@link #setStartDate(LocalDateTime)}.
      */
-    public void setEndDate(Date endDate) {
-        this.endDate = (endDate == null ? null : new Date(endDate.getTime()));
+    public void setEndDate(LocalDateTime endDate) {
+        this.endDate = endDate;
     }
 
     /**
@@ -92,50 +90,40 @@ public class StatisticsSolrDateFilter implements StatisticsFilter {
         if (startDate == null || endDate == null) {
             // We have got strings instead of dates so calculate our dates out
             // of these strings
-            Calendar startCal = Calendar.getInstance();
+            LocalDate startCal = LocalDate.now();
 
-            startCal.clear(Calendar.MILLISECOND);
-            startCal.clear(Calendar.SECOND);
-            startCal.clear(Calendar.MINUTE);
-            startCal.set(Calendar.HOUR_OF_DAY, 0);
-
-            int dateType = -1;
+            ChronoUnit dateType;
             if (typeStr.equalsIgnoreCase("day")) {
-                dateType = Calendar.DATE;
+                dateType = ChronoUnit.DAYS;
             } else if (typeStr.equalsIgnoreCase("month")) {
-                dateType = Calendar.MONTH;
-                startCal.set(Calendar.DATE, 1);
+                dateType = ChronoUnit.MONTHS;
+                startCal = startCal.withDayOfMonth(1);
             } else if (typeStr.equalsIgnoreCase("year")) {
-                startCal.clear(Calendar.MONTH);
-                startCal.set(Calendar.DATE, 1);
-                dateType = Calendar.YEAR;
+                startCal = startCal.withDayOfYear(1);
+                dateType = ChronoUnit.YEARS;
             } else {
                 return "";
             }
 
-            Calendar endCal = (Calendar) startCal.clone();
+            LocalDate endCal = startCal;
 
             if (startDate == null) {
                 if (startStr.startsWith("+")) {
                     startStr = startStr.substring(startStr.indexOf('+') + 1);
                 }
-
-                startCal.add(dateType, Integer.parseInt(startStr));
-                startDate = startCal.getTime();
+                startDate = startCal.plus(Integer.parseInt(startStr), dateType).atStartOfDay();
             }
 
             if (endDate == null) {
                 if (endStr.startsWith("+")) {
                     endStr = endStr.substring(endStr.indexOf('+') + 1);
                 }
-
-                endCal.add(dateType, Integer.parseInt(endStr));
-                endDate = endCal.getTime();
+                endDate = endCal.plus(Integer.parseInt(endStr), dateType).atStartOfDay();
             }
         }
 
         //Parse the dates
-        SimpleDateFormat formatter = new SimpleDateFormat(SolrLoggerServiceImpl.DATE_FORMAT_8601);
+        DateTimeFormatter formatter = DateTimeFormatter.ISO_INSTANT;
         String startDateParsed = formatter.format(startDate);
         String endDateParsed = formatter.format(endDate);
 

--- a/dspace-api/src/main/java/org/dspace/statistics/export/OpenURLTracker.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/export/OpenURLTracker.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.statistics.export;
 
-import java.util.Date;
+import java.time.LocalDate;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -16,8 +16,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
-import jakarta.persistence.Temporal;
-import jakarta.persistence.TemporalType;
 import org.dspace.core.HibernateProxyHelper;
 import org.dspace.core.ReloadableEntity;
 
@@ -39,8 +37,7 @@ public class OpenURLTracker implements ReloadableEntity<Integer> {
     private String url;
 
     @Column(name = "uploaddate")
-    @Temporal(TemporalType.DATE)
-    private Date uploadDate;
+    private LocalDate uploadDate;
 
     protected OpenURLTracker() {
     }
@@ -74,7 +71,7 @@ public class OpenURLTracker implements ReloadableEntity<Integer> {
      * Returns the upload date
      * @return upload date
      */
-    public Date getUploadDate() {
+    public LocalDate getUploadDate() {
         return uploadDate;
     }
 
@@ -82,7 +79,7 @@ public class OpenURLTracker implements ReloadableEntity<Integer> {
      * Set the upload date
      * @param uploadDate
      */
-    public void setUploadDate(Date uploadDate) {
+    public void setUploadDate(LocalDate uploadDate) {
         this.uploadDate = uploadDate;
     }
 

--- a/dspace-api/src/main/java/org/dspace/statistics/export/processor/ExportEventProcessor.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/export/processor/ExportEventProcessor.java
@@ -11,9 +11,9 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.sql.SQLException;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -156,7 +156,7 @@ public abstract class ExportEventProcessor {
      * @return the current date as a string
      */
     protected String getCurrentDateString() {
-        return new DCDate(new Date()).toString();
+        return new DCDate(LocalDateTime.now()).toString();
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/statistics/export/processor/ExportEventProcessor.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/export/processor/ExportEventProcessor.java
@@ -11,7 +11,8 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.sql.SQLException;
-import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -156,7 +157,7 @@ public abstract class ExportEventProcessor {
      * @return the current date as a string
      */
     protected String getCurrentDateString() {
-        return new DCDate(LocalDateTime.now()).toString();
+        return new DCDate(ZonedDateTime.now(ZoneOffset.UTC)).toString();
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/statistics/export/service/OpenUrlServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/export/service/OpenUrlServiceImpl.java
@@ -10,7 +10,8 @@ package org.dspace.statistics.export.service;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
+import java.time.LocalDate;
 import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
@@ -51,7 +52,7 @@ public class OpenUrlServiceImpl implements OpenUrlService {
             if (responseCode != HttpURLConnection.HTTP_OK) {
                 logfailed(c, urlStr);
             } else if (log.isDebugEnabled()) {
-                log.debug("Successfully posted " + urlStr + " on " + new Date());
+                log.debug("Successfully posted " + urlStr + " on " + Instant.now());
             }
         } catch (Exception e) {
             log.error("Failed to send url to tracker URL: " + urlStr);
@@ -141,7 +142,7 @@ public class OpenUrlServiceImpl implements OpenUrlService {
      */
     @Override
     public void logfailed(Context context, String url) throws SQLException {
-        Date now = new Date();
+        LocalDate now = LocalDate.now();
         if (StringUtils.isBlank(url)) {
             return;
         }

--- a/dspace-api/src/main/java/org/dspace/statistics/util/ClassicDSpaceLogConverter.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/util/ClassicDSpaceLogConverter.java
@@ -19,7 +19,7 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.sql.SQLException;
 import java.text.ParsePosition;
-import java.time.format.DateTimeFormatter;
+import java.text.SimpleDateFormat;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -70,22 +70,22 @@ public class ClassicDSpaceLogConverter {
     /**
      * Date format (in) from the log line
      */
-    private final DateTimeFormatter dateFormatIn = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    private final SimpleDateFormat dateFormatIn = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
 
     /**
      * Date format out (for solr)
      */
-    private final DateTimeFormatter dateFormatOut = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+    private final SimpleDateFormat dateFormatOut = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
 
     /**
      * Date format (in) from the log line for the UID
      */
-    private final DateTimeFormatter dateFormatInUID = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss,SSS");
+    private final SimpleDateFormat dateFormatInUID = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss,SSS");
 
     /**
      * Date format out (for uid)
      */
-    private final DateTimeFormatter dateFormatOutUID = DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSS");
+    private final SimpleDateFormat dateFormatOutUID = new SimpleDateFormat("yyyyMMddHHmmssSSS");
 
 
     /**

--- a/dspace-api/src/main/java/org/dspace/statistics/util/ClassicDSpaceLogConverter.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/util/ClassicDSpaceLogConverter.java
@@ -19,7 +19,7 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.sql.SQLException;
 import java.text.ParsePosition;
-import java.text.SimpleDateFormat;
+import java.time.format.DateTimeFormatter;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -70,22 +70,22 @@ public class ClassicDSpaceLogConverter {
     /**
      * Date format (in) from the log line
      */
-    private final SimpleDateFormat dateFormatIn = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+    private final DateTimeFormatter dateFormatIn = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
     /**
      * Date format out (for solr)
      */
-    private final SimpleDateFormat dateFormatOut = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+    private final DateTimeFormatter dateFormatOut = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
 
     /**
      * Date format (in) from the log line for the UID
      */
-    private final SimpleDateFormat dateFormatInUID = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss,SSS");
+    private final DateTimeFormatter dateFormatInUID = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss,SSS");
 
     /**
      * Date format out (for uid)
      */
-    private final SimpleDateFormat dateFormatOutUID = new SimpleDateFormat("yyyyMMddHHmmssSSS");
+    private final DateTimeFormatter dateFormatOutUID = DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSS");
 
 
     /**

--- a/dspace-api/src/main/java/org/dspace/statistics/util/StatisticsImporter.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/util/StatisticsImporter.java
@@ -18,7 +18,8 @@ import java.net.InetAddress;
 import java.sql.SQLException;
 import java.text.DecimalFormat;
 import java.time.Instant;
-import java.time.format.DateTimeFormatter;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -237,7 +238,7 @@ public class StatisticsImporter {
                 action = parts[1];
                 id = parts[2];
                 // Date format (for solr)
-                date = DateTimeFormatter.ISO_LOCAL_DATE_TIME.parse(parts[3], Instant::from);
+                date = LocalDateTime.parse(parts[3]).toInstant(ZoneOffset.UTC);
                 user = parts[4];
                 ip = parts[5];
 

--- a/dspace-api/src/main/java/org/dspace/statistics/util/StatisticsImporter.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/util/StatisticsImporter.java
@@ -16,12 +16,10 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.InetAddress;
 import java.sql.SQLException;
-import java.text.DateFormat;
 import java.text.DecimalFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -36,7 +34,6 @@ import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
-import org.apache.commons.lang3.time.DateFormatUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.solr.client.solrj.SolrServerException;
@@ -58,7 +55,6 @@ import org.dspace.eperson.EPerson;
 import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
-import org.dspace.statistics.SolrLoggerServiceImpl;
 import org.dspace.statistics.factory.StatisticsServiceFactory;
 import org.dspace.statistics.service.SolrLoggerService;
 
@@ -70,16 +66,6 @@ import org.dspace.statistics.service.SolrLoggerService;
  */
 public class StatisticsImporter {
     private static final Logger log = LogManager.getLogger(StatisticsImporter.class);
-
-    /**
-     * Date format (for solr)
-     */
-    private static final ThreadLocal<DateFormat> dateFormat = new ThreadLocal<DateFormat>() {
-        @Override
-        protected DateFormat initialValue() {
-            return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-        }
-    };
 
     protected final SolrLoggerService solrLoggerService
             = StatisticsServiceFactory.getInstance().getSolrLoggerService();
@@ -222,7 +208,7 @@ public class StatisticsImporter {
 //            String uuid;
             String action;
             String id;
-            Date date;
+            Instant date;
             String user;
             String ip;
 
@@ -250,7 +236,8 @@ public class StatisticsImporter {
 //                uuid = parts[0];
                 action = parts[1];
                 id = parts[2];
-                date = dateFormat.get().parse(parts[3]);
+                // Date format (for solr)
+                date = DateTimeFormatter.ISO_LOCAL_DATE_TIME.parse(parts[3], Instant::from);
                 user = parts[4];
                 ip = parts[5];
 
@@ -358,7 +345,7 @@ public class StatisticsImporter {
                 sid.addField("ip", ip);
                 sid.addField("type", dso.getType());
                 sid.addField("id", dso.getID().toString());
-                sid.addField("time", DateFormatUtils.format(date, SolrLoggerServiceImpl.DATE_FORMAT_8601));
+                sid.addField("time", date.toString());
                 sid.addField("continent", continent);
                 sid.addField("country", country);
                 sid.addField("countryCode", countryCode);
@@ -377,7 +364,7 @@ public class StatisticsImporter {
 
         } catch (RuntimeException re) {
             throw re;
-        } catch (IOException | SQLException | ParseException | SolrServerException e) {
+        } catch (IOException | SQLException | SolrServerException e) {
             System.err.println(e.getMessage());
             log.error(e.getMessage(), e);
         }

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamStorageServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamStorageServiceImpl.java
@@ -10,6 +10,7 @@ package org.dspace.storage.bitstore;
 import java.io.IOException;
 import java.io.InputStream;
 import java.sql.SQLException;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -478,7 +479,7 @@ public class BitstreamStorageServiceImpl implements BitstreamStorageService, Ini
      * @return True if this file is too recent to be deleted
      */
     protected boolean isRecent(Long lastModified) {
-        long now = new java.util.Date().getTime();
+        long now = Instant.now().toEpochMilli();
 
         if (lastModified >= now) {
             return true;

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/S3BitStoreService.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/S3BitStoreService.java
@@ -554,14 +554,14 @@ public class S3BitStoreService extends BaseBitStoreService {
         store.s3Service.createBucket(store.bucketName);
         /* Broken in DSpace 6 TODO Refactor
         // time everything, todo, switch to caliper
-        long start = System.currentTimeMillis();
+        long start = Instant.now().toEpochMilli();
         // Case 1: store a file
         String id = store.generateId();
         System.out.print("put() file " + assetFile + " under ID " + id + ": ");
         FileInputStream fis = new FileInputStream(assetFile);
         //TODO create bitstream for assetfile...
         Map attrs = store.put(fis, id);
-        long now =  System.currentTimeMillis();
+        long now =  Instant.now().toEpochMilli();
         System.out.println((now - start) + " msecs");
         start = now;
         // examine the metadata returned
@@ -575,7 +575,7 @@ public class S3BitStoreService extends BaseBitStoreService {
         // Case 2: get metadata and compare
         System.out.print("about() file with ID " + id + ": ");
         Map attrs2 = store.about(id, attrs);
-        now =  System.currentTimeMillis();
+        now =  Instant.now().toEpochMilli();
         System.out.println((now - start) + " msecs");
         start = now;
         iter = attrs2.keySet().iterator();
@@ -592,13 +592,13 @@ public class S3BitStoreService extends BaseBitStoreService {
         Utils.bufferedCopy(in, fos);
         fos.close();
         in.close();
-        now =  System.currentTimeMillis();
+        now =  Instant.now().toEpochMilli();
         System.out.println((now - start) + " msecs");
         start = now;
         // Case 4: remove asset
         System.out.print("remove() file with ID: " + id + ": ");
         store.remove(id);
-        now =  System.currentTimeMillis();
+        now =  Instant.now().toEpochMilli();
         System.out.println((now - start) + " msecs");
         System.out.flush();
         // should get nothing back now - will throw exception

--- a/dspace-api/src/main/java/org/dspace/submit/model/AccessConditionOption.java
+++ b/dspace-api/src/main/java/org/dspace/submit/model/AccessConditionOption.java
@@ -8,7 +8,7 @@
 package org.dspace.submit.model;
 import java.sql.SQLException;
 import java.text.ParseException;
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.Objects;
 
 import org.apache.logging.log4j.LogManager;
@@ -23,7 +23,6 @@ import org.dspace.core.Context;
 import org.dspace.eperson.Group;
 import org.dspace.eperson.service.GroupService;
 import org.dspace.util.DateMathParser;
-import org.dspace.util.TimeHelpers;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -154,7 +153,7 @@ public class AccessConditionOption {
      * @throws ParseException passed through (indicates problem with a date).
      */
     public void createResourcePolicy(Context context, DSpaceObject obj, String name, String description,
-                                     Date startDate, Date endDate)
+                                     LocalDate startDate, LocalDate endDate)
             throws SQLException, AuthorizeException, ParseException {
         validateResourcePolicy(context, name, startDate, endDate);
         Group group = groupService.findByName(context, getGroupName());
@@ -195,7 +194,7 @@ public class AccessConditionOption {
      *              configured maximum.
      * @throws ParseException passed through.
      */
-    public void validateResourcePolicy(Context context, String name, Date startDate, Date endDate)
+    public void validateResourcePolicy(Context context, String name, LocalDate startDate, LocalDate endDate)
            throws IllegalStateException, ParseException {
         LOG.debug("Validate policy dates:  name '{}', startDate {}, endDate {}",
                 name, startDate, endDate);
@@ -214,20 +213,20 @@ public class AccessConditionOption {
 
         DateMathParser dateMathParser = new DateMathParser();
 
-        Date latestStartDate = null;
+        LocalDate latestStartDate = null;
         if (Objects.nonNull(getStartDateLimit())) {
-            latestStartDate = TimeHelpers.toMidnightUTC(dateMathParser.parseMath(getStartDateLimit()));
+            latestStartDate = LocalDate.from(dateMathParser.parseMath(getStartDateLimit()));
         }
 
-        Date latestEndDate = null;
+        LocalDate latestEndDate = null;
         if (Objects.nonNull(getEndDateLimit())) {
-            latestEndDate = TimeHelpers.toMidnightUTC(dateMathParser.parseMath(getEndDateLimit()));
+            latestEndDate = LocalDate.from(dateMathParser.parseMath(getEndDateLimit()));
         }
 
         LOG.debug("  latestStartDate {}, latestEndDate {}",
                 latestStartDate, latestEndDate);
         // throw if startDate after latestStartDate
-        if (Objects.nonNull(startDate) && Objects.nonNull(latestStartDate) && startDate.after(latestStartDate)) {
+        if (Objects.nonNull(startDate) && Objects.nonNull(latestStartDate) && startDate.isAfter(latestStartDate)) {
             throw new IllegalStateException(String.format(
                 "The start date of access condition %s should be earlier than %s from now (%s).",
                 getName(), getStartDateLimit(), dateMathParser.getNow()
@@ -235,7 +234,7 @@ public class AccessConditionOption {
         }
 
         // throw if endDate after latestEndDate
-        if (Objects.nonNull(endDate) && Objects.nonNull(latestEndDate)  && endDate.after(latestEndDate)) {
+        if (Objects.nonNull(endDate) && Objects.nonNull(latestEndDate)  && endDate.isAfter(latestEndDate)) {
             throw new IllegalStateException(String.format(
                 "The end date of access condition %s should be earlier than %s from now (%s).",
                 getName(), getEndDateLimit(), dateMathParser.getNow()

--- a/dspace-api/src/main/java/org/dspace/usage/TabFileUsageEventListener.java
+++ b/dspace-api/src/main/java/org/dspace/usage/TabFileUsageEventListener.java
@@ -12,8 +12,8 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -43,8 +43,7 @@ public class TabFileUsageEventListener
     /**
      * ISO 8601 Basic string format for record timestamps.
      */
-    private static final SimpleDateFormat dateFormat = new SimpleDateFormat(
-        "yyyyMMdd'T'HHmmssSSS");
+    private static final DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmssSSS");
 
     /**
      * File on which to write event records.
@@ -115,7 +114,7 @@ public class TabFileUsageEventListener
 
         UsageEvent ue = (UsageEvent) event;
 
-        eventLog.append(dateFormat.format(new Date()))
+        eventLog.append(dateFormat.format(Instant.now()))
                 .append('\t').append(ue.getName()) // event type
                 .append('\t').append(Constants.typeText[ue.getObject().getType()])
                 .append('\t').append(ue.getObject().getID().toString())

--- a/dspace-api/src/main/java/org/dspace/usage/TabFileUsageEventListener.java
+++ b/dspace-api/src/main/java/org/dspace/usage/TabFileUsageEventListener.java
@@ -12,7 +12,8 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
-import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 
 import org.apache.logging.log4j.LogManager;
@@ -114,7 +115,7 @@ public class TabFileUsageEventListener
 
         UsageEvent ue = (UsageEvent) event;
 
-        eventLog.append(dateFormat.format(Instant.now()))
+        eventLog.append(dateFormat.format(LocalDateTime.now(ZoneOffset.UTC)))
                 .append('\t').append(ue.getName()) // event type
                 .append('\t').append(Constants.typeText[ue.getObject().getType()])
                 .append('\t').append(ue.getObject().getID().toString())

--- a/dspace-api/src/main/java/org/dspace/util/DateMathParser.java
+++ b/dspace-api/src/main/java/org/dspace/util/DateMathParser.java
@@ -8,7 +8,6 @@
 package org.dspace.util;
 
 import java.text.ParseException;
-import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -18,8 +17,6 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
-import java.util.Calendar;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -80,7 +77,7 @@ import org.apache.logging.log4j.Logger;
  * distinct calls to parse (Assuming no other thread calls
  * "<code>setNow</code>" in the interim).  The default value of 'now' is
  * the time at the moment the <code>DateMathParser</code> instance is
- * constructed, unless overridden by the {@link CommonParams#NOW NOW}
+ * constructed, unless overridden by the <code>NOW</code>
  * request parameter.
  * </p>
  *
@@ -90,8 +87,7 @@ import org.apache.logging.log4j.Logger;
  * day starts.  This not only impacts rounding/adding of DAYs, but also
  * cascades to rounding of HOUR, MIN, MONTH, YEAR as well.  The default
  * <code>TimeZone</code> used is <code>UTC</code> unless  overridden by the
- * {@link CommonParams#TZ TZ}
- * request parameter.
+ * <code>TZ</code> request parameter.
  * </p>
  *
  * <p>
@@ -99,9 +95,6 @@ import org.apache.logging.log4j.Logger;
  * Gregorian system/algorithm.  It does <em>not</em> switch to Julian or
  * anything else, unlike the default {@link java.util.GregorianCalendar}.
  * </p>
- *
- * @see SolrRequestInfo#getClientTimeZone
- * @see SolrRequestInfo#getNOW
  */
 public class DateMathParser {
 
@@ -132,8 +125,6 @@ public class DateMathParser {
      * for convenience (i.e. <code>DATE==DAYS</code>,
      * <code>MILLI==MILLIS</code>)
      * </p>
-     *
-     * @see Calendar
      */
     public static final Map<String, ChronoUnit> CALENDAR_UNITS = makeUnitsMap();
 
@@ -228,7 +219,7 @@ public class DateMathParser {
      * @return result of applying the parsed expression to "NOW".
      * @throws Exception
      */
-    public static Date parseMath(Date now, String val) throws Exception {
+    public static LocalDateTime parseMath(LocalDateTime now, String val) throws Exception {
         String math;
         final DateMathParser p = new DateMathParser();
 
@@ -269,24 +260,21 @@ public class DateMathParser {
      * Parsing Solr dates <b>without DateMath</b>.
      * This is the standard/pervasive ISO-8601 UTC format but is configured with some leniency.
      *
-     * Callers should almost always call {@link #parseMath(Date, String)} instead.
+     * Callers should almost always call {@link #parseMath(LocalDateTime, String)} instead.
      *
      * @throws DateTimeParseException if it can't parse
      */
-    private static Date parseNoMath(String val) {
-        //TODO write the equivalent of a Date::from; avoids Instant -> Date
-        return new Date(PARSER.parse(val, Instant::from).toEpochMilli());
+    private static LocalDateTime parseNoMath(String val) {
+        return PARSER.parse(val, LocalDateTime::from);
     }
 
     private TimeZone zone;
     private Locale loc;
-    private Date now;
+    private LocalDateTime now;
 
     /**
      * Default constructor that assumes UTC should be used for rounding unless
      * otherwise specified in the SolrRequestInfo
-     *
-     * @see SolrRequestInfo#getClientTimeZone
      */
     public DateMathParser() {
         this(null);
@@ -297,8 +285,6 @@ public class DateMathParser {
      *           defaults
      *           to the value dictated by the SolrRequestInfo if it exists -- otherwise it uses UTC.
      * @see #DEFAULT_MATH_TZ
-     * @see Calendar#getInstance(TimeZone, Locale)
-     * @see SolrRequestInfo#getClientTimeZone
      */
     public DateMathParser(TimeZone tz) {
         zone = (null != tz) ? tz : DEFAULT_MATH_TZ;
@@ -317,7 +303,7 @@ public class DateMathParser {
      * @param n new value of "now".
      * @see #getNow
      */
-    public void setNow(Date n) {
+    public void setNow(LocalDateTime n) {
         now = n;
     }
 
@@ -330,14 +316,13 @@ public class DateMathParser {
      *
      * @return "now".
      * @see #setNow
-     * @see SolrRequestInfo#getNOW
      */
-    public Date getNow() {
+    public LocalDateTime getNow() {
         if (now == null) {
             // fall back to current time if no request info set
-            now = new Date();
+            now = LocalDateTime.now();
         }
-        return (Date) now.clone();
+        return now;
     }
 
     /**
@@ -348,7 +333,7 @@ public class DateMathParser {
      * @throws ParseException positions in ParseExceptions are token positions,
      *          not character positions.
      */
-    public Date parseMath(String math) throws ParseException {
+    public LocalDateTime parseMath(String math) throws ParseException {
         /* check for No-Op */
         if (0 == math.length()) {
             return getNow();
@@ -358,7 +343,7 @@ public class DateMathParser {
 
         ZoneId zoneId = zone.toZoneId();
         // localDateTime is a date and time local to the timezone specified
-        LocalDateTime localDateTime = ZonedDateTime.ofInstant(getNow().toInstant(), zoneId).toLocalDateTime();
+        LocalDateTime localDateTime = ZonedDateTime.of(getNow(), zoneId).toLocalDateTime();
 
         String[] ops = splitter.split(math);
         int pos = 0;
@@ -407,7 +392,7 @@ public class DateMathParser {
         }
 
         LOG.debug("returning {}", localDateTime);
-        return Date.from(ZonedDateTime.of(localDateTime, zoneId).toInstant());
+        return ZonedDateTime.of(localDateTime, zoneId).toLocalDateTime();
     }
 
     private static Pattern splitter = Pattern.compile("\\b|(?<=\\d)(?=\\D)");
@@ -423,7 +408,7 @@ public class DateMathParser {
             throws Exception {
         DateMathParser parser = new DateMathParser();
         try {
-            Date parsed;
+            LocalDateTime parsed;
 
             if (argv.length <= 0) {
                 System.err.println("Date math expression(s) expected.");
@@ -436,7 +421,7 @@ public class DateMathParser {
             }
 
             if (argv.length > 1) {
-                parsed = DateMathParser.parseMath(new Date(), argv[1]);
+                parsed = DateMathParser.parseMath(LocalDateTime.now(), argv[1]);
                 System.out.format("Applied %s to explicit current time:  %s%n",
                         argv[1], parsed.toString());
             }

--- a/dspace-api/src/main/java/org/dspace/util/DateMathParser.java
+++ b/dspace-api/src/main/java/org/dspace/util/DateMathParser.java
@@ -12,6 +12,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
@@ -100,7 +101,7 @@ public class DateMathParser {
 
     private static final Logger LOG = LogManager.getLogger();
 
-    public static final TimeZone UTC = TimeZone.getTimeZone("UTC");
+    public static final TimeZone UTC = TimeZone.getTimeZone(ZoneOffset.UTC);
 
     /**
      * Default TimeZone for DateMath rounding (UTC)

--- a/dspace-api/src/main/java/org/dspace/util/DateMathParser.java
+++ b/dspace-api/src/main/java/org/dspace/util/DateMathParser.java
@@ -321,7 +321,7 @@ public class DateMathParser {
     public LocalDateTime getNow() {
         if (now == null) {
             // fall back to current time if no request info set
-            now = LocalDateTime.now();
+            now = LocalDateTime.now(zone.toZoneId());
         }
         return now;
     }
@@ -422,7 +422,7 @@ public class DateMathParser {
             }
 
             if (argv.length > 1) {
-                parsed = DateMathParser.parseMath(LocalDateTime.now(), argv[1]);
+                parsed = DateMathParser.parseMath(LocalDateTime.now(ZoneOffset.UTC), argv[1]);
                 System.out.format("Applied %s to explicit current time:  %s%n",
                         argv[1], parsed.toString());
             }

--- a/dspace-api/src/main/java/org/dspace/util/MultiFormatDateDeserializer.java
+++ b/dspace-api/src/main/java/org/dspace/util/MultiFormatDateDeserializer.java
@@ -8,7 +8,7 @@
 package org.dspace.util;
 
 import java.io.IOException;
-import java.util.Date;
+import java.time.LocalDate;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
  * Dates are parsed as being in the UTC zone.
  *
  */
-public class MultiFormatDateDeserializer extends StdDeserializer<Date> {
+public class MultiFormatDateDeserializer extends StdDeserializer<LocalDate> {
 
     public MultiFormatDateDeserializer() {
         this(null);
@@ -33,9 +33,9 @@ public class MultiFormatDateDeserializer extends StdDeserializer<Date> {
     }
 
     @Override
-    public Date deserialize(JsonParser jsonparser, DeserializationContext context)
+    public LocalDate deserialize(JsonParser jsonparser, DeserializationContext context)
             throws IOException, JsonProcessingException {
         String date = jsonparser.getText();
-        return MultiFormatDateParser.parse(date);
+        return MultiFormatDateParser.parse(date).toLocalDate();
     }
 }

--- a/dspace-api/src/main/java/org/dspace/util/MultiFormatDateParser.java
+++ b/dspace-api/src/main/java/org/dspace/util/MultiFormatDateParser.java
@@ -10,15 +10,14 @@ package org.dspace.util;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.TimeZone;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
@@ -29,7 +28,7 @@ import org.dspace.servicemanager.DSpaceKernelInit;
 
 /**
  * Attempt to parse date strings in a variety of formats.  This uses an external
- * list of regular expressions and associated SimpleDateFormat strings.  Inject
+ * list of regular expressions and associated DateTimeFormatter patterns.  Inject
  * the list as pairs of strings using {@link #setPatterns}.  {@link #parse} walks
  * the provided list in the order provided and tries each entry against a String.
  *
@@ -45,23 +44,7 @@ public class MultiFormatDateParser {
      */
     private static final ArrayList<Rule> rules = new ArrayList<>();
 
-    private static final TimeZone UTC_ZONE = TimeZone.getTimeZone("UTC");
-
-    /**
-     * Format for displaying a result of testing.
-     */
-    private static final ThreadLocal<DateFormat> formatter;
-
-    static {
-        formatter = new ThreadLocal<DateFormat>() {
-            @Override
-            protected DateFormat initialValue() {
-                DateFormat dateTimeInstance = SimpleDateFormat.getDateTimeInstance();
-                dateTimeInstance.setTimeZone(UTC_ZONE);
-                return dateTimeInstance;
-            }
-        };
-    }
+    private static final ZoneId UTC_ZONE = ZoneOffset.UTC;
 
     @Inject
     public void setPatterns(Map<String, String> patterns) {
@@ -75,16 +58,14 @@ public class MultiFormatDateParser {
                 continue;
             }
 
-            SimpleDateFormat format;
+            DateTimeFormatter format;
             try {
-                format = new SimpleDateFormat(rule.getValue());
+                format = DateTimeFormatter.ofPattern(rule.getValue()).withZone(UTC_ZONE);
             } catch (IllegalArgumentException ex) {
                 log.error("Skipping uninterpretable date format '{}'",
                         rule::getValue);
                 continue;
             }
-            format.setCalendar(Calendar.getInstance(UTC_ZONE));
-            format.setLenient(false);
 
             rules.add(new Rule(pattern, format));
         }
@@ -97,17 +78,17 @@ public class MultiFormatDateParser {
      * @param dateString the supposed date to be parsed.
      * @return the result of the first successful parse, or {@code null} if none.
      */
-    static public Date parse(String dateString) {
+    static public ZonedDateTime parse(String dateString) {
         for (Rule candidate : rules) {
             if (candidate.pattern.matcher(dateString).matches()) {
-                Date result;
+                ZonedDateTime result;
                 try {
                     synchronized (candidate.format) {
-                        result = candidate.format.parse(dateString);
+                        result = ZonedDateTime.parse(dateString, candidate.format);
                     }
-                } catch (ParseException ex) {
+                } catch (DateTimeParseException ex) {
                     log.info("Date string '{}' matched pattern '{}' but did not parse:  {}",
-                        () -> dateString, candidate.format::toPattern, ex::getMessage);
+                        () -> dateString, candidate.format::toString, ex::getMessage);
                     continue;
                 }
                 return result;
@@ -152,22 +133,23 @@ public class MultiFormatDateParser {
      * @param arg date-time string to be tested.
      */
     private static void testDate(String arg) {
-        Date result = parse(arg);
+        ZonedDateTime result = parse(arg);
         if (null == result) {
             System.out.println("Did not match any pattern.");
         } else {
-            System.out.println(formatter.get().format(result));
+            // NOTE: This formats dates as an instant in UTC (e.g. '2011-12-03T10:15:30Z')
+            System.out.println(result.format(DateTimeFormatter.ISO_INSTANT));
         }
     }
 
     /**
-     * Holder for a pair:  compiled regex, compiled SimpleDateFormat.
+     * Holder for a pair:  compiled regex, compiled DateTimeFormatter.
      */
     private static class Rule {
         final Pattern pattern;
-        final SimpleDateFormat format;
+        final DateTimeFormatter format;
 
-        public Rule(Pattern pattern, SimpleDateFormat format) {
+        public Rule(Pattern pattern, DateTimeFormatter format) {
             this.pattern = pattern;
             this.format = format;
         }

--- a/dspace-api/src/main/java/org/dspace/util/SolrImportExport.java
+++ b/dspace-api/src/main/java/org/dspace/util/SolrImportExport.java
@@ -11,14 +11,13 @@ import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.net.URL;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.TimeZone;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -53,36 +52,7 @@ import org.dspace.services.factory.DSpaceServicesFactory;
  * @author Andrea Schweer schweer@waikato.ac.nz for the LCoNZ Institutional Research Repositories
  */
 public class SolrImportExport {
-
-    private static final ThreadLocal<DateFormat> SOLR_DATE_FORMAT;
-    private static final ThreadLocal<DateFormat> SOLR_DATE_FORMAT_NO_MS;
-    private static final ThreadLocal<DateFormat> EXPORT_DATE_FORMAT;
     private static final String EXPORT_SEP = "_export_";
-
-    static {
-        SOLR_DATE_FORMAT = new ThreadLocal<DateFormat>() {
-            @Override
-            protected DateFormat initialValue() {
-                SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
-                simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
-                return simpleDateFormat;
-            }
-        };
-        SOLR_DATE_FORMAT_NO_MS = new ThreadLocal<DateFormat>() {
-            @Override
-            protected DateFormat initialValue() {
-                return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
-            }
-        };
-        EXPORT_DATE_FORMAT = new ThreadLocal<DateFormat>() {
-            @Override
-            protected DateFormat initialValue() {
-                SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM");
-                simpleDateFormat.setTimeZone(TimeZone.getDefault());
-                return simpleDateFormat;
-            }
-        };
-    }
 
     private static final String ACTION_OPTION = "a";
     private static final String CLEAR_OPTION = "c";
@@ -567,14 +537,14 @@ public class SolrImportExport {
                 solrUrl, indexName, timeField, fromWhen));
             return;
         }
-        Date earliestTimestamp = (Date) timeFieldInfo.getMin();
+        Instant earliestTimestamp = Instant.parse((String) timeFieldInfo.getMin());
 
         query.setGetFieldStatistics(false);
         query.clearSorts();
         query.setRows(0);
         query.setFacet(true);
         query.add(FacetParams.FACET_RANGE, timeField);
-        query.add(FacetParams.FACET_RANGE_START, SOLR_DATE_FORMAT.get().format(earliestTimestamp) + "/MONTH");
+        query.add(FacetParams.FACET_RANGE_START, earliestTimestamp + "/MONTH");
         query.add(FacetParams.FACET_RANGE_END, "NOW/MONTH+1MONTH");
         query.add(FacetParams.FACET_RANGE_GAP, "+1MONTH");
         query.setFacetMinCount(1);
@@ -582,11 +552,11 @@ public class SolrImportExport {
         List<RangeFacet.Count> monthFacets = solr.query(query).getFacetRanges().get(0).getCounts();
 
         for (RangeFacet.Count monthFacet : monthFacets) {
-            Date monthStartDate;
+            Instant monthStartDate;
             String monthStart = monthFacet.getValue();
             try {
-                monthStartDate = SOLR_DATE_FORMAT_NO_MS.get().parse(monthStart);
-            } catch (java.text.ParseException e) {
+                monthStartDate = Instant.parse(monthStart);
+            } catch (DateTimeParseException e) {
                 throw new SolrImportExportException("Could not read start of month batch as date: " + monthStart, e);
             }
             int docsThisMonth = monthFacet.getCount();
@@ -649,7 +619,7 @@ public class SolrImportExport {
             // other acceptable value: a number, specifying how many days back to export
             days = Integer.valueOf(lastValue); // TODO check value?
         }
-        return timeField + ":[NOW/DAY-" + days + "DAYS TO " + SOLR_DATE_FORMAT.get().format(new Date()) + "]";
+        return timeField + ":[NOW/DAY-" + days + "DAYS TO " + Instant.now() + "]";
     }
 
     /**
@@ -675,7 +645,7 @@ public class SolrImportExport {
      * @param index        The index of the current batch.
      * @return A file name that is appropriate to use for exporting the batch of data described by the parameters.
      */
-    private static String makeExportFilename(String indexName, Date exportStart, long totalRecords, int index) {
+    private static String makeExportFilename(String indexName, Instant exportStart, long totalRecords, int index) {
         String exportFileNumber = "";
         if (totalRecords > ROWS_PER_FILE) {
             exportFileNumber = StringUtils
@@ -683,7 +653,7 @@ public class SolrImportExport {
         }
         return indexName
             + EXPORT_SEP
-            + EXPORT_DATE_FORMAT.get().format(exportStart)
+            + DateTimeFormatter.ofPattern("yyyy-MM").format(exportStart)
             + (StringUtils.isNotBlank(exportFileNumber) ? "_" + exportFileNumber : "")
             + ".csv";
     }

--- a/dspace-api/src/main/java/org/dspace/util/SolrImportExport.java
+++ b/dspace-api/src/main/java/org/dspace/util/SolrImportExport.java
@@ -12,6 +12,7 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.net.URL;
 import java.time.Instant;
+import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
@@ -552,10 +553,10 @@ public class SolrImportExport {
         List<RangeFacet.Count> monthFacets = solr.query(query).getFacetRanges().get(0).getCounts();
 
         for (RangeFacet.Count monthFacet : monthFacets) {
-            Instant monthStartDate;
+            YearMonth monthStartDate;
             String monthStart = monthFacet.getValue();
             try {
-                monthStartDate = Instant.parse(monthStart);
+                monthStartDate = YearMonth.parse(monthStart);
             } catch (DateTimeParseException e) {
                 throw new SolrImportExportException("Could not read start of month batch as date: " + monthStart, e);
             }
@@ -645,7 +646,7 @@ public class SolrImportExport {
      * @param index        The index of the current batch.
      * @return A file name that is appropriate to use for exporting the batch of data described by the parameters.
      */
-    private static String makeExportFilename(String indexName, Instant exportStart, long totalRecords, int index) {
+    private static String makeExportFilename(String indexName, YearMonth exportStart, long totalRecords, int index) {
         String exportFileNumber = "";
         if (totalRecords > ROWS_PER_FILE) {
             exportFileNumber = StringUtils

--- a/dspace-api/src/main/java/org/dspace/util/SolrImportExport.java
+++ b/dspace-api/src/main/java/org/dspace/util/SolrImportExport.java
@@ -537,7 +537,7 @@ public class SolrImportExport {
                 solrUrl, indexName, timeField, fromWhen));
             return;
         }
-        Instant earliestTimestamp = Instant.parse((String) timeFieldInfo.getMin());
+        Instant earliestTimestamp = ((java.util.Date) timeFieldInfo.getMin()).toInstant();
 
         query.setGetFieldStatistics(false);
         query.clearSorts();

--- a/dspace-api/src/main/java/org/dspace/util/SolrUpgradePre6xStatistics.java
+++ b/dspace-api/src/main/java/org/dspace/util/SolrUpgradePre6xStatistics.java
@@ -9,9 +9,9 @@ package org.dspace.util;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
@@ -210,7 +210,7 @@ public class SolrUpgradePre6xStatistics {
      */
     private long logTime(boolean fromStart) {
         long ret = 0;
-        long cur = new Date().getTime();
+        long cur = Instant.now().toEpochMilli();
         if (lastTime == -1) {
             startTime = cur;
         } else if (fromStart) {

--- a/dspace-api/src/main/java/org/dspace/util/SolrUtils.java
+++ b/dspace-api/src/main/java/org/dspace/util/SolrUtils.java
@@ -8,10 +8,9 @@
 
 package org.dspace.util;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
-import java.util.TimeZone;
+import java.time.format.DateTimeFormatter;
 
 /**
  * Common constants and static methods for working with Solr.
@@ -20,7 +19,7 @@ import java.util.TimeZone;
  */
 public class SolrUtils {
     /** Solr uses UTC always. */
-    public static final TimeZone SOLR_TIME_ZONE = TimeZone.getTimeZone(ZoneOffset.UTC);
+    public static final ZoneId SOLR_TIME_ZONE = ZoneOffset.UTC;
 
     /** Restricted ISO 8601 format used by Solr. */
     public static final String SOLR_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
@@ -30,13 +29,12 @@ public class SolrUtils {
 
     /**
      * Create a formatter configured for Solr-style date strings and the UTC time zone.
-     * @see SOLR_DATE_FORMAT
+     * @see #SOLR_DATE_FORMAT
      *
      * @return date formatter compatible with Solr.
      */
-    public static DateFormat getDateFormatter() {
-        DateFormat formatter = new SimpleDateFormat(SolrUtils.SOLR_DATE_FORMAT);
-        formatter.setTimeZone(SOLR_TIME_ZONE);
-        return formatter;
+    public static DateTimeFormatter getDateFormatter() {
+        // TODO: Can this be replaced with DateTimeFormatter.ISO_INSTANT?
+        return DateTimeFormatter.ofPattern(SOLR_DATE_FORMAT).withZone(SOLR_TIME_ZONE);
     }
 }

--- a/dspace-api/src/main/java/org/dspace/util/TimeHelpers.java
+++ b/dspace-api/src/main/java/org/dspace/util/TimeHelpers.java
@@ -7,8 +7,7 @@
  */
 package org.dspace.util;
 
-import java.util.Date;
-import java.util.GregorianCalendar;
+import java.time.LocalDateTime;
 import java.util.TimeZone;
 
 /**
@@ -30,13 +29,7 @@ public class TimeHelpers {
      * @param from some date-time.
      * @return midnight UTC of the supplied date-time.
      */
-    public static Date toMidnightUTC(Date from) {
-        GregorianCalendar calendar = new GregorianCalendar(UTC);
-        calendar.setTime(from);
-        calendar.set(GregorianCalendar.HOUR_OF_DAY, 0);
-        calendar.set(GregorianCalendar.MINUTE, 0);
-        calendar.set(GregorianCalendar.SECOND, 0);
-        calendar.set(GregorianCalendar.MILLISECOND, 0);
-        return calendar.getTime();
+    public static LocalDateTime toMidnightUTC(LocalDateTime from) {
+        return from.withHour(0).withMinute(0).withSecond(0).withNano(0);
     }
 }

--- a/dspace-api/src/main/java/org/dspace/util/TimeHelpers.java
+++ b/dspace-api/src/main/java/org/dspace/util/TimeHelpers.java
@@ -8,7 +8,6 @@
 package org.dspace.util;
 
 import java.time.LocalDateTime;
-import java.util.TimeZone;
 
 /**
  * Various manipulations of dates and times.
@@ -16,8 +15,6 @@ import java.util.TimeZone;
  * @author mwood
  */
 public class TimeHelpers {
-    private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
-
     /**
      * Never instantiate this class.
      */

--- a/dspace-api/src/main/java/org/dspace/versioning/Version.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/Version.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.versioning;
 
-import java.util.Date;
+import java.time.Instant;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -19,8 +19,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
-import jakarta.persistence.Temporal;
-import jakarta.persistence.TemporalType;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
 import org.dspace.core.HibernateProxyHelper;
@@ -55,8 +53,7 @@ public class Version implements ReloadableEntity<Integer> {
     private EPerson ePerson;
 
     @Column(name = "version_date")
-    @Temporal(TemporalType.TIMESTAMP)
-    private Date versionDate;
+    private Instant versionDate;
 
     @Column(name = "version_summary", length = 255)
     private String summary;
@@ -72,7 +69,7 @@ public class Version implements ReloadableEntity<Integer> {
      * {@link org.dspace.versioning.service.VersioningService#createNewVersion(Context, Item, String)}
      * or
      * {@link org.dspace.versioning.service.VersioningService#createNewVersion(Context, VersionHistory,
-     * Item, String, Date, int)}
+     * Item, String, Instant, int)}
      */
     protected Version() {
 
@@ -107,11 +104,11 @@ public class Version implements ReloadableEntity<Integer> {
         this.ePerson = ePerson;
     }
 
-    public Date getVersionDate() {
+    public Instant getVersionDate() {
         return versionDate;
     }
 
-    public void setVersionDate(Date versionDate) {
+    public void setVersionDate(Instant versionDate) {
         this.versionDate = versionDate;
     }
 

--- a/dspace-api/src/main/java/org/dspace/versioning/VersioningServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/VersioningServiceImpl.java
@@ -9,6 +9,7 @@ package org.dspace.versioning;
 
 import java.sql.SQLException;
 import java.time.Instant;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Objects;
@@ -75,7 +76,7 @@ public class VersioningServiceImpl implements VersioningService {
 
                 // get dc:date.accessioned to be set as first version date...
                 List<MetadataValue> values = itemService.getMetadata(item, "dc", "date", "accessioned", Item.ANY);
-                ZonedDateTime versionDate = ZonedDateTime.now();
+                ZonedDateTime versionDate = ZonedDateTime.now(ZoneOffset.UTC);
                 if (values != null && values.size() > 0) {
                     String date = values.get(0).getValue();
                     versionDate = new DCDate(date).toDate();
@@ -86,7 +87,7 @@ public class VersioningServiceImpl implements VersioningService {
             Item itemNew = provider.createNewItemAndAddItInWorkspace(c, item);
 
             // create new version
-            Version version = createVersion(c, vh, itemNew, summary, ZonedDateTime.now());
+            Version version = createVersion(c, vh, itemNew, summary, ZonedDateTime.now(ZoneOffset.UTC));
 
             // Complete any update of the Item and new Identifier generation that needs to happen
             provider.updateItemState(c, itemNew, item);

--- a/dspace-api/src/main/java/org/dspace/versioning/VersioningServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/VersioningServiceImpl.java
@@ -8,7 +8,8 @@
 package org.dspace.versioning;
 
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Objects;
 
@@ -74,7 +75,7 @@ public class VersioningServiceImpl implements VersioningService {
 
                 // get dc:date.accessioned to be set as first version date...
                 List<MetadataValue> values = itemService.getMetadata(item, "dc", "date", "accessioned", Item.ANY);
-                Date versionDate = new Date();
+                ZonedDateTime versionDate = ZonedDateTime.now();
                 if (values != null && values.size() > 0) {
                     String date = values.get(0).getValue();
                     versionDate = new DCDate(date).toDate();
@@ -85,7 +86,7 @@ public class VersioningServiceImpl implements VersioningService {
             Item itemNew = provider.createNewItemAndAddItInWorkspace(c, item);
 
             // create new version
-            Version version = createVersion(c, vh, itemNew, summary, new Date());
+            Version version = createVersion(c, vh, itemNew, summary, ZonedDateTime.now());
 
             // Complete any update of the Item and new Identifier generation that needs to happen
             provider.updateItemState(c, itemNew, item);
@@ -193,7 +194,7 @@ public class VersioningServiceImpl implements VersioningService {
     }
 
     @Override
-    public Version createNewVersion(Context context, VersionHistory history, Item item, String summary, Date date,
+    public Version createNewVersion(Context context, VersionHistory history, Item item, String summary, Instant date,
                                     int versionNumber) {
         try {
             Version version = versionDAO.create(context, new Version());
@@ -239,9 +240,9 @@ public class VersioningServiceImpl implements VersioningService {
 
 // **** PROTECTED METHODS!!
 
-    protected Version createVersion(Context c, VersionHistory vh, Item item, String summary, Date date)
+    protected Version createVersion(Context c, VersionHistory vh, Item item, String summary, ZonedDateTime date)
         throws SQLException {
-        return createNewVersion(c, vh, item, summary, date, getNextVersionNumer(c, vh));
+        return createNewVersion(c, vh, item, summary, date.toInstant(), getNextVersionNumer(c, vh));
     }
 
     protected int getNextVersionNumer(Context c, VersionHistory vh) throws SQLException {

--- a/dspace-api/src/main/java/org/dspace/versioning/service/VersioningService.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/service/VersioningService.java
@@ -8,7 +8,7 @@
 package org.dspace.versioning.service;
 
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 
 import org.dspace.content.Item;
@@ -76,7 +76,7 @@ public interface VersioningService {
 
     Version getVersion(Context c, Item item) throws SQLException;
 
-    Version createNewVersion(Context context, VersionHistory history, Item item, String summary, Date date,
+    Version createNewVersion(Context context, VersionHistory history, Item item, String summary, Instant date,
                              int versionNumber);
 
     /**

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/WorkflowUtils.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/WorkflowUtils.java
@@ -11,7 +11,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.Enumeration;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -165,7 +165,7 @@ public class WorkflowUtils extends Util {
 
                 email.addRecipient(recipient);
                 email.addArgument(configurationService.getProperty("dspace.ui.url"));
-                email.addArgument(new Date());
+                email.addArgument(Instant.now());
                 email.addArgument(request.getSession().getId());
                 email.addArgument(logInfo);
 

--- a/dspace-api/src/test/java/org/dspace/AbstractDSpaceIntegrationTest.java
+++ b/dspace-api/src/test/java/org/dspace/AbstractDSpaceIntegrationTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.fail;
 import java.io.IOException;
 import java.net.URL;
 import java.sql.SQLException;
+import java.time.ZoneOffset;
 import java.util.Properties;
 import java.util.TimeZone;
 
@@ -73,8 +74,10 @@ public class AbstractDSpaceIntegrationTest {
             //Stops System.exit(0) throws exception instead of exiting
             System.setSecurityManager(new NoExitSecurityManager());
 
-            //set a standard time zone for the tests
-            TimeZone.setDefault(TimeZone.getTimeZone("Europe/Dublin"));
+            // All tests should assume UTC timezone by default (unless overridden in the test itself)
+            // This ensures that Spring doesn't attempt to change the timezone of dates that are read from the
+            // database (via Hibernate). We store all dates in the database as UTC.
+            TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.UTC));
 
             //load the properties of the tests
             testProps = new Properties();

--- a/dspace-api/src/test/java/org/dspace/AbstractDSpaceTest.java
+++ b/dspace-api/src/test/java/org/dspace/AbstractDSpaceTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.fail;
 import java.io.IOException;
 import java.net.URL;
 import java.sql.SQLException;
+import java.time.ZoneOffset;
 import java.util.Properties;
 import java.util.TimeZone;
 
@@ -82,8 +83,10 @@ public class AbstractDSpaceTest {
     @BeforeClass
     public static void initKernel() {
         try {
-            //set a standard time zone for the tests
-            TimeZone.setDefault(TimeZone.getTimeZone("Europe/Dublin"));
+            // All tests should assume UTC timezone by default (unless overridden in the test itself)
+            // This ensures that Spring doesn't attempt to change the timezone of dates that are read from the
+            // database (via Hibernate). We store all dates in the database as UTC.
+            TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.UTC));
 
             //load the properties of the tests
             testProps = new Properties();

--- a/dspace-api/src/test/java/org/dspace/access/status/DefaultAccessStatusHelperTest.java
+++ b/dspace-api/src/test/java/org/dspace/access/status/DefaultAccessStatusHelperTest.java
@@ -15,9 +15,7 @@ import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.time.LocalDate;
-import java.time.ZoneId;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 import org.apache.logging.log4j.LogManager;
@@ -65,7 +63,7 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
     private Item itemWithPrimaryAndMultipleBitstreams;
     private Item itemWithoutPrimaryAndMultipleBitstreams;
     private DefaultAccessStatusHelper helper;
-    private Date threshold;
+    private LocalDate threshold;
 
     protected CommunityService communityService =
             ContentServiceFactory.getInstance().getCommunityService();
@@ -130,7 +128,7 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
             fail("SQL Error in init: " + ex.getMessage());
         }
         helper = new DefaultAccessStatusHelper();
-        threshold = dateFrom(10000, 1, 1);
+        threshold = LocalDate.of(10000, 1, 1);
     }
 
     /**
@@ -266,7 +264,7 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         ResourcePolicy policy = resourcePolicyService.create(context, null, group);
         policy.setRpName("Embargo");
         policy.setAction(Constants.READ);
-        policy.setStartDate(dateFrom(9999, 12, 31));
+        policy.setStartDate(LocalDate.of(9999, 12, 31));
         policies.add(policy);
         authorizeService.removeAllPolicies(context, bitstream);
         authorizeService.addPolicies(context, policies, bitstream);
@@ -294,7 +292,7 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         ResourcePolicy policy = resourcePolicyService.create(context, null, group);
         policy.setRpName("Restriction");
         policy.setAction(Constants.READ);
-        policy.setStartDate(dateFrom(10000, 1, 1));
+        policy.setStartDate(LocalDate.of(10000, 1, 1));
         policies.add(policy);
         authorizeService.removeAllPolicies(context, bitstream);
         authorizeService.addPolicies(context, policies, bitstream);
@@ -382,7 +380,7 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         ResourcePolicy policy = resourcePolicyService.create(context, null, group);
         policy.setRpName("Embargo");
         policy.setAction(Constants.READ);
-        policy.setStartDate(dateFrom(9999, 12, 31));
+        policy.setStartDate(LocalDate.of(9999, 12, 31));
         policies.add(policy);
         authorizeService.removeAllPolicies(context, primaryBitstream);
         authorizeService.addPolicies(context, policies, primaryBitstream);
@@ -412,7 +410,7 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         ResourcePolicy policy = resourcePolicyService.create(context, null, group);
         policy.setRpName("Embargo");
         policy.setAction(Constants.READ);
-        policy.setStartDate(dateFrom(9999, 12, 31));
+        policy.setStartDate(LocalDate.of(9999, 12, 31));
         policies.add(policy);
         authorizeService.removeAllPolicies(context, anotherBitstream);
         authorizeService.addPolicies(context, policies, anotherBitstream);
@@ -421,20 +419,5 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         assertThat("testWithNoPrimaryAndMultipleBitstreams 0", status, equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
         String embargoDate = helper.getEmbargoFromItem(context, itemWithEmbargo, threshold);
         assertThat("testWithNoPrimaryAndMultipleBitstreams 1", embargoDate, equalTo(null));
-    }
-
-    /**
-     * Create a Date from local year, month, day.
-     *
-     * @param year the year.
-     * @param month the month.
-     * @param day the day.
-     * @return the assembled date.
-     */
-    private Date dateFrom(int year, int month, int day) {
-        return Date.from(LocalDate.of(year, month, day)
-                .atStartOfDay()
-                .atZone(ZoneId.systemDefault())
-                .toInstant());
     }
 }

--- a/dspace-api/src/test/java/org/dspace/administer/ProcessCleanerIT.java
+++ b/dspace-api/src/test/java/org/dspace/administer/ProcessCleanerIT.java
@@ -7,7 +7,6 @@
  */
 package org.dspace.administer;
 
-import static org.apache.commons.lang.time.DateUtils.addDays;
 import static org.dspace.content.ProcessStatus.COMPLETED;
 import static org.dspace.content.ProcessStatus.FAILED;
 import static org.dspace.content.ProcessStatus.RUNNING;
@@ -19,7 +18,8 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import org.dspace.AbstractIntegrationTestWithDatabase;
@@ -49,9 +49,9 @@ public class ProcessCleanerIT extends AbstractIntegrationTestWithDatabase {
     @Test
     public void testWithoutProcessToDelete() throws Exception {
 
-        Process process_1 = buildProcess(COMPLETED, addDays(new Date(), -2));
-        Process process_2 = buildProcess(RUNNING, addDays(new Date(), -1));
-        Process process_3 = buildProcess(FAILED, addDays(new Date(), -3));
+        Process process_1 = buildProcess(COMPLETED, Instant.now().minus(2, ChronoUnit.DAYS));
+        Process process_2 = buildProcess(RUNNING, Instant.now().minus(1, ChronoUnit.DAYS));
+        Process process_3 = buildProcess(FAILED, Instant.now().minus(3, ChronoUnit.DAYS));
 
         configurationService.setProperty("process-cleaner.days", 5);
 
@@ -78,13 +78,13 @@ public class ProcessCleanerIT extends AbstractIntegrationTestWithDatabase {
     @Test
     public void testWithoutSpecifiedStatus() throws Exception {
 
-        Process process_1 = buildProcess(COMPLETED, addDays(new Date(), -2));
-        Process process_2 = buildProcess(RUNNING, addDays(new Date(), -1));
-        Process process_3 = buildProcess(FAILED, addDays(new Date(), -3));
-        Process process_4 = buildProcess(COMPLETED, addDays(new Date(), -6));
-        Process process_5 = buildProcess(COMPLETED, addDays(new Date(), -8));
-        Process process_6 = buildProcess(RUNNING, addDays(new Date(), -7));
-        Process process_7 = buildProcess(FAILED, addDays(new Date(), -8));
+        Process process_1 = buildProcess(COMPLETED, Instant.now().minus(2, ChronoUnit.DAYS));
+        Process process_2 = buildProcess(RUNNING, Instant.now().minus(1, ChronoUnit.DAYS));
+        Process process_3 = buildProcess(FAILED, Instant.now().minus(3, ChronoUnit.DAYS));
+        Process process_4 = buildProcess(COMPLETED, Instant.now().minus(6, ChronoUnit.DAYS));
+        Process process_5 = buildProcess(COMPLETED, Instant.now().minus(8, ChronoUnit.DAYS));
+        Process process_6 = buildProcess(RUNNING, Instant.now().minus(7, ChronoUnit.DAYS));
+        Process process_7 = buildProcess(FAILED, Instant.now().minus(8, ChronoUnit.DAYS));
 
         configurationService.setProperty("process-cleaner.days", 5);
 
@@ -115,13 +115,13 @@ public class ProcessCleanerIT extends AbstractIntegrationTestWithDatabase {
     @Test
     public void testWithCompletedStatus() throws Exception {
 
-        Process process_1 = buildProcess(COMPLETED, addDays(new Date(), -2));
-        Process process_2 = buildProcess(RUNNING, addDays(new Date(), -1));
-        Process process_3 = buildProcess(FAILED, addDays(new Date(), -3));
-        Process process_4 = buildProcess(COMPLETED, addDays(new Date(), -6));
-        Process process_5 = buildProcess(COMPLETED, addDays(new Date(), -8));
-        Process process_6 = buildProcess(RUNNING, addDays(new Date(), -7));
-        Process process_7 = buildProcess(FAILED, addDays(new Date(), -8));
+        Process process_1 = buildProcess(COMPLETED, Instant.now().minus(2, ChronoUnit.DAYS));
+        Process process_2 = buildProcess(RUNNING, Instant.now().minus(1, ChronoUnit.DAYS));
+        Process process_3 = buildProcess(FAILED, Instant.now().minus(3, ChronoUnit.DAYS));
+        Process process_4 = buildProcess(COMPLETED, Instant.now().minus(6, ChronoUnit.DAYS));
+        Process process_5 = buildProcess(COMPLETED, Instant.now().minus(8, ChronoUnit.DAYS));
+        Process process_6 = buildProcess(RUNNING, Instant.now().minus(7, ChronoUnit.DAYS));
+        Process process_7 = buildProcess(FAILED, Instant.now().minus(8, ChronoUnit.DAYS));
 
         configurationService.setProperty("process-cleaner.days", 5);
 
@@ -152,14 +152,14 @@ public class ProcessCleanerIT extends AbstractIntegrationTestWithDatabase {
     @Test
     public void testWithRunningStatus() throws Exception {
 
-        Process process_1 = buildProcess(COMPLETED, addDays(new Date(), -2));
-        Process process_2 = buildProcess(RUNNING, addDays(new Date(), -1));
-        Process process_3 = buildProcess(FAILED, addDays(new Date(), -3));
-        Process process_4 = buildProcess(COMPLETED, addDays(new Date(), -6));
-        Process process_5 = buildProcess(COMPLETED, addDays(new Date(), -8));
-        Process process_6 = buildProcess(RUNNING, addDays(new Date(), -7));
-        Process process_7 = buildProcess(FAILED, addDays(new Date(), -8));
-        Process process_8 = buildProcess(RUNNING, addDays(new Date(), -9));
+        Process process_1 = buildProcess(COMPLETED, Instant.now().minus(2, ChronoUnit.DAYS));
+        Process process_2 = buildProcess(RUNNING, Instant.now().minus(1, ChronoUnit.DAYS));
+        Process process_3 = buildProcess(FAILED, Instant.now().minus(3, ChronoUnit.DAYS));
+        Process process_4 = buildProcess(COMPLETED, Instant.now().minus(6, ChronoUnit.DAYS));
+        Process process_5 = buildProcess(COMPLETED, Instant.now().minus(8, ChronoUnit.DAYS));
+        Process process_6 = buildProcess(RUNNING, Instant.now().minus(7, ChronoUnit.DAYS));
+        Process process_7 = buildProcess(FAILED, Instant.now().minus(8, ChronoUnit.DAYS));
+        Process process_8 = buildProcess(RUNNING, Instant.now().minus(9, ChronoUnit.DAYS));
 
         configurationService.setProperty("process-cleaner.days", 5);
 
@@ -191,14 +191,14 @@ public class ProcessCleanerIT extends AbstractIntegrationTestWithDatabase {
     @Test
     public void testWithFailedStatus() throws Exception {
 
-        Process process_1 = buildProcess(COMPLETED, addDays(new Date(), -2));
-        Process process_2 = buildProcess(RUNNING, addDays(new Date(), -1));
-        Process process_3 = buildProcess(FAILED, addDays(new Date(), -3));
-        Process process_4 = buildProcess(COMPLETED, addDays(new Date(), -6));
-        Process process_5 = buildProcess(COMPLETED, addDays(new Date(), -8));
-        Process process_6 = buildProcess(RUNNING, addDays(new Date(), -7));
-        Process process_7 = buildProcess(FAILED, addDays(new Date(), -8));
-        Process process_8 = buildProcess(FAILED, addDays(new Date(), -9));
+        Process process_1 = buildProcess(COMPLETED, Instant.now().minus(2, ChronoUnit.DAYS));
+        Process process_2 = buildProcess(RUNNING, Instant.now().minus(1, ChronoUnit.DAYS));
+        Process process_3 = buildProcess(FAILED, Instant.now().minus(3, ChronoUnit.DAYS));
+        Process process_4 = buildProcess(COMPLETED, Instant.now().minus(6, ChronoUnit.DAYS));
+        Process process_5 = buildProcess(COMPLETED, Instant.now().minus(8, ChronoUnit.DAYS));
+        Process process_6 = buildProcess(RUNNING, Instant.now().minus(7, ChronoUnit.DAYS));
+        Process process_7 = buildProcess(FAILED, Instant.now().minus(8, ChronoUnit.DAYS));
+        Process process_8 = buildProcess(FAILED, Instant.now().minus(9, ChronoUnit.DAYS));
 
         configurationService.setProperty("process-cleaner.days", 5);
 
@@ -230,14 +230,14 @@ public class ProcessCleanerIT extends AbstractIntegrationTestWithDatabase {
     @Test
     public void testWithCompletedAndFailedStatus() throws Exception {
 
-        Process process_1 = buildProcess(COMPLETED, addDays(new Date(), -2));
-        Process process_2 = buildProcess(RUNNING, addDays(new Date(), -1));
-        Process process_3 = buildProcess(FAILED, addDays(new Date(), -3));
-        Process process_4 = buildProcess(COMPLETED, addDays(new Date(), -6));
-        Process process_5 = buildProcess(COMPLETED, addDays(new Date(), -8));
-        Process process_6 = buildProcess(RUNNING, addDays(new Date(), -7));
-        Process process_7 = buildProcess(FAILED, addDays(new Date(), -8));
-        Process process_8 = buildProcess(FAILED, addDays(new Date(), -9));
+        Process process_1 = buildProcess(COMPLETED, Instant.now().minus(2, ChronoUnit.DAYS));
+        Process process_2 = buildProcess(RUNNING, Instant.now().minus(1, ChronoUnit.DAYS));
+        Process process_3 = buildProcess(FAILED, Instant.now().minus(3, ChronoUnit.DAYS));
+        Process process_4 = buildProcess(COMPLETED, Instant.now().minus(6, ChronoUnit.DAYS));
+        Process process_5 = buildProcess(COMPLETED, Instant.now().minus(8, ChronoUnit.DAYS));
+        Process process_6 = buildProcess(RUNNING, Instant.now().minus(7, ChronoUnit.DAYS));
+        Process process_7 = buildProcess(FAILED, Instant.now().minus(8, ChronoUnit.DAYS));
+        Process process_8 = buildProcess(FAILED, Instant.now().minus(9, ChronoUnit.DAYS));
 
         configurationService.setProperty("process-cleaner.days", 5);
 
@@ -266,14 +266,14 @@ public class ProcessCleanerIT extends AbstractIntegrationTestWithDatabase {
     @Test
     public void testWithCompletedAndRunningStatus() throws Exception {
 
-        Process process_1 = buildProcess(COMPLETED, addDays(new Date(), -2));
-        Process process_2 = buildProcess(RUNNING, addDays(new Date(), -1));
-        Process process_3 = buildProcess(FAILED, addDays(new Date(), -3));
-        Process process_4 = buildProcess(COMPLETED, addDays(new Date(), -6));
-        Process process_5 = buildProcess(COMPLETED, addDays(new Date(), -8));
-        Process process_6 = buildProcess(RUNNING, addDays(new Date(), -7));
-        Process process_7 = buildProcess(FAILED, addDays(new Date(), -8));
-        Process process_8 = buildProcess(RUNNING, addDays(new Date(), -9));
+        Process process_1 = buildProcess(COMPLETED, Instant.now().minus(2, ChronoUnit.DAYS));
+        Process process_2 = buildProcess(RUNNING, Instant.now().minus(1, ChronoUnit.DAYS));
+        Process process_3 = buildProcess(FAILED, Instant.now().minus(3, ChronoUnit.DAYS));
+        Process process_4 = buildProcess(COMPLETED, Instant.now().minus(6, ChronoUnit.DAYS));
+        Process process_5 = buildProcess(COMPLETED, Instant.now().minus(8, ChronoUnit.DAYS));
+        Process process_6 = buildProcess(RUNNING, Instant.now().minus(7, ChronoUnit.DAYS));
+        Process process_7 = buildProcess(FAILED, Instant.now().minus(8, ChronoUnit.DAYS));
+        Process process_8 = buildProcess(RUNNING, Instant.now().minus(9, ChronoUnit.DAYS));
 
         configurationService.setProperty("process-cleaner.days", 5);
 
@@ -302,14 +302,14 @@ public class ProcessCleanerIT extends AbstractIntegrationTestWithDatabase {
     @Test
     public void testWithFailedAndRunningStatus() throws Exception {
 
-        Process process_1 = buildProcess(COMPLETED, addDays(new Date(), -2));
-        Process process_2 = buildProcess(RUNNING, addDays(new Date(), -1));
-        Process process_3 = buildProcess(FAILED, addDays(new Date(), -3));
-        Process process_4 = buildProcess(COMPLETED, addDays(new Date(), -6));
-        Process process_5 = buildProcess(COMPLETED, addDays(new Date(), -8));
-        Process process_6 = buildProcess(RUNNING, addDays(new Date(), -7));
-        Process process_7 = buildProcess(FAILED, addDays(new Date(), -8));
-        Process process_8 = buildProcess(RUNNING, addDays(new Date(), -9));
+        Process process_1 = buildProcess(COMPLETED, Instant.now().minus(2, ChronoUnit.DAYS));
+        Process process_2 = buildProcess(RUNNING, Instant.now().minus(1, ChronoUnit.DAYS));
+        Process process_3 = buildProcess(FAILED, Instant.now().minus(3, ChronoUnit.DAYS));
+        Process process_4 = buildProcess(COMPLETED, Instant.now().minus(6, ChronoUnit.DAYS));
+        Process process_5 = buildProcess(COMPLETED, Instant.now().minus(8, ChronoUnit.DAYS));
+        Process process_6 = buildProcess(RUNNING, Instant.now().minus(7, ChronoUnit.DAYS));
+        Process process_7 = buildProcess(FAILED, Instant.now().minus(8, ChronoUnit.DAYS));
+        Process process_8 = buildProcess(RUNNING, Instant.now().minus(9, ChronoUnit.DAYS));
 
         configurationService.setProperty("process-cleaner.days", 5);
 
@@ -338,14 +338,14 @@ public class ProcessCleanerIT extends AbstractIntegrationTestWithDatabase {
     @Test
     public void testWithCompletedFailedAndRunningStatus() throws Exception {
 
-        Process process_1 = buildProcess(COMPLETED, addDays(new Date(), -2));
-        Process process_2 = buildProcess(RUNNING, addDays(new Date(), -1));
-        Process process_3 = buildProcess(FAILED, addDays(new Date(), -3));
-        Process process_4 = buildProcess(COMPLETED, addDays(new Date(), -6));
-        Process process_5 = buildProcess(COMPLETED, addDays(new Date(), -8));
-        Process process_6 = buildProcess(RUNNING, addDays(new Date(), -7));
-        Process process_7 = buildProcess(FAILED, addDays(new Date(), -8));
-        Process process_8 = buildProcess(RUNNING, addDays(new Date(), -9));
+        Process process_1 = buildProcess(COMPLETED, Instant.now().minus(2, ChronoUnit.DAYS));
+        Process process_2 = buildProcess(RUNNING, Instant.now().minus(1, ChronoUnit.DAYS));
+        Process process_3 = buildProcess(FAILED, Instant.now().minus(3, ChronoUnit.DAYS));
+        Process process_4 = buildProcess(COMPLETED, Instant.now().minus(6, ChronoUnit.DAYS));
+        Process process_5 = buildProcess(COMPLETED, Instant.now().minus(8, ChronoUnit.DAYS));
+        Process process_6 = buildProcess(RUNNING, Instant.now().minus(7, ChronoUnit.DAYS));
+        Process process_7 = buildProcess(FAILED, Instant.now().minus(8, ChronoUnit.DAYS));
+        Process process_8 = buildProcess(RUNNING, Instant.now().minus(9, ChronoUnit.DAYS));
 
         configurationService.setProperty("process-cleaner.days", 5);
 
@@ -371,7 +371,7 @@ public class ProcessCleanerIT extends AbstractIntegrationTestWithDatabase {
 
     }
 
-    private Process buildProcess(ProcessStatus processStatus, Date creationTime) throws SQLException {
+    private Process buildProcess(ProcessStatus processStatus, Instant creationTime) throws SQLException {
         return ProcessBuilder.createProcess(context, admin, "test", List.of())
             .withProcessStatus(processStatus)
             .withCreationTime(creationTime)

--- a/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataExportSearchIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataExportSearchIT.java
@@ -74,20 +74,27 @@ public class MetadataExportSearchIT extends AbstractIntegrationTestWithDatabase 
         filename = configurationService.getProperty("dspace.dir")
             + testProps.get("test.exportcsv").toString();
 
-
         for (int i = 0; i < numberItemsSubject1; i++) {
+            // Create different issue dates for each Item, all in month of Sept 2020
+            String issueDate = "2020-09-";
+            int dayOfMonth = i + 1;
+            issueDate += (dayOfMonth < 10 ? "0" + dayOfMonth : dayOfMonth);
             itemsSubject1[i] = ItemBuilder.createItem(context, collection)
                 .withTitle(String.format("%s item %d", subject1, i))
                 .withSubject(subject1)
-                .withIssueDate("2020-09-" + i)
+                .withIssueDate(issueDate)
                 .build();
         }
 
         for (int i = 0; i < numberItemsSubject2; i++) {
+            // Create different issue dates for each Item, all in month of Sept 2021
+            String issueDate = "2021-09-";
+            int dayOfMonth = i + 1;
+            issueDate += (dayOfMonth < 10 ? "0" + dayOfMonth : dayOfMonth);
             itemsSubject2[i] = ItemBuilder.createItem(context, collection)
                 .withTitle(String.format("%s item %d", subject2, i))
                 .withSubject(subject2)
-                .withIssueDate("2021-09-" + i)
+                .withIssueDate(issueDate)
                 .build();
         }
         context.restoreAuthSystemState();

--- a/dspace-api/src/test/java/org/dspace/app/matcher/ResourcePolicyMatcher.java
+++ b/dspace-api/src/test/java/org/dspace/app/matcher/ResourcePolicyMatcher.java
@@ -11,7 +11,7 @@ import static org.dspace.util.MultiFormatDateParser.parse;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
-import java.util.Date;
+import java.time.LocalDate;
 
 import org.dspace.authorize.ResourcePolicy;
 import org.dspace.eperson.EPerson;
@@ -40,13 +40,13 @@ public class ResourcePolicyMatcher extends TypeSafeMatcher<ResourcePolicy> {
 
     private final Matcher<String> description;
 
-    private final Matcher<Date> startDate;
+    private final Matcher<LocalDate> startDate;
 
-    private final Matcher<Date> endDate;
+    private final Matcher<LocalDate> endDate;
 
     public ResourcePolicyMatcher(Matcher<Integer> actionId, Matcher<EPerson> ePerson, Matcher<Group> group,
-                                 Matcher<String> rpName, Matcher<String> rptype, Matcher<Date> startDate,
-                                 Matcher<Date> endDate, Matcher<String> description) {
+                                 Matcher<String> rpName, Matcher<String> rptype, Matcher<LocalDate> startDate,
+                                 Matcher<LocalDate> endDate, Matcher<String> description) {
         this.actionId = actionId;
         this.ePerson = ePerson;
         this.group = group;
@@ -71,40 +71,40 @@ public class ResourcePolicyMatcher extends TypeSafeMatcher<ResourcePolicy> {
 
     public static ResourcePolicyMatcher matches(int actionId, EPerson ePerson, String rptype) {
         return new ResourcePolicyMatcher(is(actionId), is(ePerson), nullValue(Group.class),
-            any(String.class), is(rptype), any(Date.class), any(Date.class), any(String.class));
+            any(String.class), is(rptype), any(LocalDate.class), any(LocalDate.class), any(String.class));
     }
 
     public static ResourcePolicyMatcher matches(int actionId, EPerson ePerson, String rpName, String rptype) {
         return new ResourcePolicyMatcher(is(actionId), is(ePerson), nullValue(Group.class),
-            is(rpName), is(rptype), any(Date.class), any(Date.class), any(String.class));
+            is(rpName), is(rptype), any(LocalDate.class), any(LocalDate.class), any(String.class));
     }
 
     public static ResourcePolicyMatcher matches(int actionId, Group group, String rptype) {
         return new ResourcePolicyMatcher(is(actionId), nullValue(EPerson.class), is(group),
-            any(String.class), is(rptype), any(Date.class), any(Date.class), any(String.class));
+            any(String.class), is(rptype), any(LocalDate.class), any(LocalDate.class), any(String.class));
     }
 
     public static ResourcePolicyMatcher matches(int actionId, Group group, String rpName, String rptype) {
         return new ResourcePolicyMatcher(is(actionId), nullValue(EPerson.class), is(group), is(rpName),
-            is(rptype), any(Date.class), any(Date.class), any(String.class));
+            is(rptype), any(LocalDate.class), any(LocalDate.class), any(String.class));
     }
 
     public static ResourcePolicyMatcher matches(int actionId, Group group, String rpName, String rptype,
         String description) {
         return new ResourcePolicyMatcher(is(actionId), nullValue(EPerson.class), is(group), is(rpName),
-            is(rptype), any(Date.class), any(Date.class), is(description));
+            is(rptype), any(LocalDate.class), any(LocalDate.class), is(description));
     }
 
-    public static ResourcePolicyMatcher matches(int actionId, Group group, String rpName, String rpType, Date startDate,
-        Date endDate, String description) {
+    public static ResourcePolicyMatcher matches(int actionId, Group group, String rpName, String rpType,
+                                                LocalDate startDate, LocalDate endDate, String description) {
         return new ResourcePolicyMatcher(is(actionId), nullValue(EPerson.class), is(group), is(rpName),
             is(rpType), is(startDate), is(endDate), is(description));
     }
 
     public static ResourcePolicyMatcher matches(int actionId, Group group, String rpName, String rpType,
         String startDate, String endDate, String description) {
-        return matches(actionId, group, rpName, rpType, startDate != null ? parse(startDate) : null,
-            endDate != null ? parse(endDate) : null, description);
+        return matches(actionId, group, rpName, rpType, startDate != null ? parse(startDate).toLocalDate() : null,
+            endDate != null ? parse(endDate).toLocalDate() : null, description);
     }
 
     @Override

--- a/dspace-api/src/test/java/org/dspace/app/suggestion/SuggestionUtilsIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/suggestion/SuggestionUtilsIT.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.net.URL;
-import java.util.Date;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
@@ -170,7 +170,7 @@ public class SuggestionUtilsIT extends AbstractIntegrationTestWithDatabase  {
         suggestion.getMetadata().add(
                 new MetadataValueDTO("dc", "title", null, null, "dcTitle"));
         suggestion.setDisplay(getFirstEntryByMetadatum(externalDataObject, "dc", "title", null));
-        suggestion.getMetadata().add(new MetadataValueDTO("dc", "date", "issued", null, new Date().toString()));
+        suggestion.getMetadata().add(new MetadataValueDTO("dc", "date", "issued", null, Instant.now().toString()));
         suggestion.getMetadata().add(new MetadataValueDTO("dc", "description", "abstract", null, "description"));
         suggestion.setExternalSourceUri(cfg.getProperty("dspace.server.url")
                 + "/api/integration/externalsources/" + primaryProvider.getSourceIdentifier() + "/entryValues/"

--- a/dspace-api/src/test/java/org/dspace/app/util/GoogleMetadataTest.java
+++ b/dspace-api/src/test/java/org/dspace/app/util/GoogleMetadataTest.java
@@ -16,10 +16,9 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
+import java.time.LocalDate;
 import java.time.Period;
 import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -348,9 +347,7 @@ public class GoogleMetadataTest extends AbstractUnitTest {
         bundleService.addBitstream(context, bundle, b);
         // Set 3 month embargo on pdf
         Period period = Period.ofMonths(3);
-        Date embargoDate = Date.from(ZonedDateTime.now(ZoneOffset.UTC)
-                .plus(period)
-                .toInstant());
+        LocalDate embargoDate = LocalDate.now(ZoneOffset.UTC).plus(period);
         Group anonGroup = groupService.findByName(context, Group.ANONYMOUS);
         authorizeService.removeAllPolicies(context, b);
         resourcePolicyService.removeAllPolicies(context, b);

--- a/dspace-api/src/test/java/org/dspace/authority/AuthorityValueTest.java
+++ b/dspace-api/src/test/java/org/dspace/authority/AuthorityValueTest.java
@@ -10,10 +10,10 @@ package org.dspace.authority;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
-import java.util.Date;
 
 import org.junit.Test;
 
@@ -27,24 +27,24 @@ public class AuthorityValueTest {
      */
     @Test
     public void testStringToDate() {
-        Date expected;
-        Date actual;
+        Instant expected;
+        Instant actual;
 
         // Test an invalid date.
         actual = AuthorityValue.stringToDate("not a date");
         assertNull("Unparsable date should return null", actual);
 
         // Test a date-time without zone or offset.
-        expected = Date.from(LocalDateTime.of(1957, 01, 27, 01, 23, 45)
-                .atZone(ZoneId.systemDefault())
-                .toInstant());
+        expected = LocalDateTime.of(1957, 01, 27, 01, 23, 45)
+                                .atZone(ZoneId.systemDefault())
+                                .toInstant();
         actual = AuthorityValue.stringToDate("1957-01-27T01:23:45");
         assertEquals("Local date-time should convert", expected, actual);
 
         // Test a date-time with milliseconds and offset from UTC.
-        expected = Date.from(LocalDateTime.of(1957, 01, 27, 01, 23, 45, 678_000_000)
-                .atZone(ZoneOffset.of("-05"))
-                .toInstant());
+        expected = LocalDateTime.of(1957, 01, 27, 01, 23, 45, 678_000_000)
+                                .atZone(ZoneOffset.of("-05"))
+                                .toInstant();
         actual = AuthorityValue.stringToDate("1957-01-27T01:23:45.678-05");
         assertEquals("Zoned date-time with milliseconds should convert",
                 expected, actual);

--- a/dspace-api/src/test/java/org/dspace/builder/AbstractDSpaceObjectBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/AbstractDSpaceObjectBuilder.java
@@ -8,11 +8,8 @@
 package org.dspace.builder;
 
 import java.sql.SQLException;
-import java.time.Instant;
 import java.time.LocalDate;
 import java.time.Period;
-import java.time.ZoneId;
-import java.util.Date;
 
 import org.apache.logging.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
@@ -126,12 +123,7 @@ public abstract class AbstractDSpaceObjectBuilder<T extends DSpaceObject>
     protected <B extends AbstractDSpaceObjectBuilder<T>> B setEmbargo(Period embargoPeriod, DSpaceObject dso) {
         // add policy just for anonymous
         try {
-            Instant embargoInstant = LocalDate.now()
-                    .plus(embargoPeriod)
-                    .atStartOfDay()
-                    .atZone(ZoneId.systemDefault())
-                    .toInstant();
-            Date embargoDate = Date.from(embargoInstant);
+            LocalDate embargoDate = LocalDate.now().plus(embargoPeriod);
 
             return setOnlyReadPermission(dso, groupService.findByName(context, Group.ANONYMOUS), embargoDate);
         } catch (Exception e) {
@@ -155,7 +147,7 @@ public abstract class AbstractDSpaceObjectBuilder<T extends DSpaceObject>
      *            object only for the specified group.
      */
     protected <B extends AbstractDSpaceObjectBuilder<T>> B setOnlyReadPermission(DSpaceObject dso, Group group,
-                                                                                 Date startDate) {
+                                                                                 LocalDate startDate) {
         // add policy just for anonymous
         try {
             authorizeService.removeAllPolicies(context, dso);
@@ -187,7 +179,7 @@ public abstract class AbstractDSpaceObjectBuilder<T extends DSpaceObject>
      *            additional admin permission.
      */
     protected <B extends AbstractDSpaceObjectBuilder<T>> B setAdminPermission(DSpaceObject dso, EPerson eperson,
-                                                                                 Date startDate) {
+                                                                              LocalDate startDate) {
         try {
 
             ResourcePolicy rp = authorizeService.createOrModifyPolicy(null, context, null, null,
@@ -217,7 +209,7 @@ public abstract class AbstractDSpaceObjectBuilder<T extends DSpaceObject>
      */
     protected <B extends AbstractDSpaceObjectBuilder<T>> B setRemovePermissionForEperson(DSpaceObject dso,
                                                                                          EPerson eperson,
-                                                                                         Date startDate) {
+                                                                                         LocalDate startDate) {
         try {
 
             ResourcePolicy rp = authorizeService.createOrModifyPolicy(null, context, null, null,
@@ -247,7 +239,7 @@ public abstract class AbstractDSpaceObjectBuilder<T extends DSpaceObject>
      */
     protected <B extends AbstractDSpaceObjectBuilder<T>> B setAddPermissionForEperson(DSpaceObject dso,
                                                                                       EPerson eperson,
-                                                                                      Date startDate) {
+                                                                                      LocalDate startDate) {
         try {
 
             ResourcePolicy rp = authorizeService.createOrModifyPolicy(null, context, null, null,
@@ -277,7 +269,7 @@ public abstract class AbstractDSpaceObjectBuilder<T extends DSpaceObject>
      */
     protected <B extends AbstractDSpaceObjectBuilder<T>> B setWritePermissionForEperson(DSpaceObject dso,
                                                                                         EPerson eperson,
-                                                                                        Date startDate) {
+                                                                                        LocalDate startDate) {
         try {
 
             ResourcePolicy rp = authorizeService.createOrModifyPolicy(null, context, null, null,

--- a/dspace-api/src/test/java/org/dspace/builder/OrcidHistoryBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/OrcidHistoryBuilder.java
@@ -9,7 +9,7 @@ package org.dspace.builder;
 
 import java.io.IOException;
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -146,7 +146,7 @@ public class OrcidHistoryBuilder extends  AbstractBuilder<OrcidHistory, OrcidHis
         return this;
     }
 
-    public OrcidHistoryBuilder withTimestamp(Date timestamp) {
+    public OrcidHistoryBuilder withTimestamp(Instant timestamp) {
         orcidHistory.setTimestamp(timestamp);
         return this;
     }

--- a/dspace-api/src/test/java/org/dspace/builder/ProcessBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/ProcessBuilder.java
@@ -9,11 +9,9 @@ package org.dspace.builder;
 
 import java.io.IOException;
 import java.sql.SQLException;
-import java.text.ParseException;
 import java.time.Instant;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Set;
 
@@ -68,12 +66,17 @@ public class ProcessBuilder extends AbstractBuilder<Process, ProcessService> {
         return this;
     }
 
-    public ProcessBuilder withStartAndEndTime(String startTime, String endTime) throws ParseException {
-        DateTimeFormatter simpleDateFormat = DateTimeFormatter.ofPattern("dd/MM/yyyy");
-        process.setStartTime(startTime == null ? null : LocalDateTime.parse(startTime, simpleDateFormat)
-                                                                     .atZone(ZoneId.systemDefault()).toInstant());
-        process.setFinishedTime(endTime == null ? null : LocalDateTime.parse(endTime, simpleDateFormat)
-                                                                      .atZone(ZoneId.systemDefault()).toInstant());
+    /**
+     * Create a process with the given start & end dates. The dates are expected to be in YYYY-MM-DD format.
+     * @param startTime date in YYYY-MM-DD format used to represent start time
+     * @param endTime date in YYYY-MM-DD format used to represent end time
+     * @return ProcessBuilder
+     */
+    public ProcessBuilder withStartAndEndTime(String startTime, String endTime) {
+        process.setStartTime(startTime == null ? null : LocalDate.parse(startTime).atStartOfDay()
+                                                                 .atZone(ZoneId.systemDefault()).toInstant());
+        process.setFinishedTime(endTime == null ? null : LocalDate.parse(endTime).atStartOfDay()
+                                                                  .atZone(ZoneId.systemDefault()).toInstant());
         return this;
     }
 

--- a/dspace-api/src/test/java/org/dspace/builder/ProcessBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/ProcessBuilder.java
@@ -10,8 +10,10 @@ package org.dspace.builder;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Set;
 
@@ -61,15 +63,17 @@ public class ProcessBuilder extends AbstractBuilder<Process, ProcessService> {
         return this;
     }
 
-    public ProcessBuilder withCreationTime(Date creationTime) {
+    public ProcessBuilder withCreationTime(Instant creationTime) {
         process.setCreationTime(creationTime);
         return this;
     }
 
     public ProcessBuilder withStartAndEndTime(String startTime, String endTime) throws ParseException {
-        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("dd/MM/yyyy");
-        process.setStartTime(startTime == null ? null : simpleDateFormat.parse(startTime));
-        process.setFinishedTime(endTime == null ? null : simpleDateFormat.parse(endTime));
+        DateTimeFormatter simpleDateFormat = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+        process.setStartTime(startTime == null ? null : LocalDateTime.parse(startTime, simpleDateFormat)
+                                                                     .atZone(ZoneId.systemDefault()).toInstant());
+        process.setFinishedTime(endTime == null ? null : LocalDateTime.parse(endTime, simpleDateFormat)
+                                                                      .atZone(ZoneId.systemDefault()).toInstant());
         return this;
     }
 

--- a/dspace-api/src/test/java/org/dspace/builder/QAEventBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/QAEventBuilder.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.builder;
 
-import java.util.Date;
+import java.time.Instant;
 
 import org.dspace.content.Collection;
 import org.dspace.content.Item;
@@ -42,7 +42,7 @@ public class QAEventBuilder extends AbstractBuilder<QAEvent, QAEventService> {
      * */
     private String relatedItem;
     private double trust = 0.5;
-    private Date lastUpdate = new Date();
+    private Instant lastUpdate = Instant.now();
 
     protected QAEventBuilder(Context context) {
         super(context);
@@ -99,7 +99,7 @@ public class QAEventBuilder extends AbstractBuilder<QAEvent, QAEventService> {
         this.trust = trust;
         return this;
     }
-    public QAEventBuilder withLastUpdate(final Date lastUpdate) {
+    public QAEventBuilder withLastUpdate(final Instant lastUpdate) {
         this.lastUpdate = lastUpdate;
         return this;
     }

--- a/dspace-api/src/test/java/org/dspace/builder/RequestItemBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/RequestItemBuilder.java
@@ -9,7 +9,7 @@
 package org.dspace.builder;
 
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
 
 import jakarta.validation.constraints.NotNull;
 import org.apache.logging.log4j.LogManager;
@@ -37,7 +37,7 @@ public class RequestItemBuilder
     private RequestItem requestItem;
     private Item item;
     private Bitstream bitstream;
-    private Date decisionDate;
+    private Instant decisionDate;
     private boolean accepted;
 
     protected RequestItemBuilder(Context context) {
@@ -70,7 +70,7 @@ public class RequestItemBuilder
      * @param date the date of the decision.
      * @return this builder.
      */
-    public RequestItemBuilder withDecisionDate(Date date) {
+    public RequestItemBuilder withDecisionDate(Instant date) {
         this.decisionDate = date;
         return this;
     }

--- a/dspace-api/src/test/java/org/dspace/builder/ResourcePolicyBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/ResourcePolicyBuilder.java
@@ -9,7 +9,7 @@ package org.dspace.builder;
 
 import java.io.IOException;
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.LocalDate;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -142,12 +142,12 @@ public class ResourcePolicyBuilder extends AbstractBuilder<ResourcePolicy, Resou
         return this;
     }
 
-    public ResourcePolicyBuilder withStartDate(Date data) throws SQLException {
+    public ResourcePolicyBuilder withStartDate(LocalDate data) throws SQLException {
         resourcePolicy.setStartDate(data);
         return this;
     }
 
-    public ResourcePolicyBuilder withEndDate(Date data) throws SQLException {
+    public ResourcePolicyBuilder withEndDate(LocalDate data) throws SQLException {
         resourcePolicy.setEndDate(data);
         return this;
     }

--- a/dspace-api/src/test/java/org/dspace/builder/SystemWideAlertBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/SystemWideAlertBuilder.java
@@ -8,7 +8,7 @@
 package org.dspace.builder;
 
 import java.sql.SQLException;
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 
 import org.dspace.alerts.AllowSessionsEnum;
 import org.dspace.alerts.SystemWideAlert;
@@ -31,7 +31,7 @@ public class SystemWideAlertBuilder extends AbstractBuilder<SystemWideAlert, Sys
     }
 
     private SystemWideAlertBuilder create(Context context, String message, AllowSessionsEnum allowSessionsType,
-                                          LocalDateTime countdownTo, boolean active)
+                                          ZonedDateTime countdownTo, boolean active)
             throws SQLException, AuthorizeException {
         this.context = context;
         this.systemWideAlert = systemWideAlertService.create(context, message, allowSessionsType, countdownTo, active);
@@ -43,7 +43,7 @@ public class SystemWideAlertBuilder extends AbstractBuilder<SystemWideAlert, Sys
         return this;
     }
 
-    public SystemWideAlertBuilder withCountdownDate(LocalDateTime countdownTo) {
+    public SystemWideAlertBuilder withCountdownDate(ZonedDateTime countdownTo) {
         systemWideAlert.setCountdownTo(countdownTo);
         return this;
     }

--- a/dspace-api/src/test/java/org/dspace/builder/SystemWideAlertBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/SystemWideAlertBuilder.java
@@ -8,7 +8,7 @@
 package org.dspace.builder;
 
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import org.dspace.alerts.AllowSessionsEnum;
 import org.dspace.alerts.SystemWideAlert;
@@ -31,7 +31,7 @@ public class SystemWideAlertBuilder extends AbstractBuilder<SystemWideAlert, Sys
     }
 
     private SystemWideAlertBuilder create(Context context, String message, AllowSessionsEnum allowSessionsType,
-                                          Date countdownTo, boolean active)
+                                          LocalDateTime countdownTo, boolean active)
             throws SQLException, AuthorizeException {
         this.context = context;
         this.systemWideAlert = systemWideAlertService.create(context, message, allowSessionsType, countdownTo, active);
@@ -43,7 +43,7 @@ public class SystemWideAlertBuilder extends AbstractBuilder<SystemWideAlert, Sys
         return this;
     }
 
-    public SystemWideAlertBuilder withCountdownDate(Date countdownTo) {
+    public SystemWideAlertBuilder withCountdownDate(LocalDateTime countdownTo) {
         systemWideAlert.setCountdownTo(countdownTo);
         return this;
     }

--- a/dspace-api/src/test/java/org/dspace/checker/dao/impl/ChecksumHistoryDAOImplTest.java
+++ b/dspace-api/src/test/java/org/dspace/checker/dao/impl/ChecksumHistoryDAOImplTest.java
@@ -12,9 +12,8 @@ import static org.junit.Assert.assertEquals;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.sql.SQLException;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.GregorianCalendar;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 
 import jakarta.persistence.Query;
 import org.dspace.AbstractUnitTest;
@@ -62,10 +61,7 @@ public class ChecksumHistoryDAOImplTest
     @Test
     public void testDeleteByDateAndCode()
         throws Exception {
-        System.out.println("deleteByDateAndCode");
-
-        GregorianCalendar cal = new GregorianCalendar();
-        Date retentionDate = cal.getTime();
+        Instant retentionDate = Instant.now();
         ChecksumResultCode resultCode = ChecksumResultCode.CHECKSUM_MATCH;
 
         // Create two older rows
@@ -84,8 +80,7 @@ public class ChecksumHistoryDAOImplTest
         bss.update(context, bs);
         context.restoreAuthSystemState();
 
-        cal.add(Calendar.DATE, -1);
-        Date matchDate = cal.getTime();
+        Instant matchDate = retentionDate.minus(1, ChronoUnit.DAYS);
         checkId++;
         qry.setParameter("id", checkId);
         qry.setParameter("date", matchDate);
@@ -94,8 +89,7 @@ public class ChecksumHistoryDAOImplTest
         qry.executeUpdate();
 
         // Row with nonmatching result code
-        cal.add(Calendar.DATE, -1);
-        Date noMatchDate = cal.getTime();
+        Instant noMatchDate = retentionDate.minus(2, ChronoUnit.DAYS);
         checkId++;
         qry.setParameter("id", checkId);
         qry.setParameter("date", noMatchDate);
@@ -104,11 +98,10 @@ public class ChecksumHistoryDAOImplTest
         qry.executeUpdate();
 
         // Create one newer row
-        cal.add(Calendar.DATE, +3);
-        Date futureDate = cal.getTime();
+        Instant futureDate = retentionDate.plus(3, ChronoUnit.DAYS);
         checkId++;
         qry.setParameter("id", checkId);
-        qry.setParameter("date", new java.sql.Date(futureDate.getTime()));
+        qry.setParameter("date", futureDate);
         qry.setParameter("result", ChecksumResultCode.CHECKSUM_MATCH.name());
         qry.setParameter("bitstream", bs.getID()); // FIXME identifier not being set???
         qry.executeUpdate();

--- a/dspace-api/src/test/java/org/dspace/checker/dao/impl/ChecksumHistoryDAOImplTest.java
+++ b/dspace-api/src/test/java/org/dspace/checker/dao/impl/ChecksumHistoryDAOImplTest.java
@@ -70,9 +70,7 @@ public class ChecksumHistoryDAOImplTest
             "INSERT INTO checksum_history"
                 + "(check_id, process_end_date, result, bitstream_id)"
                 + " VALUES (:id, :date, :result, :bitstream)");
-        int checkId = 0;
 
-        // Row with matching result code
         BitstreamService bss = ContentServiceFactory.getInstance().getBitstreamService();
         InputStream is = new ByteArrayInputStream(new byte[0]);
         Bitstream bs = bss.create(context, is);
@@ -80,27 +78,28 @@ public class ChecksumHistoryDAOImplTest
         bss.update(context, bs);
         context.restoreAuthSystemState();
 
+        // Add a past date row with matching result code
         Instant matchDate = retentionDate.minus(1, ChronoUnit.DAYS);
-        checkId++;
-        qry.setParameter("id", checkId);
+        int matchId = 0;
+        qry.setParameter("id", matchId);
         qry.setParameter("date", matchDate);
         qry.setParameter("result", ChecksumResultCode.CHECKSUM_MATCH.name());
         qry.setParameter("bitstream", bs.getID()); // FIXME identifier not being set???
         qry.executeUpdate();
 
-        // Row with nonmatching result code
+        // Add a past date row with a nonmatching result code
         Instant noMatchDate = retentionDate.minus(2, ChronoUnit.DAYS);
-        checkId++;
-        qry.setParameter("id", checkId);
+        int noMatchId = 1;
+        qry.setParameter("id", noMatchId);
         qry.setParameter("date", noMatchDate);
         qry.setParameter("result", ChecksumResultCode.CHECKSUM_NO_MATCH.name());
         qry.setParameter("bitstream", bs.getID()); // FIXME identifier not being set???
         qry.executeUpdate();
 
-        // Create one newer row
+        // Add a future date row with a matching result code
         Instant futureDate = retentionDate.plus(3, ChronoUnit.DAYS);
-        checkId++;
-        qry.setParameter("id", checkId);
+        int futureMatchId = 2;
+        qry.setParameter("id", futureMatchId);
         qry.setParameter("date", futureDate);
         qry.setParameter("result", ChecksumResultCode.CHECKSUM_MATCH.name());
         qry.setParameter("bitstream", bs.getID()); // FIXME identifier not being set???
@@ -115,20 +114,20 @@ public class ChecksumHistoryDAOImplTest
 
         // See if matching old row is gone.
         qry = dbc.getSession().createQuery(
-            "SELECT COUNT(*) FROM ChecksumHistory WHERE processEndDate = :date");
+            "SELECT COUNT(*) FROM ChecksumHistory WHERE id = :id");
         long count;
 
-        qry.setParameter("date", matchDate);
+        qry.setParameter("id", matchId);
         count = (Long) qry.getSingleResult();
         assertEquals("Should find no row at matchDate", 0, count);
 
         // See if nonmatching old row is still present.
-        qry.setParameter("date", noMatchDate);
+        qry.setParameter("id", noMatchId);
         count = (Long) qry.getSingleResult();
         assertEquals("Should find one row at noMatchDate", 1, count);
 
-        // See if new row is still present.
-        qry.setParameter("date", futureDate);
+        // See if future date row is still present.
+        qry.setParameter("id", futureMatchId);
         count = (Long) qry.getSingleResult();
         assertEquals("Should find one row at futureDate", 1, count);
     }

--- a/dspace-api/src/test/java/org/dspace/content/DCDateTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/DCDateTest.java
@@ -13,7 +13,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Locale;
 import java.util.TimeZone;
 
@@ -33,7 +35,7 @@ public class DCDateTest {
     /**
      * Object to use in the tests
      */
-    private LocalDateTime ldt;
+    private ZonedDateTime zdt;
 
     /**
      * This method will be run before every test as per @Before. It will
@@ -44,6 +46,8 @@ public class DCDateTest {
      */
     @Before
     public void init() {
+        // Set the default timezone for all tests to GMT-8
+        // This will also ensure ZoneId.systemDefault() returns GMT-8
         TimeZone.setDefault(TimeZone.getTimeZone("GMT-8"));
     }
 
@@ -57,7 +61,7 @@ public class DCDateTest {
     @After
     public void destroy() {
         dc = null;
-        ldt = null;
+        zdt = null;
     }
 
     /**
@@ -80,8 +84,10 @@ public class DCDateTest {
         assertThat("testDCDateDate 11", dc.getMinuteUTC(), equalTo(-1));
         assertThat("testDCDateDate 12", dc.getSecondUTC(), equalTo(-1));
 
-        ldt = LocalDateTime.of(2010, 1, 1, 0, 0, 0);
-        dc = new DCDate(ldt);
+        // NOTE: In "init()" the default timezone is set to GMT-8 to ensure the getHour() and getHourUTC() tests
+        // below will result in an 8-hour time difference.
+        zdt = ZonedDateTime.of(2010, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        dc = new DCDate(zdt);
 
         assertThat("testDCDateDate 1 ", dc.getYear(), equalTo(2010));
         assertThat("testDCDateDate 2 ", dc.getMonth(), equalTo(1));
@@ -97,8 +103,10 @@ public class DCDateTest {
         assertThat("testDCDateDate 11 ", dc.getMinuteUTC(), equalTo(0));
         assertThat("testDCDateDate 12 ", dc.getSecondUTC(), equalTo(0));
 
-        ldt = LocalDateTime.of(2009, 12, 31, 18, 30, 0);
-        dc = new DCDate(ldt);
+        // NOTE: In "init()" the default timezone is set to GMT-8 to ensure the getHour() and getHourUTC() tests
+        // below will result in an 8-hour time difference.
+        zdt = ZonedDateTime.of(2009, 12, 31, 18, 30, 0, 0, ZoneId.systemDefault());
+        dc = new DCDate(zdt);
 
         assertThat("testDCDateDate 13 ", dc.getYear(), equalTo(2009));
         assertThat("testDCDateDate 14 ", dc.getMonth(), equalTo(12));
@@ -159,6 +167,7 @@ public class DCDateTest {
      */
     @Test
     public void testDCDateString() {
+        // Verify null returns empty date
         dc = new DCDate((String) null);
         assertThat("testDCDateString 1", dc.getYear(), equalTo(-1));
         assertThat("testDCDateString 2", dc.getMonth(), equalTo(-1));
@@ -174,6 +183,7 @@ public class DCDateTest {
         assertThat("testDCDateString 11", dc.getMinuteUTC(), equalTo(-1));
         assertThat("testDCDateString 12", dc.getSecondUTC(), equalTo(-1));
 
+        // Verify empty string returns empty date
         dc = new DCDate("");
         assertThat("testDCDateString 1", dc.getYear(), equalTo(-1));
         assertThat("testDCDateString 2", dc.getMonth(), equalTo(-1));
@@ -189,6 +199,7 @@ public class DCDateTest {
         assertThat("testDCDateString 11", dc.getMinuteUTC(), equalTo(-1));
         assertThat("testDCDateString 12", dc.getSecondUTC(), equalTo(-1));
 
+        // Verify only year is set when date is a year
         dc = new DCDate("2010");
         assertThat("testDCDateString 1", dc.getYear(), equalTo(2010));
         assertThat("testDCDateString 2", dc.getMonth(), equalTo(-1));
@@ -204,6 +215,7 @@ public class DCDateTest {
         assertThat("testDCDateString 11", dc.getMinuteUTC(), equalTo(-1));
         assertThat("testDCDateString 12", dc.getSecondUTC(), equalTo(-1));
 
+        // Verify only month & year is set when date is a month.
         dc = new DCDate("2010-04");
         assertThat("testDCDateString 1", dc.getYear(), equalTo(2010));
         assertThat("testDCDateString 2", dc.getMonth(), equalTo(04));
@@ -219,6 +231,7 @@ public class DCDateTest {
         assertThat("testDCDateString 11", dc.getMinuteUTC(), equalTo(-1));
         assertThat("testDCDateString 12", dc.getSecondUTC(), equalTo(-1));
 
+        // Verify only month, day, and year is set when date is a day.
         dc = new DCDate("2010-04-14");
         assertThat("testDCDateString 1", dc.getYear(), equalTo(2010));
         assertThat("testDCDateString 2", dc.getMonth(), equalTo(04));
@@ -234,6 +247,7 @@ public class DCDateTest {
         assertThat("testDCDateString 11", dc.getMinuteUTC(), equalTo(-1));
         assertThat("testDCDateString 12", dc.getSecondUTC(), equalTo(-1));
 
+        // Verify hour is also set when date includes hour.  Verify 8-hour difference with UTC
         dc = new DCDate("2010-04-14T01");
         assertThat("testDCDateString 1", dc.getYear(), equalTo(2010));
         assertThat("testDCDateString 2", dc.getMonth(), equalTo(04));
@@ -249,6 +263,7 @@ public class DCDateTest {
         assertThat("testDCDateString 11", dc.getMinuteUTC(), equalTo(0));
         assertThat("testDCDateString 12", dc.getSecondUTC(), equalTo(0));
 
+        // Verify minute is also set when date includes minute.  Verify 8-hour difference with UTC
         dc = new DCDate("2010-04-14T00:01");
         assertThat("testDCDateString 1", dc.getYear(), equalTo(2010));
         assertThat("testDCDateString 2", dc.getMonth(), equalTo(04));
@@ -264,6 +279,7 @@ public class DCDateTest {
         assertThat("testDCDateString 11", dc.getMinuteUTC(), equalTo(1));
         assertThat("testDCDateString 12", dc.getSecondUTC(), equalTo(0));
 
+        // Verify full UTC time is parse correctly.  Verify NO difference with UTC (as "Z" is a zero timezone)
         dc = new DCDate("2010-04-14T00:00:01Z");
         assertThat("testDCDateString 1", dc.getYear(), equalTo(2010));
         assertThat("testDCDateString 2", dc.getMonth(), equalTo(04));
@@ -279,7 +295,7 @@ public class DCDateTest {
         assertThat("testDCDateString 11", dc.getMinuteUTC(), equalTo(0));
         assertThat("testDCDateString 12", dc.getSecondUTC(), equalTo(1));
 
-        // test additional ISO format
+        // Verify millisecond can be parsed.  Verify 8-hour difference with UTC
         dc = new DCDate("2010-04-14T00:00:01.000");
         assertThat("testDCDateString 1", dc.getYear(), equalTo(2010));
         assertThat("testDCDateString 2", dc.getMonth(), equalTo(04));
@@ -294,7 +310,6 @@ public class DCDateTest {
         assertThat("testDCDateString 10", dc.getHourUTC(), equalTo(0));
         assertThat("testDCDateString 11", dc.getMinuteUTC(), equalTo(0));
         assertThat("testDCDateString 12", dc.getSecondUTC(), equalTo(1));
-
     }
 
 
@@ -335,24 +350,24 @@ public class DCDateTest {
      */
     @Test
     public void testToDate() {
-        dc = new DCDate((LocalDateTime) null);
+        dc = new DCDate((ZonedDateTime) null);
         assertThat("testToDate 0", dc.toDate(), nullValue());
 
-        ldt = LocalDateTime.of(2010, 1, 1, 0, 0, 0);
-        dc = new DCDate(ldt);
-        assertThat("testToDate 1", dc.toDate().toLocalDateTime(), equalTo(ldt));
+        zdt = ZonedDateTime.of(2010, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+        dc = new DCDate(zdt);
+        assertThat("testToDate 1", dc.toDate(), equalTo(zdt));
 
-        ldt = LocalDateTime.of(2010, 5, 1, 0, 0, 0);
-        dc = new DCDate(ldt);
-        assertThat("testToDate 2", dc.toDate().toLocalDateTime(), equalTo(ldt));
+        zdt = ZonedDateTime.of(2010, 5, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+        dc = new DCDate(zdt);
+        assertThat("testToDate 2", dc.toDate(), equalTo(zdt));
 
-        ldt = LocalDateTime.of(2010, 5, 15, 0, 0, 0);
-        dc = new DCDate(ldt);
-        assertThat("testToDate 3", dc.toDate().toLocalDateTime(), equalTo(ldt));
+        zdt = ZonedDateTime.of(2010, 5, 15, 0, 0, 0, 0, ZoneOffset.UTC);
+        dc = new DCDate(zdt);
+        assertThat("testToDate 3", dc.toDate(), equalTo(zdt));
 
-        ldt = LocalDateTime.of(2010, 5, 15, 0, 0, 1);
-        dc = new DCDate(ldt);
-        assertThat("testToDate 4", dc.toDate().toLocalDateTime(), equalTo(ldt));
+        zdt = ZonedDateTime.of(2010, 5, 15, 0, 0, 1, 0, ZoneOffset.UTC);
+        dc = new DCDate(zdt);
+        assertThat("testToDate 4", dc.toDate(), equalTo(zdt));
     }
 
 

--- a/dspace-api/src/test/java/org/dspace/content/DCDateTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/DCDateTest.java
@@ -10,15 +10,13 @@ package org.dspace.content;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
-import java.util.Calendar;
-import java.util.Date;
-import java.util.GregorianCalendar;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Locale;
 import java.util.TimeZone;
 
-import org.apache.commons.lang3.time.DateUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -35,7 +33,7 @@ public class DCDateTest {
     /**
      * Object to use in the tests
      */
-    private Calendar c;
+    private LocalDateTime ldt;
 
     /**
      * This method will be run before every test as per @Before. It will
@@ -59,7 +57,7 @@ public class DCDateTest {
     @After
     public void destroy() {
         dc = null;
-        c = null;
+        ldt = null;
     }
 
     /**
@@ -82,9 +80,8 @@ public class DCDateTest {
         assertThat("testDCDateDate 11", dc.getMinuteUTC(), equalTo(-1));
         assertThat("testDCDateDate 12", dc.getSecondUTC(), equalTo(-1));
 
-        // NB. Months begin at 0 in GregorianCalendar so 0 is January.
-        c = new GregorianCalendar(2010, 0, 1);
-        dc = new DCDate(c.getTime());
+        ldt = LocalDateTime.of(2010, 1, 1, 0, 0, 0);
+        dc = new DCDate(ldt);
 
         assertThat("testDCDateDate 1 ", dc.getYear(), equalTo(2010));
         assertThat("testDCDateDate 2 ", dc.getMonth(), equalTo(1));
@@ -100,8 +97,8 @@ public class DCDateTest {
         assertThat("testDCDateDate 11 ", dc.getMinuteUTC(), equalTo(0));
         assertThat("testDCDateDate 12 ", dc.getSecondUTC(), equalTo(0));
 
-        c = new GregorianCalendar(2009, 11, 31, 18, 30);
-        dc = new DCDate(c.getTime());
+        ldt = LocalDateTime.of(2009, 12, 31, 18, 30, 0);
+        dc = new DCDate(ldt);
 
         assertThat("testDCDateDate 13 ", dc.getYear(), equalTo(2009));
         assertThat("testDCDateDate 14 ", dc.getMonth(), equalTo(12));
@@ -338,24 +335,24 @@ public class DCDateTest {
      */
     @Test
     public void testToDate() {
-        dc = new DCDate((Date) null);
+        dc = new DCDate((LocalDateTime) null);
         assertThat("testToDate 0", dc.toDate(), nullValue());
 
-        c = new GregorianCalendar(2010, 0, 0);
-        dc = new DCDate(c.getTime());
-        assertThat("testToDate 1", dc.toDate(), equalTo(c.getTime()));
+        ldt = LocalDateTime.of(2010, 1, 1, 0, 0, 0);
+        dc = new DCDate(ldt);
+        assertThat("testToDate 1", dc.toDate().toLocalDateTime(), equalTo(ldt));
 
-        c = new GregorianCalendar(2010, 4, 0);
-        dc = new DCDate(c.getTime());
-        assertThat("testToDate 2", dc.toDate(), equalTo(c.getTime()));
+        ldt = LocalDateTime.of(2010, 5, 1, 0, 0, 0);
+        dc = new DCDate(ldt);
+        assertThat("testToDate 2", dc.toDate().toLocalDateTime(), equalTo(ldt));
 
-        c = new GregorianCalendar(2010, 4, 14);
-        dc = new DCDate(c.getTime());
-        assertThat("testToDate 3", dc.toDate(), equalTo(c.getTime()));
+        ldt = LocalDateTime.of(2010, 5, 15, 0, 0, 0);
+        dc = new DCDate(ldt);
+        assertThat("testToDate 3", dc.toDate().toLocalDateTime(), equalTo(ldt));
 
-        c = new GregorianCalendar(2010, 4, 14, 0, 0, 1);
-        dc = new DCDate(c.getTime());
-        assertThat("testToDate 4", dc.toDate(), equalTo(c.getTime()));
+        ldt = LocalDateTime.of(2010, 5, 15, 0, 0, 1);
+        dc = new DCDate(ldt);
+        assertThat("testToDate 4", dc.toDate().toLocalDateTime(), equalTo(ldt));
     }
 
 
@@ -410,10 +407,8 @@ public class DCDateTest {
      */
     @Test
     public void testGetCurrent() {
-        Calendar calendar = Calendar.getInstance();
-        calendar.setTimeInMillis(System.currentTimeMillis());
-        calendar.setTimeZone(TimeZone.getTimeZone("UTC"));
-        assertTrue("testGetCurrent 0", DateUtils.isSameDay(DCDate.getCurrent().toDate(), calendar.getTime()));
+        LocalDate today = LocalDate.now();
+        assertEquals("testGetCurrent 0", DCDate.getCurrent().toDate().toLocalDate(), today);
     }
 
 

--- a/dspace-api/src/test/java/org/dspace/content/InstallItemTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/InstallItemTest.java
@@ -16,10 +16,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.sql.SQLException;
-import java.text.SimpleDateFormat;
-import java.util.Calendar;
+import java.time.LocalDate;
 import java.util.List;
-import java.util.TimeZone;
 
 import org.apache.logging.log4j.Logger;
 import org.dspace.AbstractUnitTest;
@@ -239,14 +237,8 @@ public class InstallItemTest extends AbstractUnitTest {
         itemService.addMetadata(context, is.getItem(), "dc", "date", "issued", Item.ANY, "today");
         itemService.addMetadata(context, is.getItem(), "dc", "date", "issued", Item.ANY, "2011-01-01");
 
-        //get current date
-        Calendar calendar = Calendar.getInstance();
-        calendar.setTimeInMillis(System.currentTimeMillis());
-        calendar.setTimeZone(TimeZone.getTimeZone("UTC"));
-
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
-
-        String date = sdf.format(calendar.getTime());
+        //get current date in YYYY-MM-DD format
+        String date = LocalDate.now().toString();
 
         Item result = installItemService.installItem(context, is, handle);
         context.restoreAuthSystemState();
@@ -290,12 +282,8 @@ public class InstallItemTest extends AbstractUnitTest {
         itemService.addMetadata(context, is.getItem(), "dc", "date", "issued", Item.ANY, "today");
         itemService.addMetadata(context, is.getItem(), "dc", "date", "issued", Item.ANY, "2011-01-01");
 
-        //get current date
-        Calendar calendar = Calendar.getInstance();
-        calendar.setTimeInMillis(System.currentTimeMillis());
-        calendar.setTimeZone(TimeZone.getTimeZone("UTC"));
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
-        String date = sdf.format(calendar.getTime());
+        //get current date in YYYY-MM-DD format
+        String date = LocalDate.now().toString();
 
         Item result = installItemService.restoreItem(context, is, handle);
         context.restoreAuthSystemState();

--- a/dspace-api/src/test/java/org/dspace/content/ItemTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/ItemTest.java
@@ -30,14 +30,15 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.sql.SQLException;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
 
-import org.apache.commons.lang3.time.DateUtils;
 import org.apache.logging.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.ResourcePolicy;
@@ -255,7 +256,7 @@ public class ItemTest extends AbstractDSpaceObjectTest {
         it.setDiscoverable(true);
          // Test 0: Using a future 'modified since' date, we should get non-null list, with no items
         Iterator<Item> all = itemService.findInArchiveOrWithdrawnDiscoverableModifiedSince(context,
-                DateUtils.addDays(it.getLastModified(),1));
+                it.getLastModified().plus(1, ChronoUnit.DAYS));
         assertThat("Returned list should not be null", all, notNullValue());
         boolean added = false;
         while (all.hasNext()) {
@@ -268,7 +269,7 @@ public class ItemTest extends AbstractDSpaceObjectTest {
         assertFalse("List should not contain item when passing a date newer than item last-modified date", added);
          // Test 2: Using a past 'modified since' date, we should get a non-null list containing our item
         all = itemService.findInArchiveOrWithdrawnDiscoverableModifiedSince(context,
-                DateUtils.addDays(it.getLastModified(),-1));
+                it.getLastModified().minus(1, ChronoUnit.DAYS));
         assertThat("Returned list should not be null", all, notNullValue());
         added = false;
         while (all.hasNext()) {
@@ -284,7 +285,7 @@ public class ItemTest extends AbstractDSpaceObjectTest {
         it.setArchived(true);
          // Test 4: Using a past 'modified since' date, we should get a non-null list containing our item
         all = itemService.findInArchiveOrWithdrawnDiscoverableModifiedSince(context,
-                DateUtils.addDays(it.getLastModified(),-1));
+                it.getLastModified().minus(1, ChronoUnit.DAYS));
         assertThat("Returned list should not be null", all, notNullValue());
         added = false;
         while (all.hasNext()) {
@@ -298,7 +299,7 @@ public class ItemTest extends AbstractDSpaceObjectTest {
          // Test 6: Make sure non-discoverable items are not returned, regardless of archived/withdrawn state
         it.setDiscoverable(false);
         all = itemService.findInArchiveOrWithdrawnDiscoverableModifiedSince(context,
-                DateUtils.addDays(it.getLastModified(),-1));
+                it.getLastModified().minus(1, ChronoUnit.DAYS));
         assertThat("Returned list should not be null", all, notNullValue());
         added = false;
         while (all.hasNext()) {
@@ -322,7 +323,7 @@ public class ItemTest extends AbstractDSpaceObjectTest {
         it.setDiscoverable(false);
          // Test 0: Using a future 'modified since' date, we should get non-null list, with no items
         Iterator<Item> all = itemService.findInArchiveOrWithdrawnNonDiscoverableModifiedSince(context,
-                DateUtils.addDays(it.getLastModified(),1));
+                it.getLastModified().plus(1, ChronoUnit.DAYS));
         assertThat("Returned list should not be null", all, notNullValue());
         boolean added = false;
         while (all.hasNext()) {
@@ -335,7 +336,7 @@ public class ItemTest extends AbstractDSpaceObjectTest {
         assertFalse("List should not contain item when passing a date newer than item last-modified date", added);
          // Test 2: Using a past 'modified since' date, we should get a non-null list containing our item
         all = itemService.findInArchiveOrWithdrawnNonDiscoverableModifiedSince(context,
-                DateUtils.addDays(it.getLastModified(),-1));
+                it.getLastModified().minus(1, ChronoUnit.DAYS));
         assertThat("Returned list should not be null", all, notNullValue());
         added = false;
         while (all.hasNext()) {
@@ -350,7 +351,7 @@ public class ItemTest extends AbstractDSpaceObjectTest {
         it.setDiscoverable(true);
          // Test 4: Now we should still get a non-null list with NO items since item is discoverable
         all = itemService.findInArchiveOrWithdrawnNonDiscoverableModifiedSince(context,
-                DateUtils.addDays(it.getLastModified(),-1));
+                it.getLastModified().minus(1, ChronoUnit.DAYS));
         assertThat("Returned list should not be null", all, notNullValue());
         added = false;
         while (all.hasNext()) {
@@ -411,7 +412,8 @@ public class ItemTest extends AbstractDSpaceObjectTest {
     @Test
     public void testGetLastModified() {
         assertThat("testGetLastModified 0", it.getLastModified(), notNullValue());
-        assertTrue("testGetLastModified 1", DateUtils.isSameDay(it.getLastModified(), new Date()));
+        assertEquals("testGetLastModified is same day", it.getLastModified().atZone(ZoneOffset.UTC).toLocalDate(),
+                     LocalDate.now(ZoneOffset.UTC));
     }
 
     /**

--- a/dspace-api/src/test/java/org/dspace/content/MetadataFieldPerformanceTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/MetadataFieldPerformanceTest.java
@@ -8,6 +8,7 @@
 package org.dspace.content;
 
 import java.sql.SQLException;
+import java.time.Instant;
 
 import org.dspace.AbstractUnitTest;
 import org.dspace.authorize.AuthorizeException;
@@ -33,13 +34,13 @@ public class MetadataFieldPerformanceTest extends AbstractUnitTest {
     @Test
     public void testManyQueries() throws SQLException {
 
-        long startTime = System.currentTimeMillis();
+        long startTime = Instant.now().toEpochMilli();
 
         int amount = 50000;
         for (int i = 0; i < amount; i++) {
             metadataFieldService.findByElement(context, "dc", "description", null);
         }
-        long endTime = System.currentTimeMillis();
+        long endTime = Instant.now().toEpochMilli();
 
         long duration = (endTime - startTime);
 
@@ -61,7 +62,7 @@ public class MetadataFieldPerformanceTest extends AbstractUnitTest {
         //we need to commit the changes so we don't block the table for testing
         context.restoreAuthSystemState();
 
-        long startTime = System.currentTimeMillis();
+        long startTime = Instant.now().toEpochMilli();
 
         int amount = 5000;
         for (int i = 0; i < amount; i++) {
@@ -70,7 +71,7 @@ public class MetadataFieldPerformanceTest extends AbstractUnitTest {
             collectionService.clearMetadata(context, collection,
                     "dc", "description", null, null);
         }
-        long endTime = System.currentTimeMillis();
+        long endTime = Instant.now().toEpochMilli();
 
         long duration = (endTime - startTime);
 

--- a/dspace-api/src/test/java/org/dspace/identifier/DOIIdentifierProviderTest.java
+++ b/dspace-api/src/test/java/org/dspace/identifier/DOIIdentifierProviderTest.java
@@ -19,8 +19,8 @@ import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Random;
 
@@ -241,7 +241,7 @@ public class DOIIdentifierProviderTest
         Random random = new Random();
         if (null == doi) {
             doi = DOI.SCHEME + PREFIX + "/" + NAMESPACE_SEPARATOR
-                + Long.toHexString(new Date().getTime()) + "-"
+                + Long.toHexString(Instant.now().toEpochMilli()) + "-"
                 + random.nextInt(997);
         }
 
@@ -310,7 +310,7 @@ public class DOIIdentifierProviderTest
         WorkflowException {
         Item item = newItem();
         String doi = DOI.SCHEME + PREFIX + "/" + NAMESPACE_SEPARATOR
-            + Long.toHexString(new Date().getTime());
+            + Long.toHexString(Instant.now().toEpochMilli());
         context.turnOffAuthorisationSystem();
         provider.saveDOIToObject(context, item, doi);
         context.restoreAuthSystemState();
@@ -334,7 +334,7 @@ public class DOIIdentifierProviderTest
         WorkflowException {
         Item item = newItem();
         String doi = DOI.SCHEME + PREFIX + "/" + NAMESPACE_SEPARATOR
-            + Long.toHexString(new Date().getTime());
+            + Long.toHexString(Instant.now().toEpochMilli());
 
         context.turnOffAuthorisationSystem();
         itemService.addMetadata(context, item, DOIIdentifierProvider.MD_SCHEMA,
@@ -355,7 +355,7 @@ public class DOIIdentifierProviderTest
         IllegalAccessException {
         Item item = newItem();
         String doi = DOI.SCHEME + PREFIX + "/" + NAMESPACE_SEPARATOR
-            + Long.toHexString(new Date().getTime());
+            + Long.toHexString(Instant.now().toEpochMilli());
 
         context.turnOffAuthorisationSystem();
         itemService.addMetadata(context, item, DOIIdentifierProvider.MD_SCHEMA,

--- a/dspace-api/src/test/java/org/dspace/matcher/DateMatcher.java
+++ b/dspace-api/src/test/java/org/dspace/matcher/DateMatcher.java
@@ -7,9 +7,9 @@
  */
 package org.dspace.matcher;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
@@ -22,16 +22,16 @@ import org.hamcrest.Description;
  */
 public class DateMatcher
         extends BaseMatcher<String> {
-    private static final SimpleDateFormat dateFormat
-            = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX");
+    private static final DateTimeFormatter dateFormat
+            = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
 
-    private final Date matchDate;
+    private final LocalDateTime matchDate;
 
     /**
      * Create a matcher for a given Date.
      * @param matchDate The date that tested values should match.
      */
-    public DateMatcher(Date matchDate) {
+    public DateMatcher(LocalDateTime matchDate) {
         this.matchDate = matchDate;
     }
 
@@ -53,10 +53,10 @@ public class DateMatcher
         }
 
         // Decode the string to a Date
-        Date testDateDecoded;
+        LocalDateTime testDateDecoded;
         try {
-            testDateDecoded = dateFormat.parse((String)testDate);
-        } catch (ParseException ex) {
+            testDateDecoded = LocalDateTime.parse((String) testDate, dateFormat);
+        } catch (DateTimeParseException ex) {
             throw new IllegalArgumentException("Argument '" + testDate
                     + "' is not an ISO 8601 zoned date", ex);
         }
@@ -76,7 +76,7 @@ public class DateMatcher
      * @param matchDate the date which tested values should match.
      * @return a new Matcher for matchDate.
      */
-    static public DateMatcher dateMatcher(Date matchDate) {
+    static public DateMatcher dateMatcher(LocalDateTime matchDate) {
         return new DateMatcher(matchDate);
     }
 }

--- a/dspace-api/src/test/java/org/dspace/orcid/OrcidQueueConsumerIT.java
+++ b/dspace-api/src/test/java/org/dspace/orcid/OrcidQueueConsumerIT.java
@@ -27,7 +27,6 @@ import static org.hamcrest.Matchers.is;
 
 import java.sql.SQLException;
 import java.time.Instant;
-import java.util.Date;
 import java.util.List;
 
 import org.dspace.AbstractIntegrationTestWithDatabase;
@@ -212,7 +211,7 @@ public class OrcidQueueConsumerIT extends AbstractIntegrationTestWithDatabase {
             .withMetadata("person.country::IT")
             .withPutCode("123456")
             .withOperation(OrcidOperation.INSERT)
-            .withTimestamp(Date.from(Instant.ofEpochMilli(100000)))
+            .withTimestamp(Instant.ofEpochMilli(100000))
             .withStatus(201)
             .build();
 
@@ -221,7 +220,7 @@ public class OrcidQueueConsumerIT extends AbstractIntegrationTestWithDatabase {
             .withMetadata("person.country::IT")
             .withPutCode("123456")
             .withOperation(OrcidOperation.DELETE)
-            .withTimestamp(Date.from(Instant.ofEpochMilli(200000)))
+            .withTimestamp(Instant.ofEpochMilli(200000))
             .withStatus(204)
             .build();
 
@@ -256,7 +255,7 @@ public class OrcidQueueConsumerIT extends AbstractIntegrationTestWithDatabase {
             .withMetadata("person.country::IT")
             .withPutCode("123456")
             .withOperation(OrcidOperation.INSERT)
-            .withTimestamp(Date.from(Instant.ofEpochMilli(100000)))
+            .withTimestamp(Instant.ofEpochMilli(100000))
             .withStatus(201)
             .build();
 
@@ -265,7 +264,7 @@ public class OrcidQueueConsumerIT extends AbstractIntegrationTestWithDatabase {
             .withMetadata("person.country::IT")
             .withPutCode("123456")
             .withOperation(OrcidOperation.DELETE)
-            .withTimestamp(Date.from(Instant.ofEpochMilli(200000)))
+            .withTimestamp(Instant.ofEpochMilli(200000))
             .withStatus(204)
             .build();
 
@@ -274,7 +273,7 @@ public class OrcidQueueConsumerIT extends AbstractIntegrationTestWithDatabase {
             .withMetadata("person.country::IT")
             .withPutCode("123456")
             .withOperation(OrcidOperation.INSERT)
-            .withTimestamp(Date.from(Instant.ofEpochMilli(300000)))
+            .withTimestamp(Instant.ofEpochMilli(300000))
             .withStatus(201)
             .build();
 
@@ -308,7 +307,7 @@ public class OrcidQueueConsumerIT extends AbstractIntegrationTestWithDatabase {
             .withMetadata("person.country::IT")
             .withPutCode("123456")
             .withOperation(OrcidOperation.INSERT)
-            .withTimestamp(Date.from(Instant.ofEpochMilli(100000)))
+            .withTimestamp(Instant.ofEpochMilli(100000))
             .withStatus(201)
             .build();
 
@@ -317,7 +316,7 @@ public class OrcidQueueConsumerIT extends AbstractIntegrationTestWithDatabase {
             .withMetadata("person.country::IT")
             .withPutCode("123456")
             .withOperation(OrcidOperation.DELETE)
-            .withTimestamp(Date.from(Instant.ofEpochMilli(200000)))
+            .withTimestamp(Instant.ofEpochMilli(200000))
             .withStatus(400)
             .build();
 

--- a/dspace-api/src/test/java/org/dspace/statistics/AnonymizeStatisticsIT.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/AnonymizeStatisticsIT.java
@@ -8,17 +8,15 @@
 package org.dspace.statistics;
 
 import static java.util.Arrays.asList;
-import static java.util.Calendar.DAY_OF_YEAR;
-import static org.apache.commons.lang.time.DateFormatUtils.format;
 import static org.dspace.core.Constants.BITSTREAM;
 import static org.dspace.core.Constants.COLLECTION;
 import static org.dspace.core.Constants.COMMUNITY;
 import static org.dspace.core.Constants.ITEM;
-import static org.dspace.statistics.SolrLoggerServiceImpl.DATE_FORMAT_8601;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
-import java.util.Calendar;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import org.apache.commons.lang3.tuple.Pair;
@@ -243,8 +241,6 @@ public class AnonymizeStatisticsIT
     }
 
     private String getTimeNDaysAgo(int daysAgo) {
-        Calendar calendar = Calendar.getInstance();
-        calendar.add(DAY_OF_YEAR, -daysAgo);
-        return format(calendar, DATE_FORMAT_8601);
+        return Instant.now().minus(daysAgo, ChronoUnit.DAYS).toString();
     }
 }

--- a/dspace-api/src/test/java/org/dspace/statistics/SolrLoggerServiceImplIT.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/SolrLoggerServiceImplIT.java
@@ -7,7 +7,6 @@
  */
 package org.dspace.statistics;
 
-import static org.dspace.statistics.SolrLoggerServiceImpl.DATE_FORMAT_8601;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -19,9 +18,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
-import java.util.Date;
+import java.time.Instant;
 
-import org.apache.commons.lang3.time.DateFormatUtils;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrServerException;
@@ -161,25 +159,25 @@ public class SolrLoggerServiceImplIT
         doc.setField(F_IP, NOT_BOT_IP);
         doc.setField(F_DNS, NOT_BOT_DNS);
         doc.setField(F_AGENT, NOT_BOT_AGENT);
-        doc.setField(F_TIME, DateFormatUtils.format(new Date(), DATE_FORMAT_8601));
+        doc.setField(F_TIME, Instant.now().toString());
         client.add(doc);
 
         doc.setField(F_IP, BOT_IP);
         doc.setField(F_DNS, BOT_DNS);
         doc.setField(F_AGENT, NOT_BOT_AGENT);
-        doc.setField(F_TIME, DateFormatUtils.format(new Date(), DATE_FORMAT_8601));
+        doc.setField(F_TIME, Instant.now().toString());
         client.add(doc);
 
         doc.setField(F_IP, NOT_BOT_IP);
         doc.setField(F_DNS, NOT_BOT_DNS);
         doc.setField(F_AGENT, BOT_AGENT);
-        doc.setField(F_TIME, DateFormatUtils.format(new Date(), DATE_FORMAT_8601));
+        doc.setField(F_TIME, Instant.now().toString());
         client.add(doc);
 
         doc.setField(F_IP, BOT_IP);
         doc.setField(F_DNS, BOT_DNS);
         doc.setField(F_AGENT, BOT_AGENT);
-        doc.setField(F_TIME, DateFormatUtils.format(new Date(), DATE_FORMAT_8601));
+        doc.setField(F_TIME, Instant.now().toString());
         client.add(doc);
 
         client.commit(true, true);
@@ -259,28 +257,28 @@ public class SolrLoggerServiceImplIT
         doc.setField(F_IP, NOT_BOT_IP);
         doc.setField(F_DNS, NOT_BOT_DNS);
         doc.setField(F_AGENT, NOT_BOT_AGENT);
-        doc.setField(F_TIME, DateFormatUtils.format(new Date(), DATE_FORMAT_8601));
+        doc.setField(F_TIME, Instant.now().toString());
         doc.setField(F_IS_BOT, Boolean.FALSE.toString());
         client.add(doc);
 
         doc.setField(F_IP, BOT_IP);
         doc.setField(F_DNS, BOT_DNS);
         doc.setField(F_AGENT, NOT_BOT_AGENT);
-        doc.setField(F_TIME, DateFormatUtils.format(new Date(), DATE_FORMAT_8601));
+        doc.setField(F_TIME, Instant.now().toString());
         doc.setField(F_IS_BOT, Boolean.TRUE.toString());
         client.add(doc);
 
         doc.setField(F_IP, NOT_BOT_IP);
         doc.setField(F_DNS, NOT_BOT_DNS);
         doc.setField(F_AGENT, BOT_AGENT);
-        doc.setField(F_TIME, DateFormatUtils.format(new Date(), DATE_FORMAT_8601));
+        doc.setField(F_TIME, Instant.now().toString());
         doc.setField(F_IS_BOT, Boolean.TRUE.toString());
         client.add(doc);
 
         doc.setField(F_IP, BOT_IP);
         doc.setField(F_DNS, BOT_DNS);
         doc.setField(F_AGENT, BOT_AGENT);
-        doc.setField(F_TIME, DateFormatUtils.format(new Date(), DATE_FORMAT_8601));
+        doc.setField(F_TIME, Instant.now().toString());
         doc.setField(F_IS_BOT, Boolean.TRUE.toString());
         client.add(doc);
 

--- a/dspace-api/src/test/java/org/dspace/statistics/export/service/OpenUrlServiceImplTest.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/export/service/OpenUrlServiceImplTest.java
@@ -9,7 +9,6 @@ package org.dspace.statistics.export.service;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.closeTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -21,10 +20,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
-import java.math.BigDecimal;
 import java.net.HttpURLConnection;
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.List;
 
 import org.apache.http.HttpResponse;
@@ -35,7 +33,6 @@ import org.dspace.statistics.export.OpenURLTracker;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -172,13 +169,8 @@ public class OpenUrlServiceImplTest {
 
         verify(tracker1).setUrl(failedUrl);
 
-        // NOTE: verify that setUploadDate received a timestamp whose value is no less than 5 seconds from now
-        ArgumentCaptor<Date> dateArgCaptor = ArgumentCaptor.forClass(Date.class);
-        verify(tracker1).setUploadDate(dateArgCaptor.capture());
-        assertThat(
-            new BigDecimal(dateArgCaptor.getValue().getTime()),
-            closeTo(new BigDecimal(new Date().getTime()), new BigDecimal(5000))
-        );
+        // Verify setUploadDate is set to today
+        verify(tracker1).setUploadDate(LocalDate.now());
     }
 
     /**

--- a/dspace-api/src/test/java/org/dspace/util/MultiFormatDateParserTest.java
+++ b/dspace-api/src/test/java/org/dspace/util/MultiFormatDateParserTest.java
@@ -10,15 +10,14 @@ package org.dspace.util;
 
 import static org.junit.Assert.assertEquals;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
-import java.util.TimeZone;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -145,10 +144,9 @@ public class MultiFormatDateParserTest {
      * Test of parse method, of class MultiFormatDateParser.
      */
     @Test
-    public void testParse() throws ParseException {
-        SimpleDateFormat simpleDateFormat = new SimpleDateFormat(expectedFormat);
-        simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
-        Date result = MultiFormatDateParser.parse(toParseDate);
-        assertEquals(testMessage, expectedResult, simpleDateFormat.parse(toParseDate).equals(result));
+    public void testParse() {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(expectedFormat).withZone(ZoneOffset.UTC);
+        ZonedDateTime result = MultiFormatDateParser.parse(toParseDate);
+        assertEquals(testMessage, expectedResult, ZonedDateTime.parse(toParseDate, formatter).equals(result));
     }
 }

--- a/dspace-api/src/test/java/org/dspace/util/MultiFormatDateParserTest.java
+++ b/dspace-api/src/test/java/org/dspace/util/MultiFormatDateParserTest.java
@@ -9,10 +9,9 @@
 package org.dspace.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -20,7 +19,6 @@ import java.util.Locale;
 import java.util.Map;
 
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -36,18 +34,16 @@ import org.junit.runners.Parameterized;
 @RunWith(Parameterized.class)
 public class MultiFormatDateParserTest {
     private static Locale vmLocale;
-    private final String testMessage;
     private final String toParseDate;
     private final String expectedFormat;
-    private final boolean expectedResult;
+    private final String expectedResult;
 
     /**
      * Test a single date format.
      * JUnit will instantiate this class repeatedly with data from {@link #dateFormatsToTest}.
      */
-    public MultiFormatDateParserTest(String testMessage, String toParseDate,
-                                     String expectedFormat, boolean expectedResult) {
-        this.testMessage = testMessage;
+    public MultiFormatDateParserTest(String toParseDate,
+                                     String expectedFormat, String expectedResult) {
         this.toParseDate = toParseDate;
         this.expectedFormat = expectedFormat;
         this.expectedResult = expectedResult;
@@ -58,40 +54,37 @@ public class MultiFormatDateParserTest {
      */
     @Parameterized.Parameters
     public static Collection dateFormatsToTest() {
+        // Format: "String to parse", "format of string", "expected result in UTC"
         return Arrays.asList(new Object[][] {
-            {"Should parse: yyyyMMdd", "19570127", "yyyyMMdd", true},
-            {"Should parse: dd-MM-yyyy", "27-01-1957", "dd-MM-yyyy", true},
-            {"Should parse: yyyy-MM-dd", "1957-01-27", "yyyy-MM-dd", true},
-            {"Should parse: MM/dd/yyyy", "01/27/1957", "MM/dd/yyyy", true},
-            {"Should parse: yyyy/MM/dd", "1957/01/27", "yyyy/MM/dd", true},
-            {"Should parse: yyyyMMddHHmm", "195701272006", "yyyyMMddHHmm", true},
-            {"Should parse: yyyyMMdd HHmm", "19570127 2006", "yyyyMMdd HHmm", true},
-            {"Should parse: dd-MM-yyyy HH:mm", "27-01-1957 20:06", "dd-MM-yyyy HH:mm", true},
-            {"Should parse: yyyy-MM-dd HH:mm", "1957-01-27 20:06", "yyyy-MM-dd HH:mm", true},
-            {"Should parse: MM/dd/yyyy HH:mm", "01/27/1957 20:06", "MM/dd/yyyy HH:mm", true},
-            {"Should parse: yyyy/MM/dd HH:mm", "1957/01/27 20:06", "yyyy/MM/dd HH:mm", true},
-            {"Should parse: yyyyMMddHHmmss", "19570127200620", "yyyyMMddHHmmss", true},
-            {"Should parse: yyyyMMdd HHmmss", "19570127 200620", "yyyyMMdd HHmmss", true},
-            {"Should parse: dd-MM-yyyy HH:mm:ss", "27-01-1957 20:06:20", "dd-MM-yyyy HH:mm:ss", true},
-            {"Should parse: MM/dd/yyyy HH:mm:ss", "01/27/1957 20:06:20", "MM/dd/yyyy HH:mm:ss", true},
-            {"Should parse: yyyy/MM/dd HH:mm:ss", "1957/01/27 20:06:20", "yyyy/MM/dd HH:mm:ss", true},
-            {"Should parse: yyyy MMM dd", "1957 Jan 27", "yyyy MMM dd", true},
-            {"Should parse: yyyy-MM", "1957-01", "yyyy-MM", true},
-            {"Should parse: yyyyMM", "195701", "yyyyMM", true},
-            {"Should parse: yyyy", "1957", "yyyy", true},
-            {"Should parse: yyyy-MM-dd'T'HH:mm:ss'Z'", "1957-01-27T12:34:56Z", "yyyy-MM-dd'T'HH:mm:ss'Z'", true},
-            {"Should parse: yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", "1957-01-27T12:34:56.789Z", "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
-                true},
-            {"Shouldn't parse: yyyy/MM/ddHH:mm:ss", "1957/01/2720:06:20", "yyyy/MM/ddHH:mm:ss", false}
+            {"19570127", "yyyyMMdd", "1957-01-27T00:00Z"},
+            {"27-01-1957", "dd-MM-yyyy", "1957-01-27T00:00Z"},
+            {"1957-01-27", "yyyy-MM-dd", "1957-01-27T00:00Z"},
+            {"01/27/1957", "MM/dd/yyyy", "1957-01-27T00:00Z"},
+            {"1957/01/27", "yyyy/MM/dd","1957-01-27T00:00Z"},
+            {"195701272006", "yyyyMMddHHmm", "1957-01-27T20:06Z"},
+            {"19570127 2006", "yyyyMMdd HHmm", "1957-01-27T20:06Z"},
+            {"27-01-1957 20:06", "dd-MM-yyyy HH:mm", "1957-01-27T20:06Z"},
+            {"1957-01-27 20:06", "yyyy-MM-dd HH:mm", "1957-01-27T20:06Z"},
+            {"01/27/1957 20:06", "MM/dd/yyyy HH:mm", "1957-01-27T20:06Z"},
+            {"1957/01/27 20:06", "yyyy/MM/dd HH:mm", "1957-01-27T20:06Z"},
+            {"19570127200620", "yyyyMMddHHmmss", "1957-01-27T20:06:20Z"},
+            {"19570127 200620", "yyyyMMdd HHmmss", "1957-01-27T20:06:20Z"},
+            {"27-01-1957 20:06:20", "dd-MM-yyyy HH:mm:ss", "1957-01-27T20:06:20Z"},
+            {"01/27/1957 20:06:20", "MM/dd/yyyy HH:mm:ss", "1957-01-27T20:06:20Z"},
+            {"1957/01/27 20:06:20", "yyyy/MM/dd HH:mm:ss", "1957-01-27T20:06:20Z"},
+            {"1957 Jan 27", "yyyy MMM dd", "1957-01-27T00:00Z"},
+            {"1957-01", "yyyy-MM", "1957-01-01T00:00Z"},
+            {"195701", "yyyyMM", "1957-01-01T00:00Z"},
+            {"1957", "yyyy", "1957-01-01T00:00Z"},
+            {"1957-01-27T12:34:56Z", "yyyy-MM-dd'T'HH:mm:ss'Z'", "1957-01-27T12:34:56Z"},
+            {"1957-01-27T12:34:56.789Z", "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", "1957-01-27T12:34:56.789Z"},
+            // Empty string result means that this should not parse successfully
+            {"1957/01/2720:06:20", "yyyy/MM/ddHH:mm:ss", ""}
         });
     }
 
     @BeforeClass
     public static void setUpClass() {
-        // store default locale of the environment
-        vmLocale = Locale.getDefault();
-        // set default locale to English just for the test of this class
-        Locale.setDefault(Locale.ENGLISH);
         Map<String, String> formats = new HashMap<>(32);
         formats.put("\\d{8}", "yyyyMMdd");
         formats.put("\\d{1,2}-\\d{1,2}-\\d{4}", "dd-MM-yyyy");
@@ -126,12 +119,6 @@ public class MultiFormatDateParserTest {
         new MultiFormatDateParser().setPatterns(formats);
     }
 
-    @AfterClass
-    public static void tearDownClass() {
-        // restore locale
-        Locale.setDefault(vmLocale);
-    }
-
     @Before
     public void setUp() {
     }
@@ -145,8 +132,12 @@ public class MultiFormatDateParserTest {
      */
     @Test
     public void testParse() {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(expectedFormat).withZone(ZoneOffset.UTC);
         ZonedDateTime result = MultiFormatDateParser.parse(toParseDate);
-        assertEquals(testMessage, expectedResult, ZonedDateTime.parse(toParseDate, formatter).equals(result));
+        // Verify that the parsed ZonedDateTime is equal to the expected String result (or null if result is empty)
+        if (!expectedResult.isEmpty()) {
+            assertEquals("Should parse: " + expectedFormat, expectedResult, result.toString());
+        } else {
+            assertNull("Should not parse: " + expectedFormat, result);
+        }
     }
 }

--- a/dspace-api/src/test/java/org/dspace/util/TimeHelpersTest.java
+++ b/dspace-api/src/test/java/org/dspace/util/TimeHelpersTest.java
@@ -9,9 +9,9 @@ package org.dspace.util;
 
 import static org.junit.Assert.assertEquals;
 
+import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.util.Date;
 
 import org.junit.Test;
 
@@ -26,9 +26,11 @@ public class TimeHelpersTest {
     @Test
     public void testToMidnightUTC() {
         System.out.println("toMidnightUTC");
-        Date from = Date.from(ZonedDateTime.of(1957, 01, 27, 04, 05, 06, 007, ZoneOffset.UTC).toInstant());
-        Date expResult = Date.from(ZonedDateTime.of(1957, 01, 27, 00, 00, 00, 000, ZoneOffset.UTC).toInstant());
-        Date result = TimeHelpers.toMidnightUTC(from);
+        LocalDateTime from = ZonedDateTime.of(1957, 01, 27, 04, 05, 06, 007,
+                                              ZoneOffset.UTC).toLocalDateTime();
+        LocalDateTime expResult = ZonedDateTime.of(1957, 01, 27, 00, 00, 00, 000,
+                                                   ZoneOffset.UTC).toLocalDateTime();
+        LocalDateTime result = TimeHelpers.toMidnightUTC(from);
         assertEquals(expResult, result);
     }
 }

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
@@ -167,7 +167,8 @@ public class XOAI {
                     System.out.println("There are no indexed documents, using full import.");
                     result = this.indexAll();
                 } else {
-                    result = this.index(Instant.parse((String) results.get(0).getFieldValue("item.lastmodified")));
+                    result = this.index(((java.util.Date) results.get(0).getFieldValue("item.lastmodified"))
+                                            .toInstant());
                 }
 
             }

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
@@ -18,10 +18,12 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.sql.SQLException;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -165,21 +167,21 @@ public class XOAI {
                     System.out.println("There are no indexed documents, using full import.");
                     result = this.indexAll();
                 } else {
-                    result = this.index((Date) results.get(0).getFieldValue("item.lastmodified"));
+                    result = this.index(Instant.parse((String) results.get(0).getFieldValue("item.lastmodified")));
                 }
 
             }
             solrServerResolver.getServer().commit();
 
             // Set last compilation date
-            xoaiLastCompilationCacheService.put(new Date());
+            xoaiLastCompilationCacheService.put(Instant.now());
             return result;
         } catch (DSpaceSolrException | SolrServerException | IOException ex) {
             throw new DSpaceSolrIndexerException(ex.getMessage(), ex);
         }
     }
 
-    private int index(Date last) throws DSpaceSolrIndexerException, IOException {
+    private int index(Instant last) throws DSpaceSolrIndexerException, IOException {
         System.out.println("Incremental import. Searching for documents modified after: " + last.toString());
         /*
          * Index all changed or new items or items whose visibility is viable to change
@@ -208,7 +210,8 @@ public class XOAI {
      *         since the last update.
      * @throws DSpaceSolrIndexerException
      */
-    private Iterator<Item> getItemsWithPossibleChangesBefore(Date last) throws DSpaceSolrIndexerException, IOException {
+    private Iterator<Item> getItemsWithPossibleChangesBefore(Instant last)
+        throws DSpaceSolrIndexerException, IOException {
         try {
             SolrQuery params = new SolrQuery("item.willChangeStatus:true").addField("item.id").setRows(100)
                     .addSort("item.handle", SolrQuery.ORDER.asc);
@@ -232,7 +235,7 @@ public class XOAI {
                     Item item = itemService.find(context, UUID.fromString((String) document.getFieldValue("item.id")));
                     if (nonNull(item)) {
                         if (nonNull(item.getLastModified())) {
-                            if (item.getLastModified().before(last)) {
+                            if (item.getLastModified().isBefore(last)) {
                                 items.add(item);
                             }
                         } else {
@@ -364,26 +367,26 @@ public class XOAI {
      * @return date
      * @throws SQLException
      */
-    private Date getMostRecentModificationDate(Item item) throws SQLException {
-        List<Date> dates = new LinkedList<>();
+    private Instant getMostRecentModificationDate(Item item) throws SQLException {
+        List<Instant> dates = new LinkedList<>();
         List<ResourcePolicy> policies = authorizeService.getPoliciesActionFilter(context, item, Constants.READ);
         for (ResourcePolicy policy : policies) {
             if ((policy.getGroup() != null) && (policy.getGroup().getName().equals("Anonymous"))) {
                 if (policy.getStartDate() != null) {
-                    dates.add(policy.getStartDate());
+                    dates.add(policy.getStartDate().atStartOfDay(ZoneId.systemDefault()).toInstant());
                 }
                 if (policy.getEndDate() != null) {
-                    dates.add(policy.getEndDate());
+                    dates.add(policy.getEndDate().atStartOfDay(ZoneId.systemDefault()).toInstant());
                 }
             }
             context.uncacheEntity(policy);
         }
         dates.add(item.getLastModified());
         Collections.sort(dates);
-        Date now = new Date();
-        Date lastChange = null;
-        for (Date d : dates) {
-            if (d.before(now)) {
+        Instant now = Instant.now();
+        Instant lastChange = null;
+        for (Instant d : dates) {
+            if (d.isBefore(now)) {
                 lastChange = d;
             }
         }
@@ -513,10 +516,10 @@ public class XOAI {
         List<ResourcePolicy> policies = authorizeService.getPoliciesActionFilter(context, item, Constants.READ);
         for (ResourcePolicy policy : policies) {
             if ((policy.getGroup() != null) && (policy.getGroup().getName().equals("Anonymous"))) {
-                if (policy.getStartDate() != null && policy.getStartDate().after(new Date())) {
+                if (policy.getStartDate() != null && policy.getStartDate().isAfter(LocalDate.now())) {
                     return true;
                 }
-                if (policy.getEndDate() != null && policy.getEndDate().after(new Date())) {
+                if (policy.getEndDate() != null && policy.getEndDate().isAfter(LocalDate.now())) {
                     return true;
                 }
             }
@@ -620,7 +623,7 @@ public class XOAI {
 
             if (!line.hasOption('h') && run) {
                 System.out.println("OAI 2.0 manager action started");
-                long start = System.currentTimeMillis();
+                long start = Instant.now().toEpochMilli();
 
                 String command = line.getArgs()[0];
 
@@ -651,7 +654,7 @@ public class XOAI {
                 }
 
                 System.out.println("OAI 2.0 manager action ended. It took "
-                        + ((System.currentTimeMillis() - start) / 1000) + " seconds.");
+                        + ((Instant.now().toEpochMilli() - start) / 1000) + " seconds.");
             } else {
                 usage();
             }
@@ -676,7 +679,7 @@ public class XOAI {
     private void compile() throws CompilingException {
         Iterator<Item> iterator;
         try {
-            Date last = xoaiLastCompilationCacheService.get();
+            Instant last = xoaiLastCompilationCacheService.get();
 
             if (last == null) {
                 System.out.println("Retrieving all items to be compiled");
@@ -694,7 +697,7 @@ public class XOAI {
                 xoaiItemCacheService.put(item, retrieveMetadata(context, item));
             }
 
-            xoaiLastCompilationCacheService.put(new Date());
+            xoaiLastCompilationCacheService.put(Instant.now());
         } catch (SQLException | IOException e) {
             throw new CompilingException(e);
         }

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
@@ -20,7 +20,7 @@ import java.net.ConnectException;
 import java.sql.SQLException;
 import java.time.Instant;
 import java.time.LocalDate;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -374,10 +374,10 @@ public class XOAI {
         for (ResourcePolicy policy : policies) {
             if ((policy.getGroup() != null) && (policy.getGroup().getName().equals("Anonymous"))) {
                 if (policy.getStartDate() != null) {
-                    dates.add(policy.getStartDate().atStartOfDay(ZoneId.systemDefault()).toInstant());
+                    dates.add(policy.getStartDate().atStartOfDay(ZoneOffset.UTC).toInstant());
                 }
                 if (policy.getEndDate() != null) {
-                    dates.add(policy.getEndDate().atStartOfDay(ZoneId.systemDefault()).toInstant());
+                    dates.add(policy.getEndDate().atStartOfDay(ZoneOffset.UTC).toInstant());
                 }
             }
             context.uncacheEntity(policy);
@@ -517,10 +517,10 @@ public class XOAI {
         List<ResourcePolicy> policies = authorizeService.getPoliciesActionFilter(context, item, Constants.READ);
         for (ResourcePolicy policy : policies) {
             if ((policy.getGroup() != null) && (policy.getGroup().getName().equals("Anonymous"))) {
-                if (policy.getStartDate() != null && policy.getStartDate().isAfter(LocalDate.now())) {
+                if (policy.getStartDate() != null && policy.getStartDate().isAfter(LocalDate.now(ZoneOffset.UTC))) {
                     return true;
                 }
-                if (policy.getEndDate() != null && policy.getEndDate().isAfter(LocalDate.now())) {
+                if (policy.getEndDate() != null && policy.getEndDate().isAfter(LocalDate.now(ZoneOffset.UTC))) {
                     return true;
                 }
             }

--- a/dspace-oai/src/main/java/org/dspace/xoai/data/DSpaceSolrItem.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/data/DSpaceSolrItem.java
@@ -7,9 +7,9 @@
  */
 package org.dspace.xoai.data;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Date;
 import java.util.List;
 
 import com.lyncode.xoai.dataprovider.core.ItemMetadata;
@@ -28,7 +28,7 @@ public class DSpaceSolrItem extends DSpaceItem {
     private final String unparsedMD;
     private ItemMetadata metadata;
     private final String handle;
-    private final Date lastMod;
+    private final Instant lastMod;
     private final List<ReferenceSet> sets;
     private final boolean deleted;
 
@@ -36,7 +36,7 @@ public class DSpaceSolrItem extends DSpaceItem {
         log.debug("Creating OAI Item from Solr source");
         unparsedMD = (String) doc.getFieldValue("item.compile");
         handle = (String) doc.getFieldValue("item.handle");
-        lastMod = (Date) doc.getFieldValue("item.lastmodified");
+        lastMod = Instant.parse((String) doc.getFieldValue("item.lastmodified"));
         sets = new ArrayList<>();
 
         Collection<Object> fieldValues;
@@ -67,8 +67,8 @@ public class DSpaceSolrItem extends DSpaceItem {
     }
 
     @Override
-    public Date getDatestamp() {
-        return lastMod;
+    public java.util.Date getDatestamp() {
+        return java.util.Date.from(lastMod);
     }
 
     @Override

--- a/dspace-oai/src/main/java/org/dspace/xoai/data/DSpaceSolrItem.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/data/DSpaceSolrItem.java
@@ -36,7 +36,7 @@ public class DSpaceSolrItem extends DSpaceItem {
         log.debug("Creating OAI Item from Solr source");
         unparsedMD = (String) doc.getFieldValue("item.compile");
         handle = (String) doc.getFieldValue("item.handle");
-        lastMod = Instant.parse((String) doc.getFieldValue("item.lastmodified"));
+        lastMod = ((java.util.Date) doc.getFieldValue("item.lastmodified")).toInstant();
         sets = new ArrayList<>();
 
         Collection<Object> fieldValues;

--- a/dspace-oai/src/main/java/org/dspace/xoai/filter/DateUntilFilter.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/filter/DateUntilFilter.java
@@ -7,8 +7,8 @@
  */
 package org.dspace.xoai.filter;
 
-import java.util.Calendar;
-import java.util.Date;
+import java.time.Instant;
+import java.time.temporal.ChronoField;
 
 import com.lyncode.xoai.dataprovider.services.api.DateProvider;
 import com.lyncode.xoai.dataprovider.services.impl.BaseDateProvider;
@@ -21,19 +21,16 @@ import org.dspace.xoai.filter.results.SolrFilterResult;
  */
 public class DateUntilFilter extends DSpaceFilter {
     private static final DateProvider dateProvider = new BaseDateProvider();
-    private final Date date;
+    private final Instant date;
 
-    public DateUntilFilter(Date date) {
-        Calendar calendar =  Calendar.getInstance();
-        calendar.setTime(date);
+    public DateUntilFilter(Instant date) {
         // As this is an 'until' filter, ensure milliseconds are set to 999 (maximum value)
-        calendar.set(Calendar.MILLISECOND, 999);
-        this.date = calendar.getTime();
+        this.date = date.with(ChronoField.MILLI_OF_SECOND, 999);
     }
 
     @Override
     public boolean isShown(DSpaceItem item) {
-        if (item.getDatestamp().compareTo(date) <= 0) {
+        if (!item.getDatestamp().toInstant().isAfter(date)) {
             return true;
         }
         return false;
@@ -41,7 +38,8 @@ public class DateUntilFilter extends DSpaceFilter {
 
     @Override
     public SolrFilterResult buildSolrQuery() {
-        String format = dateProvider.format(date).replace("Z", ".999Z"); // Tweak to set the milliseconds
+        // Tweak to set the milliseconds
+        String format = dateProvider.format(java.util.Date.from(date)).replace("Z", ".999Z");
         // if date has timestamp of 00:00:00, switch it to refer to end of day
         if (format.substring(11, 19).equals("00:00:00")) {
             format = format.substring(0, 11) + "23:59:59" + format.substring(19);

--- a/dspace-oai/src/main/java/org/dspace/xoai/services/api/EarliestDateResolver.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/api/EarliestDateResolver.java
@@ -8,11 +8,11 @@
 package org.dspace.xoai.services.api;
 
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
 
 import org.dspace.core.Context;
 import org.dspace.xoai.exceptions.InvalidMetadataFieldException;
 
 public interface EarliestDateResolver {
-    public Date getEarliestDate(Context context) throws InvalidMetadataFieldException, SQLException;
+    public Instant getEarliestDate(Context context) throws InvalidMetadataFieldException, SQLException;
 }

--- a/dspace-oai/src/main/java/org/dspace/xoai/services/api/cache/XOAILastCompilationCacheService.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/api/cache/XOAILastCompilationCacheService.java
@@ -8,13 +8,13 @@
 package org.dspace.xoai.services.api.cache;
 
 import java.io.IOException;
-import java.util.Date;
+import java.time.Instant;
 
 
 public interface XOAILastCompilationCacheService {
     boolean hasCache();
 
-    void put(Date date) throws IOException;
+    void put(Instant date) throws IOException;
 
-    Date get() throws IOException;
+    Instant get() throws IOException;
 }

--- a/dspace-oai/src/main/java/org/dspace/xoai/services/impl/DSpaceEarliestDateResolver.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/impl/DSpaceEarliestDateResolver.java
@@ -8,7 +8,7 @@
 package org.dspace.xoai.services.impl;
 
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
 
 import jakarta.persistence.NoResultException;
 import org.apache.logging.log4j.LogManager;
@@ -20,7 +20,6 @@ import org.dspace.core.Context;
 import org.dspace.xoai.exceptions.InvalidMetadataFieldException;
 import org.dspace.xoai.services.api.EarliestDateResolver;
 import org.dspace.xoai.services.api.FieldResolver;
-import org.dspace.xoai.util.DateUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class DSpaceEarliestDateResolver implements EarliestDateResolver {
@@ -30,7 +29,7 @@ public class DSpaceEarliestDateResolver implements EarliestDateResolver {
     private FieldResolver fieldResolver;
 
     @Override
-    public Date getEarliestDate(Context context) throws InvalidMetadataFieldException, SQLException {
+    public Instant getEarliestDate(Context context) throws InvalidMetadataFieldException, SQLException {
         MetadataValueService metadataValueService = ContentServiceFactory.getInstance().getMetadataValueService();
         MetadataValue minimum = null;
         try {
@@ -44,7 +43,7 @@ public class DSpaceEarliestDateResolver implements EarliestDateResolver {
         if (null != minimum) {
             String str = minimum.getValue();
             try {
-                Date d = DateUtils.parse(str);
+                Instant d = Instant.parse(str);
                 if (d != null) {
                     return d;
                 }
@@ -53,6 +52,6 @@ public class DSpaceEarliestDateResolver implements EarliestDateResolver {
             }
         }
 
-        return new Date();
+        return Instant.now();
     }
 }

--- a/dspace-oai/src/main/java/org/dspace/xoai/services/impl/cache/DSpaceXOAICacheService.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/impl/cache/DSpaceXOAICacheService.java
@@ -18,7 +18,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.Date;
+import java.time.Instant;
 import javax.xml.stream.XMLStreamException;
 
 import com.lyncode.xoai.dataprovider.core.XOAIManager;
@@ -49,7 +49,7 @@ public class DSpaceXOAICacheService implements XOAICacheService {
         return baseDir;
     }
 
-    private static String getStaticHead(XOAIManager manager, Date date) {
+    private static String getStaticHead(XOAIManager manager, Instant date) {
         if (staticHead == null) {
             staticHead = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
                 + ((manager.hasStyleSheet()) ? ("<?xml-stylesheet type=\"text/xsl\" href=\""
@@ -92,7 +92,7 @@ public class DSpaceXOAICacheService implements XOAICacheService {
     @Override
     public void handle(String requestID, OutputStream out) throws IOException {
         InputStream in = new FileInputStream(this.getCacheFile(requestID));
-        write(getStaticHead(manager, new Date()), out);
+        write(getStaticHead(manager, Instant.now()), out);
         copy(in, out);
         in.close();
     }

--- a/dspace-oai/src/main/java/org/dspace/xoai/services/impl/cache/DSpaceXOAILastCompilationCacheService.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/impl/cache/DSpaceXOAILastCompilationCacheService.java
@@ -9,10 +9,8 @@ package org.dspace.xoai.services.impl.cache;
 
 import java.io.File;
 import java.io.IOException;
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
 
 import org.apache.commons.io.FileUtils;
 import org.dspace.xoai.services.api.cache.XOAILastCompilationCacheService;
@@ -22,12 +20,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 public class DSpaceXOAILastCompilationCacheService implements XOAILastCompilationCacheService {
 
-    private static final ThreadLocal<DateFormat> format = new ThreadLocal<DateFormat>() {
-        @Override
-        protected DateFormat initialValue() {
-            return new SimpleDateFormat();
-        }
-    };
     private static final String DATEFILE = File.separator + "date.file";
 
     private static File file = null;
@@ -51,16 +43,16 @@ public class DSpaceXOAILastCompilationCacheService implements XOAILastCompilatio
 
 
     @Override
-    public void put(Date date) throws IOException {
-        FileUtils.write(getFile(), format.get().format(date));
+    public void put(Instant date) throws IOException {
+        FileUtils.write(getFile(),date.toString());
     }
 
 
     @Override
-    public Date get() throws IOException {
+    public Instant get() throws IOException {
         try {
-            return format.get().parse(FileUtils.readFileToString(getFile()).trim());
-        } catch (ParseException e) {
+            return Instant.parse(FileUtils.readFileToString(getFile()).trim());
+        } catch (DateTimeParseException e) {
             throw new IOException(e);
         }
     }

--- a/dspace-oai/src/main/java/org/dspace/xoai/services/impl/xoai/DSpaceItemRepository.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/impl/xoai/DSpaceItemRepository.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.xoai.services.impl.xoai;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 
 import com.lyncode.xoai.dataprovider.core.ListItemIdentifiersResult;
@@ -37,60 +37,60 @@ public abstract class DSpaceItemRepository implements ItemRepository {
     }
 
     @Override
-    public ListItemIdentifiersResult getItemIdentifiers(
-        List<ScopedFilter> filters, int offset, int length, Date from) throws OAIException {
-        filters.add(new ScopedFilter(getDateFromCondition(from), Scope.Query));
+    public ListItemIdentifiersResult getItemIdentifiers(List<ScopedFilter> filters, int offset, int length,
+                                                        java.util.Date from) throws OAIException {
+        filters.add(new ScopedFilter(getDateFromCondition(from.toInstant()), Scope.Query));
         return this.getItemIdentifiers(filters, offset, length);
     }
 
     @Override
-    public ListItemIdentifiersResult getItemIdentifiers(
-        List<ScopedFilter> filters, int offset, int length, String setSpec) throws OAIException {
+    public ListItemIdentifiersResult getItemIdentifiers(List<ScopedFilter> filters, int offset, int length,
+                                                        String setSpec) throws OAIException {
         filters.add(new ScopedFilter(getDSpaceSetSpecFilter(setSpec), Scope.Query));
         return this.getItemIdentifiers(filters, offset, length);
     }
 
     @Override
-    public ListItemIdentifiersResult getItemIdentifiers(
-        List<ScopedFilter> filters, int offset, int length, Date from, Date until) throws OAIException {
-        filters.add(new ScopedFilter(getDateFromCondition(from), Scope.Query));
-        filters.add(new ScopedFilter(getDateUntilFilter(until), Scope.Query));
+    public ListItemIdentifiersResult getItemIdentifiers(List<ScopedFilter> filters, int offset, int length,
+                                                        java.util.Date from, java.util.Date until)
+        throws OAIException {
+        filters.add(new ScopedFilter(getDateFromCondition(from.toInstant()), Scope.Query));
+        filters.add(new ScopedFilter(getDateUntilFilter(until.toInstant()), Scope.Query));
         return this.getItemIdentifiers(filters, offset, length);
     }
 
     @Override
-    public ListItemIdentifiersResult getItemIdentifiers(
-        List<ScopedFilter> filters, int offset, int length, String setSpec,
-        Date from) throws OAIException {
-        filters.add(new ScopedFilter(getDateFromCondition(from), Scope.Query));
+    public ListItemIdentifiersResult getItemIdentifiers(List<ScopedFilter> filters, int offset, int length,
+                                                        String setSpec, java.util.Date from) throws OAIException {
+        filters.add(new ScopedFilter(getDateFromCondition(from.toInstant()), Scope.Query));
         filters.add(new ScopedFilter(getDSpaceSetSpecFilter(setSpec),
                                      Scope.Query));
         return this.getItemIdentifiers(filters, offset, length);
     }
 
     @Override
-    public ListItemIdentifiersResult getItemIdentifiers(
-        List<ScopedFilter> filters, int offset, int length, String setSpec,
-        Date from, Date until) throws OAIException {
-        filters.add(new ScopedFilter(getDateFromCondition(from), Scope.Query));
-        filters.add(new ScopedFilter(getDateUntilFilter(until), Scope.Query));
+    public ListItemIdentifiersResult getItemIdentifiers(List<ScopedFilter> filters, int offset, int length,
+                                                        String setSpec, java.util.Date from, java.util.Date until)
+        throws OAIException {
+        filters.add(new ScopedFilter(getDateFromCondition(from.toInstant()), Scope.Query));
+        filters.add(new ScopedFilter(getDateUntilFilter(until.toInstant()), Scope.Query));
         filters.add(new ScopedFilter(getDSpaceSetSpecFilter(setSpec),
                                      Scope.Query));
         return this.getItemIdentifiers(filters, offset, length);
     }
 
     @Override
-    public ListItemIdentifiersResult getItemIdentifiersUntil(
-        List<ScopedFilter> filters, int offset, int length, Date until) throws OAIException {
-        filters.add(new ScopedFilter(getDateUntilFilter(until), Scope.Query));
+    public ListItemIdentifiersResult getItemIdentifiersUntil(List<ScopedFilter> filters, int offset, int length,
+                                                             java.util.Date until) throws OAIException {
+        filters.add(new ScopedFilter(getDateUntilFilter(until.toInstant()), Scope.Query));
         return this.getItemIdentifiers(filters, offset, length);
     }
 
     @Override
-    public ListItemIdentifiersResult getItemIdentifiersUntil(
-        List<ScopedFilter> filters, int offset, int length, String setSpec,
-        Date until) throws OAIException {
-        filters.add(new ScopedFilter(getDateUntilFilter(until), Scope.Query));
+    public ListItemIdentifiersResult getItemIdentifiersUntil(List<ScopedFilter> filters, int offset, int length,
+                                                             String setSpec, java.util.Date until)
+        throws OAIException {
+        filters.add(new ScopedFilter(getDateUntilFilter(until.toInstant()), Scope.Query));
         filters.add(new ScopedFilter(getDSpaceSetSpecFilter(setSpec),
                                      Scope.Query));
         return this.getItemIdentifiers(filters, offset, length);
@@ -98,8 +98,8 @@ public abstract class DSpaceItemRepository implements ItemRepository {
 
     @Override
     public ListItemsResults getItems(List<ScopedFilter> filters, int offset,
-                                     int length, Date from) throws OAIException {
-        filters.add(new ScopedFilter(getDateFromCondition(from), Scope.Query));
+                                     int length, java.util.Date from) throws OAIException {
+        filters.add(new ScopedFilter(getDateFromCondition(from.toInstant()), Scope.Query));
         return this.getItems(filters, offset, length);
     }
 
@@ -113,16 +113,16 @@ public abstract class DSpaceItemRepository implements ItemRepository {
 
     @Override
     public ListItemsResults getItems(List<ScopedFilter> filters, int offset,
-                                     int length, Date from, Date until) throws OAIException {
-        filters.add(new ScopedFilter(getDateFromCondition(from), Scope.Query));
-        filters.add(new ScopedFilter(getDateUntilFilter(until), Scope.Query));
+                                     int length, java.util.Date from, java.util.Date until) throws OAIException {
+        filters.add(new ScopedFilter(getDateFromCondition(from.toInstant()), Scope.Query));
+        filters.add(new ScopedFilter(getDateUntilFilter(until.toInstant()), Scope.Query));
         return this.getItems(filters, offset, length);
     }
 
     @Override
     public ListItemsResults getItems(List<ScopedFilter> filters, int offset,
-                                     int length, String setSpec, Date from) throws OAIException {
-        filters.add(new ScopedFilter(getDateFromCondition(from), Scope.Query));
+                                     int length, String setSpec, java.util.Date from) throws OAIException {
+        filters.add(new ScopedFilter(getDateFromCondition(from.toInstant()), Scope.Query));
         filters.add(new ScopedFilter(getDSpaceSetSpecFilter(setSpec),
                                      Scope.Query));
         return this.getItems(filters, offset, length);
@@ -130,9 +130,10 @@ public abstract class DSpaceItemRepository implements ItemRepository {
 
     @Override
     public ListItemsResults getItems(List<ScopedFilter> filters, int offset,
-                                     int length, String setSpec, Date from, Date until) throws OAIException {
-        filters.add(new ScopedFilter(getDateFromCondition(from), Scope.Query));
-        filters.add(new ScopedFilter(getDateUntilFilter(until), Scope.Query));
+                                     int length, String setSpec, java.util.Date from, java.util.Date until)
+        throws OAIException {
+        filters.add(new ScopedFilter(getDateFromCondition(from.toInstant()), Scope.Query));
+        filters.add(new ScopedFilter(getDateUntilFilter(until.toInstant()), Scope.Query));
         filters.add(new ScopedFilter(getDSpaceSetSpecFilter(setSpec),
                                      Scope.Query));
         return this.getItems(filters, offset, length);
@@ -140,21 +141,21 @@ public abstract class DSpaceItemRepository implements ItemRepository {
 
     @Override
     public ListItemsResults getItemsUntil(List<ScopedFilter> filters, int offset,
-                                          int length, Date until) throws OAIException {
-        filters.add(new ScopedFilter(getDateUntilFilter(until), Scope.Query));
+                                          int length, java.util.Date until) throws OAIException {
+        filters.add(new ScopedFilter(getDateUntilFilter(until.toInstant()), Scope.Query));
         return this.getItems(filters, offset, length);
     }
 
     @Override
     public ListItemsResults getItemsUntil(List<ScopedFilter> filters, int offset,
-                                          int length, String setSpec, Date from) throws OAIException {
-        filters.add(new ScopedFilter(getDateUntilFilter(from), Scope.Query));
+                                          int length, String setSpec, java.util.Date from) throws OAIException {
+        filters.add(new ScopedFilter(getDateUntilFilter(from.toInstant()), Scope.Query));
         filters.add(new ScopedFilter(getDSpaceSetSpecFilter(setSpec),
                                      Scope.Query));
         return this.getItems(filters, offset, length);
     }
 
-    private Condition getDateFromCondition(final Date from) {
+    private Condition getDateFromCondition(final Instant from) {
         return new Condition() {
             @Override
             public Filter getFilter() {
@@ -172,7 +173,7 @@ public abstract class DSpaceItemRepository implements ItemRepository {
         };
     }
 
-    private Condition getDateUntilFilter(final Date until) {
+    private Condition getDateUntilFilter(final Instant until) {
         return new Condition() {
             @Override
             public Filter getFilter() {

--- a/dspace-oai/src/main/java/org/dspace/xoai/services/impl/xoai/DSpaceRepositoryConfiguration.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/impl/xoai/DSpaceRepositoryConfiguration.java
@@ -11,8 +11,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
+import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 import com.lyncode.xoai.dataprovider.core.DeleteMethod;
@@ -101,16 +101,16 @@ public class DSpaceRepositoryConfiguration implements RepositoryConfiguration {
     }
 
     @Override
-    public Date getEarliestDate() {
+    public java.util.Date getEarliestDate() {
         // Look at the database!
         try {
-            return dateResolver.getEarliestDate(context);
+            return java.util.Date.from(dateResolver.getEarliestDate(context));
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
         } catch (InvalidMetadataFieldException e) {
             log.error(e.getMessage(), e);
         }
-        return new Date();
+        return java.util.Date.from(Instant.now());
     }
 
     @Override

--- a/dspace-oai/src/main/java/org/dspace/xoai/services/impl/xoai/DSpaceResumptionTokenFormatter.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/impl/xoai/DSpaceResumptionTokenFormatter.java
@@ -7,8 +7,6 @@
  */
 package org.dspace.xoai.services.impl.xoai;
 
-import java.util.Date;
-
 import com.lyncode.xoai.dataprovider.core.ResumptionToken;
 import com.lyncode.xoai.dataprovider.exceptions.BadResumptionToken;
 import com.lyncode.xoai.dataprovider.services.api.ResumptionTokenFormatter;
@@ -38,8 +36,8 @@ public class DSpaceResumptionTokenFormatter implements ResumptionTokenFormatter 
                 int offset = Integer.parseInt(res[4]);
                 String prefix = (res[0].equals("")) ? null : res[0];
                 String set = (res[3].equals("")) ? null : res[3];
-                Date from = (res[1].equals("")) ? null : DateUtils.parse(res[1]);
-                Date until = res[2].equals("") ? null : DateUtils.parse(res[2]);
+                java.util.Date from = (res[1].equals("")) ? null : java.util.Date.from(DateUtils.parse(res[1]));
+                java.util.Date until = res[2].equals("") ? null : java.util.Date.from(DateUtils.parse(res[2]));
                 return new ResumptionToken(offset, prefix, set, from, until);
             } catch (Exception e) {
                 log.error(e.getMessage(), e);
@@ -57,11 +55,11 @@ public class DSpaceResumptionTokenFormatter implements ResumptionTokenFormatter 
         }
         result += "/";
         if (resumptionToken.hasFrom()) {
-            result += DateUtils.format(resumptionToken.getFrom());
+            result += DateUtils.format(resumptionToken.getFrom().toInstant());
         }
         result += "/";
         if (resumptionToken.hasUntil()) {
-            result += DateUtils.format(resumptionToken.getUntil());
+            result += DateUtils.format(resumptionToken.getUntil().toInstant());
         }
         result += "/";
         if (resumptionToken.hasSet()) {

--- a/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
@@ -11,8 +11,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.sql.SQLException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import com.lyncode.xoai.dataprovider.xml.xoai.Element;
@@ -185,10 +185,10 @@ public class ItemUtils {
             String groupName = policy.getGroup() != null ? policy.getGroup().getName() : null;
             String user = policy.getEPerson() != null ? policy.getEPerson().getName() : null;
             String action = Constants.actionText[policy.getAction()];
-            Date startDate = policy.getStartDate();
-            Date endDate = policy.getEndDate();
+            LocalDate startDate = policy.getStartDate();
+            LocalDate endDate = policy.getEndDate();
 
-            SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
+            DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE;
 
             Element resourcePolicyEl = create("resourcePolicy");
             resourcePolicyEl.getField().add(createValue("group", groupName));

--- a/dspace-oai/src/test/java/org/dspace/xoai/tests/unit/services/impl/AbstractQueryResolverTest.java
+++ b/dspace-oai/src/test/java/org/dspace/xoai/tests/unit/services/impl/AbstractQueryResolverTest.java
@@ -9,8 +9,8 @@ package org.dspace.xoai.tests.unit.services.impl;
 
 import static org.mockito.Mockito.mock;
 
-import java.util.Calendar;
-import java.util.Date;
+import java.time.Instant;
+import java.time.temporal.ChronoField;
 
 import com.lyncode.xoai.dataprovider.services.impl.BaseDateProvider;
 import org.apache.solr.client.solrj.util.ClientUtils;
@@ -57,21 +57,20 @@ public abstract class AbstractQueryResolverTest {
         return (StubbedFieldResolver) applicationContext.getBean(FieldResolver.class);
     }
 
-    protected String escapedFromDate(Date date) {
+    protected String escapedFromDate(Instant date) {
         return ClientUtils.escapeQueryChars(
-            baseDateProvider.format(dateWithMilliseconds(date, 0)).replace("Z", ".000Z"));
+            baseDateProvider.format(java.util.Date.from(dateWithMilliseconds(date, 0)))
+                            .replace("Z", ".000Z"));
     }
 
-    protected String escapedUntilDate(Date date) {
+    protected String escapedUntilDate(Instant date) {
         return ClientUtils.escapeQueryChars(
-            baseDateProvider.format(dateWithMilliseconds(date, 999)).replace("Z", ".999Z"));
+            baseDateProvider.format(java.util.Date.from(dateWithMilliseconds(date, 999)))
+                            .replace("Z", ".999Z"));
     }
 
     // Return date with specified milliseconds value
-    private Date dateWithMilliseconds(Date date, int milliseconds) {
-        Calendar calendar =  Calendar.getInstance();
-        calendar.setTime(date);
-        calendar.set(Calendar.MILLISECOND, milliseconds);
-        return calendar.getTime();
+    private Instant dateWithMilliseconds(Instant date, int milliseconds) {
+        return date.with(ChronoField.MILLI_OF_SECOND, milliseconds);
     }
 }

--- a/dspace-oai/src/test/java/org/dspace/xoai/tests/unit/services/impl/solr/DSpaceSolrQueryResolverTest.java
+++ b/dspace-oai/src/test/java/org/dspace/xoai/tests/unit/services/impl/solr/DSpaceSolrQueryResolverTest.java
@@ -10,8 +10,8 @@ package org.dspace.xoai.tests.unit.services.impl.solr;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
+import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 import com.lyncode.xoai.dataprovider.data.Filter;
@@ -34,7 +34,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class DSpaceSolrQueryResolverTest extends AbstractQueryResolverTest {
-    private static final Date DATE = new Date();
+    private static final Instant DATE = Instant.now();
     private static final String SET = "col_testSet";
     private static final String FIELD_1 = "dc.title";
     private static final String FIELD_2 = "dc.type";

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/CollectionItemTemplateController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/CollectionItemTemplateController.java
@@ -64,6 +64,9 @@ public class CollectionItemTemplateController {
     @Autowired
     private ConverterService converter;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     /**
      * This method will create an Item and add it as a template to a Collection.
      *
@@ -114,7 +117,6 @@ public class CollectionItemTemplateController {
 
         TemplateItemRest inputTemplateItemRest;
         try {
-            ObjectMapper mapper = new ObjectMapper();
             inputTemplateItemRest = mapper.readValue(itemBody.toString(), TemplateItemRest.class);
         } catch (IOException e1) {
             throw new UnprocessableEntityException("Error parsing request body", e1);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/ItemAddBundleController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/ItemAddBundleController.java
@@ -79,6 +79,9 @@ public class ItemAddBundleController {
     @Autowired
     Utils utils;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     /**
      * Method to add a Bundle to an Item with the given UUID in the URL. This will create a Bundle with the
      * name provided in the request and attach this to the Item that matches the UUID in the URL.
@@ -101,7 +104,7 @@ public class ItemAddBundleController {
 
         BundleRest bundleRest;
         try {
-            bundleRest = new ObjectMapper().readValue(request.getInputStream(), BundleRest.class);
+            bundleRest = mapper.readValue(request.getInputStream(), BundleRest.class);
         } catch (IOException excIO) {
             throw new UnprocessableEntityException("Could not parse request body");
         }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/LDNMessageRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/LDNMessageRestController.java
@@ -60,6 +60,9 @@ public class LDNMessageRestController implements InitializingBean {
     @Autowired
     private DiscoverableEndpointsService discoverableEndpointsService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     @Override
     public void afterPropertiesSet() {
         discoverableEndpointsService.register(this,
@@ -85,7 +88,7 @@ public class LDNMessageRestController implements InitializingBean {
             ldnMessageEntity, utils.obtainProjection());
 
         context.complete();
-        String result = new ObjectMapper()
+        String result = mapper
             .writerWithDefaultPrettyPrinter().writeValueAsString(resultRequestStatusRests);
 
         return new ResponseEntity<>(result, HttpStatus.OK);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/NotifyRequestStatusRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/NotifyRequestStatusRestController.java
@@ -72,6 +72,9 @@ public class NotifyRequestStatusRestController implements InitializingBean {
     @Autowired
     private DiscoverableEndpointsService discoverableEndpointsService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     @Override
     public void afterPropertiesSet() {
         discoverableEndpointsService.register(this,
@@ -98,7 +101,7 @@ public class NotifyRequestStatusRestController implements InitializingBean {
             resultRequests, utils.obtainProjection());
 
         context.complete();
-        String result = new ObjectMapper()
+        String result = mapper
             .writerWithDefaultPrettyPrinter().writeValueAsString(resultRequestStatusRests);
 
         return new ResponseEntity<>(result, HttpStatus.OK);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/WebApplication.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/WebApplication.java
@@ -9,8 +9,11 @@ package org.dspace.app.rest;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.time.ZoneOffset;
 import java.util.List;
+import java.util.TimeZone;
 
+import jakarta.annotation.PostConstruct;
 import jakarta.servlet.Filter;
 import org.dspace.app.ldn.LDNQueueExtractor;
 import org.dspace.app.ldn.LDNQueueTimeoutChecker;
@@ -245,5 +248,13 @@ public class WebApplication {
                 argumentResolvers.add(new SearchFilterResolver());
             }
         };
+    }
+
+    @PostConstruct
+    public void setDefaultTimezone() {
+        // Set the default timezone in Spring Boot to UTC.
+        // This ensures that Spring Boot doesn't attempt to change the timezone of dates that are read from the
+        // database (via Hibernate). We store all dates in the database as UTC.
+        TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.UTC));
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/BulkAccessConditionConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/BulkAccessConditionConverter.java
@@ -51,7 +51,7 @@ public class BulkAccessConditionConverter
         optionRest.setHasEndDate(option.getHasEndDate());
         if (StringUtils.isNotBlank(option.getStartDateLimit())) {
             try {
-                optionRest.setMaxStartDate(dateMathParser.parseMath(option.getStartDateLimit()));
+                optionRest.setMaxStartDate(dateMathParser.parseMath(option.getStartDateLimit()).toLocalDate());
             } catch (ParseException e) {
                 throw new IllegalStateException("Wrong start date limit configuration for the access condition "
                         + "option named  " + option.getName());
@@ -59,7 +59,7 @@ public class BulkAccessConditionConverter
         }
         if (StringUtils.isNotBlank(option.getEndDateLimit())) {
             try {
-                optionRest.setMaxEndDate(dateMathParser.parseMath(option.getEndDateLimit()));
+                optionRest.setMaxEndDate(dateMathParser.parseMath(option.getEndDateLimit()).toLocalDate());
             } catch (ParseException e) {
                 throw new IllegalStateException("Wrong end date limit configuration for the access condition "
                         + "option named  " + option.getName());

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionAccessOptionConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionAccessOptionConverter.java
@@ -8,7 +8,7 @@
 package org.dspace.app.rest.converter;
 
 import java.text.ParseException;
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import org.apache.commons.lang3.StringUtils;
 import org.dspace.app.rest.model.AccessConditionOptionRest;
@@ -43,8 +43,8 @@ public class SubmissionAccessOptionConverter
             optionRest.setHasEndDate(option.getHasEndDate());
             if (StringUtils.isNotBlank(option.getStartDateLimit())) {
                 try {
-                    Date requested = dateMathParser.parseMath(option.getStartDateLimit());
-                    optionRest.setMaxStartDate(TimeHelpers.toMidnightUTC(requested));
+                    LocalDateTime requested = dateMathParser.parseMath(option.getStartDateLimit());
+                    optionRest.setMaxStartDate(TimeHelpers.toMidnightUTC(requested).toLocalDate());
                 } catch (ParseException e) {
                     throw new IllegalStateException("Wrong start date limit configuration for the access condition "
                             + "option named  " + option.getName());
@@ -52,8 +52,8 @@ public class SubmissionAccessOptionConverter
             }
             if (StringUtils.isNotBlank(option.getEndDateLimit())) {
                 try {
-                    Date requested = dateMathParser.parseMath(option.getEndDateLimit());
-                    optionRest.setMaxEndDate(TimeHelpers.toMidnightUTC(requested));
+                    LocalDateTime requested = dateMathParser.parseMath(option.getEndDateLimit());
+                    optionRest.setMaxEndDate(TimeHelpers.toMidnightUTC(requested).toLocalDate());
                 } catch (ParseException e) {
                     throw new IllegalStateException("Wrong end date limit configuration for the access condition "
                             + "option named  " + option.getName());

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/hdlresolver/HdlResolverRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/hdlresolver/HdlResolverRestController.java
@@ -51,6 +51,9 @@ public class HdlResolverRestController {
     @Autowired
     private HdlResolverService hdlResolverService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     @GetMapping(
         value = "**",
         produces = "application/json;charset=UTF-8"
@@ -187,7 +190,7 @@ public class HdlResolverRestController {
         String json = "null";
         if (jsonList != null && !jsonList.isEmpty()) {
             try {
-                json = new ObjectMapper().writeValueAsString(jsonList);
+                json = mapper.writeValueAsString(jsonList);
             } catch (JsonProcessingException e) {
                 log.error("Error during conversion of response!", e);
             }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/AInprogressSubmissionRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/AInprogressSubmissionRest.java
@@ -8,7 +8,7 @@
 package org.dspace.app.rest.model;
 
 import java.io.Serializable;
-import java.util.Date;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -23,16 +23,16 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 public abstract class AInprogressSubmissionRest extends BaseObjectRest<Integer> {
 
 
-    private Date lastModified = new Date();
+    private Instant lastModified = Instant.now();
     private Map<String, Serializable> sections;
     @JsonIgnore
     private SubmissionDefinitionRest submissionDefinition;
 
-    public Date getLastModified() {
+    public Instant getLastModified() {
         return lastModified;
     }
 
-    public void setLastModified(Date lastModified) {
+    public void setLastModified(Instant lastModified) {
         this.lastModified = lastModified;
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/AccessConditionDTO.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/AccessConditionDTO.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.app.rest.model;
 
-import java.util.Date;
+import java.time.LocalDate;
 
 /**
  * The AccessConditionDTO is a partial representation of the DSpace
@@ -31,9 +31,9 @@ public class AccessConditionDTO  {
 
     private String description;
 
-    private Date startDate;
+    private LocalDate startDate;
 
-    private Date endDate;
+    private LocalDate endDate;
 
     public Integer getId() {
         return id;
@@ -59,19 +59,19 @@ public class AccessConditionDTO  {
         this.description = description;
     }
 
-    public Date getStartDate() {
+    public LocalDate getStartDate() {
         return startDate;
     }
 
-    public void setStartDate(Date startDate) {
+    public void setStartDate(LocalDate startDate) {
         this.startDate = startDate;
     }
 
-    public Date getEndDate() {
+    public LocalDate getEndDate() {
         return endDate;
     }
 
-    public void setEndDate(Date endDate) {
+    public void setEndDate(LocalDate endDate) {
         this.endDate = endDate;
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/AccessConditionOptionRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/AccessConditionOptionRest.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.app.rest.model;
 
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.UUID;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -33,16 +33,16 @@ public class AccessConditionOptionRest {
     private Boolean hasEndDate;
 
     @JsonInclude(Include.NON_NULL)
-    private Date maxStartDate;
+    private LocalDate maxStartDate;
 
     @JsonInclude(Include.NON_NULL)
-    private Date maxEndDate;
+    private LocalDate maxEndDate;
 
-    public Date getMaxEndDate() {
+    public LocalDate getMaxEndDate() {
         return maxEndDate;
     }
 
-    public void setMaxEndDate(Date maxEndDate) {
+    public void setMaxEndDate(LocalDate maxEndDate) {
         this.maxEndDate = maxEndDate;
     }
 
@@ -62,11 +62,11 @@ public class AccessConditionOptionRest {
         this.hasEndDate = hasEndDate;
     }
 
-    public Date getMaxStartDate() {
+    public LocalDate getMaxStartDate() {
         return maxStartDate;
     }
 
-    public void setMaxStartDate(Date maxStartDate) {
+    public void setMaxStartDate(LocalDate maxStartDate) {
         this.maxStartDate = maxStartDate;
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/EPersonRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/EPersonRest.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.app.rest.model;
 
-import java.util.Date;
+import java.time.Instant;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
@@ -31,7 +31,7 @@ public class EPersonRest extends DSpaceObjectRest {
 
     private String netid;
 
-    private Date lastActive;
+    private Instant lastActive;
 
     private boolean canLogIn;
 
@@ -63,11 +63,11 @@ public class EPersonRest extends DSpaceObjectRest {
         this.netid = netid;
     }
 
-    public Date getLastActive() {
+    public Instant getLastActive() {
         return lastActive;
     }
 
-    public void setLastActive(Date lastActive) {
+    public void setLastActive(Instant lastActive) {
         this.lastActive = lastActive;
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/FilteredItemRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/FilteredItemRest.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.app.rest.model;
 
-import java.util.Date;
+import java.time.Instant;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -35,7 +35,7 @@ public class FilteredItemRest {
     private boolean inArchive = false;
     private boolean discoverable = false;
     private boolean withdrawn = false;
-    private Date lastModified = new Date();
+    private Instant lastModified = Instant.now();
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private String entityType = null;
     private CollectionRest owningCollection;
@@ -101,11 +101,11 @@ public class FilteredItemRest {
         this.withdrawn = withdrawn;
     }
 
-    public Date getLastModified() {
+    public Instant getLastModified() {
         return lastModified;
     }
 
-    public void setLastModified(Date lastModified) {
+    public void setLastModified(Instant lastModified) {
         this.lastModified = lastModified;
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/HarvestedCollectionRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/HarvestedCollectionRest.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.app.rest.model;
 
-import java.util.Date;
+import java.time.Instant;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -43,10 +43,10 @@ public class HarvestedCollectionRest extends BaseObjectRest<Integer> {
     private HarvestStatusEnum harvestStatus;
 
     @JsonProperty("harvest_start_time")
-    private Date harvestStartTime;
+    private Instant harvestStartTime;
 
     @JsonProperty("last_harvested")
-    private Date lastHarvested;
+    private Instant lastHarvested;
 
     private HarvesterMetadataRest metadata_configs;
 
@@ -146,19 +146,19 @@ public class HarvestedCollectionRest extends BaseObjectRest<Integer> {
         this.harvestStatus = harvestStatus;
     }
 
-    public Date getHarvestStartTime() {
+    public Instant getHarvestStartTime() {
         return harvestStartTime;
     }
 
-    public void setHarvestStartTime(Date harvestStartTime) {
+    public void setHarvestStartTime(Instant harvestStartTime) {
         this.harvestStartTime = harvestStartTime;
     }
 
-    public Date getLastHarvested() {
+    public Instant getLastHarvested() {
         return lastHarvested;
     }
 
-    public void setLastHarvested(Date lastHarvested) {
+    public void setLastHarvested(Instant lastHarvested) {
         this.lastHarvested = lastHarvested;
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/ItemRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/ItemRest.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.app.rest.model;
 
-import java.util.Date;
+import java.time.Instant;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -48,7 +48,7 @@ public class ItemRest extends DSpaceObjectRest {
     private boolean inArchive = false;
     private boolean discoverable = false;
     private boolean withdrawn = false;
-    private Date lastModified = new Date();
+    private Instant lastModified = Instant.now();
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private String entityType = null;
 
@@ -92,11 +92,11 @@ public class ItemRest extends DSpaceObjectRest {
         this.withdrawn = withdrawn;
     }
 
-    public Date getLastModified() {
+    public Instant getLastModified() {
         return lastModified;
     }
 
-    public void setLastModified(Date lastModified) {
+    public void setLastModified(Instant lastModified) {
         this.lastModified = lastModified;
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/LDNMessageEntityRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/LDNMessageEntityRest.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.app.rest.model;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.UUID;
 
 import org.dspace.app.rest.RestResourceController;
@@ -45,9 +45,9 @@ public class LDNMessageEntityRest extends BaseObjectRest<String> {
 
     private Integer queueAttempts;
 
-    private Date queueLastStartTime;
+    private Instant queueLastStartTime;
 
-    private Date queueTimeout;
+    private Instant queueTimeout;
 
     private String notificationType;
 
@@ -157,19 +157,19 @@ public class LDNMessageEntityRest extends BaseObjectRest<String> {
         this.queueAttempts = queueAttempts;
     }
 
-    public Date getQueueLastStartTime() {
+    public Instant getQueueLastStartTime() {
         return queueLastStartTime;
     }
 
-    public void setQueueLastStartTime(Date queueLastStartTime) {
+    public void setQueueLastStartTime(Instant queueLastStartTime) {
         this.queueLastStartTime = queueLastStartTime;
     }
 
-    public Date getQueueTimeout() {
+    public Instant getQueueTimeout() {
         return queueTimeout;
     }
 
-    public void setQueueTimeout(Date queueTimeout) {
+    public void setQueueTimeout(Instant queueTimeout) {
         this.queueTimeout = queueTimeout;
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/OrcidHistoryRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/OrcidHistoryRest.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.app.rest.model;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.UUID;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -35,7 +35,7 @@ public class OrcidHistoryRest extends BaseObjectRest<Integer> {
 
     private String putCode;
 
-    private Date timestamp;
+    private Instant timestamp;
 
     private String responseMessage;
 
@@ -94,11 +94,11 @@ public class OrcidHistoryRest extends BaseObjectRest<Integer> {
         this.putCode = putCode;
     }
 
-    public Date getTimestamp() {
+    public Instant getTimestamp() {
         return timestamp;
     }
 
-    public void setTimestamp(Date timestamp) {
+    public void setTimestamp(Instant timestamp) {
         this.timestamp = timestamp;
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/ProcessRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/ProcessRest.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.app.rest.model;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
@@ -54,9 +54,9 @@ public class ProcessRest extends BaseObjectRest<Integer> {
     private String scriptName;
     private UUID userId;
     private Integer processId;
-    private Date startTime;
-    private Date endTime;
-    private Date creationTime;
+    private Instant startTime;
+    private Instant endTime;
+    private Instant creationTime;
     private ProcessStatus processStatus;
     @JsonProperty(value = "parameters")
     private List<ParameterValueRest> parameterRestList;
@@ -93,19 +93,19 @@ public class ProcessRest extends BaseObjectRest<Integer> {
         this.parameterRestList = parameterRestList;
     }
 
-    public Date getStartTime() {
+    public Instant getStartTime() {
         return startTime;
     }
 
-    public void setStartTime(Date startTime) {
+    public void setStartTime(Instant startTime) {
         this.startTime = startTime;
     }
 
-    public Date getCreationTime() {
+    public Instant getCreationTime() {
         return creationTime;
     }
 
-    public void setCreationTime(Date creationTime) {
+    public void setCreationTime(Instant creationTime) {
         this.creationTime = creationTime;
     }
 
@@ -117,11 +117,11 @@ public class ProcessRest extends BaseObjectRest<Integer> {
         this.scriptName = scriptName;
     }
 
-    public Date getEndTime() {
+    public Instant getEndTime() {
         return endTime;
     }
 
-    public void setEndTime(Date endTime) {
+    public void setEndTime(Instant endTime) {
         this.endTime = endTime;
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/QAEventRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/QAEventRest.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.app.rest.model;
 
-import java.util.Date;
+import java.time.Instant;
 
 import org.dspace.app.rest.RestResourceController;
 
@@ -38,7 +38,7 @@ public class QAEventRest extends BaseObjectRest<String> {
     private String title;
     private String topic;
     private String trust;
-    private Date eventDate;
+    private Instant eventDate;
     private QAEventMessageRest message;
     private String status;
 
@@ -102,11 +102,11 @@ public class QAEventRest extends BaseObjectRest<String> {
         this.trust = trust;
     }
 
-    public Date getEventDate() {
+    public Instant getEventDate() {
         return eventDate;
     }
 
-    public void setEventDate(Date eventDate) {
+    public void setEventDate(Instant eventDate) {
         this.eventDate = eventDate;
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/QASourceRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/QASourceRest.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.app.rest.model;
 
-import java.util.Date;
+import java.time.Instant;
 
 import org.dspace.app.rest.RestResourceController;
 
@@ -25,7 +25,7 @@ public class QASourceRest extends BaseObjectRest<String> {
     public static final String PLURAL_NAME = "qualityassurancesources";
     public static final String CATEGORY = RestAddressableModel.INTEGRATION;
 
-    private Date lastEvent;
+    private Instant lastEvent;
     private long totalEvents;
 
     @Override
@@ -48,11 +48,11 @@ public class QASourceRest extends BaseObjectRest<String> {
         return RestResourceController.class;
     }
 
-    public Date getLastEvent() {
+    public Instant getLastEvent() {
         return lastEvent;
     }
 
-    public void setLastEvent(Date lastEvent) {
+    public void setLastEvent(Instant lastEvent) {
         this.lastEvent = lastEvent;
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/QATopicRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/QATopicRest.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.app.rest.model;
 
-import java.util.Date;
+import java.time.Instant;
 
 import org.dspace.app.rest.RestResourceController;
 
@@ -27,7 +27,7 @@ public class QATopicRest extends BaseObjectRest<String> {
 
     private String id;
     private String name;
-    private Date lastEvent;
+    private Instant lastEvent;
     private long totalEvents;
 
     @Override
@@ -66,11 +66,11 @@ public class QATopicRest extends BaseObjectRest<String> {
         this.name = name;
     }
 
-    public Date getLastEvent() {
+    public Instant getLastEvent() {
         return lastEvent;
     }
 
-    public void setLastEvent(Date lastEvent) {
+    public void setLastEvent(Instant lastEvent) {
         this.lastEvent = lastEvent;
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/RequestItemRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/RequestItemRest.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.app.rest.model;
 
-import java.util.Date;
+import java.time.Instant;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.dspace.app.rest.RestResourceController;
@@ -31,9 +31,9 @@ public class RequestItemRest extends BaseObjectRest<Integer> {
     protected String bitstream_id;
 
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
-    protected Date decisionDate;
+    protected Instant decisionDate;
 
-    protected Date expires;
+    protected Instant expires;
 
     protected String item_id;
 
@@ -44,7 +44,7 @@ public class RequestItemRest extends BaseObjectRest<Integer> {
     protected String reqName;
 
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
-    protected Date requestDate;
+    protected Instant requestDate;
 
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     protected String token;
@@ -70,28 +70,28 @@ public class RequestItemRest extends BaseObjectRest<Integer> {
     /**
      * @return the decisionDate
      */
-    public Date getDecisionDate() {
+    public Instant getDecisionDate() {
         return decisionDate;
     }
 
     /**
      * @param decided the decisionDate to set
      */
-    public void setDecisionDate(Date decided) {
+    public void setDecisionDate(Instant decided) {
         this.decisionDate = decided;
     }
 
     /**
      * @return the expires
      */
-    public Date getExpires() {
+    public Instant getExpires() {
         return expires;
     }
 
     /**
      * @param expires the expires to set
      */
-    public void setExpires(Date expires) {
+    public void setExpires(Instant expires) {
         this.expires = expires;
     }
 
@@ -154,14 +154,14 @@ public class RequestItemRest extends BaseObjectRest<Integer> {
     /**
      * @return the requestDate
      */
-    public Date getRequestDate() {
+    public Instant getRequestDate() {
         return requestDate;
     }
 
     /**
      * @param requested the requestDate to set
      */
-    public void setRequestDate(Date requested) {
+    public void setRequestDate(Instant requested) {
         this.requestDate = requested;
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/ResourcePolicyRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/ResourcePolicyRest.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.app.rest.model;
 
-import java.util.Date;
+import java.time.LocalDate;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -45,15 +45,15 @@ public class ResourcePolicyRest extends BaseObjectRest<Integer> {
 
     private String action;
 
-    private Date startDate;
+    private LocalDate startDate;
 
-    private Date endDate;
+    private LocalDate endDate;
 
-    public Date getEndDate() {
+    public LocalDate getEndDate() {
         return endDate;
     }
 
-    public void setEndDate(Date endDate) {
+    public void setEndDate(LocalDate endDate) {
         this.endDate = endDate;
     }
 
@@ -134,11 +134,11 @@ public class ResourcePolicyRest extends BaseObjectRest<Integer> {
         this.action = action;
     }
 
-    public Date getStartDate() {
+    public LocalDate getStartDate() {
         return startDate;
     }
 
-    public void setStartDate(Date startDate) {
+    public void setStartDate(LocalDate startDate) {
         this.startDate = startDate;
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/SystemWideAlertRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/SystemWideAlertRest.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.app.rest.model;
 
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -43,7 +43,7 @@ public class SystemWideAlertRest extends BaseObjectRest<Integer> {
     private Integer alertId;
     private String message;
     private String allowSessions;
-    private LocalDateTime countdownTo;
+    private ZonedDateTime countdownTo;
     private boolean active;
 
     public Integer getAlertId() {
@@ -70,11 +70,11 @@ public class SystemWideAlertRest extends BaseObjectRest<Integer> {
         this.allowSessions = allowSessions;
     }
 
-    public LocalDateTime getCountdownTo() {
+    public ZonedDateTime getCountdownTo() {
         return countdownTo;
     }
 
-    public void setCountdownTo(final LocalDateTime countdownTo) {
+    public void setCountdownTo(final ZonedDateTime countdownTo) {
         this.countdownTo = countdownTo;
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/SystemWideAlertRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/SystemWideAlertRest.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.app.rest.model;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -43,7 +43,7 @@ public class SystemWideAlertRest extends BaseObjectRest<Integer> {
     private Integer alertId;
     private String message;
     private String allowSessions;
-    private Date countdownTo;
+    private LocalDateTime countdownTo;
     private boolean active;
 
     public Integer getAlertId() {
@@ -70,11 +70,11 @@ public class SystemWideAlertRest extends BaseObjectRest<Integer> {
         this.allowSessions = allowSessions;
     }
 
-    public Date getCountdownTo() {
+    public LocalDateTime getCountdownTo() {
         return countdownTo;
     }
 
-    public void setCountdownTo(final Date countdownTo) {
+    public void setCountdownTo(final LocalDateTime countdownTo) {
         this.countdownTo = countdownTo;
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/TemplateItemRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/TemplateItemRest.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.app.rest.model;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.UUID;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -26,13 +26,13 @@ public class TemplateItemRest extends BaseObjectRest<UUID> {
     @JsonIgnore
     private CollectionRest templateItemOf;
     MetadataRest metadata = new MetadataRest();
-    private Date lastModified = new Date();
+    private Instant lastModified = Instant.now();
 
-    public Date getLastModified() {
+    public Instant getLastModified() {
         return lastModified;
     }
 
-    public void setLastModified(Date lastModified) {
+    public void setLastModified(Instant lastModified) {
         this.lastModified = lastModified;
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/VersionRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/VersionRest.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.app.rest.model;
 
-import java.util.Date;
+import java.time.Instant;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import org.dspace.app.rest.RestResourceController;
@@ -30,7 +30,7 @@ public class VersionRest extends BaseObjectRest<Integer> {
 
     private Integer id;
     private Integer version;
-    private Date created;
+    private Instant created;
     private String summary;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -74,7 +74,7 @@ public class VersionRest extends BaseObjectRest<Integer> {
      * Generic getter for the created
      * @return the created value of this VersionRest
      */
-    public Date getCreated() {
+    public Instant getCreated() {
         return created;
     }
 
@@ -82,7 +82,7 @@ public class VersionRest extends BaseObjectRest<Integer> {
      * Generic setter for the created
      * @param created   The created to be set on this VersionRest
      */
-    public void setCreated(Date created) {
+    public void setCreated(Instant created) {
         this.created = created;
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/step/SherpaPolicy.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/step/SherpaPolicy.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.app.rest.model.step;
 
-import java.util.Date;
+import java.time.Instant;
 
 import org.dspace.app.sherpa.v2.SHERPAResponse;
 
@@ -20,15 +20,15 @@ public class SherpaPolicy implements SectionData {
 
     private static final long serialVersionUID = 2440249335255683173L;
 
-    private Date retrievalTime;
+    private Instant retrievalTime;
 
     private SHERPAResponse sherpaResponse;
 
-    public Date getRetrievalTime() {
+    public Instant getRetrievalTime() {
         return retrievalTime;
     }
 
-    public void setRetrievalTime(Date retrievalTime) {
+    public void setRetrievalTime(Instant retrievalTime) {
         this.retrievalTime = retrievalTime;
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/wrapper/TemplateItem.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/wrapper/TemplateItem.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.app.rest.model.wrapper;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
@@ -42,7 +42,7 @@ public class TemplateItem {
         return item.getID();
     }
 
-    public Date getLastModified() {
+    public Instant getLastModified() {
         return item.getLastModified();
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamFormatRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamFormatRestRepository.java
@@ -41,6 +41,9 @@ public class BitstreamFormatRestRepository extends DSpaceRestRepository<Bitstrea
     @Autowired
     BitstreamFormatService bitstreamFormatService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     @Override
     @PreAuthorize("permitAll()")
     public BitstreamFormatRest findOne(Context context, Integer id) {
@@ -70,7 +73,6 @@ public class BitstreamFormatRestRepository extends DSpaceRestRepository<Bitstrea
     @PreAuthorize("hasAuthority('ADMIN')")
     protected BitstreamFormatRest createAndReturn(Context context) throws AuthorizeException {
         HttpServletRequest req = getRequestService().getCurrentRequest().getHttpServletRequest();
-        ObjectMapper mapper = new ObjectMapper();
         BitstreamFormatRest bitstreamFormatRest = null;
         try {
             ServletInputStream input = req.getInputStream();
@@ -98,7 +100,7 @@ public class BitstreamFormatRestRepository extends DSpaceRestRepository<Bitstrea
                                       Integer id, JsonNode jsonNode) throws SQLException, AuthorizeException {
         BitstreamFormatRest bitstreamFormatRest = null;
         try {
-            bitstreamFormatRest = new ObjectMapper().readValue(jsonNode.toString(), BitstreamFormatRest.class);
+            bitstreamFormatRest = mapper.readValue(jsonNode.toString(), BitstreamFormatRest.class);
         } catch (IOException e) {
             throw new UnprocessableEntityException("Error parsing collection json: " + e.getMessage());
         }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamRestRepository.java
@@ -80,6 +80,9 @@ public class BitstreamRestRepository extends DSpaceObjectRestRepository<Bitstrea
     ConfigurationService configurationService;
 
     @Autowired
+    private ObjectMapper mapper;
+
+    @Autowired
     public BitstreamRestRepository(BitstreamService dsoService) {
         super(dsoService);
         this.bs = dsoService;
@@ -266,7 +269,6 @@ public class BitstreamRestRepository extends DSpaceObjectRestRepository<Bitstrea
      */
     public void patchBitstreamsInBulk(Context context, JsonNode jsonNode) throws SQLException {
         int operationsLimit = configurationService.getIntProperty("rest.patch.operations.limit", 1000);
-        ObjectMapper mapper = new ObjectMapper();
         JsonPatchConverter patchConverter = new JsonPatchConverter(mapper);
         Patch patch = patchConverter.convert(jsonNode);
         if (patch.getOperations().size() > operationsLimit) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BundleRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BundleRestRepository.java
@@ -69,6 +69,9 @@ public class BundleRestRepository extends DSpaceObjectRestRepository<Bundle, Bun
     @Autowired
     private BitstreamFormatService bitstreamFormatService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     public BundleRestRepository(BundleService dsoService) {
         super(dsoService);
         this.bundleService = dsoService;
@@ -168,7 +171,6 @@ public class BundleRestRepository extends DSpaceObjectRestRepository<Bundle, Bun
 
         Bitstream bitstream = null;
         if (StringUtils.isNotBlank(properties)) {
-            ObjectMapper mapper = new ObjectMapper();
             BitstreamRest bitstreamRest = null;
             try {
                 bitstreamRest = mapper.readValue(properties, BitstreamRest.class);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CollectionRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CollectionRestRepository.java
@@ -122,6 +122,9 @@ public class CollectionRestRepository extends DSpaceObjectRestRepository<Collect
     @Autowired
     SearchService searchService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     public CollectionRestRepository(CollectionService dsoService) {
         super(dsoService);
     }
@@ -319,7 +322,6 @@ public class CollectionRestRepository extends DSpaceObjectRestRepository<Collect
         }
 
         HttpServletRequest req = getRequestService().getCurrentRequest().getHttpServletRequest();
-        ObjectMapper mapper = new ObjectMapper();
         CollectionRest collectionRest;
         try {
             ServletInputStream input = req.getInputStream();
@@ -352,7 +354,7 @@ public class CollectionRestRepository extends DSpaceObjectRestRepository<Collect
         throws RepositoryMethodNotImplementedException, SQLException, AuthorizeException {
         CollectionRest collectionRest;
         try {
-            collectionRest = new ObjectMapper().readValue(jsonNode.toString(), CollectionRest.class);
+            collectionRest = mapper.readValue(jsonNode.toString(), CollectionRest.class);
         } catch (IOException e) {
             throw new UnprocessableEntityException("Error parsing collection json: " + e.getMessage());
         }
@@ -603,7 +605,6 @@ public class CollectionRestRepository extends DSpaceObjectRestRepository<Collect
 
     private GroupRest populateGroupInformation(Context context, HttpServletRequest request, Group group)
         throws SQLException, AuthorizeException {
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         try {
             ServletInputStream input = request.getInputStream();

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CommunityRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CommunityRestRepository.java
@@ -82,6 +82,9 @@ public class CommunityRestRepository extends DSpaceObjectRestRepository<Communit
     @Autowired
     AuthorizeService authorizeService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     private CommunityService cs;
 
     public CommunityRestRepository(CommunityService dsoService) {
@@ -127,7 +130,6 @@ public class CommunityRestRepository extends DSpaceObjectRestRepository<Communit
 
     private Community createCommunity(Context context, Community parent) throws AuthorizeException {
         HttpServletRequest req = getRequestService().getCurrentRequest().getHttpServletRequest();
-        ObjectMapper mapper = new ObjectMapper();
         CommunityRest communityRest;
         try {
             ServletInputStream input = req.getInputStream();
@@ -251,7 +253,7 @@ public class CommunityRestRepository extends DSpaceObjectRestRepository<Communit
         throws RepositoryMethodNotImplementedException, SQLException, AuthorizeException {
         CommunityRest communityRest;
         try {
-            communityRest = new ObjectMapper().readValue(jsonNode.toString(), CommunityRest.class);
+            communityRest = mapper.readValue(jsonNode.toString(), CommunityRest.class);
         } catch (IOException e) {
             throw new UnprocessableEntityException("Error parsing community json: " + e.getMessage());
         }
@@ -327,7 +329,6 @@ public class CommunityRestRepository extends DSpaceObjectRestRepository<Communit
         throws SQLException, AuthorizeException {
 
         Group group = cs.createAdministrators(context, community);
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         try {
             ServletInputStream input = request.getInputStream();

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/EPersonRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/EPersonRestRepository.java
@@ -84,6 +84,9 @@ public class EPersonRestRepository extends DSpaceObjectRestRepository<EPerson, E
     @Autowired
     private GroupService groupService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     private final EPersonService es;
 
 
@@ -97,7 +100,6 @@ public class EPersonRestRepository extends DSpaceObjectRestRepository<EPerson, E
             throws AuthorizeException {
         // this need to be revisited we should receive an EPersonRest as input
         HttpServletRequest req = getRequestService().getCurrentRequest().getHttpServletRequest();
-        ObjectMapper mapper = new ObjectMapper();
         EPersonRest epersonRest = null;
         try {
             epersonRest = mapper.readValue(req.getInputStream(), EPersonRest.class);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/FeedbackRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/FeedbackRestRepository.java
@@ -41,6 +41,9 @@ public class FeedbackRestRepository extends DSpaceRestRepository<FeedbackRest, I
     @Autowired
     private ConfigurationService configurationService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     @Override
     @PreAuthorize("hasAuthority('AUTHENTICATED')")
     public Page<FeedbackRest> findAll(Context context, Pageable pageable) {
@@ -57,7 +60,6 @@ public class FeedbackRestRepository extends DSpaceRestRepository<FeedbackRest, I
     @PreAuthorize("permitAll()")
     protected FeedbackRest createAndReturn(Context context) throws AuthorizeException, SQLException {
         HttpServletRequest req = getRequestService().getCurrentRequest().getHttpServletRequest();
-        ObjectMapper mapper = new ObjectMapper();
         FeedbackRest feedbackRest = null;
 
         String recipientEmail = configurationService.getProperty("feedback.recipient");

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/GroupRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/GroupRestRepository.java
@@ -48,6 +48,9 @@ public class GroupRestRepository extends DSpaceObjectRestRepository<Group, Group
     GroupService gs;
 
     @Autowired
+    private ObjectMapper mapper;
+
+    @Autowired
     GroupRestRepository(GroupService dsoService) {
         super(dsoService);
         this.gs = dsoService;
@@ -62,7 +65,6 @@ public class GroupRestRepository extends DSpaceObjectRestRepository<Group, Group
             throws AuthorizeException, RepositoryMethodNotImplementedException {
 
         HttpServletRequest req = getRequestService().getCurrentRequest().getHttpServletRequest();
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest;
 
         try {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/HarvestedCollectionRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/HarvestedCollectionRestRepository.java
@@ -44,6 +44,9 @@ public class HarvestedCollectionRestRepository extends AbstractDSpaceRestReposit
     @Autowired
     HarvestedCollectionConverter harvestedCollectionConverter;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     public HarvestedCollectionRest findOne(Collection collection) throws SQLException {
         Context context = obtainContext();
 
@@ -110,7 +113,6 @@ public class HarvestedCollectionRestRepository extends AbstractDSpaceRestReposit
     private HarvestedCollectionRest parseHarvestedCollectionRest(Context context,
                                                                  HttpServletRequest request,
                                                                  Collection collection) throws SQLException {
-        ObjectMapper mapper = new ObjectMapper();
         HarvestedCollectionRest harvestedCollectionRest;
 
         try {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ItemRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ItemRestRepository.java
@@ -95,6 +95,9 @@ public class ItemRestRepository extends DSpaceObjectRestRepository<Item, ItemRes
     @Autowired
     private UriListHandlerService uriListHandlerService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     public ItemRestRepository(ItemService dsoService) {
         super(dsoService);
     }
@@ -273,7 +276,6 @@ public class ItemRestRepository extends DSpaceObjectRestRepository<Item, ItemRes
     protected ItemRest createAndReturn(Context context) throws AuthorizeException, SQLException {
         HttpServletRequest req = getRequestService().getCurrentRequest().getHttpServletRequest();
         String owningCollectionUuidString = req.getParameter("owningCollection");
-        ObjectMapper mapper = new ObjectMapper();
         ItemRest itemRest = null;
         try {
             ServletInputStream input = req.getInputStream();
@@ -310,7 +312,6 @@ public class ItemRestRepository extends DSpaceObjectRestRepository<Item, ItemRes
                            JsonNode jsonNode)
         throws RepositoryMethodNotImplementedException, SQLException, AuthorizeException {
         HttpServletRequest req = getRequestService().getCurrentRequest().getHttpServletRequest();
-        ObjectMapper mapper = new ObjectMapper();
         ItemRest itemRest = null;
         try {
             itemRest = mapper.readValue(jsonNode.toString(), ItemRest.class);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataFieldRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataFieldRestRepository.java
@@ -71,6 +71,9 @@ public class MetadataFieldRestRepository extends DSpaceRestRepository<MetadataFi
     @Autowired
     private SearchService searchService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     @Override
     @PreAuthorize("permitAll()")
     public MetadataFieldRest findOne(Context context, Integer id) {
@@ -239,7 +242,7 @@ public class MetadataFieldRestRepository extends DSpaceRestRepository<MetadataFi
         // parse request body
         MetadataFieldRest metadataFieldRest;
         try {
-            metadataFieldRest = new ObjectMapper().readValue(
+            metadataFieldRest = mapper.readValue(
                 getRequestService().getCurrentRequest().getHttpServletRequest().getInputStream(),
                 MetadataFieldRest.class
                                                             );
@@ -319,7 +322,7 @@ public class MetadataFieldRestRepository extends DSpaceRestRepository<MetadataFi
 
         MetadataFieldRest metadataFieldRest;
         try {
-            metadataFieldRest = new ObjectMapper().readValue(jsonNode.toString(), MetadataFieldRest.class);
+            metadataFieldRest = mapper.readValue(jsonNode.toString(), MetadataFieldRest.class);
         } catch (JsonProcessingException e) {
             throw new DSpaceBadRequestException("Cannot parse JSON in request body", e);
         }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataSchemaRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/MetadataSchemaRestRepository.java
@@ -44,6 +44,9 @@ public class MetadataSchemaRestRepository extends DSpaceRestRepository<MetadataS
     @Autowired
     MetadataSchemaService metadataSchemaService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     @Override
     @PreAuthorize("permitAll()")
     public MetadataSchemaRest findOne(Context context, Integer id) {
@@ -82,7 +85,7 @@ public class MetadataSchemaRestRepository extends DSpaceRestRepository<MetadataS
         // parse request body
         MetadataSchemaRest metadataSchemaRest;
         try {
-            metadataSchemaRest = new ObjectMapper().readValue(
+            metadataSchemaRest = mapper.readValue(
                     getRequestService().getCurrentRequest().getHttpServletRequest().getInputStream(),
                     MetadataSchemaRest.class
             );
@@ -144,7 +147,7 @@ public class MetadataSchemaRestRepository extends DSpaceRestRepository<MetadataS
 
         MetadataSchemaRest metadataSchemaRest;
         try {
-            metadataSchemaRest = new ObjectMapper().readValue(jsonNode.toString(), MetadataSchemaRest.class);
+            metadataSchemaRest = mapper.readValue(jsonNode.toString(), MetadataSchemaRest.class);
         } catch (JsonProcessingException e) {
             throw new DSpaceBadRequestException("Cannot parse JSON in request body", e);
         }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/NotifyServiceRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/NotifyServiceRestRepository.java
@@ -57,6 +57,9 @@ public class NotifyServiceRestRepository extends DSpaceRestRepository<NotifyServ
     @Autowired
     ResourcePatch<NotifyServiceEntity> resourcePatch;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     @Override
     @PreAuthorize("hasAuthority('AUTHENTICATED')")
     public NotifyServiceRest findOne(Context context, Integer id) {
@@ -85,7 +88,6 @@ public class NotifyServiceRestRepository extends DSpaceRestRepository<NotifyServ
     @PreAuthorize("hasAuthority('ADMIN')")
     protected NotifyServiceRest createAndReturn(Context context) throws AuthorizeException, SQLException {
         HttpServletRequest req = getRequestService().getCurrentRequest().getHttpServletRequest();
-        ObjectMapper mapper = new ObjectMapper();
         NotifyServiceRest notifyServiceRest;
         try {
             ServletInputStream input = req.getInputStream();

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/QAEventRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/QAEventRestRepository.java
@@ -68,6 +68,9 @@ public class QAEventRestRepository extends DSpaceRestRepository<QAEventRest, Str
     @Autowired
     private CorrectionTypeService correctionTypeService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     @Override
     public Page<QAEventRest> findAll(Context context, Pageable pageable) {
         throw new RepositoryMethodNotImplementedException(QAEventRest.NAME, "findAll");
@@ -181,7 +184,6 @@ public class QAEventRestRepository extends DSpaceRestRepository<QAEventRest, Str
             throw new UnprocessableEntityException("This item cannot be processed by this correction type!");
         }
 
-        ObjectMapper mapper = new ObjectMapper();
         CorrectionTypeMessageDTO reason = null;
         try {
             reason = mapper.readValue(request.getInputStream(), CorrectionTypeMessageDTO.class);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RegistrationRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RegistrationRestRepository.java
@@ -79,6 +79,9 @@ public class RegistrationRestRepository extends DSpaceRestRepository<Registratio
     @Autowired
     private RegistrationDataService registrationDataService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     @Override
     @PreAuthorize("permitAll()")
     public RegistrationRest findOne(Context context, Integer integer) {
@@ -93,7 +96,6 @@ public class RegistrationRestRepository extends DSpaceRestRepository<Registratio
     @Override
     public RegistrationRest createAndReturn(Context context) {
         HttpServletRequest request = requestService.getCurrentRequest().getHttpServletRequest();
-        ObjectMapper mapper = new ObjectMapper();
         RegistrationRest registrationRest;
         String accountType = request.getParameter(TYPE_QUERY_PARAM);
         if (StringUtils.isBlank(accountType) ||

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RelationshipRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RelationshipRestRepository.java
@@ -80,6 +80,9 @@ public class RelationshipRestRepository extends DSpaceRestRepository<Relationshi
     @Autowired
     private RequestService requestService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     @Override
     @PreAuthorize("permitAll()")
     public RelationshipRest findOne(Context context, Integer integer) {
@@ -238,7 +241,7 @@ public class RelationshipRestRepository extends DSpaceRestRepository<Relationshi
             RelationshipRest relationshipRest;
 
             try {
-                relationshipRest = new ObjectMapper().readValue(jsonNode.toString(), RelationshipRest.class);
+                relationshipRest = mapper.readValue(jsonNode.toString(), RelationshipRest.class);
             } catch (IOException e) {
                 throw new UnprocessableEntityException("Error parsing request body: " + e.toString());
             }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RequestItemRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RequestItemRepository.java
@@ -14,7 +14,7 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
@@ -228,7 +228,7 @@ public class RequestItemRepository
         }
 
         // Do not permit updates after a decision has been given.
-        Date decisionDate = ri.getDecision_date();
+        Instant decisionDate = ri.getDecision_date();
         if (null != decisionDate) {
             throw new UnprocessableEntityException("Request was "
                     + (ri.isAccept_request() ? "granted" : "denied")
@@ -254,7 +254,7 @@ public class RequestItemRepository
         if (responseSubjectNode != null && !responseSubjectNode.isNull()) {
             subject = responseSubjectNode.asText();
         }
-        ri.setDecision_date(new Date());
+        ri.setDecision_date(Instant.now());
         requestItemService.update(context, ri);
 
         // Send the response email

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RequestItemRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RequestItemRepository.java
@@ -78,6 +78,9 @@ public class RequestItemRepository
     @Autowired(required = true)
     protected RequestItemEmailNotifier requestItemEmailNotifier;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     /*
      * DSpaceRestRepository
      */
@@ -106,7 +109,6 @@ public class RequestItemRepository
         HttpServletRequest req = getRequestService()
                 .getCurrentRequest()
                 .getHttpServletRequest();
-        ObjectMapper mapper = new ObjectMapper();
         RequestItemRest rir;
         try {
             rir = mapper.readValue(req.getInputStream(), RequestItemRest.class);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ResourcePolicyRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ResourcePolicyRestRepository.java
@@ -76,6 +76,9 @@ public class ResourcePolicyRestRepository extends DSpaceRestRepository<ResourceP
     @Autowired
     DiscoverableEndpointsService discoverableEndpointsService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     @Override
     @PreAuthorize("hasPermission(#id, 'resourcepolicy', 'READ')")
     public ResourcePolicyRest findOne(Context context, Integer id) {
@@ -238,7 +241,6 @@ public class ResourcePolicyRestRepository extends DSpaceRestRepository<ResourceP
         }
 
         HttpServletRequest req = getRequestService().getCurrentRequest().getHttpServletRequest();
-        ObjectMapper mapper = new ObjectMapper();
         ResourcePolicyRest resourcePolicyRest = null;
         ResourcePolicy resourcePolicy = null;
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ScriptRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ScriptRestRepository.java
@@ -57,6 +57,9 @@ public class ScriptRestRepository extends DSpaceRestRepository<ScriptRest, Strin
     @Autowired
     private DSpaceRunnableParameterConverter dSpaceRunnableParameterConverter;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     @Override
     // authorization is verified inside the method
     @PreAuthorize("hasAuthority('AUTHENTICATED')")
@@ -123,9 +126,8 @@ public class ScriptRestRepository extends DSpaceRestRepository<ScriptRest, Strin
     private List<DSpaceCommandLineParameter> processPropertiesToDSpaceCommandLineParameters(String propertiesJson)
         throws IOException {
         List<ParameterValueRest> parameterValueRestList = new LinkedList<>();
-        ObjectMapper objectMapper = new ObjectMapper();
         if (StringUtils.isNotBlank(propertiesJson)) {
-            parameterValueRestList = Arrays.asList(objectMapper.readValue(propertiesJson, ParameterValueRest[].class));
+            parameterValueRestList = Arrays.asList(mapper.readValue(propertiesJson, ParameterValueRest[].class));
         }
 
         List<DSpaceCommandLineParameter> dSpaceCommandLineParameters = new LinkedList<>();

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/SearchEventRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/SearchEventRestRepository.java
@@ -34,12 +34,14 @@ public class SearchEventRestRepository extends AbstractDSpaceRestRepository {
     @Autowired
     private SearchEventConverter searchEventConverter;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     public SearchEventRest createSearchEvent() {
 
         Context context = obtainContext();
         HttpServletRequest req = getRequestService().getCurrentRequest().getHttpServletRequest();
 
-        ObjectMapper mapper = new ObjectMapper();
         SearchEventRest searchEventRest = null;
         try {
             ServletInputStream input = req.getInputStream();

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/SubmissionUploadRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/SubmissionUploadRestRepository.java
@@ -8,9 +8,10 @@
 package org.dspace.app.rest.repository;
 
 import java.text.ParseException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Date;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
@@ -95,18 +96,18 @@ public class SubmissionUploadRestRepository extends DSpaceRestRepository<Submiss
             optionRest.setHasEndDate(option.getHasEndDate());
             if (StringUtils.isNotBlank(option.getStartDateLimit())) {
                 try {
-                    Date requested = dateMathParser.parseMath(option.getStartDateLimit());
-                    optionRest.setMaxStartDate(TimeHelpers.toMidnightUTC(requested));
-                } catch (ParseException e) {
+                    LocalDateTime requested = dateMathParser.parseMath(option.getStartDateLimit());
+                    optionRest.setMaxStartDate(TimeHelpers.toMidnightUTC(requested).toLocalDate());
+                } catch (DateTimeParseException | ParseException e) {
                     throw new IllegalStateException("Wrong start date limit configuration for the access condition "
                             + "option named  " + option.getName());
                 }
             }
             if (StringUtils.isNotBlank(option.getEndDateLimit())) {
                 try {
-                    Date requested = dateMathParser.parseMath(option.getEndDateLimit());
-                    optionRest.setMaxEndDate(TimeHelpers.toMidnightUTC(requested));
-                } catch (ParseException e) {
+                    LocalDateTime requested = dateMathParser.parseMath(option.getEndDateLimit());
+                    optionRest.setMaxEndDate(TimeHelpers.toMidnightUTC(requested).toLocalDate());
+                } catch (DateTimeParseException | ParseException e) {
                     throw new IllegalStateException("Wrong end date limit configuration for the access condition "
                             + "option named  " + option.getName());
                 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/SubscriptionRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/SubscriptionRestRepository.java
@@ -79,6 +79,8 @@ public class SubscriptionRestRepository extends DSpaceRestRepository<Subscriptio
     private DiscoverableEndpointsService discoverableEndpointsService;
     @Autowired
     private SubscriptionEmailNotificationService subscriptionEmailNotificationService;
+    @Autowired
+    private ObjectMapper mapper;
 
     @Override
     @PreAuthorize("hasPermission(#id, 'subscription', 'READ')")
@@ -180,7 +182,7 @@ public class SubscriptionRestRepository extends DSpaceRestRepository<Subscriptio
             if (dSpaceObject.getType() == COMMUNITY || dSpaceObject.getType() == COLLECTION) {
                 Subscription subscription = null;
                 ServletInputStream input = req.getInputStream();
-                SubscriptionRest subscriptionRest = new ObjectMapper().readValue(input, SubscriptionRest.class);
+                SubscriptionRest subscriptionRest = mapper.readValue(input, SubscriptionRest.class);
                 List<SubscriptionParameterRest> subscriptionParameterList = subscriptionRest
                         .getSubscriptionParameterList();
                 if (CollectionUtils.isNotEmpty(subscriptionParameterList)) {
@@ -232,7 +234,7 @@ public class SubscriptionRestRepository extends DSpaceRestRepository<Subscriptio
 
         SubscriptionRest subscriptionRest;
         try {
-            subscriptionRest = new ObjectMapper().readValue(jsonNode.toString(), SubscriptionRest.class);
+            subscriptionRest = mapper.readValue(jsonNode.toString(), SubscriptionRest.class);
         } catch (IOException e) {
             throw new UnprocessableEntityException("Error parsing subscription json: " + e.getMessage(), e);
         }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/SystemWideAlertRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/SystemWideAlertRestRepository.java
@@ -51,6 +51,9 @@ public class SystemWideAlertRestRepository extends DSpaceRestRepository<SystemWi
     @Autowired
     private AuthorizeService authorizeService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     @Override
     @PreAuthorize("hasAuthority('ADMIN')")
     protected SystemWideAlertRest createAndReturn(Context context) throws SQLException, AuthorizeException {
@@ -110,7 +113,7 @@ public class SystemWideAlertRestRepository extends DSpaceRestRepository<SystemWi
 
         SystemWideAlertRest systemWideAlertRest;
         try {
-            systemWideAlertRest = new ObjectMapper().readValue(jsonNode.toString(), SystemWideAlertRest.class);
+            systemWideAlertRest = mapper.readValue(jsonNode.toString(), SystemWideAlertRest.class);
         } catch (JsonProcessingException e) {
             throw new UnprocessableEntityException("Cannot parse JSON in request body", e);
         }
@@ -153,7 +156,6 @@ public class SystemWideAlertRestRepository extends DSpaceRestRepository<SystemWi
 
 
         HttpServletRequest req = getRequestService().getCurrentRequest().getHttpServletRequest();
-        ObjectMapper mapper = new ObjectMapper();
         SystemWideAlertRest systemWideAlertRest;
         try {
             ServletInputStream input = req.getInputStream();

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/TemplateItemRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/TemplateItemRestRepository.java
@@ -49,6 +49,9 @@ public class TemplateItemRestRepository extends DSpaceRestRepository<TemplateIte
     @Autowired
     ResourcePatch<Item> resourcePatch;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     @Override
     @PreAuthorize("permitAll()")
     public TemplateItemRest findOne(Context context, UUID uuid) {
@@ -90,7 +93,6 @@ public class TemplateItemRestRepository extends DSpaceRestRepository<TemplateIte
      */
     public TemplateItemRest patchTemplateItem(TemplateItem templateItem, JsonNode jsonNode)
         throws SQLException, AuthorizeException {
-        ObjectMapper mapper = new ObjectMapper();
         JsonPatchConverter patchConverter = new JsonPatchConverter(mapper);
         Patch patch = patchConverter.convert(jsonNode);
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ViewEventRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ViewEventRestRepository.java
@@ -37,13 +37,15 @@ public class ViewEventRestRepository extends AbstractDSpaceRestRepository {
     @Autowired
     private EventService eventService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     private final List<String> typeList = Arrays.asList(Constants.typeText);
 
     public ViewEventRest createViewEvent() throws AuthorizeException, SQLException {
 
         Context context = obtainContext();
         HttpServletRequest req = getRequestService().getCurrentRequest().getHttpServletRequest();
-        ObjectMapper mapper = new ObjectMapper();
         ViewEventRest viewEventRest = null;
         try {
             ServletInputStream input = req.getInputStream();

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataPatchUtils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataPatchUtils.java
@@ -31,7 +31,8 @@ import org.springframework.stereotype.Component;
 @Component
 public final class DSpaceObjectMetadataPatchUtils {
 
-    private ObjectMapper objectMapper = new ObjectMapper();
+    @Autowired
+    private ObjectMapper mapper;
 
     @Autowired
     private MetadataFieldService metadataFieldService;
@@ -56,9 +57,9 @@ public final class DSpaceObjectMetadataPatchUtils {
                 if (operation.getValue() instanceof JsonValueEvaluator) {
                     JsonNode valueNode = ((JsonValueEvaluator) operation.getValue()).getValueNode();
                     if (valueNode.isArray()) {
-                        metadataValue = objectMapper.treeToValue(valueNode.get(0), MetadataValueRest.class);
+                        metadataValue = mapper.treeToValue(valueNode.get(0), MetadataValueRest.class);
                     } else {
-                        metadataValue = objectMapper.treeToValue(valueNode, MetadataValueRest.class);
+                        metadataValue = mapper.treeToValue(valueNode, MetadataValueRest.class);
                     }
                 }
                 if (operation.getValue() instanceof String) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/ldn/NotifyServicePatchUtils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/ldn/NotifyServicePatchUtils.java
@@ -19,6 +19,7 @@ import org.dspace.app.ldn.NotifyServiceInboundPattern;
 import org.dspace.app.rest.exception.DSpaceBadRequestException;
 import org.dspace.app.rest.model.patch.JsonValueEvaluator;
 import org.dspace.app.rest.model.patch.Operation;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /**
@@ -30,7 +31,8 @@ public final class NotifyServicePatchUtils {
 
     public static final String NOTIFY_SERVICE_INBOUND_PATTERNS = "notifyServiceInboundPatterns";
 
-    private ObjectMapper objectMapper = new ObjectMapper();
+    @Autowired
+    private ObjectMapper mapper;
 
     private NotifyServicePatchUtils() {
     }
@@ -47,10 +49,10 @@ public final class NotifyServicePatchUtils {
         try {
             if (operation.getValue() != null) {
                 if (operation.getValue() instanceof JsonValueEvaluator) {
-                    inboundPattern = objectMapper.readValue(((JsonValueEvaluator) operation.getValue())
+                    inboundPattern = mapper.readValue(((JsonValueEvaluator) operation.getValue())
                             .getValueNode().toString(), NotifyServiceInboundPattern.class);
                 } else if (operation.getValue() instanceof String) {
-                    inboundPattern = objectMapper.readValue((String) operation.getValue(),
+                    inboundPattern = mapper.readValue((String) operation.getValue(),
                         NotifyServiceInboundPattern.class);
                 }
             }
@@ -76,8 +78,8 @@ public final class NotifyServicePatchUtils {
         try {
             if (operation.getValue() != null) {
                 if (operation.getValue() instanceof String) {
-                    inboundPatterns = objectMapper.readValue((String) operation.getValue(),
-                        objectMapper.getTypeFactory().constructCollectionType(ArrayList.class,
+                    inboundPatterns = mapper.readValue((String) operation.getValue(),
+                        mapper.getTypeFactory().constructCollectionType(ArrayList.class,
                             NotifyServiceInboundPattern.class));
                 }
             }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/resourcePolicy/ResourcePolicyEndDateAddOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/resourcePolicy/ResourcePolicyEndDateAddOperation.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.app.rest.repository.patch.operation.resourcePolicy;
 
-import java.util.Date;
+import java.time.ZonedDateTime;
 
 import org.dspace.app.rest.exception.DSpaceBadRequestException;
 import org.dspace.app.rest.model.patch.Operation;
@@ -58,8 +58,8 @@ public class ResourcePolicyEndDateAddOperation<R> extends PatchOperation<R> {
      */
     private void add(ResourcePolicy resourcePolicy, Operation operation) {
         String dateS = (String) operation.getValue();
-        Date date = MultiFormatDateParser.parse(dateS);
-        resourcePolicy.setEndDate(date);
+        ZonedDateTime date = MultiFormatDateParser.parse(dateS);
+        resourcePolicy.setEndDate(date.toLocalDate());
         if (date == null) {
             throw new DSpaceBadRequestException("Invalid endDate value " + dateS);
         }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/resourcePolicy/ResourcePolicyEndDateReplaceOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/resourcePolicy/ResourcePolicyEndDateReplaceOperation.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.app.rest.repository.patch.operation.resourcePolicy;
 
-import java.util.Date;
+import java.time.ZonedDateTime;
 
 import org.dspace.app.rest.exception.DSpaceBadRequestException;
 import org.dspace.app.rest.model.patch.Operation;
@@ -58,11 +58,11 @@ public class ResourcePolicyEndDateReplaceOperation<R> extends PatchOperation<R> 
      */
     private void replace(ResourcePolicy resourcePolicy, Operation operation) {
         String dateS = (String) operation.getValue();
-        Date date = MultiFormatDateParser.parse(dateS);
+        ZonedDateTime date = MultiFormatDateParser.parse(dateS);
         if (date == null) {
             throw new DSpaceBadRequestException("Invalid endDate value " + dateS);
         }
-        resourcePolicy.setEndDate(date);
+        resourcePolicy.setEndDate(date.toLocalDate());
     }
 
     @Override

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/resourcePolicy/ResourcePolicyStartDateAddOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/resourcePolicy/ResourcePolicyStartDateAddOperation.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.app.rest.repository.patch.operation.resourcePolicy;
 
-import java.util.Date;
+import java.time.ZonedDateTime;
 
 import org.dspace.app.rest.exception.DSpaceBadRequestException;
 import org.dspace.app.rest.model.patch.Operation;
@@ -59,11 +59,11 @@ public class ResourcePolicyStartDateAddOperation<R> extends PatchOperation<R> {
      */
     private void add(ResourcePolicy resourcePolicy, Operation operation) {
         String dateS = (String) operation.getValue();
-        Date date = MultiFormatDateParser.parse(dateS);
+        ZonedDateTime date = MultiFormatDateParser.parse(dateS);
         if (date == null) {
             throw new DSpaceBadRequestException("Invalid startDate value " + dateS);
         }
-        resourcePolicy.setStartDate(date);
+        resourcePolicy.setStartDate(date.toLocalDate());
     }
 
     @Override

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/resourcePolicy/ResourcePolicyStartDateReplaceOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/resourcePolicy/ResourcePolicyStartDateReplaceOperation.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.app.rest.repository.patch.operation.resourcePolicy;
 
-import java.util.Date;
+import java.time.ZonedDateTime;
 
 import org.dspace.app.rest.exception.DSpaceBadRequestException;
 import org.dspace.app.rest.model.patch.Operation;
@@ -58,11 +58,11 @@ public class ResourcePolicyStartDateReplaceOperation<R> extends PatchOperation<R
      */
     private void replace(ResourcePolicy resourcePolicy, Operation operation) {
         String dateS = (String) operation.getValue();
-        Date date = MultiFormatDateParser.parse(dateS);
+        ZonedDateTime date = MultiFormatDateParser.parse(dateS);
         if (date == null) {
             throw new DSpaceBadRequestException("Invalid startDate value " + dateS);
         }
-        resourcePolicy.setStartDate(date);
+        resourcePolicy.setStartDate(date.toLocalDate());
     }
 
     @Override

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/resourcePolicy/ResourcePolicyUtils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/resourcePolicy/ResourcePolicyUtils.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.app.rest.repository.patch.operation.resourcePolicy;
 
-import java.util.Date;
+import java.time.ZonedDateTime;
 
 import org.dspace.app.rest.exception.DSpaceBadRequestException;
 import org.dspace.app.rest.model.patch.Operation;
@@ -109,11 +109,11 @@ public class ResourcePolicyUtils {
      */
     public void checkResourcePolicyForConsistentStartDateValue(ResourcePolicy resource, Operation operation) {
         String dateS = (String) operation.getValue();
-        Date date = MultiFormatDateParser.parse(dateS);
+        ZonedDateTime date = MultiFormatDateParser.parse(dateS);
         if (date == null) {
             throw new DSpaceBadRequestException("Invalid startDate value " + dateS);
         }
-        if (resource.getEndDate() != null && resource.getEndDate().before(date)) {
+        if (resource.getEndDate() != null && resource.getEndDate().isBefore(date.toLocalDate())) {
             throw new DSpaceBadRequestException("Attempting to set an invalid startDate greater than the endDate.");
         }
     }
@@ -130,11 +130,11 @@ public class ResourcePolicyUtils {
      */
     public void checkResourcePolicyForConsistentEndDateValue(ResourcePolicy resource, Operation operation) {
         String dateS = (String) operation.getValue();
-        Date date = MultiFormatDateParser.parse(dateS);
+        ZonedDateTime date = MultiFormatDateParser.parse(dateS);
         if (date == null) {
             throw new DSpaceBadRequestException("Invalid endDate value " + dateS);
         }
-        if (resource.getStartDate() != null && resource.getStartDate().after(date)) {
+        if (resource.getStartDate() != null && resource.getStartDate().isAfter(date.toLocalDate())) {
             throw new DSpaceBadRequestException("Attempting to set an invalid endDate smaller than the startDate.");
         }
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/DSpaceAuthentication.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/DSpaceAuthentication.java
@@ -7,8 +7,8 @@
  */
 package org.dspace.app.rest.security;
 
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import java.util.List;
 
 import org.dspace.eperson.EPerson;
@@ -24,7 +24,7 @@ import org.springframework.security.core.GrantedAuthority;
 public class DSpaceAuthentication implements Authentication {
 
 
-    private Date previousLoginDate;
+    private Instant previousLoginDate;
     private String username;
     private String password;
     private List<GrantedAuthority> authorities;
@@ -99,7 +99,7 @@ public class DSpaceAuthentication implements Authentication {
         return username;
     }
 
-    public Date getPreviousLoginDate() {
+    public Instant getPreviousLoginDate() {
         return previousLoginDate;
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/jwt/ShortLivedJWTTokenHandler.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/jwt/ShortLivedJWTTokenHandler.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.app.rest.security.jwt;
 
-import java.util.Date;
+import java.time.Instant;
 
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSVerifier;
@@ -48,11 +48,11 @@ public class ShortLivedJWTTokenHandler extends JWTTokenHandler {
             JWSVerifier verifier = new MACVerifier(buildSigningKey(ePerson));
 
             //If token is valid and not expired return eperson in token
-            Date expirationTime = jwtClaimsSet.getExpirationTime();
+            java.util.Date expirationTime = jwtClaimsSet.getExpirationTime();
             return signedJWT.verify(verifier)
                 && expirationTime != null
                 //Ensure expiration timestamp is after the current time
-                && DateUtils.isAfter(expirationTime, new Date(), 0);
+                && DateUtils.isAfter(expirationTime, java.util.Date.from(Instant.now()), 0);
         }
     }
 
@@ -63,7 +63,7 @@ public class ShortLivedJWTTokenHandler extends JWTTokenHandler {
      * @return EPerson object of current user, with an updated session salt
      */
     @Override
-    protected EPerson updateSessionSalt(final Context context, final Date previousLoginDate) {
+    protected EPerson updateSessionSalt(final Context context, final Instant previousLoginDate) {
         return context.getCurrentUser();
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/AccessConditionAddPatchOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/AccessConditionAddPatchOperation.java
@@ -7,17 +7,14 @@
  */
 package org.dspace.app.rest.submit.factory.impl;
 
-import java.sql.SQLException;
-import java.text.ParseException;
+import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 import jakarta.servlet.http.HttpServletRequest;
 import org.dspace.app.rest.exception.UnprocessableEntityException;
 import org.dspace.app.rest.model.AccessConditionDTO;
 import org.dspace.app.rest.model.patch.LateObjectEvaluator;
-import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.ResourcePolicy;
 import org.dspace.authorize.service.ResourcePolicyService;
 import org.dspace.content.InProgressSubmission;
@@ -25,7 +22,6 @@ import org.dspace.content.Item;
 import org.dspace.core.Context;
 import org.dspace.submit.model.AccessConditionConfiguration;
 import org.dspace.submit.model.AccessConditionConfigurationService;
-import org.dspace.util.TimeHelpers;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -57,13 +53,13 @@ public class AccessConditionAddPatchOperation extends AddPatchOperation<AccessCo
 
         // Clamp access condition dates to midnight UTC
         for (AccessConditionDTO condition : accessConditions) {
-            Date date = condition.getStartDate();
+            LocalDate date = condition.getStartDate();
             if (null != date) {
-                condition.setStartDate(TimeHelpers.toMidnightUTC(date));
+                condition.setStartDate(date);
             }
             date = condition.getEndDate();
             if (null != date) {
-                condition.setEndDate(TimeHelpers.toMidnightUTC(date));
+                condition.setEndDate(date);
             }
         }
 
@@ -92,7 +88,7 @@ public class AccessConditionAddPatchOperation extends AddPatchOperation<AccessCo
     }
 
     private void verifyAccessConditions(Context context, AccessConditionConfiguration configuration,
-            List<AccessConditionDTO> accessConditions) throws SQLException, AuthorizeException, ParseException {
+            List<AccessConditionDTO> accessConditions) {
         for (AccessConditionDTO dto : accessConditions) {
             AccessConditionResourcePolicyUtils.canApplyResourcePolicy(context, configuration.getOptions(),
                     dto.getName(), dto.getStartDate(), dto.getEndDate());

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/AccessConditionReplacePatchOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/AccessConditionReplacePatchOperation.java
@@ -8,10 +8,10 @@
 package org.dspace.app.rest.submit.factory.impl;
 
 import java.sql.SQLException;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 
@@ -32,7 +32,6 @@ import org.dspace.core.Context;
 import org.dspace.submit.model.AccessConditionConfiguration;
 import org.dspace.submit.model.AccessConditionConfigurationService;
 import org.dspace.submit.model.AccessConditionOption;
-import org.dspace.util.TimeHelpers;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -108,8 +107,7 @@ public class AccessConditionReplacePatchOperation extends ReplacePatchOperation<
         return null;
     }
 
-    private AccessConditionDTO createDTO(ResourcePolicy rpToReplace, String attributeReplace, String valueToReplace)
-            throws ParseException {
+    private AccessConditionDTO createDTO(ResourcePolicy rpToReplace, String attributeReplace, String valueToReplace) {
         AccessConditionDTO accessCondition = new AccessConditionDTO();
         accessCondition.setName(rpToReplace.getRpName());
         accessCondition.setStartDate(rpToReplace.getStartDate());
@@ -119,10 +117,10 @@ public class AccessConditionReplacePatchOperation extends ReplacePatchOperation<
                 accessCondition.setName(valueToReplace);
                 return accessCondition;
             case "startDate":
-                accessCondition.setStartDate(TimeHelpers.toMidnightUTC(parseDate(valueToReplace)));
+                accessCondition.setStartDate(parseDate(valueToReplace));
                 return accessCondition;
             case "endDate":
-                accessCondition.setEndDate(TimeHelpers.toMidnightUTC(parseDate(valueToReplace)));
+                accessCondition.setEndDate(parseDate(valueToReplace));
                 return accessCondition;
             default:
                 throw new UnprocessableEntityException("The provided attribute: "
@@ -137,26 +135,26 @@ public class AccessConditionReplacePatchOperation extends ReplacePatchOperation<
                 rpToReplace.setRpName(valueToReplace);
                 break;
             case "startDate":
-                rpToReplace.setStartDate(TimeHelpers.toMidnightUTC(parseDate(valueToReplace)));
+                rpToReplace.setStartDate(parseDate(valueToReplace));
                 break;
             case "endDate":
-                rpToReplace.setEndDate(TimeHelpers.toMidnightUTC(parseDate(valueToReplace)));
+                rpToReplace.setEndDate(parseDate(valueToReplace));
                 break;
             default:
                 throw new IllegalArgumentException("Attribute to replace is not valid:" + attributeReplace);
         }
     }
 
-    private Date parseDate(String date) {
-        List<SimpleDateFormat> knownPatterns = Arrays.asList(
-                                new SimpleDateFormat("yyyy-MM-dd"),
-                                new SimpleDateFormat("dd-MM-yyyy"),
-                                new SimpleDateFormat("yyyy/MM/dd"),
-                                new SimpleDateFormat("dd/MM/yyyy"));
-        for (SimpleDateFormat pattern : knownPatterns) {
+    private LocalDate parseDate(String date) {
+        List<DateTimeFormatter> knownPatterns = Arrays.asList(
+                                DateTimeFormatter.ISO_LOCAL_DATE,
+                                DateTimeFormatter.ofPattern("dd-MM-yyyy"),
+                                DateTimeFormatter.ofPattern("yyyy/MM/dd"),
+                                DateTimeFormatter.ofPattern("dd/MM/yyyy"));
+        for (DateTimeFormatter pattern : knownPatterns) {
             try {
-                return pattern.parse(date);
-            } catch (ParseException e) {
+                return LocalDate.parse(date, pattern);
+            } catch (DateTimeParseException e) {
                 log.error(e::getMessage, e);
             }
         }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/AccessConditionResourcePolicyUtils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/AccessConditionResourcePolicyUtils.java
@@ -8,7 +8,7 @@
 package org.dspace.app.rest.submit.factory.impl;
 import java.sql.SQLException;
 import java.text.ParseException;
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.List;
 
 import org.dspace.app.rest.exception.UnprocessableEntityException;
@@ -47,8 +47,8 @@ public class AccessConditionResourcePolicyUtils {
             String name = newAccessCondition.getName();
             String description = newAccessCondition.getDescription();
 
-            Date startDate = newAccessCondition.getStartDate();
-            Date endDate = newAccessCondition.getEndDate();
+            LocalDate startDate = newAccessCondition.getStartDate();
+            LocalDate endDate = newAccessCondition.getEndDate();
 
             findApplyResourcePolicy(context, accessConditionOptions, obj, name, description, startDate, endDate);
         }
@@ -72,8 +72,9 @@ public class AccessConditionResourcePolicyUtils {
      * @throws ParseException           if parser error
      */
     public static void findApplyResourcePolicy(Context context,
-            List<AccessConditionOption> accessConditionOptions, DSpaceObject obj, String name,
-            String description, Date startDate, Date endDate) throws SQLException, AuthorizeException, ParseException {
+                                               List<AccessConditionOption> accessConditionOptions, DSpaceObject obj,
+                                               String name, String description, LocalDate startDate, LocalDate endDate)
+        throws SQLException, AuthorizeException, ParseException {
         boolean found = false;
         for (AccessConditionOption accessConditionOption : accessConditionOptions) {
             if (!found && accessConditionOption.getName().equalsIgnoreCase(name)) {
@@ -100,7 +101,7 @@ public class AccessConditionResourcePolicyUtils {
      * @throws ParseException          if parser error
      */
     public static void canApplyResourcePolicy(Context context, List<AccessConditionOption> accessConditionOptions,
-            String name, Date startDate, Date endDate) throws SQLException, AuthorizeException, ParseException {
+                                              String name, LocalDate startDate, LocalDate endDate) {
         boolean found = false;
         for (AccessConditionOption ac : accessConditionOptions) {
             if (ac.getName().equalsIgnoreCase(name)) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/BitstreamResourcePolicyReplacePatchOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/BitstreamResourcePolicyReplacePatchOperation.java
@@ -7,8 +7,8 @@
  */
 package org.dspace.app.rest.submit.factory.impl;
 
+import java.time.LocalDate;
 import java.util.Collection;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 
@@ -84,8 +84,8 @@ public class BitstreamResourcePolicyReplacePatchOperation extends ReplacePatchOp
 
                             String name = newAccessCondition.getName();
                             String description = newAccessCondition.getDescription();
-                            Date startDate = newAccessCondition.getStartDate();
-                            Date endDate = newAccessCondition.getEndDate();
+                            LocalDate startDate = newAccessCondition.getStartDate();
+                            LocalDate endDate = newAccessCondition.getEndDate();
                             // TODO manage duplicate policy
                             BitstreamResourcePolicyUtils.findApplyResourcePolicy(context, uploadConfigs.next(), b, name,
                                     description, startDate, endDate);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/BitstreamResourcePolicyUtils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/BitstreamResourcePolicyUtils.java
@@ -9,7 +9,7 @@ package org.dspace.app.rest.submit.factory.impl;
 
 import java.sql.SQLException;
 import java.text.ParseException;
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.List;
 
 import org.dspace.app.rest.exception.UnprocessableEntityException;
@@ -51,8 +51,8 @@ public class BitstreamResourcePolicyUtils {
             String name = newAccessCondition.getName();
             String description = newAccessCondition.getDescription();
 
-            Date startDate = newAccessCondition.getStartDate();
-            Date endDate = newAccessCondition.getEndDate();
+            LocalDate startDate = newAccessCondition.getStartDate();
+            LocalDate endDate = newAccessCondition.getEndDate();
 
             findApplyResourcePolicy(context, uploadConfiguration, obj, name, description, startDate, endDate);
         }
@@ -75,8 +75,8 @@ public class BitstreamResourcePolicyUtils {
      * @throws ParseException       If parse error
      */
     public static void findApplyResourcePolicy(Context context, UploadConfiguration uploadConfiguration,
-            DSpaceObject obj, String name, String description,
-                                               Date startDate, Date endDate)
+                                               DSpaceObject obj, String name, String description,
+                                               LocalDate startDate, LocalDate endDate)
             throws SQLException, AuthorizeException, ParseException {
         boolean found = false;
         for (AccessConditionOption aco : uploadConfiguration.getOptions()) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/HttpHeadersInitializer.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/HttpHeadersInitializer.java
@@ -12,6 +12,7 @@ import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Objects;
@@ -149,7 +150,7 @@ public class HttpHeadersInitializer {
         }
         httpHeaders.put(LAST_MODIFIED, Collections.singletonList(FastHttpDateFormat.formatDate(lastModified)));
         httpHeaders.put(EXPIRES, Collections.singletonList(FastHttpDateFormat.formatDate(
-            System.currentTimeMillis() + DEFAULT_EXPIRE_TIME)));
+            Instant.now().toEpochMilli() + DEFAULT_EXPIRE_TIME)));
 
         //No-cache so that we can log every download
         httpHeaders.put(CACHE_CONTROL, Collections.singletonList(CACHE_CONTROL_SETTING));

--- a/dspace-server-webapp/src/test/java/org/dspace/app/bulkaccesscontrol/BulkAccessControlScriptIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/bulkaccesscontrol/BulkAccessControlScriptIT.java
@@ -67,6 +67,9 @@ public class BulkAccessControlScriptIT extends AbstractEntityIntegrationTest {
     @Autowired
     private ProcessService processService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     private final static String SCRIPTS_ENDPOINT = "/api/" + ScriptRest.CATEGORY + "/" + ScriptRest.PLURAL_NAME;
     private final static String CURATE_SCRIPT_ENDPOINT = SCRIPTS_ENDPOINT + "/bulk-access-control/" +
         ProcessRest.PLURAL_NAME;
@@ -140,7 +143,7 @@ public class BulkAccessControlScriptIT extends AbstractEntityIntegrationTest {
                 .perform(
                     multipart(CURATE_SCRIPT_ENDPOINT)
                         .file(bitstreamFile)
-                        .param("properties", new ObjectMapper().writeValueAsString(list)))
+                        .param("properties", mapper.writeValueAsString(list)))
                 .andExpect(status().isAccepted())
                 .andDo(result -> idRef.set(read(result.getResponse().getContentAsString(), "$.processId")));
         } finally {
@@ -194,7 +197,7 @@ public class BulkAccessControlScriptIT extends AbstractEntityIntegrationTest {
                 .perform(
                     multipart(CURATE_SCRIPT_ENDPOINT)
                         .file(bitstreamFile)
-                        .param("properties", new ObjectMapper().writeValueAsString(list)))
+                        .param("properties", mapper.writeValueAsString(list)))
                 .andExpect(status().isAccepted())
                 .andDo(result -> idRef.set(read(result.getResponse().getContentAsString(), "$.processId")));
         } finally {
@@ -256,7 +259,7 @@ public class BulkAccessControlScriptIT extends AbstractEntityIntegrationTest {
                 .perform(
                     multipart(CURATE_SCRIPT_ENDPOINT)
                         .file(bitstreamFile)
-                        .param("properties", new ObjectMapper().writeValueAsString(list)))
+                        .param("properties", mapper.writeValueAsString(list)))
                 .andExpect(status().isAccepted())
                 .andDo(result -> idRef.set(read(result.getResponse().getContentAsString(), "$.processId")));
         } finally {
@@ -323,7 +326,7 @@ public class BulkAccessControlScriptIT extends AbstractEntityIntegrationTest {
                 .perform(
                     multipart(CURATE_SCRIPT_ENDPOINT)
                         .file(bitstreamFile)
-                        .param("properties", new ObjectMapper().writeValueAsString(list)))
+                        .param("properties", mapper.writeValueAsString(list)))
                 .andExpect(status().isAccepted())
                 .andDo(result -> idRef.set(read(result.getResponse().getContentAsString(), "$.processId")));
         } finally {
@@ -398,7 +401,7 @@ public class BulkAccessControlScriptIT extends AbstractEntityIntegrationTest {
                 .perform(
                     multipart(CURATE_SCRIPT_ENDPOINT)
                         .file(bitstreamFile)
-                        .param("properties", new ObjectMapper().writeValueAsString(list)))
+                        .param("properties", mapper.writeValueAsString(list)))
                 .andExpect(status().isAccepted())
                 .andDo(result -> idRef.set(read(result.getResponse().getContentAsString(), "$.processId")));
 
@@ -445,7 +448,7 @@ public class BulkAccessControlScriptIT extends AbstractEntityIntegrationTest {
         getClient(token)
             .perform(
                 multipart(CURATE_SCRIPT_ENDPOINT)
-                    .param("properties", new ObjectMapper().writeValueAsString(List.of()))
+                    .param("properties", mapper.writeValueAsString(List.of()))
             )
             .andExpect(status().isInternalServerError())
             .andExpect(result -> assertTrue(result.getResolvedException()
@@ -495,7 +498,7 @@ public class BulkAccessControlScriptIT extends AbstractEntityIntegrationTest {
             .perform(
                 multipart(CURATE_SCRIPT_ENDPOINT)
                     .file(bitstreamFile)
-                    .param("properties", new ObjectMapper().writeValueAsString(list)))
+                    .param("properties", mapper.writeValueAsString(list)))
             .andExpect(status().isForbidden());
     }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/itemexport/ItemExportIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/itemexport/ItemExportIT.java
@@ -76,6 +76,8 @@ public class ItemExportIT extends AbstractControllerIntegrationTest {
     private ProcessService processService;
     @Autowired
     private DSpaceRunnableParameterConverter dSpaceRunnableParameterConverter;
+    @Autowired
+    private ObjectMapper mapper;
     private Collection collection;
     private Path workDir;
 
@@ -327,7 +329,7 @@ public class ItemExportIT extends AbstractControllerIntegrationTest {
 
             getClient(token)
                 .perform(multipart("/api/system/scripts/export/processes")
-                        .param("properties", new ObjectMapper().writeValueAsString(list)))
+                        .param("properties", mapper.writeValueAsString(list)))
                 .andExpect(status().isAccepted())
                 .andExpect(jsonPath("$", is(
                         ProcessMatcher.matchProcess("export",

--- a/dspace-server-webapp/src/test/java/org/dspace/app/itemimport/ItemImportIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/itemimport/ItemImportIT.java
@@ -81,6 +81,9 @@ public class ItemImportIT extends AbstractEntityIntegrationTest {
     private ProcessService processService;
     @Autowired
     private DSpaceRunnableParameterConverter dSpaceRunnableParameterConverter;
+    @Autowired
+    private ObjectMapper mapper;
+
     private Collection collection;
     private Path workDir;
     private static final String TEMP_DIR = ItemImport.TEMP_DIR;
@@ -232,7 +235,7 @@ public class ItemImportIT extends AbstractEntityIntegrationTest {
             getClient(getAuthToken(admin.getEmail(), password))
                 .perform(multipart("/api/system/scripts/import/processes")
                         .file(bitstreamFile)
-                        .param("properties", new ObjectMapper().writeValueAsString(list)))
+                        .param("properties", mapper.writeValueAsString(list)))
                 .andExpect(status().isAccepted())
                 .andExpect(jsonPath("$", is(
                         ProcessMatcher.matchProcess("import",

--- a/dspace-server-webapp/src/test/java/org/dspace/app/oai/OAIpmhIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/oai/OAIpmhIT.java
@@ -19,8 +19,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.xpath;
 
-import java.util.Calendar;
-import java.util.Date;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 
 import com.lyncode.xoai.dataprovider.core.XOAIManager;
 import com.lyncode.xoai.dataprovider.exceptions.ConfigurationException;
@@ -28,7 +28,6 @@ import com.lyncode.xoai.dataprovider.services.api.ResourceResolver;
 import com.lyncode.xoai.dataprovider.services.impl.BaseDateProvider;
 import com.lyncode.xoai.dataprovider.xml.xoaiconfig.Configuration;
 import com.lyncode.xoai.dataprovider.xml.xoaiconfig.ContextConfiguration;
-import org.apache.commons.lang3.time.DateUtils;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
 import org.dspace.builder.CollectionBuilder;
 import org.dspace.builder.CommunityBuilder;
@@ -144,8 +143,7 @@ public class OAIpmhIT extends AbstractControllerIntegrationTest {
     public void requestForIdentifyShouldReturnTheConfiguredValues() throws Exception {
 
         // Get current date/time and store as "now", then round to nearest second (as OAI-PMH ignores milliseconds)
-        Date now = new Date();
-        Date nowToNearestSecond = DateUtils.round(now, Calendar.SECOND);
+        Instant nowToNearestSecond = Instant.now().truncatedTo(ChronoUnit.SECONDS);
         // Return "nowToNearestSecond" when "getEarliestDate()" is called for currently loaded EarliestDateResolver bean
         doReturn(nowToNearestSecond).when(earliestDateResolver).getEarliestDate(any());
 
@@ -170,7 +168,7 @@ public class OAIpmhIT extends AbstractControllerIntegrationTest {
                                   .string(configurationService.getProperty("oai.url") + "/" + DEFAULT_CONTEXT_PATH))
                    // Expect earliestDatestamp to be "now", i.e. current date, (as mocked above)
                    .andExpect(xpath("OAI-PMH/Identify/earliestDatestamp")
-                                  .string(baseDateProvider.format(nowToNearestSecond)))
+                                  .string(baseDateProvider.format(java.util.Date.from(nowToNearestSecond))))
         ;
     }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/AuthenticationRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/AuthenticationRestControllerIT.java
@@ -110,6 +110,9 @@ public class AuthenticationRestControllerIT extends AbstractControllerIntegratio
     @Autowired
     private Utils utils;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     public static final String[] PASS_ONLY = {"org.dspace.authenticate.PasswordAuthentication"};
     public static final String[] SHIB_ONLY = {"org.dspace.authenticate.ShibAuthentication"};
     public static final String[] ORCID_ONLY = { "org.dspace.authenticate.OrcidAuthentication" };
@@ -1708,8 +1711,6 @@ public class AuthenticationRestControllerIT extends AbstractControllerIntegratio
 
     // Get a short-lived token based on an active login token
     private String getShortLivedToken(String loginToken) throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-
         MvcResult mvcResult = getClient(loginToken).perform(post("/api/authn/shortlivedtokens"))
             .andReturn();
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamFormatRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamFormatRestRepositoryIT.java
@@ -56,6 +56,9 @@ public class BitstreamFormatRestRepositoryIT extends AbstractControllerIntegrati
     @Autowired
     private BitstreamFormatConverter bitstreamFormatConverter;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     private final int DEFAULT_AMOUNT_FORMATS = 86;
 
     @Test
@@ -135,7 +138,6 @@ public class BitstreamFormatRestRepositoryIT extends AbstractControllerIntegrati
 
     @Test
     public void createAdminAccess() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
         BitstreamFormatRest bitstreamFormatRest = this.createRandomMockBitstreamRest(false);
 
         //Create bitstream format
@@ -182,7 +184,6 @@ public class BitstreamFormatRestRepositoryIT extends AbstractControllerIntegrati
 
     @Test
     public void createNonValidSupportLevel() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
         BitstreamFormatRest bitstreamFormatRest = this.createRandomMockBitstreamRest(false);
         bitstreamFormatRest.setSupportLevel("NONVALID SUPPORT LVL");
         //Attempt to create bitstream with a non-valid support lvl
@@ -199,7 +200,6 @@ public class BitstreamFormatRestRepositoryIT extends AbstractControllerIntegrati
 
     @Test
     public void createNoAccess() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
         BitstreamFormatRest bitstreamFormatRest = this.createRandomMockBitstreamRest(false);
 
         //Try to create bitstreamFormat without auth token
@@ -215,7 +215,6 @@ public class BitstreamFormatRestRepositoryIT extends AbstractControllerIntegrati
 
     @Test
     public void createNonAdminAccess() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
         BitstreamFormatRest bitstreamFormatRest = this.createRandomMockBitstreamRest(false);
         context.turnOffAuthorisationSystem();
         EPerson user = EPersonBuilder.createEPerson(context)
@@ -239,7 +238,6 @@ public class BitstreamFormatRestRepositoryIT extends AbstractControllerIntegrati
 
     @Test
     public void createAlreadyExisting() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
         BitstreamFormatRest bitstreamFormatRest = this.createRandomMockBitstreamRest(true);
 
         // Capture the Id of the created BitstreamFormat (see andDo() below)
@@ -275,7 +273,6 @@ public class BitstreamFormatRestRepositoryIT extends AbstractControllerIntegrati
 
     @Test
     public void updateAdminAccess() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
         //Create bitstream format
         context.turnOffAuthorisationSystem();
         BitstreamFormat bitstreamFormat = BitstreamFormatBuilder.createBitstreamFormat(context)
@@ -306,7 +303,6 @@ public class BitstreamFormatRestRepositoryIT extends AbstractControllerIntegrati
 
     @Test
     public void updateNonValidSupportLevel() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
         //Create bitstream format
         context.turnOffAuthorisationSystem();
         BitstreamFormat bitstreamFormat = BitstreamFormatBuilder.createBitstreamFormat(context)
@@ -341,7 +337,6 @@ public class BitstreamFormatRestRepositoryIT extends AbstractControllerIntegrati
 
     @Test
     public void updateNonExistingIDInURLAndJSON() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
         //Create bitstream format
         context.turnOffAuthorisationSystem();
         BitstreamFormat bitstreamFormat = BitstreamFormatBuilder.createBitstreamFormat(context)
@@ -378,7 +373,6 @@ public class BitstreamFormatRestRepositoryIT extends AbstractControllerIntegrati
 
     @Test
     public void updateNonExistingIDInJustURL() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
         //Create bitstream format
         context.turnOffAuthorisationSystem();
         BitstreamFormat bitstreamFormat = BitstreamFormatBuilder.createBitstreamFormat(context)
@@ -414,7 +408,6 @@ public class BitstreamFormatRestRepositoryIT extends AbstractControllerIntegrati
 
     @Test
     public void updateNonExistingIDInJSONButValidInURL() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
         //Create bitstream format
         context.turnOffAuthorisationSystem();
         BitstreamFormat bitstreamFormat = BitstreamFormatBuilder
@@ -451,7 +444,6 @@ public class BitstreamFormatRestRepositoryIT extends AbstractControllerIntegrati
 
     @Test
     public void updateNotMatchingIDsInJSONAndURL() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
         //Create bitstream format
         context.turnOffAuthorisationSystem();
         BitstreamFormat bitstreamFormat1 = BitstreamFormatBuilder.createBitstreamFormat(context)
@@ -489,7 +481,6 @@ public class BitstreamFormatRestRepositoryIT extends AbstractControllerIntegrati
 
     @Test
     public void updateNoAccess() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
         //Create bitstream format
         context.turnOffAuthorisationSystem();
         BitstreamFormat bitstreamFormat = BitstreamFormatBuilder.createBitstreamFormat(context)
@@ -520,7 +511,6 @@ public class BitstreamFormatRestRepositoryIT extends AbstractControllerIntegrati
 
     @Test
     public void updateNonAdminAccess() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
         //Create bitstream format
         context.turnOffAuthorisationSystem();
         BitstreamFormat bitstreamFormat = BitstreamFormatBuilder.createBitstreamFormat(context)
@@ -547,7 +537,6 @@ public class BitstreamFormatRestRepositoryIT extends AbstractControllerIntegrati
 
     @Test
     public void deleteAdminAccess() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
         //Create bitstream format
         context.turnOffAuthorisationSystem();
         BitstreamFormat bitstreamFormat = BitstreamFormatBuilder.createBitstreamFormat(context)
@@ -568,7 +557,6 @@ public class BitstreamFormatRestRepositoryIT extends AbstractControllerIntegrati
 
     @Test
     public void deleteNonExistingID() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
         //Create bitstream format
         context.turnOffAuthorisationSystem();
         BitstreamFormat bitstreamFormat = BitstreamFormatBuilder.createBitstreamFormat(context)
@@ -587,7 +575,6 @@ public class BitstreamFormatRestRepositoryIT extends AbstractControllerIntegrati
 
     @Test
     public void deleteNoAccess() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
         //Create bitstream format
         context.turnOffAuthorisationSystem();
         BitstreamFormat bitstreamFormat = BitstreamFormatBuilder.createBitstreamFormat(context)
@@ -614,7 +601,6 @@ public class BitstreamFormatRestRepositoryIT extends AbstractControllerIntegrati
 
     @Test
     public void deleteNonAdminAccess() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
         //Create bitstream format
         context.turnOffAuthorisationSystem();
         BitstreamFormat bitstreamFormat = BitstreamFormatBuilder.createBitstreamFormat(context)

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestRepositoryIT.java
@@ -31,6 +31,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.ws.rs.core.MediaType;
 import org.apache.commons.codec.CharEncoding;
 import org.apache.commons.io.IOUtils;
@@ -99,6 +100,9 @@ public class BitstreamRestRepositoryIT extends AbstractControllerIntegrationTest
 
     @Autowired
     CommunityService communityService;
+
+    @Autowired
+    private ObjectMapper mapper;
 
     @Test
     public void findAllTest() throws Exception {
@@ -1244,7 +1248,7 @@ public class BitstreamRestRepositoryIT extends AbstractControllerIntegrationTest
         context.restoreAuthSystemState();
         String token = getAuthToken(asUser.getEmail(), password);
 
-        new MetadataPatchSuite().runWith(getClient(token), "/api/core/bitstreams/"
+        new MetadataPatchSuite(mapper).runWith(getClient(token), "/api/core/bitstreams/"
                 + parentCommunity.getLogo().getID(), expectedStatus);
     }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BundleRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BundleRestRepositoryIT.java
@@ -74,6 +74,9 @@ public class BundleRestRepositoryIT extends AbstractControllerIntegrationTest {
     @Autowired
     BundleService bundleService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     private Collection collection;
     private Item item;
     private Bundle bundle1;
@@ -224,7 +227,6 @@ public class BundleRestRepositoryIT extends AbstractControllerIntegrationTest {
 
     @Test
     public void createBundleWithoutMetadata() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
         BundleRest bundleRest = new BundleRest();
         bundleRest.setName("Create Bundle Without Metadata");
         UUID bundleUuid = null;
@@ -255,7 +257,6 @@ public class BundleRestRepositoryIT extends AbstractControllerIntegrationTest {
 
     @Test
     public void createBundleWithMetadata() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
         UUID bundleUuid = null;
         try {
         BundleRest bundleRest = new BundleRest();
@@ -300,8 +301,6 @@ public class BundleRestRepositoryIT extends AbstractControllerIntegrationTest {
 
     @Test
     public void createBundleAsAnonymous() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-
         BundleRest bundleRest = new BundleRest();
         bundleRest.setName("Create Bundle Without Metadata");
 
@@ -318,8 +317,6 @@ public class BundleRestRepositoryIT extends AbstractControllerIntegrationTest {
 
     @Test
     public void createBundleWithInsufficientPermissions() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-
         BundleRest bundleRest = new BundleRest();
         bundleRest.setName("Create Bundle Without Metadata");
 
@@ -339,8 +336,6 @@ public class BundleRestRepositoryIT extends AbstractControllerIntegrationTest {
 
     @Test
     public void createBundleWithSufficientPermissions() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-
         context.turnOffAuthorisationSystem();
 
         EPerson createBundleEperson = EPersonBuilder.createEPerson(context).withEmail("createm@bundle.org")
@@ -385,8 +380,6 @@ public class BundleRestRepositoryIT extends AbstractControllerIntegrationTest {
 
     @Test
     public void createBundleOnNonExistingItem() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-
         BundleRest bundleRest = new BundleRest();
         bundleRest.setName("Create Bundle Without Metadata");
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BundleUploadBitstreamControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BundleUploadBitstreamControllerIT.java
@@ -48,6 +48,9 @@ public class BundleUploadBitstreamControllerIT extends AbstractEntityIntegration
     @Autowired
     private AuthorizeService authorizeService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     @Test
     public void uploadBitstreamAllPossibleFieldsProperties() throws Exception {
         context.turnOffAuthorisationSystem();
@@ -99,7 +102,6 @@ public class BundleUploadBitstreamControllerIT extends AbstractEntityIntegration
         metadataRest.put("dc.title", title);
 
         bitstreamRest.setMetadata(metadataRest);
-        ObjectMapper mapper = new ObjectMapper();
 
         context.restoreAuthSystemState();
         MvcResult mvcResult = getClient(token).perform(
@@ -175,8 +177,6 @@ public class BundleUploadBitstreamControllerIT extends AbstractEntityIntegration
                 .andExpect(jsonPath("$.sequenceId", is(1)))
                 .andReturn();
 
-        ObjectMapper mapper = new ObjectMapper();
-
         String content = mvcResult.getResponse().getContentAsString();
         Map<String, Object> map = mapper.readValue(content, Map.class);
         String bitstreamId = String.valueOf(map.get("id"));
@@ -227,8 +227,6 @@ public class BundleUploadBitstreamControllerIT extends AbstractEntityIntegration
                                                .file(file))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.uuid", notNullValue())).andReturn();
-
-        ObjectMapper mapper = new ObjectMapper();
 
         String content = mvcResult.getResponse().getContentAsString();
         Map<String, Object> map = mapper.readValue(content, Map.class);
@@ -361,9 +359,6 @@ public class BundleUploadBitstreamControllerIT extends AbstractEntityIntegration
                                                        input.getBytes());
 
         BitstreamRest bitstreamRest = new BitstreamRest();
-
-        ObjectMapper mapper = new ObjectMapper();
-
 
         context.restoreAuthSystemState();
         MvcResult mvcResult = getClient(token)

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CollectionGroupRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CollectionGroupRestControllerIT.java
@@ -50,6 +50,9 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
     @Autowired
     private WorkflowService workflowService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     Collection collection;
 
     @Before
@@ -141,8 +144,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void postCollectionAdminGroupCreateAdminGroupExtraMetadataSuccess() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
         metadataRest.put("dc.description", new MetadataValueRest("testingDescription"));
@@ -175,8 +176,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void postCollectionAdminGroupCreateAdminGroupSuccess() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
 
@@ -204,8 +203,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void postCollectionAdminGroupCreateAdminGroupDcTitleUnprocessable() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
         metadataRest.put("dc.description", new MetadataValueRest("testingDescription"));
@@ -230,8 +227,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void postCollectionAdminGroupCreateAdminGroupSuccessParentCommunityAdmin() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
         metadataRest.put("dc.description", new MetadataValueRest("testingDescription"));
@@ -263,8 +258,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void postCollectionAdminGroupCreateAdminGroupSuccessCollectionAdmin() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
         metadataRest.put("dc.description", new MetadataValueRest("testingDescription"));
@@ -296,8 +289,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void postCollectionAdminGroupCreateAdminGroupUnAuthorized() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
         metadataRest.put("dc.description", new MetadataValueRest("testingDescription"));
@@ -318,8 +309,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void postCollectionAdminGroupCreateAdminGroupForbidden() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
         metadataRest.put("dc.description", new MetadataValueRest("testingDescription"));
@@ -341,8 +330,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void postCollectionAdminGroupCreateAdminGroupNotFound() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
         metadataRest.put("dc.description", new MetadataValueRest("testingDescription"));
@@ -361,8 +348,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void postCollectionAdminGroupCreateAdminGroupUnProcessableName() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         groupRest.setName("Fail");
         MetadataRest metadataRest = new MetadataRest();
@@ -384,8 +369,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void postCollectionAdminGroupCreateAdminGroupUnProcessablePermanent() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         groupRest.setPermanent(true);
         MetadataRest metadataRest = new MetadataRest();
@@ -584,8 +567,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void postCollectionSubmitterGroupCreateSubmitterGroupExtraMetadataSuccess() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
         metadataRest.put("dc.description", new MetadataValueRest("testingDescription"));
@@ -619,8 +600,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void postCollectionSubmitterGroupCreateSubmitterGroupSuccess() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
         metadataRest.put("dc.description", new MetadataValueRest("testingDescription"));
@@ -651,8 +630,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void postCollectionSubmittersGroupCreateSubmittersGroupDcTitleUnprocessable() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
         metadataRest.put("dc.description", new MetadataValueRest("testingDescription"));
@@ -675,8 +652,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void postCollectionSubmittersGroupCreateSubmittersGroupSuccessParentCommunityAdmin() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
         metadataRest.put("dc.description", new MetadataValueRest("testingDescription"));
@@ -709,8 +684,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void postCollectionSubmittersGroupCreateSubmittersGroupSuccessCollectionAdmin() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
         metadataRest.put("dc.description", new MetadataValueRest("testingDescription"));
@@ -743,8 +716,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void postCollectionSubmittersGroupCreateSubmittersGroupUnAuthorized() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
         metadataRest.put("dc.description", new MetadataValueRest("testingDescription"));
@@ -764,8 +735,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void postCollectionSubmittersGroupCreateSubmittersGroupForbidden() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
         metadataRest.put("dc.description", new MetadataValueRest("testingDescription"));
@@ -788,8 +757,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void postCollectionSubmittersGroupCreateSubmittersGroupNotFound() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
         metadataRest.put("dc.description", new MetadataValueRest("testingDescription"));
@@ -808,8 +775,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void postCollectionSubmittersGroupCreateSubmittersGroupUnProcessableName() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         groupRest.setName("Fail");
         MetadataRest metadataRest = new MetadataRest();
@@ -832,8 +797,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void postCollectionSubmittersGroupCreateSubmittersGroupUnProcessablePermanent() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         groupRest.setPermanent(true);
         MetadataRest metadataRest = new MetadataRest();
@@ -1055,8 +1018,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void postCollectionDefaultItemReadGroupCreateDefaultItemReadGroupSuccess() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
         metadataRest.put("dc.description", new MetadataValueRest("testingDescription"));
@@ -1087,8 +1048,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void postCollectionDefaultItemReadGroupCreateDefaultItemReadGroupDcTitleUnprocessable() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
         metadataRest.put("dc.description", new MetadataValueRest("testingDescription"));
@@ -1116,8 +1075,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
     @Test
     public void postCollectionDefaultItemReadGroupCreateDefaultItemReadGroupSuccessParentCommunityAdmin()
         throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
         metadataRest.put("dc.description", new MetadataValueRest("testingDescription"));
@@ -1150,8 +1107,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void postCollectionDefaultItemReadGroupCreateDefaultItemReadGroupSuccessCollectionAdmin() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
         metadataRest.put("dc.description", new MetadataValueRest("testingDescription"));
@@ -1184,8 +1139,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void postCollectionDefaultItemReadGroupCreateDefaultItemReadGroupUnAuthorized() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
         metadataRest.put("dc.description", new MetadataValueRest("testingDescription"));
@@ -1211,8 +1164,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void postCollectionDefaultItemReadGroupCreateDefaultItemReadGroupForbidden() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
         metadataRest.put("dc.description", new MetadataValueRest("testingDescription"));
@@ -1240,8 +1191,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void postCollectionDefaultItemReadGroupCreateDefaultItemReadGroupNotFound() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
         metadataRest.put("dc.description", new MetadataValueRest("testingDescription"));
@@ -1260,8 +1209,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void postCollectionDefaultItemReadGroupCreateDefaultItemReadGroupUnProcessableName() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         groupRest.setName("Fail");
         MetadataRest metadataRest = new MetadataRest();
@@ -1289,8 +1236,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void postCollectionDefaultItemReadGroupCreateDefaultItemReadGroupUnProcessablePermanent() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         groupRest.setPermanent(true);
         MetadataRest metadataRest = new MetadataRest();
@@ -1545,8 +1490,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void postCollectionDefaultBitstreamReadGroupCreateDefaultBitstreamReadGroupSuccess() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
         metadataRest.put("dc.description", new MetadataValueRest("testingDescription"));
@@ -1578,8 +1521,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
     @Test
     public void postCollectionDefaultBitstreamReadGroupCreateDefaultBitstreamReadGroupDcTitleUnprocessable()
         throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
         metadataRest.put("dc.description", new MetadataValueRest("testingDescription"));
@@ -1606,8 +1547,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
     @Test
     public void postCollectionDefaultBitstreamReadGroupCreateDefaultBitstreamReadGroupSuccessParentCommunityAdmin()
         throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
         metadataRest.put("dc.description", new MetadataValueRest("testingDescription"));
@@ -1641,8 +1580,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
     @Test
     public void postCollectionDefaultBitstreamReadGroupCreateDefaultBitstreamReadGroupSuccessCollectionAdmin()
         throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
         metadataRest.put("dc.description", new MetadataValueRest("testingDescription"));
@@ -1675,8 +1612,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void postCollectionDefaultBitstreamReadGroupCreateDefaultBitstreamReadGroupUnAuthorized() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
         metadataRest.put("dc.description", new MetadataValueRest("testingDescription"));
@@ -1702,8 +1637,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void postCollectionDefaultBitstreamReadGroupCreateDefaultBitstreamReadGroupForbidden() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
         metadataRest.put("dc.description", new MetadataValueRest("testingDescription"));
@@ -1731,8 +1664,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void postCollectionDefaultBitstreamReadGroupCreateDefaultBitstreamReadGroupNotFound() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
         metadataRest.put("dc.description", new MetadataValueRest("testingDescription"));
@@ -1752,8 +1683,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
     @Test
     public void postCollectionDefaultBitstreamReadGroupCreateDefaultBitstreamReadGroupUnProcessableName()
         throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         groupRest.setName("Fail");
         MetadataRest metadataRest = new MetadataRest();
@@ -1782,8 +1711,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
     @Test
     public void postCollectionDefaultBitstreamReadGroupCreateDefaultBitstreamReadGroupUnProcessablePermanent()
         throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         groupRest.setPermanent(true);
         MetadataRest metadataRest = new MetadataRest();
@@ -2033,8 +1960,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void postCollectionWorkflowGroupCreateWorkflowGroupSuccess() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
 
@@ -2063,8 +1988,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void postCollectionWorkflowGroupCreateWorkflowGroupExtraMetadataSuccess() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
         metadataRest.put("dc.description", new MetadataValueRest("testingDescription"));
@@ -2098,8 +2021,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void postCollectionWorkflowGroupWrongCollectionId() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
         metadataRest.put("dc.description", new MetadataValueRest("testingDescription"));
@@ -2118,8 +2039,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void postCollectionWorkflowGroupCreateWorkflowGroupWrongRole() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
         metadataRest.put("dc.description", new MetadataValueRest("testingDescription"));
@@ -2139,8 +2058,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void postCollectionWorkflowGroupCreateWorkflowGroupDcTitleUnprocessable() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
         metadataRest.put("dc.description", new MetadataValueRest("testingDescription"));
@@ -2163,8 +2080,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void postCollectionWorkflowGroupCreateWorkflowGroupSuccessParentCommunityAdmin() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
         metadataRest.put("dc.description", new MetadataValueRest("testingDescription"));
@@ -2197,8 +2112,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void postCollectionWorkflowGroupCreateWorkflowGroupSuccessCollectionAdmin() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
         metadataRest.put("dc.description", new MetadataValueRest("testingDescription"));
@@ -2231,8 +2144,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void postCollectionWorkflowGroupCreateWorkflowGroupUnAuthorized() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
         metadataRest.put("dc.description", new MetadataValueRest("testingDescription"));
@@ -2254,8 +2165,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void postCollectionWorkflowGroupCreateWorkflowGroupForbidden() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
         metadataRest.put("dc.description", new MetadataValueRest("testingDescription"));
@@ -2278,8 +2187,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void postCollectionWorkflowGroupCreateWorkflowGroupUnProcessableName() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         groupRest.setName("Fail");
         MetadataRest metadataRest = new MetadataRest();
@@ -2302,8 +2209,6 @@ public class CollectionGroupRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void postCollectionWorkflowGroupCreateWorkflowGroupUnProcessablePermanent() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         groupRest.setPermanent(true);
         MetadataRest metadataRest = new MetadataRest();

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CollectionLogoControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CollectionLogoControllerIT.java
@@ -23,6 +23,7 @@ import org.dspace.content.Community;
 import org.dspace.eperson.EPerson;
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MvcResult;
@@ -30,7 +31,9 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 public class CollectionLogoControllerIT extends AbstractControllerIntegrationTest {
 
+    @Autowired
     private ObjectMapper mapper;
+
     private String adminAuthToken;
     private String bitstreamContent;
     private MockMultipartFile bitstreamFile;
@@ -49,7 +52,6 @@ public class CollectionLogoControllerIT extends AbstractControllerIntegrationTes
         bitstreamFile = new MockMultipartFile("file",
                 "hello.txt", MediaType.TEXT_PLAIN_VALUE,
                 bitstreamContent.getBytes());
-        mapper = new ObjectMapper();
     }
 
     private String createLogoInternal() throws Exception {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CollectionRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CollectionRestRepositoryIT.java
@@ -101,6 +101,9 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
     @Autowired
     CollectionService collectionService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     private Community topLevelCommunityA;
     private Community subCommunityA;
     private Community communityB;
@@ -1015,8 +1018,6 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
 
         String token = getAuthToken(admin.getEmail(), password);
 
-        ObjectMapper mapper = new ObjectMapper();
-
         CollectionRest collectionRest = collectionConverter.convert(col1, Projection.DEFAULT);
 
         collectionRest.setMetadata(new MetadataRest()
@@ -1151,8 +1152,6 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
         AtomicReference<UUID> idRefNoEmbeds = new AtomicReference<>();
         AtomicReference<String> handle = new AtomicReference<>();
         try {
-
-        ObjectMapper mapper = new ObjectMapper();
         CollectionRest collectionRest = new CollectionRest();
         // We send a name but the created collection should set this to the title
         collectionRest.setName("Collection");
@@ -1237,7 +1236,6 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
                                           .withLogo("ThisIsSomeDummyText")
                                           .build();
 
-        ObjectMapper mapper = new ObjectMapper();
         CollectionRest collectionRest = new CollectionRest();
         // We send a name but the created collection should set this to the title
         collectionRest.setName("Collection");
@@ -1306,7 +1304,6 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
                                           .withLogo("ThisIsSomeDummyText")
                                           .build();
 
-        ObjectMapper mapper = new ObjectMapper();
         CollectionRest collectionRest = new CollectionRest();
         // We send a name but the created collection should set this to the title
         collectionRest.setName("Collection");
@@ -1428,7 +1425,6 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
         context.restoreAuthSystemState();
 
         String token = getAuthToken(eperson.getEmail(), password);
-        ObjectMapper mapper = new ObjectMapper();
 
         CollectionRest collectionRest = collectionConverter.convert(col1, Projection.DEFAULT);
 
@@ -1473,7 +1469,8 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
         context.restoreAuthSystemState();
         String token = getAuthToken(asUser.getEmail(), password);
 
-        new MetadataPatchSuite().runWith(getClient(token), "/api/core/collections/" + col.getID(), expectedStatus);
+        new MetadataPatchSuite(mapper).runWith(getClient(token), "/api/core/collections/" + col.getID(),
+                                               expectedStatus);
     }
 
     @Test
@@ -1488,7 +1485,6 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
                                           .withLogo("ThisIsSomeDummyText")
                                           .build();
 
-        ObjectMapper mapper = new ObjectMapper();
         CollectionRest collectionRest = new CollectionRest();
         // We send a name but the created collection should set this to the title
         collectionRest.setName("Collection");
@@ -1530,7 +1526,6 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
                                           .withLogo("ThisIsSomeDummyText")
                                           .build();
 
-        ObjectMapper mapper = new ObjectMapper();
         CollectionRest collectionRest = new CollectionRest();
         // We send a name but the created collection should set this to the title
         collectionRest.setName("Collection");
@@ -3272,7 +3267,6 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
                                .andExpect(jsonPath("$.page.totalElements", is(0)));
 
         AtomicReference<UUID> idRef = new AtomicReference<>();
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         String token = getAuthToken(admin.getEmail(), password);
         getClient(token).perform(post("/api/core/collections/" + col1.getID() + "/adminGroup")

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityAdminGroupRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityAdminGroupRestControllerIT.java
@@ -56,6 +56,9 @@ public class CommunityAdminGroupRestControllerIT extends AbstractControllerInteg
     @Autowired
     private ConfigurationService configurationService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     Collection collection;
 
     @Before
@@ -133,8 +136,6 @@ public class CommunityAdminGroupRestControllerIT extends AbstractControllerInteg
 
     @Test
     public void postCommunityAdminGroupCreateAdminGroupSuccess() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
 
@@ -162,8 +163,6 @@ public class CommunityAdminGroupRestControllerIT extends AbstractControllerInteg
 
     @Test
     public void postCommunityAdminGroupCreateAdminGroupExtraMetadataSuccess() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
         metadataRest.put("dc.description", new MetadataValueRest("testingDescription"));
@@ -196,8 +195,6 @@ public class CommunityAdminGroupRestControllerIT extends AbstractControllerInteg
 
     @Test
     public void postCommunityAdminGroupCreateAdminGroupDcTitleUnprocessable() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
         metadataRest.put("dc.description", new MetadataValueRest("testingDescription"));
@@ -221,8 +218,6 @@ public class CommunityAdminGroupRestControllerIT extends AbstractControllerInteg
 
     @Test
     public void postCommunityAdminGroupCreateAdminGroupSuccessCommunityAdmin() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
         metadataRest.put("dc.description", new MetadataValueRest("testingDescription"));
@@ -254,8 +249,6 @@ public class CommunityAdminGroupRestControllerIT extends AbstractControllerInteg
 
     @Test
     public void postCommunityAdminGroupCreateAdminGroupUnAuthorized() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
         metadataRest.put("dc.description", new MetadataValueRest("testingDescription"));
@@ -276,8 +269,6 @@ public class CommunityAdminGroupRestControllerIT extends AbstractControllerInteg
 
     @Test
     public void postCommunityAdminGroupCreateAdminGroupForbidden() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
         metadataRest.put("dc.description", new MetadataValueRest("testingDescription"));
@@ -301,8 +292,6 @@ public class CommunityAdminGroupRestControllerIT extends AbstractControllerInteg
 
     @Test
     public void postCommunityAdminGroupCreateAdminGroupNotFound() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         MetadataRest metadataRest = new MetadataRest();
         metadataRest.put("dc.description", new MetadataValueRest("testingDescription"));
@@ -321,8 +310,6 @@ public class CommunityAdminGroupRestControllerIT extends AbstractControllerInteg
 
     @Test
     public void postCommunityAdminGroupCreateAdminGroupUnProcessableName() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         groupRest.setName("Fail");
         MetadataRest metadataRest = new MetadataRest();
@@ -346,8 +333,6 @@ public class CommunityAdminGroupRestControllerIT extends AbstractControllerInteg
 
     @Test
     public void postCommunityAdminGroupCreateAdminGroupUnProcessablePermanent() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         groupRest.setPermanent(true);
         MetadataRest metadataRest = new MetadataRest();

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityLogoControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityLogoControllerIT.java
@@ -21,6 +21,7 @@ import org.dspace.content.Community;
 import org.dspace.eperson.EPerson;
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MvcResult;
@@ -28,7 +29,9 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 public class CommunityLogoControllerIT extends AbstractControllerIntegrationTest {
 
+    @Autowired
     private ObjectMapper mapper;
+
     private String adminAuthToken;
     private String bitstreamContent;
     private MockMultipartFile bitstreamFile;
@@ -44,7 +47,6 @@ public class CommunityLogoControllerIT extends AbstractControllerIntegrationTest
         bitstreamFile = new MockMultipartFile("file",
                 "hello.txt", MediaType.TEXT_PLAIN_VALUE,
                 bitstreamContent.getBytes());
-        mapper = new ObjectMapper();
     }
 
     private String createLogoInternal() throws Exception {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
@@ -98,6 +98,9 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
     @Autowired
     private GroupService groupService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     private Community topLevelCommunityA;
     private Community subCommunityA;
     private Community communityB;
@@ -117,7 +120,6 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
 
     @Test
     public void createTest() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
         CommunityRest comm = new CommunityRest();
         CommunityRest commNoembeds = new CommunityRest();
         // We send a name but the created community should set this to the title
@@ -227,7 +229,6 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
 
         context.restoreAuthSystemState();
 
-        ObjectMapper mapper = new ObjectMapper();
         CommunityRest comm = new CommunityRest();
         // We send a name but the created community should set this to the title
         comm.setName("Test Sub-Level Community");
@@ -267,7 +268,6 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
 
         String authToken = getAuthToken(eperson.getEmail(), password);
 
-        ObjectMapper mapper = new ObjectMapper();
         CommunityRest comm = new CommunityRest();
         // We send a name but the created community should set this to the title
         comm.setName("Test Sub-Level Community");
@@ -340,7 +340,6 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
     public void createUnauthorizedTest() throws Exception {
         context.turnOffAuthorisationSystem();
 
-        ObjectMapper mapper = new ObjectMapper();
         CommunityRest comm = new CommunityRest();
         comm.setName("Test Top-Level Community");
 
@@ -725,7 +724,6 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
 
         context.restoreAuthSystemState();
 
-        ObjectMapper mapper = new ObjectMapper();
         MvcResult result = getClient().perform(get("/api/core/communities")).andReturn();
         String response = result.getResponse().getContentAsString();
         JSONArray communities = new JSONObject(response).getJSONObject("_embedded").getJSONArray("communities");
@@ -1676,8 +1674,6 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
 
         context.turnOffAuthorisationSystem();
 
-        ObjectMapper mapper = new ObjectMapper();
-
         CommunityRest communityRest = communityConverter.convert(parentCommunity, Projection.DEFAULT);
 
         communityRest.setMetadata(new MetadataRest()
@@ -1900,8 +1896,6 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
 
         context.turnOffAuthorisationSystem();
 
-        ObjectMapper mapper = new ObjectMapper();
-
         CommunityRest communityRest = communityConverter.convert(parentCommunity, Projection.DEFAULT);
 
         communityRest.setMetadata(new MetadataRest()
@@ -2024,7 +2018,7 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
         context.restoreAuthSystemState();
         String token = getAuthToken(asUser.getEmail(), password);
 
-        new MetadataPatchSuite().runWith(getClient(token), "/api/core/communities/"
+        new MetadataPatchSuite(mapper).runWith(getClient(token), "/api/core/communities/"
                 + parentCommunity.getID(), expectedStatus);
     }
 
@@ -2032,7 +2026,6 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
     public void createTestInvalidParentCommunityBadRequest() throws Exception {
         context.turnOffAuthorisationSystem();
 
-        ObjectMapper mapper = new ObjectMapper();
         CommunityRest comm = new CommunityRest();
         // We send a name but the created community should set this to the title
         comm.setName("Test Top-Level Community");
@@ -2735,7 +2728,6 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
                                .andExpect(jsonPath("$.page.totalElements", is(0)));
 
         AtomicReference<UUID> idRef = new AtomicReference<>();
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         String token = getAuthToken(admin.getEmail(), password);
         getClient(token).perform(post("/api/core/communities/" + subCommunity.getID() + "/adminGroup")

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -95,6 +95,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
     @Autowired
     ChoiceAuthorityService choiceAuthorityService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     /**
      * This field has been created to easily modify the tests when updating the defaultConfiguration's sidebar facets
      */
@@ -6882,8 +6885,6 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
 
     @Test
     public void discoverSearchObjectsNOTIFYIncomingConfigurationTest() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-
         context.turnOffAuthorisationSystem();
 
         Community community = CommunityBuilder.createCommunity(context)
@@ -6945,8 +6946,6 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
 
     @Test
     public void discoverSearchObjectsNOTIFYOutgoingConfigurationTest() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-
         context.turnOffAuthorisationSystem();
 
         Community community = CommunityBuilder.createCommunity(context)

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/EPersonRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/EPersonRestRepositoryIT.java
@@ -102,10 +102,12 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
     @Autowired
     private ConfigurationService configurationService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     @Test
     public void createTest() throws Exception {
         // we should check how to get it from Spring
-        ObjectMapper mapper = new ObjectMapper();
         EPersonRest data = new EPersonRest();
         EPersonRest dataFull = new EPersonRest();
         MetadataRest metadataRest = new MetadataRest();
@@ -171,7 +173,6 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
     public void createAnonAccessDeniedTest() throws Exception {
         context.turnOffAuthorisationSystem();
         // we should check how to get it from Spring
-        ObjectMapper mapper = new ObjectMapper();
         EPersonRest data = new EPersonRest();
         EPersonRest dataFull = new EPersonRest();
         MetadataRest metadataRest = new MetadataRest();
@@ -2066,7 +2067,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.restoreAuthSystemState();
         String token = getAuthToken(asUser.getEmail(), password);
 
-        new MetadataPatchSuite().runWith(getClient(token), "/api/eperson/epersons/" + ePerson.getID(), expectedStatus);
+        new MetadataPatchSuite(mapper).runWith(getClient(token), "/api/eperson/epersons/" + ePerson.getID(),
+                                               expectedStatus);
     }
 
     @Test
@@ -2494,7 +2496,6 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
     public void registerNewAccountPatchUpdatePasswordRandomUserUuidFail() throws Exception {
         context.turnOffAuthorisationSystem();
 
-        ObjectMapper mapper = new ObjectMapper();
         String newRegisterEmail = "new-register@fake-email.com";
         RegistrationRest registrationRest = new RegistrationRest();
         registrationRest.setEmail(newRegisterEmail);
@@ -2542,7 +2543,6 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
     @Test
     public void postEPersonWithTokenWithoutEmailProperty() throws Exception {
         configurationService.setProperty("authentication-password.regex-validation.pattern", "");
-        ObjectMapper mapper = new ObjectMapper();
 
         String newRegisterEmail = "new-register@fake-email.com";
         RegistrationRest registrationRest = new RegistrationRest();
@@ -2607,7 +2607,6 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
     @Test
     public void postEPersonWithTokenWithEmailProperty() throws Exception {
         configurationService.setProperty("authentication-password.regex-validation.pattern", "");
-        ObjectMapper mapper = new ObjectMapper();
 
         String newRegisterEmail = "new-register@fake-email.com";
         RegistrationRest registrationRest = new RegistrationRest();
@@ -2670,7 +2669,6 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
     @Test
     public void postEPersonWithTokenWithEmailAndSelfRegisteredProperty() throws Exception {
         configurationService.setProperty("authentication-password.regex-validation.pattern", "");
-        ObjectMapper mapper = new ObjectMapper();
 
         String newRegisterEmail = "new-register@fake-email.com";
         RegistrationRest registrationRest = new RegistrationRest();
@@ -2737,8 +2735,6 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
     @Test
     public void postEPersonWithTokenWithTwoTokensDifferentEmailProperty() throws Exception {
 
-        ObjectMapper mapper = new ObjectMapper();
-
         String newRegisterEmail = "new-register@fake-email.com";
         RegistrationRest registrationRest = new RegistrationRest();
         registrationRest.setEmail(newRegisterEmail);
@@ -2798,8 +2794,6 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
     @Test
     public void postEPersonWithRandomTokenWithEmailProperty() throws Exception {
 
-        ObjectMapper mapper = new ObjectMapper();
-
         String newRegisterEmail = "new-register@fake-email.com";
         RegistrationRest registrationRest = new RegistrationRest();
         registrationRest.setEmail(newRegisterEmail);
@@ -2846,8 +2840,6 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
     @Test
     public void postEPersonWithTokenWithEmailAndSelfRegisteredFalseProperty() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
 
         String newRegisterEmail = "new-register@fake-email.com";
         RegistrationRest registrationRest = new RegistrationRest();
@@ -2896,8 +2888,6 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
     @Test
     public void postEPersonWithTokenWithoutLastNameProperty() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
 
         String newRegisterEmail = "new-register@fake-email.com";
         RegistrationRest registrationRest = new RegistrationRest();
@@ -2964,8 +2954,6 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
     @Test
     public void postEPersonWithTokenWithoutFirstNameProperty() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
 
         String newRegisterEmail = "new-register@fake-email.com";
         RegistrationRest registrationRest = new RegistrationRest();
@@ -3034,8 +3022,6 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
     @Test
     public void postEPersonWithTokenWithoutPasswordProperty() throws Exception {
 
-        ObjectMapper mapper = new ObjectMapper();
-
         String newRegisterEmail = "new-register@fake-email.com";
         RegistrationRest registrationRest = new RegistrationRest();
         registrationRest.setEmail(newRegisterEmail);
@@ -3081,8 +3067,6 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
 
     @Test
     public void postEPersonWithWrongToken() throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         String newEmail = "new-email@fake-email.com";
 
         RegistrationRest registrationRest = new RegistrationRest();
@@ -3132,7 +3116,6 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
     @Test
     public void postEPersonWithTokenWithEmailPropertyAnonUser() throws Exception {
         configurationService.setProperty("authentication-password.regex-validation.pattern", "");
-        ObjectMapper mapper = new ObjectMapper();
 
         String newRegisterEmail = "new-register@fake-email.com";
         RegistrationRest registrationRest = new RegistrationRest();
@@ -3464,8 +3447,6 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
     public void validatePasswordRobustnessContainingAtLeastAnUpperCaseCharUnprocessableTest() throws Exception {
         configurationService.setProperty("authentication-password.regex-validation.pattern", "^(?=.*[A-Z])");
 
-        ObjectMapper mapper = new ObjectMapper();
-
         String newRegisterEmail = "new-register@fake-email.com";
         RegistrationRest registrationRest = new RegistrationRest();
         registrationRest.setEmail(newRegisterEmail);
@@ -3509,8 +3490,6 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
     @Test
     public void validatePasswordRobustnessContainingAtLeastAnUpperCaseCharTest() throws Exception {
         configurationService.setProperty("authentication-password.regex-validation.pattern", "^(?=.*[A-Z])");
-
-        ObjectMapper mapper = new ObjectMapper();
 
         String newRegisterEmail = "new-register@fake-email.com";
         RegistrationRest registrationRest = new RegistrationRest();

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/FeedbackRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/FeedbackRestRepositoryIT.java
@@ -38,6 +38,9 @@ public class FeedbackRestRepositoryIT extends AbstractControllerIntegrationTest 
     @Autowired
     private FeedbackRestRepository feedbackRestRepository;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     @Test
     public void findAllTest() throws Exception {
         String authToken = getAuthToken(admin.getEmail(), password);
@@ -60,7 +63,6 @@ public class FeedbackRestRepositoryIT extends AbstractControllerIntegrationTest 
             FeedbackService feedbackServiceMock = mock (FeedbackServiceImpl.class);
             feedbackRestRepository.setFeedbackService(feedbackServiceMock);
 
-            ObjectMapper mapper = new ObjectMapper();
             FeedbackRest feedbackRest = new FeedbackRest();
 
             feedbackRest.setEmail("misha.boychuk@test.com");
@@ -89,7 +91,6 @@ public class FeedbackRestRepositoryIT extends AbstractControllerIntegrationTest 
         try {
             FeedbackService feedbackServiceMock = mock (FeedbackServiceImpl.class);
             feedbackRestRepository.setFeedbackService(feedbackServiceMock);
-            ObjectMapper mapper = new ObjectMapper();
             FeedbackRest feedbackRest = new FeedbackRest();
 
             feedbackRest.setEmail("misha.boychuk@test.com");
@@ -113,7 +114,6 @@ public class FeedbackRestRepositoryIT extends AbstractControllerIntegrationTest 
         try {
             FeedbackService feedbackServiceMock = mock (FeedbackServiceImpl.class);
             feedbackRestRepository.setFeedbackService(feedbackServiceMock);
-            ObjectMapper mapper = new ObjectMapper();
             FeedbackRest feedbackRest = new FeedbackRest();
 
             feedbackRest.setMessage("My feedback!");

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/GroupRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/GroupRestRepositoryIT.java
@@ -84,6 +84,9 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
     @Autowired
     private AuthorizeService authorizeService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     Collection collection;
 
     @Before
@@ -103,7 +106,6 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
         AtomicReference<UUID> idRef = new AtomicReference<>();
         AtomicReference<UUID> idRefNoEmbeds = new AtomicReference<>();
         try {
-            ObjectMapper mapper = new ObjectMapper();
             GroupRest groupRest = new GroupRest();
             GroupRest groupRestNoEmbeds = new GroupRest();
             String groupName = "testGroup1";
@@ -161,7 +163,6 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
     @Test
     public void createUnauthauthorizedTest()
             throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         String groupName = "testGroupUnauth1";
 
@@ -175,8 +176,6 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
     @Test
     public void createForbiddenTest()
             throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
         String groupName = "testGroupForbidden1";
 
@@ -191,8 +190,6 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
     @Test
     public void createUnprocessableTest()
             throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest();
 
         String authToken = getAuthToken(admin.getEmail(), password);
@@ -206,7 +203,6 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
 
     @Test
     public void createWithoutNameTest() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
         GroupRest groupRest = new GroupRest(); // no name set
 
         String authToken = getAuthToken(admin.getEmail(), password);
@@ -528,7 +524,8 @@ public class GroupRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.restoreAuthSystemState();
         String token = getAuthToken(asUser.getEmail(), password);
 
-        new MetadataPatchSuite().runWith(getClient(token), "/api/eperson/groups/" + group.getID(), expectedStatus);
+        new MetadataPatchSuite(mapper).runWith(getClient(token), "/api/eperson/groups/" + group.getID(),
+                                               expectedStatus);
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
@@ -122,6 +122,9 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
     @Autowired
     private ConfigurationService configurationService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     private Item publication1;
     private Item author1;
     private Item author2;
@@ -2072,7 +2075,6 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         UUID idRef = null;
         AtomicReference<UUID> idRefNoEmbeds = new AtomicReference<>();
         try {
-        ObjectMapper mapper = new ObjectMapper();
         ItemRest itemRest = new ItemRest();
         ItemRest itemRestFull = new ItemRest();
         itemRest.setName("Practices of research data curation in institutional repositories:" +
@@ -2169,7 +2171,6 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         String itemUuidString = null;
         try {
-        ObjectMapper mapper = new ObjectMapper();
         ItemRest itemRest = new ItemRest();
         itemRest.setName("Practices of research data curation in institutional repositories:" +
                              " A qualitative view from repository staff");
@@ -2252,7 +2253,6 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.restoreAuthSystemState();
         String itemUuidString = null;
         try {
-        ObjectMapper mapper = new ObjectMapper();
         ItemRest itemRest = new ItemRest();
         itemRest.setName("Practices of research data curation in institutional repositories:" +
                              " A qualitative view from repository staff");
@@ -2331,7 +2331,6 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         String itemUuidString = null;
         try {
-        ObjectMapper mapper = new ObjectMapper();
         ItemRest itemRest = new ItemRest();
         itemRest.setName("Practices of research data curation in institutional repositories:" +
                              " A qualitative view from repository staff");
@@ -2439,7 +2438,7 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.restoreAuthSystemState();
         String token = getAuthToken(asUser.getEmail(), password);
 
-        new MetadataPatchSuite().runWith(getClient(token), "/api/core/items/" + item.getID(), expectedStatus);
+        new MetadataPatchSuite(mapper).runWith(getClient(token), "/api/core/items/" + item.getID(), expectedStatus);
     }
 
     /**
@@ -2464,7 +2463,6 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
 
         context.restoreAuthSystemState();
-        ObjectMapper mapper = new ObjectMapper();
         ItemRest itemRest = new ItemRest();
         itemRest.setName("Practices of research data curation in institutional repositories:" +
                              " A qualitative view from repository staff");
@@ -2502,7 +2500,6 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
 
         context.restoreAuthSystemState();
-        ObjectMapper mapper = new ObjectMapper();
         ItemRest itemRest = new ItemRest();
         itemRest.setName("Practices of research data curation in institutional repositories:" +
                              " A qualitative view from repository staff");
@@ -2542,7 +2539,6 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         String itemUuidString = null;
         try {
-        ObjectMapper mapper = new ObjectMapper();
         ItemRest itemRest = new ItemRest();
         itemRest.setName("Practices of research data curation in institutional repositories:" +
                              " A qualitative view from repository staff");
@@ -2603,7 +2599,6 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         String itemUuidString = null;
         try {
-        ObjectMapper mapper = new ObjectMapper();
         String token = getAuthToken(admin.getEmail(), password);
         MvcResult mvcResult = getClient(token).perform(post("/api/core/items?owningCollection="
                                                                 + col1.getID().toString())

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemTemplateRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemTemplateRestControllerIT.java
@@ -47,7 +47,9 @@ public class ItemTemplateRestControllerIT extends AbstractControllerIntegrationT
     @Autowired
     ResourcePolicyService  resourcePolicyService;
 
+    @Autowired
     private ObjectMapper mapper;
+
     private String adminAuthToken;
     private Collection childCollection;
     private TemplateItemRest testTemplateItem;
@@ -62,8 +64,6 @@ public class ItemTemplateRestControllerIT extends AbstractControllerIntegrationT
         childCollection = CollectionBuilder.createCollection(context, parentCommunity)
                                            .withName("Collection 1").build();
         adminAuthToken = getAuthToken(admin.getEmail(), password);
-
-        mapper = new ObjectMapper();
     }
 
     private void setupTestTemplate() {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/LDNInboxControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/LDNInboxControllerIT.java
@@ -63,6 +63,9 @@ public class LDNInboxControllerIT extends AbstractControllerIntegrationTest {
     @Autowired
     private LDNMessageService ldnMessageService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     private QAEventService qaEventService = new DSpace().getSingletonService(QAEventService.class);
 
     @Test
@@ -88,7 +91,6 @@ public class LDNInboxControllerIT extends AbstractControllerIntegrationTest {
         String message = announceEndorsement.replaceAll("<<object>>", object);
         message = message.replaceAll("<<object_handle>>", object);
 
-        ObjectMapper mapper = new ObjectMapper();
         Notification notification = mapper.readValue(message, Notification.class);
         getClient()
             .perform(post("/ldn/inbox")
@@ -123,7 +125,6 @@ public class LDNInboxControllerIT extends AbstractControllerIntegrationTest {
         String message = announceReview.replaceAll("<<object>>", object);
         message = message.replaceAll("<<object_handle>>", object);
 
-        ObjectMapper mapper = new ObjectMapper();
         Notification notification = mapper.readValue(message, Notification.class);
         getClient()
             .perform(post("/ldn/inbox")
@@ -147,7 +148,6 @@ public class LDNInboxControllerIT extends AbstractControllerIntegrationTest {
         InputStream offerEndorsementStream = getClass().getResourceAsStream("ldn_offer_endorsement_badrequest.json");
         String message = IOUtils.toString(offerEndorsementStream, Charset.defaultCharset());
         offerEndorsementStream.close();
-        ObjectMapper mapper = new ObjectMapper();
         Notification notification = mapper.readValue(message, Notification.class);
         getClient()
             .perform(post("/ldn/inbox")
@@ -178,7 +178,6 @@ public class LDNInboxControllerIT extends AbstractControllerIntegrationTest {
         offerReviewStream.close();
         String message = announceReview.replaceAll("<<object_handle>>", object);
 
-        ObjectMapper mapper = new ObjectMapper();
         Notification notification = mapper.readValue(message, Notification.class);
         getClient()
             .perform(post("/ldn/inbox")
@@ -197,7 +196,6 @@ public class LDNInboxControllerIT extends AbstractControllerIntegrationTest {
         String ackMessage = ackReview.replaceAll("<<object_handle>>", object);
         ackMessage = ackMessage.replaceAll("<<ldn_offer_review_uuid>>",
             "urn:uuid:0370c0fb-bb78-4a9b-87f5-bed307a509de");
-        ObjectMapper ackMapper = new ObjectMapper();
         Notification ackNotification = mapper.readValue(ackMessage, Notification.class);
         getClient()
             .perform(post("/ldn/inbox")
@@ -236,7 +234,6 @@ public class LDNInboxControllerIT extends AbstractControllerIntegrationTest {
         String message = announceRelationship.replaceAll("<<object>>", object);
         message = message.replaceAll("<<object_handle>>", object);
 
-        ObjectMapper mapper = new ObjectMapper();
         Notification notification = mapper.readValue(message, Notification.class);
         getClient()
             .perform(post("/ldn/inbox")
@@ -257,7 +254,6 @@ public class LDNInboxControllerIT extends AbstractControllerIntegrationTest {
     private void checkStoredLDNMessage(Notification notification, LDNMessageEntity ldnMessage, String object)
         throws Exception {
 
-        ObjectMapper mapper = new ObjectMapper();
         Notification storedMessage = mapper.readValue(ldnMessage.getMessage(), Notification.class);
 
         assertNotNull(ldnMessage);
@@ -300,7 +296,6 @@ public class LDNInboxControllerIT extends AbstractControllerIntegrationTest {
         String message = announceEndorsement.replaceAll("<<object>>", object);
         message = message.replaceAll("<<object_handle>>", object);
 
-        ObjectMapper mapper = new ObjectMapper();
         Notification notification = mapper.readValue(message, Notification.class);
         getClient()
             .perform(post("/ldn/inbox").with(remoteHost("mydocker.url", "172.23.0.1"))
@@ -337,7 +332,6 @@ public class LDNInboxControllerIT extends AbstractControllerIntegrationTest {
         String message = announceEndorsement.replaceAll("<<object>>", object);
         message = message.replaceAll("<<object_handle>>", object);
 
-        ObjectMapper mapper = new ObjectMapper();
         Notification notification = mapper.readValue(message, Notification.class);
         getClient()
             .perform(post("/ldn/inbox")
@@ -374,7 +368,6 @@ public class LDNInboxControllerIT extends AbstractControllerIntegrationTest {
         String message = announceEndorsement.replaceAll("<<object>>", object);
         message = message.replaceAll("<<object_handle>>", object);
 
-        ObjectMapper mapper = new ObjectMapper();
         Notification notification = mapper.readValue(message, Notification.class);
         getClient()
             .perform(post("/ldn/inbox").with(remoteHost("mydocker.url", "172.23.0.1"))

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/LDNMessageRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/LDNMessageRestControllerIT.java
@@ -51,6 +51,9 @@ public class LDNMessageRestControllerIT extends AbstractControllerIntegrationTes
     @Autowired
     private LDNMessageService ldnMessageService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     @Test
     public void findByItemUnAuthorizedTest() throws Exception {
         getClient()
@@ -103,7 +106,6 @@ public class LDNMessageRestControllerIT extends AbstractControllerIntegrationTes
         String message = announceEndorsement.replaceAll("<<object>>", object);
         message = message.replaceAll("<<object_handle>>", object);
 
-        ObjectMapper mapper = new ObjectMapper();
         Notification notification = mapper.readValue(message, Notification.class);
         getClient()
             .perform(post("/ldn/inbox")

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/LDNMessageRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/LDNMessageRestRepositoryIT.java
@@ -57,6 +57,9 @@ public class LDNMessageRestRepositoryIT extends AbstractControllerIntegrationTes
     @Autowired
     private LDNMessageService ldnMessageService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     @Test
     public void findOneUnAuthorizedTest() throws Exception {
         getClient()
@@ -109,7 +112,6 @@ public class LDNMessageRestRepositoryIT extends AbstractControllerIntegrationTes
         String message = announceEndorsement.replaceAll("<<object>>", object);
         message = message.replaceAll("<<object_handle>>", object);
 
-        ObjectMapper mapper = new ObjectMapper();
         Notification notification = mapper.readValue(message, Notification.class);
         getClient()
             .perform(post("/ldn/inbox")
@@ -178,7 +180,6 @@ public class LDNMessageRestRepositoryIT extends AbstractControllerIntegrationTes
         String message = announceEndorsement.replaceAll("<<object>>", object);
         message = message.replaceAll("<<object_handle>>", object);
 
-        ObjectMapper mapper = new ObjectMapper();
         Notification notification = mapper.readValue(message, Notification.class);
         getClient()
             .perform(post("/ldn/inbox")
@@ -207,7 +208,6 @@ public class LDNMessageRestRepositoryIT extends AbstractControllerIntegrationTes
 
     @Test
     public void createLDNMessageTest() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
         LDNMessageEntityRest data = new LDNMessageEntityRest();
         String authToken = getAuthToken(admin.getEmail(), password);
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/LoginAsEPersonIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/LoginAsEPersonIT.java
@@ -58,6 +58,9 @@ public class LoginAsEPersonIT extends AbstractControllerIntegrationTest {
     @Autowired
     private GroupService groupService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     @Before
     public void setup() {
         configurationService.setProperty("webui.user.assumelogin", true);
@@ -198,8 +201,6 @@ public class LoginAsEPersonIT extends AbstractControllerIntegrationTest {
                                                   .andExpect(status().isCreated())
                                                   .andExpect(jsonPath("$._embedded.collection.id",
                                                                       is(col1.getID().toString()))).andReturn();
-
-        ObjectMapper mapper = new ObjectMapper();
 
         String content = mvcResult.getResponse().getContentAsString();
         Map<String,Object> map = mapper.readValue(content, Map.class);

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataSchemaRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataSchemaRestRepositoryIT.java
@@ -47,9 +47,12 @@ public class MetadataSchemaRestRepositoryIT extends AbstractControllerIntegratio
     private static final String TEST_NAME_UPDATED = "testSchemaNameUpdated";
     private static final String TEST_NAMESPACE_UPDATED = "testSchemaNameSpaceUpdated";
 
-
     @Autowired
     private MetadataSchemaConverter metadataSchemaConverter;
+
+    @Autowired
+    private ObjectMapper mapper;
+
     @Test
     public void findAll() throws Exception {
 
@@ -102,7 +105,7 @@ public class MetadataSchemaRestRepositoryIT extends AbstractControllerIntegratio
         try {
             getClient(authToken)
                     .perform(post("/api/core/metadataschemas")
-                            .content(new ObjectMapper().writeValueAsBytes(metadataSchemaRest))
+                            .content(mapper.writeValueAsBytes(metadataSchemaRest))
                             .contentType(contentType))
                     .andExpect(status().isCreated())
                     .andExpect(jsonPath("$", HalMatcher.matchNoEmbeds()))
@@ -132,21 +135,21 @@ public class MetadataSchemaRestRepositoryIT extends AbstractControllerIntegratio
 
         getClient(authToken)
             .perform(post("/api/core/metadataschemas")
-                         .content(new ObjectMapper().writeValueAsBytes(metadataSchemaRest))
+                         .content(mapper.writeValueAsBytes(metadataSchemaRest))
                          .contentType(contentType))
             .andExpect(status().isUnprocessableEntity());
 
         metadataSchemaRest.setPrefix("test,SchemaName");
         getClient(authToken)
             .perform(post("/api/core/metadataschemas")
-                         .content(new ObjectMapper().writeValueAsBytes(metadataSchemaRest))
+                         .content(mapper.writeValueAsBytes(metadataSchemaRest))
                          .contentType(contentType))
             .andExpect(status().isUnprocessableEntity());
 
         metadataSchemaRest.setPrefix("test SchemaName");
         getClient(authToken)
             .perform(post("/api/core/metadataschemas")
-                         .content(new ObjectMapper().writeValueAsBytes(metadataSchemaRest))
+                         .content(mapper.writeValueAsBytes(metadataSchemaRest))
                          .contentType(contentType))
             .andExpect(status().isUnprocessableEntity());
     }
@@ -160,7 +163,7 @@ public class MetadataSchemaRestRepositoryIT extends AbstractControllerIntegratio
 
         getClient()
                 .perform(post("/api/core/metadataschemas")
-                        .content(new ObjectMapper().writeValueAsBytes(metadataSchemaRest))
+                        .content(mapper.writeValueAsBytes(metadataSchemaRest))
                         .contentType(contentType))
                 .andExpect(status().isUnauthorized());
     }
@@ -242,7 +245,7 @@ public class MetadataSchemaRestRepositoryIT extends AbstractControllerIntegratio
 
         getClient(getAuthToken(admin.getEmail(), password))
                 .perform(put("/api/core/metadataschemas/" + metadataSchema.getID())
-                        .content(new ObjectMapper().writeValueAsBytes(metadataSchemaRest))
+                        .content(mapper.writeValueAsBytes(metadataSchemaRest))
                         .contentType(contentType))
                 .andExpect(status().isOk());
 
@@ -268,7 +271,7 @@ public class MetadataSchemaRestRepositoryIT extends AbstractControllerIntegratio
 
         getClient(getAuthToken(admin.getEmail(), password))
             .perform(put("/api/core/metadataschemas/" + metadataSchema.getID())
-                         .content(new ObjectMapper().writeValueAsBytes(metadataSchemaRest))
+                         .content(mapper.writeValueAsBytes(metadataSchemaRest))
                          .contentType(contentType))
             .andExpect(status().isUnprocessableEntity());
 
@@ -294,7 +297,7 @@ public class MetadataSchemaRestRepositoryIT extends AbstractControllerIntegratio
 
         getClient()
                 .perform(put("/api/core/metadataschemas/" + metadataSchema.getID())
-                        .content(new ObjectMapper().writeValueAsBytes(metadataSchemaRest))
+                        .content(mapper.writeValueAsBytes(metadataSchemaRest))
                         .contentType(contentType))
                 .andExpect(status().isUnauthorized());
 
@@ -320,7 +323,7 @@ public class MetadataSchemaRestRepositoryIT extends AbstractControllerIntegratio
 
         getClient(getAuthToken(eperson.getEmail(), password))
             .perform(put("/api/core/metadataschemas/" + metadataSchema.getID())
-                         .content(new ObjectMapper().writeValueAsBytes(metadataSchemaRest))
+                         .content(mapper.writeValueAsBytes(metadataSchemaRest))
                          .contentType(contentType))
             .andExpect(status().isForbidden());
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadatafieldRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadatafieldRestRepositoryIT.java
@@ -69,6 +69,9 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
     @Autowired
     private MetadataFieldServiceImpl metadataFieldService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     @Before
     public void setup() throws Exception {
         metadataSchema = metadataSchemaService.findAll(context).get(0);
@@ -647,7 +650,7 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
                 .perform(post("/api/core/metadatafields")
                     .param("schemaId", metadataSchema.getID() + "")
                     .param("projection", "full")
-                    .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
+                    .content(mapper.writeValueAsBytes(metadataFieldRest))
                     .contentType(contentType))
                 .andExpect(status().isCreated())
                 .andDo(result -> idRef.set(read(result.getResponse().getContentAsString(), "$.id")));
@@ -679,7 +682,7 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
                     getClient(authToken)
                             .perform(post("/api/core/metadatafields")
                                     .param("schemaId", metadataSchema.getID() + "")
-                                    .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
+                                    .content(mapper.writeValueAsBytes(metadataFieldRest))
                                     .contentType(contentType))
                             .andExpect(status().isCreated())
                             .andReturn().getResponse().getContentAsString(),
@@ -715,7 +718,7 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
                 .perform(post("/api/core/metadatafields")
                     .param("schemaId", metadataSchema.getID() + "")
                     .param("projection", "full")
-                    .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
+                    .content(mapper.writeValueAsBytes(metadataFieldRest))
                     .contentType(contentType))
                 .andExpect(status().isCreated())
                 .andDo(result -> idRef.set(read(result.getResponse().getContentAsString(), "$.id")));
@@ -752,7 +755,7 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
         getClient()
             .perform(post("/api/core/metadatafields")
                 .param("schemaId", metadataSchema.getID() + "")
-                .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
+                .content(mapper.writeValueAsBytes(metadataFieldRest))
                 .contentType(contentType))
             .andExpect(status().isUnauthorized());
     }
@@ -772,7 +775,7 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
             .perform(post("/api/core/metadatafields")
                          .param("schemaId", String.valueOf(metadataSchema.getID()))
                          .param("projection", "full")
-                         .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
+                         .content(mapper.writeValueAsBytes(metadataFieldRest))
                          .contentType(contentType))
             .andExpect(status().isUnprocessableEntity());
 
@@ -784,7 +787,7 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
             .perform(post("/api/core/metadatafields")
                          .param("schemaId", String.valueOf(metadataSchema.getID()))
                          .param("projection", "full")
-                         .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
+                         .content(mapper.writeValueAsBytes(metadataFieldRest))
                          .contentType(contentType))
             .andExpect(status().isUnprocessableEntity());
 
@@ -796,7 +799,7 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
             .perform(post("/api/core/metadatafields")
                          .param("schemaId", String.valueOf(metadataSchema.getID()))
                          .param("projection", "full")
-                         .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
+                         .content(mapper.writeValueAsBytes(metadataFieldRest))
                          .contentType(contentType))
             .andExpect(status().isUnprocessableEntity());
     }
@@ -816,7 +819,7 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
             .perform(post("/api/core/metadatafields")
                          .param("schemaId", String.valueOf(metadataSchema.getID()))
                          .param("projection", "full")
-                         .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
+                         .content(mapper.writeValueAsBytes(metadataFieldRest))
                          .contentType(contentType))
             .andExpect(status().isUnprocessableEntity());
 
@@ -828,7 +831,7 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
             .perform(post("/api/core/metadatafields")
                          .param("schemaId", String.valueOf(metadataSchema.getID()))
                          .param("projection", "full")
-                         .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
+                         .content(mapper.writeValueAsBytes(metadataFieldRest))
                          .contentType(contentType))
             .andExpect(status().isUnprocessableEntity());
 
@@ -840,7 +843,7 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
             .perform(post("/api/core/metadatafields")
                          .param("schemaId", String.valueOf(metadataSchema.getID()))
                          .param("projection", "full")
-                         .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
+                         .content(mapper.writeValueAsBytes(metadataFieldRest))
                          .contentType(contentType))
             .andExpect(status().isUnprocessableEntity());
     }
@@ -858,7 +861,7 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
         getClient(token)
             .perform(post("/api/core/metadatafields")
                 .param("schemaId", metadataSchema.getID() + "")
-                .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
+                .content(mapper.writeValueAsBytes(metadataFieldRest))
                 .contentType(contentType))
             .andExpect(status().isForbidden());
     }
@@ -1000,7 +1003,7 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
 
         getClient(getAuthToken(admin.getEmail(), password))
             .perform(put("/api/core/metadatafields/" + metadataField.getID())
-                         .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
+                         .content(mapper.writeValueAsBytes(metadataFieldRest))
                          .contentType(contentType))
             .andExpect(status().isOk());
     }
@@ -1022,7 +1025,7 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
 
         getClient(getAuthToken(admin.getEmail(), password))
             .perform(put("/api/core/metadatafields/" + metadataField.getID())
-                         .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
+                         .content(mapper.writeValueAsBytes(metadataFieldRest))
                          .contentType(contentType))
             .andExpect(status().isUnprocessableEntity());
 
@@ -1050,7 +1053,7 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
 
         getClient(getAuthToken(admin.getEmail(), password))
             .perform(put("/api/core/metadatafields/" + metadataField.getID())
-                         .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
+                         .content(mapper.writeValueAsBytes(metadataFieldRest))
                          .contentType(contentType))
             .andExpect(status().isUnprocessableEntity());
 
@@ -1089,7 +1092,7 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
 
         getClient(getAuthToken(admin.getEmail(), password))
             .perform(put("/api/core/metadatafields/" + metadataField.getID())
-                .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
+                .content(mapper.writeValueAsBytes(metadataFieldRest))
                 .contentType(contentType))
             .andExpect(status().isUnprocessableEntity());
 
@@ -1131,7 +1134,7 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
 
         getClient()
             .perform(put("/api/core/metadatafields/" + metadataField.getID())
-                .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
+                .content(mapper.writeValueAsBytes(metadataFieldRest))
                 .contentType(contentType))
             .andExpect(status().isUnauthorized());
 
@@ -1161,7 +1164,7 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
 
         getClient(getAuthToken(eperson.getEmail(), password))
             .perform(put("/api/core/metadatafields/" + metadataField.getID())
-                .content(new ObjectMapper().writeValueAsBytes(metadataFieldRest))
+                .content(mapper.writeValueAsBytes(metadataFieldRest))
                 .contentType(contentType))
             .andExpect(status().isForbidden());
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/NotifyRequestStatusRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/NotifyRequestStatusRestControllerIT.java
@@ -50,6 +50,9 @@ public class NotifyRequestStatusRestControllerIT extends AbstractControllerInteg
     @Autowired
     private LDNMessageService ldnMessageService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     @Test
     public void oneStatusReviewedTest() throws Exception {
         context.turnOffAuthorisationSystem();
@@ -70,7 +73,6 @@ public class NotifyRequestStatusRestControllerIT extends AbstractControllerInteg
         String announceReview = IOUtils.toString(offerReviewStream, Charset.defaultCharset());
         offerReviewStream.close();
         String message = announceReview.replaceAll("<<object_handle>>", object);
-        ObjectMapper mapper = new ObjectMapper();
         Notification notification = mapper.readValue(message, Notification.class);
         getClient()
             .perform(post("/ldn/inbox")
@@ -117,7 +119,6 @@ public class NotifyRequestStatusRestControllerIT extends AbstractControllerInteg
         String announceReview = IOUtils.toString(offerReviewStream, Charset.defaultCharset());
         offerReviewStream.close();
         String message = announceReview.replaceAll("<<object_handle>>", object);
-        ObjectMapper mapper = new ObjectMapper();
         Notification notification = mapper.readValue(message, Notification.class);
         getClient()
             .perform(post("/ldn/inbox")
@@ -152,7 +153,6 @@ public class NotifyRequestStatusRestControllerIT extends AbstractControllerInteg
         String announceReview = IOUtils.toString(offerReviewStream, Charset.defaultCharset());
         offerReviewStream.close();
         String message = announceReview.replaceAll("<<object_handle>>", object);
-        ObjectMapper mapper = new ObjectMapper();
         Notification notification = mapper.readValue(message, Notification.class);
         getClient()
             .perform(post("/ldn/inbox")
@@ -173,8 +173,7 @@ public class NotifyRequestStatusRestControllerIT extends AbstractControllerInteg
         ackMessage = ackMessage.replaceAll(
             "<<ldn_offer_review_uuid>>", "urn:uuid:0370c0fb-bb78-4a9b-87f5-bed307a509df");
 
-        ObjectMapper ackMapper = new ObjectMapper();
-        Notification ackNotification = ackMapper.readValue(ackMessage, Notification.class);
+        Notification ackNotification = mapper.readValue(ackMessage, Notification.class);
         getClient()
             .perform(post("/ldn/inbox")
                 .contentType("application/ld+json")

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/NotifyServiceRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/NotifyServiceRestRepositoryIT.java
@@ -65,6 +65,9 @@ public class NotifyServiceRestRepositoryIT extends AbstractControllerIntegration
     @Autowired
     private NotifyService notifyService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     @Test
     public void findAllUnAuthorizedTest() throws Exception {
         getClient().perform(get("/api/ldn/ldnservices"))
@@ -147,7 +150,6 @@ public class NotifyServiceRestRepositoryIT extends AbstractControllerIntegration
 
     @Test
     public void createForbiddenTest() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
         NotifyServiceRest notifyServiceRest = new NotifyServiceRest();
         String authToken = getAuthToken(eperson.getEmail(), password);
         getClient(authToken).perform(post("/api/ldn/ldnservices")
@@ -158,8 +160,6 @@ public class NotifyServiceRestRepositoryIT extends AbstractControllerIntegration
 
     @Test
     public void createTestScoreFail() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-
         NotifyServiceInboundPatternRest inboundPatternRestOne = new NotifyServiceInboundPatternRest();
         inboundPatternRestOne.setPattern("patternA");
         inboundPatternRestOne.setConstraint("itemFilterA");
@@ -188,8 +188,6 @@ public class NotifyServiceRestRepositoryIT extends AbstractControllerIntegration
 
     @Test
     public void createTest() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-
         NotifyServiceInboundPatternRest inboundPatternRestOne = new NotifyServiceInboundPatternRest();
         inboundPatternRestOne.setPattern("patternA");
         inboundPatternRestOne.setConstraint("itemFilterA");

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProcessRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProcessRestRepositoryIT.java
@@ -634,11 +634,11 @@ public class ProcessRestRepositoryIT extends AbstractControllerIntegrationTest {
     @Test
     public void searchProcessTestByUserSortedOnStartTimeAsc() throws Exception {
         Process newProcess1 = ProcessBuilder.createProcess(context, eperson, "mock-script", parameters)
-                                            .withStartAndEndTime("10/01/1990", "20/01/1990").build();
+                                            .withStartAndEndTime("1990-01-10", "1990-01-20").build();
         Process newProcess2 = ProcessBuilder.createProcess(context, eperson, "mock-script", parameters)
-                                            .withStartAndEndTime("11/01/1990", "19/01/1990").build();
+                                            .withStartAndEndTime("1990-01-11", "1990-01-19").build();
         Process newProcess3 = ProcessBuilder.createProcess(context, eperson, "mock-script", parameters)
-                                            .withStartAndEndTime("12/01/1990", "18/01/1990").build();
+                                            .withStartAndEndTime("1990-01-12", "1990-01-18").build();
 
         String token = getAuthToken(admin.getEmail(), password);
 
@@ -664,11 +664,11 @@ public class ProcessRestRepositoryIT extends AbstractControllerIntegrationTest {
     @Test
     public void searchProcessTestByUserSortedOnStartTimeDesc() throws Exception {
         Process newProcess1 = ProcessBuilder.createProcess(context, eperson, "mock-script", parameters)
-                                            .withStartAndEndTime("10/01/1990", "20/01/1990").build();
+                                            .withStartAndEndTime("1990-01-10", "1990-01-20").build();
         Process newProcess2 = ProcessBuilder.createProcess(context, eperson, "mock-script", parameters)
-                                            .withStartAndEndTime("11/01/1990", "19/01/1990").build();
+                                            .withStartAndEndTime("1990-01-11", "1990-01-19").build();
         Process newProcess3 = ProcessBuilder.createProcess(context, eperson, "mock-script", parameters)
-                                            .withStartAndEndTime("12/01/1990", "18/01/1990").build();
+                                            .withStartAndEndTime("1990-01-12", "1990-01-18").build();
 
         String token = getAuthToken(admin.getEmail(), password);
 
@@ -699,7 +699,7 @@ public class ProcessRestRepositoryIT extends AbstractControllerIntegrationTest {
                                             // but proves startTime is ignored on sort
                                             .withCreationTime(LocalDate.of(2000, 1, 1)
                                                                        .atStartOfDay().toInstant(ZoneOffset.UTC))
-                                            .withStartAndEndTime("01/01/1990", "01/01/1995").build();
+                                            .withStartAndEndTime("1990-01-01", "1995-01-01").build();
         Process newProcess2 = ProcessBuilder.createProcess(context, eperson, "mock-script", parameters)
                                             .withCreationTime(LocalDate.of(2005, 1, 1)
                                                                        .atStartOfDay().toInstant(ZoneOffset.UTC))
@@ -707,7 +707,7 @@ public class ProcessRestRepositoryIT extends AbstractControllerIntegrationTest {
         Process newProcess3 = ProcessBuilder.createProcess(context, eperson, "mock-script", parameters)
                                             .withCreationTime(LocalDate.of(2010, 1, 1)
                                                                        .atStartOfDay().toInstant(ZoneOffset.UTC))
-                                            .withStartAndEndTime("01/01/2015", "01/01/2020").build();
+                                            .withStartAndEndTime("2015-01-01", "2020-01-01").build();
 
         String token = getAuthToken(admin.getEmail(), password);
 
@@ -737,7 +737,7 @@ public class ProcessRestRepositoryIT extends AbstractControllerIntegrationTest {
                                             // but proves startTime is ignored on sort
                                             .withCreationTime(LocalDate.of(2000, 1, 1)
                                                                        .atStartOfDay().toInstant(ZoneOffset.UTC))
-                                            .withStartAndEndTime("01/01/1990", "01/01/1995").build();
+                                            .withStartAndEndTime("1990-01-01", "1995-01-01").build();
         Process newProcess2 = ProcessBuilder.createProcess(context, eperson, "mock-script", parameters)
                                             .withCreationTime(LocalDate.of(2005, 1, 1)
                                                                        .atStartOfDay().toInstant(ZoneOffset.UTC))
@@ -745,7 +745,7 @@ public class ProcessRestRepositoryIT extends AbstractControllerIntegrationTest {
         Process newProcess3 = ProcessBuilder.createProcess(context, eperson, "mock-script", parameters)
                                             .withCreationTime(LocalDate.of(2010, 1, 1)
                                                                        .atStartOfDay().toInstant(ZoneOffset.UTC))
-                                            .withStartAndEndTime("01/01/2015", "01/01/2020").build();
+                                            .withStartAndEndTime("2015-01-01", "2020-01-01").build();
 
         String token = getAuthToken(admin.getEmail(), password);
 
@@ -771,11 +771,11 @@ public class ProcessRestRepositoryIT extends AbstractControllerIntegrationTest {
     @Test
     public void searchProcessTestByUserSortedOnEndTimeAsc() throws Exception {
         Process newProcess1 = ProcessBuilder.createProcess(context, eperson, "mock-script", parameters)
-                                            .withStartAndEndTime("10/01/1990", "20/01/1990").build();
+                                            .withStartAndEndTime("1990-01-10", "1990-01-20").build();
         Process newProcess2 = ProcessBuilder.createProcess(context, eperson, "mock-script", parameters)
-                                            .withStartAndEndTime("11/01/1990", "19/01/1990").build();
+                                            .withStartAndEndTime("1990-01-11", "1990-01-19").build();
         Process newProcess3 = ProcessBuilder.createProcess(context, eperson, "mock-script", parameters)
-                                            .withStartAndEndTime("12/01/1990", "18/01/1990").build();
+                                            .withStartAndEndTime("1990-01-12", "1990-01-18").build();
 
         String token = getAuthToken(admin.getEmail(), password);
 
@@ -801,11 +801,11 @@ public class ProcessRestRepositoryIT extends AbstractControllerIntegrationTest {
     @Test
     public void searchProcessTestByUserSortedOnEndTimeDesc() throws Exception {
         Process newProcess1 = ProcessBuilder.createProcess(context, eperson, "mock-script", parameters)
-                                            .withStartAndEndTime("10/01/1990", "20/01/1990").build();
+                                            .withStartAndEndTime("1990-01-10", "1990-01-20").build();
         Process newProcess2 = ProcessBuilder.createProcess(context, eperson, "mock-script", parameters)
-                                            .withStartAndEndTime("11/01/1990", "19/01/1990").build();
+                                            .withStartAndEndTime("1990-01-11", "1990-01-19").build();
         Process newProcess3 = ProcessBuilder.createProcess(context, eperson, "mock-script", parameters)
-                                            .withStartAndEndTime("12/01/1990", "18/01/1990").build();
+                                            .withStartAndEndTime("1990-01-12", "1990-01-18").build();
 
         String token = getAuthToken(admin.getEmail(), password);
 
@@ -831,11 +831,11 @@ public class ProcessRestRepositoryIT extends AbstractControllerIntegrationTest {
     @Test
     public void searchProcessTestByUserSortedOnMultipleBadRequest() throws Exception {
         Process newProcess1 = ProcessBuilder.createProcess(context, eperson, "mock-script", parameters)
-                                            .withStartAndEndTime("10/01/1990", "20/01/1990").build();
+                                            .withStartAndEndTime("1990-01-10", "1990-01-20").build();
         Process newProcess2 = ProcessBuilder.createProcess(context, eperson, "mock-script", parameters)
-                                            .withStartAndEndTime("11/01/1990", "19/01/1990").build();
+                                            .withStartAndEndTime("1990-01-11", "1990-01-19").build();
         Process newProcess3 = ProcessBuilder.createProcess(context, eperson, "mock-script", parameters)
-                                            .withStartAndEndTime("12/01/1990", "18/01/1990").build();
+                                            .withStartAndEndTime("1990-01-12", "1990-01-18").build();
 
         String token = getAuthToken(admin.getEmail(), password);
 
@@ -849,11 +849,11 @@ public class ProcessRestRepositoryIT extends AbstractControllerIntegrationTest {
     @Test
     public void searchProcessTestByUserSortedOnDefault() throws Exception {
         Process newProcess1 = ProcessBuilder.createProcess(context, eperson, "mock-script", parameters)
-                                            .withStartAndEndTime("10/01/1990", "20/01/1990").build();
+                                            .withStartAndEndTime("1990-01-10", "1990-01-20").build();
         Process newProcess2 = ProcessBuilder.createProcess(context, eperson, "mock-script", parameters)
-                                            .withStartAndEndTime("11/01/1990", "19/01/1990").build();
+                                            .withStartAndEndTime("1990-01-11", "1990-01-19").build();
         Process newProcess3 = ProcessBuilder.createProcess(context, eperson, "mock-script", parameters)
-                                            .withStartAndEndTime("12/01/1990", "18/01/1990").build();
+                                            .withStartAndEndTime("1990-01-12", "1990-01-18").build();
 
         String token = getAuthToken(admin.getEmail(), password);
 
@@ -878,11 +878,11 @@ public class ProcessRestRepositoryIT extends AbstractControllerIntegrationTest {
     @Test
     public void searchProcessTestByUserSortedOnNonExistingBadRequest() throws Exception {
         Process newProcess1 = ProcessBuilder.createProcess(context, eperson, "mock-script", parameters)
-                                            .withStartAndEndTime("10/01/1990", "20/01/1990").build();
+                                            .withStartAndEndTime("1990-01-10", "1990-01-20").build();
         Process newProcess2 = ProcessBuilder.createProcess(context, eperson, "mock-script", parameters)
-                                            .withStartAndEndTime("11/01/1990", "19/01/1990").build();
+                                            .withStartAndEndTime("1990-01-11", "1990-01-19").build();
         Process newProcess3 = ProcessBuilder.createProcess(context, eperson, "mock-script", parameters)
-                                            .withStartAndEndTime("12/01/1990", "18/01/1990").build();
+                                            .withStartAndEndTime("1990-01-12", "1990-01-18").build();
 
         String token = getAuthToken(admin.getEmail(), password);
 
@@ -896,14 +896,11 @@ public class ProcessRestRepositoryIT extends AbstractControllerIntegrationTest {
     public void testFindByCurrentUser() throws Exception {
 
         Process process1 = ProcessBuilder.createProcess(context, eperson, "mock-script", parameters)
-            .withStartAndEndTime("10/01/1990", "20/01/1990")
-            .build();
+                                         .withStartAndEndTime("1990-01-10", "1990-01-20").build();
         ProcessBuilder.createProcess(context, admin, "mock-script", parameters)
-            .withStartAndEndTime("11/01/1990", "19/01/1990")
-            .build();
+                      .withStartAndEndTime("1990-01-11", "1990-01-19").build();
         Process process3 = ProcessBuilder.createProcess(context, eperson, "mock-script", parameters)
-            .withStartAndEndTime("12/01/1990", "18/01/1990")
-            .build();
+                                         .withStartAndEndTime("1990-01-12", "1990-01-18").build();
 
         String token = getAuthToken(eperson.getEmail(), password);
 
@@ -920,7 +917,7 @@ public class ProcessRestRepositoryIT extends AbstractControllerIntegrationTest {
     public void getProcessOutput() throws Exception {
         context.setCurrentUser(eperson);
         Process process1 = ProcessBuilder.createProcess(context, eperson, "mock-script", parameters)
-                .withStartAndEndTime("10/01/1990", "20/01/1990")
+                .withStartAndEndTime("1990-01-10", "1990-01-20")
                 .build();
 
         try (InputStream is = IOUtils.toInputStream("Test File For Process", CharEncoding.UTF_8)) {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProcessRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProcessRestRepositoryIT.java
@@ -18,7 +18,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.io.InputStream;
 import java.sql.SQLException;
-import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
@@ -692,17 +693,20 @@ public class ProcessRestRepositoryIT extends AbstractControllerIntegrationTest {
 
     @Test
     public void searchProcessTestByUserSortedOnCreationTimeAsc() throws Exception {
-        SimpleDateFormat date = new SimpleDateFormat("dd/MM/yyyy");
+
         Process newProcess1 = ProcessBuilder.createProcess(context, eperson, "mock-script", parameters)
                                             // not realistic to have creationTime after startTime,
                                             // but proves startTime is ignored on sort
-                                            .withCreationTime(date.parse("01/01/2000"))
+                                            .withCreationTime(LocalDate.of(2000, 1, 1)
+                                                                       .atStartOfDay().toInstant(ZoneOffset.UTC))
                                             .withStartAndEndTime("01/01/1990", "01/01/1995").build();
         Process newProcess2 = ProcessBuilder.createProcess(context, eperson, "mock-script", parameters)
-                                            .withCreationTime(date.parse("01/01/2005"))
+                                            .withCreationTime(LocalDate.of(2005, 1, 1)
+                                                                       .atStartOfDay().toInstant(ZoneOffset.UTC))
                                             .withStartAndEndTime(null, null).build();
         Process newProcess3 = ProcessBuilder.createProcess(context, eperson, "mock-script", parameters)
-                                            .withCreationTime(date.parse("01/01/2010"))
+                                            .withCreationTime(LocalDate.of(2010, 1, 1)
+                                                                       .atStartOfDay().toInstant(ZoneOffset.UTC))
                                             .withStartAndEndTime("01/01/2015", "01/01/2020").build();
 
         String token = getAuthToken(admin.getEmail(), password);
@@ -728,17 +732,19 @@ public class ProcessRestRepositoryIT extends AbstractControllerIntegrationTest {
 
     @Test
     public void searchProcessTestByUserSortedOnCreationTimeDesc() throws Exception {
-        SimpleDateFormat date = new SimpleDateFormat("dd/MM/yyyy");
         Process newProcess1 = ProcessBuilder.createProcess(context, eperson, "mock-script", parameters)
                                             // not realistic to have creationTime after startTime,
                                             // but proves startTime is ignored on sort
-                                            .withCreationTime(date.parse("01/01/2000"))
+                                            .withCreationTime(LocalDate.of(2000, 1, 1)
+                                                                       .atStartOfDay().toInstant(ZoneOffset.UTC))
                                             .withStartAndEndTime("01/01/1990", "01/01/1995").build();
         Process newProcess2 = ProcessBuilder.createProcess(context, eperson, "mock-script", parameters)
-                                            .withCreationTime(date.parse("01/01/2005"))
+                                            .withCreationTime(LocalDate.of(2005, 1, 1)
+                                                                       .atStartOfDay().toInstant(ZoneOffset.UTC))
                                             .withStartAndEndTime(null, null).build();
         Process newProcess3 = ProcessBuilder.createProcess(context, eperson, "mock-script", parameters)
-                                            .withCreationTime(date.parse("01/01/2010"))
+                                            .withCreationTime(LocalDate.of(2010, 1, 1)
+                                                                       .atStartOfDay().toInstant(ZoneOffset.UTC))
                                             .withStartAndEndTime("01/01/2015", "01/01/2020").build();
 
         String token = getAuthToken(admin.getEmail(), password);

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/QAEventRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/QAEventRestRepositoryIT.java
@@ -92,6 +92,9 @@ public class QAEventRestRepositoryIT extends AbstractControllerIntegrationTest {
     @Autowired
     private ASimpleMetadataAction AddEndorsedMetadataAction;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     @Test
     public void findAllNotImplementedTest() throws Exception {
         String adminToken = getAuthToken(admin.getEmail(), password);
@@ -1313,7 +1316,7 @@ public class QAEventRestRepositoryIT extends AbstractControllerIntegrationTest {
         getClient(ePersonToken).perform(post("/api/integration/qualityassuranceevents")
                                .param("correctionType", "request-withdrawn")
                                .param("target", publication.getID().toString())
-                               .content(new ObjectMapper().writeValueAsBytes(message))
+                               .content(mapper.writeValueAsBytes(message))
                                .contentType(contentType))
                                .andExpect(status().isCreated())
                                .andDo(result -> idRef.set(read(result.getResponse().getContentAsString(), "$.id")));
@@ -1374,7 +1377,6 @@ public class QAEventRestRepositoryIT extends AbstractControllerIntegrationTest {
 
         AtomicReference<String> idRef = new AtomicReference<String>();
 
-        ObjectMapper mapper = new ObjectMapper();
         CorrectionTypeMessageDTO dto = new CorrectionTypeMessageDTO("provided reason!");
 
         getClient(ePersonToken).perform(post("/api/integration/qualityassuranceevents")
@@ -1453,7 +1455,7 @@ public class QAEventRestRepositoryIT extends AbstractControllerIntegrationTest {
         getClient(ePersonToken).perform(post("/api/integration/qualityassuranceevents")
                                .param("correctionType", "request-withdrawn")
                                .param("target", publication.getID().toString())
-                               .content(new ObjectMapper().writeValueAsBytes(message))
+                               .content(mapper.writeValueAsBytes(message))
                                .contentType(contentType))
                                .andExpect(status().isUnprocessableEntity());
 
@@ -1462,7 +1464,7 @@ public class QAEventRestRepositoryIT extends AbstractControllerIntegrationTest {
         getClient(user1Token).perform(post("/api/integration/qualityassuranceevents")
                              .param("correctionType", "request-withdrawn")
                              .param("target", publication.getID().toString())
-                             .content(new ObjectMapper().writeValueAsBytes(message))
+                             .content(mapper.writeValueAsBytes(message))
                              .contentType(contentType))
                              .andExpect(status().isCreated())
                              .andDo(result -> idRef.set(read(result.getResponse().getContentAsString(), "$.id")));

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/RegistrationRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/RegistrationRestRepositoryIT.java
@@ -53,6 +53,8 @@ public class RegistrationRestRepositoryIT extends AbstractControllerIntegrationT
     private ConfigurationService configurationService;
     @Autowired
     private RegistrationRestRepository registrationRestRepository;
+    @Autowired
+    private ObjectMapper mapper;
 
     @Test
     public void findByTokenTestExistingUserTest() throws Exception {
@@ -111,7 +113,6 @@ public class RegistrationRestRepositoryIT extends AbstractControllerIntegrationT
     }
 
     private void createTokenForEmail(String email) throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
         RegistrationRest registrationRest = new RegistrationRest();
         registrationRest.setEmail(email);
         getClient().perform(post("/api/eperson/registrations")
@@ -126,7 +127,6 @@ public class RegistrationRestRepositoryIT extends AbstractControllerIntegrationT
         List<RegistrationData> registrationDataList = registrationDataDAO.findAll(context, RegistrationData.class);
         assertEquals(0, registrationDataList.size());
 
-        ObjectMapper mapper = new ObjectMapper();
         RegistrationRest registrationRest = new RegistrationRest();
         registrationRest.setEmail(eperson.getEmail());
 
@@ -182,7 +182,6 @@ public class RegistrationRestRepositoryIT extends AbstractControllerIntegrationT
             String email = "testPerson@test.com";
             registrationRest.setEmail(email);
 
-            ObjectMapper mapper = new ObjectMapper();
             getClient().perform(post("/api/eperson/registrations")
                                     .param(TYPE_QUERY_PARAM, TYPE_REGISTER)
                                     .content(mapper.writeValueAsBytes(registrationRest))
@@ -209,7 +208,6 @@ public class RegistrationRestRepositoryIT extends AbstractControllerIntegrationT
             String email = "testPerson@bladibla.com";
             registrationRest.setEmail(email);
 
-            ObjectMapper mapper = new ObjectMapper();
             getClient().perform(post("/api/eperson/registrations")
                                     .param(TYPE_QUERY_PARAM, TYPE_REGISTER)
                                     .content(mapper.writeValueAsBytes(registrationRest))
@@ -240,7 +238,6 @@ public class RegistrationRestRepositoryIT extends AbstractControllerIntegrationT
             RegistrationRest registrationRest = new RegistrationRest();
             registrationRest.setEmail(email);
 
-            ObjectMapper mapper = new ObjectMapper();
             getClient().perform(post("/api/eperson/registrations")
                                     .param(TYPE_QUERY_PARAM, TYPE_REGISTER)
                                     .content(mapper.writeValueAsBytes(registrationRest))
@@ -266,7 +263,6 @@ public class RegistrationRestRepositoryIT extends AbstractControllerIntegrationT
         try {
             assertEquals(0, registrationDataList.size());
 
-            ObjectMapper mapper = new ObjectMapper();
             RegistrationRest registrationRest = new RegistrationRest();
             registrationRest.setEmail(eperson.getEmail());
             getClient().perform(post("/api/eperson/registrations")
@@ -295,7 +291,6 @@ public class RegistrationRestRepositoryIT extends AbstractControllerIntegrationT
         try {
             assertEquals(0, registrationDataList.size());
 
-            ObjectMapper mapper = new ObjectMapper();
             RegistrationRest registrationRest = new RegistrationRest();
             registrationRest.setEmail(eperson.getEmail());
             getClient().perform(post("/api/eperson/registrations")
@@ -321,7 +316,6 @@ public class RegistrationRestRepositoryIT extends AbstractControllerIntegrationT
         String originVresion = configurationService.getProperty("google.recaptcha.version");
         reloadCaptchaProperties("true", "test-secret", "v2");
 
-        ObjectMapper mapper = new ObjectMapper();
         RegistrationRest registrationRest = new RegistrationRest();
         registrationRest.setEmail(eperson.getEmail());
 
@@ -342,7 +336,6 @@ public class RegistrationRestRepositoryIT extends AbstractControllerIntegrationT
         String originVresion = configurationService.getProperty("google.recaptcha.version");
         reloadCaptchaProperties("true", "test-secret", "v2");
 
-        ObjectMapper mapper = new ObjectMapper();
         RegistrationRest registrationRest = new RegistrationRest();
         registrationRest.setEmail(eperson.getEmail());
 
@@ -380,7 +373,6 @@ public class RegistrationRestRepositoryIT extends AbstractControllerIntegrationT
         List<RegistrationData> registrationDataList = registrationDataDAO.findAll(context, RegistrationData.class);
         assertEquals(0, registrationDataList.size());
 
-        ObjectMapper mapper = new ObjectMapper();
         RegistrationRest registrationRest = new RegistrationRest();
         registrationRest.setEmail(eperson.getEmail());
         try {
@@ -451,7 +443,6 @@ public class RegistrationRestRepositoryIT extends AbstractControllerIntegrationT
 
     @Test
     public void accountEndpoint_WithoutAccountTypeParam() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
         RegistrationRest registrationRest = new RegistrationRest();
         registrationRest.setEmail(eperson.getEmail());
         getClient().perform(post("/api/eperson/registrations")
@@ -462,7 +453,6 @@ public class RegistrationRestRepositoryIT extends AbstractControllerIntegrationT
 
     @Test
     public void accountEndpoint_WrongAccountTypeParam() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
         RegistrationRest registrationRest = new RegistrationRest();
         registrationRest.setEmail(eperson.getEmail());
         getClient().perform(post("/api/eperson/registrations")

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/RelationshipRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/RelationshipRestRepositoryIT.java
@@ -103,6 +103,10 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
 
     @Autowired
     MockSolrSearchCore mockSolrSearchCore;
+
+    @Autowired
+    private ObjectMapper mapper;
+
     protected Community parentCommunity;
     protected Community child1;
 
@@ -648,7 +652,7 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
 
         Map<String, String> map = new HashMap<>();
         map.put("leftwardValue", leftwardValue);
-        String json = new ObjectMapper().writeValueAsString(map);
+        String json = mapper.writeValueAsString(map);
 
         // Add leftwardValue
         getClient(token).perform(put("/api/core/relationships/" + idRef)
@@ -708,7 +712,7 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         Map<String, String> map = new HashMap<>();
         map.put("leftwardValue", leftwardValue);
         map.put("rightwardValue", rightwardValue);
-        String json = new ObjectMapper().writeValueAsString(map);
+        String json = mapper.writeValueAsString(map);
 
         // Add leftwardValue and rightwardValue
         getClient(token).perform(put("/api/core/relationships/" + idRef)
@@ -2641,7 +2645,6 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
                                               .andExpect(status().isCreated())
                                               .andReturn();
 
-        ObjectMapper mapper = new ObjectMapper();
         String content = mvcResult.getResponse().getContentAsString();
         Map<String, Object> map = mapper.readValue(content, Map.class);
         String id = String.valueOf(map.get("id"));
@@ -2689,7 +2692,6 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
                 .andExpect(status().isCreated())
                 .andReturn();
 
-            ObjectMapper mapper = new ObjectMapper();
             String content = mvcResult.getResponse().getContentAsString();
             Map<String, Object> map = mapper.readValue(content, Map.class);
             String id = String.valueOf(map.get("id"));

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/RequestItemRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/RequestItemRepositoryIT.java
@@ -93,6 +93,9 @@ public class RequestItemRepositoryIT
     @Autowired
     private ConfigurationService configurationService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     private Collection collection;
 
     private Item item;
@@ -219,7 +222,6 @@ public class RequestItemRepositoryIT
         rir.setRequestMessage(RequestItemBuilder.REQ_MESSAGE);
 
         // Create it and see if it was created correctly.
-        ObjectMapper mapper = new ObjectMapper();
         String authToken = getAuthToken(eperson.getEmail(), password);
         try {
                 getClient(authToken)
@@ -273,7 +275,6 @@ public class RequestItemRepositoryIT
         rir.setRequestName(RequestItemBuilder.REQ_NAME);
 
         // Create it and see if it was created correctly.
-        ObjectMapper mapper = new ObjectMapper();
         try {
                 getClient().perform(post(URI_ROOT)
                                 .content(mapper.writeValueAsBytes(rir))
@@ -325,7 +326,6 @@ public class RequestItemRepositoryIT
         rir.setAllfiles(false);
 
         // Try to create it, with various malformations.
-        ObjectMapper mapper = new ObjectMapper();
         String authToken = getAuthToken(eperson.getEmail(), password);
 
         // Test missing bitstream ID
@@ -411,7 +411,6 @@ public class RequestItemRepositoryIT
         rir.setRequestName(RequestItemBuilder.REQ_NAME);
         rir.setAllfiles(false);
 
-        ObjectMapper mapper = new ObjectMapper();
         getClient().perform(post(URI_ROOT)
                 .content(mapper.writeValueAsBytes(rir))
                 .contentType(contentType)
@@ -497,7 +496,7 @@ public class RequestItemRepositoryIT
                 "subject", "subject",
                 "responseMessage", "Request accepted",
                 "suggestOpenAccess", "true");
-        String content = new ObjectMapper()
+        String content = mapper
                 .writer()
                 .writeValueAsString(parameters);
 
@@ -530,7 +529,7 @@ public class RequestItemRepositoryIT
         Map<String, String> parameters;
         String content;
 
-        ObjectWriter mapperWriter = new ObjectMapper().writer();
+        ObjectWriter mapperWriter = mapper.writer();
 
         // Unauthenticated user should be allowed.
         parameters = Map.of(
@@ -558,7 +557,7 @@ public class RequestItemRepositoryIT
         Map<String, String> parameters;
         String content;
 
-        ObjectWriter mapperWriter = new ObjectMapper().writer();
+        ObjectWriter mapperWriter = mapper.writer();
 
         // Missing acceptRequest
         parameters = Map.of(
@@ -588,7 +587,7 @@ public class RequestItemRepositoryIT
                 "acceptRequest", "true",
                 "subject", "subject",
                 "responseMessage", "Request accepted");
-        ObjectWriter mapperWriter = new ObjectMapper().writer();
+        ObjectWriter mapperWriter = mapper.writer();
         String content = mapperWriter.writeValueAsString(parameters);
         String authToken = getAuthToken(eperson.getEmail(), password);
         getClient(authToken).perform(put(URI_ROOT + '/' + itemRequest.getToken())

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/RequestItemRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/RequestItemRepositoryIT.java
@@ -8,7 +8,6 @@
 package org.dspace.app.rest;
 
 import static com.jayway.jsonpath.JsonPath.read;
-import static org.exparity.hamcrest.date.DateMatchers.within;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
@@ -31,8 +30,10 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.sql.SQLException;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.UUID;
@@ -58,6 +59,7 @@ import org.dspace.content.Bitstream;
 import org.dspace.content.Collection;
 import org.dspace.content.Item;
 import org.dspace.services.ConfigurationService;
+import org.exparity.hamcrest.date.LocalDateTimeMatchers;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
@@ -513,8 +515,8 @@ public class RequestItemRepositoryIT
                 = requestItemService.findByToken(context, requestTokenRef.get());
         assertTrue("acceptRequest should be true", foundRequest.isAccept_request());
         assertThat("decision_date must be within a minute of now",
-                foundRequest.getDecision_date(),
-                within(1, ChronoUnit.MINUTES, new Date()));
+                   foundRequest.getDecision_date().atZone(ZoneOffset.UTC).toLocalDateTime(),
+                   LocalDateTimeMatchers.within(1, ChronoUnit.MINUTES, LocalDateTime.now()));
     }
 
     @Test
@@ -578,7 +580,7 @@ public class RequestItemRepositoryIT
         RequestItem itemRequest = RequestItemBuilder
                 .createRequestItem(context, item, bitstream)
                 .withAcceptRequest(false)
-                .withDecisionDate(new Date())
+                .withDecisionDate(Instant.now())
                 .build();
 
         // Try to accept it again.

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
@@ -73,6 +73,9 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
     @Autowired
     ResourcePolicyService resourcePolicyService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     @Test
     public void findAllTest() throws Exception {
 
@@ -1007,7 +1010,6 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
             context.restoreAuthSystemState();
 
-            ObjectMapper mapper = new ObjectMapper();
             ResourcePolicyRest resourcePolicyRest = new ResourcePolicyRest();
 
             resourcePolicyRest.setPolicyType(ResourcePolicy.TYPE_SUBMISSION);
@@ -1066,7 +1068,6 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
             context.restoreAuthSystemState();
 
-            ObjectMapper mapper = new ObjectMapper();
             ResourcePolicyRest resourcePolicyRest = new ResourcePolicyRest();
 
             resourcePolicyRest.setPolicyType(ResourcePolicy.TYPE_SUBMISSION);
@@ -1114,7 +1115,6 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         context.restoreAuthSystemState();
 
-        ObjectMapper mapper = new ObjectMapper();
         ResourcePolicyRest resourcePolicyRest = new ResourcePolicyRest();
 
         resourcePolicyRest.setPolicyType(ResourcePolicy.TYPE_SUBMISSION);
@@ -1151,7 +1151,6 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         context.restoreAuthSystemState();
 
-        ObjectMapper mapper = new ObjectMapper();
         ResourcePolicyRest resourcePolicyRest = new ResourcePolicyRest();
 
         resourcePolicyRest.setPolicyType(ResourcePolicy.TYPE_SUBMISSION);
@@ -1189,7 +1188,6 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         context.restoreAuthSystemState();
 
-        ObjectMapper mapper = new ObjectMapper();
         ResourcePolicyRest resourcePolicyRest = new ResourcePolicyRest();
 
         resourcePolicyRest.setPolicyType(ResourcePolicy.TYPE_SUBMISSION);

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
@@ -22,10 +22,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
@@ -1327,32 +1326,21 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
             .withTitle("Public item")
             .build();
 
-        Calendar calendar = Calendar.getInstance();
-
-        calendar.set(Calendar.YEAR, 2019);
-        calendar.set(Calendar.MONTH, 9);
-        calendar.set(Calendar.DATE, 31);
-
-        Date data = calendar.getTime();
+        LocalDate date = LocalDate.of(2019, 10, 31);
 
         ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, null,
                    EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
             .withAction(Constants.READ)
             .withDspaceObject(publicItem1)
-            .withStartDate(data)
+            .withStartDate(date)
             .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
             .build();
 
         context.restoreAuthSystemState();
 
-        Calendar newCalendar = Calendar.getInstance();
-        SimpleDateFormat formatDate = new SimpleDateFormat("yyyy-MM-dd");
+        DateTimeFormatter formatDate = DateTimeFormatter.ISO_LOCAL_DATE;
 
-        newCalendar.set(Calendar.YEAR, 2020);
-        newCalendar.set(Calendar.MONTH, 0);
-        newCalendar.set(Calendar.DATE, 1);
-
-        Date newDate = newCalendar.getTime();
+        LocalDate newDate = LocalDate.of(2020, 1, 1);
 
         List<Operation> ops = new ArrayList<Operation>();
         ReplaceOperation replaceOperation = new ReplaceOperation("/startDate", formatDate.format(newDate));
@@ -1397,13 +1385,7 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
                                       .withTitle("Public item")
                                       .build();
 
-        Calendar calendar = Calendar.getInstance();
-
-        calendar.set(Calendar.YEAR, 2019);
-        calendar.set(Calendar.MONTH, 9);
-        calendar.set(Calendar.DATE, 31);
-
-        Date date = calendar.getTime();
+        LocalDate date = LocalDate.of(2019, 10, 31);
 
         ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, null,
                            EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
@@ -1415,14 +1397,8 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         context.restoreAuthSystemState();
 
-        Calendar newCalendar = Calendar.getInstance();
-        SimpleDateFormat formatDate = new SimpleDateFormat("yyyy-MM-dd");
-
-        newCalendar.set(Calendar.YEAR, 2020);
-        newCalendar.set(Calendar.MONTH, 0);
-        newCalendar.set(Calendar.DATE, 1);
-
-        Date newDate = newCalendar.getTime();
+        DateTimeFormatter formatDate = DateTimeFormatter.ISO_LOCAL_DATE;
+        LocalDate newDate = LocalDate.of(2020, 1, 1);
 
         List<Operation> ops = new ArrayList<Operation>();
         ReplaceOperation replaceOperation = new ReplaceOperation("/endDate", formatDate.format(newDate));
@@ -1476,14 +1452,8 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         context.restoreAuthSystemState();
 
-        Calendar newCalendar = Calendar.getInstance();
-        SimpleDateFormat formatDate = new SimpleDateFormat("yyyy-MM-dd");
-
-        newCalendar.set(Calendar.YEAR, 2019);
-        newCalendar.set(Calendar.MONTH, 9);
-        newCalendar.set(Calendar.DATE, 31);
-
-        Date newDate = newCalendar.getTime();
+        DateTimeFormatter formatDate = DateTimeFormatter.ISO_LOCAL_DATE;
+        LocalDate newDate = LocalDate.of(2019, 10, 31);
 
         List<Operation> ops = new ArrayList<Operation>();
         AddOperation addOperation = new AddOperation("/startDate", formatDate.format(newDate));
@@ -1539,9 +1509,8 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         context.restoreAuthSystemState();
 
-        Calendar newCalendar = Calendar.getInstance();
-        SimpleDateFormat formatDate = new SimpleDateFormat("yyyy-MM-dd");
-        Date newDate = new Date();
+        DateTimeFormatter formatDate = DateTimeFormatter.ISO_LOCAL_DATE;
+        LocalDate newDate = LocalDate.now();
 
         List<Operation> ops = new ArrayList<Operation>();
         AddOperation addOperation = new AddOperation("/endDate", formatDate.format(newDate));
@@ -1586,19 +1555,13 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
             .withTitle("Public item")
             .build();
 
-        Calendar calendar = Calendar.getInstance();
-
-        calendar.set(Calendar.YEAR, 2019);
-        calendar.set(Calendar.MONTH, 9);
-        calendar.set(Calendar.DATE, 31);
-
-        Date data = calendar.getTime();
+        LocalDate date = LocalDate.of(2019, 10, 31);
 
         ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, null,
                        EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
             .withAction(Constants.READ)
             .withDspaceObject(publicItem1)
-            .withStartDate(data)
+            .withStartDate(date)
             .withPolicyType(ResourcePolicy.TYPE_CUSTOM)
             .build();
 
@@ -1647,13 +1610,7 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
             .withTitle("Public item")
             .build();
 
-        Calendar calendar = Calendar.getInstance();
-
-        calendar.set(Calendar.YEAR, 2019);
-        calendar.set(Calendar.MONTH, 9);
-        calendar.set(Calendar.DATE, 31);
-
-        Date date = calendar.getTime();
+        LocalDate date = LocalDate.of(2019, 10, 31);
 
         ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, null,
                            EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
@@ -1667,7 +1624,7 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
         context.restoreAuthSystemState();
 
         String wrongStartDate = "";
-        SimpleDateFormat formatDate = new SimpleDateFormat("yyyy-MM-dd");
+        DateTimeFormatter formatDate = DateTimeFormatter.ISO_LOCAL_DATE;
 
         List<Operation> ops = new ArrayList<Operation>();
         ReplaceOperation replaceOperation = new ReplaceOperation("/startDate", wrongStartDate);
@@ -1698,13 +1655,7 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         Item item = ItemBuilder.createItem(context, collection).build();
 
-        Calendar calendar = Calendar.getInstance();
-
-        calendar.set(Calendar.YEAR, 2010);
-        calendar.set(Calendar.MONTH, 5);
-        calendar.set(Calendar.DATE, 15);
-
-        Date date = calendar.getTime();
+        LocalDate date = LocalDate.of(2010, 6, 15);
 
         ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
             .withAction(Constants.WRITE)
@@ -1715,14 +1666,8 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         context.restoreAuthSystemState();
 
-        Calendar calendar2 = Calendar.getInstance();
-        SimpleDateFormat formatDate = new SimpleDateFormat("yyyy-MM-dd");
-
-        calendar2.set(Calendar.YEAR, 2021);
-        calendar2.set(Calendar.MONTH, 2);
-        calendar2.set(Calendar.DATE, 21);
-
-        Date newDate = calendar2.getTime();
+        DateTimeFormatter formatDate = DateTimeFormatter.ISO_LOCAL_DATE;
+        LocalDate newDate = LocalDate.of(2021, 3, 21);
 
         List<Operation> ops = new ArrayList<Operation>();
         ReplaceOperation replaceOperation = new ReplaceOperation("/startDate", formatDate.format(newDate));
@@ -1760,13 +1705,7 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
             .withTitle("Public item")
             .build();
 
-        Calendar calendar = Calendar.getInstance();
-
-        calendar.set(Calendar.YEAR, 2019);
-        calendar.set(Calendar.MONTH, 9);
-        calendar.set(Calendar.DATE, 31);
-
-        Date date = calendar.getTime();
+        LocalDate date = LocalDate.of(2019, 10, 31);
 
         ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, null,
                        EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
@@ -1778,17 +1717,11 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         context.restoreAuthSystemState();
 
-        Calendar calendar2 = Calendar.getInstance();
-        SimpleDateFormat formatDate = new SimpleDateFormat("yyyy-MM-dd");
-
-        calendar2.set(Calendar.YEAR, 2020);
-        calendar2.set(Calendar.MONTH, 0);
-        calendar2.set(Calendar.DATE, 1);
-
-        Date newData = calendar2.getTime();
+        DateTimeFormatter formatDate = DateTimeFormatter.ISO_LOCAL_DATE;
+        LocalDate newDate = LocalDate.of(2020, 1, 1);
 
         List<Operation> ops = new ArrayList<Operation>();
-        ReplaceOperation replaceOperation = new ReplaceOperation("/startDate", formatDate.format(newData));
+        ReplaceOperation replaceOperation = new ReplaceOperation("/startDate", formatDate.format(newDate));
         ops.add(replaceOperation);
         String patchBody = getPatchContent(ops);
 
@@ -1818,17 +1751,11 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         context.restoreAuthSystemState();
 
-        Calendar calendar2 = Calendar.getInstance();
-        SimpleDateFormat formatDate = new SimpleDateFormat("yyyy-MM-dd");
-
-        calendar2.set(Calendar.YEAR, 2020);
-        calendar2.set(Calendar.MONTH, 0);
-        calendar2.set(Calendar.DATE, 1);
-
-        Date newData = calendar2.getTime();
+        DateTimeFormatter formatDate = DateTimeFormatter.ISO_LOCAL_DATE;
+        LocalDate newDate = LocalDate.of(2020, 1, 1);
 
         List<Operation> ops = new ArrayList<Operation>();
-        ReplaceOperation replaceOperation = new ReplaceOperation("/startDate", formatDate.format(newData));
+        ReplaceOperation replaceOperation = new ReplaceOperation("/startDate", formatDate.format(newDate));
         ops.add(replaceOperation);
         String patchBody = getPatchContent(ops);
 
@@ -1858,21 +1785,8 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
             .withTitle("Public item")
             .build();
 
-        Calendar calendarStartDate = Calendar.getInstance();
-
-        calendarStartDate.set(Calendar.YEAR, 2019);
-        calendarStartDate.set(Calendar.MONTH, 10);
-        calendarStartDate.set(Calendar.DATE, 21);
-
-        Date startDate = calendarStartDate.getTime();
-
-        Calendar calendarEndDate = Calendar.getInstance();
-
-        calendarEndDate.set(Calendar.YEAR, 2020);
-        calendarEndDate.set(Calendar.MONTH, 10);
-        calendarEndDate.set(Calendar.DATE, 21);
-
-        Date endDate = calendarEndDate.getTime();
+        LocalDate startDate = LocalDate.of(2019, 11, 21);
+        LocalDate endDate = LocalDate.of(2020, 11, 21);
 
         ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, eperson1, null)
             .withAction(Constants.READ)
@@ -1884,14 +1798,8 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
 
         context.restoreAuthSystemState();
 
-        Calendar newEndDateCalendar = Calendar.getInstance();
-        SimpleDateFormat formatDate = new SimpleDateFormat("yyyy-MM-dd");
-
-        newEndDateCalendar.set(Calendar.YEAR, 2018);
-        newEndDateCalendar.set(Calendar.MONTH, 10);
-        newEndDateCalendar.set(Calendar.DATE, 21);
-
-        Date newEndDate = newEndDateCalendar.getTime();
+        DateTimeFormatter formatDate = DateTimeFormatter.ISO_LOCAL_DATE;
+        LocalDate newEndDate = LocalDate.of(2018, 11, 21);
 
         List<Operation> ops = new ArrayList<Operation>();
         ReplaceOperation replaceOperation = new ReplaceOperation("/endDate", formatDate.format(newEndDate));
@@ -2978,21 +2886,8 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
             .withTitle("Public item")
             .build();
 
-        Calendar calendarStartDate = Calendar.getInstance();
-
-        calendarStartDate.set(Calendar.YEAR, 2017);
-        calendarStartDate.set(Calendar.MONTH, 0);
-        calendarStartDate.set(Calendar.DATE, 1);
-
-        Date startDate = calendarStartDate.getTime();
-
-        Calendar calendarEndDate = Calendar.getInstance();
-
-        calendarEndDate.set(Calendar.YEAR, 2022);
-        calendarEndDate.set(Calendar.MONTH, 11);
-        calendarEndDate.set(Calendar.DATE, 31);
-
-        Date endDate = calendarEndDate.getTime();
+        LocalDate startDate = LocalDate.of(2017, 1, 1);
+        LocalDate endDate = LocalDate.of(2022, 12, 31);
 
         ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, null,
                        EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
@@ -3019,13 +2914,9 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
         ReplaceOperation replaceNameOperation = new ReplaceOperation("/name", newName);
         ops.add(replaceNameOperation);
 
-        SimpleDateFormat formatDate = new SimpleDateFormat("yyyy-MM-dd");
-        Calendar calendarNewStartDate = Calendar.getInstance();
-        calendarNewStartDate.set(Calendar.YEAR, 2018);
-        calendarNewStartDate.set(Calendar.MONTH, 1);
-        calendarNewStartDate.set(Calendar.DATE, 1);
+        DateTimeFormatter formatDate = DateTimeFormatter.ISO_LOCAL_DATE;
+        LocalDate newStartDate = LocalDate.of(2018, 2, 1);
 
-        Date newStartDate = calendarNewStartDate.getTime();
         ReplaceOperation replaceStartDateOperation = new ReplaceOperation("/startDate",
             formatDate.format(newStartDate));
         ops.add(replaceStartDateOperation);
@@ -3076,13 +2967,7 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
             .withTitle("Public item")
             .build();
 
-        Calendar calendarEndDate = Calendar.getInstance();
-
-        calendarEndDate.set(Calendar.YEAR, 2022);
-        calendarEndDate.set(Calendar.MONTH, 11);
-        calendarEndDate.set(Calendar.DATE, 31);
-
-        Date endDate = calendarEndDate.getTime();
+        LocalDate endDate = LocalDate.of(2022, 12, 31);
 
         ResourcePolicy resourcePolicy = ResourcePolicyBuilder.createResourcePolicy(context, null,
                        EPersonServiceFactory.getInstance().getGroupService().findByName(context, Group.ANONYMOUS))
@@ -3101,13 +2986,9 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
         ReplaceOperation replaceNameOperation = new ReplaceOperation("/name", newName);
         ops.add(replaceNameOperation);
 
-        SimpleDateFormat formatDate = new SimpleDateFormat("yyyy-MM-dd");
-        Calendar calendarNewStartDate = Calendar.getInstance();
-        calendarNewStartDate.set(Calendar.YEAR, 2018);
-        calendarNewStartDate.set(Calendar.MONTH, 1);
-        calendarNewStartDate.set(Calendar.DATE, 1);
+        DateTimeFormatter formatDate = DateTimeFormatter.ISO_LOCAL_DATE;
+        LocalDate newStartDate = LocalDate.of(2018, 2, 1);
 
-        Date newStartDate = calendarNewStartDate.getTime();
         ReplaceOperation replaceStartDateOperation = new ReplaceOperation("/startDate",
             formatDate.format(newStartDate));
         ops.add(replaceStartDateOperation);

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ScriptRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ScriptRestRepositoryIT.java
@@ -88,6 +88,9 @@ public class ScriptRestRepositoryIT extends AbstractControllerIntegrationTest {
     @Autowired
     private DSpaceRunnableParameterConverter dSpaceRunnableParameterConverter;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     @Test
     public void findAllScriptsTest() throws Exception {
         String token = getAuthToken(admin.getEmail(), password);
@@ -450,7 +453,7 @@ public class ScriptRestRepositoryIT extends AbstractControllerIntegrationTest {
         try {
             getClient(token)
                     .perform(multipart("/api/system/scripts/mock-script/processes")
-                                 .param("properties", new ObjectMapper().writeValueAsString(list)))
+                                 .param("properties", mapper.writeValueAsString(list)))
                     .andExpect(status().isAccepted())
                     .andExpect(jsonPath("$", is(
                             ProcessMatcher.matchProcess("mock-script",
@@ -494,7 +497,7 @@ public class ScriptRestRepositoryIT extends AbstractControllerIntegrationTest {
         try {
             getClient(token)
                     .perform(multipart("/api/system/scripts/mock-script/processes")
-                                 .param("properties", new ObjectMapper().writeValueAsString(list)))
+                                 .param("properties", mapper.writeValueAsString(list)))
                     .andExpect(status().isAccepted())
                     .andExpect(jsonPath("$", is(
                             ProcessMatcher.matchProcess("mock-script",
@@ -531,7 +534,7 @@ public class ScriptRestRepositoryIT extends AbstractControllerIntegrationTest {
         try {
             getClient(token)
                     .perform(multipart("/api/system/scripts/mock-script/processes")
-                                 .param("properties", new ObjectMapper().writeValueAsString(list)))
+                                 .param("properties", mapper.writeValueAsString(list)))
                     .andExpect(status().isAccepted())
                     .andExpect(jsonPath("$", is(
                             ProcessMatcher.matchProcess("mock-script",
@@ -646,7 +649,7 @@ public class ScriptRestRepositoryIT extends AbstractControllerIntegrationTest {
                     .perform(multipart("/api/system/scripts/mock-script/processes")
                                  .file(bitstreamFile)
                                  .characterEncoding("UTF-8")
-                                 .param("properties", new ObjectMapper().writeValueAsString(list)))
+                                 .param("properties", mapper.writeValueAsString(list)))
                     .andExpect(status().isAccepted())
                     .andExpect(jsonPath("$", is(
                             ProcessMatcher.matchProcess("mock-script",
@@ -737,7 +740,7 @@ public class ScriptRestRepositoryIT extends AbstractControllerIntegrationTest {
         try {
             getClient(token).perform(post("/api/system/scripts/mock-script/processes")
                                          .contentType("multipart/form-data")
-                                         .param("properties", new ObjectMapper().writeValueAsString(list)))
+                                         .param("properties", mapper.writeValueAsString(list)))
                 .andExpect(status().isAccepted())
                 .andExpect(jsonPath("$", is(ProcessMatcher.matchProcess("mock-script",
                                                                         String.valueOf(admin.getID()),

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SearchEventRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SearchEventRestRepositoryIT.java
@@ -27,8 +27,12 @@ import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.Item;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 public class SearchEventRestRepositoryIT extends AbstractControllerIntegrationTest {
+
+    @Autowired
+    private ObjectMapper mapper;
 
     @Test
     public void findAllTestThrowNotImplementedException() throws Exception {
@@ -88,8 +92,6 @@ public class SearchEventRestRepositoryIT extends AbstractControllerIntegrationTe
         appliedFilterList.add(appliedFilter);
         searchEventRest.setAppliedFilters(appliedFilterList);
 
-        ObjectMapper mapper = new ObjectMapper();
-
         getClient().perform(post("/api/statistics/searchevents")
                                 .content(mapper.writeValueAsBytes(searchEventRest))
                                 .contentType(contentType))
@@ -141,8 +143,6 @@ public class SearchEventRestRepositoryIT extends AbstractControllerIntegrationTe
         appliedFilterList.add(appliedFilter);
         searchEventRest.setAppliedFilters(appliedFilterList);
 
-        ObjectMapper mapper = new ObjectMapper();
-
         getClient().perform(post("/api/statistics/searchevents")
                                 .content(mapper.writeValueAsBytes(searchEventRest))
                                 .contentType(contentType))
@@ -193,8 +193,6 @@ public class SearchEventRestRepositoryIT extends AbstractControllerIntegrationTe
         List<SearchResultsRest.AppliedFilter> appliedFilterList = new LinkedList<>();
         appliedFilterList.add(appliedFilter);
         searchEventRest.setAppliedFilters(appliedFilterList);
-
-        ObjectMapper mapper = new ObjectMapper();
 
         getClient().perform(post("/api/statistics/searchevents")
                                 .content(mapper.writeValueAsBytes(searchEventRest))
@@ -248,8 +246,6 @@ public class SearchEventRestRepositoryIT extends AbstractControllerIntegrationTe
         appliedFilterList.add(appliedFilter);
         searchEventRest.setAppliedFilters(appliedFilterList);
 
-        ObjectMapper mapper = new ObjectMapper();
-
         getClient().perform(post("/api/statistics/searchevents")
                                 .content(mapper.writeValueAsBytes(searchEventRest))
                                 .contentType(contentType))
@@ -302,8 +298,6 @@ public class SearchEventRestRepositoryIT extends AbstractControllerIntegrationTe
         appliedFilterList.add(appliedFilter);
         searchEventRest.setAppliedFilters(appliedFilterList);
 
-        ObjectMapper mapper = new ObjectMapper();
-
         getClient().perform(post("/api/statistics/searchevents")
                                 .content(mapper.writeValueAsBytes(searchEventRest))
                                 .contentType(contentType))
@@ -349,8 +343,6 @@ public class SearchEventRestRepositoryIT extends AbstractControllerIntegrationTe
 
         PageRest pageRest = new PageRest(5, 20, 4, 1);
         searchEventRest.setPage(pageRest);
-
-        ObjectMapper mapper = new ObjectMapper();
 
         getClient().perform(post("/api/statistics/searchevents")
                                 .content(mapper.writeValueAsBytes(searchEventRest))
@@ -402,8 +394,6 @@ public class SearchEventRestRepositoryIT extends AbstractControllerIntegrationTe
         List<SearchResultsRest.AppliedFilter> appliedFilterList = new LinkedList<>();
         appliedFilterList.add(appliedFilter);
         searchEventRest.setAppliedFilters(appliedFilterList);
-
-        ObjectMapper mapper = new ObjectMapper();
 
         getClient().perform(post("/api/statistics/searchevents")
                                 .content(mapper.writeValueAsBytes(searchEventRest))
@@ -458,8 +448,6 @@ public class SearchEventRestRepositoryIT extends AbstractControllerIntegrationTe
         appliedFilterList.add(appliedFilter);
         searchEventRest.setAppliedFilters(appliedFilterList);
 
-        ObjectMapper mapper = new ObjectMapper();
-
         getClient().perform(post("/api/statistics/searchevents")
                         .content(mapper.writeValueAsBytes(searchEventRest))
                         .contentType(contentType))
@@ -512,8 +500,6 @@ public class SearchEventRestRepositoryIT extends AbstractControllerIntegrationTe
         List<SearchResultsRest.AppliedFilter> appliedFilterList = new LinkedList<>();
         appliedFilterList.add(appliedFilter);
         searchEventRest.setAppliedFilters(appliedFilterList);
-
-        ObjectMapper mapper = new ObjectMapper();
 
         getClient().perform(post("/api/statistics/searchevents")
                         .content(mapper.writeValueAsBytes(searchEventRest))

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SiteRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SiteRestRepositoryIT.java
@@ -16,6 +16,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.util.List;
 import java.util.UUID;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.dspace.app.rest.matcher.MetadataMatcher;
 import org.dspace.app.rest.matcher.SiteMatcher;
 import org.dspace.app.rest.model.patch.Operation;
@@ -36,6 +37,9 @@ public class SiteRestRepositoryIT extends AbstractControllerIntegrationTest {
 
     @Autowired
     private SiteService siteService;
+
+    @Autowired
+    private ObjectMapper mapper;
 
     @Test
     public void findAll() throws Exception {
@@ -164,6 +168,6 @@ public class SiteRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.restoreAuthSystemState();
         String token = getAuthToken(asUser.getEmail(), password);
 
-        new MetadataPatchSuite().runWith(getClient(token), "/api/core/sites/" + site.getID(), expectedStatus);
+        new MetadataPatchSuite(mapper).runWith(getClient(token), "/api/core/sites/" + site.getID(), expectedStatus);
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/StatisticsRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/StatisticsRestRepositoryIT.java
@@ -21,8 +21,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
@@ -1533,7 +1534,7 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
     private List<UsageReportPointRest> getListOfVisitsPerMonthsPoints(int viewsLastMonth) {
         List<UsageReportPointRest> expectedPoints = new ArrayList<>();
         int nrOfMonthsBack = 6;
-        Calendar cal = Calendar.getInstance();
+        YearMonth month = YearMonth.now();
         for (int i = 0; i <= nrOfMonthsBack; i++) {
             UsageReportPointDateRest expectedPoint = new UsageReportPointDateRest();
             if (i > 0) {
@@ -1541,11 +1542,12 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
             } else {
                 expectedPoint.addValue("views", viewsLastMonth);
             }
-            String month = cal.getDisplayName(Calendar.MONTH, Calendar.LONG, new Locale("en"));
-            expectedPoint.setId(month + " " + cal.get(Calendar.YEAR));
+            // Get month+year in long format (e.g. "February 2025") using English language
+            String monthYear = DateTimeFormatter.ofPattern("MMMM yyyy", Locale.ENGLISH).format(month);
+            expectedPoint.setId(monthYear);
 
             expectedPoints.add(expectedPoint);
-            cal.add(Calendar.MONTH, -1);
+            month = month.minusMonths(1);
         }
         return expectedPoints;
     }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/StatisticsRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/StatisticsRestRepositoryIT.java
@@ -78,6 +78,9 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
     @Autowired
     protected AuthorizeService authorizeService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     private Community communityNotVisited;
     private Community communityVisited;
     private Collection collectionNotVisited;
@@ -274,8 +277,6 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         viewEventRest.setTargetType("community");
         viewEventRest.setTargetId(communityVisited.getID());
 
-        ObjectMapper mapper = new ObjectMapper();
-
         getClient(loggedInToken).perform(post("/api/statistics/viewevents")
             .content(mapper.writeValueAsBytes(viewEventRest))
             .contentType(contentType))
@@ -324,8 +325,6 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         ViewEventRest viewEventRest = new ViewEventRest();
         viewEventRest.setTargetType("collection");
         viewEventRest.setTargetId(collectionVisited.getID());
-
-        ObjectMapper mapper = new ObjectMapper();
 
         getClient(loggedInToken).perform(post("/api/statistics/viewevents")
             .content(mapper.writeValueAsBytes(viewEventRest))
@@ -380,8 +379,6 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         ViewEventRest viewEventRest = new ViewEventRest();
         viewEventRest.setTargetType("item");
         viewEventRest.setTargetId(itemVisited.getID());
-
-        ObjectMapper mapper = new ObjectMapper();
 
         getClient(loggedInToken).perform(post("/api/statistics/viewevents")
             .content(mapper.writeValueAsBytes(viewEventRest))
@@ -469,8 +466,6 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         ViewEventRest viewEventRest = new ViewEventRest();
         viewEventRest.setTargetType("bitstream");
         viewEventRest.setTargetId(bitstreamVisited.getID());
-
-        ObjectMapper mapper = new ObjectMapper();
 
         getClient(loggedInToken).perform(post("/api/statistics/viewevents")
             .content(mapper.writeValueAsBytes(viewEventRest))
@@ -595,8 +590,6 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         viewEventRest.setTargetType("item");
         viewEventRest.setTargetId(itemVisited.getID());
 
-        ObjectMapper mapper = new ObjectMapper();
-
         getClient(loggedInToken).perform(post("/api/statistics/viewevents")
             .content(mapper.writeValueAsBytes(viewEventRest))
             .contentType(contentType))
@@ -679,8 +672,6 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         viewEventRest.setTargetType("collection");
         viewEventRest.setTargetId(collectionVisited.getID());
 
-        ObjectMapper mapper = new ObjectMapper();
-
         getClient(loggedInToken).perform(post("/api/statistics/viewevents")
             .content(mapper.writeValueAsBytes(viewEventRest))
             .contentType(contentType))
@@ -712,8 +703,6 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         ViewEventRest viewEventRest = new ViewEventRest();
         viewEventRest.setTargetType("bitstream");
         viewEventRest.setTargetId(bitstreamVisited.getID());
-
-        ObjectMapper mapper = new ObjectMapper();
 
         getClient(loggedInToken).perform(post("/api/statistics/viewevents")
             .content(mapper.writeValueAsBytes(viewEventRest))
@@ -780,8 +769,6 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         viewEventRest.setTargetType("bitstream");
         viewEventRest.setTargetId(bitstreamVisited.getID());
 
-        ObjectMapper mapper = new ObjectMapper();
-
         getClient(loggedInToken).perform(post("/api/statistics/viewevents")
             .content(mapper.writeValueAsBytes(viewEventRest))
             .contentType(contentType))
@@ -840,8 +827,6 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         ViewEventRest viewEventRest = new ViewEventRest();
         viewEventRest.setTargetType("collection");
         viewEventRest.setTargetId(collectionVisited.getID());
-
-        ObjectMapper mapper = new ObjectMapper();
 
         getClient(loggedInToken).perform(post("/api/statistics/viewevents")
             .content(mapper.writeValueAsBytes(viewEventRest))
@@ -911,8 +896,6 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         viewEventRest.setTargetType("community");
         viewEventRest.setTargetId(communityVisited.getID());
 
-        ObjectMapper mapper = new ObjectMapper();
-
         getClient(loggedInToken).perform(post("/api/statistics/viewevents")
             .content(mapper.writeValueAsBytes(viewEventRest))
             .contentType(contentType))
@@ -970,8 +953,6 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         ViewEventRest viewEventRest = new ViewEventRest();
         viewEventRest.setTargetType("item");
         viewEventRest.setTargetId(itemVisited.getID());
-
-        ObjectMapper mapper = new ObjectMapper();
 
         getClient(loggedInToken).perform(post("/api/statistics/viewevents")
             .content(mapper.writeValueAsBytes(viewEventRest))
@@ -1040,8 +1021,6 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         ViewEventRest viewEventRest = new ViewEventRest();
         viewEventRest.setTargetType("community");
         viewEventRest.setTargetId(communityVisited.getID());
-
-        ObjectMapper mapper = new ObjectMapper();
 
         getClient(loggedInToken).perform(post("/api/statistics/viewevents")
             .content(mapper.writeValueAsBytes(viewEventRest))
@@ -1193,8 +1172,6 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         viewEventRest.setTargetType("item");
         viewEventRest.setTargetId(itemVisited.getID());
 
-        ObjectMapper mapper = new ObjectMapper();
-
         getClient().perform(post("/api/statistics/viewevents")
             .content(mapper.writeValueAsBytes(viewEventRest))
             .contentType(contentType))
@@ -1204,15 +1181,13 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         viewEventRest2.setTargetType("item");
         viewEventRest2.setTargetId(itemVisited2.getID());
 
-        ObjectMapper mapper2 = new ObjectMapper();
-
         getClient().perform(post("/api/statistics/viewevents")
-            .content(mapper2.writeValueAsBytes(viewEventRest2))
+            .content(mapper.writeValueAsBytes(viewEventRest2))
             .contentType(contentType))
                    .andExpect(status().isCreated());
 
         getClient().perform(post("/api/statistics/viewevents")
-            .content(mapper2.writeValueAsBytes(viewEventRest2))
+            .content(mapper.writeValueAsBytes(viewEventRest2))
             .contentType(contentType))
                    .andExpect(status().isCreated());
 
@@ -1242,8 +1217,6 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         ViewEventRest viewEventRest = new ViewEventRest();
         viewEventRest.setTargetType("community");
         viewEventRest.setTargetId(communityVisited.getID());
-
-        ObjectMapper mapper = new ObjectMapper();
 
         getClient().perform(post("/api/statistics/viewevents")
             .content(mapper.writeValueAsBytes(viewEventRest))
@@ -1332,8 +1305,6 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         viewEventRest.setTargetType("item");
         viewEventRest.setTargetId(itemVisited.getID());
 
-        ObjectMapper mapper = new ObjectMapper();
-
         getClient().perform(post("/api/statistics/viewevents")
             .content(mapper.writeValueAsBytes(viewEventRest))
             .contentType(contentType))
@@ -1397,8 +1368,6 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         ViewEventRest viewEventRest = new ViewEventRest();
         viewEventRest.setTargetType("item");
         viewEventRest.setTargetId(itemVisited.getID());
-
-        ObjectMapper mapper = new ObjectMapper();
 
         getClient().perform(post("/api/statistics/viewevents")
             .content(mapper.writeValueAsBytes(viewEventRest))
@@ -1478,8 +1447,6 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         ViewEventRest viewEventRest = new ViewEventRest();
         viewEventRest.setTargetType("bitstream");
         viewEventRest.setTargetId(bitstreamVisited.getID());
-
-        ObjectMapper mapper = new ObjectMapper();
 
         getClient().perform(post("/api/statistics/viewevents")
             .content(mapper.writeValueAsBytes(viewEventRest))

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubscriptionRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubscriptionRestRepositoryIT.java
@@ -60,6 +60,9 @@ public class SubscriptionRestRepositoryIT extends AbstractControllerIntegrationT
     @Autowired
     private ResourcePolicyService resourcePolicyService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     private Community subCommunity;
     private Collection collection;
 
@@ -471,12 +474,10 @@ public class SubscriptionRestRepositoryIT extends AbstractControllerIntegrationT
 
         context.restoreAuthSystemState();
 
-        ObjectMapper objectMapper = new ObjectMapper();
-
         getClient().perform(post("/api/core/subscriptions")
                    .param("resource", collection.getID().toString())
                    .param("eperson_id", eperson.getID().toString())
-                   .content(objectMapper.writeValueAsString(subscriptionRest))
+                   .content(mapper.writeValueAsString(subscriptionRest))
                    .contentType(contentType))
                    .andExpect(status().isUnauthorized());
     }
@@ -503,7 +504,7 @@ public class SubscriptionRestRepositoryIT extends AbstractControllerIntegrationT
             getClient(tokenAdmin).perform(post("/api/core/subscriptions")
                                  .param("resource", collection.getID().toString())
                                  .param("eperson_id", eperson.getID().toString())
-                                 .content(new ObjectMapper().writeValueAsString(map))
+                                 .content(mapper.writeValueAsString(map))
                                  .contentType(MediaType.APPLICATION_JSON_VALUE))
                        .andExpect(status().isCreated())
                        .andExpect(jsonPath("$.subscriptionType", is("content")))
@@ -539,7 +540,7 @@ public class SubscriptionRestRepositoryIT extends AbstractControllerIntegrationT
             getClient(tokenEPerson).perform(post("/api/core/subscriptions")
                                    .param("resource", collection.getID().toString())
                                    .param("eperson_id", eperson.getID().toString())
-                                   .content(new ObjectMapper().writeValueAsString(map))
+                                   .content(mapper.writeValueAsString(map))
                                    .contentType(MediaType.APPLICATION_JSON_VALUE))
                        .andExpect(status().isCreated())
                        .andExpect(jsonPath("$.subscriptionType", is("content")))
@@ -576,7 +577,7 @@ public class SubscriptionRestRepositoryIT extends AbstractControllerIntegrationT
         getClient(tokenEPerson).perform(post("/api/core/subscriptions")
                                .param("resource", item1.getID().toString())
                                .param("eperson_id", eperson.getID().toString())
-                               .content(new ObjectMapper().writeValueAsString(map))
+                               .content(mapper.writeValueAsString(map))
                                .contentType(MediaType.APPLICATION_JSON_VALUE))
                                .andExpect(status().isBadRequest());
     }
@@ -604,7 +605,7 @@ public class SubscriptionRestRepositoryIT extends AbstractControllerIntegrationT
         getClient(tokenAdmin).perform(post("/api/core/subscriptions")
                              .param("resource", item1.getID().toString())
                              .param("eperson_id", eperson.getID().toString())
-                             .content(new ObjectMapper().writeValueAsString(map))
+                             .content(mapper.writeValueAsString(map))
                              .contentType(MediaType.APPLICATION_JSON_VALUE))
                              .andExpect(status().isBadRequest());
     }
@@ -628,7 +629,7 @@ public class SubscriptionRestRepositoryIT extends AbstractControllerIntegrationT
         getClient(tokenAdmin).perform(post("/api/core/subscriptions")
                              .param("resource", UUID.randomUUID().toString())
                              .param("eperson_id", eperson.getID().toString())
-                             .content(new ObjectMapper().writeValueAsString(map))
+                             .content(mapper.writeValueAsString(map))
                              .contentType(MediaType.APPLICATION_JSON_VALUE))
                              .andExpect(status().isBadRequest());
     }
@@ -651,7 +652,7 @@ public class SubscriptionRestRepositoryIT extends AbstractControllerIntegrationT
         String tokenAdmin = getAuthToken(admin.getEmail(), password);
         getClient(tokenAdmin).perform(post("/api/core/subscriptions")
                              .param("eperson_id", eperson.getID().toString())
-                             .content(new ObjectMapper().writeValueAsString(map))
+                             .content(mapper.writeValueAsString(map))
                              .contentType(MediaType.APPLICATION_JSON_VALUE))
                              .andExpect(status().isUnprocessableEntity());
     }
@@ -675,7 +676,7 @@ public class SubscriptionRestRepositoryIT extends AbstractControllerIntegrationT
         getClient(tokenEPerson).perform(post("/api/core/subscriptions")
                                .param("resource", collection.getID().toString())
                                .param("eperson_id", eperson.getID().toString())
-                               .content(new ObjectMapper().writeValueAsString(map))
+                               .content(mapper.writeValueAsString(map))
                                .contentType(MediaType.APPLICATION_JSON_VALUE))
                                .andExpect(status().isUnprocessableEntity());
     }
@@ -699,7 +700,7 @@ public class SubscriptionRestRepositoryIT extends AbstractControllerIntegrationT
         getClient(tokenEPerson).perform(post("/api/core/subscriptions")
                                .param("resource", collection.getID().toString())
                                .param("eperson_id", eperson.getID().toString())
-                               .content(new ObjectMapper().writeValueAsString(map))
+                               .content(mapper.writeValueAsString(map))
                                .contentType(MediaType.APPLICATION_JSON_VALUE))
                                .andExpect(status().isUnprocessableEntity());
     }
@@ -723,7 +724,7 @@ public class SubscriptionRestRepositoryIT extends AbstractControllerIntegrationT
         getClient(tokenEPerson).perform(post("/api/core/subscriptions")
                                .param("resource", collection.getID().toString())
                                .param("eperson_id", eperson.getID().toString())
-                               .content(new ObjectMapper().writeValueAsString(map))
+                               .content(mapper.writeValueAsString(map))
                                .contentType(MediaType.APPLICATION_JSON_VALUE))
                                .andExpect(status().isUnprocessableEntity());
     }
@@ -747,7 +748,7 @@ public class SubscriptionRestRepositoryIT extends AbstractControllerIntegrationT
         getClient(tokenEPerson).perform(post("/api/core/subscriptions")
                                .param("resource", collection.getID().toString())
                                .param("eperson_id", eperson.getID().toString())
-                               .content(new ObjectMapper().writeValueAsString(map))
+                               .content(mapper.writeValueAsString(map))
                                .contentType(MediaType.APPLICATION_JSON_VALUE))
                                .andExpect(status().isUnprocessableEntity());
     }
@@ -776,7 +777,7 @@ public class SubscriptionRestRepositoryIT extends AbstractControllerIntegrationT
         getClient(tokenEPerson).perform(post("/api/core/subscriptions")
                                .param("resource", collection.getID().toString())
                                .param("eperson_id", user.getID().toString())
-                               .content(new ObjectMapper().writeValueAsString(map))
+                               .content(mapper.writeValueAsString(map))
                                .contentType(MediaType.APPLICATION_JSON_VALUE))
                                .andExpect(status().isForbidden());
     }
@@ -853,7 +854,6 @@ public class SubscriptionRestRepositoryIT extends AbstractControllerIntegrationT
                 "content", collection, admin, subscriptionParameterList).build();
         context.restoreAuthSystemState();
 
-        ObjectMapper objectMapper = new ObjectMapper();
         Map<String, Object> newSubscription = new HashMap<>();
         newSubscription.put("subscriptionType", "content");
         List<Map<String, Object>> list = new ArrayList<>();
@@ -864,7 +864,7 @@ public class SubscriptionRestRepositoryIT extends AbstractControllerIntegrationT
         newSubscription.put("subscriptionParameterList", list);
 
         getClient().perform(put("/api/core/subscriptions/" + subscription.getID())
-                   .content(objectMapper.writeValueAsString(newSubscription))
+                   .content(mapper.writeValueAsString(newSubscription))
                    .contentType(MediaType.APPLICATION_JSON_VALUE))
                    .andExpect(status().isUnauthorized());
     }
@@ -881,7 +881,6 @@ public class SubscriptionRestRepositoryIT extends AbstractControllerIntegrationT
                                     "content", collection, admin, subscriptionParameterList).build();
         context.restoreAuthSystemState();
 
-        ObjectMapper objectMapper = new ObjectMapper();
         Map<String, Object> newSubscription = new HashMap<>();
         newSubscription.put("subscriptionType", "content");
         List<Map<String, Object>> list = new ArrayList<>();
@@ -893,7 +892,7 @@ public class SubscriptionRestRepositoryIT extends AbstractControllerIntegrationT
 
         String token = getAuthToken(eperson.getEmail(), password);
         getClient(token).perform(put("/api/core/subscriptions/" + subscription.getID())
-                        .content(objectMapper.writeValueAsString(newSubscription))
+                        .content(mapper.writeValueAsString(newSubscription))
                         .contentType(MediaType.APPLICATION_JSON_VALUE))
                         .andExpect(status().isForbidden());
     }
@@ -910,7 +909,6 @@ public class SubscriptionRestRepositoryIT extends AbstractControllerIntegrationT
                                     "content", collection, eperson, subscriptionParameterList).build();
         context.restoreAuthSystemState();
 
-        ObjectMapper objectMapper = new ObjectMapper();
         Map<String, Object> newSubscription = new HashMap<>();
         newSubscription.put("subscriptionType", "content");
         List<Map<String, Object>> list = new ArrayList<>();
@@ -922,7 +920,7 @@ public class SubscriptionRestRepositoryIT extends AbstractControllerIntegrationT
 
         String tokenSubscriber = getAuthToken(eperson.getEmail(), password);
         getClient(tokenSubscriber).perform(put("/api/core/subscriptions/" + subscription.getID())
-                                  .content(objectMapper.writeValueAsString(newSubscription))
+                                  .content(mapper.writeValueAsString(newSubscription))
                                   .contentType(MediaType.APPLICATION_JSON_VALUE))
                                   .andExpect(status().isOk())
                                   .andExpect(content().contentType(contentType))
@@ -945,7 +943,6 @@ public class SubscriptionRestRepositoryIT extends AbstractControllerIntegrationT
                                     "content", collection, eperson, subscriptionParameterList).build();
         context.restoreAuthSystemState();
 
-        ObjectMapper objectMapper = new ObjectMapper();
         Map<String, Object> newSubscription = new HashMap<>();
         newSubscription.put("subscriptionType", "content");
         List<Map<String, Object>> list = new ArrayList<>();
@@ -957,7 +954,7 @@ public class SubscriptionRestRepositoryIT extends AbstractControllerIntegrationT
 
         String tokenSubscriber = getAuthToken(eperson.getEmail(), password);
         getClient(tokenSubscriber).perform(put("/api/core/subscriptions/" + subscription.getID())
-                                  .content(objectMapper.writeValueAsString(newSubscription))
+                                  .content(mapper.writeValueAsString(newSubscription))
                                   .contentType(MediaType.APPLICATION_JSON_VALUE))
                                   .andExpect(status().isUnprocessableEntity());
     }
@@ -974,7 +971,6 @@ public class SubscriptionRestRepositoryIT extends AbstractControllerIntegrationT
                                     "content", collection, eperson, subscriptionParameterList).build();
         context.restoreAuthSystemState();
 
-        ObjectMapper objectMapper = new ObjectMapper();
         Map<String, Object> newSubscription = new HashMap<>();
         newSubscription.put("subscriptionType", "content");
         List<Map<String, Object>> list = new ArrayList<>();
@@ -986,7 +982,7 @@ public class SubscriptionRestRepositoryIT extends AbstractControllerIntegrationT
 
         String tokenSubscriber = getAuthToken(eperson.getEmail(), password);
         getClient(tokenSubscriber).perform(put("/api/core/subscriptions/" + subscription.getID())
-                                  .content(objectMapper.writeValueAsString(newSubscription))
+                                  .content(mapper.writeValueAsString(newSubscription))
                                   .contentType(MediaType.APPLICATION_JSON_VALUE))
                                   .andExpect(status().isUnprocessableEntity());
     }
@@ -1003,7 +999,6 @@ public class SubscriptionRestRepositoryIT extends AbstractControllerIntegrationT
                                     "content", collection, eperson, subscriptionParameterList).build();
         context.restoreAuthSystemState();
 
-        ObjectMapper objectMapper = new ObjectMapper();
         Map<String, Object> newSubscription = new HashMap<>();
         newSubscription.put("subscriptionType", "InvalidType");
         List<Map<String, Object>> list = new ArrayList<>();
@@ -1015,7 +1010,7 @@ public class SubscriptionRestRepositoryIT extends AbstractControllerIntegrationT
 
         String tokenSubscriber = getAuthToken(eperson.getEmail(), password);
         getClient(tokenSubscriber).perform(put("/api/core/subscriptions/" + subscription.getID())
-                                  .content(objectMapper.writeValueAsString(newSubscription))
+                                  .content(mapper.writeValueAsString(newSubscription))
                                   .contentType(MediaType.APPLICATION_JSON_VALUE))
                                   .andExpect(status().isUnprocessableEntity());
     }
@@ -1032,7 +1027,6 @@ public class SubscriptionRestRepositoryIT extends AbstractControllerIntegrationT
                                     "content", collection, eperson, subscriptionParameterList).build();
         context.restoreAuthSystemState();
 
-        ObjectMapper objectMapper = new ObjectMapper();
         Map<String, Object> newSubscription = new HashMap<>();
         newSubscription.put("subscriptionType", "content");
         List<Map<String, Object>> list = new ArrayList<>();
@@ -1044,7 +1038,7 @@ public class SubscriptionRestRepositoryIT extends AbstractControllerIntegrationT
 
         String tokenAdmin = getAuthToken(admin.getEmail(), password);
         getClient(tokenAdmin).perform(put("/api/core/subscriptions/" + subscription.getID())
-                             .content(objectMapper.writeValueAsString(newSubscription))
+                             .content(mapper.writeValueAsString(newSubscription))
                              .contentType(MediaType.APPLICATION_JSON_VALUE))
                              .andExpect(status().isOk())
                              .andExpect(content().contentType(contentType))

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SuggestionRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SuggestionRestRepositoryIT.java
@@ -39,6 +39,7 @@ import org.dspace.content.Item;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.MvcResult;
 
 /**
@@ -46,6 +47,9 @@ import org.springframework.test.web.servlet.MvcResult;
  */
 public class SuggestionRestRepositoryIT extends AbstractControllerIntegrationTest {
     private Collection colPeople;
+
+    @Autowired
+    private ObjectMapper mapper;
 
     @Override
     @Before
@@ -403,7 +407,6 @@ public class SuggestionRestRepositoryIT extends AbstractControllerIntegrationTes
                         Matchers.endsWith("/api/integration/suggestions/" + suggestionId)));
         Integer workspaceItemId = null;
         try {
-            ObjectMapper mapper = new ObjectMapper();
             MvcResult mvcResult = getClient(adminToken).perform(
                     post("/api/submission/workspaceitems?owningCollection=" + colPublications.getID().toString())
                             .param("embed", "item")

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SystemWideAlertRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SystemWideAlertRestRepositoryIT.java
@@ -19,12 +19,10 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.util.Calendar;
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.concurrent.atomic.AtomicReference;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.lang3.time.DateUtils;
 import org.dspace.alerts.AllowSessionsEnum;
 import org.dspace.alerts.SystemWideAlert;
 import org.dspace.app.rest.model.SystemWideAlertRest;
@@ -42,11 +40,11 @@ public class SystemWideAlertRestRepositoryIT extends AbstractControllerIntegrati
         // Create two alert entries in the db to fully test the findAll method
         // Note: It is not possible to create two alerts through the REST API
         context.turnOffAuthorisationSystem();
-        Date dateToNearestSecond = DateUtils.round(new Date(), Calendar.SECOND);
+        LocalDateTime date = LocalDateTime.now();
         SystemWideAlert systemWideAlert1 = SystemWideAlertBuilder.createSystemWideAlert(context, "Test alert 1")
                                                                  .withAllowSessions(
                                                                          AllowSessionsEnum.ALLOW_CURRENT_SESSIONS_ONLY)
-                                                                 .withCountdownDate(dateToNearestSecond)
+                                                                 .withCountdownDate(date)
                                                                  .isActive(true)
                                                                  .build();
 
@@ -67,7 +65,7 @@ public class SystemWideAlertRestRepositoryIT extends AbstractControllerIntegrati
                                    hasJsonPath("$.alertId", is(systemWideAlert1.getID())),
                                    hasJsonPath("$.message", is(systemWideAlert1.getMessage())),
                                    hasJsonPath("$.allowSessions", is(systemWideAlert1.getAllowSessions().getValue())),
-                                   hasJsonPath("$.countdownTo", dateMatcher(dateToNearestSecond)),
+                                   hasJsonPath("$.countdownTo", dateMatcher(date)),
                                    hasJsonPath("$.active", is(systemWideAlert1.isActive()))
                            ),
                            allOf(
@@ -85,7 +83,7 @@ public class SystemWideAlertRestRepositoryIT extends AbstractControllerIntegrati
         // Create two alert entries in the db to fully test the findAll method
         // Note: It is not possible to create two alerts through the REST API
         context.turnOffAuthorisationSystem();
-        Date countdownDate = new Date();
+        LocalDateTime countdownDate = LocalDateTime.now();
         SystemWideAlert systemWideAlert1 = SystemWideAlertBuilder.createSystemWideAlert(context, "Test alert 1")
                                                                  .withAllowSessions(
                                                                          AllowSessionsEnum.ALLOW_CURRENT_SESSIONS_ONLY)
@@ -111,7 +109,7 @@ public class SystemWideAlertRestRepositoryIT extends AbstractControllerIntegrati
         // Create two alert entries in the db to fully test the findAll method
         // Note: It is not possible to create two alerts through the REST API
         context.turnOffAuthorisationSystem();
-        Date countdownDate = new Date();
+        LocalDateTime countdownDate = LocalDateTime.now();
         SystemWideAlert systemWideAlert1 = SystemWideAlertBuilder.createSystemWideAlert(context, "Test alert 1")
                                                                  .withAllowSessions(
                                                                          AllowSessionsEnum.ALLOW_CURRENT_SESSIONS_ONLY)
@@ -138,7 +136,7 @@ public class SystemWideAlertRestRepositoryIT extends AbstractControllerIntegrati
         // Create two alert entries in the db to fully test the findOne method
         // Note: It is not possible to create two alerts through the REST API
         context.turnOffAuthorisationSystem();
-        Date dateToNearestSecond = DateUtils.round(new Date(), Calendar.SECOND);
+        LocalDateTime dateToNearestSecond = LocalDateTime.now();
         SystemWideAlert systemWideAlert1 = SystemWideAlertBuilder.createSystemWideAlert(context, "Test alert 1")
                                                                  .withAllowSessions(
                                                                          AllowSessionsEnum.ALLOW_CURRENT_SESSIONS_ONLY)
@@ -179,7 +177,7 @@ public class SystemWideAlertRestRepositoryIT extends AbstractControllerIntegrati
         // Create two alert entries in the db to fully test the findOne method
         // Note: It is not possible to create two alerts through the REST API
         context.turnOffAuthorisationSystem();
-        Date dateToNearestSecond = DateUtils.round(new Date(), Calendar.SECOND);
+        LocalDateTime dateToNearestSecond = LocalDateTime.now();
         SystemWideAlert systemWideAlert1 = SystemWideAlertBuilder.createSystemWideAlert(context, "Test alert 1")
                                                                  .withAllowSessions(
                                                                          AllowSessionsEnum.ALLOW_CURRENT_SESSIONS_ONLY)
@@ -222,7 +220,7 @@ public class SystemWideAlertRestRepositoryIT extends AbstractControllerIntegrati
         // Create two alert entries in the db to fully test the findOne method
         // Note: It is not possible to create two alerts through the REST API
         context.turnOffAuthorisationSystem();
-        Date dateToNearestSecond = DateUtils.round(new Date(), Calendar.SECOND);
+        LocalDateTime dateToNearestSecond = LocalDateTime.now();
         SystemWideAlert systemWideAlert1 = SystemWideAlertBuilder.createSystemWideAlert(context, "Test alert 1")
                                                                  .withAllowSessions(
                                                                          AllowSessionsEnum.ALLOW_CURRENT_SESSIONS_ONLY)
@@ -267,7 +265,7 @@ public class SystemWideAlertRestRepositoryIT extends AbstractControllerIntegrati
         // Create three alert entries in the db to fully test the findActive search method
         // Note: It is not possible to create two alerts through the REST API
         context.turnOffAuthorisationSystem();
-        Date dateToNearestSecond = DateUtils.round(new Date(), Calendar.SECOND);
+        LocalDateTime dateToNearestSecond = LocalDateTime.now();
         SystemWideAlert systemWideAlert1 = SystemWideAlertBuilder.createSystemWideAlert(context, "Test alert 1")
                                                                  .withAllowSessions(
                                                                          AllowSessionsEnum.ALLOW_CURRENT_SESSIONS_ONLY)
@@ -314,7 +312,7 @@ public class SystemWideAlertRestRepositoryIT extends AbstractControllerIntegrati
 
     @Test
     public void createTest() throws Exception {
-        Date dateToNearestSecond = DateUtils.round(new Date(), Calendar.SECOND);
+        LocalDateTime dateToNearestSecond = LocalDateTime.now();
 
         SystemWideAlertRest systemWideAlertRest = new SystemWideAlertRest();
         systemWideAlertRest.setMessage("Alert test message");
@@ -367,7 +365,7 @@ public class SystemWideAlertRestRepositoryIT extends AbstractControllerIntegrati
 
         SystemWideAlertRest systemWideAlertRest = new SystemWideAlertRest();
         systemWideAlertRest.setMessage("Alert test message");
-        systemWideAlertRest.setCountdownTo(new Date());
+        systemWideAlertRest.setCountdownTo(LocalDateTime.now());
         systemWideAlertRest.setAllowSessions(AllowSessionsEnum.ALLOW_CURRENT_SESSIONS_ONLY.getValue());
         systemWideAlertRest.setActive(true);
 
@@ -387,7 +385,7 @@ public class SystemWideAlertRestRepositoryIT extends AbstractControllerIntegrati
 
         SystemWideAlertRest systemWideAlertRest = new SystemWideAlertRest();
         systemWideAlertRest.setMessage("Alert test message");
-        systemWideAlertRest.setCountdownTo(new Date());
+        systemWideAlertRest.setCountdownTo(LocalDateTime.now());
         systemWideAlertRest.setAllowSessions(AllowSessionsEnum.ALLOW_CURRENT_SESSIONS_ONLY.getValue());
         systemWideAlertRest.setActive(true);
 
@@ -416,7 +414,7 @@ public class SystemWideAlertRestRepositoryIT extends AbstractControllerIntegrati
 
         SystemWideAlertRest systemWideAlertRest = new SystemWideAlertRest();
         systemWideAlertRest.setMessage("Alert test message");
-        systemWideAlertRest.setCountdownTo(new Date());
+        systemWideAlertRest.setCountdownTo(LocalDateTime.now());
         systemWideAlertRest.setAllowSessions(AllowSessionsEnum.ALLOW_CURRENT_SESSIONS_ONLY.getValue());
         systemWideAlertRest.setActive(true);
 
@@ -442,7 +440,7 @@ public class SystemWideAlertRestRepositoryIT extends AbstractControllerIntegrati
                                                                 .build();
         context.restoreAuthSystemState();
 
-        Date dateToNearestSecond = DateUtils.round(new Date(), Calendar.SECOND);
+        LocalDateTime dateToNearestSecond = LocalDateTime.now();
 
         SystemWideAlertRest systemWideAlertRest = new SystemWideAlertRest();
         systemWideAlertRest.setAlertId(systemWideAlert.getID());

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SystemWideAlertRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SystemWideAlertRestRepositoryIT.java
@@ -19,7 +19,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.concurrent.atomic.AtomicReference;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -44,7 +45,7 @@ public class SystemWideAlertRestRepositoryIT extends AbstractControllerIntegrati
         // Create two alert entries in the db to fully test the findAll method
         // Note: It is not possible to create two alerts through the REST API
         context.turnOffAuthorisationSystem();
-        LocalDateTime date = LocalDateTime.now();
+        ZonedDateTime date = ZonedDateTime.now(ZoneOffset.UTC);
         SystemWideAlert systemWideAlert1 = SystemWideAlertBuilder.createSystemWideAlert(context, "Test alert 1")
                                                                  .withAllowSessions(
                                                                          AllowSessionsEnum.ALLOW_CURRENT_SESSIONS_ONLY)
@@ -87,7 +88,7 @@ public class SystemWideAlertRestRepositoryIT extends AbstractControllerIntegrati
         // Create two alert entries in the db to fully test the findAll method
         // Note: It is not possible to create two alerts through the REST API
         context.turnOffAuthorisationSystem();
-        LocalDateTime countdownDate = LocalDateTime.now();
+        ZonedDateTime countdownDate = ZonedDateTime.now(ZoneOffset.UTC);
         SystemWideAlert systemWideAlert1 = SystemWideAlertBuilder.createSystemWideAlert(context, "Test alert 1")
                                                                  .withAllowSessions(
                                                                          AllowSessionsEnum.ALLOW_CURRENT_SESSIONS_ONLY)
@@ -113,7 +114,7 @@ public class SystemWideAlertRestRepositoryIT extends AbstractControllerIntegrati
         // Create two alert entries in the db to fully test the findAll method
         // Note: It is not possible to create two alerts through the REST API
         context.turnOffAuthorisationSystem();
-        LocalDateTime countdownDate = LocalDateTime.now();
+        ZonedDateTime countdownDate = ZonedDateTime.now(ZoneOffset.UTC);
         SystemWideAlert systemWideAlert1 = SystemWideAlertBuilder.createSystemWideAlert(context, "Test alert 1")
                                                                  .withAllowSessions(
                                                                          AllowSessionsEnum.ALLOW_CURRENT_SESSIONS_ONLY)
@@ -140,7 +141,7 @@ public class SystemWideAlertRestRepositoryIT extends AbstractControllerIntegrati
         // Create two alert entries in the db to fully test the findOne method
         // Note: It is not possible to create two alerts through the REST API
         context.turnOffAuthorisationSystem();
-        LocalDateTime dateToNearestSecond = LocalDateTime.now();
+        ZonedDateTime dateToNearestSecond = ZonedDateTime.now(ZoneOffset.UTC);
         SystemWideAlert systemWideAlert1 = SystemWideAlertBuilder.createSystemWideAlert(context, "Test alert 1")
                                                                  .withAllowSessions(
                                                                          AllowSessionsEnum.ALLOW_CURRENT_SESSIONS_ONLY)
@@ -181,7 +182,7 @@ public class SystemWideAlertRestRepositoryIT extends AbstractControllerIntegrati
         // Create two alert entries in the db to fully test the findOne method
         // Note: It is not possible to create two alerts through the REST API
         context.turnOffAuthorisationSystem();
-        LocalDateTime dateToNearestSecond = LocalDateTime.now();
+        ZonedDateTime dateToNearestSecond = ZonedDateTime.now(ZoneOffset.UTC);
         SystemWideAlert systemWideAlert1 = SystemWideAlertBuilder.createSystemWideAlert(context, "Test alert 1")
                                                                  .withAllowSessions(
                                                                          AllowSessionsEnum.ALLOW_CURRENT_SESSIONS_ONLY)
@@ -224,7 +225,7 @@ public class SystemWideAlertRestRepositoryIT extends AbstractControllerIntegrati
         // Create two alert entries in the db to fully test the findOne method
         // Note: It is not possible to create two alerts through the REST API
         context.turnOffAuthorisationSystem();
-        LocalDateTime dateToNearestSecond = LocalDateTime.now();
+        ZonedDateTime dateToNearestSecond = ZonedDateTime.now(ZoneOffset.UTC);
         SystemWideAlert systemWideAlert1 = SystemWideAlertBuilder.createSystemWideAlert(context, "Test alert 1")
                                                                  .withAllowSessions(
                                                                          AllowSessionsEnum.ALLOW_CURRENT_SESSIONS_ONLY)
@@ -269,7 +270,7 @@ public class SystemWideAlertRestRepositoryIT extends AbstractControllerIntegrati
         // Create three alert entries in the db to fully test the findActive search method
         // Note: It is not possible to create two alerts through the REST API
         context.turnOffAuthorisationSystem();
-        LocalDateTime dateToNearestSecond = LocalDateTime.now();
+        ZonedDateTime dateToNearestSecond = ZonedDateTime.now(ZoneOffset.UTC);
         SystemWideAlert systemWideAlert1 = SystemWideAlertBuilder.createSystemWideAlert(context, "Test alert 1")
                                                                  .withAllowSessions(
                                                                          AllowSessionsEnum.ALLOW_CURRENT_SESSIONS_ONLY)
@@ -316,7 +317,7 @@ public class SystemWideAlertRestRepositoryIT extends AbstractControllerIntegrati
 
     @Test
     public void createTest() throws Exception {
-        LocalDateTime dateToNearestSecond = LocalDateTime.now();
+        ZonedDateTime dateToNearestSecond = ZonedDateTime.now(ZoneOffset.UTC);
 
         SystemWideAlertRest systemWideAlertRest = new SystemWideAlertRest();
         systemWideAlertRest.setMessage("Alert test message");
@@ -367,7 +368,7 @@ public class SystemWideAlertRestRepositoryIT extends AbstractControllerIntegrati
 
         SystemWideAlertRest systemWideAlertRest = new SystemWideAlertRest();
         systemWideAlertRest.setMessage("Alert test message");
-        systemWideAlertRest.setCountdownTo(LocalDateTime.now());
+        systemWideAlertRest.setCountdownTo(ZonedDateTime.now(ZoneOffset.UTC));
         systemWideAlertRest.setAllowSessions(AllowSessionsEnum.ALLOW_CURRENT_SESSIONS_ONLY.getValue());
         systemWideAlertRest.setActive(true);
 
@@ -385,7 +386,7 @@ public class SystemWideAlertRestRepositoryIT extends AbstractControllerIntegrati
 
         SystemWideAlertRest systemWideAlertRest = new SystemWideAlertRest();
         systemWideAlertRest.setMessage("Alert test message");
-        systemWideAlertRest.setCountdownTo(LocalDateTime.now());
+        systemWideAlertRest.setCountdownTo(ZonedDateTime.now(ZoneOffset.UTC));
         systemWideAlertRest.setAllowSessions(AllowSessionsEnum.ALLOW_CURRENT_SESSIONS_ONLY.getValue());
         systemWideAlertRest.setActive(true);
 
@@ -412,7 +413,7 @@ public class SystemWideAlertRestRepositoryIT extends AbstractControllerIntegrati
 
         SystemWideAlertRest systemWideAlertRest = new SystemWideAlertRest();
         systemWideAlertRest.setMessage("Alert test message");
-        systemWideAlertRest.setCountdownTo(LocalDateTime.now());
+        systemWideAlertRest.setCountdownTo(ZonedDateTime.now(ZoneOffset.UTC));
         systemWideAlertRest.setAllowSessions(AllowSessionsEnum.ALLOW_CURRENT_SESSIONS_ONLY.getValue());
         systemWideAlertRest.setActive(true);
 
@@ -436,7 +437,7 @@ public class SystemWideAlertRestRepositoryIT extends AbstractControllerIntegrati
                                                                 .build();
         context.restoreAuthSystemState();
 
-        LocalDateTime dateToNearestSecond = LocalDateTime.now();
+        ZonedDateTime dateToNearestSecond = ZonedDateTime.now(ZoneOffset.UTC);
 
         SystemWideAlertRest systemWideAlertRest = new SystemWideAlertRest();
         systemWideAlertRest.setAlertId(systemWideAlert.getID());

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SystemWideAlertRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SystemWideAlertRestRepositoryIT.java
@@ -29,11 +29,15 @@ import org.dspace.app.rest.model.SystemWideAlertRest;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
 import org.dspace.builder.SystemWideAlertBuilder;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * Test class to test the operations in the SystemWideAlertRestRepository
  */
 public class SystemWideAlertRestRepositoryIT extends AbstractControllerIntegrationTest {
+
+    @Autowired
+    private ObjectMapper mapper;
 
     @Test
     public void findAllTest() throws Exception {
@@ -320,8 +324,6 @@ public class SystemWideAlertRestRepositoryIT extends AbstractControllerIntegrati
         systemWideAlertRest.setAllowSessions(AllowSessionsEnum.ALLOW_CURRENT_SESSIONS_ONLY.getValue());
         systemWideAlertRest.setActive(true);
 
-        ObjectMapper mapper = new ObjectMapper();
-
         String authToken = getAuthToken(admin.getEmail(), password);
 
         AtomicReference<Integer> idRef = new AtomicReference<>();
@@ -369,8 +371,6 @@ public class SystemWideAlertRestRepositoryIT extends AbstractControllerIntegrati
         systemWideAlertRest.setAllowSessions(AllowSessionsEnum.ALLOW_CURRENT_SESSIONS_ONLY.getValue());
         systemWideAlertRest.setActive(true);
 
-        ObjectMapper mapper = new ObjectMapper();
-
         String authToken = getAuthToken(eperson.getEmail(), password);
 
 
@@ -388,8 +388,6 @@ public class SystemWideAlertRestRepositoryIT extends AbstractControllerIntegrati
         systemWideAlertRest.setCountdownTo(LocalDateTime.now());
         systemWideAlertRest.setAllowSessions(AllowSessionsEnum.ALLOW_CURRENT_SESSIONS_ONLY.getValue());
         systemWideAlertRest.setActive(true);
-
-        ObjectMapper mapper = new ObjectMapper();
 
         getClient().perform(post("/api/system/systemwidealerts/")
                                     .content(mapper.writeValueAsBytes(systemWideAlertRest))
@@ -417,8 +415,6 @@ public class SystemWideAlertRestRepositoryIT extends AbstractControllerIntegrati
         systemWideAlertRest.setCountdownTo(LocalDateTime.now());
         systemWideAlertRest.setAllowSessions(AllowSessionsEnum.ALLOW_CURRENT_SESSIONS_ONLY.getValue());
         systemWideAlertRest.setActive(true);
-
-        ObjectMapper mapper = new ObjectMapper();
 
         String authToken = getAuthToken(admin.getEmail(), password);
 
@@ -448,8 +444,6 @@ public class SystemWideAlertRestRepositoryIT extends AbstractControllerIntegrati
         systemWideAlertRest.setCountdownTo(dateToNearestSecond);
         systemWideAlertRest.setAllowSessions(AllowSessionsEnum.ALLOW_CURRENT_SESSIONS_ONLY.getValue());
         systemWideAlertRest.setActive(true);
-
-        ObjectMapper mapper = new ObjectMapper();
 
         String authToken = getAuthToken(admin.getEmail(), password);
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ViewEventRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ViewEventRestRepositoryIT.java
@@ -36,8 +36,12 @@ import org.dspace.content.Site;
 import org.dspace.statistics.SolrStatisticsCore;
 import org.dspace.utils.DSpace;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 public class ViewEventRestRepositoryIT extends AbstractControllerIntegrationTest {
+
+    @Autowired
+    private ObjectMapper mapper;
 
     private final SolrStatisticsCore solrStatisticsCore = new DSpace().getSingletonService(SolrStatisticsCore.class);
 
@@ -84,9 +88,6 @@ public class ViewEventRestRepositoryIT extends AbstractControllerIntegrationTest
         viewEventRest.setTargetType("item");
         viewEventRest.setTargetId(publicItem1.getID());
 
-
-        ObjectMapper mapper = new ObjectMapper();
-
         getClient().perform(post("/api/statistics/viewevents")
                                                 .content(mapper.writeValueAsBytes(viewEventRest))
                                                 .contentType(contentType))
@@ -123,9 +124,6 @@ public class ViewEventRestRepositoryIT extends AbstractControllerIntegrationTest
         ViewEventRest viewEventRest = new ViewEventRest();
         viewEventRest.setTargetType("item");
         viewEventRest.setTargetId(UUID.randomUUID());
-
-
-        ObjectMapper mapper = new ObjectMapper();
 
         getClient().perform(post("/api/statistics/viewevents")
                                 .content(mapper.writeValueAsBytes(viewEventRest))
@@ -164,9 +162,6 @@ public class ViewEventRestRepositoryIT extends AbstractControllerIntegrationTest
         viewEventRest.setTargetType("item");
         viewEventRest.setTargetId(null);
 
-
-        ObjectMapper mapper = new ObjectMapper();
-
         getClient().perform(post("/api/statistics/viewevents")
                                 .content(mapper.writeValueAsBytes(viewEventRest))
                                 .contentType(contentType))
@@ -204,9 +199,6 @@ public class ViewEventRestRepositoryIT extends AbstractControllerIntegrationTest
         viewEventRest.setTargetType(null);
         viewEventRest.setTargetId(publicItem1.getID());
 
-
-        ObjectMapper mapper = new ObjectMapper();
-
         getClient().perform(post("/api/statistics/viewevents")
                                 .content(mapper.writeValueAsBytes(viewEventRest))
                                 .contentType(contentType))
@@ -243,9 +235,6 @@ public class ViewEventRestRepositoryIT extends AbstractControllerIntegrationTest
         ViewEventRest viewEventRest = new ViewEventRest();
         viewEventRest.setTargetType("aezazeaezea");
         viewEventRest.setTargetId(publicItem1.getID());
-
-
-        ObjectMapper mapper = new ObjectMapper();
 
         getClient().perform(post("/api/statistics/viewevents")
                                 .content(mapper.writeValueAsBytes(viewEventRest))
@@ -295,9 +284,6 @@ public class ViewEventRestRepositoryIT extends AbstractControllerIntegrationTest
         viewEventRest.setTargetType("bitstream");
         viewEventRest.setTargetId(bitstream.getID());
 
-
-        ObjectMapper mapper = new ObjectMapper();
-
         getClient().perform(post("/api/statistics/viewevents")
                                 .content(mapper.writeValueAsBytes(viewEventRest))
                                 .contentType(contentType))
@@ -344,9 +330,6 @@ public class ViewEventRestRepositoryIT extends AbstractControllerIntegrationTest
         ViewEventRest viewEventRest = new ViewEventRest();
         viewEventRest.setTargetType("collection");
         viewEventRest.setTargetId(col1.getID());
-
-
-        ObjectMapper mapper = new ObjectMapper();
 
         getClient().perform(post("/api/statistics/viewevents")
                                 .content(mapper.writeValueAsBytes(viewEventRest))
@@ -395,9 +378,6 @@ public class ViewEventRestRepositoryIT extends AbstractControllerIntegrationTest
         ViewEventRest viewEventRest = new ViewEventRest();
         viewEventRest.setTargetType("community");
         viewEventRest.setTargetId(child1.getID());
-
-
-        ObjectMapper mapper = new ObjectMapper();
 
         getClient().perform(post("/api/statistics/viewevents")
                                 .content(mapper.writeValueAsBytes(viewEventRest))
@@ -449,9 +429,6 @@ public class ViewEventRestRepositoryIT extends AbstractControllerIntegrationTest
         viewEventRest.setTargetType("site");
         viewEventRest.setTargetId(site.getID());
 
-
-        ObjectMapper mapper = new ObjectMapper();
-
         getClient().perform(post("/api/statistics/viewevents")
                                 .content(mapper.writeValueAsBytes(viewEventRest))
                                 .contentType(contentType))
@@ -489,9 +466,6 @@ public class ViewEventRestRepositoryIT extends AbstractControllerIntegrationTest
         ViewEventRest viewEventRest = new ViewEventRest();
         viewEventRest.setTargetType("item");
         viewEventRest.setTargetId(publicItem1.getID());
-
-
-        ObjectMapper mapper = new ObjectMapper();
 
         String token = getAuthToken(eperson.getEmail(), password);
 
@@ -532,8 +506,6 @@ public class ViewEventRestRepositoryIT extends AbstractControllerIntegrationTest
         viewEventRest.setTargetType("item");
         viewEventRest.setTargetId(publicItem1.getID());
         viewEventRest.setReferrer("test-referrer");
-
-        ObjectMapper mapper = new ObjectMapper();
 
         getClient().perform(post("/api/statistics/viewevents")
                         .content(mapper.writeValueAsBytes(viewEventRest))

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/VocabularyRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/VocabularyRestRepositoryIT.java
@@ -12,7 +12,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.Locale;
 import java.util.UUID;
 
@@ -109,8 +109,8 @@ public class VocabularyRestRepositoryIT extends AbstractControllerIntegrationTes
         person1.setFirstName("Seiko");
         person1.setValue("Shirasaka, Seiko");
         person1.setField("dc_contributor_author");
-        person1.setLastModified(new Date());
-        person1.setCreationDate(new Date());
+        person1.setLastModified(Instant.now());
+        person1.setCreationDate(Instant.now());
         AuthorityServiceFactory.getInstance().getAuthorityIndexingService().indexContent(person1);
 
         PersonAuthorityValue person2 = new PersonAuthorityValue();
@@ -119,8 +119,8 @@ public class VocabularyRestRepositoryIT extends AbstractControllerIntegrationTes
         person2.setFirstName("Tyler E");
         person2.setValue("Miller, Tyler E");
         person2.setField("dc_contributor_author");
-        person2.setLastModified(new Date());
-        person2.setCreationDate(new Date());
+        person2.setLastModified(Instant.now());
+        person2.setCreationDate(Instant.now());
         AuthorityServiceFactory.getInstance().getAuthorityIndexingService().indexContent(person2);
 
         AuthorityServiceFactory.getInstance().getAuthorityIndexingService().commit();

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkspaceItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkspaceItemRestRepositoryIT.java
@@ -37,10 +37,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -51,7 +52,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jayway.jsonpath.matchers.JsonPathMatchers;
 import jakarta.ws.rs.core.MediaType;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.time.DateUtils;
 import org.dspace.app.ldn.NotifyServiceEntity;
 import org.dspace.app.rest.matcher.CollectionMatcher;
 import org.dspace.app.rest.matcher.ItemMatcher;
@@ -4061,10 +4061,9 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
 
         context.restoreAuthSystemState();
 
-        // date
-        SimpleDateFormat dateFmt = new SimpleDateFormat("yyyy-MM-dd");
-        Date startDate = new Date();
-        String startDateStr = dateFmt.format(startDate);
+        // date in YYYY-MM-DD format
+        DateTimeFormatter dateFmt = DateTimeFormatter.ISO_LOCAL_DATE;
+        String startDateStr = dateFmt.format(Instant.now());
 
         // create a list of values to use in add operation
         List<Operation> addAccessCondition = new ArrayList<>();
@@ -5675,10 +5674,9 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
         // auth
         String authToken = getAuthToken(eperson.getEmail(), password);
 
-        // date
-        SimpleDateFormat dateFmt = new SimpleDateFormat("yyyy-MM-dd");
-        Date endDate = new Date();
-        String endDateStr = dateFmt.format(endDate);
+        // date in YYYY-MM-DD format
+        DateTimeFormatter dateFmt = DateTimeFormatter.ISO_LOCAL_DATE;
+        String endDateStr = dateFmt.format(Instant.now());
 
         // prepare patch body
         Map<String, String> accessCondition = new HashMap<>();
@@ -5723,12 +5721,10 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
         // auth
         String authToken = getAuthToken(eperson.getEmail(), password);
 
-        // date
-        SimpleDateFormat dateFmt = new SimpleDateFormat("yyyy-MM-dd");
-        Date endDate = DateUtils.addDays(
-            // lease ends 1 day too late
-            DateUtils.addMonths(new Date(), 6), 1
-        );
+        // date in YYYY-MM-DD format
+        DateTimeFormatter dateFmt = DateTimeFormatter.ISO_LOCAL_DATE;
+        // lease ends 1 day too late
+        LocalDate endDate = LocalDate.now().plus(6, ChronoUnit.MONTHS).plus(1, ChronoUnit.DAYS);
         String endDateStr = dateFmt.format(endDate);
 
         // prepare patch body
@@ -5769,10 +5765,9 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
         // auth
         String authToken = getAuthToken(eperson.getEmail(), password);
 
-        // date
-        SimpleDateFormat dateFmt = new SimpleDateFormat("yyyy-MM-dd");
-        Date startDate = new Date();
-        String startDateStr = dateFmt.format(startDate);
+        // date in YYYY-MM-DD format
+        DateTimeFormatter dateFmt = DateTimeFormatter.ISO_LOCAL_DATE;
+        String startDateStr = dateFmt.format(Instant.now());
 
         // prepare patch body
         Map<String, String> accessCondition = new HashMap<>();
@@ -5817,12 +5812,10 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
         // auth
         String authToken = getAuthToken(eperson.getEmail(), password);
 
-        // date
-        SimpleDateFormat dateFmt = new SimpleDateFormat("yyyy-MM-dd");
-        Date startDate = DateUtils.addDays(
-            // embargo ends 1 day too late
-            DateUtils.addMonths(new Date(), 36), 1
-        );
+        // date in YYYY-MM-DD format
+        DateTimeFormatter dateFmt = DateTimeFormatter.ISO_LOCAL_DATE;
+        // embargo ends 1 day too late
+        LocalDate startDate = LocalDate.now().plus(36, ChronoUnit.MONTHS).plus(1, ChronoUnit.DAYS);
         String startDateStr = dateFmt.format(startDate);
 
         // prepare patch body
@@ -5863,10 +5856,9 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
         // auth
         String authToken = getAuthToken(eperson.getEmail(), password);
 
-        // date
-        SimpleDateFormat dateFmt = new SimpleDateFormat("yyyy-MM-dd");
-        Date startDate = new Date();
-        String startDateStr = dateFmt.format(startDate);
+        // date in YYYY-MM-DD format
+        DateTimeFormatter dateFmt = DateTimeFormatter.ISO_LOCAL_DATE;
+        String startDateStr = dateFmt.format(Instant.now());
 
         // prepare patch body
         Map<String, String> accessCondition = new HashMap<>();
@@ -7151,19 +7143,13 @@ ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup)
                      .withName("administrator")
                      .build();
 
-        Calendar calendar = Calendar.getInstance();
-
-        calendar.set(Calendar.YEAR, 2020);
-        calendar.set(Calendar.MONTH, 1);
-        calendar.set(Calendar.DATE, 1);
-
-        Date data = calendar.getTime();
+        LocalDate date = LocalDate.of(2020, 2, 1);
 
         ResourcePolicyBuilder.createResourcePolicy(context, null, embargoedGroup1)
                              .withDspaceObject(witem.getItem())
                              .withPolicyType(TYPE_CUSTOM)
                              .withName("embargoed")
-                             .withStartDate(data)
+                             .withStartDate(date)
                              .build();
 
         context.restoreAuthSystemState();
@@ -7490,19 +7476,13 @@ ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup)
                              .withName("openaccess")
                              .build();
 
-        Calendar calendar = Calendar.getInstance();
-
-        calendar.set(Calendar.YEAR, 2020);
-        calendar.set(Calendar.MONTH, 1);
-        calendar.set(Calendar.DATE, 1);
-
-        Date data = calendar.getTime();
+        LocalDate date = LocalDate.of(2020, 2, 1);
 
         ResourcePolicyBuilder.createResourcePolicy(context, null, embargoedGroup1)
                              .withDspaceObject(witem.getItem())
                              .withPolicyType(TYPE_CUSTOM)
                              .withName("embargo")
-                             .withStartDate(data)
+                             .withStartDate(date)
                              .build();
 
         context.restoreAuthSystemState();
@@ -8168,7 +8148,7 @@ ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup)
                         .andDo(result -> retrievalTime.set(read(
                                result.getResponse().getContentAsString(), "$.sections.sherpaPolicies.retrievalTime")));
 
-        Date date = new SimpleDateFormat(dateFormat).parse(retrievalTime.get());
+        Instant date = DateTimeFormatter.ofPattern(dateFormat).parse(retrievalTime.get(), Instant::from);
 
         // reload page, to verify that the retrievalTime is not changed
         getClient(token).perform(get("/api/submission/workspaceitems/" + witem.getID()))
@@ -8184,7 +8164,7 @@ ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup)
                         .andDo(result -> retrievalTime2.set(read(
                                result.getResponse().getContentAsString(), "$.sections.sherpaPolicies.retrievalTime")));
 
-        Date date2 = new SimpleDateFormat(dateFormat).parse(retrievalTime2.get());
+        Instant date2 = DateTimeFormatter.ofPattern(dateFormat).parse(retrievalTime2.get(), Instant::from);
 
         assertTrue(date.equals(date2));
 
@@ -8209,9 +8189,9 @@ ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup)
                         .andDo(result -> retrievalTime.set(read(
                                result.getResponse().getContentAsString(), "$.sections.sherpaPolicies.retrievalTime")));
 
-        date = new SimpleDateFormat(dateFormat).parse(retrievalTime.get());
+        date = DateTimeFormatter.ofPattern(dateFormat).parse(retrievalTime.get(), Instant::from);
 
-        assertTrue(date.after(date2));
+        assertTrue(date.isAfter(date2));
 
         // reload page, to verify that the retrievalTime is not changed
         getClient(token).perform(get("/api/submission/workspaceitems/" + witem.getID()))
@@ -8227,7 +8207,7 @@ ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup)
                         .andDo(result -> retrievalTime2.set(read(
                                result.getResponse().getContentAsString(), "$.sections.sherpaPolicies.retrievalTime")));
 
-        date2 = new SimpleDateFormat(dateFormat).parse(retrievalTime2.get());
+        date2 = DateTimeFormatter.ofPattern(dateFormat).parse(retrievalTime2.get(), Instant::from);
         assertTrue(date.equals(date2));
     }
 
@@ -8268,7 +8248,7 @@ ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup)
                         .andDo(result -> retrievalTime.set(read(
                                result.getResponse().getContentAsString(), "$.sections.sherpaPolicies.retrievalTime")));
 
-        Date date = new SimpleDateFormat(dateFormat).parse(retrievalTime.get());
+        Instant date = DateTimeFormatter.ofPattern(dateFormat).parse(retrievalTime.get(), Instant::from);
 
         // reload page, to verify that the retrievalTime is not changed
         getClient(token).perform(get("/api/submission/workspaceitems/" + witem.getID()))
@@ -8282,7 +8262,7 @@ ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup)
                         .andDo(result -> retrievalTime2.set(read(
                                result.getResponse().getContentAsString(), "$.sections.sherpaPolicies.retrievalTime")));
 
-        Date date2 = new SimpleDateFormat(dateFormat).parse(retrievalTime2.get());
+        Instant date2 = DateTimeFormatter.ofPattern(dateFormat).parse(retrievalTime2.get(), Instant::from);
 
         assertTrue(date.equals(date2));
 
@@ -8305,9 +8285,9 @@ ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup)
                         .andDo(result -> retrievalTime.set(read(
                                result.getResponse().getContentAsString(), "$.sections.sherpaPolicies.retrievalTime")));
 
-        date = new SimpleDateFormat(dateFormat).parse(retrievalTime.get());
+        date = DateTimeFormatter.ofPattern(dateFormat).parse(retrievalTime.get(), Instant::from);
 
-        assertTrue(date.after(date2));
+        assertTrue(date.isAfter(date2));
 
         // reload page, to verify that the retrievalTime is not changed
         getClient(token).perform(get("/api/submission/workspaceitems/" + witem.getID()))
@@ -8321,7 +8301,7 @@ ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup)
                         .andDo(result -> retrievalTime2.set(read(
                                result.getResponse().getContentAsString(), "$.sections.sherpaPolicies.retrievalTime")));
 
-        date2 = new SimpleDateFormat(dateFormat).parse(retrievalTime2.get());
+        date2 = DateTimeFormatter.ofPattern(dateFormat).parse(retrievalTime2.get(), Instant::from);
         assertTrue(date.equals(date2));
     }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkspaceItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkspaceItemRestRepositoryIT.java
@@ -4066,7 +4066,7 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
 
         // date in YYYY-MM-DD format
         DateTimeFormatter dateFmt = DateTimeFormatter.ISO_LOCAL_DATE;
-        String startDateStr = dateFmt.format(Instant.now());
+        String startDateStr = dateFmt.format(LocalDate.now());
 
         // create a list of values to use in add operation
         List<Operation> addAccessCondition = new ArrayList<>();
@@ -4885,7 +4885,6 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
                                            .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1, "123456789/extraction-test")
                 .withName("Collection 1").build();
-        String authToken = getAuthToken(admin.getEmail(), password);
 
         WorkspaceItem witem = WorkspaceItemBuilder.createWorkspaceItem(context, col1)
                 .build();
@@ -4893,6 +4892,8 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
                 .withTitle("This is a test title")
                 .build();
         context.restoreAuthSystemState();
+
+        String authToken = getAuthToken(admin.getEmail(), password);
 
         // try to add the pmid identifier
         List<Operation> addId = new ArrayList<Operation>();
@@ -5676,7 +5677,7 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
 
         // date in YYYY-MM-DD format
         DateTimeFormatter dateFmt = DateTimeFormatter.ISO_LOCAL_DATE;
-        String endDateStr = dateFmt.format(Instant.now());
+        String endDateStr = dateFmt.format(LocalDate.now());
 
         // prepare patch body
         Map<String, String> accessCondition = new HashMap<>();
@@ -5767,7 +5768,7 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
 
         // date in YYYY-MM-DD format
         DateTimeFormatter dateFmt = DateTimeFormatter.ISO_LOCAL_DATE;
-        String startDateStr = dateFmt.format(Instant.now());
+        String startDateStr = dateFmt.format(LocalDate.now());
 
         // prepare patch body
         Map<String, String> accessCondition = new HashMap<>();
@@ -5858,7 +5859,7 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
 
         // date in YYYY-MM-DD format
         DateTimeFormatter dateFmt = DateTimeFormatter.ISO_LOCAL_DATE;
-        String startDateStr = dateFmt.format(Instant.now());
+        String startDateStr = dateFmt.format(LocalDate.now());
 
         // prepare patch body
         Map<String, String> accessCondition = new HashMap<>();
@@ -8113,8 +8114,6 @@ ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup)
     public void sherpaPolicySectionCacheTest() throws Exception {
         context.turnOffAuthorisationSystem();
 
-        String dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
-
         parentCommunity = CommunityBuilder.createCommunity(context)
                                           .withName("Parent Community")
                                           .build();
@@ -8148,7 +8147,7 @@ ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup)
                         .andDo(result -> retrievalTime.set(read(
                                result.getResponse().getContentAsString(), "$.sections.sherpaPolicies.retrievalTime")));
 
-        Instant date = DateTimeFormatter.ofPattern(dateFormat).parse(retrievalTime.get(), Instant::from);
+        Instant date = Instant.parse(retrievalTime.get());
 
         // reload page, to verify that the retrievalTime is not changed
         getClient(token).perform(get("/api/submission/workspaceitems/" + witem.getID()))
@@ -8164,7 +8163,7 @@ ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup)
                         .andDo(result -> retrievalTime2.set(read(
                                result.getResponse().getContentAsString(), "$.sections.sherpaPolicies.retrievalTime")));
 
-        Instant date2 = DateTimeFormatter.ofPattern(dateFormat).parse(retrievalTime2.get(), Instant::from);
+        Instant date2 = Instant.parse(retrievalTime2.get());
 
         assertTrue(date.equals(date2));
 
@@ -8189,7 +8188,7 @@ ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup)
                         .andDo(result -> retrievalTime.set(read(
                                result.getResponse().getContentAsString(), "$.sections.sherpaPolicies.retrievalTime")));
 
-        date = DateTimeFormatter.ofPattern(dateFormat).parse(retrievalTime.get(), Instant::from);
+        date = Instant.parse(retrievalTime.get());
 
         assertTrue(date.isAfter(date2));
 
@@ -8207,15 +8206,13 @@ ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup)
                         .andDo(result -> retrievalTime2.set(read(
                                result.getResponse().getContentAsString(), "$.sections.sherpaPolicies.retrievalTime")));
 
-        date2 = DateTimeFormatter.ofPattern(dateFormat).parse(retrievalTime2.get(), Instant::from);
+        date2 = Instant.parse(retrievalTime2.get());
         assertTrue(date.equals(date2));
     }
 
     @Test
     public void sherpaPolicySectionWithWrongIssnCacheTest() throws Exception {
         context.turnOffAuthorisationSystem();
-
-        String dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
 
         parentCommunity = CommunityBuilder.createCommunity(context)
                                           .withName("Parent Community")
@@ -8248,7 +8245,7 @@ ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup)
                         .andDo(result -> retrievalTime.set(read(
                                result.getResponse().getContentAsString(), "$.sections.sherpaPolicies.retrievalTime")));
 
-        Instant date = DateTimeFormatter.ofPattern(dateFormat).parse(retrievalTime.get(), Instant::from);
+        Instant date = Instant.parse(retrievalTime.get());
 
         // reload page, to verify that the retrievalTime is not changed
         getClient(token).perform(get("/api/submission/workspaceitems/" + witem.getID()))
@@ -8262,7 +8259,7 @@ ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup)
                         .andDo(result -> retrievalTime2.set(read(
                                result.getResponse().getContentAsString(), "$.sections.sherpaPolicies.retrievalTime")));
 
-        Instant date2 = DateTimeFormatter.ofPattern(dateFormat).parse(retrievalTime2.get(), Instant::from);
+        Instant date2 = Instant.parse(retrievalTime2.get());
 
         assertTrue(date.equals(date2));
 
@@ -8285,7 +8282,7 @@ ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup)
                         .andDo(result -> retrievalTime.set(read(
                                result.getResponse().getContentAsString(), "$.sections.sherpaPolicies.retrievalTime")));
 
-        date = DateTimeFormatter.ofPattern(dateFormat).parse(retrievalTime.get(), Instant::from);
+        date = Instant.parse(retrievalTime.get());
 
         assertTrue(date.isAfter(date2));
 
@@ -8301,7 +8298,7 @@ ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup)
                         .andDo(result -> retrievalTime2.set(read(
                                result.getResponse().getContentAsString(), "$.sections.sherpaPolicies.retrievalTime")));
 
-        date2 = DateTimeFormatter.ofPattern(dateFormat).parse(retrievalTime2.get(), Instant::from);
+        date2 = Instant.parse(retrievalTime2.get());
         assertTrue(date.equals(date2));
     }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkspaceItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkspaceItemRestRepositoryIT.java
@@ -118,6 +118,9 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
     @Autowired
     private ConfigurationService configurationService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     private GroupService groupService;
 
     private Group embargoedGroups;
@@ -4341,8 +4344,6 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
 
         Integer workspaceItemId = null;
         try {
-
-        ObjectMapper mapper = new ObjectMapper();
         // You have to be an admin to create an Item from an ExternalDataObject
         String token = getAuthToken(admin.getEmail(), password);
         MvcResult mvcResult = getClient(token).perform(post("/api/submission/workspaceitems?owningCollection="
@@ -4415,7 +4416,6 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
 
         context.restoreAuthSystemState();
 
-        ObjectMapper mapper = new ObjectMapper();
         String token = getAuthToken(eperson.getEmail(), password);
         getClient(token).perform(post("/api/submission/workspaceitems?owningCollection="
                                           + col1.getID().toString())

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/converter/ConverterServiceIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/converter/ConverterServiceIT.java
@@ -69,6 +69,9 @@ public class ConverterServiceIT extends AbstractControllerIntegrationTest {
     @Autowired
     private RequestService requestService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     @Before
     public void setup() {
         // We're mocking a request here because we've started using the Context in the ConverterService#toRest
@@ -176,12 +179,12 @@ public class ConverterServiceIT extends AbstractControllerIntegrationTest {
         r0.setRestPropNotNull(restPropNotNullValue);
         r0.setRestPropRenamed(restPropRenamedValue);
         r0.setRestPropUnannotated(restPropUnannotatedValue);
-        String r0json = new ObjectMapper().writeValueAsString(r0);
+        String r0json = mapper.writeValueAsString(r0);
 
         MockObjectResource resource = converter.toResource(r0);
 
         // The default projection should not modify the wrapped object
-        assertThat(new ObjectMapper().writeValueAsString(r0), equalTo(r0json));
+        assertThat(mapper.writeValueAsString(r0), equalTo(r0json));
 
         assertHasEmbeds(resource, new String[] {
                 "restPropUnannotated" // embedded; unannotated properties can't be omitted by projections
@@ -213,7 +216,7 @@ public class ConverterServiceIT extends AbstractControllerIntegrationTest {
         r0.setRestPropNotNull(restPropNotNullValue);
         r0.setRestPropRenamed(restPropRenamedValue);
         r0.setRestPropUnannotated(restPropUnannotatedValue);
-        String r0json = new ObjectMapper().writeValueAsString(r0);
+        String r0json = mapper.writeValueAsString(r0);
 
         // return "mockLink" LinkRelation when getRel() is called
         when(mockLink.getRel()).thenReturn(() -> "mockLink");
@@ -222,7 +225,7 @@ public class ConverterServiceIT extends AbstractControllerIntegrationTest {
         MockObjectResource resource = converter.toResource(r0);
 
         // The mock projection should not modify the wrapped object
-        assertThat(new ObjectMapper().writeValueAsString(r0), equalTo(r0json));
+        assertThat(mapper.writeValueAsString(r0), equalTo(r0json));
 
         assertHasEmbeds(resource, new String[] {
                 "restPropNotNull",

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/csv/CsvExportIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/csv/CsvExportIT.java
@@ -42,6 +42,9 @@ public class CsvExportIT extends AbstractControllerIntegrationTest {
     @Autowired
     private DSpaceRunnableParameterConverter dSpaceRunnableParameterConverter;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     @Test
     public void metadataExportTestWithoutFileParameterSucceeds() throws Exception {
 
@@ -77,7 +80,7 @@ public class CsvExportIT extends AbstractControllerIntegrationTest {
 
             getClient(token)
                 .perform(multipart("/api/system/scripts/metadata-export/processes")
-                             .param("properties", new ObjectMapper().writeValueAsString(list)))
+                             .param("properties", mapper.writeValueAsString(list)))
                 .andExpect(status().isAccepted())
                 .andExpect(jsonPath("$", is(
                     ProcessMatcher.matchProcess("metadata-export",
@@ -128,7 +131,7 @@ public class CsvExportIT extends AbstractControllerIntegrationTest {
 
             getClient(token)
                 .perform(multipart("/api/system/scripts/metadata-export/processes")
-                             .param("properties", new ObjectMapper().writeValueAsString(list)))
+                             .param("properties", mapper.writeValueAsString(list)))
                 .andExpect(status().isAccepted())
                 .andExpect(jsonPath("$", is(
                     ProcessMatcher.matchProcess("metadata-export",

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/csv/CsvImportIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/csv/CsvImportIT.java
@@ -74,6 +74,9 @@ public class CsvImportIT extends AbstractEntityIntegrationTest {
     @Autowired
     private DSpaceRunnableParameterConverter dSpaceRunnableParameterConverter;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     @Test
     public void createRelationshipsWithCsvImportTest() throws Exception {
         context.turnOffAuthorisationSystem();
@@ -285,7 +288,7 @@ public class CsvImportIT extends AbstractEntityIntegrationTest {
 
             getClient(token)
                 .perform(multipart("/api/system/scripts/metadata-import/processes").file(bitstreamFile)
-                                          .param("properties", new ObjectMapper().writeValueAsString(list)))
+                                          .param("properties", mapper.writeValueAsString(list)))
                 .andExpect(status().isAccepted())
                 .andDo(result -> idRef
                     .set(read(result.getResponse().getContentAsString(), "$.processId")));
@@ -344,7 +347,7 @@ public class CsvImportIT extends AbstractEntityIntegrationTest {
 
             getClient(token)
                 .perform(multipart("/api/system/scripts/metadata-import/processes").file(bitstreamFile)
-                                             .param("properties", new ObjectMapper().writeValueAsString(list)))
+                                             .param("properties", mapper.writeValueAsString(list)))
                 .andExpect(status().isAccepted())
                 .andExpect(jsonPath("$", is(
                     ProcessMatcher.matchProcess("metadata-import",

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/csv/CsvSearchExportIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/csv/CsvSearchExportIT.java
@@ -39,6 +39,10 @@ public class CsvSearchExportIT extends AbstractControllerIntegrationTest {
 
     @Autowired
     private DSpaceRunnableParameterConverter dSpaceRunnableParameterConverter;
+
+    @Autowired
+    private ObjectMapper mapper;
+
     private ProcessService processService = ScriptServiceFactory.getInstance().getProcessService();
 
     @Test
@@ -54,7 +58,7 @@ public class CsvSearchExportIT extends AbstractControllerIntegrationTest {
         try {
             String token = getAuthToken(admin.getEmail(), password);
             getClient(token).perform(multipart("/api/system/scripts/metadata-export-search/processes")
-                    .param("properties", new ObjectMapper().writeValueAsString(restparams)))
+                    .param("properties", mapper.writeValueAsString(restparams)))
                 .andExpect(status().isAccepted())
                 .andExpect(jsonPath("$",
                     ProcessMatcher.matchProcess("metadata-export-search", admin.getID().toString(), parameterList,
@@ -75,7 +79,7 @@ public class CsvSearchExportIT extends AbstractControllerIntegrationTest {
                 Collectors.toList());
 
         getClient().perform(multipart("/api/system/scripts/metadata-export-search/processes")
-                .param("properties", new ObjectMapper().writeValueAsString(restparams)))
+                .param("properties", mapper.writeValueAsString(restparams)))
             .andExpect(status().isUnauthorized());
     }
 
@@ -90,7 +94,7 @@ public class CsvSearchExportIT extends AbstractControllerIntegrationTest {
 
         String token = getAuthToken(eperson.getEmail(), password);
         getClient(token).perform(multipart("/api/system/scripts/metadata-export-search/processes")
-                .param("properties", new ObjectMapper().writeValueAsString(restparams)))
+                .param("properties", mapper.writeValueAsString(restparams)))
             .andExpect(status().isForbidden());
     }
 
@@ -108,7 +112,7 @@ public class CsvSearchExportIT extends AbstractControllerIntegrationTest {
         String token = getAuthToken(admin.getEmail(), password);
         try {
             getClient(token).perform(multipart("/api/system/scripts/metadata-export-search/processes")
-                                         .param("properties", new ObjectMapper().writeValueAsString(restparams)))
+                                         .param("properties", mapper.writeValueAsString(restparams)))
                             .andExpect(status().isAccepted())
                             .andDo(result -> System.out.println(result.getResponse().getContentAsString()))
                             .andDo(result -> idRef.set(read(result.getResponse().getContentAsString(), "$.processId")));
@@ -129,7 +133,7 @@ public class CsvSearchExportIT extends AbstractControllerIntegrationTest {
 
         String token = getAuthToken(admin.getEmail(), password);
         getClient(token).perform(multipart("/api/system/scripts/metadata-export-search/processes")
-                .param("properties", new ObjectMapper().writeValueAsString(restparams)))
+                .param("properties", mapper.writeValueAsString(restparams)))
             .andExpect(status().isInternalServerError());
 
         // NOTE: While the above call returns 500 (from Discovery), it DOES create a Process.

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/RequestCopyMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/RequestCopyMatcher.java
@@ -35,13 +35,13 @@ public class RequestCopyMatcher {
                 hasJsonPath("$.requestEmail", is(request.getReqEmail())),
                 hasJsonPath("$.requestName", is(request.getReqName())),
                 hasJsonPath("$.requestMessage", is(request.getReqMessage())),
-                hasJsonPath("$.requestDate", dateMatcher(request.getRequest_date()
-                                                                .atZone(ZoneOffset.UTC))),
+                hasJsonPath("$.requestDate", dateMatcher(
+                    request.getRequest_date() != null ? request.getRequest_date().atZone(ZoneOffset.UTC) : null)),
                 hasJsonPath("$.acceptRequest", is(request.isAccept_request())),
-                hasJsonPath("$.decisionDate", dateMatcher(request.getDecision_date()
-                                                                 .atZone(ZoneOffset.UTC))),
-                hasJsonPath("$.expires", dateMatcher(request.getExpires()
-                                                            .atZone(ZoneOffset.UTC))),
+                hasJsonPath("$.decisionDate", dateMatcher(
+                    request.getDecision_date() != null ? request.getDecision_date().atZone(ZoneOffset.UTC) : null)),
+                hasJsonPath("$.expires", dateMatcher(
+                    request.getExpires() != null ? request.getExpires().atZone(ZoneOffset.UTC) : null)),
                 hasJsonPath("$.type", is(RequestItemRest.NAME)),
                 hasJsonPath("$._links.self.href",
                         Matchers.containsString(RequestItemRepositoryIT.URI_ROOT))

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/RequestCopyMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/RequestCopyMatcher.java
@@ -36,12 +36,12 @@ public class RequestCopyMatcher {
                 hasJsonPath("$.requestName", is(request.getReqName())),
                 hasJsonPath("$.requestMessage", is(request.getReqMessage())),
                 hasJsonPath("$.requestDate", dateMatcher(request.getRequest_date()
-                                                                .atZone(ZoneOffset.UTC).toLocalDateTime())),
+                                                                .atZone(ZoneOffset.UTC))),
                 hasJsonPath("$.acceptRequest", is(request.isAccept_request())),
                 hasJsonPath("$.decisionDate", dateMatcher(request.getDecision_date()
-                                                                 .atZone(ZoneOffset.UTC).toLocalDateTime())),
+                                                                 .atZone(ZoneOffset.UTC))),
                 hasJsonPath("$.expires", dateMatcher(request.getExpires()
-                                                            .atZone(ZoneOffset.UTC).toLocalDateTime())),
+                                                            .atZone(ZoneOffset.UTC))),
                 hasJsonPath("$.type", is(RequestItemRest.NAME)),
                 hasJsonPath("$._links.self.href",
                         Matchers.containsString(RequestItemRepositoryIT.URI_ROOT))

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/RequestCopyMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/RequestCopyMatcher.java
@@ -13,6 +13,8 @@ import static org.dspace.matcher.DateMatcher.dateMatcher;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.is;
 
+import java.time.ZoneOffset;
+
 import org.dspace.app.requestitem.RequestItem;
 import org.dspace.app.rest.RequestItemRepositoryIT;
 import org.dspace.app.rest.model.RequestItemRest;
@@ -33,10 +35,13 @@ public class RequestCopyMatcher {
                 hasJsonPath("$.requestEmail", is(request.getReqEmail())),
                 hasJsonPath("$.requestName", is(request.getReqName())),
                 hasJsonPath("$.requestMessage", is(request.getReqMessage())),
-                hasJsonPath("$.requestDate", dateMatcher(request.getRequest_date())),
+                hasJsonPath("$.requestDate", dateMatcher(request.getRequest_date()
+                                                                .atZone(ZoneOffset.UTC).toLocalDateTime())),
                 hasJsonPath("$.acceptRequest", is(request.isAccept_request())),
-                hasJsonPath("$.decisionDate", dateMatcher(request.getDecision_date())),
-                hasJsonPath("$.expires", dateMatcher(request.getExpires())),
+                hasJsonPath("$.decisionDate", dateMatcher(request.getDecision_date()
+                                                                 .atZone(ZoneOffset.UTC).toLocalDateTime())),
+                hasJsonPath("$.expires", dateMatcher(request.getExpires()
+                                                            .atZone(ZoneOffset.UTC).toLocalDateTime())),
                 hasJsonPath("$.type", is(RequestItemRest.NAME)),
                 hasJsonPath("$._links.self.href",
                         Matchers.containsString(RequestItemRepositoryIT.URI_ROOT))

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/jwt/JWTTokenHandlerTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/jwt/JWTTokenHandlerTest.java
@@ -12,9 +12,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.text.ParseException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Base64;
-import java.util.Date;
 import java.util.List;
 
 import com.nimbusds.jwt.JWTClaimsSet;
@@ -76,7 +77,7 @@ public class JWTTokenHandlerTest {
     @Before
     public void setUp() throws Exception {
         when(ePerson.getSessionSalt()).thenReturn("01234567890123456789012345678901");
-        when(ePerson.getLastActive()).thenReturn(new Date());
+        when(ePerson.getLastActive()).thenReturn(Instant.now());
         when(context.getCurrentUser()).thenReturn(ePerson);
         when(clientInfoService.getClientIp(any())).thenReturn("123.123.123.123");
         when(ePersonClaimProvider.getKey()).thenReturn("eid");
@@ -90,7 +91,7 @@ public class JWTTokenHandlerTest {
 
     @Test
     public void testJWTNoEncryption() throws Exception {
-        Date previous = new Date(System.currentTimeMillis() - 10000000000L);
+        Instant previous = Instant.now().minus(10000000000L, ChronoUnit.MILLIS);
         String token = loginJWTTokenHandler
             .createTokenForEPerson(context, new MockHttpServletRequest(), previous);
         SignedJWT signedJWT = SignedJWT.parse(token);
@@ -101,7 +102,7 @@ public class JWTTokenHandlerTest {
     @Test(expected = ParseException.class)
     public void testJWTEncrypted() throws Exception {
         when(loginJWTTokenHandler.isEncryptionEnabled()).thenReturn(true);
-        Date previous = new Date(System.currentTimeMillis() - 10000000000L);
+        Instant previous = Instant.now().minus(10000000000L, ChronoUnit.MILLIS);
         StringKeyGenerator keyGenerator = KeyGenerators.string();
         when(configurationService.getProperty("jwt.login.encryption.secret")).thenReturn(keyGenerator.generateKey());
         String token = loginJWTTokenHandler
@@ -114,7 +115,7 @@ public class JWTTokenHandlerTest {
     public void testExpiredToken() throws Exception {
         when(configurationService.getLongProperty("jwt.login.token.expiration", 1800000)).thenReturn(-99999999L);
         when(ePersonClaimProvider.getEPerson(any(Context.class), any(JWTClaimsSet.class))).thenReturn(ePerson);
-        Date previous = new Date(new Date().getTime() - 10000000000L);
+        Instant previous = Instant.now().minus(10000000000L, ChronoUnit.MILLIS);
         String token = loginJWTTokenHandler
             .createTokenForEPerson(context, new MockHttpServletRequest(), previous);
         EPerson parsed = loginJWTTokenHandler.parseEPersonFromToken(token, httpServletRequest, context);
@@ -127,11 +128,11 @@ public class JWTTokenHandlerTest {
     public void testTokenTampering() throws Exception {
         when(loginJWTTokenHandler.getExpirationPeriod()).thenReturn(-99999999L);
         when(ePersonClaimProvider.getEPerson(any(Context.class), any(JWTClaimsSet.class))).thenReturn(ePerson);
-        Date previous = new Date(new Date().getTime() - 10000000000L);
+        Instant previous = Instant.now().minus(10000000000L, ChronoUnit.MILLIS);
         String token = loginJWTTokenHandler
             .createTokenForEPerson(context, new MockHttpServletRequest(), previous);
         JWTClaimsSet jwtClaimsSet = new JWTClaimsSet.Builder().claim("eid", "epersonID").expirationTime(
-            new Date(System.currentTimeMillis() + 99999999)).build();
+            java.util.Date.from(Instant.now().plus(99999999, ChronoUnit.MILLIS))).build();
         String tamperedPayload = new String(Base64.getUrlEncoder().encode(jwtClaimsSet.toString().getBytes()));
         String[] splitToken = token.split("\\.");
         String tamperedToken = splitToken[0] + "." + tamperedPayload + "." + splitToken[2];
@@ -141,7 +142,7 @@ public class JWTTokenHandlerTest {
 
     @Test
     public void testInvalidatedToken() throws Exception {
-        Date previous = new Date(System.currentTimeMillis() - 10000000000L);
+        Instant previous = Instant.now().minus(10000000000L, ChronoUnit.MILLIS);
         // create a new token
         String token = loginJWTTokenHandler
             .createTokenForEPerson(context, new MockHttpServletRequest(), previous);

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/jwt/ShortLivedJWTTokenHandlerTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/jwt/ShortLivedJWTTokenHandlerTest.java
@@ -12,8 +12,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.text.ParseException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Base64;
-import java.util.Date;
 
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
@@ -53,7 +54,7 @@ public class ShortLivedJWTTokenHandlerTest extends JWTTokenHandlerTest {
 
     @Test
     public void testJWTNoEncryption() throws Exception {
-        Date previous = new Date(System.currentTimeMillis() - 10000000000L);
+        Instant previous = Instant.now().minus(10000000000L, ChronoUnit.MILLIS);
         String token = shortLivedJWTTokenHandler
             .createTokenForEPerson(context, new MockHttpServletRequest(), previous);
         SignedJWT signedJWT = SignedJWT.parse(token);
@@ -64,7 +65,7 @@ public class ShortLivedJWTTokenHandlerTest extends JWTTokenHandlerTest {
     @Test(expected = ParseException.class)
     public void testJWTEncrypted() throws Exception {
         when(shortLivedJWTTokenHandler.isEncryptionEnabled()).thenReturn(true);
-        Date previous = new Date(System.currentTimeMillis() - 10000000000L);
+        Instant previous = Instant.now().minus(10000000000L, ChronoUnit.MILLIS);
         StringKeyGenerator keyGenerator = KeyGenerators.string();
         when(configurationService.getProperty("jwt.shortLived.encryption.secret"))
             .thenReturn(keyGenerator.generateKey());
@@ -79,7 +80,7 @@ public class ShortLivedJWTTokenHandlerTest extends JWTTokenHandlerTest {
         when(configurationService.getLongProperty("jwt.shortLived.token.expiration", 1800000))
             .thenReturn(-99999999L);
         when(ePersonClaimProvider.getEPerson(any(Context.class), any(JWTClaimsSet.class))).thenReturn(ePerson);
-        Date previous = new Date(new Date().getTime() - 10000000000L);
+        Instant previous = Instant.now().minus(10000000000L, ChronoUnit.MILLIS);
         String token = shortLivedJWTTokenHandler
             .createTokenForEPerson(context, new MockHttpServletRequest(), previous);
         EPerson parsed = shortLivedJWTTokenHandler.parseEPersonFromToken(token, httpServletRequest, context);
@@ -92,11 +93,11 @@ public class ShortLivedJWTTokenHandlerTest extends JWTTokenHandlerTest {
     public void testTokenTampering() throws Exception {
         when(shortLivedJWTTokenHandler.getExpirationPeriod()).thenReturn(-99999999L);
         when(ePersonClaimProvider.getEPerson(any(Context.class), any(JWTClaimsSet.class))).thenReturn(ePerson);
-        Date previous = new Date(new Date().getTime() - 10000000000L);
+        Instant previous = Instant.now().minus(10000000000L, ChronoUnit.MILLIS);
         String token = shortLivedJWTTokenHandler
             .createTokenForEPerson(context, new MockHttpServletRequest(), previous);
         JWTClaimsSet jwtClaimsSet = new JWTClaimsSet.Builder().claim("eid", "epersonID").expirationTime(
-            new Date(System.currentTimeMillis() + 99999999)).build();
+            java.util.Date.from(Instant.now().plus(99999999, ChronoUnit.MILLIS))).build();
         String tamperedPayload = new String(Base64.getUrlEncoder().encode(jwtClaimsSet.toString().getBytes()));
         String[] splitToken = token.split("\\.");
         String tamperedToken = splitToken[0] + "." + tamperedPayload + "." + splitToken[2];
@@ -106,7 +107,7 @@ public class ShortLivedJWTTokenHandlerTest extends JWTTokenHandlerTest {
 
     @Test
     public void testInvalidatedToken() throws Exception {
-        Date previous = new Date(System.currentTimeMillis() - 10000000000L);
+        Instant previous = Instant.now().minus(10000000000L, ChronoUnit.MILLIS);
         // create a new token
         String token = shortLivedJWTTokenHandler
             .createTokenForEPerson(context, new MockHttpServletRequest(), previous);

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/signposting/controller/LinksetRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/signposting/controller/LinksetRestControllerIT.java
@@ -15,11 +15,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.io.InputStream;
-import java.text.DateFormat;
 import java.text.MessageFormat;
-import java.text.SimpleDateFormat;
 import java.time.Period;
-import java.util.Date;
 
 import org.apache.commons.codec.CharEncoding;
 import org.apache.commons.io.IOUtils;
@@ -867,8 +864,6 @@ public class LinksetRestControllerIT extends AbstractControllerIntegrationTest {
     @Test
     public void getDescribedBy() throws Exception {
         context.turnOffAuthorisationSystem();
-        DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
-        String currentDateInFormat = dateFormat.format(new Date());
         String title = "Item Test";
         Item item = ItemBuilder.createItem(context, collection)
                 .withTitle(title)

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/test/AbstractControllerIntegrationTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/test/AbstractControllerIntegrationTest.java
@@ -108,6 +108,9 @@ public class AbstractControllerIntegrationTest extends AbstractIntegrationTestWi
     private List<Filter> requestFilters;
 
     @Autowired
+    private ObjectMapper mapper;
+
+    @Autowired
     void setConverters(HttpMessageConverter<?>[] converters) {
 
         this.mappingJackson2HttpMessageConverter = Arrays.asList(converters).stream().filter(
@@ -187,9 +190,8 @@ public class AbstractControllerIntegrationTest extends AbstractIntegrationTestWi
     }
 
     public String getPatchContent(List<Operation> ops) {
-        ObjectMapper objectMapper = new ObjectMapper();
         try {
-            return objectMapper.writeValueAsString(ops);
+            return mapper.writeValueAsString(ops);
         } catch (JsonProcessingException e) {
             e.printStackTrace();
         }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/test/MetadataPatchSuite.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/test/MetadataPatchSuite.java
@@ -23,16 +23,19 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
  * Utility class for performing metadata patch tests sourced from a common json file (see constructor).
  */
 public class MetadataPatchSuite {
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper mapper;
+
     private final JsonNode suite;
 
     /**
      * Initializes the suite by parsing the json file of tests.
      *
+     * @param mapper the initialized ObjectMapper (e.g. from Spring Boot)
      * @throws Exception if there is an error reading the file.
      */
-    public MetadataPatchSuite() throws Exception {
-        suite = objectMapper.readTree(getClass().getResourceAsStream("metadata-patch-suite.json"));
+    public MetadataPatchSuite(ObjectMapper mapper) throws Exception {
+        this.mapper = mapper;
+        suite = mapper.readTree(getClass().getResourceAsStream("metadata-patch-suite.json"));
     }
 
     /**
@@ -78,7 +81,7 @@ public class MetadataPatchSuite {
                 .andExpect(status().is(expectedStatus));
         if (expectedStatus >= 200 && expectedStatus < 300) {
           String responseBody = resultActions.andReturn().getResponse().getContentAsString();
-          JsonNode responseJson =  objectMapper.readTree(responseBody);
+          JsonNode responseJson =  mapper.readTree(responseBody);
           String responseMetadata = responseJson.get("metadata").toString();
           if (!responseMetadata.equals(expectedMetadata)) {
               Assert.fail("Expected metadata in " + verb + " response: " + expectedMetadata

--- a/dspace-server-webapp/src/test/java/org/dspace/curate/CurationScriptIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/curate/CurationScriptIT.java
@@ -65,6 +65,9 @@ public class CurationScriptIT extends AbstractControllerIntegrationTest {
     @Autowired
     private ScriptService scriptService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     private final static String SCRIPTS_ENDPOINT = "/api/" + ScriptRest.CATEGORY + "/" + ScriptRest.PLURAL_NAME;
     private final static String CURATE_SCRIPT_ENDPOINT = SCRIPTS_ENDPOINT + "/curate/" + ProcessRest.PLURAL_NAME;
 
@@ -104,7 +107,7 @@ public class CurationScriptIT extends AbstractControllerIntegrationTest {
         // Request with -t <invalidTaskOption>
         getClient(token)
             .perform(multipart(CURATE_SCRIPT_ENDPOINT)
-                         .param("properties", new ObjectMapper().writeValueAsString(list)))
+                         .param("properties", mapper.writeValueAsString(list)))
             // Illegal Argument Exception
             .andExpect(status().isBadRequest());
     }
@@ -125,7 +128,7 @@ public class CurationScriptIT extends AbstractControllerIntegrationTest {
         // Request with missing required -i <handle>
         getClient(token)
             .perform(multipart(CURATE_SCRIPT_ENDPOINT)
-                         .param("properties", new ObjectMapper().writeValueAsString(list)))
+                         .param("properties", mapper.writeValueAsString(list)))
             // Illegal Argument Exception
             .andExpect(status().isBadRequest());
     }
@@ -147,7 +150,7 @@ public class CurationScriptIT extends AbstractControllerIntegrationTest {
         // Request with missing required -i <handle>
         getClient(token)
             .perform(multipart(CURATE_SCRIPT_ENDPOINT)
-                         .param("properties", new ObjectMapper().writeValueAsString(list)))
+                         .param("properties", mapper.writeValueAsString(list)))
             // Illegal Argument Exception
             .andExpect(status().isBadRequest());
     }
@@ -187,7 +190,7 @@ public class CurationScriptIT extends AbstractControllerIntegrationTest {
         // Request without -t <task> or -T <taskFile> (and no -q <queue>)
         getClient(token)
             .perform(multipart(CURATE_SCRIPT_ENDPOINT)
-                         .param("properties", new ObjectMapper().writeValueAsString(list)))
+                         .param("properties", mapper.writeValueAsString(list)))
             // Illegal Argument Exception
             .andExpect(status().isBadRequest());
     }
@@ -209,7 +212,7 @@ public class CurationScriptIT extends AbstractControllerIntegrationTest {
         // Request with invalid -s <scope>; must be object, curation or open
         getClient(token)
             .perform(multipart(CURATE_SCRIPT_ENDPOINT)
-                         .param("properties", new ObjectMapper().writeValueAsString(list)))
+                         .param("properties", mapper.writeValueAsString(list)))
             // Illegal Argument Exception
             .andExpect(status().isBadRequest());
     }
@@ -231,7 +234,7 @@ public class CurationScriptIT extends AbstractControllerIntegrationTest {
         // Request with invalid -s <scope>; must be object, curation or open
         getClient(token)
             .perform(multipart(CURATE_SCRIPT_ENDPOINT)
-                         .param("properties", new ObjectMapper().writeValueAsString(list)))
+                         .param("properties", mapper.writeValueAsString(list)))
             // Illegal Argument Exception
             .andExpect(status().isBadRequest());
     }
@@ -273,7 +276,7 @@ public class CurationScriptIT extends AbstractControllerIntegrationTest {
         try {
             getClient(token)
                 .perform(multipart(CURATE_SCRIPT_ENDPOINT)
-                             .param("properties", new ObjectMapper().writeValueAsString(list)))
+                             .param("properties", mapper.writeValueAsString(list)))
                 .andExpect(status().isAccepted())
                 .andExpect(jsonPath("$", is(
                     ProcessMatcher.matchProcess("curate",
@@ -324,7 +327,7 @@ public class CurationScriptIT extends AbstractControllerIntegrationTest {
         try {
             getClient(token)
                 .perform(multipart(CURATE_SCRIPT_ENDPOINT)
-                             .param("properties", new ObjectMapper().writeValueAsString(list)))
+                             .param("properties", mapper.writeValueAsString(list)))
                 .andExpect(status().isAccepted())
                 .andExpect(jsonPath("$", is(
                     ProcessMatcher.matchProcess("curate",
@@ -375,7 +378,7 @@ public class CurationScriptIT extends AbstractControllerIntegrationTest {
 
             getClient(token)
                 .perform(multipart(CURATE_SCRIPT_ENDPOINT)
-                             .param("properties", new ObjectMapper().writeValueAsString(list)))
+                             .param("properties", mapper.writeValueAsString(list)))
                 .andExpect(jsonPath("$", is(
                     ProcessMatcher.matchProcess("curate",
                                                 String.valueOf(admin.getID()), parameters,
@@ -498,7 +501,7 @@ public class CurationScriptIT extends AbstractControllerIntegrationTest {
             // start a process as general admin
             getClient(adminToken)
                     .perform(multipart("/api/system/scripts/" + curateScriptConfiguration.getName() + "/processes")
-                                 .param("properties", new ObjectMapper().writeValueAsString(listCurateSite)))
+                                 .param("properties", mapper.writeValueAsString(listCurateSite)))
                     .andExpect(status().isAccepted())
                     .andExpect(jsonPath("$", is(
                             ProcessMatcher.matchProcess("curate",
@@ -511,7 +514,7 @@ public class CurationScriptIT extends AbstractControllerIntegrationTest {
             // check with the com admin
             getClient(comAdminToken)
                     .perform(multipart("/api/system/scripts/" + curateScriptConfiguration.getName() + "/processes")
-                                 .param("properties", new ObjectMapper().writeValueAsString(listCom)))
+                                 .param("properties", mapper.writeValueAsString(listCom)))
                     .andExpect(status().isAccepted())
                     .andExpect(jsonPath("$", is(
                             ProcessMatcher.matchProcess("curate",
@@ -523,7 +526,7 @@ public class CurationScriptIT extends AbstractControllerIntegrationTest {
             // the com admin should be able to run the curate also over the children collection and item
             getClient(comAdminToken)
                     .perform(multipart("/api/system/scripts/" + curateScriptConfiguration.getName() + "/processes")
-                                 .param("properties", new ObjectMapper().writeValueAsString(listCol)))
+                                 .param("properties", mapper.writeValueAsString(listCol)))
                     .andExpect(status().isAccepted())
                     .andExpect(jsonPath("$", is(
                             ProcessMatcher.matchProcess("curate",
@@ -534,7 +537,7 @@ public class CurationScriptIT extends AbstractControllerIntegrationTest {
                             .set(read(result.getResponse().getContentAsString(), "$.processId")));
             getClient(comAdminToken)
                     .perform(multipart("/api/system/scripts/" + curateScriptConfiguration.getName() + "/processes")
-                                 .param("properties", new ObjectMapper().writeValueAsString(listItem)))
+                                 .param("properties", mapper.writeValueAsString(listItem)))
                     .andExpect(status().isAccepted())
                     .andExpect(jsonPath("$", is(
                             ProcessMatcher.matchProcess("curate",
@@ -546,25 +549,25 @@ public class CurationScriptIT extends AbstractControllerIntegrationTest {
             // the com admin should be NOT able to run the curate over other com, col or items
             getClient(comAdminToken)
                     .perform(multipart("/api/system/scripts/" + curateScriptConfiguration.getName() + "/processes")
-                                 .param("properties", new ObjectMapper().writeValueAsString(listCurateSite)))
+                                 .param("properties", mapper.writeValueAsString(listCurateSite)))
                     .andExpect(status().isForbidden());
             getClient(comAdminToken)
                     .perform(multipart("/api/system/scripts/" + curateScriptConfiguration.getName() + "/processes")
-                                 .param("properties", new ObjectMapper().writeValueAsString(listAnotherCom)))
+                                 .param("properties", mapper.writeValueAsString(listAnotherCom)))
                     .andExpect(status().isForbidden());
             getClient(comAdminToken)
                     .perform(multipart("/api/system/scripts/" + curateScriptConfiguration.getName() + "/processes")
-                                 .param("properties", new ObjectMapper().writeValueAsString(listAnotherCol)))
+                                 .param("properties", mapper.writeValueAsString(listAnotherCol)))
                     .andExpect(status().isForbidden());
             getClient(comAdminToken)
                     .perform(multipart("/api/system/scripts/" + curateScriptConfiguration.getName() + "/processes")
-                                 .param("properties", new ObjectMapper().writeValueAsString(listAnotherItem)))
+                                 .param("properties", mapper.writeValueAsString(listAnotherItem)))
                     .andExpect(status().isForbidden());
 
             // check with the col admin
             getClient(colAdminToken)
                     .perform(multipart("/api/system/scripts/" + curateScriptConfiguration.getName() + "/processes")
-                                 .param("properties", new ObjectMapper().writeValueAsString(listCol)))
+                                 .param("properties", mapper.writeValueAsString(listCol)))
                     .andExpect(status().isAccepted())
                     .andExpect(jsonPath("$", is(
                             ProcessMatcher.matchProcess("curate",
@@ -576,7 +579,7 @@ public class CurationScriptIT extends AbstractControllerIntegrationTest {
             // the col admin should be able to run the curate also over the owned item
             getClient(colAdminToken)
                     .perform(multipart("/api/system/scripts/" + curateScriptConfiguration.getName() + "/processes")
-                                 .param("properties", new ObjectMapper().writeValueAsString(listItem)))
+                                 .param("properties", mapper.writeValueAsString(listItem)))
                     .andExpect(status().isAccepted())
                     .andExpect(jsonPath("$", is(
                             ProcessMatcher.matchProcess("curate",
@@ -590,25 +593,25 @@ public class CurationScriptIT extends AbstractControllerIntegrationTest {
             // on a not owned item
             getClient(colAdminToken)
                 .perform(multipart("/api/system/scripts/" + curateScriptConfiguration.getName() + "/processes")
-                             .param("properties", new ObjectMapper().writeValueAsString(listCurateSite)))
+                             .param("properties", mapper.writeValueAsString(listCurateSite)))
                 .andExpect(status().isForbidden());
             getClient(colAdminToken)
                 .perform(multipart("/api/system/scripts/" + curateScriptConfiguration.getName() + "/processes")
-                             .param("properties", new ObjectMapper().writeValueAsString(listCom)))
+                             .param("properties", mapper.writeValueAsString(listCom)))
                 .andExpect(status().isForbidden());
             getClient(colAdminToken)
                 .perform(multipart("/api/system/scripts/" + curateScriptConfiguration.getName() + "/processes")
-                             .param("properties", new ObjectMapper().writeValueAsString(listAnotherCol)))
+                             .param("properties", mapper.writeValueAsString(listAnotherCol)))
                 .andExpect(status().isForbidden());
             getClient(colAdminToken)
                     .perform(multipart("/api/system/scripts/" + curateScriptConfiguration.getName() + "/processes")
-                                 .param("properties", new ObjectMapper().writeValueAsString(listAnotherItem)))
+                                 .param("properties", mapper.writeValueAsString(listAnotherItem)))
                     .andExpect(status().isForbidden());
 
             // check with the item admin
             getClient(itemAdminToken)
                     .perform(multipart("/api/system/scripts/" + curateScriptConfiguration.getName() + "/processes")
-                                 .param("properties", new ObjectMapper().writeValueAsString(listItem)))
+                                 .param("properties", mapper.writeValueAsString(listItem)))
                     .andExpect(status().isAccepted())
                     .andExpect(jsonPath("$", is(
                             ProcessMatcher.matchProcess("curate",
@@ -621,19 +624,19 @@ public class CurationScriptIT extends AbstractControllerIntegrationTest {
             // on a not owned item
             getClient(itemAdminToken)
                 .perform(multipart("/api/system/scripts/" + curateScriptConfiguration.getName() + "/processes")
-                             .param("properties", new ObjectMapper().writeValueAsString(listCurateSite)))
+                             .param("properties", mapper.writeValueAsString(listCurateSite)))
                 .andExpect(status().isForbidden());
             getClient(itemAdminToken)
                 .perform(multipart("/api/system/scripts/" + curateScriptConfiguration.getName() + "/processes")
-                             .param("properties", new ObjectMapper().writeValueAsString(listCom)))
+                             .param("properties", mapper.writeValueAsString(listCom)))
                 .andExpect(status().isForbidden());
             getClient(itemAdminToken)
                 .perform(multipart("/api/system/scripts/" + curateScriptConfiguration.getName() + "/processes")
-                             .param("properties", new ObjectMapper().writeValueAsString(listCol)))
+                             .param("properties", mapper.writeValueAsString(listCol)))
                 .andExpect(status().isForbidden());
             getClient(itemAdminToken)
                     .perform(multipart("/api/system/scripts/" + curateScriptConfiguration.getName() + "/processes")
-                                 .param("properties", new ObjectMapper().writeValueAsString(listAnotherItem)))
+                                 .param("properties", mapper.writeValueAsString(listAnotherItem)))
                     .andExpect(status().isForbidden());
 
         } finally {

--- a/dspace-services/src/main/java/org/dspace/servicemanager/DSpaceKernelImpl.java
+++ b/dspace-services/src/main/java/org/dspace/servicemanager/DSpaceKernelImpl.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.servicemanager;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 import javax.management.Attribute;
 import javax.management.AttributeList;
@@ -147,8 +147,8 @@ public final class DSpaceKernelImpl implements DSpaceKernel, DynamicMBean {
         }
 
         synchronized (lock) {
-            lastLoadDate = new Date();
-            long startTime = System.currentTimeMillis();
+            lastLoadDate = Instant.now();
+            long startTime = lastLoadDate.toEpochMilli();
 
             // create the configuration service and get the configuration
             DSpaceConfigurationService dsConfigService = new DSpaceConfigurationService(dspaceHome);
@@ -161,7 +161,7 @@ public final class DSpaceKernelImpl implements DSpaceKernel, DynamicMBean {
             // initialize the static
 //            DSpace.initialize(serviceManagerSystem);
 
-            loadTime = System.currentTimeMillis() - startTime;
+            loadTime = Instant.now().toEpochMilli() - startTime;
 
             kernel = this;
             running = true;
@@ -274,15 +274,15 @@ public final class DSpaceKernelImpl implements DSpaceKernel, DynamicMBean {
 
     // MBEAN methods
 
-    private Date lastLoadDate;
+    private Instant lastLoadDate;
 
     /**
-     * Time that this kernel was started, as a java.util.Date.
+     * Time that this kernel was started, as an Instant
      *
      * @return date object
      **/
-    public Date getLastLoadDate() {
-        return new Date(lastLoadDate.getTime());
+    public Instant getLastLoadDate() {
+        return lastLoadDate;
     }
 
     private long loadTime;
@@ -312,7 +312,7 @@ public final class DSpaceKernelImpl implements DSpaceKernel, DynamicMBean {
             "getMethod=getLoadTime"});
 
         ModelMBeanAttributeInfo[] mmbai = new ModelMBeanAttributeInfo[2];
-        mmbai[0] = new ModelMBeanAttributeInfo("LastLoadDate", "java.util.Date", "Last Load Date",
+        mmbai[0] = new ModelMBeanAttributeInfo("LastLoadDate", "java.time.Instant", "Last Load Date",
                                                true, false, false, lastLoadDateDesc);
 
         mmbai[1] = new ModelMBeanAttributeInfo("LastLoadTime", "java.lang.Long", "Last Load Time",

--- a/dspace-services/src/main/java/org/dspace/servicemanager/DSpaceServiceManager.java
+++ b/dspace-services/src/main/java/org/dspace/servicemanager/DSpaceServiceManager.java
@@ -11,6 +11,7 @@ import static org.apache.logging.log4j.Level.DEBUG;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -257,7 +258,7 @@ public final class DSpaceServiceManager implements ServiceManagerSystem {
             }
         }
 
-        long startTime = System.currentTimeMillis();
+        long startTime = Instant.now().toEpochMilli();
         try {
             // have to put this at the top because otherwise initializing beans will die when they try to use the SMS
             this.running = true;
@@ -294,7 +295,7 @@ public final class DSpaceServiceManager implements ServiceManagerSystem {
             throw new RuntimeException(message, e);
         }
 
-        long totalTime = System.currentTimeMillis() - startTime;
+        long totalTime = Instant.now().toEpochMilli() - startTime;
         log.info("Service Manager started up in {} ms with {} services...",
                 totalTime, applicationContext.getBeanDefinitionCount());
     }

--- a/dspace-services/src/main/java/org/dspace/services/events/SystemEventService.java
+++ b/dspace-services/src/main/java/org/dspace/services/events/SystemEventService.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.services.events;
 
+import java.time.Instant;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
@@ -233,7 +234,7 @@ public final class SystemEventService implements EventService {
      * @return event Id
      */
     private String makeEventId() {
-        return "event-" + random.nextInt(1000) + "-" + System.currentTimeMillis();
+        return "event-" + random.nextInt(1000) + "-" + Instant.now().toEpochMilli();
     }
 
     /**

--- a/dspace-services/src/main/java/org/dspace/services/sessions/model/AbstractRequestImpl.java
+++ b/dspace-services/src/main/java/org/dspace/services/sessions/model/AbstractRequestImpl.java
@@ -7,10 +7,11 @@
  */
 package org.dspace.services.sessions.model;
 
+import java.time.Instant;
 import java.util.Random;
 
 public abstract class AbstractRequestImpl {
-    private String requestId = "request-" + new Random().nextInt(1000) + "-" + System.currentTimeMillis();
+    private String requestId = "request-" + new Random().nextInt(1000) + "-" + Instant.now().toEpochMilli();
 
     public final String getRequestId() {
         return requestId;

--- a/dspace-sword/src/main/java/org/dspace/sword/DepositManager.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/DepositManager.java
@@ -18,7 +18,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintWriter;
-import java.util.Date;
+import java.time.Instant;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
@@ -106,7 +106,7 @@ public class DepositManager {
         throws DSpaceSWORDException, SWORDErrorException,
         SWORDAuthenticationException {
         // start the timer, and initialise the verboseness of the request
-        Date start = new Date();
+        Instant start = Instant.now();
         swordService.message("Initialising verbose deposit");
 
         // get the things out of the service that we need
@@ -215,8 +215,8 @@ public class DepositManager {
 
         entry.setNoOp(deposit.isNoOp());
 
-        Date finish = new Date();
-        long delta = finish.getTime() - start.getTime();
+        Instant finish = Instant.now();
+        long delta = finish.toEpochMilli() - start.toEpochMilli();
         swordService.message(
             "Total time for deposit processing: " + delta + " ms");
         entry.setVerboseDescription(
@@ -244,7 +244,7 @@ public class DepositManager {
         }
 
         String filenameBase =
-            "sword-" + deposit.getUsername() + "-" + (new Date()).getTime();
+            "sword-" + deposit.getUsername() + "-" + Instant.now().toEpochMilli();
         // No dots or slashes allowed in filename
         filenameBase = filenameBase.replaceAll("\\.", "").replaceAll("/", ""). replaceAll("\\\\", "");
 

--- a/dspace-sword/src/main/java/org/dspace/sword/SWORDMETSIngester.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/SWORDMETSIngester.java
@@ -9,7 +9,7 @@ package org.dspace.sword;
 
 import java.io.File;
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.StringTokenizer;
 
 import org.apache.logging.log4j.LogManager;
@@ -196,7 +196,7 @@ public class SWORDMETSIngester implements SWORDIngester {
         try {
             itemService.clearMetadata(context, item, dc.schema, dc.element,
                                       dc.qualifier, Item.ANY);
-            DCDate date = new DCDate(new Date());
+            DCDate date = new DCDate(LocalDateTime.now());
             itemService.addMetadata(context, item, dc.schema, dc.element,
                                     dc.qualifier, null, date.toString());
         } catch (SQLException e) {

--- a/dspace-sword/src/main/java/org/dspace/sword/SWORDMETSIngester.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/SWORDMETSIngester.java
@@ -9,7 +9,8 @@ package org.dspace.sword;
 
 import java.io.File;
 import java.sql.SQLException;
-import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.StringTokenizer;
 
 import org.apache.logging.log4j.LogManager;
@@ -196,7 +197,7 @@ public class SWORDMETSIngester implements SWORDIngester {
         try {
             itemService.clearMetadata(context, item, dc.schema, dc.element,
                                       dc.qualifier, Item.ANY);
-            DCDate date = new DCDate(LocalDateTime.now());
+            DCDate date = new DCDate(ZonedDateTime.now(ZoneOffset.UTC));
             itemService.addMetadata(context, item, dc.schema, dc.element,
                                     dc.qualifier, null, date.toString());
         } catch (SQLException e) {

--- a/dspace-sword/src/main/java/org/dspace/sword/SWORDService.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/SWORDService.java
@@ -9,6 +9,9 @@ package org.dspace.sword;
 
 import java.sql.SQLException;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
@@ -132,7 +135,7 @@ public class SWORDService {
      */
     public void message(String message) {
         // build the processing message
-        String msg = dateFormat.format(Instant.now()) + " " + message + "; \n\n";
+        String msg = dateFormat.format(LocalDateTime.now(ZoneOffset.UTC)) + " " + message + "; \n\n";
 
         // if this is a verbose deposit, then log it
         if (this.verbose) {
@@ -166,7 +169,7 @@ public class SWORDService {
             String fn = deposit.getFilename();
             if (fn == null || "".equals(fn)) {
                 // use date in YYYY-MM-DD format
-                fn = "sword-" + DateTimeFormatter.ISO_LOCAL_DATE.format(Instant.now());
+                fn = "sword-" + DateTimeFormatter.ISO_LOCAL_DATE.format(LocalDate.now(ZoneOffset.UTC));
                 if (original) {
                     fn = fn + ".original";
                 }

--- a/dspace-sword/src/main/java/org/dspace/sword/SWORDService.java
+++ b/dspace-sword/src/main/java/org/dspace/sword/SWORDService.java
@@ -8,8 +8,8 @@
 package org.dspace.sword;
 
 import java.sql.SQLException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import org.apache.logging.log4j.Logger;
@@ -66,7 +66,7 @@ public class SWORDService {
     /**
      * date formatter
      */
-    private SimpleDateFormat dateFormat;
+    private DateTimeFormatter dateFormat;
 
     /**
      * Construct a new service instance around the given authenticated
@@ -79,7 +79,7 @@ public class SWORDService {
         this.swordConfig = new SWORDConfiguration();
         this.urlManager = new SWORDUrlManager(this.swordConfig,
                                               this.swordContext.getContext());
-        dateFormat = new SimpleDateFormat("[yyyy-MM-dd HH:mm:ss.S]");
+        dateFormat = DateTimeFormatter.ofPattern("[yyyy-MM-dd HH:mm:ss.S]");
     }
 
     public SWORDUrlManager getUrlManager() {
@@ -132,7 +132,7 @@ public class SWORDService {
      */
     public void message(String message) {
         // build the processing message
-        String msg = dateFormat.format(new Date()) + " " + message + "; \n\n";
+        String msg = dateFormat.format(Instant.now()) + " " + message + "; \n\n";
 
         // if this is a verbose deposit, then log it
         if (this.verbose) {
@@ -165,8 +165,8 @@ public class SWORDService {
 
             String fn = deposit.getFilename();
             if (fn == null || "".equals(fn)) {
-                SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
-                fn = "sword-" + sdf.format(new Date());
+                // use date in YYYY-MM-DD format
+                fn = "sword-" + DateTimeFormatter.ISO_LOCAL_DATE.format(Instant.now());
                 if (original) {
                     fn = fn + ".original";
                 }
@@ -187,6 +187,6 @@ public class SWORDService {
      * @return the name of the temp file that should be used
      */
     public String getTempFilename() {
-        return "sword-" + (new Date()).getTime();
+        return "sword-" + Instant.now().toEpochMilli();
     }
 }

--- a/dspace-sword/src/main/java/org/purl/sword/server/DepositServlet.java
+++ b/dspace-sword/src/main/java/org/purl/sword/server/DepositServlet.java
@@ -14,9 +14,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.security.NoSuchAlgorithmException;
-import java.text.SimpleDateFormat;
-import java.util.Calendar;
-import java.util.Date;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.StringTokenizer;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -182,7 +181,7 @@ public class DepositServlet extends HttpServlet {
         throws ServletException, IOException {
         // Create the Deposit request
         Deposit d = new Deposit();
-        Date date = new Date();
+        Instant date = Instant.now();
         log.debug("Starting deposit processing at " + date.toString() + " by "
                       + request.getRemoteAddr());
 
@@ -389,10 +388,8 @@ public class DepositServlet extends HttpServlet {
         Title title = new Title();
         title.setContent("ERROR");
         sed.setTitle(title);
-        Calendar calendar = Calendar.getInstance();
         String utcformat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
-        SimpleDateFormat zulu = new SimpleDateFormat(utcformat);
-        String serializeddate = zulu.format(calendar.getTime());
+        String serializeddate = DateTimeFormatter.ofPattern(utcformat).format(Instant.now());
         sed.setUpdated(serializeddate);
         Summary sum = new Summary();
         sum.setContent(summary);

--- a/dspace-sword/src/main/java/org/purl/sword/server/DepositServlet.java
+++ b/dspace-sword/src/main/java/org/purl/sword/server/DepositServlet.java
@@ -15,7 +15,6 @@ import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
-import java.time.format.DateTimeFormatter;
 import java.util.StringTokenizer;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -388,8 +387,7 @@ public class DepositServlet extends HttpServlet {
         Title title = new Title();
         title.setContent("ERROR");
         sed.setTitle(title);
-        String utcformat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
-        String serializeddate = DateTimeFormatter.ofPattern(utcformat).format(Instant.now());
+        String serializeddate = Instant.now().toString();
         sed.setUpdated(serializeddate);
         Summary sum = new Summary();
         sum.setContent(summary);

--- a/dspace-sword/src/main/java/org/purl/sword/server/DummyServer.java
+++ b/dspace-sword/src/main/java/org/purl/sword/server/DummyServer.java
@@ -10,9 +10,7 @@ package org.purl.sword.server;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.TimeZone;
+import java.time.Instant;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -269,11 +267,7 @@ public class DummyServer implements SWORDServer {
             se.setId("ID: " + counter);
         }
 
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
-        TimeZone utc = TimeZone.getTimeZone("UTC");
-        sdf.setTimeZone(utc);
-        String milliFormat = sdf.format(new Date());
-        se.setUpdated(milliFormat);
+        se.setUpdated(Instant.now().toString());
 
         Summary s = new Summary();
         s.setContent(filenames.toString());

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/AbstractSwordContentIngester.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/AbstractSwordContentIngester.java
@@ -8,7 +8,8 @@
 package org.dspace.sword2;
 
 import java.sql.SQLException;
-import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.StringTokenizer;
 
@@ -128,7 +129,7 @@ public abstract class AbstractSwordContentIngester
         try {
             itemService.clearMetadata(context, item, info.schema, info.element,
                                       info.qualifier, Item.ANY);
-            DCDate date = new DCDate(LocalDateTime.now());
+            DCDate date = new DCDate(ZonedDateTime.now(ZoneOffset.UTC));
             itemService.addMetadata(context, item, info.schema, info.element,
                                     info.qualifier, null, date.toString());
         } catch (SQLException e) {

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/AbstractSwordContentIngester.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/AbstractSwordContentIngester.java
@@ -8,7 +8,7 @@
 package org.dspace.sword2;
 
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.StringTokenizer;
 
@@ -128,7 +128,7 @@ public abstract class AbstractSwordContentIngester
         try {
             itemService.clearMetadata(context, item, info.schema, info.element,
                                       info.qualifier, Item.ANY);
-            DCDate date = new DCDate(new Date());
+            DCDate date = new DCDate(LocalDateTime.now());
             itemService.addMetadata(context, item, info.schema, info.element,
                                     info.qualifier, null, date.toString());
         } catch (SQLException e) {

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/CollectionDepositManagerDSpace.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/CollectionDepositManagerDSpace.java
@@ -8,7 +8,7 @@
 package org.dspace.sword2;
 
 import java.io.IOException;
-import java.util.Date;
+import java.time.Instant;
 
 import org.apache.logging.log4j.Logger;
 import org.dspace.content.Collection;
@@ -42,7 +42,7 @@ public class CollectionDepositManagerDSpace extends DSpaceSwordAPI
                                     AuthCredentials authCredentials, SwordConfiguration swordConfig)
         throws SwordError, SwordServerException, SwordAuthException {
         // start the timer
-        Date start = new Date();
+        Instant start = Instant.now();
 
         // store up the verbose description, which we can then give back at the end if necessary
         this.verboseDescription.append("Initialising verbose deposit");
@@ -139,8 +139,8 @@ public class CollectionDepositManagerDSpace extends DSpaceSwordAPI
             DepositReceipt receipt = genny
                 .createReceipt(context, result, config);
 
-            Date finish = new Date();
-            long delta = finish.getTime() - start.getTime();
+            Instant finish = Instant.now();
+            long delta = finish.toEpochMilli() - start.toEpochMilli();
 
             this.verboseDescription
                 .append("Total time for deposit processing: " + delta +

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/ContainerManagerDSpace.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/ContainerManagerDSpace.java
@@ -9,7 +9,7 @@ package org.dspace.sword2;
 
 import java.io.IOException;
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -127,7 +127,7 @@ public class ContainerManagerDSpace extends DSpaceSwordAPI
                                           AuthCredentials authCredentials, SwordConfiguration swordConfig)
         throws SwordError, SwordServerException, SwordAuthException {
         // start the timer
-        Date start = new Date();
+        Instant start = Instant.now();
 
         // store up the verbose description, which we can then give back at the end if necessary
         this.verboseDescription.append(
@@ -202,8 +202,8 @@ public class ContainerManagerDSpace extends DSpaceSwordAPI
             DepositReceipt receipt = genny.createReceipt(
                 context, result, config);
 
-            Date finish = new Date();
-            long delta = finish.getTime() - start.getTime();
+            Instant finish = Instant.now();
+            long delta = finish.toEpochMilli() - start.toEpochMilli();
 
             this.verboseDescription.append(
                 "Total time for deposit processing: " + delta + " ms");
@@ -230,7 +230,7 @@ public class ContainerManagerDSpace extends DSpaceSwordAPI
                                                           SwordConfiguration swordConfig)
         throws SwordError, SwordServerException, SwordAuthException {
         // start the timer
-        Date start = new Date();
+        Instant start = Instant.now();
 
         // store up the verbose description, which we can then give back at the end if necessary
         this.verboseDescription.append(
@@ -309,8 +309,8 @@ public class ContainerManagerDSpace extends DSpaceSwordAPI
             DepositReceipt receipt = genny.createReceipt(
                 context, result, config);
 
-            Date finish = new Date();
-            long delta = finish.getTime() - start.getTime();
+            Instant finish = Instant.now();
+            long delta = finish.toEpochMilli() - start.toEpochMilli();
 
             this.verboseDescription.append(
                 "Total time for deposit processing: " + delta + " ms");
@@ -342,7 +342,7 @@ public class ContainerManagerDSpace extends DSpaceSwordAPI
                                       AuthCredentials authCredentials, SwordConfiguration swordConfig)
         throws SwordError, SwordServerException, SwordAuthException {
         // start the timer
-        Date start = new Date();
+        Instant start = Instant.now();
 
         // store up the verbose description, which we can then give back at the end if necessary
         this.verboseDescription.append(
@@ -417,8 +417,8 @@ public class ContainerManagerDSpace extends DSpaceSwordAPI
             DepositReceipt receipt = genny.createReceipt(
                 context, result, config);
 
-            Date finish = new Date();
-            long delta = finish.getTime() - start.getTime();
+            Instant finish = Instant.now();
+            long delta = finish.toEpochMilli() - start.toEpochMilli();
 
             this.verboseDescription.append(
                 "Total time for deposit processing: " + delta + " ms");
@@ -450,7 +450,7 @@ public class ContainerManagerDSpace extends DSpaceSwordAPI
                                 SwordConfiguration swordConfig)
         throws SwordError, SwordServerException, SwordAuthException {
         // start the timer
-        Date start = new Date();
+        Instant start = Instant.now();
 
         // store up the verbose description, which we can then give back at the end if necessary
         this.verboseDescription.append("Initialising verbose container delete");
@@ -504,8 +504,8 @@ public class ContainerManagerDSpace extends DSpaceSwordAPI
 
             this.doContainerDelete(sc, item, authCredentials, config);
 
-            Date finish = new Date();
-            long delta = finish.getTime() - start.getTime();
+            Instant finish = Instant.now();
+            long delta = finish.toEpochMilli() - start.toEpochMilli();
 
             this.verboseDescription.append(
                 "Total time for deposit processing: " + delta + " ms");
@@ -528,7 +528,7 @@ public class ContainerManagerDSpace extends DSpaceSwordAPI
                                      AuthCredentials authCredentials, SwordConfiguration swordConfig)
         throws SwordError, SwordServerException, SwordAuthException {
         // start the timer
-        Date start = new Date();
+        Instant start = Instant.now();
 
         // store up the verbose description, which we can then give back at the end if necessary
         this.verboseDescription.append(
@@ -592,8 +592,8 @@ public class ContainerManagerDSpace extends DSpaceSwordAPI
             ReceiptGenerator genny = new ReceiptGenerator();
             DepositReceipt receipt = genny.createReceipt(context, item, config);
 
-            Date finish = new Date();
-            long delta = finish.getTime() - start.getTime();
+            Instant finish = Instant.now();
+            long delta = finish.toEpochMilli() - start.toEpochMilli();
 
             this.verboseDescription.append(
                 "Total time for modify processing: " + delta + " ms");

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/DSpaceSwordAPI.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/DSpaceSwordAPI.java
@@ -20,9 +20,9 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.sql.SQLException;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -376,9 +376,8 @@ public class DSpaceSwordAPI {
 
             String fn = deposit.getFilename();
             if (fn == null || "".equals(fn)) {
-                SimpleDateFormat sdf = new SimpleDateFormat(
-                    "yyyy-MM-dd'T'HH:mm:ss");
-                fn = "sword-" + sdf.format(new Date());
+                DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+                fn = "sword-" + formatter.format(Instant.now());
                 if (original) {
                     fn = fn + ".original";
                 }
@@ -397,8 +396,8 @@ public class DSpaceSwordAPI {
                                       boolean original)
         throws DSpaceSwordException {
 
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-        String fn = "sword-" + sdf.format(new Date());
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+        String fn = "sword-" + formatter.format(Instant.now());
         if (original) {
             fn = fn + ".original";
         }
@@ -426,7 +425,7 @@ public class DSpaceSwordAPI {
         }
 
         String filenameBase =
-            "sword-" + auth.getUsername() + "-" + (new Date()).getTime();
+            "sword-" + auth.getUsername() + "-" + Instant.now().toEpochMilli();
 
         File packageFile = new File(path, filenameBase);
         File headersFile = new File(path, filenameBase + "-headers");
@@ -472,7 +471,7 @@ public class DSpaceSwordAPI {
         }
 
         String filenameBase =
-            "sword-" + auth.getUsername() + "-" + (new Date()).getTime();
+            "sword-" + auth.getUsername() + "-" + Instant.now().toEpochMilli();
 
         File packageFile = new File(path, filenameBase);
         File headersFile = new File(path, filenameBase + "-headers");

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/DSpaceSwordAPI.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/DSpaceSwordAPI.java
@@ -21,6 +21,8 @@ import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.sql.SQLException;
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
@@ -377,7 +379,7 @@ public class DSpaceSwordAPI {
             String fn = deposit.getFilename();
             if (fn == null || "".equals(fn)) {
                 DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
-                fn = "sword-" + formatter.format(Instant.now());
+                fn = "sword-" + formatter.format(LocalDateTime.now(ZoneOffset.UTC));
                 if (original) {
                     fn = fn + ".original";
                 }
@@ -397,7 +399,7 @@ public class DSpaceSwordAPI {
         throws DSpaceSwordException {
 
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
-        String fn = "sword-" + formatter.format(Instant.now());
+        String fn = "sword-" + formatter.format(LocalDateTime.now(ZoneOffset.UTC));
         if (original) {
             fn = fn + ".original";
         }

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/FeedContentDisseminator.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/FeedContentDisseminator.java
@@ -12,7 +12,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
@@ -112,7 +112,7 @@ public class FeedContentDisseminator extends AbstractSimpleDC
             desc = bitstream.getName();
         }
         entry.setSummary(desc);
-        entry.setUpdated(new Date()); // required, though content is spurious
+        entry.setUpdated(java.util.Date.from(Instant.now())); // required, though content is spurious
 
         // add an edit-media link for the bitstream ...
         Abdera abdera = new Abdera();

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/GenericStatementDisseminator.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/GenericStatementDisseminator.java
@@ -8,8 +8,8 @@
 package org.dspace.sword2;
 
 import java.sql.SQLException;
+import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -59,8 +59,8 @@ public abstract class GenericStatementDisseminator
             .getResourceParts(context, item, includeBundles);
         statement.setResources(resources);
 
-        Date lastModified = this.getLastModified(context, item);
-        statement.setLastModified(lastModified);
+        Instant lastModified = this.getLastModified(context, item);
+        statement.setLastModified(java.util.Date.from(lastModified));
     }
 
     protected List<OriginalDeposit> getOriginalDeposits(Context context,
@@ -85,7 +85,7 @@ public abstract class GenericStatementDisseminator
                                 bitstream));
                         deposit.setMediaType(bitstream
                                                  .getFormat(context).getMIMEType());
-                        deposit.setDepositedOn(this.getDateOfDeposit(item));
+                        deposit.setDepositedOn(java.util.Date.from(this.getDateOfDeposit(item)));
                         originalDeposits.add(deposit);
                     }
                 }
@@ -153,7 +153,7 @@ public abstract class GenericStatementDisseminator
         }
     }
 
-    protected Date getLastModified(Context context, Item item) {
+    protected Instant getLastModified(Context context, Item item) {
         return item.getLastModified();
     }
 
@@ -182,12 +182,12 @@ public abstract class GenericStatementDisseminator
         return swordBundle;
     }
 
-    private Date getDateOfDeposit(Item item) {
+    private Instant getDateOfDeposit(Item item) {
         List<MetadataValue> values = itemService.getMetadata(item, "dc", "date", "accessioned", Item.ANY);
-        Date date = new Date();
+        Instant date = Instant.now();
         if (values != null && values.size() > 0) {
             String strDate = values.get(0).getValue();
-            date = new DCDate(strDate).toDate();
+            date = new DCDate(strDate).toDate().toInstant();
         }
         return date;
     }

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/MediaResourceManagerDSpace.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/MediaResourceManagerDSpace.java
@@ -10,8 +10,8 @@ package org.dspace.sword2;
 import java.io.IOException;
 import java.io.InputStream;
 import java.sql.SQLException;
+import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -77,7 +77,7 @@ public class MediaResourceManagerDSpace extends DSpaceSwordAPI
             MediaResource mr = new MediaResource(stream,
                                                  bitstream.getFormat(context).getMIMEType(), null, true);
             mr.setContentMD5(bitstream.getChecksum());
-            mr.setLastModified(this.getLastModified(context, bitstream));
+            mr.setLastModified(java.util.Date.from(this.getLastModified(context, bitstream)));
             return mr;
         } catch (IOException | SQLException e) {
             throw new SwordServerException(e);
@@ -228,23 +228,23 @@ public class MediaResourceManagerDSpace extends DSpaceSwordAPI
         }
     }
 
-    private Date getLastModified(Context context, Bitstream bitstream)
+    private Instant getLastModified(Context context, Bitstream bitstream)
         throws SQLException {
-        Date lm = null;
+        Instant lm = null;
         List<Bundle> bundles = bitstream.getBundles();
         for (Bundle bundle : bundles) {
             List<Item> items = bundle.getItems();
             for (Item item : items) {
-                Date possible = item.getLastModified();
+                Instant possible = item.getLastModified();
                 if (lm == null) {
                     lm = possible;
-                } else if (possible.getTime() > lm.getTime()) {
+                } else if (possible.isAfter(lm)) {
                     lm = possible;
                 }
             }
         }
         if (lm == null) {
-            return new Date();
+            return Instant.now();
         }
         return lm;
     }
@@ -253,7 +253,7 @@ public class MediaResourceManagerDSpace extends DSpaceSwordAPI
                                                AuthCredentials authCredentials, SwordConfiguration swordConfig)
         throws SwordError, SwordServerException, SwordAuthException {
         // start the timer
-        Date start = new Date();
+        Instant start = Instant.now();
 
         // store up the verbose description, which we can then give back at the end if necessary
         this.verboseDescription
@@ -390,8 +390,8 @@ public class MediaResourceManagerDSpace extends DSpaceSwordAPI
                     .createMediaResourceReceipt(context, item, config);
             }
 
-            Date finish = new Date();
-            long delta = finish.getTime() - start.getTime();
+            Instant finish = Instant.now();
+            long delta = finish.toEpochMilli() - start.toEpochMilli();
 
             this.verboseDescription
                 .append("Total time for deposit processing: " + delta +
@@ -421,7 +421,7 @@ public class MediaResourceManagerDSpace extends DSpaceSwordAPI
                                     AuthCredentials authCredentials, SwordConfiguration swordConfig)
         throws SwordError, SwordServerException, SwordAuthException {
         // start the timer
-        Date start = new Date();
+        Instant start = Instant.now();
 
         // store up the verbose description, which we can then give back at the end if necessary
         this.verboseDescription
@@ -520,8 +520,8 @@ public class MediaResourceManagerDSpace extends DSpaceSwordAPI
             //ReceiptGenerator genny = new ReceiptGenerator();
             //DepositReceipt receipt = genny.createReceipt(context, result, config);
 
-            Date finish = new Date();
-            long delta = finish.getTime() - start.getTime();
+            Instant finish = Instant.now();
+            long delta = finish.toEpochMilli() - start.toEpochMilli();
 
             this.verboseDescription
                 .append("Total time for deposit processing: " + delta +
@@ -551,7 +551,7 @@ public class MediaResourceManagerDSpace extends DSpaceSwordAPI
                                       AuthCredentials authCredentials, SwordConfiguration swordConfig)
         throws SwordError, SwordServerException, SwordAuthException {
         // start the timer
-        Date start = new Date();
+        Instant start = Instant.now();
 
         // store up the verbose description, which we can then give back at the end if necessary
         this.verboseDescription
@@ -649,8 +649,8 @@ public class MediaResourceManagerDSpace extends DSpaceSwordAPI
                 receipt = genny.createReceipt(context, result, config, true);
             }
 
-            Date finish = new Date();
-            long delta = finish.getTime() - start.getTime();
+            Instant finish = Instant.now();
+            long delta = finish.toEpochMilli() - start.toEpochMilli();
 
             this.verboseDescription
                 .append("Total time for add processing: " + delta + " ms");

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/ReceiptGenerator.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/ReceiptGenerator.java
@@ -8,7 +8,7 @@
 package org.dspace.sword2;
 
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -109,7 +109,7 @@ public class ReceiptGenerator {
         receipt.addEditMediaIRI(
             urlManager.getContentUrl(result.getItem()), "application/zip");
         receipt.setMediaFeedIRI(urlManager.getMediaFeedUrl(result.getItem()));
-        receipt.setLastModified(result.getItem().getLastModified());
+        receipt.setLastModified(java.util.Date.from(result.getItem().getLastModified()));
 
         if (mediaResourceLocation) {
             receipt.setLocation(urlManager.getContentUrl(result.getItem()));
@@ -201,7 +201,7 @@ public class ReceiptGenerator {
         receipt.addEditMediaIRI(
             urlManager.getContentUrl(item), "application/zip");
         receipt.setMediaFeedIRI(urlManager.getMediaFeedUrl(item));
-        receipt.setLastModified(item.getLastModified());
+        receipt.setLastModified(java.util.Date.from(item.getLastModified()));
 
         // add the category information to the sword entry
         this.addCategories(item, receipt);
@@ -283,8 +283,8 @@ public class ReceiptGenerator {
         List<MetadataValue> dcv = itemService.getMetadataByMetadataString(
             result.getItem(), "dc.date.issued");
         if (dcv != null && !dcv.isEmpty()) {
-            Date published = MultiFormatDateParser.parse(dcv.get(0).getValue());
-            receipt.getWrappedEntry().setPublished(published);
+            ZonedDateTime published = MultiFormatDateParser.parse(dcv.get(0).getValue());
+            receipt.getWrappedEntry().setPublished(java.util.Date.from(published.toInstant()));
         }
     }
 
@@ -298,8 +298,8 @@ public class ReceiptGenerator {
         List<MetadataValue> dcv = itemService.getMetadataByMetadataString(
             item, "dc.date.issued");
         if (dcv != null && dcv.size() == 1) {
-            Date published = MultiFormatDateParser.parse(dcv.get(0).getValue());
-            receipt.getWrappedEntry().setPublished(published);
+            ZonedDateTime published = MultiFormatDateParser.parse(dcv.get(0).getValue());
+            receipt.getWrappedEntry().setPublished(java.util.Date.from(published.toInstant()));
         }
     }
 
@@ -316,8 +316,8 @@ public class ReceiptGenerator {
         List<MetadataValue> dcv = itemService.getMetadataByMetadataString(
             result.getItem(), config);
         if (dcv != null && dcv.size() == 1) {
-            Date updated = MultiFormatDateParser.parse(dcv.get(0).getValue());
-            receipt.getWrappedEntry().setUpdated(updated);
+            ZonedDateTime updated = MultiFormatDateParser.parse(dcv.get(0).getValue());
+            receipt.getWrappedEntry().setUpdated(java.util.Date.from(updated.toInstant()));
         }
     }
 
@@ -333,8 +333,8 @@ public class ReceiptGenerator {
         List<MetadataValue> dcv = itemService.getMetadataByMetadataString(
             item, config);
         if (dcv != null && dcv.size() == 1) {
-            Date updated = MultiFormatDateParser.parse(dcv.get(0).getValue());
-            receipt.getWrappedEntry().setUpdated(updated);
+            ZonedDateTime updated = MultiFormatDateParser.parse(dcv.get(0).getValue());
+            receipt.getWrappedEntry().setUpdated(java.util.Date.from(updated.toInstant()));
         }
     }
 }

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/SimpleDCEntryIngester.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/SimpleDCEntryIngester.java
@@ -8,7 +8,7 @@
 package org.dspace.sword2;
 
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -308,7 +308,7 @@ public class SimpleDCEntryIngester extends AbstractSimpleDC
         try {
             itemService.clearMetadata(context, item,
                                       info.schema, info.element, info.qualifier, Item.ANY);
-            DCDate date = new DCDate(new Date());
+            DCDate date = new DCDate(LocalDateTime.now());
             itemService.addMetadata(context, item, info.schema,
                                     info.element, info.qualifier, null, date.toString());
         } catch (SQLException e) {

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/SimpleDCEntryIngester.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/SimpleDCEntryIngester.java
@@ -8,7 +8,8 @@
 package org.dspace.sword2;
 
 import java.sql.SQLException;
-import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -308,7 +309,7 @@ public class SimpleDCEntryIngester extends AbstractSimpleDC
         try {
             itemService.clearMetadata(context, item,
                                       info.schema, info.element, info.qualifier, Item.ANY);
-            DCDate date = new DCDate(LocalDateTime.now());
+            DCDate date = new DCDate(ZonedDateTime.now(ZoneOffset.UTC));
             itemService.addMetadata(context, item, info.schema,
                                     info.element, info.qualifier, null, date.toString());
         } catch (SQLException e) {

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/VerboseDescription.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/VerboseDescription.java
@@ -7,8 +7,8 @@
  */
 package org.dspace.sword2;
 
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 
 public class VerboseDescription {
     private StringBuilder sb;
@@ -27,7 +27,7 @@ public class VerboseDescription {
     }
 
     private String getDatePrefix() {
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-        return "[" + sdf.format(new Date()) + "] ";
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        return "[" + formatter.format(Instant.now()) + "] ";
     }
 }

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/VerboseDescription.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/VerboseDescription.java
@@ -7,7 +7,8 @@
  */
 package org.dspace.sword2;
 
-import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 
 public class VerboseDescription {
@@ -28,6 +29,6 @@ public class VerboseDescription {
 
     private String getDatePrefix() {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-        return "[" + formatter.format(Instant.now()) + "] ";
+        return "[" + formatter.format(LocalDateTime.now(ZoneOffset.UTC)) + "] ";
     }
 }

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/VersionManager.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/VersionManager.java
@@ -9,8 +9,8 @@ package org.dspace.sword2;
 
 import java.io.IOException;
 import java.sql.SQLException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.Iterator;
 import java.util.List;
 
@@ -112,9 +112,8 @@ public class VersionManager {
 
         // there is nowhere in the metadata to say when this file was moved, so we
         // are going to drop it into the description
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
         String desc = bitstream.getDescription();
-        String newDesc = "[Deleted on: " + sdf.format(new Date()) + "] ";
+        String newDesc = "[Deleted on: " + Instant.now().toString() + "] ";
         if (desc != null) {
             newDesc += desc;
         }
@@ -151,9 +150,8 @@ public class VersionManager {
 
     private void archiveBundle(Context context, Item item, Bundle source)
         throws SQLException, AuthorizeException, IOException {
-        // get the datestamped root bundle name
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
-        String oldName = "VER" + sdf.format(new Date());
+        // get the datestamped root bundle name (YYYY-MM-DD format)
+        String oldName = "VER" + DateTimeFormatter.ISO_LOCAL_DATE.format(Instant.now());
         oldName = this.getNumberedName(item, oldName, 0);
 
         Bundle old = bundleService.create(context, item, oldName);

--- a/dspace-swordv2/src/main/java/org/dspace/sword2/VersionManager.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/VersionManager.java
@@ -10,6 +10,8 @@ package org.dspace.sword2;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Iterator;
 import java.util.List;
@@ -151,7 +153,7 @@ public class VersionManager {
     private void archiveBundle(Context context, Item item, Bundle source)
         throws SQLException, AuthorizeException, IOException {
         // get the datestamped root bundle name (YYYY-MM-DD format)
-        String oldName = "VER" + DateTimeFormatter.ISO_LOCAL_DATE.format(Instant.now());
+        String oldName = "VER" + DateTimeFormatter.ISO_LOCAL_DATE.format(LocalDate.now(ZoneOffset.UTC));
         oldName = this.getNumberedName(item, oldName, 0);
 
         Bundle old = bundleService.create(context, item, oldName);

--- a/dspace/config/hibernate.cfg.xml
+++ b/dspace/config/hibernate.cfg.xml
@@ -14,6 +14,11 @@
         <property name="hibernate.connection.autocommit">false</property>
         <property name="hibernate.jdbc.batch_size">20</property>
         <property name="hibernate.current_session_context_class">org.hibernate.context.internal.ThreadLocalSessionContext</property>
+        <!-- Tell Hibernate to use UTC as the default timezone for all timestamps -->
+        <property name="hibernate.jdbc.time_zone">UTC</property>
+        <!-- Tell Hibernate to use "SqlType.TIMESTAMP" for java.time.Instant (by default it will use SqlType.TIMESTAMP_UTC)
+             Retains the current way DSpace stores timestamps. Changing it would require a database migration. -->
+        <property name="hibernate.type.preferred_instant_jdbc_type">TIMESTAMP</property>
 
         <!--Debug property that can be used to display the sql-->
         <property name="show_sql">false</property>


### PR DESCRIPTION
## References
* Fixes #10375
* Seems to be required to upgrade to Hibernate 6.5 (or later).  See ticket above for more details.
* For System-Wide Alerts to work, https://github.com/DSpace/dspace-angular/pull/4039 is required

## Description
This PR migrates our entire backend away from using `java.util.Date`, `java.util.Calendar` and `java.text.SimpleDateFormat`.  It migrates us to using the newere `java.time.*` classes introduced in Java 8.

This is a very large PR, but it really simplifies down to making the same general changes throughout the codebase:
* All usages of `java.text.SimpleDateFormat` are replaced with `java.time.format.DateTimeFormatter` (Java 8+ equivalent)
* All usages of `java.util.Calendar` (which was primarily used for date math) have been replaced with new syntax (e.g. `Instant.now().minus(1, ChronoUnit.HOURS)` to subtract one hour from now)
    * All usages of `java.util.GregorianCalendar` and `org.apache.commons.lang3.time.DateUtils` (also primarily used for date math) have been replaced in the same manner.
* All usages of `java.util.Date` have been replaced with a more specific class in `java.time.*`, including:
    * Dates which are simply a year (YYYY) are now `java.time.Year`
    * Dates which are a month (YYYY-MM) are now `java.time.YearMonth`
    * Dates which are a date (YYYY-MM-DD) with no time are now `java.time.LocalDate`
    * Dates which have both a date and time are now either `java.time.Instant` or `java.time.ZonedDateTime` or `java.time.LocalDateTime`.
        * `java.time.Instant` is used whenever we are storing the exact date/time of something occurring (e.g. date that a process ran, etc), or are measuring time a script took to execute.  `Instant` is always in UTC so it's used heavily for database columns now.
        * `java.time.ZonedDateTime` is used whenever we are dealing with dates/time with a specific timezone.  This is used heavily now by `DCDate` as that class was used to manage timezones.
        * `java.time.LocalDateTime` is used whenever we are dealing with dates/time with *no timezone*. This is used more rarely.


**NOTE:** there **are instances of `java.util.Date` which cannot be removed at this time**.   I ran into that in several areas:
* Nimbus JOSE/JWT (used by REST API for JWTs) requires using `java.util.Date`
* Rome (used for RSS/Atom feeds) requires using `java.util.Date`
* Harvard METS library (used for METS generation in AIPs) requires using `java.util.Date`
* Jakarta Mail library (used for emails) requires using `java.util.Date`
* XOAI (used for OAI-PMH) requires using `java.util.Date` in a few places.  We likely can clean this up later by releasing an updated version of https://github.com/DSpace/xoai
* The SWORDv2 library we uses still requires using `java.util.Date` in a few places.
* In Solr, any "date" type fields will be returned as a `java.util.Date`

So, this PR remove **all usage of `java.util.Date` from our own code**.  But, we still have to occasionally use `java.util.Date` for integrations with other libraries that are not yet compatible with `java.time.*` classes.

## Instructions for Reviewers
* Review code changes.  As mentioned above, there is a large number of changes in this PR, but they are very repetitive
* Ensure all tests pass.  These code changes should be well exercised by our existing tests
* Ensure no changes in behavior of the backend.  Test command-line scripts (especially any that use dates in some way), and User Interface.
