### PR TITLE
Replace duplicated literals with manifest constants

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
@@ -1426,11 +1426,11 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
 
         if (bundleName == null) {
             // is it license.txt?
-            if ("license.txt".equals(fileName)) {
-                newBundleName = "LICENSE";
+            if (Constants.LICENSE_BITSTREAM_NAME.equals(fileName)) {
+                newBundleName = Constants.LICENSE_BUNDLE_NAME;
             } else {
                 // call it ORIGINAL
-                newBundleName = "ORIGINAL";
+                newBundleName = Constants.CONTENT_BUNDLE_NAME;
             }
         }
 
@@ -1494,11 +1494,11 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
 
         if (StringUtils.isBlank(bundleName)) {
             // is it license.txt?
-            if (bitstreamPath.endsWith("license.txt")) {
-                newBundleName = "LICENSE";
+            if (bitstreamPath.endsWith(Constants.LICENSE_BITSTREAM_NAME)) {
+                newBundleName = Constants.LICENSE_BUNDLE_NAME;
             } else {
                 // call it ORIGINAL
-                newBundleName = "ORIGINAL";
+                newBundleName = Constants.CONTENT_BUNDLE_NAME;
             }
         }
 

--- a/dspace-api/src/main/java/org/dspace/app/itemupdate/AddBitstreamsAction.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemupdate/AddBitstreamsAction.java
@@ -27,6 +27,7 @@ import org.dspace.content.Item;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.BitstreamFormatService;
 import org.dspace.content.service.InstallItemService;
+import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.eperson.Group;
 import org.dspace.eperson.factory.EPersonServiceFactory;
@@ -138,10 +139,10 @@ public class AddBitstreamsAction extends UpdateBitstreamsAction {
         String newBundleName = ce.bundlename;
 
         if (ce.bundlename == null) { // should be required but default convention established
-            if (ce.filename.equals("license.txt")) {
-                newBundleName = "LICENSE";
+            if (ce.filename.equals(Constants.LICENSE_BITSTREAM_NAME)) {
+                newBundleName = Constants.LICENSE_BUNDLE_NAME;
             } else {
-                newBundleName = "ORIGINAL";
+                newBundleName = Constants.CONTENT_BUNDLE_NAME;
             }
         }
         ItemUpdate.pr("  Bitstream " + ce.filename + " to be added to bundle: " + newBundleName);

--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -594,7 +594,7 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
     public void removeDSpaceLicense(Context context, Item item) throws SQLException, AuthorizeException, IOException {
         // get all bundles with name "LICENSE" (these are the DSpace license
         // bundles)
-        List<Bundle> bunds = getBundles(item, "LICENSE");
+        List<Bundle> bunds = getBundles(item, Constants.LICENSE_BUNDLE_NAME);
 
         for (Bundle bund : bunds) {
             // FIXME: probably serious troubles with Authorizations

--- a/dspace-api/src/main/java/org/dspace/content/LicenseUtils.java
+++ b/dspace-api/src/main/java/org/dspace/content/LicenseUtils.java
@@ -22,6 +22,7 @@ import org.dspace.content.service.BitstreamFormatService;
 import org.dspace.content.service.BitstreamService;
 import org.dspace.content.service.CollectionService;
 import org.dspace.content.service.ItemService;
+import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
 
@@ -139,10 +140,10 @@ public class LicenseUtils {
         // Store text as a bitstream
         byte[] licenseBytes = licenseText.getBytes("UTF-8");
         ByteArrayInputStream bais = new ByteArrayInputStream(licenseBytes);
-        Bitstream b = itemService.createSingleBitstream(context, bais, item, "LICENSE");
+        Bitstream b = itemService.createSingleBitstream(context, bais, item, Constants.LICENSE_BUNDLE_NAME);
 
         // Now set the format and name of the bitstream
-        b.setName(context, "license.txt");
+        b.setName(context, Constants.LICENSE_BITSTREAM_NAME);
         b.setSource(context, "Written by org.dspace.content.LicenseUtils");
 
         DCDate acceptanceDCDate = DCDate.getCurrent();

--- a/dspace-api/src/main/java/org/dspace/contentreport/Filter.java
+++ b/dspace-api/src/main/java/org/dspace/contentreport/Filter.java
@@ -26,6 +26,7 @@ import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.content.Bundle;
 import org.dspace.content.Item;
 import org.dspace.contentreport.ItemFilterUtil.BundleName;
+import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.services.factory.DSpaceServicesFactory;
 
@@ -268,7 +269,7 @@ public enum Filter {
     HAS_LICENSE_DOCUMENTATION(FilterCategory.BUNDLE, (context, item) -> {
         List<String> names = ItemFilterUtil.getBitstreamNames(BundleName.LICENSE, item);
         return names.stream()
-                .anyMatch(name -> !name.equals("license.txt"));
+                .anyMatch(name -> !name.equals(Constants.LICENSE_BITSTREAM_NAME));
     }),
 
     /**

--- a/dspace-api/src/test/java/org/dspace/content/ItemTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/ItemTest.java
@@ -1095,7 +1095,7 @@ public class ItemTest extends AbstractDSpaceObjectTest {
     public void testRemoveDSpaceLicenseAuth() throws Exception {
         // First create a bundle for test
         context.turnOffAuthorisationSystem();
-        String name = "LICENSE";
+        String name = Constants.LICENSE_BUNDLE_NAME;
         Bundle created = bundleService.create(context, it, name);
         created.setName(context, name);
         context.restoreAuthSystemState();
@@ -1117,7 +1117,7 @@ public class ItemTest extends AbstractDSpaceObjectTest {
     public void testRemoveDSpaceLicenseNoAuth() throws Exception {
         // First create a bundle for test
         context.turnOffAuthorisationSystem();
-        String name = "LICENSE";
+        String name = Constants.LICENSE_BUNDLE_NAME;
         Bundle created = bundleService.create(context, it, name);
         created.setName(context, name);
         context.restoreAuthSystemState();
@@ -1133,7 +1133,7 @@ public class ItemTest extends AbstractDSpaceObjectTest {
     public void testRemoveLicensesAuth() throws Exception {
         // First create test content
         context.turnOffAuthorisationSystem();
-        String name = "LICENSE";
+        String name = Constants.LICENSE_BUNDLE_NAME;
         Bundle created = bundleService.create(context, it, name);
         created.setName(context, name);
 
@@ -1167,7 +1167,7 @@ public class ItemTest extends AbstractDSpaceObjectTest {
     public void testRemoveLicensesNoAuth() throws Exception {
         // First create test content
         context.turnOffAuthorisationSystem();
-        String name = "LICENSE";
+        String name = Constants.LICENSE_BUNDLE_NAME;
         Bundle created = bundleService.create(context, it, name);
         created.setName(context, name);
 
@@ -1376,7 +1376,7 @@ public class ItemTest extends AbstractDSpaceObjectTest {
     public void testReplaceAllBitstreamPolicies() throws Exception {
         context.turnOffAuthorisationSystem();
         //we add some bundles for the test
-        String name = "LICENSE";
+        String name = Constants.LICENSE_BUNDLE_NAME;
         Bundle created = bundleService.create(context, it, name);
         created.setName(context, name);
 
@@ -1451,7 +1451,7 @@ public class ItemTest extends AbstractDSpaceObjectTest {
         }
 
         //we add some bundles for the test
-        String name = "LICENSE";
+        String name = Constants.LICENSE_BUNDLE_NAME;
         Bundle created = bundleService.create(context, it, name);
         created.setName(context, name);
 

--- a/dspace-api/src/test/java/org/dspace/content/LicenseUtilsTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/LicenseUtilsTest.java
@@ -31,6 +31,7 @@ import org.dspace.content.service.CommunityService;
 import org.dspace.content.service.InstallItemService;
 import org.dspace.content.service.ItemService;
 import org.dspace.content.service.WorkspaceItemService;
+import org.dspace.core.Constants;
 import org.dspace.core.factory.CoreServiceFactory;
 import org.dspace.core.service.LicenseService;
 import org.dspace.eperson.EPerson;
@@ -259,7 +260,8 @@ public class LicenseUtilsTest extends AbstractUnitTest {
 
         StringWriter writer = new StringWriter();
         IOUtils.copy(
-            bitstreamService.retrieve(context, itemService.getBundles(item, "LICENSE").get(0).getBitstreams().get(0)),
+            bitstreamService.retrieve(context,
+                    itemService.getBundles(item, Constants.LICENSE_BUNDLE_NAME).get(0).getBitstreams().get(0)),
             writer, StandardCharsets.UTF_8);
         String license = writer.toString();
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestRepositoryIT.java
@@ -2167,7 +2167,7 @@ public class BitstreamRestRepositoryIT extends AbstractControllerIntegrationTest
                                       .build();
 
         Bundle license = BundleBuilder.createBundle(context, publicItem1)
-                                      .withName("LICENSE")
+                                      .withName(Constants.LICENSE_BUNDLE_NAME)
                                       .build();
 
         String bitstreamContent = "This is an archived bitstream";
@@ -2221,7 +2221,7 @@ public class BitstreamRestRepositoryIT extends AbstractControllerIntegrationTest
                                       .build();
 
         Bundle license = BundleBuilder.createBundle(context, publicItem1)
-                                      .withName("LICENSE")
+                                      .withName(Constants.LICENSE_BUNDLE_NAME)
                                       .build();
 
         String bitstreamContent = "This is an archived bitstream";
@@ -2267,7 +2267,7 @@ public class BitstreamRestRepositoryIT extends AbstractControllerIntegrationTest
                                       .build();
 
         Bundle license = BundleBuilder.createBundle(context, publicItem1)
-                                      .withName("LICENSE")
+                                      .withName(Constants.LICENSE_BUNDLE_NAME)
                                       .build();
 
         String bitstreamContent = "This is an archived bitstream";
@@ -2332,7 +2332,7 @@ public class BitstreamRestRepositoryIT extends AbstractControllerIntegrationTest
                                       .build();
 
         Bundle license = BundleBuilder.createBundle(context, publicItem1)
-                                      .withName("LICENSE")
+                                      .withName(Constants.LICENSE_BUNDLE_NAME)
                                       .build();
 
         String bitstreamContent = "This is an archived bitstream";
@@ -2372,7 +2372,7 @@ public class BitstreamRestRepositoryIT extends AbstractControllerIntegrationTest
                                       .build();
 
         Bundle license = BundleBuilder.createBundle(context, publicItem1)
-                                      .withName("LICENSE")
+                                      .withName(Constants.LICENSE_BUNDLE_NAME)
                                       .build();
 
         String bitstreamContent = "This is an archived bitstream";

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/signposting/controller/LinksetRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/signposting/controller/LinksetRestControllerIT.java
@@ -358,7 +358,7 @@ public class LinksetRestControllerIT extends AbstractControllerIntegrationTest {
         }
 
         try (InputStream is = IOUtils.toInputStream("test", CharEncoding.UTF_8)) {
-            Bitstream bitstream4 = BitstreamBuilder.createBitstream(context, item, is, "LICENSE")
+            Bitstream bitstream4 = BitstreamBuilder.createBitstream(context, item, is, Constants.LICENSE_BUNDLE_NAME)
                     .withName("Bitstream 4")
                     .withDescription("description")
                     .withMimeType("application/pdf")


### PR DESCRIPTION
## Description
I noted numerous duplicated literal strings for the license file and its bundle, when we have definitions of these fixed strings in Constants.  Use the manifest constants instead.

## Instructions for Reviewers
List of changes in this PR:
* Numerous instances of `"license.txt"` and `"LICENSE"` are replaced with references to `Constants.LICENSE_BITSTREAM_NAME` and `Constants.LICENSE_BUNDLE_NAME`.

Testing:  check that the correct names are used in submission, updating.

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
