### PR TITLE
Fix tests failing in TikaTextExtractionFilterTest

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/TikaTextExtractionFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/TikaTextExtractionFilter.java
@@ -141,7 +141,7 @@ public class TikaTextExtractionFilter
                 @Override
                 public void characters(char[] ch, int start, int length) throws SAXException {
                     try {
-                        writer.append(new String(ch), start, length);
+                        writer.append(new String(ch, start, length));
                     } catch (IOException e) {
                         String errorMsg = String.format("Could not append to temporary file at %s " +
                                                             "when performing text extraction",
@@ -159,7 +159,7 @@ public class TikaTextExtractionFilter
                 @Override
                 public void ignorableWhitespace(char[] ch, int start, int length) throws SAXException {
                     try {
-                        writer.append(new String(ch), start, length);
+                        writer.append(new String(ch, start, length));
                     } catch (IOException e) {
                         String errorMsg = String.format("Could not append to temporary file at %s " +
                                                             "when performing text extraction",


### PR DESCRIPTION
## References
* Fixes #8588 

## Description
Tests were failing when enabling a config setting. This was because of a typo in `TikaExtractionFilter`

## Instructions for Reviewers

List of changes in this PR:
* `writer.append` had parentheses in the wrong place.

Changes can be tested by setting `textextractor.use-temp-file = true` in `dspace.cfg` and running the `TikaTextExtractionFilterTest`

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
