### PR TITLE
Translate null email message parameters to "".

### DIFF
--- a/dspace-api/src/main/java/org/dspace/core/Email.java
+++ b/dspace-api/src/main/java/org/dspace/core/Email.java
@@ -55,7 +55,7 @@ import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 
 /**
- * Class representing an e-mail message.  The {@link send} method causes the
+ * Builder representing an e-mail message.  The {@link send} method causes the
  * assembled message to be formatted and sent.
  * <p>
  * Typical use:
@@ -168,6 +168,9 @@ public class Email {
      */
     private String charset;
 
+    /** The message being assembled. */
+    MimeMessage message;
+
     private static final Logger LOG = LogManager.getLogger();
 
     /** Velocity template settings. */
@@ -187,6 +190,9 @@ public class Email {
 
     /** Velocity template for a message body */
     private Template template;
+
+    /** The message text. */
+    private String body;
 
     /**
      * Create a new email message.
@@ -254,9 +260,15 @@ public class Email {
     /**
      * Fill out the next argument in the template.
      *
-     * @param arg the value for the next argument
+     * @param arg the value for the next argument.  If {@code null},
+     *            a zero-length string is substituted.
      */
     public void addArgument(Object arg) {
+        if (null == arg) {
+            arg = "";
+            LOG.warn("Null argument {} to email template {} replaced with zero-length string",
+                    arguments.size(), contentName);
+        }
         arguments.add(arg);
     }
 
@@ -327,7 +339,27 @@ public class Email {
     }
 
     /**
-     * Sends the email.  If the template defines a Velocity context property
+     * Sends the email.  If sending is disabled then the assembled message is
+     * logged instead.
+     *
+     * @throws MessagingException if there was a problem sending the mail.
+     * @throws IOException        if IO error
+     */
+    public void send() throws MessagingException, IOException {
+        build();
+
+        ConfigurationService config
+                = DSpaceServicesFactory.getInstance().getConfigurationService();
+        boolean disabled = config.getBooleanProperty("mail.server.disabled", false);
+        if (disabled) {
+            LOG.info(format(message, body));
+        } else {
+            Transport.send(message);
+        }
+    }
+
+    /**
+     * Build the message.  If the template defines a Velocity context property
      * named among the values of DSpace configuration property
      * {@code mail.message.headers} then that name and its value will be added
      * to the message's headers.
@@ -336,11 +368,12 @@ public class Email {
      * called, the value of any "subject" property will be used as if setSubject
      * had been called with that value.  Thus a template may define its subject,
      * but the caller may override it.
-     *
-     * @throws MessagingException if there was a problem sending the mail.
-     * @throws IOException        if IO error
+     * 
+     * @throws MessagingException if there is no template, or passed through.
+     * @throws IOException passed through.
      */
-    public void send() throws MessagingException, IOException {
+    void build()
+            throws MessagingException, IOException {
         if (null == template) {
             // No template -- no content -- PANIC!!!
             throw new MessagingException("Email has no body");
@@ -351,7 +384,6 @@ public class Email {
 
         // Get the mail configuration properties
         String from = config.getProperty("mail.from.address");
-        boolean disabled = config.getBooleanProperty("mail.server.disabled", false);
 
         // If no character set specified, attempt to retrieve a default
         if (charset == null) {
@@ -362,7 +394,7 @@ public class Email {
         Session session = DSpaceServicesFactory.getInstance().getEmailService().getSession();
 
         // Create message
-        MimeMessage message = new MimeMessage(session);
+        message = new MimeMessage(session);
 
         // Set the recipients of the message
         for (String recipient : recipients) {
@@ -385,7 +417,7 @@ public class Email {
             LOG.error("Template not merged:  {}", ex.getMessage());
             throw new MessagingException("Template not merged", ex);
         }
-        String fullMessage = writer.toString();
+        body = writer.toString();
 
         // Set some message header fields
         Instant date = Instant.now();
@@ -412,20 +444,19 @@ public class Email {
             message.setSubject(subject);
         }
 
-        // Add attachments
-        if (attachments.isEmpty() && moreAttachments.isEmpty()) {
-            // If a character set has been specified, or a default exists
+        // Attach the body.
+        if (attachments.isEmpty() && moreAttachments.isEmpty()) { // Flat body.
             if (charset != null) {
-                message.setText(fullMessage, charset);
+                message.setText(body, charset);
             } else {
-                message.setText(fullMessage);
+                message.setText(body);
             }
-        } else {
+        } else { // Add attachments.
             Multipart multipart = new MimeMultipart();
 
             // create the first part of the email
             BodyPart messageBodyPart = new MimeBodyPart();
-            messageBodyPart.setText(fullMessage);
+            messageBodyPart.setText(body);
             multipart.addBodyPart(messageBodyPart);
 
             // Add file attachments
@@ -457,30 +488,47 @@ public class Email {
             replyToAddr[0] = new InternetAddress(replyTo);
             message.setReplyTo(replyToAddr);
         }
+    }
 
-        if (disabled) {
-            StringBuilder text = new StringBuilder(
-                "Message not sent due to mail.server.disabled:\n");
+    /**
+     * Flatten the email into a string.
+     *
+     * @param message the message headers, attachments, etc.
+     * @param body the message body.
+     * @return stringified email message.
+     * @throws MessagingException passed through.
+     */
+    private String format(MimeMessage message, String body)
+            throws MessagingException {
+        StringBuilder text = new StringBuilder(
+            "Message not sent due to mail.server.disabled:\n");
 
-            Enumeration<String> headers = message.getAllHeaderLines();
-            while (headers.hasMoreElements()) {
-                text.append(headers.nextElement()).append('\n');
-            }
-
-            if (!attachments.isEmpty()) {
-                text.append("\nAttachments:\n");
-                for (FileAttachment f : attachments) {
-                    text.append(f.name).append('\n');
-                }
-                text.append('\n');
-            }
-
-            text.append('\n').append(fullMessage);
-
-            LOG.info(text.toString());
-        } else {
-            Transport.send(message);
+        Enumeration<String> headers = message.getAllHeaderLines();
+        while (headers.hasMoreElements()) {
+            text.append(headers.nextElement()).append('\n');
         }
+
+        if (!attachments.isEmpty()) {
+            text.append("\nAttachments:\n");
+            for (FileAttachment f : attachments) {
+                text.append(f.name).append('\n');
+            }
+            text.append('\n');
+        }
+
+        text.append('\n').append(body);
+        return text.toString();
+    }
+
+    /**
+     * Get the formatted message for testing.
+     *
+     * @return the message flattened to a String.
+     * @throws MessagingException passed through.
+     */
+    String getMessage()
+            throws MessagingException {
+        return format(message, body);
     }
 
     /**

--- a/dspace-api/src/test/java/org/dspace/core/EmailTest.java
+++ b/dspace-api/src/test/java/org/dspace/core/EmailTest.java
@@ -1,0 +1,68 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.core;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+import java.io.IOException;
+
+import jakarta.mail.MessagingException;
+import org.dspace.AbstractDSpaceTest;
+import org.dspace.services.ConfigurationService;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for email sender.
+ *
+ * @author mwood
+ */
+public class EmailTest
+        extends AbstractDSpaceTest {
+    private ConfigurationService config;
+
+    @Before
+    public void init_test() {
+        config = kernelImpl.getConfigurationService();
+    }
+
+    @Test
+    public void testNullParameter()
+            throws MessagingException, IOException {
+        // Ensure that no mail goes out
+        config.setProperty("mail.server.disabled", "true");
+
+        Email email = new Email();
+        email.setContent("null test",
+                "Testing: parameter value is /${params[0]}/.");
+        email.addArgument(null);
+        email.build();
+        String message = email.getMessage();
+        assertThat("Null message parameter should be transformed to empty",
+                message, not(containsString("(null)")));
+    }
+
+    @Test
+    public void testNotNullParameter()
+            throws MessagingException, IOException {
+        // Ensure that no mail goes out
+        config.setProperty("mail.server.disabled", "true");
+
+        Email email = new Email();
+        email.setContent("not-null test",
+                "Testing: parameter value is /${params[0]}/.");
+        String testParam = "axolotl";
+        email.addArgument(testParam);
+        email.build();
+        String message = email.getMessage();
+        assertThat("Null message parameter should be transformed to empty",
+                message, containsString(testParam));
+    }
+}


### PR DESCRIPTION
Some other issue results in composing emails with null message parameters, which should be handled more gracefully.

## References
* Fixes #10581

## Description
Replace null message parameters to avoid puzzling "(null)" insertions.

## Instructions for Reviewers
List of changes in this PR:
* Replace null message parameters with "".
* Reorganize and add minimal test suite to show that null and non-null parameters are handled as intended.

See the referenced Issue for suggestions re: testing.

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
