### PR TITLE
Potential fix for code scanning alert no. 40: XPath injection

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/authority/DSpaceControlledVocabulary.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/DSpaceControlledVocabulary.java
@@ -178,13 +178,13 @@ public class DSpaceControlledVocabulary extends SelfNamedPlugin implements Hiera
     public Choices getMatches(String text, int start, int limit, String locale) {
         init(locale);
         log.debug("Getting matches for '" + text + "'");
-        String xpathExpression = "";
         String[] textHierarchy = text.split(hierarchyDelimiter, -1);
-        for (int i = 0; i < textHierarchy.length; i++) {
-            xpathExpression +=
-                String.format(xpathTemplate, textHierarchy[i].replaceAll("'", "&apos;").toLowerCase());
-        }
+        String xpathExpression = xpathTemplate.repeat(textHierarchy.length);
         XPath xpath = XPathFactory.newInstance().newXPath();
+        xpath.setXPathVariableResolver(variableName -> {
+            int index = Integer.parseInt(variableName.getLocalPart().substring(4)); // Extract index from "paramX"
+            return textHierarchy[index].toLowerCase();
+        });
         int total = 0;
         List<Choice> choices = new ArrayList<Choice>();
         try {
@@ -203,13 +203,13 @@ public class DSpaceControlledVocabulary extends SelfNamedPlugin implements Hiera
     public Choices getBestMatch(String text, String locale) {
         init(locale);
         log.debug("Getting best matches for '" + text + "'");
-        String xpathExpression = "";
         String[] textHierarchy = text.split(hierarchyDelimiter, -1);
-        for (int i = 0; i < textHierarchy.length; i++) {
-            xpathExpression +=
-                String.format(valueTemplate, textHierarchy[i].replaceAll("'", "&apos;"));
-        }
+        String xpathExpression = valueTemplate.repeat(textHierarchy.length);
         XPath xpath = XPathFactory.newInstance().newXPath();
+        xpath.setXPathVariableResolver(variableName -> {
+            int index = Integer.parseInt(variableName.getLocalPart().substring(4)); // Extract index from "paramX"
+            return textHierarchy[index];
+        });
         List<Choice> choices = new ArrayList<Choice>();
         try {
             NodeList results = (NodeList) xpath.evaluate(xpathExpression, vocabulary, XPathConstants.NODESET);


### PR DESCRIPTION
Potential fix for [https://github.com/DSpace/DSpace/security/code-scanning/40](https://github.com/DSpace/DSpace/security/code-scanning/40)

To fix the XPath injection vulnerability, the dynamic construction of the `xpathExpression` should be replaced with a parameterized approach. The `XPath` API allows the use of variable resolvers to safely include user input in queries. This ensures that user input is treated as a literal value rather than executable XPath code.

Steps to fix:
1. Replace the dynamic string concatenation of `xpathExpression` with a parameterized query using variables (e.g., `$param`).
2. Use `XPathVariableResolver` to bind user-provided values to these variables.
3. Update the `getBestMatch` and `getMatches` methods to use this approach.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
