### PR TITLE
Update to Solr 9 compatibility

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,7 @@ services:
       additional_contexts:
         solrconfigs: ./dspace/solr/
       args:
-        SOLR_VERSION: "${SOLR_VER:-8.11}"
+        SOLR_VERSION: "${SOLR_VER:-9.8}"
     networks:
       dspacenet:
     ports:
@@ -105,10 +105,15 @@ services:
     volumes:
     # Keep Solr data directory between reboots
     - solr_data:/var/solr/data
+    # NOTE: We are not running Solr as "root", but we need root permissions to copy our cores to the mounted
+    # /var/solr/data directory. Then we start Solr as the "solr" user.
+    user: root
     # Initialize all DSpace Solr cores then start Solr:
     # * First, run precreate-core to create the core (if it doesn't yet exist). If exists already, this is a no-op
     # * Second, copy configsets to this core:
     #   Updates to Solr configs require the container to be rebuilt/restarted: `docker compose -p d7 up -d --build dspacesolr`
+    # * Third, ensure all new folders are owned by "solr" user
+    # * Finally, start Solr as the "solr" user via the provided solr-foreground script
     entrypoint:
     - /bin/bash
     - '-c'
@@ -126,7 +131,8 @@ services:
       cp -r /opt/solr/server/solr/configsets/qaevent/* qaevent
       precreate-core suggestion /opt/solr/server/solr/configsets/suggestion
       cp -r /opt/solr/server/solr/configsets/suggestion/* suggestion
-      exec solr -f
+      chown -R solr:solr /var/solr
+      runuser -u solr -- solr-foreground
 volumes:
   assetstore:
   pgdata:

--- a/dspace-api/src/main/java/org/dspace/authorize/ResourcePolicy.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/ResourcePolicy.java
@@ -21,7 +21,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
-import org.apache.solr.common.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.dspace.content.DSpaceObject;
 import org.dspace.core.Context;
 import org.dspace.core.HibernateProxyHelper;

--- a/dspace-api/src/main/java/org/dspace/discovery/indexobject/IndexFactoryImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/indexobject/IndexFactoryImpl.java
@@ -181,6 +181,11 @@ public abstract class IndexFactoryImpl<T extends IndexableObject, S> implements 
      */
     protected void addFacetIndex(SolrInputDocument document, String field, String sortValue, String authority,
                                  String fvalue) {
+        // If facet value is null/blank, then we cannot index
+        if (StringUtils.isBlank(fvalue)) {
+            return;
+        }
+
         // the separator for the filter can be eventually configured
         String separator = DSpaceServicesFactory.getInstance().getConfigurationService()
                 .getProperty("discovery.solr.facets.split.char");

--- a/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataExportFilteredItemsReportIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataExportFilteredItemsReportIT.java
@@ -27,7 +27,7 @@ import com.google.common.io.Files;
 import com.opencsv.CSVReader;
 import com.opencsv.exceptions.CsvException;
 import org.apache.commons.lang3.function.TriFunction;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
 import org.dspace.AbstractIntegrationTestWithDatabase;
 import org.dspace.builder.CollectionBuilder;
 import org.dspace.builder.CommunityBuilder;
@@ -52,7 +52,7 @@ public class MetadataExportFilteredItemsReportIT extends AbstractIntegrationTest
     private int[][] itemCountPerSubjectThenPerAuthor = {{12, 15}, {9, 4}};
 
     private String filename;
-    private Logger logger = Logger.getLogger(MetadataExportFilteredItemsReportIT.class);
+    private Logger logger = org.apache.logging.log4j.LogManager.getLogger();
     private ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
 
     @Override

--- a/dspace/solr/qaevent/conf/solrconfig.xml
+++ b/dspace/solr/qaevent/conf/solrconfig.xml
@@ -26,10 +26,11 @@
     <luceneMatchVersion>8.8.1</luceneMatchVersion>
     
     <!-- Include contributed libraries that we use in DSpace. -->
-    <lib dir='${solr.install.dir}/contrib/analysis-extras/lib/'
-         regex='icu4j-.*\.jar'/>
-    <lib dir='${solr.install.dir}/contrib/analysis-extras/lucene-libs/'
-         regex='lucene-analyzers-icu-.*\.jar'/>
+    <!-- NOTE: When using Solr >=9.8, you MUST start Solr with `-Dsolr.config.lib.enabled=true` for this to work -->
+    <lib dir='${solr.install.dir}/modules/analysis-extras/lib/'
+         regex='icu4j-.*\.jar' />
+    <lib dir='${solr.install.dir}/modules/analysis-extras/lib/'
+         regex='lucene-analysis-icu-.*\.jar' />
 
     <dataDir>${solr.data.dir:}</dataDir>
 

--- a/dspace/solr/search/conf/solrconfig.xml
+++ b/dspace/solr/search/conf/solrconfig.xml
@@ -26,10 +26,11 @@
     <luceneMatchVersion>8.8.1</luceneMatchVersion>
 
     <!-- Include contributed libraries that we use in DSpace. -->
-    <lib dir='${solr.install.dir}/contrib/analysis-extras/lib/'
-         regex='icu4j-.*\.jar'/>
-    <lib dir='${solr.install.dir}/contrib/analysis-extras/lucene-libs/'
-         regex='lucene-analyzers-icu-.*\.jar'/>
+    <!-- NOTE: When using Solr >=9.8, you MUST start Solr with `-Dsolr.config.lib.enabled=true` for this to work -->
+    <lib dir='${solr.install.dir}/modules/analysis-extras/lib/'
+         regex='icu4j-.*\.jar' />
+    <lib dir='${solr.install.dir}/modules/analysis-extras/lib/'
+         regex='lucene-analysis-icu-.*\.jar' />
 
     <dataDir>${solr.data.dir:}</dataDir>
 

--- a/dspace/solr/suggestion/conf/solrconfig.xml
+++ b/dspace/solr/suggestion/conf/solrconfig.xml
@@ -24,12 +24,13 @@
 -->
 <config>
     <luceneMatchVersion>8.8.1</luceneMatchVersion>
-    
+
     <!-- Include contributed libraries that we use in DSpace. -->
-    <lib dir='${solr.install.dir}/contrib/analysis-extras/lib/'
-         regex='icu4j-.*\.jar'/>
-    <lib dir='${solr.install.dir}/contrib/analysis-extras/lucene-libs/'
-         regex='lucene-analyzers-icu-.*\.jar'/>
+    <!-- NOTE: When using Solr >=9.8, you MUST start Solr with `-Dsolr.config.lib.enabled=true` for this to work -->
+    <lib dir='${solr.install.dir}/modules/analysis-extras/lib/'
+         regex='icu4j-.*\.jar' />
+    <lib dir='${solr.install.dir}/modules/analysis-extras/lib/'
+         regex='lucene-analysis-icu-.*\.jar' />
 
     <dataDir>${solr.data.dir:}</dataDir>
 

--- a/dspace/src/main/docker/dspace-solr/Dockerfile
+++ b/dspace/src/main/docker/dspace-solr/Dockerfile
@@ -7,14 +7,18 @@
 #
 
 # To build use root as context for (easier) access to solr cfgs
-# docker build --build-arg SOLR_VERSION=8.11 -f ./dspace/src/main/docker/dspace-solr/Dockerfile .
+# docker build --build-arg SOLR_VERSION=9.8 -f ./dspace/src/main/docker/dspace-solr/Dockerfile .
 # This will be published as dspace/dspace-solr:$DSPACE_VERSION
 
-ARG SOLR_VERSION=8.11
+ARG SOLR_VERSION=9.8
 
-FROM docker.io/solr:${SOLR_VERSION}-slim
+# NOTE: Cannot use the "-slim" image because it doesn't include the extra modules needed for DSpace (e.g. icu4j)
+FROM docker.io/solr:${SOLR_VERSION}
 
-ENV AUTHORITY_CONFIGSET_PATH=/opt/solr/server/solr/configsets/authority/conf \
+# Customize SOLR_OPTS to enable "<lib>" tags in solrconfig.xml files
+# Also set several environment variables to save configset paths used below
+ENV SOLR_OPTS="-Dsolr.config.lib.enabled=true" \
+    AUTHORITY_CONFIGSET_PATH=/opt/solr/server/solr/configsets/authority/conf \
     OAI_CONFIGSET_PATH=/opt/solr/server/solr/configsets/oai/conf \
     SEARCH_CONFIGSET_PATH=/opt/solr/server/solr/configsets/search/conf \
     STATISTICS_CONFIGSET_PATH=/opt/solr/server/solr/configsets/statistics/conf \


### PR DESCRIPTION
## References
* Fixes #9300 
* Fixes #10050

## Description
This small PR upgrades our backend to compatibility with Solr v9.  Keep in mind, these changes are NOT backwards compatible with Solr v8, but Solr 8 is now EOL anyways.

The following changes are made:
* Update our `solrconfig.xml` files (where necessary) for all cores to ensure Solr 9 compatibility.  See https://github.com/DSpace/DSpace/commit/150d8f435718e57ef964e8b4929d697318a07784   This change is based on the [suggestions from others who are already using DSpace 7 and Solr 9](https://wiki.lyrasis.org/display/DSDOC7x/Installing+DSpace?focusedCommentId=246284451#comment-246284451)
* Update our Dockerfile & Docker Compose scripts to use Solr 9.8. See d84a17067a0a153c73a25e2739f866e2d6f15085
* Fixed a few minor issues located in testing this PR
     * First, I ran into a NPE while reindexing into Solr 9 because of bad data in my local test database. Nonetheless, I fixed by 5fd1f5c027627a8df7948ed334e37229b136923d
     * Second, I stumbled on some incorrect imports (old log4j and wrong StringUtils) in a few classes.

NOTE: This PR purposefully **does not upgrade SolrJ (Solr Client) to version 9**, because I've found it to require more significant changes to our codebase.  As of version 9, SolrJ has deprecated the `HttpSolrClient` class that we use heavily throughout our codebase.  When attempting to use this deprecated version, I ran into immediate errors (`Caused by: java.lang.IllegalStateException: Connection pool shut down`) when running queries against Solr.   

However, if we stay on SolrJ version 8.x, then DSpace has no issues communicating with a Solr 9 backend.  So, this upgrade of SolrJ should wait until we can do a more significant code refactor.

## Instructions for Reviewers
* Verify all tests pass
* Test this PR with Solr 9 (you can use the contained Dockerfile and/or docker-compose scripts, if you wish).  I've tested this PR locally and found no issues.