### PR TITLE
fix Solr query in FrontendUrlService: use `AND` instead of `and` as boolean operator

### DIFF
--- a/dspace-api/src/main/java/org/dspace/util/FrontendUrlService.java
+++ b/dspace-api/src/main/java/org/dspace/util/FrontendUrlService.java
@@ -67,7 +67,7 @@ public class FrontendUrlService {
 
     private Optional<String> generateUrlWithSearchService(Item item, String uiURLStem, Context context) {
         DiscoverQuery entityQuery = new DiscoverQuery();
-        entityQuery.setQuery("search.uniqueid:\"Item-" + item.getID() + "\" and entityType:*");
+        entityQuery.setQuery("search.uniqueid:Item-" + item.getID() + " AND entityType:*");
         entityQuery.addSearchField("entityType");
 
         try {


### PR DESCRIPTION
## Description

This PR fixes two problems in the Solr query in `FrontendUrlService::generateUrlWithSearchService`. Boolean operators should use uppercase characters (AND) only. Since index field `search.uniqueid` is of type `string`, we do not need a phrase query (no tokenization takes place).