### PR TITLE
Add Gmail XOAUTH2 token-based auth for JavaMail SMTP support (#8627)

### DIFF
--- a/dspace-services/pom.xml
+++ b/dspace-services/pom.xml
@@ -31,14 +31,14 @@
             <build>
                 <plugins>
                     <!-- This plugin allows us to run a Groovy script in our Maven POM
-                         (see: https://groovy.github.io/gmaven/groovy-maven-plugin/execute.html )
-                         We are generating a OS-agnostic version (agnostic.build.dir) of
-                         the ${project.build.directory} property (full path of target dir).
-                         This is needed by the Surefire plugin (see below) to
-                         initialize the Unit Test environment's dspace.dir setting.
-                         Otherwise, the Unit Test Framework will not work on Windows OS.
-                         This Groovy code was mostly borrowed from:
-                         http://stackoverflow.com/questions/3872355/how-to-convert-file-separator-in-maven
+                        (see: https://groovy.github.io/gmaven/groovy-maven-plugin/execute.html )
+                        We are generating a OS-agnostic version (agnostic.build.dir) of
+                        the ${project.build.directory} property (full path of target dir).
+                        This is needed by the Surefire plugin (see below) to
+                        initialize the Unit Test environment's dspace.dir setting.
+                        Otherwise, the Unit Test Framework will not work on Windows OS.
+                        This Groovy code was mostly borrowed from:
+                        http://stackoverflow.com/questions/3872355/how-to-convert-file-separator-in-maven
                     -->
                     <plugin>
                         <groupId>org.codehaus.gmaven</groupId>
@@ -68,7 +68,7 @@
                                 <!-- Specify the dspace.dir to use for test environment -->
                                 <!-- ${agnostic.build.dir} is set dynamically by groovy-maven-plugin above -->
                                 <!-- For "dspace-services" we don't need a full test environment, we just need
-                                     a valid "config-definition.xml" which exists in target/test-classes/ -->
+                                    a valid "config-definition.xml" which exists in target/test-classes/ -->
                                 <dspace.dir>${agnostic.build.dir}/test-classes</dspace.dir>
                             </systemPropertyVariables>
                         </configuration>
@@ -146,6 +146,16 @@
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>com.google.api-client</groupId>
+            <artifactId>google-api-client</artifactId>
+            <version>2.7.2</version>
+        </dependency>
+    
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.10.0.pr1</version>
+        </dependency>
     </dependencies>
 </project>

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -147,8 +147,21 @@ db.removeabandonedtimeout = 300
 mail.server = smtp.example.com
 
 # SMTP mail server authentication username and password (if required)
-#mail.server.username =
-#mail.server.password =
+# mail.server.username =
+# mail.server.password =
+
+# If your Google email server requires an OAUTH2 token, you can set it here.
+# You will need a refresh token to generate access tokens for sending mail.
+# See https://www.labnol.org/gmail-smtp-send-emails-220530 for more information.
+
+# If you are version-controlling this file, you may want to define these as environment variables
+# (e.g., in your ~/.bashrc) and reference them here as ${OAUTH2_*}. These parameters do not need
+# to be uncommented in this file if they are available in the environment, but including them
+# here is recommended for documentation purposes.
+
+# mail.oauth2.clientId = ${OAUTH2_CLIENT_ID}
+# mail.oauth2.clientSecret = ${OAUTH2_CLIENT_SECRET}
+# mail.oauth2.refreshToken = ${OAUTH2_TOKEN}
 
 # SMTP mail server alternate port (defaults to 25)
 mail.server.port = 25
@@ -195,7 +208,8 @@ mail.charset = UTF-8
 #mail.allowed.referrers = ${dspace.hostname}
 
 # Pass extra settings to the Java mail library. Comma-separated, equals sign between
-# the key and the value. For example:
+# the key and the value. See https://javaee.github.io/javamail/docs/api/com/sun/mail/smtp/package-summary.html for more info.
+# For example:
 #mail.extraproperties = mail.smtp.socketFactory.port=465, \
 #                       mail.smtp.socketFactory.class=javax.net.ssl.SSLSocketFactory, \
 #                       mail.smtp.socketFactory.fallback=false

--- a/pom.xml
+++ b/pom.xml
@@ -1354,6 +1354,26 @@
                 <artifactId>gson</artifactId>
                 <version>2.11.0</version>
             </dependency>
+            <dependency>
+                <groupId>com.google.http-client</groupId>
+                <artifactId>google-http-client</artifactId>
+                <version>1.45.2</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.http-client</groupId>
+                <artifactId>google-http-client-gson</artifactId>
+                <version>1.45.2</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.j2objc</groupId>
+                <artifactId>j2objc-annotations</artifactId>
+                <version>3.0.0</version>
+            </dependency>
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-context</artifactId>
+                <version>1.27.2</version>
+            </dependency>
 
             <!-- Reminder: Keep icu4j (in Parent POM) synced with version used by lucene-analyzers-icu below,
              otherwise ICUFoldingFilterFactory may throw errors in tests.  -->


### PR DESCRIPTION
## References
* Fixes #8627 (Only partially – _adds support for Google but not yet for Microsoft_)
* [JavaMail SMTP Documentation](https://javaee.github.io/javamail/docs/api/com/sun/mail/smtp/package-summary.html)
* [Gmail Setup](https://www.labnol.org/gmail-smtp-send-emails-220530)
* [Google API Client Library for Java](https://developers.google.com/api-client-library/java)
* @mwoodiupui's [advice on how to get started](https://github.com/DSpace/DSpace/issues/8627#issuecomment-2847292581).

## Description
Google began enforcing OAuth2 token-based authentication for SMTP access, breaking traditional username/password logins for Gmail-based email servers. To restore DSpace’s ability to send emails via Gmail, we extended `EmailServiceImpl` to support OAuth2 access tokens, including auto-generation via a refresh token.

One of the changes we included was supplying sensitive mail-authentication-related arguments via environmental variables. They can also be explicitly set.

For now, these changes are specific to Gmail, though in the future, we could further expand to Microsoft's email services as well.

## Instructions for Reviewers

* Added support for Gmail SMTP OAuth2 authentication using access + refresh tokens
* Added ability to auto-generate new access tokens from a refresh token
* Refactored configuration loading to support both `dspace.cfg` and environment variables
* Modified Maven `pom.xml` to include required Google API libraries, resolving dependency conflicts

How to test this PR:

1. Obtain a Gmail client_id, client_secret, and refresh_token by following [this guide](https://www.labnol.org/gmail-smtp-send-emails-220530).
2. Add the following to the DSpace user's `~/.bashrc`:

```
export OAUTH2_REFRESH_TOKEN=xxx
export OAUTH2_CLIENT_SECRET=xxx
export OAUTH2_CLIENT_ID=xxx
```

OR add the following to your `dspace.cfg`:

```
mail.oauth2.clientId = xxx
mail.oauth2.clientSecret = xxx
mail.oauth2.refreshToken = xxx
```

Defining both is redundant but personally recommended for production for better documentation.

3. Send a test email through DSpace (`./bin/dspace test-email`).

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).

I made these changes against the 8.1 tag – hopefully that doesn't cause a major issue.

- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.

I have not done this.

- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
