### PR TITLE
Fix sort order in AbstractHibernateDAO findByX

### DIFF
--- a/dspace-api/src/main/java/org/dspace/core/AbstractHibernateDAO.java
+++ b/dspace-api/src/main/java/org/dspace/core/AbstractHibernateDAO.java
@@ -468,6 +468,9 @@ public abstract class AbstractHibernateDAO<T> implements GenericDAO<T> {
         for (Map.Entry<String, Object> entry : equals.entrySet()) {
             criteria.where(criteriaBuilder.equal(root.get(entry.getKey()), entry.getValue()));
         }
+
+        criteria.orderBy(criteriaBuilder.asc(root.get("id")));
+
         return executeCriteriaQuery(context, criteria, cacheable, maxResults, offset);
     }
 

--- a/dspace-api/src/test/java/org/dspace/content/BitstreamTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/BitstreamTest.java
@@ -12,6 +12,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -25,6 +26,9 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
 
@@ -146,6 +150,44 @@ public class BitstreamTest extends AbstractDSpaceObjectTest {
             }
         }
         assertTrue("testFindAll 2", added);
+    }
+
+    @Test
+    public void testFindAllBatches() throws Exception {
+        //Adding some data for processing and cleaning this up at the end
+        context.turnOffAuthorisationSystem();
+        File f = new File(testProps.get("test.bitstream").toString());
+        List<Bitstream> inserted = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            Bitstream bs = bitstreamService.create(context, new FileInputStream(f));
+            inserted.add(bs);
+        }
+        context.restoreAuthSystemState();
+
+        // sorted list of all bitstreams
+        List<Bitstream> all = bitstreamService.findAll(context);
+        List<Bitstream> expected = new ArrayList<>(all);
+        expected.sort(Comparator.comparing(bs -> bs.getID().toString()));
+
+        int total = bitstreamService.countTotal(context);
+        int batchSize = 2;
+        int numberOfBatches = (int) Math.ceil((double) total / batchSize);
+
+        //collect in batches
+        List<Bitstream> collected = new ArrayList<>();
+        for (int i = 0; i < numberOfBatches; i++) {
+            Iterator<Bitstream> it = bitstreamService.findAll(context, batchSize, i * batchSize);
+            it.forEachRemaining(collected::add);
+        }
+
+        assertEquals("Batched results should match sorted findAll", expected, collected);
+
+        // Cleanup
+        context.turnOffAuthorisationSystem();
+        for (Bitstream b : inserted) {
+            bitstreamService.delete(context, b);
+        }
+        context.restoreAuthSystemState();
     }
 
     /**


### PR DESCRIPTION
## References
* Fixes #8390 

## Description
Added a sortby to `AbstractHibernateDAO#findByX`

## Instructions for Reviewers

List of changes in this PR:
* Sort clause in `AbstractHibernateDAO#findByX`
* Extra test case in `BitstreamTest`

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
