### PR TITLE
Request-a-copy Captcha implementation bugfixes

### DIFF
--- a/dspace-api/src/main/java/org/dspace/eperson/factory/CaptchaServiceFactory.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/factory/CaptchaServiceFactory.java
@@ -10,12 +10,45 @@ package org.dspace.eperson.factory;
 import org.dspace.eperson.service.CaptchaService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 
+/**
+ * Factory to get services for Captcha protection of DSpace forms / endpoints
+ *
+ * @author Kim Shepherd
+ */
 public abstract class CaptchaServiceFactory {
 
-    public abstract CaptchaService getCaptchaService();
-
+    /**
+     * Get the singleton instance of this class
+     * @return singleton instance of this class
+     */
     public static CaptchaServiceFactory getInstance() {
         return DSpaceServicesFactory.getInstance().getServiceManager()
-                                    .getServiceByName("captchaServiceFactory", CaptchaServiceFactory.class);
+                .getServiceByName("captchaServiceFactory", CaptchaServiceFactory.class);
     }
+
+    /**
+     * Get the configured CaptchService
+     * TODO: This will be fully "operational" once we have full coverage of all
+     *       forms by all supported captcha providers. Until then, REST repositories
+     *       should request the specific captcha service required.
+     * @return the configured CaptchaService
+     */
+    public abstract CaptchaService getCaptchaService();
+
+
+    /**
+     * Get the configured Altcha CaptchaService. This is needed by REST repositories
+     * processing captcha payloads for forms that are *only* protected by Altcha.
+     * TODO: We are working towards full coverage of all forms by all providers
+     * @return the configured Altcha CaptchaService
+     */
+    public abstract CaptchaService getAltchaCaptchaService();
+
+    /**
+     * Get the configured Google CaptchaService. This is needed by REST repositories
+     * processing captcha payloads for forms that are *only* protected by Google.
+     * TODO: We are working towards full coverage of all forms by all providers
+     * @return the configured Google CaptchaService
+     */
+    public abstract CaptchaService getGoogleCaptchaService();
 }

--- a/dspace-api/src/main/java/org/dspace/eperson/factory/CaptchaServiceFactoryImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/factory/CaptchaServiceFactoryImpl.java
@@ -12,6 +12,11 @@ import org.dspace.services.ConfigurationService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 
+/**
+ * Factory to get services for Captcha protection of DSpace forms / endpoints
+ *
+ * @author Kim Shepherd
+ */
 public class CaptchaServiceFactoryImpl extends CaptchaServiceFactory {
 
     @Autowired
@@ -25,14 +30,43 @@ public class CaptchaServiceFactoryImpl extends CaptchaServiceFactory {
     @Autowired
     private ConfigurationService configurationService;
 
+    /**
+     * Get the configured CaptchService
+     * TODO: This will be fully "operational" once we have full coverage of all
+     *       forms by all supported captcha providers. Until then, REST repositories
+     *       should request the specific captcha service required.
+     * @return the configured CaptchaService
+     */
     @Override
     public CaptchaService getCaptchaService() {
-        String provider = configurationService.getProperty("captcha.provider");
+        String provider = configurationService.getProperty("captcha.provider", "google");
 
         if ("altcha".equalsIgnoreCase(provider)) {
             return altchaCaptchaService;
         }
 
         return googleCaptchaService; // default to Google ReCaptcha
+    }
+
+    /**
+     * Get the configured Altcha CaptchaService. This is needed by REST repositories
+     * processing captcha payloads for forms that are *only* protected by Altcha.
+     * TODO: We are working towards full coverage of all forms by all providers
+     * @return the configured Altcha CaptchaService
+     */
+    @Override
+    public CaptchaService getAltchaCaptchaService() {
+        return altchaCaptchaService;
+    }
+
+    /**
+     * Get the configured Google CaptchaService. This is needed by REST repositories
+     * processing captcha payloads for forms that are *only* protected by Google.
+     * TODO: We are working towards full coverage of all forms by all providers
+     * @return the configured Google CaptchaService
+     */
+    @Override
+    public CaptchaService getGoogleCaptchaService() {
+        return googleCaptchaService;
     }
 }

--- a/dspace-api/src/test/java/org/dspace/eperson/AltchaCaptchaServiceTest.java
+++ b/dspace-api/src/test/java/org/dspace/eperson/AltchaCaptchaServiceTest.java
@@ -40,7 +40,7 @@ public class AltchaCaptchaServiceTest extends AbstractUnitTest {
     public void setUp() {
         configurationService.setProperty("captcha.provider", "altcha");
         configurationService.setProperty("altcha.hmac.key", "onetwothreesecret");
-        captchaService = CaptchaServiceFactory.getInstance().getCaptchaService();
+        captchaService = CaptchaServiceFactory.getInstance().getAltchaCaptchaService();
     }
 
     @Test

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/AltchaCaptchaRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/AltchaCaptchaRestController.java
@@ -71,11 +71,7 @@ public class AltchaCaptchaRestController implements InitializingBean {
     @GetMapping("/challenge")
     @PreAuthorize("permitAll()")
     public ResponseEntity getAltchaChallenge(HttpServletRequest request, HttpServletResponse response) {
-        // Check if captcha provider is set to altcha
-        if (!configurationService.getProperty("captcha.provider", "google").equals("altcha")) {
-            log.error("altcha is not enabled");
-            return ControllerUtils.toEmptyResponse(HttpStatus.BAD_REQUEST);
-        }
+
         // Set algorithm and hmac key
         // Algorithm
         String algorithm = configurationService.getProperty("altcha.algorithm", "SHA-256");

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RegistrationRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RegistrationRestRepository.java
@@ -78,7 +78,8 @@ public class RegistrationRestRepository extends DSpaceRestRepository<Registratio
     @Autowired
     private RequestService requestService;
 
-    private CaptchaService captchaService = CaptchaServiceFactory.getInstance().getCaptchaService();
+    // TODO: Work towards full coverage of captcha, so we can use getCaptchaService() here instead
+    private CaptchaService captchaService = CaptchaServiceFactory.getInstance().getGoogleCaptchaService();
 
     @Autowired
     private ConfigurationService configurationService;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RequestItemRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RequestItemRepository.java
@@ -87,7 +87,8 @@ public class RequestItemRepository
     @Autowired
     protected AuthorizeService authorizeService;
 
-    private CaptchaService captchaService = CaptchaServiceFactory.getInstance().getCaptchaService();
+    // TODO: Work towards full coverage of captcha, so we can use getCaptchaService() instead
+    private CaptchaService captchaService = CaptchaServiceFactory.getInstance().getAltchaCaptchaService();
 
     private static final Logger log = LogManager.getLogger();
 

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1597,9 +1597,6 @@ solr-database-resync.cron = 0 15 2 * * ?
 # (see modules/requestitem.cfg to enable CAPTCHA verification for request-a-copy)
 registration.verification.enabled = false
 
-# Captcha provider to use, either google (default) or altcha (see modules/altcha.cfg)
-# captcha.provider = google
-
 # version we want to use, possible values (v2 or v3)
 #google.recaptcha.version =
 

--- a/dspace/config/modules/altcha.cfg
+++ b/dspace/config/modules/altcha.cfg
@@ -1,7 +1,5 @@
 ##
-# Configuration of altcha captcha service.
-# To enable this service, make sure AltchaCaptchaServiceImpl is declared as a bean in core-services.xml instead
-# of CaptchaServiceImpl (Google ReCaptcha, the default service)
+# Configuration of ALTCHA captcha service.
 ##
 
 # Algorithm to use. Currently, this must be SHA-256 but configurable here to allow for future work.

--- a/dspace/config/modules/requestitem.cfg
+++ b/dspace/config/modules/requestitem.cfg
@@ -23,10 +23,10 @@ request.item.reject.email = true
 request.item.grant.bundles = ORIGINAL
 #request.item.grant.bundles = PRESERVATION
 
-## By default a granted request will send the file as an attachment.
+# Prior to DSpace 9.0, all granted requests would send the file as an attachment.
 # If a secure web link to the bitstream(s) should be sent when files are over a certain file
 # size threshold, enable the following property
-# Default: false
+# Default: true
 request.item.grant.link = true
 
 # If request.item.grant.link is enabled, you can specify a minimum file size (in megabytes) to use as
@@ -64,4 +64,4 @@ request.item.grant.link.dateformat = yyyy-MM-dd
 # Require a captcha for item request creation
 # Note, this requires altcha.cfg to be configured with a valid HMAC key
 # Default: false
-#request.item.create.captcha=true
+#request.item.create.captcha=false

--- a/dspace/config/modules/requestitem.cfg
+++ b/dspace/config/modules/requestitem.cfg
@@ -62,5 +62,6 @@ request.item.grant.link.dateformat = yyyy-MM-dd
 #request.item.grant.link.dateformat = MM/dd/yy
 
 # Require a captcha for item request creation
+# Note, this requires altcha.cfg to be configured with a valid HMAC key
 # Default: false
 #request.item.create.captcha=true


### PR DESCRIPTION
## References
Fixes some bugs related to Captcha, and inline doco mistakes introduced with new feature #10407 

## Description
While writing documentation and testing some testathon scenarios, I realised that my work in preparing for configurable Captcha providers made it impossible to use both Google reCAPTCHA (protecting the user registration form) *and* the ALTCHA service (protecting request a copy form).

So, I still want my ground-work to remain as we work to full coverage of captchas, but instead of documenting the (now "hidden") `captcha.provider` configuration property, I now have explicit `getGoogleCaptchaService` and `getAltchaCaptchaService` methods for REST repositories to use when processing captcha payloads.

I also added TODO comments where appropriate, to note that we are working on full coverage so that in a future version we can reinstate `captcha.provider` configuration, and use `getCaptchaService` consistently to get a single provider protecting all forms.

List of changes in this PR:
* Extend `CaptchaServiceFactory` to be able to return Google and Altcha services explicitly
* Hide the `captcha.provider` config from dspace.cfg and documentation for now, as while WIP, it is just used "under the hood"
* Add TODO comments to note the current and eventual states of captcha coverage
* Fix a couple of small errors in requestitem.cfg

To test, try enabling both ALTCHA on the request copy form and Google RECAPTCHA version on the user registration form, and ensure both work.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
