### PR TITLE
Improve DSpaceObjectService string comparison tests

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/DSpaceObjectServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/DSpaceObjectServiceImpl.java
@@ -187,11 +187,11 @@ public abstract class DSpaceObjectServiceImpl<T extends DSpaceObject> implements
                                            String authority) {
         List<MetadataValue> metadata = getMetadata(dso, schema, element, qualifier, lang);
         List<MetadataValue> result = new ArrayList<>(metadata);
-        if (!authority.equals(Item.ANY)) {
+        if (!Item.ANY.equals(authority)) {
             Iterator<MetadataValue> iterator = result.iterator();
             while (iterator.hasNext()) {
                 MetadataValue metadataValue = iterator.next();
-                if (!authority.equals(metadataValue.getAuthority())) {
+                if (!StringUtils.equals(authority, metadataValue.getAuthority())) {
                     iterator.remove();
                 }
             }
@@ -509,7 +509,7 @@ public abstract class DSpaceObjectServiceImpl<T extends DSpaceObject> implements
         MetadataField metadataField = metadataValue.getMetadataField();
         MetadataSchema metadataSchema = metadataField.getMetadataSchema();
         // We will attempt to disprove a match - if we can't we have a match
-        if (!element.equals(Item.ANY) && !element.equals(metadataField.getElement())) {
+        if (!Item.ANY.equals(element) && !StringUtils.equals(element, metadataField.getElement())) {
             // Elements do not match, no wildcard
             return false;
         }
@@ -520,9 +520,9 @@ public abstract class DSpaceObjectServiceImpl<T extends DSpaceObject> implements
                 // Value is qualified, so no match
                 return false;
             }
-        } else if (!qualifier.equals(Item.ANY)) {
+        } else if (!Item.ANY.equals(qualifier)) {
             // Not a wildcard, so qualifier must match exactly
-            if (!qualifier.equals(metadataField.getQualifier())) {
+            if (!StringUtils.equals(qualifier, metadataField.getQualifier())) {
                 return false;
             }
         }
@@ -533,15 +533,15 @@ public abstract class DSpaceObjectServiceImpl<T extends DSpaceObject> implements
                 // Value is qualified, so no match
                 return false;
             }
-        } else if (!language.equals(Item.ANY)) {
+        } else if (!Item.ANY.equals(language)) {
             // Not a wildcard, so language must match exactly
-            if (!language.equals(metadataValue.getLanguage())) {
+            if (!StringUtils.equals(language, metadataValue.getLanguage())) {
                 return false;
             }
         }
 
-        if (!schema.equals(Item.ANY)) {
-            if (metadataSchema != null && !metadataSchema.getName().equals(schema)) {
+        if (!Item.ANY.equals(schema)) {
+            if (!StringUtils.equals(schema, metadataSchema.getName())) {
                 // The namespace doesn't match
                 return false;
             }

--- a/dspace-api/src/main/java/org/dspace/content/service/DSpaceObjectService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/DSpaceObjectService.java
@@ -202,7 +202,7 @@ public interface DSpaceObjectService<T extends DSpaceObject> {
      * Get the value(s) of a metadata field.
      * @param dSpaceObject the object whose metadata are sought.
      * @param mdString the name of the field:  {@code schema.element.qualifier}.
-     * @param authority name of the authority which controls these values, or null.
+     * @param authority name of the authority which controls these values, or Item.ANY, or null.
      * @return all matching metadata values, or null if none.
      */
     public List<MetadataValue> getMetadata(T dSpaceObject, String mdString, String authority);
@@ -216,7 +216,7 @@ public interface DSpaceObjectService<T extends DSpaceObject> {
      * @param lang the language of the requested field value(s),
      *              null if explicitly no language,
      *              or {@link org.dspace.content.Item.ANY} to match all languages.
-     * @param authority name of the authority which controls these values, or null.
+     * @param authority name of the authority which controls these values, or Item.ANY, or null.
      * @return value(s) of the indicated field for the given DSO, or null.
      */
     public List<MetadataValue> getMetadata(T dSpaceObject, String schema,


### PR DESCRIPTION
## References
* Fixes #10744 

## Description
Improved String comparison in `DSpaceObjectService` where a `NullPointerException` could be thrown, and should be avoided.
Updated Javadoc in interface to better reflect usage.

List of changes in this PR:
* Any equality checks involving `Item.ANY` now always puts this (never null) value on the left, and the value which may be null on the right. E.g. `Item.ANY.equals(authority)`
* Any equality checks where either side could be null, use `org.apache.commons.lang3.StringUtils.equals(left, right)` so that nulls are properly compared without error
* Javadoc updated

## To test
* Make sure the various `getMetadata()` methods for any DSO type still work as expected, and observe integration tests. This is a fairly low-level change that should either pass or fail basic tests fairly obviously
* To test the improvements in code, consider the `DSpaceObjectService` javadoc that specifies authority may be `null` in `getMetadata(DSpaceObject dso, String fieldName, String authority)` and observe that it actually throws an NPE. Then try the same with this PR applied.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
