### PR TITLE
#10476: Fix debug port conflicts in Dockerfile test env

### DIFF
--- a/dspace/bin/dspace
+++ b/dspace/bin/dspace
@@ -33,8 +33,8 @@ if [ "$1" = "classpath" ]; then
   exit 0
 fi
 
-# Reset JAVA_TOOL_OPTIONS to empty, so that any debug ports don't conflict
-JAVA_TOOL_OPTIONS=""
+# Unset JAVA_TOOL_OPTIONS (exported by Dockerfile) so that any debug ports don't conflict
+unset JAVA_TOOL_OPTIONS
 # Note, if you wish to also debug the CLI launcher, the following line is an
 # example of how to do so - note the different port number and 'suspend=y' which
 # means the JVM will not begin execution until a debugger is attached.

--- a/dspace/bin/dspace
+++ b/dspace/bin/dspace
@@ -33,7 +33,14 @@ if [ "$1" = "classpath" ]; then
   exit 0
 fi
 
-#Allow user to specify java options through JAVA_OPTS variable
+# Reset JAVA_TOOL_OPTIONS to empty, so that any debug ports don't conflict
+JAVA_TOOL_OPTIONS=""
+# Note, if you wish to also debug the CLI launcher, the following line is an
+# example of how to do so - note the different port number and 'suspend=y' which
+# means the JVM will not begin execution until a debugger is attached.
+#JAVA_TOOL_OPTIONS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:1043"
+
+# Allow user to specify java options through JAVA_OPTS variable
 if [ "$JAVA_OPTS" = "" ]; then
   #Default Java to use 256MB of memory
   JAVA_OPTS="-Xmx256m -Dfile.encoding=UTF-8"


### PR DESCRIPTION
Reset JAVA_TOOL_OPTIONS in the launcher
Include commented example of CLI debugging in launcher

## References
* Fixes #10476 

## Description
`Dockerfile.test` sets a `JAVA_TOOL_OPTIONS` environment variable to allow remote JVM debugging in the web application. This environment variable is also used in the dspace CLI launcher, which causes an error about port conflicts, since the JDWP server tries to run again on the same port.

This PR edits the `dspace` launcher script to reset the `JAVA_TOOL_OPTIONS` env var (not used anywhere else), and it also includes a commented-out example of how one can set up separate CLI debugging with a separate port number and suspending the JVM.

## Instructions for Reviewers
* Use this PR to build a new test docker image
* Run, and test that normal port-8000 remote JVM debug works
* Exec the dspace launcher and ensure no port conflict messages are logged
* Optionally, try out the example CLI debug config

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
