### PR TITLE
Set Dependabot to always run to 2am UTC

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      time: "02:00"
     # Allow up to 10 open PRs for dependencies
     open-pull-requests-limit: 10
     # Group together some upgrades in a single PR


### PR DESCRIPTION
## Description
This is a minor configuration change to `dependabot` to have it always run at 02:00 UTC.   The reason for this change is that our dependabot runner has a tendency to run right around 00:00 UTC (midnight UTC), which can result in random Integration Test failures because of failing date comparisons.  Essentially, a test will sometimes start on one day and end on a different day...when test are specifically comparing dates or expecting a specific date in the result, then the result will sometimes be off by one day.

These random failures are always solved by re-running the test.  But, since dependabot will create several dependency PRs at once, this sometimes means I have to re-run the tests of 3-5 dependabot PRs which are all showing this same random failure.

This PR attempts to fix that random error by telling Dependabot we don't want it to run at/around midnight UTC.  Instead, it will run at 02:00 UTC

## Instructions for Reviewers
* No new DSpace code here.  This is just  change to the configuration of dependabot.