### PR TITLE
Fix NPE in RSS/Atom feeds which occurs when invalid date is encountered

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/SyndicationFeed.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/SyndicationFeed.java
@@ -262,7 +262,8 @@ public class SyndicationFeed {
                         entry.setPublishedDate(java.util.Date.from(pubDate.toInstant()));
                         hasDate = true;
                     } else {
-                        log.warn("Publication date value for item {} could not be parsed: {}", item.getID(), pubDateString);
+                        log.warn("Date field {} for item {} could not be parsed: {}", dateField, item.getID(),
+                                 pubDateString);
                     }
                 }
                 // date of last change to Item

--- a/dspace-api/src/main/java/org/dspace/app/util/SyndicationFeed.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/SyndicationFeed.java
@@ -257,8 +257,11 @@ public class SyndicationFeed {
                 String pubDateString = getOneDC(item, dateField);
                 if (pubDateString != null) {
                     ZonedDateTime pubDate = new DCDate(pubDateString).toDate();
-                    entry.setPublishedDate(java.util.Date.from(pubDate.toInstant()));
-                    hasDate = true;
+                    // If date string could not be parsed as a date, then pubDate will be null
+                    if (pubDate != null) {
+                        entry.setPublishedDate(java.util.Date.from(pubDate.toInstant()));
+                        hasDate = true;
+                    }
                 }
                 // date of last change to Item
                 entry.setUpdatedDate(java.util.Date.from(item.getLastModified()));

--- a/dspace-api/src/main/java/org/dspace/app/util/SyndicationFeed.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/SyndicationFeed.java
@@ -261,6 +261,8 @@ public class SyndicationFeed {
                     if (pubDate != null) {
                         entry.setPublishedDate(java.util.Date.from(pubDate.toInstant()));
                         hasDate = true;
+                    } else {
+                        log.warn("Publication date value for item {} could not be parsed: {}", item.getID(), pubDateString);
                     }
                 }
                 // date of last change to Item


### PR DESCRIPTION

## Description
While I was testing #10549, I stumbled on a frequent NullPointerException which can occur in our RSS / Atom Feeds if an invalid Date is encountered.  This seems to have been overlooked in the Date refactor work in #10432 and seems specific to 9.0

This small PR fixes the NPE.  I've tested it thoroughly as I encountered this NPE during my own verification testing of #10549, and I used this PR to solve the NPE errors.

## Instructions for Reviewers
* Review code for sanity. It's a simple check for null values.
* If desired, test it.  As noted above, I've tested this thoroughly already.