### PR TITLE
Refactoring the function to retrieve the number of browse entries (fix errors using Solr 9.x)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -41,6 +41,8 @@ import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.response.FacetField;
 import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.client.solrj.response.json.BucketBasedJsonFacet;
+import org.apache.solr.client.solrj.response.json.NestableJsonFacet;
 import org.apache.solr.client.solrj.util.ClientUtils;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
@@ -1105,13 +1107,11 @@ public class SolrServiceImpl implements SearchService, IndexingService {
      */
     private void resolveEntriesCount(DiscoverResult result, QueryResponse solrQueryResponse) {
 
-        Object facetsObj = solrQueryResponse.getResponse().get("facets");
-        if (facetsObj instanceof NamedList) {
-            NamedList<Object> facets = (NamedList<Object>) facetsObj;
-            Object bucketsInfoObj = facets.get("entries_count");
-            if (bucketsInfoObj instanceof NamedList) {
-                NamedList<Object> bucketsInfo = (NamedList<Object>) bucketsInfoObj;
-                result.setTotalEntries((int) bucketsInfo.get("numBuckets"));
+        NestableJsonFacet response = solrQueryResponse.getJsonFacetingResponse();
+        if (response != null) {
+            BucketBasedJsonFacet facet = response.getBucketBasedFacets("entries_count");
+            if (facet != null) {
+                result.setTotalEntries(facet.getNumBucketsCount());
             }
         }
     }


### PR DESCRIPTION
## References
* Related to #10057 

## Description

In #10057, the use of the JSON Facet API request was introduced to get the total number of browse entries. The function that processes the results currently parses the resulting JSON and fails when using Solr 9.x.

This PR modifies how these results are retrieved by using functions and objects from the SolrJ library to process them more naturally and avoid errors. This version should be compatible with Solr 8.x and Solr 9.x.

## Instructions for Reviewers

To review, verify that the author and subject indices work correctly and accurately return the total number of values, regardless of whether filters are applied. Also, check that it does not affect other functionalities that may use Solr queries, both when using Solr 8.x and Solr 9.x.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
