### PR TITLE
Add bitstream null check to XOAI.java

### DIFF
--- a/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
@@ -112,7 +112,7 @@ public class XOAI {
         try {
             for (Bundle b : itemService.getBundles(item, "ORIGINAL")) {
                 for (Bitstream bs : b.getBitstreams()) {
-                    if (!formats.contains(bs.getFormat(context).getMIMEType())) {
+                    if (bs != null && !formats.contains(bs.getFormat(context).getMIMEType())) {
                         formats.add(bs.getFormat(context).getMIMEType());
                     }
                 }


### PR DESCRIPTION
## References
Resolves [issue 10510](https://github.com/DSpace/DSpace/issues/10510)

## Description
Add a null check to `dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java`.