### PR TITLE
improve robustness of search in index field submit (use filter query)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/EntityTypeServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/EntityTypeServiceImpl.java
@@ -30,6 +30,7 @@ import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.discovery.SolrSearchCore;
 import org.dspace.discovery.indexobject.IndexableCollection;
+import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
 import org.dspace.eperson.service.GroupService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -124,24 +125,33 @@ public class EntityTypeServiceImpl implements EntityTypeService {
     public List<String> getSubmitAuthorizedTypes(Context context)
             throws SQLException, SolrServerException, IOException {
         List<String> types = new ArrayList<>();
-        StringBuilder query = new StringBuilder();
-        org.dspace.eperson.EPerson currentUser = context.getCurrentUser();
+        StringBuilder query = null;
+        EPerson currentUser = context.getCurrentUser();
         if (!authorizeService.isAdmin(context)) {
             String userId = "";
             if (currentUser != null) {
                 userId = currentUser.getID().toString();
+                query = new StringBuilder();
+                query.append("submit:(e").append(userId);    
             }
-            query.append("submit:(e").append(userId);
+            
             Set<Group> groups = groupService.allMemberGroupsSet(context, currentUser);
             for (Group group : groups) {
-                query.append(" OR g").append(group.getID());
+                if (query == null) {
+                    query = new StringBuilder();
+                    query.append("submit:(g");
+                } else {                                        
+                    query.append(" OR g");
+                }
+                query.append(group.getID());
             }
             query.append(")");
-        } else {
-            query.append("*:*");
         }
-
-        SolrQuery sQuery = new SolrQuery(query.toString());
+        
+        SolrQuery sQuery = new SolrQuery("*:*");
+        if (query != null) {
+            sQuery.addFilterQuery(query.toString());
+        }                
         sQuery.addFilterQuery("search.resourcetype:" + IndexableCollection.TYPE);
         sQuery.setRows(0);
         sQuery.addFacetField("search.entitytype");

--- a/dspace-api/src/main/java/org/dspace/content/EntityTypeServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/EntityTypeServiceImpl.java
@@ -132,26 +132,26 @@ public class EntityTypeServiceImpl implements EntityTypeService {
             if (currentUser != null) {
                 userId = currentUser.getID().toString();
                 query = new StringBuilder();
-                query.append("submit:(e").append(userId);    
+                query.append("submit:(e").append(userId);
             }
-            
+
             Set<Group> groups = groupService.allMemberGroupsSet(context, currentUser);
             for (Group group : groups) {
                 if (query == null) {
                     query = new StringBuilder();
                     query.append("submit:(g");
-                } else {                                        
+                } else {                
                     query.append(" OR g");
                 }
                 query.append(group.getID());
             }
             query.append(")");
         }
-        
+
         SolrQuery sQuery = new SolrQuery("*:*");
         if (query != null) {
             sQuery.addFilterQuery(query.toString());
-        }                
+        }
         sQuery.addFilterQuery("search.resourcetype:" + IndexableCollection.TYPE);
         sQuery.setRows(0);
         sQuery.addFacetField("search.entitytype");

--- a/dspace-api/src/main/java/org/dspace/content/EntityTypeServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/EntityTypeServiceImpl.java
@@ -140,7 +140,7 @@ public class EntityTypeServiceImpl implements EntityTypeService {
                 if (query == null) {
                     query = new StringBuilder();
                     query.append("submit:(g");
-                } else {                
+                } else {
                     query.append(" OR g");
                 }
                 query.append(group.getID());


### PR DESCRIPTION
## Description

This is a preparatory PR for issue https://github.com/DSpace/DSpace/issues/10494.

This PR enhances the robustness of search in the `submit` index field.

Additionally, the query type is changed to a **filter query** which improves caching (Solr's `filterCache` is a dedicated filter query cache).