### PR TITLE
Use application/json as mime type for iiif manifests

### DIFF
--- a/dspace-iiif/src/main/java/org/dspace/app/iiif/IIIFController.java
+++ b/dspace-iiif/src/main/java/org/dspace/app/iiif/IIIFController.java
@@ -48,7 +48,7 @@ public class IIIFController {
      * @param id DSpace Item uuid
      * @return manifest as JSON
      */
-    @RequestMapping(method = RequestMethod.GET, value = "/{id}/manifest")
+    @RequestMapping(method = RequestMethod.GET, value = "/{id}/manifest", produces = "application/json")
     public String findOne(@PathVariable UUID id) {
         Context context = ContextUtil.obtainCurrentRequestContext();
         return iiifFacade.getManifest(context, id);

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/iiif/IIIFControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/iiif/IIIFControllerIT.java
@@ -11,6 +11,7 @@ import static org.hamcrest.Matchers.is;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -126,6 +127,7 @@ public class IIIFControllerIT extends AbstractControllerIntegrationTest {
         // Default canvas size and label.
         getClient().perform(get("/iiif/" + publicItem1.getID() + "/manifest"))
                 .andExpect(status().isOk())
+                .andExpect(header().string("Content-Type", "application/json;charset=UTF-8"))
                 .andExpect(jsonPath("$.@context", is("http://iiif.io/api/presentation/2/context.json")))
                 .andExpect(jsonPath("$.service.profile", is("http://iiif.io/api/search/0/search")))
                 .andExpect(jsonPath("$.thumbnail.@id", Matchers.containsString("/iiif/2/"
@@ -206,6 +208,7 @@ public class IIIFControllerIT extends AbstractControllerIntegrationTest {
         // Expect canvas label, width and height to match bitstream description.
         getClient().perform(get("/iiif/" + publicItem1.getID() + "/manifest"))
                 .andExpect(status().isOk())
+                .andExpect(header().string("Content-Type", "application/json;charset=UTF-8"))
                 .andExpect(jsonPath("$.@context", is("http://iiif.io/api/presentation/2/context.json")))
                 .andExpect(jsonPath("$.sequences[0].canvases[0].@id",
                         Matchers.containsString("/iiif/" + publicItem1.getID() + "/canvas/c0")))
@@ -257,6 +260,7 @@ public class IIIFControllerIT extends AbstractControllerIntegrationTest {
         // Expect canvas label, width and height to match bitstream description.
         getClient().perform(get("/iiif/" + publicItem1.getID() + "/manifest"))
                 .andExpect(status().isOk())
+                .andExpect(header().string("Content-Type", "application/json;charset=UTF-8"))
                 .andExpect(jsonPath("$.sequences[0].canvases", Matchers.hasSize(1)))
                 .andExpect(jsonPath("$.@context", is("http://iiif.io/api/presentation/2/context.json")))
                 .andExpect(jsonPath("$.sequences[0].canvases[0].@id",
@@ -300,6 +304,7 @@ public class IIIFControllerIT extends AbstractControllerIntegrationTest {
         // Expect canvas label, width and height to match bitstream description.
         getClient().perform(get("/iiif/" + publicItem1.getID() + "/manifest"))
                 .andExpect(status().isOk())
+                .andExpect(header().string("Content-Type", "application/json;charset=UTF-8"))
                 .andExpect(jsonPath("$.sequences[0].canvases", Matchers.hasSize(1)))
                 .andExpect(jsonPath("$.@context", is("http://iiif.io/api/presentation/2/context.json")))
                 .andExpect(jsonPath("$.sequences[0].canvases[0].@id",
@@ -340,6 +345,7 @@ public class IIIFControllerIT extends AbstractControllerIntegrationTest {
         // Expect canvas label, width and height to match bitstream description.
         getClient().perform(get("/iiif/" + publicItem1.getID() + "/manifest"))
                 .andExpect(status().isOk())
+                .andExpect(header().string("Content-Type", "application/json;charset=UTF-8"))
                 .andExpect(jsonPath("$.@context", is("http://iiif.io/api/presentation/2/context.json")))
                 .andExpect(jsonPath("$.sequences[0].canvases[0].@id",
                         Matchers.containsString("/iiif/" + publicItem1.getID() + "/canvas/c0")))
@@ -425,6 +431,7 @@ public class IIIFControllerIT extends AbstractControllerIntegrationTest {
         // The sequence viewing hint should be "individuals" in the item metadata.
         getClient().perform(get("/iiif/" + publicItem1.getID() + "/manifest"))
                 .andExpect(status().isOk())
+                .andExpect(header().string("Content-Type", "application/json;charset=UTF-8"))
                 .andExpect(jsonPath("$.license", is("https://license.org")))
                 .andExpect(jsonPath("$.@context", is("http://iiif.io/api/presentation/2/context.json")))
                 .andExpect(jsonPath("$.sequences[0].canvases", Matchers.hasSize(3)))
@@ -433,6 +440,7 @@ public class IIIFControllerIT extends AbstractControllerIntegrationTest {
 
         getClient().perform(get("/iiif/" + publicItem2.getID() + "/manifest"))
             .andExpect(status().isOk())
+            .andExpect(header().string("Content-Type", "application/json;charset=UTF-8"))
             .andExpect(jsonPath("$.license", is("https://license.org")))
             .andExpect(jsonPath("$.@context", is("http://iiif.io/api/presentation/2/context.json")))
             .andExpect(jsonPath("$.sequences[0].canvases", Matchers.hasSize(3)))
@@ -490,6 +498,7 @@ public class IIIFControllerIT extends AbstractControllerIntegrationTest {
         // expect structures elements with label and canvas id.
         getClient().perform(get("/iiif/" + publicItem1.getID() + "/manifest"))
                 .andExpect(status().isOk())
+                .andExpect(header().string("Content-Type", "application/json;charset=UTF-8"))
                 .andExpect(jsonPath("$.@context", is("http://iiif.io/api/presentation/2/context.json")))
                 .andExpect(jsonPath("$.sequences[0].canvases[0].@id",
                         Matchers.containsString("/iiif/" + publicItem1.getID() + "/canvas/c0")))
@@ -570,6 +579,7 @@ public class IIIFControllerIT extends AbstractControllerIntegrationTest {
         // that each Bundle exists in the manifest with Canvases corresponding to each bitstream.
         getClient().perform(get("/iiif/" + publicItem1.getID() + "/manifest"))
                    .andExpect(status().isOk())
+                   .andExpect(header().string("Content-Type", "application/json;charset=UTF-8"))
                    .andExpect(jsonPath("$.@context", is("http://iiif.io/api/presentation/2/context.json")))
                    // should contain 3 canvases, corresponding to each bitstream
                    .andExpect(jsonPath("$.sequences[0].canvases[*].label",
@@ -693,6 +703,7 @@ public class IIIFControllerIT extends AbstractControllerIntegrationTest {
         // expect structures elements with label and canvas id.
         getClient().perform(get("/iiif/" + publicItem1.getID() + "/manifest"))
                 .andExpect(status().isOk())
+                .andExpect(header().string("Content-Type", "application/json;charset=UTF-8"))
                 .andExpect(jsonPath("$.@context", is("http://iiif.io/api/presentation/2/context.json")))
                 .andExpect(jsonPath("$.sequences[0].canvases", Matchers.hasSize(8)))
                 .andExpect(jsonPath("$.sequences[0].canvases[0].@id",
@@ -843,6 +854,7 @@ public class IIIFControllerIT extends AbstractControllerIntegrationTest {
         // Expected a rendering element and no structures (because all images are inside the toc excluded bundle)
         getClient().perform(get("/iiif/" + publicItem1.getID() + "/manifest"))
                    .andExpect(status().isOk())
+                   .andExpect(header().string("Content-Type", "application/json;charset=UTF-8"))
                    .andExpect(jsonPath("$.@context", is("http://iiif.io/api/presentation/2/context.json")))
                    // should contain 3 canvases, corresponding to each bitstream
                    .andExpect(jsonPath("$.sequences[0].canvases[*].label",
@@ -891,6 +903,7 @@ public class IIIFControllerIT extends AbstractControllerIntegrationTest {
 
         getClient().perform(get("/iiif/" + publicItem1.getID() + "/manifest"))
                 .andExpect(status().isOk())
+                .andExpect(header().string("Content-Type", "application/json;charset=UTF-8"))
                 .andExpect(jsonPath("$.license", is("https://license.org")))
                 .andExpect(jsonPath("$.@context", is("http://iiif.io/api/presentation/2/context.json")))
                 .andExpect(jsonPath("$.sequences[0].canvases[0].@id",
@@ -937,6 +950,7 @@ public class IIIFControllerIT extends AbstractControllerIntegrationTest {
         // Expect seeAlso annotation list.
         getClient().perform(get("/iiif/" + publicItem1.getID() + "/manifest"))
                 .andExpect(status().isOk())
+                .andExpect(header().string("Content-Type", "application/json;charset=UTF-8"))
                 .andExpect(jsonPath("$.license", is("https://license.org")))
                 .andExpect(jsonPath("$.@context", is("http://iiif.io/api/presentation/2/context.json")))
                 .andExpect(jsonPath("$.seeAlso.@type", is("sc:AnnotationList")))
@@ -991,6 +1005,7 @@ public class IIIFControllerIT extends AbstractControllerIntegrationTest {
         // Image in the ORIGINAL bundle added as canvas; MP4 ignored, PDF offered as rendering...
         getClient().perform(get("/iiif/" + publicItem1.getID() + "/manifest"))
                 .andExpect(status().isOk())
+                .andExpect(header().string("Content-Type", "application/json;charset=UTF-8"))
                 .andExpect(jsonPath("$.@context", is("http://iiif.io/api/presentation/2/context.json")))
                 .andExpect(jsonPath("$.sequences[0].canvases", Matchers.hasSize(1)))
                 .andExpect(jsonPath("$.sequences[0].canvases[0].@id",
@@ -1066,6 +1081,7 @@ public class IIIFControllerIT extends AbstractControllerIntegrationTest {
         getClient(getAuthToken(staffEperson.getEmail(), password))
                 .perform(get("/iiif/" + restrictedItem1.getID() + "/manifest"))
                 .andExpect(status().isOk())
+                .andExpect(header().string("Content-Type", "application/json;charset=UTF-8"))
                 .andExpect(jsonPath("$.@context", is("http://iiif.io/api/presentation/2/context.json")))
                 .andExpect(jsonPath("$.sequences[0].canvases[0].@id",
                         Matchers.containsString("/iiif/" + restrictedItem1.getID() + "/canvas/c0")))
@@ -1109,6 +1125,7 @@ public class IIIFControllerIT extends AbstractControllerIntegrationTest {
         // Single canvas.
         getClient().perform(get("/iiif/" + publicItem1.getID() + "/canvas/c0"))
                 .andExpect(status().isOk())
+                .andExpect(header().string("Content-Type", "application/json;charset=UTF-8"))
                 .andExpect(jsonPath("$.@type", is("sc:Canvas")))
                 .andExpect(jsonPath("$.metadata[0].label", is("File name")))
                 .andExpect(jsonPath("$.metadata[0].value", is("IMG1.jpg")))
@@ -1242,6 +1259,7 @@ public class IIIFControllerIT extends AbstractControllerIntegrationTest {
         // Default canvas size and label.
         getClient().perform(get("/iiif/" + publicItem1.getID() + "/manifest"))
                    .andExpect(status().isOk())
+                   .andExpect(header().string("Content-Type", "application/json;charset=UTF-8"))
                    .andExpect(jsonPath("$.metadata[0].label", is("Title")))
                    .andExpect(jsonPath("$.metadata[0].value", is("Public item 1")))
                    .andExpect(jsonPath("$.sequences[0].canvases[1].label", is("Original label")));
@@ -1257,6 +1275,7 @@ public class IIIFControllerIT extends AbstractControllerIntegrationTest {
         // Verify that the updated canvas label is in the manifest.
         getClient().perform(get("/iiif/" + publicItem1.getID() + "/manifest"))
                    .andExpect(status().isOk())
+                   .andExpect(header().string("Content-Type", "application/json;charset=UTF-8"))
                    .andExpect(jsonPath("$.sequences[0].canvases[1].label", is("Test label")));
     }
 
@@ -1363,6 +1382,7 @@ public class IIIFControllerIT extends AbstractControllerIntegrationTest {
         // Default canvas size and label.
         getClient().perform(get("/iiif/" + publicItem1.getID() + "/manifest"))
                    .andExpect(status().isOk())
+                   .andExpect(header().string("Content-Type", "application/json;charset=UTF-8"))
                    .andExpect(jsonPath("$.metadata[0].label", is("Title")))
                    .andExpect(jsonPath("$.metadata[0].value", is("Public item 1")));
 
@@ -1377,6 +1397,7 @@ public class IIIFControllerIT extends AbstractControllerIntegrationTest {
         // Verify that the updated title is in the manifest.
         getClient().perform(get("/iiif/" + publicItem1.getID() + "/manifest"))
                    .andExpect(status().isOk())
+                   .andExpect(header().string("Content-Type", "application/json;charset=UTF-8"))
                    .andExpect(jsonPath("$.metadata[0].value", is("Public item (revised)")));
     }
 
@@ -1417,6 +1438,7 @@ public class IIIFControllerIT extends AbstractControllerIntegrationTest {
         // canvas dimensions using bitstream in the custom bundle (no bitstreams in ORIGINAL)
         getClient().perform(get("/iiif/" + publicItem1.getID() + "/manifest"))
                    .andExpect(status().isOk())
+                   .andExpect(header().string("Content-Type", "application/json;charset=UTF-8"))
                    .andExpect(jsonPath("$.sequences[0].canvases[0].width", is(64)))
                    .andExpect(jsonPath("$.sequences[0].canvases[0].height", is(64)));
     }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/iiif/IIIFControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/iiif/IIIFControllerIT.java
@@ -1125,7 +1125,6 @@ public class IIIFControllerIT extends AbstractControllerIntegrationTest {
         // Single canvas.
         getClient().perform(get("/iiif/" + publicItem1.getID() + "/canvas/c0"))
                 .andExpect(status().isOk())
-                .andExpect(header().string("Content-Type", "application/json;charset=UTF-8"))
                 .andExpect(jsonPath("$.@type", is("sc:Canvas")))
                 .andExpect(jsonPath("$.metadata[0].label", is("File name")))
                 .andExpect(jsonPath("$.metadata[0].value", is("IMG1.jpg")))


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* https://presentation-validator.iiif.io

## Description
The IIIF Presentation validator warns that DSpace does not send back the right mime type for IIIF manifests. This PR is a one line fix. As long as we support IIIF Presentation API 2.1.1 we will be sending back JSON. Changing to IIIF Presentation API 3.0 would bring many code changes, so I don't think it is an issue to hard-code the mime-type here.

## Instructions for Reviewers

- Set `iiif.enabled = true` in DSpace's configuration
- create an item with at least one image, add a metadata field `dspace.iiif.enable` with the value `true`.
- use curl or your web developer tools to see the Content-Type header of the response against '<your-local-test-domain>/server/iiif/<uuid-of-the-item>`. It should report `application/json` in the Content-Type header.

You do not need an image server to test this. If you don't have an image server DSpace will log an exception in dspace.log that you can ignore.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
