### PR TITLE
Optimization of Solr Queries: Transition to Filter Queries

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/sitemap/GenerateSitemaps.java
+++ b/dspace-api/src/main/java/org/dspace/app/sitemap/GenerateSitemaps.java
@@ -37,6 +37,8 @@ import org.dspace.discovery.SearchUtils;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 
+import static org.dspace.discovery.SearchUtils.RESOURCE_TYPE_FIELD;
+
 /**
  * Command-line utility for generating HTML and Sitemaps.org protocol Sitemaps.
  *
@@ -188,7 +190,8 @@ public class GenerateSitemaps {
         try {
             DiscoverQuery discoveryQuery = new DiscoverQuery();
             discoveryQuery.setMaxResults(PAGE_SIZE);
-            discoveryQuery.setQuery("search.resourcetype:Community");
+            discoveryQuery.setQuery("*:*");
+            discoveryQuery.addFilterQueries(RESOURCE_TYPE_FIELD + ":Community");
             do {
                 discoveryQuery.setStart(offset);
                 DiscoverResult discoverResult = searchService.search(c, discoveryQuery);
@@ -212,7 +215,8 @@ public class GenerateSitemaps {
             offset = 0;
             discoveryQuery = new DiscoverQuery();
             discoveryQuery.setMaxResults(PAGE_SIZE);
-            discoveryQuery.setQuery("search.resourcetype:Collection");
+            discoveryQuery.setQuery("*:*");
+            discoveryQuery.addFilterQueries(RESOURCE_TYPE_FIELD + ":Collection");
             do {
                 discoveryQuery.setStart(offset);
                 DiscoverResult discoverResult = searchService.search(c, discoveryQuery);
@@ -236,7 +240,8 @@ public class GenerateSitemaps {
             offset = 0;
             discoveryQuery = new DiscoverQuery();
             discoveryQuery.setMaxResults(PAGE_SIZE);
-            discoveryQuery.setQuery("search.resourcetype:Item");
+            discoveryQuery.setQuery("*:*");
+            discoveryQuery.addFilterQueries(RESOURCE_TYPE_FIELD + ":Item");
             discoveryQuery.addSearchField("search.entitytype");
             do {
 

--- a/dspace-api/src/main/java/org/dspace/app/sitemap/GenerateSitemaps.java
+++ b/dspace-api/src/main/java/org/dspace/app/sitemap/GenerateSitemaps.java
@@ -7,6 +7,8 @@
  */
 package org.dspace.app.sitemap;
 
+import static org.dspace.discovery.SearchUtils.RESOURCE_TYPE_FIELD;
+
 import java.io.File;
 import java.io.IOException;
 import java.sql.SQLException;
@@ -36,8 +38,6 @@ import org.dspace.discovery.SearchServiceException;
 import org.dspace.discovery.SearchUtils;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
-
-import static org.dspace.discovery.SearchUtils.RESOURCE_TYPE_FIELD;
 
 /**
  * Command-line utility for generating HTML and Sitemaps.org protocol Sitemaps.

--- a/dspace-api/src/main/java/org/dspace/app/solrdatabaseresync/SolrDatabaseResyncCli.java
+++ b/dspace-api/src/main/java/org/dspace/app/solrdatabaseresync/SolrDatabaseResyncCli.java
@@ -99,7 +99,8 @@ public class SolrDatabaseResyncCli extends DSpaceRunnable<SolrDatabaseResyncCliS
 
     private void performStatusUpdate(Context context) throws SearchServiceException, SolrServerException, IOException {
         SolrQuery solrQuery = new SolrQuery();
-        solrQuery.setQuery(STATUS_FIELD + ":" + STATUS_FIELD_PREDB);
+        solrQuery.setQuery("*:*");
+        solrQuery.addFilterQuery(STATUS_FIELD + ":" + STATUS_FIELD_PREDB);
         solrQuery.addFilterQuery(SearchUtils.RESOURCE_TYPE_FIELD + ":" + IndexableItem.TYPE);
         String dateRangeFilter = SearchUtils.LAST_INDEXED_FIELD + ":[* TO " + maxTime + "]";
         logDebugAndOut("Date range filter used; " + dateRangeFilter);

--- a/dspace-api/src/main/java/org/dspace/browse/SolrBrowseDAO.java
+++ b/dspace-api/src/main/java/org/dspace/browse/SolrBrowseDAO.java
@@ -38,6 +38,9 @@ import org.dspace.discovery.configuration.DiscoveryConfigurationParameters;
 import org.dspace.discovery.indexobject.IndexableItem;
 import org.dspace.services.factory.DSpaceServicesFactory;
 
+import static org.dspace.discovery.SearchUtils.RESOURCE_ID_FIELD;
+import static org.dspace.discovery.SearchUtils.RESOURCE_TYPE_FIELD;
+
 /**
  * @author Andrea Bollini (CILEA)
  * @author Adán Román Ruiz at arvo.es (bugfix)

--- a/dspace-api/src/main/java/org/dspace/browse/SolrBrowseDAO.java
+++ b/dspace-api/src/main/java/org/dspace/browse/SolrBrowseDAO.java
@@ -325,8 +325,10 @@ public class SolrBrowseDAO implements BrowseDAO {
     public String doMaxQuery(String column, String table, int itemID)
         throws BrowseException {
         DiscoverQuery query = new DiscoverQuery();
-        query.setQuery("search.resourceid:" + itemID
-                           + " AND search.resourcetype:" + IndexableItem.TYPE);
+        query.setQuery("*:*");
+        query.addFilterQueries(
+                RESOURCE_ID_FIELD + ":" + itemID,
+                RESOURCE_TYPE_FIELD + ":" + IndexableItem.TYPE);
         query.setMaxResults(1);
         DiscoverResult resp = null;
         try {

--- a/dspace-api/src/main/java/org/dspace/browse/SolrBrowseDAO.java
+++ b/dspace-api/src/main/java/org/dspace/browse/SolrBrowseDAO.java
@@ -7,6 +7,9 @@
  */
 package org.dspace.browse;
 
+import static org.dspace.discovery.SearchUtils.RESOURCE_ID_FIELD;
+import static org.dspace.discovery.SearchUtils.RESOURCE_TYPE_FIELD;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -37,9 +40,6 @@ import org.dspace.discovery.configuration.DiscoveryConfiguration;
 import org.dspace.discovery.configuration.DiscoveryConfigurationParameters;
 import org.dspace.discovery.indexobject.IndexableItem;
 import org.dspace.services.factory.DSpaceServicesFactory;
-
-import static org.dspace.discovery.SearchUtils.RESOURCE_ID_FIELD;
-import static org.dspace.discovery.SearchUtils.RESOURCE_TYPE_FIELD;
 
 /**
  * @author Andrea Bollini (CILEA)

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrSearchCore.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrSearchCore.java
@@ -88,9 +88,11 @@ public class SolrSearchCore {
                     solrServer.setBaseURL(solrService);
                     solrServer.setUseMultiPartPost(true);
                     // Dummy/test query to search for Item (type=2) of ID=1
-                    SolrQuery solrQuery = new SolrQuery()
-                        .setQuery(SearchUtils.RESOURCE_TYPE_FIELD + ":" + IndexableItem.TYPE +
-                                " AND " + SearchUtils.RESOURCE_ID_FIELD + ":1");
+                    SolrQuery solrQuery = new SolrQuery();
+                    solrQuery.setQuery("*:*");
+                    solrQuery.addFilterQuery(
+                            SearchUtils.RESOURCE_TYPE_FIELD + ":" + IndexableItem.TYPE,
+                            SearchUtils.RESOURCE_ID_FIELD + ":1");
                     // Only return obj identifier fields in result doc
                     solrQuery.setFields(SearchUtils.RESOURCE_TYPE_FIELD, SearchUtils.RESOURCE_ID_FIELD);
                     solrServer.query(solrQuery, REQUEST_METHOD);

--- a/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java
@@ -1034,7 +1034,6 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
             return null;
         }
 
-        // System.out.println("QUERY");
         SolrQuery solrQuery = new SolrQuery().setRows(rows).setQuery(query)
                                              .setFacetMinCount(facetMinCount);
         addAdditionalSolrYearCores(solrQuery);


### PR DESCRIPTION
## Description

This PR improves Solr query handling by replacing regular queries (`setQuery()`) with filter queries (`addFilterQueries()`).

Solr stores filter query results in a dedicated cache, improving efficiency for subsequent search requests.

Additionally, unlike "regular" queries, filter queries are not processed by the edismax query parser, preventing unintended interpretation and weighting.

This PR is related to https://github.com/DSpace/DSpace/issues/10494. Please note, that this PR is still compatible with the current search implementation in DSpace which is based on Solr's Standard Query Handler.
