### PR TITLE
XOAI ingestion crosswalk

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/XOAIIngestionCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/XOAIIngestionCrosswalk.java
@@ -1,0 +1,166 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.crosswalk;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.content.DSpaceObject;
+import org.dspace.content.Item;
+import org.dspace.content.MetadataField;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.ItemService;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+import org.jdom2.Element;
+
+
+
+/**
+ * XOAI ingestion crosswalk
+ * <p>
+ * Processes raw XOAI metadata in element/field nested nodes and populates the given DSO with
+ * the parsed metadata. This is useful for DSpace-DSpace harvests where metadata can be
+ * effectively copied using the source system's metadata schema.
+ *
+ * @author Kim Shepherd
+ */
+public class XOAIIngestionCrosswalk implements IngestionCrosswalk {
+
+    protected ItemService itemService = ContentServiceFactory.getInstance().getItemService();
+    private CrosswalkMetadataValidator metadataValidator = new CrosswalkMetadataValidator();
+    private static Logger log = LogManager.getLogger(XOAIIngestionCrosswalk.class);
+
+    /**
+     * Ingest metadata from a list of XML elements into a DSpace object.
+     * @param context                     DSpace context.
+     * @param dso                         DSpace Object (Item, Bitstream, etc) to which new metadata gets attached.
+     * @param metadata                    List of XML Elements of metadata
+     * @param createMissingMetadataFields whether to create missing fields
+     * @throws CrosswalkException
+     * @throws IOException
+     * @throws SQLException
+     * @throws AuthorizeException
+     */
+    @Override
+    public void ingest(Context context, DSpaceObject dso, List<Element> metadata, boolean createMissingMetadataFields)
+            throws CrosswalkException, IOException, SQLException, AuthorizeException {
+        // As with other crosswalks, wrap this in a root element before parsing
+        Element root = new Element("wrap", metadata.get(0).getNamespace());
+        root.addContent(metadata);
+        ingest(context, dso, root, createMissingMetadataFields);
+    }
+
+    /**
+     * Ingest XOAI metadata.
+     * @param context                     DSpace context.
+     * @param dso                         DSpace Object (usually an Item) to which new metadata gets attached.
+     * @param root                        root Element of metadata document.
+     * @param createMissingMetadataFields whether to create missing fields
+     * @throws CrosswalkException
+     * @throws IOException
+     * @throws SQLException
+     * @throws AuthorizeException
+     */
+    @Override
+    public void ingest(Context context, DSpaceObject dso, Element root, boolean createMissingMetadataFields)
+            throws CrosswalkException, IOException, SQLException, AuthorizeException {
+
+        if (root == null) {
+            log.error("The element received by ingest was null");
+            return;
+        }
+        // Only ingest if the DSO is an Item
+        if (dso.getType() != Constants.ITEM) {
+            throw new CrosswalkObjectNotSupported("XOAIIngestionCrosswalk can only crosswalk an Item.");
+        }
+        Item item = (Item)dso;
+
+
+
+        List<Element> schemaNodes = root.getChildren();
+
+        // First level: SCHEMA (or special node)
+        for (Element schemaNode : schemaNodes) {
+            // Check if this node name is a reserved string for a different type
+            // eg bundles, others, repository
+            String schema = schemaNode.getAttributeValue("name");
+            if ("bundles".equals(schema)) {
+                // We could ingest bitstreams here if we wanted to implement ORE capability
+                continue;
+            } else if ("others".equals(schema)) {
+                // contains handle, identifier, lastModifyDate
+                continue;
+            } else if ("repository".equals(schema)) {
+                // contains name and mail
+                continue;
+            }
+
+            // Second level: ELEMENT
+            List<Element> elementNodes = schemaNode.getChildren();
+            for (Element elementNode : elementNodes) {
+                String element = elementNode.getAttributeValue("name");
+
+                // Third level: QUALIFIER
+                // Values of "none" are crosswalked to NULL
+                List<Element> thirdLevelNodes = elementNode.getChildren();
+                for (Element thirdLevelNode : thirdLevelNodes) {
+
+                    String qualifier = thirdLevelNode.getAttributeValue("name");
+                    qualifier = ("none".equals(qualifier) ? null : qualifier);
+
+                    // Test to see how deep remaining tree is, to test whether qualifier node
+                    // actually does exist. If not, this node is actually language, not qualifier.
+                    List<Element> fourthLevelNodes = thirdLevelNode.getChildren();
+                    if (!fourthLevelNodes.isEmpty()
+                            && !fourthLevelNodes.get(0).getChildren().isEmpty()) {
+                        // Fourth level: LANGUAGE
+                        // Values of "none are crosswalked to NULL
+                        for (Element fourthLevelNode : fourthLevelNodes) {
+                            String language = fourthLevelNode.getAttributeValue("name");
+                            language = ("none".equals(language) ? null : language);
+
+                            // Fifth level: FIELD VALUE
+                            List<Element> fifthLevelNodes = fourthLevelNode.getChildren();
+                            for (Element fifthLevelNode : fifthLevelNodes) {
+                                String value = fifthLevelNode.getText();
+                                MetadataField metadataField = metadataValidator.checkMetadata(context,
+                                        schema,
+                                        element,
+                                        qualifier,
+                                        createMissingMetadataFields);
+                                itemService.addMetadata(context, item, metadataField, language, value);
+
+                            }
+                        }
+                    } else {
+                        // Third level: LANGUAGE
+                        String language = qualifier;
+
+                        // Fourth level: FIELD VALUE
+                        List<Element> fieldNodes = thirdLevelNode.getChildren();
+                        for (Element fieldNode : fieldNodes) {
+                            String value = fieldNode.getText();
+                            MetadataField metadataField = metadataValidator.checkMetadata(context,
+                                    schema,
+                                    element,
+                                    null,
+                                    createMissingMetadataFields);
+                            itemService.addMetadata(context, item, metadataField, language, value);
+                        }
+                    }
+
+                }
+            }
+        }
+    }
+}

--- a/dspace-api/src/test/java/org/dspace/content/crosswalk/XOAIIngestionCrosswalkIT.java
+++ b/dspace-api/src/test/java/org/dspace/content/crosswalk/XOAIIngestionCrosswalkIT.java
@@ -1,0 +1,231 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.crosswalk;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.List;
+
+import org.dspace.AbstractIntegrationTestWithDatabase;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.WorkspaceItemBuilder;
+import org.dspace.content.Collection;
+import org.dspace.content.Item;
+import org.dspace.content.MetadataValue;
+import org.dspace.content.WorkspaceItem;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.ItemService;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.input.SAXBuilder;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Integration test for XOAIIngestionCrosswalk
+ * 
+ * This test verifies that XOAI metadata with authority and confidence values
+ * is properly ingested into DSpace items.
+ */
+public class XOAIIngestionCrosswalkIT extends AbstractIntegrationTestWithDatabase {
+
+    private XOAIIngestionCrosswalk crosswalk;
+    @Autowired
+    private ItemService itemService;
+    private Collection collection;
+    private Item item;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        context.turnOffAuthorisationSystem();
+        
+        crosswalk = new XOAIIngestionCrosswalk();
+        itemService = ContentServiceFactory.getInstance().getItemService();
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+        Collection collection = CollectionBuilder.createCollection(context, parentCommunity).withName("Collection 1").build();
+        WorkspaceItem workspaceItem = WorkspaceItemBuilder.createWorkspaceItem(context, collection)
+                                      .build();
+        item = workspaceItem.getItem();
+        
+        context.restoreAuthSystemState();
+    }
+
+    @Test
+    public void testIngestXOAIMetadataWithAuthorityAndConfidence() throws Exception {
+        // Sample XOAI XML with authority and confidence values
+        String xmlContent = getTestXMLContent();
+        
+        // Parse XML
+        SAXBuilder builder = new SAXBuilder();
+        InputStream xmlStream = new ByteArrayInputStream(xmlContent.getBytes("UTF-8"));
+        Document document = builder.build(xmlStream);
+        Element rootElement = document.getRootElement();
+        
+        // Execute crosswalk
+        context.turnOffAuthorisationSystem();
+        crosswalk.ingest(context, item, rootElement, true);
+        context.restoreAuthSystemState();
+        //context.commit();
+        
+        // Verify author metadata with authority and confidence
+        List<MetadataValue> authors = itemService.getMetadata(item, "dc", "contributor", "author", Item.ANY);
+        assertNotNull("Authors metadata should not be null", authors);
+        assertTrue("Should have at least 4 author entries", authors.size() >= 4);
+        
+        // Verify first author (English) with authority and confidence
+        MetadataValue author1 = findMetadataByValue(authors, "Smith, John A.");
+        assertNotNull("First author should exist", author1);
+        assertEquals("First author authority should match", "smith-john-a-0000-0001-2345-6789", author1.getAuthority());
+        assertEquals("First author confidence should match", 600, author1.getConfidence());
+        assertEquals("First author language should be English", "en", author1.getLanguage());
+        
+        // Verify second author (English) with authority and confidence
+        MetadataValue author2 = findMetadataByValue(authors, "Doe, Jane B.");
+        assertNotNull("Second author should exist", author2);
+        assertEquals("Second author authority should match", "doe-jane-b-0000-0002-3456-7890", author2.getAuthority());
+        assertEquals("Second author confidence should match", 500, author2.getConfidence());
+        assertEquals("Second author language should be English", "en", author2.getLanguage());
+        
+        // Verify third author (English) without authority/confidence
+        MetadataValue author3 = findMetadataByValue(authors, "Brown, Michael C.");
+        assertNotNull("Third author should exist", author3);
+        assertEquals("Third author should have no authority", null, author3.getAuthority());
+        assertEquals("Third author confidence should be default", -1, author3.getConfidence());
+        assertEquals("Third author language should be English", "en", author3.getLanguage());
+        
+        // Verify fourth author (German) with authority and confidence
+        MetadataValue author4 = findMetadataByValue(authors, "Mueller, Hans D.");
+        assertNotNull("Fourth author should exist", author4);
+        assertEquals("Fourth author authority should match", "mueller-hans-d-0000-0003-4567-8901", author4.getAuthority());
+        assertEquals("Fourth author confidence should match", 400, author4.getConfidence());
+        assertEquals("Fourth author language should be German", "de", author4.getLanguage());
+        
+        // Verify subject metadata with authority and confidence
+        List<MetadataValue> subjects = itemService.getMetadata(item, "dc", "subject", "lcsh", Item.ANY);
+        assertNotNull("Subjects metadata should not be null", subjects);
+        assertTrue("Should have at least 2 subject entries", subjects.size() >= 2);
+        
+        MetadataValue subject1 = findMetadataByValue(subjects, "Computer Science");
+        assertNotNull("First subject should exist", subject1);
+        assertEquals("First subject authority should match", "sh85029552", subject1.getAuthority());
+        assertEquals("First subject confidence should match", 600, subject1.getConfidence());
+        
+        MetadataValue subject2 = findMetadataByValue(subjects, "Artificial Intelligence");
+        assertNotNull("Second subject should exist", subject2);
+        assertEquals("Second subject authority should match", "sh85008180", subject2.getAuthority());
+        assertEquals("Second subject confidence should match", 500, subject2.getConfidence());
+        
+        // Verify title metadata (no authority/confidence expected)
+        List<MetadataValue> titles = itemService.getMetadata(item, "dc", "title", null, Item.ANY);
+        assertNotNull("Titles metadata should not be null", titles);
+        assertTrue("Should have at least 1 title entry", titles.size() >= 1);
+        
+        MetadataValue title = findMetadataByValue(titles, "Advanced Research in Computational Science");
+        assertNotNull("Title should exist", title);
+        assertEquals("Title should have no authority", null, title.getAuthority());
+        assertEquals("Title confidence should be default", -1, title.getConfidence());
+    }
+
+    @Test
+    public void testIngestHandlesNullRoot() throws Exception {
+        // Test that crosswalk handles null root element gracefully
+        crosswalk.ingest(context, item, (Element) null, true);
+        
+        // Should not throw exception and item should remain unchanged
+        List<MetadataValue> metadata = itemService.getMetadata(item, Item.ANY, Item.ANY, Item.ANY, Item.ANY);
+        assertTrue("Item should have no metadata after null root ingestion", metadata.isEmpty());
+    }
+
+    /**
+     * Helper method to find metadata value by its text content
+     */
+    private MetadataValue findMetadataByValue(List<MetadataValue> metadataList, String value) {
+        return metadataList.stream()
+                .filter(mv -> value.equals(mv.getValue()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    /**
+     * Returns the test XML content with authority and confidence values
+     */
+    private String getTestXMLContent() {
+        return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<metadata xmlns=\"http://www.lyncode.com/xoai\" " +
+                "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" " +
+                "xsi:schemaLocation=\"http://www.lyncode.com/xoai http://www.lyncode.com/xsd/xoai.xsd\">\n" +
+                "    <element name=\"dc\">\n" +
+                "        <element name=\"contributor\">\n" +
+                "            <element name=\"author\">\n" +
+                "                <element name=\"en\">\n" +
+                "                    <field name=\"value\">Smith, John A.</field>\n" +
+                "                    <field name=\"authority\">smith-john-a-0000-0001-2345-6789</field>\n" +
+                "                    <field name=\"confidence\">600</field>\n" +
+                "                    <field name=\"value\">Doe, Jane B.</field>\n" +
+                "                    <field name=\"authority\">doe-jane-b-0000-0002-3456-7890</field>\n" +
+                "                    <field name=\"confidence\">500</field>\n" +
+                "                    <field name=\"value\">Brown, Michael C.</field>\n" +
+                "                </element>\n" +
+                "                <element name=\"de\">\n" +
+                "                    <field name=\"value\">Mueller, Hans D.</field>\n" +
+                "                    <field name=\"authority\">mueller-hans-d-0000-0003-4567-8901</field>\n" +
+                "                    <field name=\"confidence\">400</field>\n" +
+                "                </element>\n" +
+                "            </element>\n" +
+                "        </element>\n" +
+                "        <element name=\"title\">\n" +
+                "            <element name=\"none\">\n" +
+                "                <field name=\"value\">Advanced Research in Computational Science</field>\n" +
+                "            </element>\n" +
+                "        </element>\n" +
+                "        <element name=\"subject\">\n" +
+                "            <element name=\"lcsh\">\n" +
+                "                <element name=\"en\">\n" +
+                "                    <field name=\"value\">Computer Science</field>\n" +
+                "                    <field name=\"authority\">sh85029552</field>\n" +
+                "                    <field name=\"confidence\">600</field>\n" +
+                "                    <field name=\"value\">Artificial Intelligence</field>\n" +
+                "                    <field name=\"authority\">sh85008180</field>\n" +
+                "                    <field name=\"confidence\">500</field>\n" +
+                "                </element>\n" +
+                "            </element>\n" +
+                "        </element>\n" +
+                "        <element name=\"description\">\n" +
+                "            <element name=\"abstract\">\n" +
+                "                <element name=\"en\">\n" +
+                "                    <field name=\"value\">This paper presents a comprehensive analysis of modern computational methods.</field>\n" +
+                "                </element>\n" +
+                "            </element>\n" +
+                "        </element>\n" +
+                "        <element name=\"date\">\n" +
+                "            <element name=\"issued\">\n" +
+                "                <element name=\"none\">\n" +
+                "                    <field name=\"value\">2024-03-15</field>\n" +
+                "                </element>\n" +
+                "            </element>\n" +
+                "        </element>\n" +
+                "        <element name=\"type\">\n" +
+                "            <element name=\"document\">\n" +
+                "                <element name=\"en\">\n" +
+                "                    <field name=\"value\">journal article</field>\n" +
+                "                </element>\n" +
+                "            </element>\n" +
+                "        </element>\n" +
+                "    </element>\n" +
+                "</metadata>";
+    }
+}

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -634,6 +634,7 @@ plugin.named.org.dspace.content.crosswalk.IngestionCrosswalk = \
   org.dspace.content.crosswalk.NullIngestionCrosswalk = NIL, \
   org.dspace.content.crosswalk.OAIDCIngestionCrosswalk = dc, \
   org.dspace.content.crosswalk.DIMIngestionCrosswalk = dim, \
+  org.dspace.content.crosswalk.XOAIIngestionCrosswalk = xoai, \
   org.dspace.content.crosswalk.METSRightsCrosswalk = METSRIGHTS, \
   org.dspace.content.crosswalk.RoleCrosswalk = DSPACE-ROLES
 

--- a/dspace/config/modules/oai.cfg
+++ b/dspace/config/modules/oai.cfg
@@ -70,6 +70,7 @@ oai.import.batch.size = 1000
 oai.harvester.metadataformats.dc = http://www.openarchives.org/OAI/2.0/oai_dc/\, Simple Dublin Core
 oai.harvester.metadataformats.qdc = http://purl.org/dc/terms/\, Qualified Dublin Core
 oai.harvester.metadataformats.dim = http://www.dspace.org/xmlns/dspace/dim\, DSpace Intermediate Metadata
+oai.harvester.metadataformats.xoai = http://www.lyncode.com/xoai\, XOAI
 
 # This field works in much the same way as oai.harvester.metadataformats.PluginName
 # The {name} must correspond to a declared ingestion crosswalk, while the


### PR DESCRIPTION
Adds a simple XOAI ingestion crosswalk for use with the OAI harvester (and potentially other import methods).

DSpace repositories can disseminate OAI metadata using the base "xoai" dissemination plugin, which actually just disseminates the same XML that the other XSL oai crosswalks use as input.

Ingesting this metadata format from another DSpace OAI server using xoai metadataPrefix, to a DSpace "OAI Harvested Content" collection, provides a way of getting an exact copy of the metadata without any further crosswalking, which can be very useful in certain situations.

(When testing a full harvest from a repository with a lot of custom metadata fields, you may wish to enable `oai.harvester.unknownField = add` and/or `oai.harvester.unknownSchema = add` to make sure missing schemas and fields are automatically created)

We could also do an ORE ingest with this crosswalk with some minor changes, if that is of interest to people.

## Instructions for Reviewers

The plugin comes configured as "xoai" and should already be available in the list of ingest formats in the OAI harvester UI.

1. Set up a new test collection and configure the content source
2. Enter a valid DSpace OAI server URL in the source provider, e.g. `https://demo.dspace.org/server/oai/request`
3. Ensure the server disseminates XOAI (the demo server does) and select this ingest format in the UI
4. Select a set if you like, or leave blank to harvest the whole repository
5. Begin the import and observe the results

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
(https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
