### PR TITLE
Fix ENTRYPOINT in Dockerfile and Dockerfile.test

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -71,4 +71,14 @@ ENV JAVA_OPTS=-Xmx2000m
 # enable JVM debugging via JDWP
 ENV JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8000
 # On startup, run DSpace Runnable JAR
-ENTRYPOINT ["java", "-jar", "webapps/server-boot.jar", "--dspace.dir=$DSPACE_INSTALL"]
+# Variable substitution doesn't works in ENTRYPOINT, 'tini' is used to init the java CMD
+ENV TINI_VERSION=v0.19.0
+ARG TINI_DOWNLOAD_URL=https://github.com/krallin/tini/releases/download/
+ADD ${TINI_DOWNLOAD_URL}/${TINI_VERSION}/tini /tini
+RUN wget --no-check-certificate --no-cookies --quiet ${TINI_DOWNLOAD_URL}/${TINI_VERSION}/tini-amd64 \
+    && wget --no-check-certificate --no-cookies --quiet ${TINI_DOWNLOAD_URL}/${TINI_VERSION}/tini-amd64.sha256sum \
+    && echo "$(cat tini-amd64.sha256sum)" | sha256sum -c
+RUN chmod +x /tini
+ENTRYPOINT ["/tini", "--"]
+# Will give a 'JSONArgsRecommended' warning, can be ignored because tini is handling the OS signals
+CMD java -jar webapps/server-boot.jar --dspace.dir=$DSPACE_INSTALL


### PR DESCRIPTION
## References
* Fixes #10493

## Description
Fixes Dockerfile ENTRYPOINT instruction.

## Instructions for Reviewers
List of changes in this PR:
* Changes the actual `ENTRYPOINT` instruction to run [tini](https://github.com/krallin/tini)
* Changes the previous `ENTRYPOINT` that was in [exec form](https://docs.docker.com/reference/dockerfile/#exec-form), which cannot do variable substitution for `$DSPACE_INSTALL`, to a `CMD` instruction in [shell form](https://docs.docker.com/reference/dockerfile/#shell-form).

To test:
1. Start the DB and Solr containers from the docker-compose file by running:
  ```bash
  docker compose up -d dspacedb dspacesolr
  ```
2. Build the Docker image directly from the Dockerfile:
  ```bash
  docker build -t dspace-dockerfile-fix -f Dockerfile .
  ```
  This will give a `JSONArgsRecommended` warning because of the `CMD` command. However,  this can be ignored since we are using *tini* as the actual entrypoint.

3. Run the container for the first time using a bash as the entrypoint. Without the fix in this PR this step would already fail.
  ```bash
  docker run \
  -p 8080:8080 \
  --network=dspace_dspacenet \
  -e dspace__P__dir=/dspace \
  -e dspace__P__name='DSpace Started with docker run' \
  -e db__P__url='jdbc:postgresql://dspacedb:5432/dspace' \
  -e solr__P__server=http://dspacesolr:8983/solr \
  -e proxies__P__trusted__P__ipranges='172.23.0' \
  -e LOGGING_CONFIG=/dspace/config/log4j2-container.xml \
  -it --rm dspace-dockerfile-fix \
  /bin/bash
  ```
  Now, run the command bellow inside the container to create the database tables in the `dspacedb` container:
  ```bash
  ./bin/dspace database migrate; exit;
  ```

4. Back to the host, run the container again, now to start the DSpace backend:
  ```bash
  docker run \
  -p 8080:8080 \
  --network=dspace_dspacenet \
  -e dspace__P__dir=/dspace \
  -e dspace__P__name='DSpace Started with docker run' \
  -e db__P__url='jdbc:postgresql://dspacedb:5432/dspace' \
  -e solr__P__server=http://dspacesolr:8983/solr \
  -e proxies__P__trusted__P__ipranges='172.23.0' \
  -e LOGGING_CONFIG=/dspace/config/log4j2-container.xml \
  -it --rm dspace-dockerfile-fix
  ```

5. Check that http://localhost:8080/server opens properly

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
