### PR TITLE
adjust field type of index field admin

### DIFF
--- a/dspace/solr/search/conf/schema.xml
+++ b/dspace/solr/search/conf/schema.xml
@@ -254,6 +254,7 @@
     <field name="discoverable" type="string" indexed="true" stored="true" omitNorms="true" docValues="true" />
 
     <field name="read" type="string" indexed="true" stored="true" omitNorms="true" multiValued="true" docValues="true" />
+    <field name="admin" type="string" indexed="true" stored="true" omitNorms="true" multiValued="true" docValues="true" />
 
     <!-- used to track who submitted an item -->
     <field name="submitter" type="string" indexed="true" stored="true" omitNorms="true" multiValued="true" docValues="true" />


### PR DESCRIPTION
## Description

This PR is a preparatory step for the future introduction of the DisMax Query Parser (see GitHub issue https://github.com/DSpace/DSpace/issues/10494). 

The index field `admin` is currently used for exact searches based on UUIDs. Therefore, tokenization and additional indexing steps are not necessary for this index field. For this reason – as was already done for the index field `read` – the index field type is set to string.

⚠️ This change requires a full destroy & reindex – see https://github.com/DSpace/DSpace/pull/10526#issuecomment-3629405350 for details.