### PR TITLE
[Port dspace-7_x] FIX Submission patch operation weird recognition check

### DIFF
--- a/dspace-api/src/test/data/dspaceFolder/config/item-submission.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/item-submission.xml
@@ -26,6 +26,7 @@
         <name-map collection-handle="123456789/test-hidden" submission-name="test-hidden"/>
         <name-map collection-handle="123456789/collection-test" submission-name="collectiontest"/>
         <name-map collection-entity-type="CustomEntityType" submission-name="entitytypetest"/>
+        <name-map collection-handle="123456789/collection-test-patch" submission-name="publicationTestPatch"/>
     </submission-map>
 
 
@@ -179,6 +180,11 @@
             <scope visibility="hidden" visibilityOutside="hidden">submission</scope>
         </step-definition>
 
+        <step-definition id="upload-no-required-metadata" mandatory="true">
+            <heading>submit.progressbar.upload-no-required-metadata</heading>
+            <processing-class>org.dspace.app.rest.submit.step.UploadStep</processing-class>
+            <type>upload</type>
+        </step-definition>
     </step-definitions>
 
     <!-- The submission-definitions map lays out the detailed definition of -->
@@ -267,6 +273,12 @@
             <step id="collection"/>
         </submission-process>
 
+        <submission-process name="publicationTestPatch">
+            <step id="collection" />
+            <step id="traditionalpageone" />
+            <step id="upload-no-required-metadata" />
+            <step id="license" />
+        </submission-process>
     </submission-definitions>
 
 </item-submission>

--- a/dspace-api/src/test/data/dspaceFolder/config/spring/api/access-conditions.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/spring/api/access-conditions.xml
@@ -55,6 +55,7 @@
         <property name="map">
             <map>
                 <entry key="upload" value-ref="uploadConfigurationDefault" />
+                <entry key="upload-no-required-metadata" value-ref="uploadConfigurationPublicationTestPatch" />
             </map>
         </property>
     </bean>
@@ -112,6 +113,18 @@
         <property name="bulkAccessConditionConfigurations">
             <list>
                 <ref bean="defaultBulkAccessConditionConfiguration"/>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="uploadConfigurationPublicationTestPatch" class="org.dspace.submit.model.UploadConfiguration">
+        <property name="name" value="upload-no-required-metadata"/>
+        <property name="metadata" value="bitstream-metadata" />
+        <property name="options">
+            <list>
+                <ref bean="administrator"/>
+                <ref bean="openAccess"/>
+                <ref bean="embargoed" />
             </list>
         </property>
     </bean>

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/UploadStep.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/UploadStep.java
@@ -10,6 +10,7 @@ package org.dspace.app.rest.submit.step;
 import java.io.BufferedInputStream;
 import java.io.InputStream;
 import java.util.List;
+import java.util.regex.Pattern;
 import javax.servlet.http.HttpServletRequest;
 
 import org.apache.logging.log4j.Logger;
@@ -48,6 +49,13 @@ public class UploadStep extends AbstractProcessingStep
 
     public static final String UPLOAD_STEP_METADATA_SECTION = "bitstream-metadata";
 
+    private static final Pattern UPDATE_METADATA_PATTERN =
+        Pattern.compile("^/sections/[^/]+/files/[^/]+/metadata/[^/]+(/[^/]+)?$");
+    private static final Pattern PRIMARY_FLAG_PATTERN =
+        Pattern.compile("^/sections/[^/]+/primary$");
+    private static final Pattern ACCESS_CONDITION_PATTERN =
+        Pattern.compile("^/sections/[^/]+/files/[^/]+/accessConditions(/[^/]+)?$");
+
     @Override
     public DataUpload getData(SubmissionService submissionService, InProgressSubmission obj,
                               SubmissionStepConfig config) throws Exception {
@@ -69,23 +77,23 @@ public class UploadStep extends AbstractProcessingStep
 
         String instance = null;
         if ("remove".equals(op.getOp())) {
-            if (op.getPath().contains(UPLOAD_STEP_METADATA_PATH)) {
+            if (UPDATE_METADATA_PATTERN.matcher(op.getPath()).matches()) {
                 instance = UPLOAD_STEP_METADATA_OPERATION_ENTRY;
-            } else if (op.getPath().contains(UPLOAD_STEP_ACCESSCONDITIONS_OPERATION_ENTRY)) {
+            } else if (ACCESS_CONDITION_PATTERN.matcher(op.getPath()).matches()) {
                 instance = stepConf.getType() + "." + UPLOAD_STEP_ACCESSCONDITIONS_OPERATION_ENTRY;
             } else {
                 instance = UPLOAD_STEP_REMOVE_OPERATION_ENTRY;
             }
         } else if ("move".equals(op.getOp())) {
-            if (op.getPath().contains(UPLOAD_STEP_METADATA_PATH)) {
+            if (UPDATE_METADATA_PATTERN.matcher(op.getPath()).matches()) {
                 instance = UPLOAD_STEP_METADATA_OPERATION_ENTRY;
             } else {
                 instance = UPLOAD_STEP_MOVE_OPERATION_ENTRY;
             }
         } else {
-            if (op.getPath().contains(UPLOAD_STEP_ACCESSCONDITIONS_OPERATION_ENTRY)) {
+            if (ACCESS_CONDITION_PATTERN.matcher(op.getPath()).matches()) {
                 instance = stepConf.getType() + "." + UPLOAD_STEP_ACCESSCONDITIONS_OPERATION_ENTRY;
-            } else if (op.getPath().contains(UPLOAD_STEP_METADATA_PATH)) {
+            } else if (UPDATE_METADATA_PATTERN.matcher(op.getPath()).matches()) {
                 instance = UPLOAD_STEP_METADATA_OPERATION_ENTRY;
             }
         }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionDefinitionsControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionDefinitionsControllerIT.java
@@ -35,7 +35,7 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
     // The total number of expected submission definitions is referred to in multiple tests and assertions as
     // is the last page (totalDefinitions - 1)
     // This integer should be maintained along with any changes to item-submissions.xml
-    private static final int totalDefinitions = 9;
+    private static final int totalDefinitions = 10;
 
     @Test
     public void findAll() throws Exception {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkflowItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkflowItemRestRepositoryIT.java
@@ -9,6 +9,7 @@ package org.dspace.app.rest;
 
 import static com.jayway.jsonpath.JsonPath.read;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -2216,6 +2217,51 @@ public class WorkflowItemRestRepositoryIT extends AbstractControllerIntegrationT
             .andExpect(jsonPath("$.sections.test-never-hidden").exists())
             .andExpect(jsonPath("$.sections.test-always-hidden").doesNotExist());
 
+    }
+
+    @Test
+    public void deleteBitstreamTest()
+        throws Exception {
+        context.turnOffAuthorisationSystem();
+        EPerson submitter = EPersonBuilder.createEPerson(context)
+            .withEmail("submitter@example.com")
+            .withPassword(password)
+            .build();
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .build();
+        Collection collection1 = CollectionBuilder.createCollection(context, parentCommunity,
+                "123456789/collection-test-patch")
+            .withName("Collection 1")
+            .build();
+        Bitstream bitstream = null;
+        WorkspaceItem witem = null;
+        String bitstreamContent = "0123456789";
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, Charset.defaultCharset())) {
+            context.setCurrentUser(submitter);
+            witem = WorkspaceItemBuilder.createWorkspaceItem(context, collection1)
+                .withTitle("Test WorkspaceItem")
+                .withIssueDate("2019-10-01")
+                .grantLicense()
+                .build();
+            bitstream = BitstreamBuilder.createBitstream(context, witem.getItem(), is)
+                .withName("Test bitstream")
+                .withDescription("This is a bitstream to test range requests")
+                .withMimeType("text/plain")
+                .build();
+        }
+        context.restoreAuthSystemState();
+        String tokenSubmitter = getAuthToken(submitter.getEmail(), password);
+        List<Operation> deleteFile = new ArrayList<>();
+        deleteFile.add(new RemoveOperation("/sections/bitstream-metadata-publication/files/0/"));
+        getClient(tokenSubmitter).perform(patch("/api/submission/workspaceitems/" + witem.getID())
+                .content(getPatchContent(deleteFile))
+                .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+            .andExpect(status().isOk());
+        // verify that the patch removed bitstream
+        getClient(tokenSubmitter).perform(get("/api/submission/workspaceitems/" + witem.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.sections.bitstream-metadata-publication.files",hasSize(0)));
     }
 
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkflowItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkflowItemRestRepositoryIT.java
@@ -2253,7 +2253,7 @@ public class WorkflowItemRestRepositoryIT extends AbstractControllerIntegrationT
         context.restoreAuthSystemState();
         String tokenSubmitter = getAuthToken(submitter.getEmail(), password);
         List<Operation> deleteFile = new ArrayList<>();
-        deleteFile.add(new RemoveOperation("/sections/bitstream-metadata-publication/files/0/"));
+        deleteFile.add(new RemoveOperation("/sections/upload-no-required-metadata/files/0/"));
         getClient(tokenSubmitter).perform(patch("/api/submission/workspaceitems/" + witem.getID())
                 .content(getPatchContent(deleteFile))
                 .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
@@ -2261,7 +2261,7 @@ public class WorkflowItemRestRepositoryIT extends AbstractControllerIntegrationT
         // verify that the patch removed bitstream
         getClient(tokenSubmitter).perform(get("/api/submission/workspaceitems/" + witem.getID()))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.sections.bitstream-metadata-publication.files",hasSize(0)));
+            .andExpect(jsonPath("$.sections.upload-no-required-metadata.files",hasSize(0)));
     }
 
 }


### PR DESCRIPTION
## References
* Fixes #10452 

## Description
Improved the check on the Rest application when a patch request is received. Now we make use of Regex instead of checking using keywords 

**Fixes the ability to delete uploaded files when using a custom upload step**

## Instructions for Reviewers
without installing this fix test:

1. configure a new upload step called `upload-no-required-metadata` or any other upload step which included metadata in it
2. upload a file during the submission
3. delete the just uploaded file during the submission
4. the delete/remove operation fails with 422 error since the Remove patch operation is wrongly recognized as a RemoveMetadataValue operation

List of changes in this PR:
* Integration test to check for the broken behavior (to avoid any further change to the code will break again this behavior)
* Improved check for the patch request


## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
