### PR TITLE
Add null check in SolrServiceFileInfoPlugin for index-discovery

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceFileInfoPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceFileInfoPlugin.java
@@ -52,21 +52,24 @@ public class SolrServiceFileInfoPlugin implements SolrServiceIndexPlugin {
                         List<Bitstream> bitstreams = bundle.getBitstreams();
                         if (bitstreams != null) {
                             for (Bitstream bitstream : bitstreams) {
-                                document.addField(SOLR_FIELD_NAME_FOR_FILENAMES, bitstream.getName());
-                                // Add _keyword and _filter fields which are necessary to support filtering and faceting
-                                // for the file names
-                                document.addField(SOLR_FIELD_NAME_FOR_FILENAMES + "_keyword", bitstream.getName());
-                                document.addField(SOLR_FIELD_NAME_FOR_FILENAMES + "_filter", bitstream.getName());
+                                if (bitstream != null)
+                                {
+                                    document.addField(SOLR_FIELD_NAME_FOR_FILENAMES, bitstream.getName());
+                                    // Add _keyword and _filter fields which are necessary to support filtering and faceting
+                                    // for the file names
+                                    document.addField(SOLR_FIELD_NAME_FOR_FILENAMES + "_keyword", bitstream.getName());
+                                    document.addField(SOLR_FIELD_NAME_FOR_FILENAMES + "_filter", bitstream.getName());
 
-                                String description = bitstream.getDescription();
-                                if ((description != null) && !description.isEmpty()) {
-                                    document.addField(SOLR_FIELD_NAME_FOR_DESCRIPTIONS, description);
-                                    // Add _keyword and _filter fields which are necessary to support filtering and
-                                    // faceting for the descriptions
-                                    document.addField(SOLR_FIELD_NAME_FOR_DESCRIPTIONS + "_keyword",
-                                                      description);
-                                    document.addField(SOLR_FIELD_NAME_FOR_DESCRIPTIONS + "_filter",
-                                                      description);
+                                    String description = bitstream.getDescription();
+                                    if ((description != null) && !description.isEmpty()) {
+                                        document.addField(SOLR_FIELD_NAME_FOR_DESCRIPTIONS, description);
+                                        // Add _keyword and _filter fields which are necessary to support filtering and
+                                        // faceting for the descriptions
+                                        document.addField(SOLR_FIELD_NAME_FOR_DESCRIPTIONS + "_keyword",
+                                                        description);
+                                        document.addField(SOLR_FIELD_NAME_FOR_DESCRIPTIONS + "_filter",
+                                                        description);
+                                    }
                                 }
                             }
                         }

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceFileInfoPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceFileInfoPlugin.java
@@ -54,8 +54,8 @@ public class SolrServiceFileInfoPlugin implements SolrServiceIndexPlugin {
                             for (Bitstream bitstream : bitstreams) {
                                 if (bitstream != null) {
                                     document.addField(SOLR_FIELD_NAME_FOR_FILENAMES, bitstream.getName());
-                                    // Add _keyword and _filter fields which are necessary to support filtering and faceting
-                                    // for the file names
+                                    // Add _keyword and _filter fields which are necessary to
+                                    // support filtering and faceting for the file names
                                     document.addField(SOLR_FIELD_NAME_FOR_FILENAMES + "_keyword", bitstream.getName());
                                     document.addField(SOLR_FIELD_NAME_FOR_FILENAMES + "_filter", bitstream.getName());
 

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceFileInfoPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceFileInfoPlugin.java
@@ -52,8 +52,7 @@ public class SolrServiceFileInfoPlugin implements SolrServiceIndexPlugin {
                         List<Bitstream> bitstreams = bundle.getBitstreams();
                         if (bitstreams != null) {
                             for (Bitstream bitstream : bitstreams) {
-                                if (bitstream != null)
-                                {
+                                if (bitstream != null) {
                                     document.addField(SOLR_FIELD_NAME_FOR_FILENAMES, bitstream.getName());
                                     // Add _keyword and _filter fields which are necessary to support filtering and faceting
                                     // for the file names


### PR DESCRIPTION
### Description

This essentially resolves the issue mentioned here: https://groups.google.com/g/dspace-tech/c/Zey_-scOsqc/m/CcXy13rVCgAJ . Admittedly it's a data/database issue, but until the null bitstream is found and fixed, lacking the null check will prevent the `index-discovery` from further processing other items as soon as a null bitstream is encountered.