### PR TITLE
Bump XOAI to 3.4.1

### DIFF
--- a/dspace-oai/pom.xml
+++ b/dspace-oai/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <!-- This is the path to the root [dspace-src] directory. -->
         <root.basedir>${basedir}/..</root.basedir>
-        <xoai.version>3.4.0</xoai.version>
+        <xoai.version>3.4.1</xoai.version>
     </properties>
 
     <build>


### PR DESCRIPTION
## Description
Minor update to latest version of `xoai` just released today, version 3.4.1

Release Notes: https://github.com/DSpace/xoai/releases/tag/xoai-3.4.1

Will test manually prior to merger.  But, for DSpace's purposes, this version of XOAI just provides updates to the dependencies used by XOAI. 

Should also be safe to backport to 7.x & 8.x