### PR TITLE
fix Solr queries in SolrAuthority: use `OR` instead of `or` as boolean operator

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/authority/SolrAuthority.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/SolrAuthority.java
@@ -82,9 +82,9 @@ public class SolrAuthority implements ChoiceAuthority {
                 localSearchField = searchField + "_" + locale;
             }
 
-            String query = "(" + toQuery(searchField, text) + ") ";
+            String query = "(" + toQuery(searchField, text) + ")";
             if (!localSearchField.equals("")) {
-                query += " or (" + toQuery(localSearchField, text) + ")";
+                query += " OR (" + toQuery(localSearchField, text) + ")";
             }
             queryArgs.setQuery(query);
         }
@@ -200,7 +200,7 @@ public class SolrAuthority implements ChoiceAuthority {
     }
 
     private String toQuery(String searchField, String text) {
-        return searchField + ":(" + text.toLowerCase().replaceAll(":", "\\\\:") + "*) or " + searchField + ":(" + text
+        return searchField + ":(" + text.toLowerCase().replaceAll(":", "\\\\:") + "*) OR " + searchField + ":(" + text
             .toLowerCase().replaceAll(":", "\\\\:") + ")";
     }
 


### PR DESCRIPTION
## Description

This PR replaces the spelling of the boolean operator `OR` (instead of `or`) in `SolrAuthority`.