### PR TITLE
Fix login endpoints not automatically closing their Context

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/CustomLogoutHandler.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/CustomLogoutHandler.java
@@ -45,7 +45,7 @@ public class CustomLogoutHandler implements LogoutHandler {
         try {
             Context context = ContextUtil.obtainContext(httpServletRequest);
             restAuthenticationService.invalidateAuthenticationData(httpServletRequest, httpServletResponse, context);
-            context.commit();
+            context.complete();
 
         } catch (Exception e) {
             log.error("Unable to logout", e);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/EPersonRestAuthenticationProvider.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/EPersonRestAuthenticationProvider.java
@@ -85,7 +85,7 @@ public class EPersonRestAuthenticationProvider implements AuthenticationProvider
         } else {
             // Otherwise, this is a new login & we need to attempt authentication
             log.debug("Request to authenticate new login");
-            return authenticateNewLogin(authentication);
+            return authenticateNewLogin(context, authentication);
         }
     }
 
@@ -107,56 +107,44 @@ public class EPersonRestAuthenticationProvider implements AuthenticationProvider
      * If login is successful, returns a NEW Authentication class containing the logged in EPerson and their list of
      * GrantedAuthority objects.  If login fails, a BadCredentialsException is thrown. If no valid login found implicit
      * or explicit, then null is returned.
+     *
+     * @param context The current DSpace context
      * @param authentication Authentication class to attempt authentication.
      * @return new Authentication class containing logged-in user information or null
      */
-    private Authentication authenticateNewLogin(Authentication authentication) {
-        Context newContext = null;
+    private Authentication authenticateNewLogin(Context context, Authentication authentication) {
         Authentication output = null;
 
         if (authentication != null) {
-            try {
-                newContext = new Context();
-                String name = authentication.getName();
-                String password = Objects.toString(authentication.getCredentials(), null);
+            String name = authentication.getName();
+            String password = Objects.toString(authentication.getCredentials(), null);
 
-                int implicitStatus = authenticationService.authenticateImplicit(newContext, null, null, null, request);
+            int implicitStatus = authenticationService.authenticateImplicit(context, null, null, null, request);
 
-                if (implicitStatus == AuthenticationMethod.SUCCESS) {
-                    log.info(LogHelper.getHeader(newContext, "login", "type=implicit"));
-                    output = createAuthentication(newContext);
-                } else {
-                    int authenticateResult = authenticationService
-                        .authenticate(newContext, name, password, null, request);
-                    if (AuthenticationMethod.SUCCESS == authenticateResult) {
+            if (implicitStatus == AuthenticationMethod.SUCCESS) {
+                log.info(LogHelper.getHeader(context, "login", "type=implicit"));
+                output = createAuthentication(context);
+            } else {
+                int authenticateResult = authenticationService.authenticate(context, name, password, null, request);
+                if (AuthenticationMethod.SUCCESS == authenticateResult) {
 
-                        log.info(LogHelper
-                                     .getHeader(newContext, "login", "type=explicit"));
+                    log.info(LogHelper.getHeader(context, "login", "type=explicit"));
 
-                        output = createAuthentication(newContext);
+                    output = createAuthentication(context);
 
-                        for (PostLoggedInAction action : postLoggedInActions) {
-                            try {
-                                action.loggedIn(newContext);
-                            } catch (Exception ex) {
-                                log.error("An error occurs performing post logged in action", ex);
-                            }
+                    for (PostLoggedInAction action : postLoggedInActions) {
+                        try {
+                            action.loggedIn(context);
+                        } catch (Exception ex) {
+                            log.error("An error occurs performing post logged in action", ex);
                         }
+                    }
 
-                    } else {
-                        log.info(LogHelper.getHeader(newContext, "failed_login", "email="
-                            + name + ", result="
-                            + authenticateResult));
-                        throw new BadCredentialsException("Login failed");
-                    }
-                }
-            } finally {
-                if (newContext != null && newContext.isValid()) {
-                    try {
-                        newContext.complete();
-                    } catch (SQLException e) {
-                        log.error(e.getMessage() + " occurred while trying to close", e);
-                    }
+                } else {
+                    log.info(LogHelper.getHeader(context, "failed_login", "email="
+                        + name + ", result="
+                        + authenticateResult));
+                    throw new BadCredentialsException("Login failed");
                 }
             }
         }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/OidcLoginFilter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/OidcLoginFilter.java
@@ -10,11 +10,18 @@ package org.dspace.app.rest.security;
 import static org.dspace.authenticate.OidcAuthenticationBean.OIDC_AUTH_ATTRIBUTE;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.dspace.core.Utils;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
@@ -26,6 +33,11 @@ import org.springframework.security.core.AuthenticationException;
  */
 
 public class OidcLoginFilter extends StatelessLoginFilter {
+
+    private static final Logger log = LogManager.getLogger(OidcLoginFilter.class);
+
+    private final ConfigurationService configurationService = DSpaceServicesFactory.getInstance()
+        .getConfigurationService();
 
     public OidcLoginFilter(String url, AuthenticationManager authenticationManager,
             RestAuthenticationService restAuthenticationService) {
@@ -44,7 +56,45 @@ public class OidcLoginFilter extends StatelessLoginFilter {
     protected void successfulAuthentication(HttpServletRequest req, HttpServletResponse res, FilterChain chain,
         Authentication auth) throws IOException, ServletException {
         restAuthenticationService.addAuthenticationDataForUser(req, res, (DSpaceAuthentication) auth, true);
-        chain.doFilter(req, res);
+        redirectAfterSuccess(req, res);
+    }
+
+    /**
+     * After successful login, redirect to the DSpace URL specified by this OIDC
+     * request (in the "redirectUrl" request parameter). If that 'redirectUrl' is
+     * not valid or trusted for this DSpace site, then return a 400 error.
+     * @param  request
+     * @param  response
+     * @throws IOException
+     */
+    private void redirectAfterSuccess(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        // Get redirect URL from request parameter
+        String redirectUrl = request.getParameter("redirectUrl");
+
+        // If redirectUrl unspecified, default to the configured UI
+        if (StringUtils.isEmpty(redirectUrl)) {
+            redirectUrl = configurationService.getProperty("dspace.ui.url");
+        }
+
+        // Validate that the redirectURL matches either the server or UI hostname. It
+        // *cannot* be an arbitrary URL.
+        String redirectHostName = Utils.getHostName(redirectUrl);
+        String serverHostName = Utils.getHostName(configurationService.getProperty("dspace.server.url"));
+        ArrayList<String> allowedHostNames = new ArrayList<>();
+        allowedHostNames.add(serverHostName);
+        String[] allowedUrls = configurationService.getArrayProperty("rest.cors.allowed-origins");
+        for (String url : allowedUrls) {
+            allowedHostNames.add(Utils.getHostName(url));
+        }
+
+        if (StringUtils.equalsAnyIgnoreCase(redirectHostName, allowedHostNames.toArray(new String[0]))) {
+            log.debug("OIDC redirecting to " + redirectUrl);
+            response.sendRedirect(redirectUrl);
+        } else {
+            log.error("Invalid OIDC redirectURL=" + redirectUrl + ". URL doesn't match hostname of server or UI!");
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST,
+                    "Invalid redirectURL! Must match server or ui hostname.");
+        }
     }
 
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/jwt/JWTTokenRestAuthenticationServiceImpl.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/jwt/JWTTokenRestAuthenticationServiceImpl.java
@@ -84,6 +84,9 @@ public class JWTTokenRestAuthenticationServiceImpl implements RestAuthentication
             String token = loginJWTTokenHandler.createTokenForEPerson(context, request,
                                                                  authentication.getPreviousLoginDate());
             context.commit();
+            // Close the Context, because the DSpaceRequestContextFilter is not called for requests that trigger
+            // the authentication filters (filters that extend AbstractAuthenticationProcessingFilter)
+            context.close();
 
             // Add newly generated auth token to the response
             addTokenToResponse(request, response, token, addCookie);


### PR DESCRIPTION
## References
* Fixes #10598
* Fixes #10622 

## Description
Fixed bug where the `Context` is not closed when performing an authentication request.

## Instructions for Reviewers
List of changes in this PR:
* Updated the code of `EPersonRestAuthenticationProvider#authenticateNewLogin` to reuse the already previously created `Context`
* Closed the context manually in `JWTTokenRestAuthenticationServiceImpl` since the authentication endpoints skip the `DSpaceRequestContextFilter`. They skip this filter by default (see `AbstractAuthenticationProcessingFilter#doFilter`) because we still need the `Context ` in `successfulAuthentication` in order to create the JWT token
* The `OidcLoginFilter` has also been refactored to work in a similar way to the other authentication filters by removing the manual call to the `doFilter` since the `Context` is already closed by the `addAuthenticationDataForUser` method. Fixes #10622 

**See #10598 on how to test this**

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
