### PR TITLE
Fix Collection Admin cannot see withdrawn item metadata

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ItemConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ItemConverter.java
@@ -76,7 +76,7 @@ public class ItemConverter
         try {
             if (obj.isWithdrawn() && (Objects.isNull(context) ||
                                       Objects.isNull(context.getCurrentUser()) ||
-                !(authorizeService.isAdmin(context) || authorizeService.isAdmin(context, obj)))) {
+                !authorizeService.isAdmin(context, obj))) {
                 return new MetadataValueList(List.of());
             }
             if (context != null && (authorizeService.isAdmin(context) || itemService.canEdit(context, obj))) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ItemConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ItemConverter.java
@@ -76,7 +76,7 @@ public class ItemConverter
         try {
             if (obj.isWithdrawn() && (Objects.isNull(context) ||
                                       Objects.isNull(context.getCurrentUser()) ||
-                !(authorizeService.isAdmin(context) || authorizeService.isCollectionAdmin(context)))) {
+                !(authorizeService.isAdmin(context) || authorizeService.isAdmin(context, obj)))) {
                 return new MetadataValueList(List.of());
             }
             if (context != null && (authorizeService.isAdmin(context) || itemService.canEdit(context, obj))) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ItemConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ItemConverter.java
@@ -63,6 +63,9 @@ public class ItemConverter
     /**
      * Retrieves the metadata list filtered according to the hidden metadata configuration
      * When the context is null, it will return the metadatalist as for an anonymous user
+     * When the context is not null, it will return the full metadata list if the user
+     * is allowed to edit the item or if the user is an admin. Otherwise, it will
+     * return the metadata list filtered according to the hidden metadata configuration
      * Overrides the parent method to include virtual metadata
      * @param context The context
      * @param obj     The object of which the filtered metadata will be retrieved

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ItemConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ItemConverter.java
@@ -8,7 +8,6 @@
 package org.dspace.app.rest.converter;
 
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
@@ -76,8 +75,9 @@ public class ItemConverter
         List<MetadataValue> returnList = new LinkedList<>();
         try {
             if (obj.isWithdrawn() && (Objects.isNull(context) ||
-                                      Objects.isNull(context.getCurrentUser()) || !authorizeService.isAdmin(context))) {
-                return new MetadataValueList(new ArrayList<MetadataValue>());
+                                      Objects.isNull(context.getCurrentUser()) ||
+                !(authorizeService.isAdmin(context) || authorizeService.isCollectionAdmin(context)))) {
+                return new MetadataValueList(List.of());
             }
             if (context != null && (authorizeService.isAdmin(context) || itemService.canEdit(context, obj))) {
                 return new MetadataValueList(fullList);


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/DSpace/issues/10584

## Description
Collection administrators cannot view the metadata of withdrawn items on collections they administer; instead they see the message 'This item currently doesn't contain any metadata. Click Add to start adding metadata'. They are able to add metadata. All the other tabs display item content as expected.
The error happens on both item page and edit item page (actually anywhere the item rest endpoints are involved)

## Instructions for Reviewers
1. As Administrator withdrawn a specific item
2. Create a new user and set the user as collection admin of the collection containing the withdrawn item
3. Login as Collection Admin
4. Navigate to the item's page
5. With the fixes in this PR the collection administrator can see the item's metadata in any section 


## Checklist

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
