### PR TITLE
restrict maximum value of URL parameter `rpp` in OpenSearchController to a reasonable default

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/OpenSearchServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/OpenSearchServiceImpl.java
@@ -100,6 +100,14 @@ public class OpenSearchServiceImpl implements OpenSearchService {
             configurationService.getProperty("websvc.opensearch.uicontext");
     }
 
+    /**
+     * Get base search UI URL (websvc.opensearch.max_num_of_items_per_request)
+     */
+    public int getMaxNumOfItemsPerRequest() {
+        return configurationService.getIntProperty(
+                "websvc.opensearch.max_num_of_items_per_request", 100);
+    }
+
     @Override
     public String getContentType(String format) {
         return "html".equals(format) ? "text/html" :

--- a/dspace-api/src/main/java/org/dspace/app/util/service/OpenSearchService.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/service/OpenSearchService.java
@@ -112,4 +112,10 @@ public interface OpenSearchService {
 
     public DSpaceObject resolveScope(Context context, String scope) throws SQLException;
 
+    /**
+     * Retrieves the maximum number of items that can be included in a single opensearch request.
+     *
+     * @return the maximum number of items allowed per request
+     */
+    int getMaxNumOfItemsPerRequest();
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/OpenSearchController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/OpenSearchController.java
@@ -30,11 +30,6 @@ import org.dspace.app.rest.utils.RestDiscoverQueryBuilder;
 import org.dspace.app.rest.utils.ScopeResolver;
 import org.dspace.app.util.factory.UtilServiceFactory;
 import org.dspace.app.util.service.OpenSearchService;
-import org.dspace.authorize.factory.AuthorizeServiceFactory;
-import org.dspace.authorize.service.AuthorizeService;
-import org.dspace.content.factory.ContentServiceFactory;
-import org.dspace.content.service.CollectionService;
-import org.dspace.content.service.CommunityService;
 import org.dspace.core.Context;
 import org.dspace.core.LogHelper;
 import org.dspace.core.Utils;
@@ -56,7 +51,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -73,12 +67,9 @@ import org.w3c.dom.Document;
 public class OpenSearchController {
 
     private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
-    private static final String errorpath = "/error";
+
     private List<String> searchIndices = null;
 
-    private CommunityService communityService;
-    private CollectionService collectionService;
-    private AuthorizeService authorizeService;
     private OpenSearchService openSearchService;
 
     @Autowired
@@ -110,23 +101,27 @@ public class OpenSearchController {
                        @RequestParam(name = "sort_direction", required = false) String sortDirection,
                        @RequestParam(name = "scope", required = false) String dsoObject,
                        @RequestParam(name = "configuration", required = false) String configuration,
-                       List<SearchFilter> searchFilters,
-                       Model model) throws IOException, ServletException {
+                       List<SearchFilter> searchFilters) throws IOException, ServletException {
         context = ContextUtil.obtainContext(request);
 
-        if (start == null) {
-            start = 0;
-        }
-        if (count == null) {
-            count = -1;
-        }
         if (openSearchService == null) {
             openSearchService = UtilServiceFactory.getInstance().getOpenSearchService();
         }
+
         if (openSearchService.isEnabled()) {
             init();
+
+            if (start == null) {
+                start = 0;
+            }
+
+            if (count == null) {
+                count = -1;
+            }
+            count = Math.min(count, openSearchService.getMaxNumOfItemsPerRequest()));
+
             // get enough request parameters to decide on action to take
-            if (format == null || "".equals(format)) {
+            if (StringUtils.isEmpty(format)) {
                 // default to atom
                 format = "atom";
             }
@@ -297,9 +292,6 @@ public class OpenSearchController {
                 searchIndices.add(sFilter.getIndexFieldName());
             }
         }
-        communityService = ContentServiceFactory.getInstance().getCommunityService();
-        collectionService = ContentServiceFactory.getInstance().getCollectionService();
-        authorizeService = AuthorizeServiceFactory.getInstance().getAuthorizeService();
     }
 
     public void setOpenSearchService(OpenSearchService oSS) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/OpenSearchController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/OpenSearchController.java
@@ -118,7 +118,7 @@ public class OpenSearchController {
             if (count == null) {
                 count = -1;
             }
-            count = Math.min(count, openSearchService.getMaxNumOfItemsPerRequest()));
+            count = Math.min(count, openSearchService.getMaxNumOfItemsPerRequest());
 
             // get enough request parameters to decide on action to take
             if (StringUtils.isEmpty(format)) {

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1401,7 +1401,8 @@ websvc.opensearch.tags = IR DSpace
 # result formats offered - use 1 or more comma-separated from: html,atom,rss
 # html uses the normal search module
 websvc.opensearch.formats = html,atom,rss
-
+# maximum number of item per request
+websvc.opensearch.max_num_of_items_per_request = 100
 
 #### Content Inline Disposition Threshold ####
 #


### PR DESCRIPTION
## Description

This PR restricts the maximum value of URL parameter `rpp`.

Currently, the `rpp` parameter in `OpenSearchController::search` allows arbitrarily large values. This allows "easy harvesting" of all archived items in the repository. Additionally, large values of `rpp` can create high load on the backend. Therefore, the maximum value should be restricted to a reasonable default. The default maximum value of 100 is configurable via configuration key `websvc.opensearch.max_num_of_items_per_request` in `dspace.cfg`.

Fixes #7840