### PR TITLE
Bulk access control fails to iterate over each item in a collection, producing duplicate policies for some items

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/bulkaccesscontrol/BulkAccessControl.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkaccesscontrol/BulkAccessControl.java
@@ -416,7 +416,7 @@ public class BulkAccessControl extends DSpaceRunnable<BulkAccessControlScriptCon
         discoverQuery.setQuery(query);
         discoverQuery.setStart(start);
         discoverQuery.setMaxResults(limit);
-
+        discoverQuery.setSortField("search.resourceid", DiscoverQuery.SORT_ORDER.asc);
         return discoverQuery;
     }
 

--- a/dspace-api/src/test/java/org/dspace/app/bulkaccesscontrol/BulkAccessControlIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/bulkaccesscontrol/BulkAccessControlIT.java
@@ -32,8 +32,10 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -1830,6 +1832,88 @@ public class BulkAccessControlIT extends AbstractIntegrationTestWithDatabase {
         assertThat(testDSpaceRunnableHandler.getErrorMessages(), empty());
         assertThat(testDSpaceRunnableHandler.getWarningMessages(), empty());
     }
+
+
+    @Test
+    public void bulkAccessControlShouldProcessEachItemOnceWithPagination() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        Community community = CommunityBuilder.createCommunity(context)
+                                              .withName("Test Community")
+                                              .build();
+
+        Collection collection = CollectionBuilder.createCollection(context, community)
+                                                 .withName("Test Collection")
+                                                 .build();
+
+        List<UUID> createdItemIDs = new ArrayList<>();
+
+        for (int i = 0; i < 25; i++) {
+            Item item = ItemBuilder.createItem(context, collection).build();
+
+            Bundle bundle = BundleBuilder.createBundle(context, item)
+                                         .withName("ORIGINAL")
+                                         .build();
+
+            BitstreamBuilder.createBitstream(context, bundle,
+                                             IOUtils.toInputStream("Bitstream content " + i,
+                                                                   CharEncoding.UTF_8))
+                            .withName("bitstream_" + i)
+                            .build();
+
+            createdItemIDs.add(item.getID());
+        }
+
+        context.restoreAuthSystemState();
+
+        // JSON without constraints: apply to ALL items
+        String json = """
+            { "item": {
+                  "mode": "add",
+                  "accessConditions": [
+                      {
+                        "name": "openaccess"
+                      }
+                  ]
+               }}
+            """;
+
+        buildJsonFile(json);
+
+        String[] args = {
+            "bulk-access-control",
+            "-u", community.getID().toString(),
+            "-f", tempFilePath,
+            "-e", admin.getEmail()
+        };
+
+        TestDSpaceRunnableHandler testHandler = new TestDSpaceRunnableHandler();
+        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), testHandler, kernelImpl);
+
+        assertThat(testHandler.getErrorMessages(), empty());
+        assertThat(testHandler.getWarningMessages(), empty());
+
+        // Collect item IDs from the info messages
+        List<String> infoMessages = testHandler.getInfoMessages();
+        List<UUID> updatedItemIDs = infoMessages.stream()
+                                                .map(msg -> {
+                                                    int startIdx = msg.indexOf("Item {") + 6;
+                                                    int endIdx = msg.indexOf("}", startIdx);
+                                                    return UUID.fromString(msg.substring(startIdx, endIdx));
+                                                })
+                                                .toList();
+
+        Set<UUID> uniqueUpdatedItemIDs = new HashSet<>(updatedItemIDs);
+
+        // Check if any item was processed multiple times
+        assertThat("Some items were processed more than once!",
+                   uniqueUpdatedItemIDs.size(), is(updatedItemIDs.size()));
+
+        // Check all items were updated once
+        assertThat("Not all created items were updated!",
+                   createdItemIDs, containsInAnyOrder(uniqueUpdatedItemIDs.toArray()));
+    }
+
 
     private List<Item> findItems(String query) throws SearchServiceException {
 


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/DSpace/issues/9208

## Description

Added `discoverQuery.setSortField("search.resourceid", DiscoverQuery.SORT_ORDER.asc)`  to enforce a stable ordering when paginating over items returned by Solr. 
This prevents duplicate processing of items when handling large datasets in batches.


## Instructions for Reviewers


List of changes in this PR:
* Updated BulkAccessControl to retrieve items with uuid sorting
* Added an integration tests to reproduce the issue

Follow the instructions at https://github.com/DSpace/DSpace/issues/9208. 
NOTE: it is sufficent to have a collection with more then 20 items to reproduce the issue.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
