### PR TITLE
Consider all selected dc.types when validating input fields in submission/review-form

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/DCInputSet.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/DCInputSet.java
@@ -320,4 +320,42 @@ public class DCInputSet {
         return allowedFieldNames;
     }
 
+    public List<String> populateAllowedFieldNames(List<String> documentTypeValues) {
+        List<String> allowedFieldNames = new ArrayList<>();
+        // Before iterating each input for validation, run through all inputs + fields and populate a lookup
+        // map with inputs for this type. Because an input can be configured repeatedly in a form (for example
+        // it could be required for type Book, and allowed but not required for type Article), allowed=true will
+        // always take precedence
+        for (DCInput[] row : inputs) {
+            for (DCInput input : row) {
+                if (input.isQualdropValue()) {
+                    List<Object> inputPairs = input.getPairs();
+                    //starting from the second element of the list and skipping one every time because the display
+                    // values are also in the list and before the stored values.
+                    for (int i = 1; i < inputPairs.size(); i += 2) {
+                        String fullFieldname = input.getFieldName() + "." + inputPairs.get(i);
+                        if ((documentTypeValues.isEmpty() && input.isAllowedFor("")) || documentTypeValues.stream()
+                            .anyMatch(input::isAllowedFor)) {
+                            if (!allowedFieldNames.contains(fullFieldname)) {
+                                allowedFieldNames.add(fullFieldname);
+                            }
+                            // For the purposes of qualdrop, we have to add the field name without the qualifier
+                            // too, or a required qualdrop will get confused and incorrectly reject a value
+                            if (!allowedFieldNames.contains(input.getFieldName())) {
+                                allowedFieldNames.add(input.getFieldName());
+                            }
+                        }
+                    }
+                } else {
+                    if (((documentTypeValues.isEmpty() && input.isAllowedFor("")) || documentTypeValues.stream()
+                        .anyMatch(input::isAllowedFor)) &&
+                        !allowedFieldNames.contains(input.getFieldName())) {
+                        allowedFieldNames.add(input.getFieldName());
+                    }
+                }
+            }
+        }
+        return allowedFieldNames;
+    }
+
 }

--- a/dspace-api/src/main/java/org/dspace/app/util/DCInputSet.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/DCInputSet.java
@@ -282,44 +282,9 @@ public class DCInputSet {
      * <p>Special handling for qualdrop_value fields: Both the base field name and all qualified variations
      * (field name + qualifier) are added to the list to ensure proper validation.</p>
      *
-     * @param documentTypeValue the document type to check against, for example "Article" or "Book"
+     * @param documentTypeValues the document types to check against, for example "Article, Book"
      * @return a list of field names that are allowed for the specified document type
      */
-    public List<String> populateAllowedFieldNames(String documentTypeValue) {
-        List<String> allowedFieldNames = new ArrayList<>();
-        // Before iterating each input for validation, run through all inputs + fields and populate a lookup
-        // map with inputs for this type. Because an input can be configured repeatedly in a form (for example
-        // it could be required for type Book, and allowed but not required for type Article), allowed=true will
-        // always take precedence
-        for (DCInput[] row : inputs) {
-            for (DCInput input : row) {
-                if (input.isQualdropValue()) {
-                    List<Object> inputPairs = input.getPairs();
-                    //starting from the second element of the list and skipping one every time because the display
-                    // values are also in the list and before the stored values.
-                    for (int i = 1; i < inputPairs.size(); i += 2) {
-                        String fullFieldname = input.getFieldName() + "." + inputPairs.get(i);
-                        if (input.isAllowedFor(documentTypeValue)) {
-                            if (!allowedFieldNames.contains(fullFieldname)) {
-                                allowedFieldNames.add(fullFieldname);
-                            }
-                            // For the purposes of qualdrop, we have to add the field name without the qualifier
-                            // too, or a required qualdrop will get confused and incorrectly reject a value
-                            if (!allowedFieldNames.contains(input.getFieldName())) {
-                                allowedFieldNames.add(input.getFieldName());
-                            }
-                        }
-                    }
-                } else {
-                    if (input.isAllowedFor(documentTypeValue) && !allowedFieldNames.contains(input.getFieldName())) {
-                        allowedFieldNames.add(input.getFieldName());
-                    }
-                }
-            }
-        }
-        return allowedFieldNames;
-    }
-
     public List<String> populateAllowedFieldNames(List<String> documentTypeValues) {
         List<String> allowedFieldNames = new ArrayList<>();
         // Before iterating each input for validation, run through all inputs + fields and populate a lookup

--- a/dspace-api/src/main/java/org/dspace/app/util/TypeBindUtils.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/TypeBindUtils.java
@@ -9,7 +9,6 @@ package org.dspace.app.util;
 
 import java.util.List;
 
-import org.apache.commons.lang3.StringUtils;
 import org.dspace.content.InProgressSubmission;
 import org.dspace.content.MetadataValue;
 import org.dspace.content.authority.factory.ContentAuthorityServiceFactory;
@@ -47,22 +46,13 @@ public class TypeBindUtils {
     }
 
     /**
-     * Gets the value of the type-bind field from the current item in the submission.
+     * Gets all metadata values of the type-bind field from the current item in the submission.
      *
      * @param obj the in-progress submission
-     * @return the value of the type-bind field, or null if not set
+     * @return the list of MetadataValue objects of the type-bind field
      */
-    public static String getTypeBindValue(InProgressSubmission<?> obj) {
-        List<MetadataValue> documentType = itemService.getMetadataByMetadataString(
-            obj.getItem(), getTypeBindField());
-
-        // check empty type-bind field
-        if (documentType == null || documentType.isEmpty()
-            || StringUtils.isBlank(documentType.get(0).getValue())) {
-            return null;
-        }
-
-        return documentType.get(0).getValue();
+    public static List<MetadataValue> getTypeBindMetadataValues(InProgressSubmission<?> obj) {
+        return itemService.getMetadataByMetadataString(obj.getItem(), getTypeBindField());
     }
 
 }

--- a/dspace-api/src/main/java/org/dspace/validation/MetadataValidator.java
+++ b/dspace-api/src/main/java/org/dspace/validation/MetadataValidator.java
@@ -80,10 +80,11 @@ public class MetadataValidator implements SubmissionStepValidator {
         List<ValidationError> errors = new ArrayList<>();
 
         DCInputSet inputConfig = getDCInputSet(config);
-        String documentType = TypeBindUtils.getTypeBindValue(obj);
+        List<MetadataValue> documentTypes = TypeBindUtils.getTypeBindMetadataValues(obj);
 
         // Get list of all field names (including qualdrop names) allowed for this dc.type
-        List<String> allowedFieldNames = inputConfig.populateAllowedFieldNames(documentType);
+        List<String> allowedFieldNames =
+            inputConfig.populateAllowedFieldNames(documentTypes.stream().map(MetadataValue::getValue).toList());
 
         for (DCInput[] row : inputConfig.getFields()) {
             for (DCInput input : row) {
@@ -103,8 +104,10 @@ public class MetadataValidator implements SubmissionStepValidator {
 
                         // Check the lookup list. If no other inputs of the same field name allow this type,
                         // then remove. This includes field name without qualifier.
-                        if (!input.isAllowedFor(documentType) && (!allowedFieldNames.contains(fullFieldname)
-                            && !allowedFieldNames.contains(input.getFieldName()))) {
+                        if (((documentTypes.isEmpty() && !input.isAllowedFor("")) ||
+                            documentTypes.stream().noneMatch(dt -> input.isAllowedFor(dt.getValue()))) &&
+                            (!allowedFieldNames.contains(fullFieldname) &&
+                                !allowedFieldNames.contains(input.getFieldName()))) {
                             removeMetadataValues(context, obj.getItem(), mdv);
                         } else {
                             validateMetadataValues(obj.getCollection(), mdv, input, config, isAuthorityControlled,
@@ -132,19 +135,20 @@ public class MetadataValidator implements SubmissionStepValidator {
                 for (String fieldName : fieldsName) {
                     boolean valuesRemoved = false;
                     List<MetadataValue> mdv = itemService.getMetadataByMetadataString(obj.getItem(), fieldName);
-                    if (!input.isAllowedFor(documentType)) {
+                    if ((documentTypes.isEmpty() && !input.isAllowedFor("")) ||
+                        documentTypes.stream().noneMatch(dt -> input.isAllowedFor(dt.getValue()))) {
                         // Check the lookup list. If no other inputs of the same field name allow this type,
                         // then remove. Otherwise, do not
                         if (!(allowedFieldNames.contains(fieldName))) {
                             removeMetadataValues(context, obj.getItem(), mdv);
                             valuesRemoved = true;
-                            log.debug("Stripping metadata values for " + input.getFieldName() + " on type "
-                                          + documentType + " as it is allowed by another input of the same field " +
-                                          "name");
+                            log.debug("Stripping metadata values for " + input.getFieldName() + " on type " +
+                                          documentTypes.stream().map(MetadataValue::getValue).toList() + " as it is" +
+                                          " allowed by another input of the same field name");
                         } else {
                             log.debug("Not removing unallowed metadata values for " + input.getFieldName() + " on type "
-                                          + documentType + " as it is allowed by another input of the same field " +
-                                          "name");
+                                          + documentTypes.stream().map(MetadataValue::getValue).toList() + " as it is" +
+                                          " allowed by another input of the same field name");
                         }
                     }
                     validateMetadataValues(obj.getCollection(), mdv, input, config,
@@ -155,7 +159,8 @@ public class MetadataValidator implements SubmissionStepValidator {
                         && !valuesRemoved) {
                         // Is the input required for *this* type? In other words, are we looking at a required
                         // input that is also allowed for this document type
-                        if (input.isAllowedFor(documentType)) {
+                        if ((documentTypes.isEmpty() && input.isAllowedFor("")) ||
+                            documentTypes.stream().anyMatch(dt -> input.isAllowedFor(dt.getValue()))) {
                             // since this field is missing add to list of error
                             // fields
                             addError(errors, ERROR_VALIDATION_REQUIRED,

--- a/dspace-api/src/test/java/org/dspace/app/util/SubmissionConfigTest.java
+++ b/dspace-api/src/test/java/org/dspace/app/util/SubmissionConfigTest.java
@@ -87,12 +87,19 @@ public class SubmissionConfigTest extends AbstractUnitTest {
         List<String> allowedFieldsForBook = inputConfig.populateAllowedFieldNames("Book");
         List<String> allowedFieldsForBookChapter = inputConfig.populateAllowedFieldNames("Book chapter");
         List<String> allowedFieldsForArticle = inputConfig.populateAllowedFieldNames("Article");
-        List<String> allowedFieldsForNoType = inputConfig.populateAllowedFieldNames(null);
+        List<String> allowedFieldsForArticleAndBook = inputConfig.populateAllowedFieldNames(List.of("Article", "Book"));
+        List<String> allowedFieldsForBookAndArticle = inputConfig.populateAllowedFieldNames(List.of("Book", "Article"));
+        String nullValue = null;
+        List<String> allowedFieldsForNoType = inputConfig.populateAllowedFieldNames(nullValue);
+        List<String> allowedFieldsForWrongTypes = inputConfig.populateAllowedFieldNames(List.of("foo", "bar"));
         // Book and book chapter should be allowed all 5 fields (each is bound to dc.identifier.isbn)
         assertEquals(allConfiguredFields, allowedFieldsForBook);
         assertEquals(allConfiguredFields, allowedFieldsForBookChapter);
+        assertEquals(allConfiguredFields, allowedFieldsForArticleAndBook);
+        assertEquals(allConfiguredFields, allowedFieldsForBookAndArticle);
         // Article and type should match a subset of the fields without ISBN
         assertEquals(unboundFields, allowedFieldsForArticle);
         assertEquals(unboundFields, allowedFieldsForNoType);
+        assertEquals(unboundFields, allowedFieldsForWrongTypes);
     }
 }

--- a/dspace-api/src/test/java/org/dspace/app/util/SubmissionConfigTest.java
+++ b/dspace-api/src/test/java/org/dspace/app/util/SubmissionConfigTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.dspace.AbstractUnitTest;
@@ -84,13 +85,12 @@ public class SubmissionConfigTest extends AbstractUnitTest {
         assertEquals(typeBindSubmissionStepName, submissionStepConfig.getId());
         // Get inputs and allowed fields
         DCInputSet inputConfig = inputReader.getInputsByFormName(submissionStepConfig.getId());
-        List<String> allowedFieldsForBook = inputConfig.populateAllowedFieldNames("Book");
-        List<String> allowedFieldsForBookChapter = inputConfig.populateAllowedFieldNames("Book chapter");
-        List<String> allowedFieldsForArticle = inputConfig.populateAllowedFieldNames("Article");
+        List<String> allowedFieldsForBook = inputConfig.populateAllowedFieldNames(List.of("Book"));
+        List<String> allowedFieldsForBookChapter = inputConfig.populateAllowedFieldNames(List.of("Book chapter"));
+        List<String> allowedFieldsForArticle = inputConfig.populateAllowedFieldNames(List.of("Article"));
         List<String> allowedFieldsForArticleAndBook = inputConfig.populateAllowedFieldNames(List.of("Article", "Book"));
         List<String> allowedFieldsForBookAndArticle = inputConfig.populateAllowedFieldNames(List.of("Book", "Article"));
-        String nullValue = null;
-        List<String> allowedFieldsForNoType = inputConfig.populateAllowedFieldNames(nullValue);
+        List<String> allowedFieldsForNoType = inputConfig.populateAllowedFieldNames(Collections.emptyList());
         List<String> allowedFieldsForWrongTypes = inputConfig.populateAllowedFieldNames(List.of("foo", "bar"));
         // Book and book chapter should be allowed all 5 fields (each is bound to dc.identifier.isbn)
         assertEquals(allConfiguredFields, allowedFieldsForBook);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/DescribeStep.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/DescribeStep.java
@@ -76,15 +76,12 @@ public class DescribeStep extends AbstractProcessingStep {
 
     private void readField(InProgressSubmission obj, SubmissionStepConfig config, DataDescribe data,
                            DCInputSet inputConfig) throws DCInputsReaderException {
-        String documentTypeValue = "";
-        List<MetadataValue> documentType = itemService.getMetadataByMetadataString(obj.getItem(),
+        List<MetadataValue> documentTypes = itemService.getMetadataByMetadataString(obj.getItem(),
                 configurationService.getProperty("submit.type-bind.field", "dc.type"));
-        if (documentType.size() > 0) {
-            documentTypeValue = documentType.get(0).getValue();
-        }
 
         // Get list of all field names (including qualdrop names) allowed for this dc.type
-        List<String> allowedFieldNames = inputConfig.populateAllowedFieldNames(documentTypeValue);
+        List<String> allowedFieldNames =
+            inputConfig.populateAllowedFieldNames(documentTypes.stream().map(MetadataValue::getValue).toList());
 
         // Loop input rows and process submitted metadata
         for (DCInput[] row : inputConfig.getFields()) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/DescribeStep.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/DescribeStep.java
@@ -28,6 +28,7 @@ import org.dspace.app.util.DCInputSet;
 import org.dspace.app.util.DCInputsReader;
 import org.dspace.app.util.DCInputsReaderException;
 import org.dspace.app.util.SubmissionStepConfig;
+import org.dspace.app.util.TypeBindUtils;
 import org.dspace.content.InProgressSubmission;
 import org.dspace.content.MetadataValue;
 import org.dspace.content.RelationshipMetadataService;
@@ -76,8 +77,7 @@ public class DescribeStep extends AbstractProcessingStep {
 
     private void readField(InProgressSubmission obj, SubmissionStepConfig config, DataDescribe data,
                            DCInputSet inputConfig) throws DCInputsReaderException {
-        List<MetadataValue> documentTypes = itemService.getMetadataByMetadataString(obj.getItem(),
-                configurationService.getProperty("submit.type-bind.field", "dc.type"));
+        List<MetadataValue> documentTypes = TypeBindUtils.getTypeBindMetadataValues(obj);
 
         // Get list of all field names (including qualdrop names) allowed for this dc.type
         List<String> allowedFieldNames =


### PR DESCRIPTION
If the "dc.type" metadata is configured as "repeatable", the validation will now check for all selected types, not just the first one, with the benefit of not losing data in type-bound input fields.

## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #10601

## Description
The code before this change did only recognize the first dc.type value. Now you can have multiple types selected and the validation as well as the form sections data returned by the backend should contain all data.

## Instructions for Reviewers / Guidance how to test
1. Make sure your dc.type field is defined as repeatable
```
            <row>
                <field>
                    <dc-schema>dc</dc-schema>
                    <dc-element>type</dc-element>
                    <dc-qualifier></dc-qualifier>
                    <repeatable>true</repeatable>
                    <label>Type</label>
                    <input-type value-pairs-name="common_types">list</input-type>
                    <hint>Select the type(s) of content of the item. To select more than one value in the list, you may
                        have to hold down the "CTRL" or "Shift" key.
                    </hint>
                    <required>You must choose at least one type.</required>
                </field>
            </row>
```
2. Configure your submission-form with at least one field, where the type-bind looks like this e.g.:

```
            <row>
                <field>
                    <dc-schema>dc</dc-schema>
                    <dc-element>title</dc-element>
                    <dc-qualifier>alternative</dc-qualifier>
                    <repeatable>true</repeatable>
                    <label>Other Titles</label>
                    <type-bind>Article</type-bind>
                    <input-type>onebox</input-type>
                    <hint>If the item has any alternative titles, please enter them here.</hint>
                    <required></required>
                </field>
            </row>
```
 3. Open your local DSpace instance in the browser and log-in (as administrator e.g.)
 4. Start a new submission with the collection containing the new type-bound field (dc.title.alternative in my case)
 5. First choose any dc.type, but not "Article" from the checkbox list
 6. Choose now "Article" -- as a result, the "Other titles" input field should appear
 7. Enter any value to the new "Other titles" input field
 8. Save your submission
 9. Check the PATCH response for the "dc.title.alternative" metadata at two places:
<img width="567" alt="Bildschirmfoto 2025-04-14 um 16 35 07" src="https://github.com/user-attachments/assets/cfcb381c-c570-4284-8e0b-8ad399fd1a6a" />

10. After a page reload, the other titles information should still be present

**List of changes in this PR:**
* Check for more than the first dc.type value
* I wanted to leave the old logic as much as possible, but had of course to rewrite the conditions, and extended the logic to handle a List<String>, e.g. like this line of code:
  * `(documentTypes.isEmpty() && input.isAllowedFor("")) || documentTypes.stream().anyMatch(dt -> input.isAllowedFor(dt.getValue()))`
* `SubmissionConfigTest` extended with new cases

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
