### PR TITLE
Error when using WOS import service

### DIFF
--- a/dspace-api/src/main/java/org/dspace/importer/external/wos/service/WOSImportMetadataSourceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/wos/service/WOSImportMetadataSourceServiceImpl.java
@@ -57,7 +57,7 @@ public class WOSImportMetadataSourceServiceImpl extends AbstractImportMetadataSo
     private static final String AI_PATTERN  = "^AI=(.*)";
     private static final Pattern ISI_PATTERN = Pattern.compile("^\\d{15}$");
 
-    private int timeout = 1000;
+    private final int timeout = 1000;
 
     private String url;
     private String urlSearch;
@@ -127,7 +127,7 @@ public class WOSImportMetadataSourceServiceImpl extends AbstractImportMetadataSo
      */
     private class SearchNBByQueryCallable implements Callable<Integer> {
 
-        private String query;
+        private final String query;
 
         private SearchNBByQueryCallable(String queryString) {
             this.query = queryString;
@@ -156,7 +156,8 @@ public class WOSImportMetadataSourceServiceImpl extends AbstractImportMetadataSo
                 Element tot = xpath.evaluateFirst(root);
                 return Integer.valueOf(tot.getValue());
             }
-            return null;
+            log.warn("API key is missing: cannot execute count request.");
+            return 0;
         }
     }
 
@@ -167,7 +168,7 @@ public class WOSImportMetadataSourceServiceImpl extends AbstractImportMetadataSo
      */
     private class FindByIdCallable implements Callable<List<ImportRecord>> {
 
-        private String doi;
+        private final String doi;
 
         private FindByIdCallable(String doi) {
             this.doi = URLEncoder.encode(doi, StandardCharsets.UTF_8);
@@ -186,6 +187,8 @@ public class WOSImportMetadataSourceServiceImpl extends AbstractImportMetadataSo
                 for (Element record : elements) {
                     results.add(transformSourceRecords(record));
                 }
+            } else {
+                log.warn("API key is missing: cannot execute live import request.");
             }
             return results;
         }
@@ -203,7 +206,7 @@ public class WOSImportMetadataSourceServiceImpl extends AbstractImportMetadataSo
      */
     private class SearchByQueryCallable implements Callable<List<ImportRecord>> {
 
-        private Query query;
+        private final Query query;
 
         private SearchByQueryCallable(String queryString, Integer maxResult, Integer start) {
             query = new Query();
@@ -233,6 +236,8 @@ public class WOSImportMetadataSourceServiceImpl extends AbstractImportMetadataSo
                 for (Element el : omElements) {
                     results.add(transformSourceRecords(el));
                 }
+            } else {
+                log.warn("API key is missing: cannot execute live import request.");
             }
             return results;
         }
@@ -271,9 +276,7 @@ public class WOSImportMetadataSourceServiceImpl extends AbstractImportMetadataSo
         } else if (isIsi(query)) {
             return "UT=(" + query + ")";
         }
-        StringBuilder queryBuilder =  new StringBuilder("TS=(");
-        queryBuilder.append(query).append(")");
-        return queryBuilder.toString();
+        return "TS=(" + query + ")";
     }
 
     private boolean isIsi(String query) {


### PR DESCRIPTION
## References
* Fixes [#10621](https://github.com/DSpace/DSpace/issues/10621)


## Description
 Handled missing Web of Science API key to prevent runtime errors and improve error visibility.

## Instructions for Reviewers
List of changes in this PR:
* Aligned behavior with getRecords(), which already handles missing API keys by returning an empty list.
* Added warn messages in case of missing api key.

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
