### PR TITLE
ISSN code not imported when using SHERPA import

### DIFF
--- a/dspace-api/src/main/java/org/dspace/external/provider/impl/SHERPAv2JournalDataProvider.java
+++ b/dspace-api/src/main/java/org/dspace/external/provider/impl/SHERPAv2JournalDataProvider.java
@@ -97,7 +97,7 @@ public class SHERPAv2JournalDataProvider extends AbstractExternalDataProvider {
         if (CollectionUtils.isNotEmpty(sherpaJournal.getIssns())) {
             String issn = sherpaJournal.getIssns().get(0);
             externalDataObject.addMetadata(new MetadataValueDTO(
-                    "dc", "identifier", "issn", null, issn));
+                "creativeworkseries", "issn", null, null, issn));
 
         }
 

--- a/dspace-api/src/main/java/org/dspace/external/provider/impl/SHERPAv2JournalISSNDataProvider.java
+++ b/dspace-api/src/main/java/org/dspace/external/provider/impl/SHERPAv2JournalISSNDataProvider.java
@@ -106,8 +106,7 @@ public class SHERPAv2JournalISSNDataProvider extends AbstractExternalDataProvide
             String issn = sherpaJournal.getIssns().get(0);
             externalDataObject.setId(issn);
             externalDataObject.addMetadata(new MetadataValueDTO(
-                "dc", "identifier", "issn", null, issn));
-
+                "creativeworkseries", "issn", null, null, issn));
         }
 
         log.debug("New external data object. Title=" + externalDataObject.getValue() + ". ID="

--- a/dspace-api/src/test/java/org/dspace/app/sherpa/SHERPADataProviderTest.java
+++ b/dspace-api/src/test/java/org/dspace/app/sherpa/SHERPADataProviderTest.java
@@ -38,6 +38,12 @@ public class SHERPADataProviderTest extends AbstractDSpaceTest {
     ExternalDataProvider sherpaPublisherProvider;
     ExternalDataProvider sherpaJournalIssnProvider;
 
+    private static final MetadataFieldRef TITLE_FIELD = new MetadataFieldRef("dc", "title", null);
+    private static final MetadataFieldRef ISSN_FIELD = new MetadataFieldRef("creativeworkseries", "issn", null);
+    private static final MetadataFieldRef SHERPA_PUBLISHER_FIELD =
+        new MetadataFieldRef("dc", "identifier", "sherpaPublisher");
+    private static final MetadataFieldRef OTHER_FIELD = new MetadataFieldRef("dc", "identifier", "other");
+
     @BeforeClass
     public static void setUpClass() {
     }
@@ -84,11 +90,9 @@ public class SHERPADataProviderTest extends AbstractDSpaceTest {
         String title = null;
         String identifier = null;
         for (MetadataValueDTO metadataValue : dataObject.getMetadata()) {
-            if (metadataValue.getSchema().equalsIgnoreCase("dc") &&
-            metadataValue.getElement().equalsIgnoreCase("title")) {
+            if (TITLE_FIELD.matches(metadataValue)) {
                 title = metadataValue.getValue();
-            } else if (metadataValue.getSchema().equalsIgnoreCase("creativeworkseries")
-                && metadataValue.getElement().equalsIgnoreCase("issn")) {
+            } else if (ISSN_FIELD.matches(metadataValue)) {
                 identifier = metadataValue.getValue();
             }
         }
@@ -132,11 +136,9 @@ public class SHERPADataProviderTest extends AbstractDSpaceTest {
         String title = null;
         String identifier = null;
         for (MetadataValueDTO metadataValue : dataObject.getMetadata()) {
-            if (metadataValue.getSchema().equalsIgnoreCase("dc") &&
-                metadataValue.getElement().equalsIgnoreCase("title")) {
+            if (TITLE_FIELD.matches(metadataValue)) {
                 title = metadataValue.getValue();
-            } else if (metadataValue.getSchema().equalsIgnoreCase("creativeworkseries")
-                && metadataValue.getElement().equalsIgnoreCase("issn")) {
+            } else if (ISSN_FIELD.matches(metadataValue)) {
                 identifier = metadataValue.getValue();
             }
         }
@@ -172,12 +174,9 @@ public class SHERPADataProviderTest extends AbstractDSpaceTest {
         String title = null;
         String identifier = null;
         for (MetadataValueDTO metadataValue : dataObject.getMetadata()) {
-            if (metadataValue.getSchema().equalsIgnoreCase("dc") &&
-                metadataValue.getElement().equalsIgnoreCase("title")) {
+            if (TITLE_FIELD.matches(metadataValue)) {
                 title = metadataValue.getValue();
-            } else if (metadataValue.getSchema().equalsIgnoreCase("dc")
-                && metadataValue.getElement().equalsIgnoreCase("identifier")
-                && metadataValue.getQualifier().equalsIgnoreCase("issn")) {
+            } else if (ISSN_FIELD.matches(metadataValue)) {
                 identifier = metadataValue.getValue();
             }
         }
@@ -222,12 +221,9 @@ public class SHERPADataProviderTest extends AbstractDSpaceTest {
         String title = null;
         String identifier = null;
         for (MetadataValueDTO metadataValue : dataObject.getMetadata()) {
-            if (metadataValue.getSchema().equalsIgnoreCase("dc") &&
-                metadataValue.getElement().equalsIgnoreCase("title")) {
+            if (TITLE_FIELD.matches(metadataValue)) {
                 title = metadataValue.getValue();
-            } else if (metadataValue.getSchema().equalsIgnoreCase("dc")
-                && metadataValue.getElement().equalsIgnoreCase("identifier")
-                && metadataValue.getQualifier().equalsIgnoreCase("issn")) {
+            } else if (ISSN_FIELD.matches(metadataValue)) {
                 identifier = metadataValue.getValue();
             }
         }
@@ -268,16 +264,11 @@ public class SHERPADataProviderTest extends AbstractDSpaceTest {
         String identifier = null;
         String url = null;
         for (MetadataValueDTO metadataValue : dataObject.getMetadata()) {
-            if (metadataValue.getSchema().equalsIgnoreCase("dc") &&
-                metadataValue.getElement().equalsIgnoreCase("title")) {
+            if (TITLE_FIELD.matches(metadataValue)) {
                 title = metadataValue.getValue();
-            } else if (metadataValue.getSchema().equalsIgnoreCase("dc")
-                && metadataValue.getElement().equalsIgnoreCase("identifier")
-                && metadataValue.getQualifier().equalsIgnoreCase("sherpaPublisher")) {
+            } else if (SHERPA_PUBLISHER_FIELD.matches(metadataValue)) {
                 identifier = metadataValue.getValue();
-            } else if (metadataValue.getSchema().equalsIgnoreCase("dc")
-                && metadataValue.getElement().equalsIgnoreCase("identifier")
-                && metadataValue.getQualifier().equalsIgnoreCase("other")) {
+            } else if (OTHER_FIELD.matches(metadataValue)) {
                 url = metadataValue.getValue();
             }
         }
@@ -328,16 +319,11 @@ public class SHERPADataProviderTest extends AbstractDSpaceTest {
         String identifier = null;
         String url = null;
         for (MetadataValueDTO metadataValue : dataObject.getMetadata()) {
-            if (metadataValue.getSchema().equalsIgnoreCase("dc") &&
-                metadataValue.getElement().equalsIgnoreCase("title")) {
+            if (TITLE_FIELD.matches(metadataValue)) {
                 title = metadataValue.getValue();
-            } else if (metadataValue.getSchema().equalsIgnoreCase("dc")
-                && metadataValue.getElement().equalsIgnoreCase("identifier")
-                && metadataValue.getQualifier().equalsIgnoreCase("sherpaPublisher")) {
+            } else if (SHERPA_PUBLISHER_FIELD.matches(metadataValue)) {
                 identifier = metadataValue.getValue();
-            } else if (metadataValue.getSchema().equalsIgnoreCase("dc")
-                && metadataValue.getElement().equalsIgnoreCase("identifier")
-                && metadataValue.getQualifier().equalsIgnoreCase("other")) {
+            } else if (OTHER_FIELD.matches(metadataValue)) {
                 url = metadataValue.getValue();
             }
         }
@@ -378,12 +364,9 @@ public class SHERPADataProviderTest extends AbstractDSpaceTest {
         exemplarDataObject.setId(validIdentifier);
         exemplarDataObject.setValue(validName);
         exemplarDataObject.setDisplayValue(validName);
-        exemplarDataObject.addMetadata(new MetadataValueDTO("dc", "title", null, null,
-                validName));
-        exemplarDataObject.addMetadata(new MetadataValueDTO("dc", "identifier", "sherpaPublisher", null,
-                validIdentifier));
-        exemplarDataObject.addMetadata(new MetadataValueDTO("dc", "identifier", "other", null,
-                validUrl));
+        exemplarDataObject.addMetadata(TITLE_FIELD.toMetadata(validName));
+        exemplarDataObject.addMetadata(SHERPA_PUBLISHER_FIELD.toMetadata(validIdentifier));
+        exemplarDataObject.addMetadata(OTHER_FIELD.toMetadata(validUrl));
 
         // Exemplar object 2 has a different order of metadata values
         // (we still expect it to be 'equal' when comparing since there is no concept of place for DTOs)
@@ -392,12 +375,9 @@ public class SHERPADataProviderTest extends AbstractDSpaceTest {
         exemplarDataObject2.setId(validIdentifier);
         exemplarDataObject2.setValue(validName);
         exemplarDataObject2.setDisplayValue(validName);
-        exemplarDataObject2.addMetadata(new MetadataValueDTO("dc", "identifier", "other", null,
-                validUrl));
-        exemplarDataObject2.addMetadata(new MetadataValueDTO("dc", "title", null, null,
-                validName));
-        exemplarDataObject2.addMetadata(new MetadataValueDTO("dc", "identifier", "sherpaPublisher", null,
-                validIdentifier));
+        exemplarDataObject2.addMetadata(OTHER_FIELD.toMetadata(validUrl));
+        exemplarDataObject2.addMetadata(TITLE_FIELD.toMetadata(validName));
+        exemplarDataObject2.addMetadata(SHERPA_PUBLISHER_FIELD.toMetadata(validIdentifier));
 
         // Nonequal object should NOT evaluate as equal to our data
         ExternalDataObject nonEqualObject = new ExternalDataObject();
@@ -405,12 +385,9 @@ public class SHERPADataProviderTest extends AbstractDSpaceTest {
         nonEqualObject.setId(validIdentifier);
         nonEqualObject.setValue(validName);
         nonEqualObject.setDisplayValue(validName);
-        nonEqualObject.addMetadata(new MetadataValueDTO("dc", "title", null, null,
-                "Private Library of Science"));
-        nonEqualObject.addMetadata(new MetadataValueDTO("dc", "identifier", "sherpaPublisher", null,
-                validIdentifier));
-        nonEqualObject.addMetadata(new MetadataValueDTO("dc", "identifier", "other", null,
-                validUrl));
+        nonEqualObject.addMetadata(TITLE_FIELD.toMetadata("Private Library of Science"));
+        nonEqualObject.addMetadata(SHERPA_PUBLISHER_FIELD.toMetadata(validIdentifier));
+        nonEqualObject.addMetadata(OTHER_FIELD.toMetadata(validUrl));
 
 
         // Retrieve the dataobject(s) from the data provider
@@ -435,4 +412,28 @@ public class SHERPADataProviderTest extends AbstractDSpaceTest {
         // Assert NON-equality to the 3rd object
         assertNotEquals(nonEqualObject, dataObject);
     }
+
+    private static class MetadataFieldRef {
+        public final String schema;
+        public final String element;
+        public final String qualifier;
+
+        public MetadataFieldRef(String schema, String element, String qualifier) {
+            this.schema = schema;
+            this.element = element;
+            this.qualifier = qualifier;
+        }
+
+        public boolean matches(MetadataValueDTO value) {
+            return schema.equalsIgnoreCase(value.getSchema()) &&
+                element.equalsIgnoreCase(value.getElement()) &&
+                (qualifier == null ? value.getQualifier() == null
+                    : qualifier.equalsIgnoreCase(value.getQualifier()));
+        }
+
+        public MetadataValueDTO toMetadata(String value) {
+            return new MetadataValueDTO(schema, element, qualifier, null, value);
+        }
+    }
+
 }

--- a/dspace-api/src/test/java/org/dspace/app/sherpa/SHERPADataProviderTest.java
+++ b/dspace-api/src/test/java/org/dspace/app/sherpa/SHERPADataProviderTest.java
@@ -87,9 +87,8 @@ public class SHERPADataProviderTest extends AbstractDSpaceTest {
             if (metadataValue.getSchema().equalsIgnoreCase("dc") &&
             metadataValue.getElement().equalsIgnoreCase("title")) {
                 title = metadataValue.getValue();
-            } else if (metadataValue.getSchema().equalsIgnoreCase("dc")
-                && metadataValue.getElement().equalsIgnoreCase("identifier")
-                && metadataValue.getQualifier().equalsIgnoreCase("issn")) {
+            } else if (metadataValue.getSchema().equalsIgnoreCase("creativeworkseries")
+                && metadataValue.getElement().equalsIgnoreCase("issn")) {
                 identifier = metadataValue.getValue();
             }
         }
@@ -136,9 +135,8 @@ public class SHERPADataProviderTest extends AbstractDSpaceTest {
             if (metadataValue.getSchema().equalsIgnoreCase("dc") &&
                 metadataValue.getElement().equalsIgnoreCase("title")) {
                 title = metadataValue.getValue();
-            } else if (metadataValue.getSchema().equalsIgnoreCase("dc")
-                && metadataValue.getElement().equalsIgnoreCase("identifier")
-                && metadataValue.getQualifier().equalsIgnoreCase("issn")) {
+            } else if (metadataValue.getSchema().equalsIgnoreCase("creativeworkseries")
+                && metadataValue.getElement().equalsIgnoreCase("issn")) {
                 identifier = metadataValue.getValue();
             }
         }

--- a/dspace/config/spring/api/sherpa.xml
+++ b/dspace/config/spring/api/sherpa.xml
@@ -17,7 +17,7 @@
 				<bean class="org.dspace.app.sherpa.submit.MetadataValueISSNExtractor">
 					<property name="metadataList">
 						<list>
-							<value>dc.identifier.issn</value>
+							<value>creativeworkseries.issn</value>
 						</list>
 					</property>
 				</bean>


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/DSpace/issues/10620


## Description
Updated Sherpa journal live import to correctly map the ISSN field.

## Instructions for Reviewers

List of changes in this PR:
* Updated Sherpa mapping to use creativeworkseries.issn instead of dc.identifier.issn

Steps to test the solution:
1. Go to MyDSpace -> Import from external sources and select journals
2. Choose a SHERPA service (if ISSN, use this code 1470-3572)
3. Start the import and check the imported metadata
4. Verify that ISSN code is present in the dedicated field

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
