### PR TITLE
Fix bug where LDN Queue Date cannot be indexed properly

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/indexobject/LDNMessageEntityIndexFactoryImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/indexobject/LDNMessageEntityIndexFactoryImpl.java
@@ -25,6 +25,7 @@ import org.dspace.app.ldn.service.LDNMessageService;
 import org.dspace.content.Item;
 import org.dspace.content.service.ItemService;
 import org.dspace.core.Context;
+import org.dspace.util.SolrUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -146,7 +147,7 @@ public class LDNMessageEntityIndexFactoryImpl extends IndexFactoryImpl<Indexable
                                                                                        ZoneOffset.UTC));
             addFacetIndex(doc, "queue_last_start_time", value, value);
             doc.addField("queue_last_start_time", value);
-            doc.addField("queue_last_start_time_dt", queueLastStartTime);
+            doc.addField("queue_last_start_time_dt", SolrUtils.getDateFormatter().format(queueLastStartTime));
             doc.addField("queue_last_start_time_min", value);
             doc.addField("queue_last_start_time_min_sort", value);
             doc.addField("queue_last_start_time_max", value);


### PR DESCRIPTION
## References
* Related to #10432

## Description
Currently, on `main`, if you have LDN enabled and reindex your site (`./dspace index-discovery -b`), you will see errors like these for any LDN events that are reindexed:
```
2025-03-17 20:48:06.127 ERROR (qtp1341706533-24) [   x:search] o.a.s.h.RequestHandlerBase org.apache.solr.common.SolrException: ERROR: [doc=LDNMessageEntity-urn:uuid:af5c0ad5-5ce9-4a37-83a7-4a6402ca8a19] Error adding field 'queue_last_start_time_dt'='java.time.Instant:2025-03-17T19:37:00.004560Z' msg=Invalid Date in Date Math String:'java.time.Instant:2025-03-17T19:37:00.004560Z' => org.apache.solr.common.SolrException: ERROR: [doc=LDNMessageEntity-urn:uuid:af5c0ad5-5ce9-4a37-83a7-4a6402ca8a19] Error adding field 'queue_last_start_time_dt'='java.time.Instant:2025-03-17T19:37:00.004560Z' msg=Invalid Date in Date Math String:'java.time.Instant:2025-03-17T19:37:00.004560Z'
   at org.apache.solr.update.DocumentBuilder.toDocument(DocumentBuilder.java:219)
 org.apache.solr.common.SolrException: ERROR: [doc=LDNMessageEntity-urn:uuid:af5c0ad5-5ce9-4a37-83a7-4a6402ca8a19] Error adding field 'queue_last_start_time_dt'='java.time.Instant:2025-03-17T19:37:00.004560Z' msg=Invalid Date in Date Math String:'java.time.Instant:2025-03-17T19:37:00.004560Z'
```

The issue is that the value that we send to Solr for `queue_last_start_time_dt` is of an invalid format. This invalid format was accidentally overlooked in #10432.  

For all other Dates we send to Solr, we use `SolrUtils.getDateFormatter().format()`. This small PR just updates that line of code to also use that approach.

This issue only impacts the `main` branch as it was accidentally caused by #10432.

## Instructions for Reviewers
* Prior to this PR, the above error will occur.
* After this PR, the error will no longer occur when doing a full reindex.

