### PR TITLE
Fix incorrect parsing of access-status metadata

### DIFF
--- a/dspace/config/crosswalks/oai/metadataFormats/dim.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/dim.xsl
@@ -36,6 +36,18 @@
         </xsl:call-template>
     </xsl:template>
 
+    <xsl:template match="/doc:metadata/doc:element/doc:element/doc:field[@name='value']">
+        <xsl:call-template name="dimfield">
+            <xsl:with-param name="mdschema" select="../../@name"/>
+            <xsl:with-param name="element" select="../@name"/>
+            <xsl:with-param name="qualifier" />
+            <xsl:with-param name="language" />
+            <xsl:with-param name="authority" />
+            <xsl:with-param name="confidence" />
+            <xsl:with-param name="value" select="text()"/>
+        </xsl:call-template>
+    </xsl:template>
+
     <xsl:template name="dimfield">
         <xsl:param name="mdschema"/>
         <xsl:param name="element"/>
@@ -62,6 +74,7 @@
 
             <xsl:choose>
                 <xsl:when test="$language='none'"/>
+                <xsl:when test="$language=''"/>
                 <xsl:otherwise>
                     <xsl:attribute name="lang">
                         <xsl:value-of select="$language"/>


### PR DESCRIPTION

## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #10397 

## Description
Adds a new template to deal with metadata elements under the "others" element, which was missing and causing the generation of invalid xml when access-status element is present in the metadata

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [X] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
