### PR TITLE
Enforce non-repeatable fields in submission forms

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/validation/MetadataValidation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/validation/MetadataValidation.java
@@ -44,6 +44,8 @@ public class MetadataValidation extends AbstractValidation {
 
     private static final String ERROR_VALIDATION_REGEX = "error.validation.regex";
 
+    private static final String ERROR_VALIDATION_NOT_REPEATABLE = "error.validation.not.repeatable";
+
     private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(MetadataValidation.class);
 
     private DCInputsReader inputReader;
@@ -144,6 +146,16 @@ public class MetadataValidation extends AbstractValidation {
                             addError(errors, ERROR_VALIDATION_REQUIRED, "/"
                                     + WorkspaceItemRestRepository.OPERATION_PATH_SECTIONS + "/" + config.getId() + "/" +
                                             input.getFieldName());
+                        }
+                    }
+                    // If there are multiple values for a visible input that is non-repeatable
+                    //   Then add a validation error
+                    if ((!input.isRepeatable() && mdv.size() > 1) && input.isVisible(DCInput.SUBMISSION_SCOPE)
+                            && !valuesRemoved) {
+                        if (input.isAllowedFor(documentTypeValue)) {
+                            addError(errors, ERROR_VALIDATION_NOT_REPEATABLE, "/"
+                                    + WorkspaceItemRestRepository.OPERATION_PATH_SECTIONS + "/" + config.getId() + "/" +
+                                    input.getFieldName());
                         }
                     }
                 }


### PR DESCRIPTION
## References

* Fixes #10560
* Angular PR Dspace/dspace-angular#4274

## Description

Updated the Metadata validation to add an error when a non-repeatable visible input has multiple values.
To prevent imports from submitting items that have multiple values for non-repeatable input fields.

## Instructions for Reviewers

List of changes in this PR:

* Updated `MetadataValidation#validate` to add error (`error.validation.not.repeatable`) when a non-repeatable visible input has multiple values.

How to test:

* Make `dc.contributor.author` non-repeatable in the `traditionalpageone` form (`dspace/config/submission-forms.xml`)
* Login as a submitter
* Navigate to `/import-external`
* Search for `38940749` with `Pubmed` => Import `Comparing Gold-Standard Sanger Sequencing with Two Next-Generation Sequencing Platforms of HIV-1 Single Genome Amplicons.`
* You should see multiple Authors even though the field isn't repeatable.
* Upload a file and accept the license and click "Deposit"
    - This should fail.
    - In the `POST server/api/submission/workspaceitems` reques, verify that an error is returned:
    ```
    "message" : "error.validation.not.repeatable",
    "paths" : [ "/sections/traditionalpageone/dc.contributor.author" ]
    ```

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
