### PR TITLE
Resolving XML external entity in user-controlled data in PubMedImport

### DIFF
--- a/dspace-api/src/main/java/org/dspace/importer/external/pubmed/service/PubmedImportMetadataSourceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/pubmed/service/PubmedImportMetadataSourceServiceImpl.java
@@ -235,6 +235,8 @@ public class PubmedImportMetadataSourceServiceImpl extends AbstractImportMetadat
 
         try {
             SAXBuilder saxBuilder = new SAXBuilder();
+            saxBuilder.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            saxBuilder.setFeature("http://xml.org/sax/features/external-general-entities", false);
             Document document = saxBuilder.build(new StringReader(src));
             Element root = document.getRootElement();
 

--- a/dspace-api/src/main/java/org/dspace/importer/external/pubmed/service/PubmedImportMetadataSourceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/pubmed/service/PubmedImportMetadataSourceServiceImpl.java
@@ -235,8 +235,10 @@ public class PubmedImportMetadataSourceServiceImpl extends AbstractImportMetadat
 
         try {
             SAXBuilder saxBuilder = new SAXBuilder();
-            saxBuilder.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            // Disallow external entities & entity expansion to protect against XXE attacks
+            // (NOTE: We receive errors if we disable all DTDs for PubMed, so this is the best we can do)
             saxBuilder.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            saxBuilder.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
             Document document = saxBuilder.build(new StringReader(src));
             Element root = document.getRootElement();
 


### PR DESCRIPTION
Potential fix for [https://github.com/DSpace/DSpace/security/code-scanning/30](https://github.com/DSpace/DSpace/security/code-scanning/30)

To fix the issue, we need to configure the `SAXBuilder` instance to disable DTD processing and external entity resolution. This can be achieved by setting the appropriate features on the underlying XML parser. Specifically:
1. ~~Disable DTD declarations by setting the feature `http://apache.org/xml/features/disallow-doctype-decl` to `true`.~~
    * PubMed will return errors if you attempt to query it with DTDs disabled.  So, instead we disallow entity expansion by setting `http://xml.org/sax/features/external-parameter-entities` to `false`.
2. Disable external entity resolution by setting the feature `http://xml.org/sax/features/external-general-entities` to `false`.

These changes ensure that the XML parser is secure against XXE attacks. The fix will be applied in the `getSingleElementValue` method in `PubmedImportMetadataSourceServiceImpl.java`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
