### PR TITLE
New solr plugin: AccessStatus to enable filtering results by item access status

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceIndexAccessStatusPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceIndexAccessStatusPlugin.java
@@ -8,14 +8,11 @@
 package org.dspace.discovery;
 
 import java.sql.SQLException;
-import java.util.List;
 
 import org.apache.solr.common.SolrInputDocument;
+import org.dspace.access.status.DefaultAccessStatusHelper;
 import org.dspace.access.status.factory.AccessStatusServiceFactory;
 import org.dspace.access.status.service.AccessStatusService;
-import org.dspace.access.status.DefaultAccessStatusHelper;
-import org.dspace.content.Bitstream;
-import org.dspace.content.Bundle;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
 import org.dspace.discovery.indexobject.IndexableItem;
@@ -56,7 +53,7 @@ public class SolrServiceIndexAccessStatusPlugin implements SolrServiceIndexPlugi
      * containing at least one bitstream.
      *
      * @param item to check
-     * @return String with one of the following controlled values 
+     * @return String with one of the following controlled values
         EMBARGO = "embargo"
         METADATA_ONLY = "metadata.only"
         OPEN_ACCESS = "open.access"

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceIndexAccessStatusPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceIndexAccessStatusPlugin.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package org.dspace.discovery;
 
 import java.sql.SQLException;
@@ -17,7 +24,7 @@ import org.dspace.discovery.indexobject.IndexableItem;
 /**
  * This plugin enables the indexing of access status for the item as a filter
  * and keyword
- * @author pgraca
+ * @author paulo-graca
  *
  */
 public class SolrServiceIndexAccessStatusPlugin implements SolrServiceIndexPlugin {

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceIndexAccessStatusPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceIndexAccessStatusPlugin.java
@@ -1,0 +1,62 @@
+package org.dspace.discovery;
+
+import java.sql.SQLException;
+import java.util.List;
+
+import org.apache.solr.common.SolrInputDocument;
+import org.dspace.access.status.factory.AccessStatusServiceFactory;
+import org.dspace.access.status.service.AccessStatusService;
+import org.dspace.access.status.DefaultAccessStatusHelper;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Bundle;
+import org.dspace.content.Item;
+import org.dspace.core.Context;
+import org.dspace.discovery.indexobject.IndexableItem;
+
+
+/**
+ * This plugin enables the indexing of access status for the item as a filter
+ * and keyword
+ * @author pgraca
+ *
+ */
+public class SolrServiceIndexAccessStatusPlugin implements SolrServiceIndexPlugin {
+
+    AccessStatusService accessStatusService = AccessStatusServiceFactory.getInstance().getAccessStatusService();
+
+    @Override
+    public void additionalIndex(Context context, IndexableObject indexableObject, SolrInputDocument document) {
+        if (indexableObject instanceof IndexableItem) {
+            Item item = ((IndexableItem) indexableObject).getIndexedObject();
+            String accessStatus;
+
+            try {
+                accessStatus = retrieveItemAccessStatus(context,item);
+            } catch (SQLException e) {
+                accessStatus = DefaultAccessStatusHelper.UNKNOWN;
+            }
+
+            // _keyword and _filter because
+            // they are needed in order to work as a facet and filter.
+            document.addField("access_status_keyword", accessStatus);
+            document.addField("access_status_filter", accessStatus);
+
+        }
+    }
+
+    /**
+     * Checks whether the given item has a bundle with the name ORIGINAL
+     * containing at least one bitstream.
+     *
+     * @param item to check
+     * @return String with one of the following controlled values 
+        EMBARGO = "embargo"
+        METADATA_ONLY = "metadata.only"
+        OPEN_ACCESS = "open.access"
+        RESTRICTED = "restricted"
+        UNKNOWN = "unknown"
+     */
+    private String retrieveItemAccessStatus(Context context, Item item) throws SQLException {
+        return accessStatusService.getAccessStatus(context, item);
+    }
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -1235,6 +1235,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
             SearchFilterMatcher.hasFileNameInOriginalBundleFilter(),
             SearchFilterMatcher.hasFileDescriptionInOriginalBundleFilter(),
             SearchFilterMatcher.entityTypeFilter(),
+            SearchFilterMatcher.accessStatusFilter(),
             SearchFilterMatcher.isAuthorOfPublicationRelation(),
             SearchFilterMatcher.isProjectOfPublicationRelation(),
             SearchFilterMatcher.isOrgUnitOfPublicationRelation(),

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -137,6 +137,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         allExpectedSidebarFacets.addAll(List.of(
             FacetEntryMatcher.authorFacet(false),
             FacetEntryMatcher.entityTypeFacet(false),
+            FacetEntryMatcher.accessStatusFacet(false),
             FacetEntryMatcher.dateIssuedFacet(false),
             FacetEntryMatcher.subjectFacet(false),
             FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
@@ -1376,6 +1377,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         allExpectedSidebarFacets.addAll(List.of(
             FacetEntryMatcher.authorFacet(false),
             FacetEntryMatcher.entityTypeFacet(false),
+            FacetEntryMatcher.accessStatusFacet(false),
             FacetEntryMatcher.subjectFacet(false),
             FacetEntryMatcher.dateIssuedFacet(false),
             FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
@@ -1514,6 +1516,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         allExpectedSidebarFacets.addAll(List.of(
             FacetEntryMatcher.authorFacet(true),
             FacetEntryMatcher.entityTypeFacet(false),
+            FacetEntryMatcher.accessStatusFacet(false),
             FacetEntryMatcher.subjectFacet(false),
             FacetEntryMatcher.dateIssuedFacet(false),
             FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
@@ -1608,6 +1611,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         allExpectedSidebarFacets.addAll(List.of(
             FacetEntryMatcher.authorFacet(false),
             FacetEntryMatcher.entityTypeFacet(false),
+            FacetEntryMatcher.accessStatusFacet(false),
             FacetEntryMatcher.subjectFacet(true),
             FacetEntryMatcher.dateIssuedFacet(false),
             FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
@@ -1692,6 +1696,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         allExpectedSidebarFacets.addAll(List.of(
             FacetEntryMatcher.authorFacet(false),
             FacetEntryMatcher.entityTypeFacet(false),
+            FacetEntryMatcher.accessStatusFacet(false),
             FacetEntryMatcher.subjectFacet(false),
             FacetEntryMatcher.dateIssuedFacet(false),
             FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
@@ -1800,6 +1805,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         allExpectedSidebarFacets.addAll(List.of(
             FacetEntryMatcher.authorFacet(false),
             FacetEntryMatcher.entityTypeFacet(false),
+            FacetEntryMatcher.accessStatusFacet(false),
             FacetEntryMatcher.subjectFacet(false),
             FacetEntryMatcher.dateIssuedFacet(false),
             FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
@@ -1887,6 +1893,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         allExpectedSidebarFacetsWithDsoTypeItem.addAll(List.of(
             FacetEntryMatcher.authorFacet(false),
             FacetEntryMatcher.entityTypeFacet(false),
+            FacetEntryMatcher.accessStatusFacet(false),
             FacetEntryMatcher.subjectFacet(false),
             FacetEntryMatcher.dateIssuedFacet(false),
             FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
@@ -1923,6 +1930,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         allExpectedSidebarFacetsWithDsoTypesComCol.addAll(List.of(
             FacetEntryMatcher.authorFacet(false),
             FacetEntryMatcher.entityTypeFacet(false),
+            FacetEntryMatcher.accessStatusFacet(false),
             FacetEntryMatcher.subjectFacet(false),
             FacetEntryMatcher.dateIssuedFacet(false),
             FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
@@ -1962,6 +1970,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         allExpectedSidebarFacetsWithDsoTypesColItem.addAll(List.of(
             FacetEntryMatcher.authorFacet(false),
             FacetEntryMatcher.entityTypeFacet(false),
+            FacetEntryMatcher.accessStatusFacet(false),
             FacetEntryMatcher.subjectFacet(false),
             FacetEntryMatcher.dateIssuedFacet(false),
             FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
@@ -2002,6 +2011,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         allExpectedSidebarFacetsWithDsoTypesComColItem.addAll(List.of(
             FacetEntryMatcher.authorFacet(false),
             FacetEntryMatcher.entityTypeFacet(false),
+            FacetEntryMatcher.accessStatusFacet(false),
             FacetEntryMatcher.subjectFacet(false),
             FacetEntryMatcher.dateIssuedFacet(false),
             FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
@@ -2090,6 +2100,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         allExpectedSidebarFacets.addAll(List.of(
             FacetEntryMatcher.authorFacet(false),
             FacetEntryMatcher.entityTypeFacet(false),
+            FacetEntryMatcher.accessStatusFacet(false),
             FacetEntryMatcher.subjectFacet(false),
             FacetEntryMatcher.dateIssuedFacet(false),
             FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
@@ -2315,7 +2326,8 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
             FacetEntryMatcher.subjectFacet(true),
             FacetEntryMatcher.dateIssuedFacet(false),
             FacetEntryMatcher.hasContentInOriginalBundleFacet(false),
-            FacetEntryMatcher.entityTypeFacet(false)
+            FacetEntryMatcher.entityTypeFacet(false),
+            FacetEntryMatcher.accessStatusFacet(false)
         ));
         getClient().perform(get("/api/discover/search/objects")
                 .param("size", "2")
@@ -2408,6 +2420,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         allExpectedSidebarFacets.addAll(List.of(
             FacetEntryMatcher.authorFacet(false),
             FacetEntryMatcher.entityTypeFacet(false),
+            FacetEntryMatcher.accessStatusFacet(false),
             FacetEntryMatcher.subjectFacet(false),
             FacetEntryMatcher.dateIssuedFacet(false),
             FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
@@ -2489,6 +2502,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         allExpectedSidebarFacets.addAll(List.of(
             FacetEntryMatcher.authorFacet(false),
             FacetEntryMatcher.entityTypeFacet(false),
+            FacetEntryMatcher.accessStatusFacet(false),
             FacetEntryMatcher.subjectFacet(false),
             FacetEntryMatcher.dateIssuedFacet(false),
             FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
@@ -2663,6 +2677,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         allExpectedSidebarFacets.addAll(List.of(
             FacetEntryMatcher.authorFacet(false),
             FacetEntryMatcher.entityTypeFacet(false),
+            FacetEntryMatcher.accessStatusFacet(false),
             FacetEntryMatcher.subjectFacet(false),
             FacetEntryMatcher.dateIssuedFacet(false),
             FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
@@ -2744,6 +2759,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         allExpectedSidebarFacets.addAll(List.of(
             FacetEntryMatcher.authorFacet(false),
             FacetEntryMatcher.entityTypeFacet(false),
+            FacetEntryMatcher.accessStatusFacet(false),
             FacetEntryMatcher.subjectFacet(false),
             FacetEntryMatcher.dateIssuedFacet(false),
             FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
@@ -2935,6 +2951,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         allExpectedSidebarFacets.addAll(List.of(
             FacetEntryMatcher.authorFacet(false),
             FacetEntryMatcher.entityTypeFacet(false),
+            FacetEntryMatcher.accessStatusFacet(false),
             FacetEntryMatcher.subjectFacet(false),
             FacetEntryMatcher.dateIssuedFacet(false),
             FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
@@ -3082,6 +3099,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         allExpectedSidebarFacets.addAll(List.of(
             FacetEntryMatcher.authorFacet(false),
             FacetEntryMatcher.entityTypeFacet(false),
+            FacetEntryMatcher.accessStatusFacet(false),
             FacetEntryMatcher.subjectFacet(false),
             FacetEntryMatcher.dateIssuedFacet(false),
             FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
@@ -3159,6 +3177,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         allExpectedSidebarFacets.addAll(List.of(
             FacetEntryMatcher.authorFacet(false),
             FacetEntryMatcher.entityTypeFacet(false),
+            FacetEntryMatcher.accessStatusFacet(false),
             FacetEntryMatcher.subjectFacet(false),
             FacetEntryMatcher.dateIssuedFacet(false),
             FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
@@ -3236,6 +3255,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         allExpectedSidebarFacets.addAll(List.of(
             FacetEntryMatcher.authorFacet(false),
             FacetEntryMatcher.entityTypeFacet(false),
+            FacetEntryMatcher.accessStatusFacet(false),
             FacetEntryMatcher.subjectFacet(false),
             FacetEntryMatcher.dateIssuedFacet(false),
             FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
@@ -3312,6 +3332,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         allExpectedSidebarFacets.addAll(List.of(
             FacetEntryMatcher.authorFacet(false),
             FacetEntryMatcher.entityTypeFacet(false),
+            FacetEntryMatcher.accessStatusFacet(false),
             FacetEntryMatcher.subjectFacet(false),
             FacetEntryMatcher.dateIssuedFacet(false),
             FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
@@ -3395,6 +3416,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         allExpectedSidebarFacets.addAll(List.of(
             FacetEntryMatcher.authorFacetWithMinMax(true, "Doe, Jane", "Testing, Works"),
             FacetEntryMatcher.entityTypeFacet(false),
+            FacetEntryMatcher.accessStatusFacet(false),
             FacetEntryMatcher.subjectFacet(true),
             FacetEntryMatcher.dateIssuedFacetWithMinMax(false, "1990-02-13", "2010-10-17"),
             FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
@@ -3482,6 +3504,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         allExpectedSidebarFacets.addAll(List.of(
             FacetEntryMatcher.authorFacetWithMinMax(true, "Doe, Jane", "Testing, Works"),
             FacetEntryMatcher.entityTypeFacet(false),
+            FacetEntryMatcher.accessStatusFacet(false),
             FacetEntryMatcher.subjectFacet(true),
             FacetEntryMatcher.dateIssuedFacetWithMinMax(false, "1990-02-13", "2010-10-17"),
             FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
@@ -3546,6 +3569,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         allExpectedSidebarFacets.addAll(List.of(
             FacetEntryMatcher.authorFacet(false),
             FacetEntryMatcher.entityTypeFacet(false),
+            FacetEntryMatcher.accessStatusFacet(false),
             FacetEntryMatcher.subjectFacet(false),
             FacetEntryMatcher.dateIssuedFacet(false),
             FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
@@ -3622,6 +3646,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         allExpectedSidebarFacets.addAll(List.of(
             FacetEntryMatcher.authorFacet(false),
             FacetEntryMatcher.entityTypeFacet(false),
+            FacetEntryMatcher.accessStatusFacet(false),
             FacetEntryMatcher.subjectFacet(false),
             FacetEntryMatcher.dateIssuedFacet(false),
             FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
@@ -3697,6 +3722,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         allExpectedSidebarFacets.addAll(List.of(
             FacetEntryMatcher.authorFacet(false),
             FacetEntryMatcher.entityTypeFacet(false),
+            FacetEntryMatcher.accessStatusFacet(false),
             FacetEntryMatcher.subjectFacet(false),
             FacetEntryMatcher.dateIssuedFacet(false),
             FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
@@ -3774,6 +3800,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         allExpectedSidebarFacets.addAll(List.of(
             FacetEntryMatcher.authorFacet(false),
             FacetEntryMatcher.entityTypeFacet(false),
+            FacetEntryMatcher.accessStatusFacet(false),
             FacetEntryMatcher.subjectFacet(false),
             FacetEntryMatcher.dateIssuedFacet(false),
             FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
@@ -3850,6 +3877,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         allExpectedSidebarFacets.addAll(List.of(
             FacetEntryMatcher.authorFacet(false),
             FacetEntryMatcher.entityTypeFacet(false),
+            FacetEntryMatcher.accessStatusFacet(false),
             FacetEntryMatcher.subjectFacet(false),
             FacetEntryMatcher.dateIssuedFacet(false),
             FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
@@ -3926,6 +3954,7 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
         allExpectedSidebarFacets.addAll(List.of(
             FacetEntryMatcher.authorFacet(false),
             FacetEntryMatcher.entityTypeFacet(false),
+            FacetEntryMatcher.accessStatusFacet(false),
             FacetEntryMatcher.subjectFacet(false),
             FacetEntryMatcher.dateIssuedFacet(false),
             FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
@@ -4359,7 +4388,8 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
             FacetEntryMatcher.subjectFacet(false),
             FacetEntryMatcher.dateIssuedFacet(false),
             FacetEntryMatcher.hasContentInOriginalBundleFacet(false),
-            FacetEntryMatcher.entityTypeFacet(false)
+            FacetEntryMatcher.entityTypeFacet(false),
+            FacetEntryMatcher.accessStatusFacet(false)
         ));
         String[] tokens = new String[] {
             null,

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryScopeBasedRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryScopeBasedRestControllerIT.java
@@ -506,7 +506,8 @@ public class DiscoveryScopeBasedRestControllerIT extends AbstractControllerInteg
                                       FacetEntryMatcher.subjectFacet(false),
                                       FacetEntryMatcher.dateIssuedFacet(false),
                                       FacetEntryMatcher.hasContentInOriginalBundleFacet(false),
-                                      FacetEntryMatcher.entityTypeFacet(false)
+                                      FacetEntryMatcher.entityTypeFacet(false),
+                                      FacetEntryMatcher.accessStatusFacet(false)
                               ))
                    );
     }
@@ -618,7 +619,8 @@ public class DiscoveryScopeBasedRestControllerIT extends AbstractControllerInteg
                                       FacetEntryMatcher.subjectFacet(false),
                                       FacetEntryMatcher.dateIssuedFacet(false),
                                       FacetEntryMatcher.hasContentInOriginalBundleFacet(false),
-                                      FacetEntryMatcher.entityTypeFacet(false)
+                                      FacetEntryMatcher.entityTypeFacet(false),
+                                      FacetEntryMatcher.accessStatusFacet(false)
                               ))
                    );
     }
@@ -668,7 +670,8 @@ public class DiscoveryScopeBasedRestControllerIT extends AbstractControllerInteg
                                       FacetEntryMatcher.subjectFacet(false),
                                       FacetEntryMatcher.dateIssuedFacet(false),
                                       FacetEntryMatcher.hasContentInOriginalBundleFacet(false),
-                                      FacetEntryMatcher.entityTypeFacet(false)
+                                      FacetEntryMatcher.entityTypeFacet(false),
+                                      FacetEntryMatcher.accessStatusFacet(false)
                               ))
                    );
     }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/FacetEntryMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/FacetEntryMatcher.java
@@ -170,6 +170,16 @@ public class FacetEntryMatcher {
         );
     }
 
+    public static Matcher<? super Object> accessStatusFacet(boolean hasNext) {
+        return allOf(
+            hasJsonPath("$.name", is("access_status")),
+            hasJsonPath("$.facetType", is("text")),
+            hasJsonPath("$.facetLimit", any(Integer.class)),
+            hasJsonPath("$._links.self.href", containsString("api/discover/facets/access_status")),
+            hasJsonPath("$._links", matchNextLink(hasNext, "api/discover/facets/access_status"))
+        );
+    }
+
     public static Matcher<? super Object> relatedItemFacet(boolean b) {
         return allOf(
             hasJsonPath("$.name", is("relateditem")),

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/SearchFilterMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/SearchFilterMatcher.java
@@ -114,7 +114,7 @@ public class SearchFilterMatcher {
 
     public static Matcher<? super Object> accessStatusFilter() {
         return allOf(
-            hasJsonPath("$.filter", is("access-status")),
+            hasJsonPath("$.filter", is("access_status")),
             hasJsonPath("$.hasFacets", is(true)),
             hasJsonPath("$.type", is("text")),
             hasJsonPath("$.openByDefault", is(false)),

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/SearchFilterMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/SearchFilterMatcher.java
@@ -111,6 +111,17 @@ public class SearchFilterMatcher {
             checkOperators()
         );
     }
+
+    public static Matcher<? super Object> accessStatusFilter() {
+        return allOf(
+            hasJsonPath("$.filter", is("access-status")),
+            hasJsonPath("$.hasFacets", is(true)),
+            hasJsonPath("$.type", is("text")),
+            hasJsonPath("$.openByDefault", is(false)),
+            checkOperators()
+        );
+    }
+
     public static Matcher<? super Object> isAuthorOfPublicationRelation() {
         return allOf(
             hasJsonPath("$.filter", is("isAuthorOfPublication")),

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -47,6 +47,9 @@
     <!-- Additional indexing plugin that normalises and indexes value(s) for comparison to be used in e.g. duplication detection -->
     <bean id="solrServiceIndexComparisonPlugin" class="org.dspace.discovery.SolrServiceIndexComparisonPlugin" scope="prototype"/>
 
+    <!-- Additional indexing plugin that enables filtering items by access status -->
+    <bean id="solrServiceIndexAccessStatusPlugin" class="org.dspace.discovery.SolrServiceIndexAccessStatusPlugin" scope="prototype"/>
+
     <!--Bean that is used for mapping communities/collections to certain discovery configurations.-->
     <bean id="org.dspace.discovery.configuration.DiscoveryConfigurationService" class="org.dspace.discovery.configuration.DiscoveryConfigurationService">
         <property name="map">
@@ -190,6 +193,7 @@
                 <ref bean="searchFilterIssued" />
                 <ref bean="searchFilterContentInOriginalBundle"/>
                 <ref bean="searchFilterEntityType"/>
+                <ref bean="searchFilterAccessStatus" />
             </list>
         </property>
         <!-- Set TagCloud configuration per discovery configuration -->
@@ -205,6 +209,7 @@
                 <ref bean="searchFilterFileNameInOriginalBundle" />
                 <ref bean="searchFilterFileDescriptionInOriginalBundle" />
                 <ref bean="searchFilterEntityType"/>
+                <ref bean="searchFilterAccessStatus" />
                 <ref bean="searchFilterIsAuthorOfPublicationRelation"/>
                 <ref bean="searchFilterIsProjectOfPublicationRelation"/>
                 <ref bean="searchFilterIsOrgUnitOfPublicationRelation"/>
@@ -2648,6 +2653,13 @@
             <list>
                 <value>dc.type</value>
             </list>
+        </property>
+    </bean>
+
+    <bean id="searchFilterAccessStatus" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
+        <property name="indexFieldName" value="access_status" />
+        <property name="metadataFields">
+            <list/>
         </property>
     </bean>
 


### PR DESCRIPTION
## References
* Related with #8518
* Available translations: https://github.com/DSpace/DSpace-angular/pull/4038

## Description
This PR adds a new plugin that enables indexing of access status for the item as new a filter and faceted keyword. Enabling something like:
![image](https://github.com/user-attachments/assets/b1a691e3-610f-4dff-99e3-7b81cccf7026)


## Instructions for Reviewers
This PR adds a new plugin and changes discovery.xml spring configuration to support it.
To test it, you will need to perform a full index of your repository in order to have the new field in your solr.
```
[dspace]/bin/dspace index-discovery -b
```
and you can check the new filter in your frontend.

**Two important notes:**
- this PR depends on an angular PR to add the necessary UI translations
- this PR adds the Access type to the index. For embargoes, it's necessary a complementary solution to force the indexing of items that should be publicly available. For that, we currently using a bash script that we run everyday. But we want a more DSpace's integrated solution (to be also supported in other systems), something like the old embargo lifter.

We are using:
[dspace]/bin/dspace-embargo-lifter.sh
```
#!/bin/sh

# paulo-graca
# this script executes embargo lifter by reindexing content

# JAVA memory allocation
export JAVA_OPTS="-Xmx2048M -Xms512M -Dfile.encoding=UTF-8"

# Current script dir
SCRIPTPATH=$(dirname "$0")

LOG_FILE="${SCRIPTPATH}/../log/dspace_embargo_lifter.log"

usage()
{
cat <<EOF
Usage: $(basename "$0") [options]

This shell script executes filter media from dspace
in an incremental way for all recently changed records.

Options:

  --n-days          Number of days to consider for incremental.
                    Default '5'

  --log-file        Log file location.
                    Default: '../log/dspace_embargo_lifter.log'

Example:

   $(basename "$0") --log-file /dspace/log/dspace_embargo_lifter.log

EOF
} 

N_DAYS="1"

while [ "$1" ]; do
  case "$1" in
        --n-days)
            shift
            N_DAYS="$1"
            ;;
        --log-file)
            shift
            LOG_FILE="$1"
            ;;
        --help)
            usage
            exit 0
            ;;
        *)
            echo "$(basename "$0"): invalid option $1" >&2
            echo "see --help for usage"
            exit 1
                  ;;
  esac
  shift
done

### yyyy-mm-dd ###
now="$(date +'%Y-%m-%d %H:%M:%S')"
echo "[$now] BEGIN" >> "${LOG_FILE}"

DB_USERNAME=$(echo "$(${SCRIPTPATH}/dspace dsprop -property db.username)")
DB_PASSWORD=$(echo "$(${SCRIPTPATH}/dspace dsprop -property db.password)")
DB_URL=$(echo "$(${SCRIPTPATH}/dspace dsprop -property db.url)")
DB_DATABASE=$(echo "${DB_URL}"|rev|cut -d'/' -f1|rev)
DB_PORT=$(echo "${DB_URL}"|rev|cut -d'/' -f2|cut -d':' -f1|rev)
DB_HOST=$(echo "${DB_URL}"|rev|cut -d'/' -f2|cut -d':' -f2|rev)

# processing bitstreams

HANDLES=$(echo "SELECT handle FROM handle WHERE resource_id IN ( SELECT item_id FROM item2bundle AS i2b INNER JOIN bundle2bitstream AS b2b ON b2b.bundle_id = i2b.bundle_id INNER JOIN resourcepolicy AS rp ON rp.dspace_object = b2b.bitstream_id WHERE rp.resource_type_id = 0 AND ( (start_date >= date_trunc('day', current_date - interval '${N_DAYS}' DAY) AND start_date < date_trunc('day', current_date)) OR ((end_date >= date_trunc('day', current_date - interval '${N_DAYS}' DAY) AND end_date < date_trunc('day', current_date))) ) );" | PGPASSWORD="${DB_PASSWORD}" psql -tU "${DB_USERNAME}" -h "${DB_HOST}" -p "${DB_PORT}" "${DB_DATABASE}")

NUMBER_ITEMS=0

for HANDLE in $HANDLES
do
  #Filter media execution - /dspace/bin/dspace filter-media
  echo "... processing ${HANDLE}" >> "${LOG_FILE}"
  "${SCRIPTPATH}/dspace" index-discovery -i "${HANDLE}" >> "${LOG_FILE}"
  #first, retrieve the number of archived items processed
  NUMBER_ITEMS=$((NUMBER_ITEMS+1))
done

# processing items

HANDLES=$(echo "SELECT handle FROM handle WHERE resource_id IN ( SELECT rp.dspace_object FROM resourcepolicy AS rp WHERE rp.resource_type_id = 2 AND ( (start_date >= date_trunc('day', current_date - interval '${N_DAYS}' DAY) AND start_date < date_trunc('day', current_date)) OR ((end_date >= date_trunc('day', current_date - interval '${N_DAYS}' DAY) AND end_date < date_trunc('day', current_date))) ));" | PGPASSWORD="${DB_PASSWORD}" psql -tU "${DB_USERNAME}" -h "${DB_HOST}" -p "${DB_PORT}" "${DB_DATABASE}")


for HANDLE in $HANDLES
do
  #Filter media execution - /dspace/bin/dspace filter-media
  echo "... processing ${HANDLE}" >> "${LOG_FILE}"
  "${SCRIPTPATH}/dspace" index-discovery -i "${HANDLE}" >> "${LOG_FILE}"
  #first, retrieve the number of archived items processed
  NUMBER_ITEMS=$((NUMBER_ITEMS+1))
done

echo "Processed: ${NUMBER_ITEMS} handles" >> "${LOG_FILE}"

### yyyy-mm-dd ###
now="$(date +'%Y-%m-%d %H:%M:%S')"
echo "[$now] END" >> "${LOG_FILE}"
```
