### PR TITLE
Fix invalid cast in DOIOrganiser exception handling

### DIFF
--- a/dspace-api/src/main/java/org/dspace/identifier/doi/DOIOrganiser.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/doi/DOIOrganiser.java
@@ -448,28 +448,28 @@ public class DOIOrganiser {
                                        + " is successfully registered.");
             }
         } catch (IdentifierException ex) {
+            String message;
             if (!(ex instanceof DOIIdentifierException)) {
-                LOG.error("It wasn't possible to register this identifier: "
-                              + DOI.SCHEME + doiRow.getDoi()
-                              + " online. ", ex);
+                message = "It wasn't possible to register this identifier: "
+                    + DOI.SCHEME + doiRow.getDoi()
+                    + " online. ";
+            } else {
+                DOIIdentifierException doiIdentifierException = (DOIIdentifierException) ex;
+                message = "It wasn't possible to register this identifier : "
+                    + DOI.SCHEME + doiRow.getDoi()
+                    + " online. Exceptions code: "
+                    + DOIIdentifierException.codeToString(doiIdentifierException.getCode());
             }
-
-            DOIIdentifierException doiIdentifierException = (DOIIdentifierException) ex;
 
             try {
                 sendAlertMail("Register", dso,
                               DOI.SCHEME + doiRow.getDoi(),
-                              doiIdentifierException.codeToString(doiIdentifierException
-                                                                      .getCode()));
+                              message);
             } catch (IOException ioe) {
                 LOG.error("Couldn't send mail", ioe);
             }
 
-            LOG.error("It wasn't possible to register this identifier : "
-                          + DOI.SCHEME + doiRow.getDoi()
-                          + " online. Exceptions code: "
-                          + doiIdentifierException
-                .codeToString(doiIdentifierException.getCode()), ex);
+            LOG.error(message, ex);
 
             if (!quiet) {
                 System.err.println("It wasn't possible to register this identifier: "
@@ -541,27 +541,27 @@ public class DOIOrganiser {
                 System.out.println("This identifier : " + DOI.SCHEME + doiRow.getDoi() + " is successfully reserved.");
             }
         } catch (IdentifierException ex) {
+            String message;
             if (!(ex instanceof DOIIdentifierException)) {
-                LOG.error("It wasn't possible to register this identifier : "
-                              + DOI.SCHEME + doiRow.getDoi()
-                              + " online. ", ex);
+                message = "It wasn't possible to register this identifier : "
+                    + DOI.SCHEME + doiRow.getDoi()
+                    + " online. ";
+            } else {
+                DOIIdentifierException doiIdentifierException = (DOIIdentifierException) ex;
+                message = "It wasn't possible to reserve the identifier online. "
+                    + " Exceptions code:  "
+                    + DOIIdentifierException.codeToString(doiIdentifierException.getCode());
             }
-
-            DOIIdentifierException doiIdentifierException = (DOIIdentifierException) ex;
 
             try {
                 sendAlertMail("Reserve", dso,
                               DOI.SCHEME + doiRow.getDoi(),
-                              DOIIdentifierException.codeToString(
-                                  doiIdentifierException.getCode()));
+                              message);
             } catch (IOException ioe) {
                 LOG.error("Couldn't send mail", ioe);
             }
 
-            LOG.error("It wasn't possible to reserve the identifier online. "
-                          + " Exceptions code:  "
-                          + DOIIdentifierException
-                .codeToString(doiIdentifierException.getCode()), ex);
+            LOG.error(message, ex);
 
             if (!quiet) {
                 System.err.println("It wasn't possible to reserve this identifier: " + DOI.SCHEME + doiRow.getDoi());
@@ -606,27 +606,27 @@ public class DOIOrganiser {
                                        + doiRow.getDoi() + ".");
             }
         } catch (IdentifierException ex) {
+            String message;
             if (!(ex instanceof DOIIdentifierException)) {
-                LOG.error("Registering DOI {} for object {}:  the registrar returned an error.",
-                        doiRow.getDoi(), dso.getID(), ex);
+                message = String.format("Registering DOI %s for object %s:  the registrar returned an error.",
+                                        doiRow.getDoi(), dso.getID());
+            } else {
+                DOIIdentifierException doiIdentifierException = (DOIIdentifierException) ex;
+                message = "It wasn't possible to update this identifier:  "
+                    + DOI.SCHEME + doiRow.getDoi()
+                    + " Exceptions code:  "
+                    + DOIIdentifierException.codeToString(doiIdentifierException.getCode());
             }
-
-            DOIIdentifierException doiIdentifierException = (DOIIdentifierException) ex;
 
             try {
                 sendAlertMail("Update", dso,
                               DOI.SCHEME + doiRow.getDoi(),
-                              doiIdentifierException.codeToString(doiIdentifierException
-                                                                      .getCode()));
+                              message);
             } catch (IOException ioe) {
                 LOG.error("Couldn't send mail", ioe);
             }
 
-            LOG.error("It wasn't possible to update this identifier:  "
-                          + DOI.SCHEME + doiRow.getDoi()
-                          + " Exceptions code:  "
-                          + doiIdentifierException
-                .codeToString(doiIdentifierException.getCode()), ex);
+            LOG.error(message, ex);
 
             if (!quiet) {
                 System.err.println("It wasn't possible to update this identifier: " + DOI.SCHEME + doiRow.getDoi());


### PR DESCRIPTION
## References
* Fixes #10484

## Description
Refactored exception handling in `DOIOrganiser` to remove the invalid cast. Instead of casting after a negative `instanceof` check, the code now handles `DOIIdentifierException` separately, constructing appropriate error messages and ensuring safe type usage before sending alerts and logging the exception.

## Instructions for Reviewers

List of changes in this PR:
* First, removed the invalid cast of `IdentifierException` to `DOIIdentifierException`. Previously, the code checked if `ex` was **not** an instance of `DOIIdentifierException` and then still attempted to cast it, which could cause a `ClassCastException`.
* Second, introduced a `message` variable to store the appropriate error message. This ensures the message is correctly assigned based on whether `ex` is a `DOIIdentifierException` or a different type of exception.
* Third, updated both the `sendAlertMail` method and `LOG.error` calls to use the `message` variable instead of directly accessing `doiIdentifierException`.

Steps to Reproduce the Bug
1. Run the `doi-organiser` script with the `--reserve-doi` option.
2. Apply a filter that should exclude a specific item from DOI reservation.
3. The `DOIIdentifierProvider#checkMintable` method throws a `DOIIdentifierNotApplicableException` for the filtered-out item.
4. The exception is caught in `DOIOrganiser`, but the code attempts to cast `DOIIdentifierNotApplicableException` to `DOIIdentifierException`.
5. This results in a `ClassCastException`:
```
ClassCastException: class org.dspace.identifier.doi.DOIIdentifierNotApplicableException 
cannot be cast to class org.dspace.identifier.doi.DOIIdentifierException 
(org.dspace.identifier.doi.DOIIdentifierNotApplicableException and 
org.dspace.identifier.doi.DOIIdentifierException are in unnamed module of loader 'app')
```

Expected Behavior
The script should correctly handle `DOIIdentifierNotApplicableException` without attempting an invalid cast, allowing proper error logging and handling instead of crashing with a `ClassCastException`.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
