### PR TITLE
Potential fix for code scanning alert no. 3549: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/dspace-swordv2/src/main/java/org/dspace/sword2/SimpleZipContentIngester.java
+++ b/dspace-swordv2/src/main/java/org/dspace/sword2/SimpleZipContentIngester.java
@@ -138,12 +138,18 @@ public class SimpleZipContentIngester extends AbstractSwordContentIngester {
             Enumeration zenum = zip.entries();
             while (zenum.hasMoreElements()) {
                 ZipEntry entry = (ZipEntry) zenum.nextElement();
+                String entryName = entry.getName();
+                java.nio.file.Path entryPath = java.nio.file.Paths.get(entryName).normalize();
+                if (entryPath.isAbsolute() || entryPath.startsWith("..")) {
+                    throw new SwordError(UriRegistry.ERROR_BAD_REQUEST, "Invalid zip entry: " + entryName);
+                }
+
                 InputStream stream = zip.getInputStream(entry);
                 Bitstream bs = bitstreamService.create(context, target, stream);
                 BitstreamFormat format = this
-                    .getFormat(context, entry.getName());
+                    .getFormat(context, entryName);
                 bs.setFormat(context, format);
-                bs.setName(context, entry.getName());
+                bs.setName(context, entryName);
                 bitstreamService.update(context, bs);
                 derivedResources.add(bs);
             }


### PR DESCRIPTION
Potential fix for [https://github.com/DSpace/DSpace/security/code-scanning/3549](https://github.com/DSpace/DSpace/security/code-scanning/3549)

To fix the issue, we need to validate the zip entry names to ensure they do not contain directory traversal sequences or other invalid characters. This can be achieved by normalizing the entry path and verifying that it resides within the intended directory. Specifically:

1. Use `java.nio.file.Path` to normalize the zip entry name and ensure it does not escape the intended directory.
2. Reject any zip entries with names that resolve to paths outside the target directory.
3. Update the `unzipToBundle` method to include this validation before processing each zip entry.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
