### PR TITLE
Add HTTP timeouts in LiveImportClient to improve robustness

### DIFF
--- a/dspace-api/src/main/java/org/dspace/importer/external/liveimportclient/service/LiveImportClientImpl.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/liveimportclient/service/LiveImportClientImpl.java
@@ -50,7 +50,11 @@ public class LiveImportClientImpl implements LiveImportClient {
     @Override
     public String executeHttpGetRequest(int timeout, String URL, Map<String, Map<String, String>> params) {
         HttpGet method = null;
-        RequestConfig config = RequestConfig.custom().setConnectionRequestTimeout(timeout).build();
+        RequestConfig config = RequestConfig.custom()
+            .setConnectionRequestTimeout(timeout)
+            .setConnectTimeout(timeout)
+            .setSocketTimeout(timeout)
+            .build();
         try (CloseableHttpClient httpClient = Optional.ofNullable(this.httpClient)
                                         .orElse(DSpaceHttpClientFactory.getInstance().buildWithRequestConfig(config))) {
             String uri = buildUrl(URL, params.get(URI_PARAMETERS));


### PR DESCRIPTION
## Description

This PR enhances the robustness of HTTP GET requests in `LiveImportClientImpl` by explicitly setting all **timeout parameters**:

* `connectionRequestTimeout`: Maximum time (in ms) to wait for a connection from the connection pool (still present)
* `connectTimeout`: Maximum time (in ms) to establish a connection to the server (new)
* `socketTimeout`: Maximum time (in ms) to wait for data to be read from the server (new)

Without these settings, the DSpace backend (LiveImportClient) could potentially block indefinitely in case of network issues or slow servers. 

Let me know if you’d like to have **separate timeout values**.