### PR TITLE
[GitHub Actions] Update Docker scripts to use new Ubuntu ARM64 runner instead of emulation

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -86,17 +86,16 @@ jobs:
       matrix:
         # Architectures / Platforms for which we will build Docker images
         arch: [ 'linux/amd64', 'linux/arm64' ]
-        os: [ ubuntu-latest ]
         isPr:
           - ${{ github.event_name == 'pull_request' }}
         # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
         # The below exclude therefore ensures we do NOT build ARM64 for PRs.
         exclude:
           - isPr: true
-            os: ubuntu-latest
             arch: linux/arm64
 
-    runs-on: ${{ matrix.os }}
+    # If ARM64, then use the Ubuntu ARM64 runner. Otherwise, use the Ubuntu AMD64 runner
+    runs-on: ${{ matrix.arch == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
 
     steps:
       # This step converts the slashes in the "arch" matrix values above into dashes & saves to env.ARCH_NAME
@@ -121,10 +120,6 @@ jobs:
           registry: ${{ env.DOCKER_BUILD_REGISTRY }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      # https://github.com/docker/setup-qemu-action
-      - name: Set up QEMU emulation to build for multiple architectures
-        uses: docker/setup-qemu-action@v3
 
       # https://github.com/docker/setup-buildx-action
       - name: Setup Docker Buildx


### PR DESCRIPTION
## Description
Update our `reusable-docker-build.yml` GitHub Action script to use the new Ubuntu ARM64 runner for any ARM64 images.  

This allows us to no longer do emulation for ARM64. (The current emulation process can be **very slow** for some builds.  A 10 minute build can take an hour or more)

See https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

## Instructions for Reviewers
* I pushed this to `DSpace/DSpace` as a branch in order to run a test build at https://github.com/DSpace/DSpace/actions/runs/14314229817
* Assuming this build works and runs **faster**, then I'll merge this immediately.  Currently, because of emulation, these ARM64 Docker image builds can take upwards of an hour.