### PR TITLE
Fix checkpointing for DSpace "checker" command

### DIFF
--- a/dspace-api/src/main/java/org/dspace/checker/CheckerCommand.java
+++ b/dspace-api/src/main/java/org/dspace/checker/CheckerCommand.java
@@ -131,7 +131,7 @@ public final class CheckerCommand {
                 collector.collect(context, info);
             }
 
-            context.uncacheEntity(bitstream);
+            context.commit();
             bitstream = dispatcher.next();
         }
     }

--- a/dspace-api/src/test/java/org/dspace/checker/ChecksumCheckerIT.java
+++ b/dspace-api/src/test/java/org/dspace/checker/ChecksumCheckerIT.java
@@ -1,0 +1,192 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.checker;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.io.IOUtils;
+import org.dspace.AbstractIntegrationTestWithDatabase;
+import org.dspace.builder.BitstreamBuilder;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.ItemBuilder;
+import org.dspace.checker.factory.CheckerServiceFactory;
+import org.dspace.checker.service.ChecksumHistoryService;
+import org.dspace.checker.service.MostRecentChecksumService;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.Item;
+import org.dspace.core.Context;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ChecksumCheckerIT extends AbstractIntegrationTestWithDatabase {
+    protected List<Bitstream> bitstreams;
+    protected MostRecentChecksumService checksumService =
+        CheckerServiceFactory.getInstance().getMostRecentChecksumService();
+
+    @Before
+    public void setup() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        Community parentCommunity = CommunityBuilder.createCommunity(context).build();
+        Collection collection = CollectionBuilder.createCollection(context, parentCommunity)
+            .build();
+        Item item = ItemBuilder.createItem(context, collection).withTitle("Test item")
+            .build();
+
+        int numBitstreams = 3;
+        bitstreams = new ArrayList<>();
+        for (int i = 0; i < numBitstreams; i++) {
+            String content = "Test bitstream " + i;
+            bitstreams.add(
+                BitstreamBuilder.createBitstream(
+                    context, item, IOUtils.toInputStream(content, UTF_8)
+                ).build()
+            );
+        }
+
+        context.restoreAuthSystemState();
+
+        // Call the "updateMissingBitstreams" method so that the test bitstreams
+        // already have checksums in the past when CheckerCommand runs.
+        // Otherwise, the CheckerCommand will simply update the test
+        // bitstreams without going through the BitstreamDispatcher.
+        checksumService = CheckerServiceFactory.getInstance().getMostRecentChecksumService();
+        checksumService.updateMissingBitstreams(context);
+
+        // The "updateMissingBitstreams" method updates the test bitstreams in
+        // a random order. To verify that the expected bitstreams were
+        // processed, reset the timestamps so that the bitstreams are
+        // checked in a specific order (oldest first).
+        Instant checksumInstant = Instant.ofEpochMilli(0);
+        for (Bitstream bitstream: bitstreams) {
+            MostRecentChecksum mrc = checksumService.findByBitstream(context, bitstream);
+            mrc.setProcessStartDate(checksumInstant);
+            mrc.setProcessEndDate(checksumInstant);
+            checksumInstant = checksumInstant.plusSeconds(10);
+        }
+        context.commit();
+    }
+
+    @After
+    public void cleanUp() throws SQLException {
+        // Need to clean up ChecksumHistory because of a referential integrity
+        // constraint violation between the most_recent_checksum table and
+        // bitstream tables
+        ChecksumHistoryService checksumHistoryService = CheckerServiceFactory.getInstance().getChecksumHistoryService();
+
+        for (Bitstream bitstream: bitstreams) {
+            checksumHistoryService.deleteByBitstream(context, bitstream);
+        }
+    }
+
+    @Test
+    public void testChecksumsRecordedWhenProcesingIsInterrupted() throws SQLException {
+        CheckerCommand checker = new CheckerCommand(context);
+
+        // The start date to use for the checker process
+        Instant checkerStartDate = Instant.now();
+
+        // Verify that all checksums are before the checker start date
+        for (Bitstream bitstream: bitstreams) {
+            MostRecentChecksum checksum = checksumService.findByBitstream(context, bitstream);
+            Instant lastChecksumDate = checksum.getProcessStartDate();
+            assertTrue("lastChecksumDate (" + lastChecksumDate + ") <= checkerStartDate (" + checkerStartDate + ")",
+                lastChecksumDate.isBefore(checkerStartDate));
+        }
+
+        // Dispatcher that throws an exception when a third bitstream is
+        // retrieved.
+        BitstreamDispatcher dispatcher = new ExpectionThrowingDispatcher(
+            context, checkerStartDate, false, 2);
+        checker.setDispatcher(dispatcher);
+
+
+        // Run the checksum checker
+        checker.setProcessStartDate(checkerStartDate);
+        try {
+            checker.process();
+            fail("SQLException should have been thrown");
+        } catch (SQLException sqle) {
+            // Rollback any pending transaction
+            context.rollback();
+        }
+
+        // Verify that the checksums of the first two bitstreams (that were
+        // processed before the exception) have been successfully recorded in
+        // the database, while the third bitstream was not updated.
+        int bitstreamCount = 0;
+        for (Bitstream bitstream: bitstreams) {
+            MostRecentChecksum checksum = checksumService.findByBitstream(context, bitstream);
+            Instant lastChecksumDate = checksum.getProcessStartDate();
+
+            bitstreamCount = bitstreamCount + 1;
+            if (bitstreamCount <= 2) {
+                assertTrue("lastChecksumDate (" + lastChecksumDate + ") <= checkerStartDate (" + checkerStartDate + ")",
+                    lastChecksumDate.isAfter(checkerStartDate));
+            } else {
+                assertTrue("lastChecksumDate (" + lastChecksumDate + ") >= checkerStartDate (" + checkerStartDate + ")",
+                    lastChecksumDate.isBefore(checkerStartDate));
+            }
+        }
+    }
+
+    /**
+     * Subclass of SimpleDispatcher that only allows a limited number of "next"
+     * class before throwing a SQLException.
+     */
+    class ExpectionThrowingDispatcher extends SimpleDispatcher {
+        // The number of "next" calls to allow before throwing a SQLException
+        protected int maxNextCalls;
+
+        // The number of "next" method calls seen so far.
+        protected int numNextCalls = 0;
+
+        /**
+         * Constructor.
+         *
+         * @param context   Context
+         * @param startTime timestamp for beginning of checker process
+         * @param looping   indicates whether checker should loop infinitely
+         *                  through most_recent_checksum table
+         * @param maxNextCalls the number of "next" method calls to allow before
+         * throwing a SQLException.
+         */
+        public ExpectionThrowingDispatcher(Context context, Instant startTime, boolean looping, int maxNextCalls) {
+            super(context, startTime, looping);
+            this.maxNextCalls = maxNextCalls;
+        }
+
+        /**
+         * Selects the next candidate bitstream.
+         *
+         * After "maxNextClass" number of calls, this method throws a
+         * SQLException.
+         *
+         * @throws SQLException if database error
+         */
+        @Override
+        public synchronized Bitstream next() throws SQLException {
+            numNextCalls = numNextCalls + 1;
+            if (numNextCalls > maxNextCalls) {
+                throw new SQLException("Max 'next' method calls exceeded");
+            }
+            return super.next();
+        }
+    }
+}


### PR DESCRIPTION
## References
* Fixes #10507

## Description

Fixes the checkpointing of the DSpace "checker" command by actually committing the changes to the database, even if the process is interrupted.

## Instructions for Reviewers

List of changes in this PR:
* In the "process" method of "dspace-api/src/main/java/org/dspace/checker/CheckerCommand.java", changed the "context.uncacheEntity(bitstream);" call used for checkpointing migration progress to "context.commit();", as testing indicates that this is necessary for the changes to actually be stored in the database if the checksum process stops unexpectedly.
* Added the "dspace-api/src/test/java/org/dspace/checker/ChecksumCheckerIT.java" integration test to verify that checksum are properly committed, even if the checksum process is interrupted.

There is an integration test provided in the pull request that verifies this functionality.

See the "To Reproduce" steps in the linked issue #10507 if manual testing is desired. When using the changes in this pull request, in Step 12, a list of 10 different bitstreams would be displayed, because the "checker" command would have properly updated the "most_recent_checksum" records for bitstreams that were checked before the process was interrupted.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [X] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [X] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [X] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
