### PR TITLE
Make DiscoveryConfigurationService "get all facet configs" return UNIQUE set

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/authority/ChoiceAuthorityServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/ChoiceAuthorityServiceImpl.java
@@ -581,7 +581,7 @@ public final class ChoiceAuthorityServiceImpl implements ChoiceAuthorityService 
                             .collect(Collectors.toList()));
                 }
                 DiscoverySearchFilterFacet matchingFacet = null;
-                for (DiscoverySearchFilterFacet facetConfig : searchConfigurationService.getAllFacetsConfig()) {
+                for (DiscoverySearchFilterFacet facetConfig : searchConfigurationService.getAllUniqueFacetsConfig()) {
                     boolean coversAllFieldsFromVocab = true;
                     for (String fieldFromVocab: metadataFields) {
                         boolean coversFieldFromVocab = false;

--- a/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoveryConfigurationService.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoveryConfigurationService.java
@@ -10,8 +10,10 @@ package org.dspace.discovery.configuration;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -197,15 +199,19 @@ public class DiscoveryConfigurationService {
     }
 
     /**
-     * @return All configurations for {@link org.dspace.discovery.configuration.DiscoverySearchFilterFacet}
+     * Get the unique set of configured Discovery facets. This is used when inspecting configuration
+     * to include hierarchical vocabularies in the browse menu.
+     *
+     * @return All unique instances of {@link org.dspace.discovery.configuration.DiscoverySearchFilterFacet}
+     * included in "sidebarFacets" bean, across all Discovery configurations.
      */
-    public List<DiscoverySearchFilterFacet> getAllFacetsConfig() {
-        List<DiscoverySearchFilterFacet> configs = new ArrayList<>();
+    public List<DiscoverySearchFilterFacet> getAllUniqueFacetsConfig() {
+        Set<DiscoverySearchFilterFacet> configs = new LinkedHashSet<>();
         for (String key : map.keySet()) {
             DiscoveryConfiguration config = map.get(key);
             configs.addAll(config.getSidebarFacets());
         }
-        return configs;
+        return new ArrayList<>(configs);
     }
 
     public static void main(String[] args) {


### PR DESCRIPTION
Improve performance and debuggability by refactoring `DiscoveryConfigurationService#getAllFacetConfigs` to `DiscoveryConfigurationService#getAllUniqueFacetConfigs`. Used only by `ChoiceAuthorityService` to generate a hierarchical vocabulary map/cache for including in the browse menu (for example, the default SRSC hierarchical browse).

In a typical default configuration, the previous method could return 100s of these configurations, most of them the same duplicate filters included across many configurations (searchFilterSubject, searchFilterAuthor, etc..).

Given the method is only used for one purpose, and that the returned facet configurations don't include any context as to their parent configuration object, it seems an obvious improvement to refactor this method to return a unique set of facets instead (cutting down the >100 to ~30).

I renamed it for clarify. I've included "port to 8.x" and "port to 7.x" labels just because this is small and I've verified it cleanly picks across to those branches.

## Instructions for Reviewers
As well as a code review, if you want to inspect the output you could debug the return value of the method with and without this PR applied. There is no direct REST endpoint to inspect.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
