### PR TITLE
Alphabetize external source importers by service name (on MyDSpace, etc)

### DIFF
--- a/dspace/config/spring/api/external-services.xml
+++ b/dspace/config/spring/api/external-services.xml
@@ -16,69 +16,109 @@
 
     <bean class="org.dspace.importer.external.liveimportclient.service.LiveImportClientImpl"/>
 
-    <bean class="org.dspace.external.provider.impl.SHERPAv2JournalISSNDataProvider" init-method="init">
-        <property name="sherpaService">
-            <bean class="org.dspace.app.sherpa.SHERPAService">
-                <property name="maxNumberOfTries" value="3"/>
-                <property name="sleepBetweenTimeouts" value="2000"/>
-                <property name="timeout" value="5000"/>
-            </bean>
-        </property>
-        <property name="sourceIdentifier" value="sherpaJournalIssn"/>
+    <!-- arXiv importer -->
+    <bean id="arxivLiveImportDataProvider" class="org.dspace.external.provider.impl.LiveImportDataProvider">
+        <property name="metadataSource" ref="ArXivImportService"/>
+        <property name="sourceIdentifier" value="arxiv"/>
+        <property name="recordIdMetadata" value="dc.identifier.other"/>
         <property name="supportedEntityTypes">
             <list>
-                <value>Journal</value>
-            </list>
-        </property>
-    </bean>
-    <bean class="org.dspace.external.provider.impl.SHERPAv2JournalDataProvider" init-method="init">
-        <property name="sourceIdentifier" value="sherpaJournal"/>
-        <property name="sherpaService">
-            <bean class="org.dspace.app.sherpa.SHERPAService">
-                <property name="maxNumberOfTries" value="3"/>
-                <property name="sleepBetweenTimeouts" value="2000"/>
-                <property name="timeout" value="5000"/>
-            </bean>
-        </property>
-        <property name="supportedEntityTypes">
-            <list>
-                <value>Journal</value>
-            </list>
-        </property>
-    </bean>
-    <bean class="org.dspace.external.provider.impl.SHERPAv2PublisherDataProvider" init-method="init">
-        <property name="sourceIdentifier" value="sherpaPublisher"/>
-        <property name="sherpaService">
-            <bean class="org.dspace.app.sherpa.SHERPAService">
-                <property name="maxNumberOfTries" value="3"/>
-                <property name="sleepBetweenTimeouts" value="2000"/>
-                <property name="timeout" value="5000"/>
-            </bean>
-        </property>
-        <property name="supportedEntityTypes">
-            <list>
-                <value>OrgUnit</value>
-            </list>
-        </property>
-    </bean>
-    <bean class="org.dspace.external.provider.impl.OrcidV3AuthorDataProvider" init-method="init">
-        <property name="sourceIdentifier" value="orcid"/>
-        <property name="orcidUrl" value="${orcid.domain-url}" />
-        <property name="clientId" value="${orcid.application-client-id}" />
-        <property name="clientSecret" value="${orcid.application-client-secret}" />
-        <property name="OAUTHUrl" value="${orcid.token-url}" />
-        <property name="orcidRestConnector" ref="orcidRestConnector"/>
-        <property name="supportedEntityTypes">
-            <list>
-                <value>Person</value>
+                <value>Publication</value>
+                <value>none</value>
             </list>
         </property>
     </bean>
 
-    <bean id="orcidRestConnector" class="org.dspace.external.OrcidRestConnector">
-        <constructor-arg value="${orcid.api-url}"/>
+    <!-- CiNii importer -->
+    <bean id="ciniiLiveImportDataProvider" class="org.dspace.external.provider.impl.LiveImportDataProvider">
+        <property name="metadataSource" ref="CiniiImportService"/>
+        <property name="sourceIdentifier" value="cinii"/>
+        <property name="recordIdMetadata" value="dc.identifier.other"/>
+        <property name="supportedEntityTypes">
+            <list>
+                <value>Publication</value>
+                <value>none</value>
+            </list>
+        </property>
     </bean>
-    
+
+    <!-- CrossRef importer -->
+    <bean id="crossRefLiveImportDataProvider" class="org.dspace.external.provider.impl.LiveImportDataProvider">
+        <property name="metadataSource" ref="CrossRefImportService"/>
+        <property name="sourceIdentifier" value="crossref"/>
+        <property name="recordIdMetadata" value="dc.identifier.doi"/>
+        <property name="supportedEntityTypes">
+            <list>
+                <value>Publication</value>
+                <value>none</value>
+            </list>
+        </property>
+    </bean>
+
+    <!-- DataCite importers -->
+    <bean id="dataciteLiveImportDataProvider" class="org.dspace.external.provider.impl.LiveImportDataProvider">
+        <property name="metadataSource" ref="DataCiteImportService"/>
+        <property name="sourceIdentifier" value="datacite"/>
+        <property name="recordIdMetadata" value="dc.identifier.doi"/>
+        <property name="supportedEntityTypes">
+            <list>
+                <value>Publication</value>
+                <value>none</value>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="dataciteProjectLiveImportDataProvider" class="org.dspace.external.provider.impl.LiveImportDataProvider">
+        <property name="metadataSource" ref="DataCiteProjectImportService"/>
+        <property name="sourceIdentifier" value="dataciteProject"/>
+        <property name="recordIdMetadata" value="dc.identifier"/>
+        <property name="supportedEntityTypes">
+            <list>
+                <value>Project</value>
+            </list>
+        </property>
+    </bean>
+
+    <!-- DOI generic importer -->
+    <bean id="doiLiveImportDataProvider" class="org.dspace.external.provider.impl.LiveImportDataProvider">
+        <property name="metadataSource" ref="DoiImportService"/>
+        <property name="sourceIdentifier" value="doi"/>
+        <property name="recordIdMetadata" value="dc.identifier.doi"/>
+        <property name="supportedEntityTypes">
+            <list>
+                <value>Publication</value>
+                <value>none</value>
+            </list>
+        </property>
+    </bean>
+
+    <!-- European Patent Office (EPO) importer -->
+    <bean id="epoLiveImportDataProvider" class="org.dspace.external.provider.impl.LiveImportDataProvider">
+        <property name="metadataSource" ref="EpoImportService"/>
+        <property name="sourceIdentifier" value="epo"/>
+        <property name="recordIdMetadata" value="dc.identifier.other"/>
+        <property name="supportedEntityTypes">
+            <list>
+                <value>Publication</value>
+                <value>none</value>
+            </list>
+        </property>
+    </bean>
+
+    <!-- NASA/ADS importer -->
+    <bean id="adsLiveImportDataProvider" class="org.dspace.external.provider.impl.LiveImportDataProvider">
+        <property name="metadataSource" ref="ADSImportService"/>
+        <property name="sourceIdentifier" value="ads"/>
+        <property name="recordIdMetadata" value="dc.identifier.other"/>
+        <property name="supportedEntityTypes">
+            <list>
+                <value>Publication</value>
+                <value>none</value>
+            </list>
+        </property>
+    </bean>
+
+    <!-- OpenAIRE importers -->
     <bean id="openaireLiveImportDataProviderByAuthor" class="org.dspace.external.provider.impl.LiveImportDataProvider">
         <property name="metadataSource" ref="openaireImportServiceByAuthor"/>
         <property name="sourceIdentifier" value="openaire"/>
@@ -103,195 +143,7 @@
         </property>
     </bean>
 
-    <bean id="pubmedLiveImportDataProvider" class="org.dspace.external.provider.impl.LiveImportDataProvider">
-        <property name="metadataSource" ref="pubmedImportService"/>
-        <property name="sourceIdentifier" value="pubmed"/>
-        <property name="recordIdMetadata" value="dc.identifier.other"/>
-        <property name="supportedEntityTypes">
-            <list>
-                <value>Publication</value>
-                <value>none</value>
-            </list>
-        </property>
-    </bean>
-
-    <bean id="arxivLiveImportDataProvider" class="org.dspace.external.provider.impl.LiveImportDataProvider">
-        <property name="metadataSource" ref="ArXivImportService"/>
-        <property name="sourceIdentifier" value="arxiv"/>
-        <property name="recordIdMetadata" value="dc.identifier.other"/>
-        <property name="supportedEntityTypes">
-            <list>
-                <value>Publication</value>
-                <value>none</value>
-            </list>
-        </property>
-    </bean>
-
-    <bean id="orcidPublicationDataProvider" class="org.dspace.external.provider.impl.OrcidPublicationDataProvider">
-        <property name="sourceIdentifier" value="orcidWorks"/>
-        <property name="fieldMapping" ref="orcidPublicationDataProviderFieldMapping"/>
-        <property name="supportedEntityTypes">
-            <list>
-                <value>Publication</value>
-            </list>
-        </property>
-    </bean>
-
-    <bean id="crossRefLiveImportDataProvider" class="org.dspace.external.provider.impl.LiveImportDataProvider">
-        <property name="metadataSource" ref="CrossRefImportService"/>
-        <property name="sourceIdentifier" value="crossref"/>
-        <property name="recordIdMetadata" value="dc.identifier.doi"/>
-        <property name="supportedEntityTypes">
-            <list>
-                <value>Publication</value>
-                <value>none</value>
-            </list>
-        </property>
-    </bean>
-
-    <bean id="scopusLiveImportDataProvider" class="org.dspace.external.provider.impl.LiveImportDataProvider">
-        <property name="metadataSource" ref="ScopusImportService"/>
-        <property name="sourceIdentifier" value="scopus"/>
-        <property name="recordIdMetadata" value="dc.identifier.other"/>
-        <property name="supportedEntityTypes">
-            <list>
-                <value>Publication</value>
-                <value>none</value>
-            </list>
-        </property>
-    </bean>
-
-    <bean id="pubmedEULiveImportDataProvider" class="org.dspace.external.provider.impl.LiveImportDataProvider">
-        <property name="metadataSource" ref="PubmedEuropeImportService"/>
-        <property name="sourceIdentifier" value="pubmedeu"/>
-        <property name="recordIdMetadata" value="dc.identifier.other"/>
-        <property name="supportedEntityTypes">
-            <list>
-                <value>Publication</value>
-                <value>none</value>
-            </list>
-        </property>
-    </bean>
-
-    <bean id="ciniiLiveImportDataProvider" class="org.dspace.external.provider.impl.LiveImportDataProvider">
-        <property name="metadataSource" ref="CiniiImportService"/>
-        <property name="sourceIdentifier" value="cinii"/>
-        <property name="recordIdMetadata" value="dc.identifier.other"/>
-        <property name="supportedEntityTypes">
-            <list>
-                <value>Publication</value>
-                <value>none</value>
-            </list>
-        </property>
-    </bean>
-
-    <bean id="epoLiveImportDataProvider" class="org.dspace.external.provider.impl.LiveImportDataProvider">
-        <property name="metadataSource" ref="EpoImportService"/>
-        <property name="sourceIdentifier" value="epo"/>
-        <property name="recordIdMetadata" value="dc.identifier.other"/>
-        <property name="supportedEntityTypes">
-            <list>
-                <value>Publication</value>
-                <value>none</value>
-            </list>
-        </property>
-    </bean>
-
-    <bean id="doiLiveImportDataProvider" class="org.dspace.external.provider.impl.LiveImportDataProvider">
-        <property name="metadataSource" ref="DoiImportService"/>
-        <property name="sourceIdentifier" value="doi"/>
-        <property name="recordIdMetadata" value="dc.identifier.doi"/>
-        <property name="supportedEntityTypes">
-            <list>
-                <value>Publication</value>
-                <value>none</value>
-            </list>
-        </property>
-    </bean>
-
-    <bean id="vufindLiveImportDataProvider" class="org.dspace.external.provider.impl.LiveImportDataProvider">
-        <property name="metadataSource" ref="vufindImportService"/>
-        <property name="sourceIdentifier" value="vufind"/>
-        <property name="recordIdMetadata" value="dc.identifier.other"/>
-        <property name="supportedEntityTypes">
-            <list>
-                <value>Publication</value>
-                <value>none</value>
-            </list>
-        </property>
-    </bean>
-
-    <bean id="adsLiveImportDataProvider" class="org.dspace.external.provider.impl.LiveImportDataProvider">
-        <property name="metadataSource" ref="ADSImportService"/>
-        <property name="sourceIdentifier" value="ads"/>
-        <property name="recordIdMetadata" value="dc.identifier.other"/>
-        <property name="supportedEntityTypes">
-            <list>
-                <value>Publication</value>
-                <value>none</value>
-            </list>
-        </property>
-    </bean>
-
-    <bean id="scieloLiveImportDataProvider" class="org.dspace.external.provider.impl.LiveImportDataProvider">
-        <property name="metadataSource" ref="ScieloImportService"/>
-        <property name="sourceIdentifier" value="scielo"/>
-        <property name="recordIdMetadata" value="dc.identifier.other"/>
-        <property name="supportedEntityTypes">
-            <list>
-                <value>Publication</value>
-                <value>none</value>
-            </list>
-        </property>
-    </bean>
-    
-    <bean id="rorDataProvider" class="org.dspace.external.provider.impl.LiveImportDataProvider" >
-        <property name="metadataSource" ref="rorImportService"/>
-        <property name="sourceIdentifier" value="ror"/>
-        <property name="recordIdMetadata" value="organization.identifier.ror"/>
-        <property name="displayMetadata" value="organization.legalName"/>
-        <property name="supportedEntityTypes">
-            <list>
-                <value>OrgUnit</value>
-            </list>
-        </property>
-    </bean>
-
-    <bean id="wosLiveImportDataProvider" class="org.dspace.external.provider.impl.LiveImportDataProvider">
-        <property name="metadataSource" ref="WosImportService"/>
-        <property name="sourceIdentifier" value="wos"/>
-        <property name="recordIdMetadata" value="dc.identifier.other"/>
-        <property name="supportedEntityTypes">
-            <list>
-                <value>Publication</value>
-                <value>none</value>
-            </list>
-        </property>
-    </bean>
-
-    <bean id="dataciteLiveImportDataProvider" class="org.dspace.external.provider.impl.LiveImportDataProvider">
-        <property name="metadataSource" ref="DataCiteImportService"/>
-        <property name="sourceIdentifier" value="datacite"/>
-        <property name="recordIdMetadata" value="dc.identifier.doi"/>
-        <property name="supportedEntityTypes">
-            <list>
-                <value>Publication</value>
-                <value>none</value>
-            </list>
-        </property>
-    </bean>
-
-    <bean id="dataciteProjectLiveImportDataProvider" class="org.dspace.external.provider.impl.LiveImportDataProvider">
-        <property name="metadataSource" ref="DataCiteProjectImportService"/>
-        <property name="sourceIdentifier" value="dataciteProject"/>
-        <property name="recordIdMetadata" value="dc.identifier"/>
-        <property name="supportedEntityTypes">
-            <list>
-                <value>Project</value>
-            </list>
-        </property>
-    </bean>
-
+    <!-- OpenAlex importers -->
     <bean id="openalexPublicationLiveImportDataProvider"
           class="org.dspace.external.provider.impl.LiveImportDataProvider">
         <property name="metadataSource" ref="openalexImportPublicationService"/>
@@ -387,6 +239,172 @@
         <property name="supportedEntityTypes">
             <list>
                 <value>OrgUnit</value>
+                <value>none</value>
+            </list>
+        </property>
+    </bean>
+
+    <!-- ORCID importers -->
+    <bean id="orcidPublicationDataProvider" class="org.dspace.external.provider.impl.OrcidPublicationDataProvider">
+        <property name="sourceIdentifier" value="orcidWorks"/>
+        <property name="fieldMapping" ref="orcidPublicationDataProviderFieldMapping"/>
+        <property name="supportedEntityTypes">
+            <list>
+                <value>Publication</value>
+            </list>
+        </property>
+    </bean>
+
+    <bean class="org.dspace.external.provider.impl.OrcidV3AuthorDataProvider" init-method="init">
+        <property name="sourceIdentifier" value="orcid"/>
+        <property name="orcidUrl" value="${orcid.domain-url}" />
+        <property name="clientId" value="${orcid.application-client-id}" />
+        <property name="clientSecret" value="${orcid.application-client-secret}" />
+        <property name="OAUTHUrl" value="${orcid.token-url}" />
+        <property name="orcidRestConnector" ref="orcidRestConnector"/>
+        <property name="supportedEntityTypes">
+            <list>
+                <value>Person</value>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="orcidRestConnector" class="org.dspace.external.OrcidRestConnector">
+        <constructor-arg value="${orcid.api-url}"/>
+    </bean>
+
+    <!-- PubMed importers -->
+    <bean id="pubmedLiveImportDataProvider" class="org.dspace.external.provider.impl.LiveImportDataProvider">
+        <property name="metadataSource" ref="pubmedImportService"/>
+        <property name="sourceIdentifier" value="pubmed"/>
+        <property name="recordIdMetadata" value="dc.identifier.other"/>
+        <property name="supportedEntityTypes">
+            <list>
+                <value>Publication</value>
+                <value>none</value>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="pubmedEULiveImportDataProvider" class="org.dspace.external.provider.impl.LiveImportDataProvider">
+        <property name="metadataSource" ref="PubmedEuropeImportService"/>
+        <property name="sourceIdentifier" value="pubmedeu"/>
+        <property name="recordIdMetadata" value="dc.identifier.other"/>
+        <property name="supportedEntityTypes">
+            <list>
+                <value>Publication</value>
+                <value>none</value>
+            </list>
+        </property>
+    </bean>
+
+    <!-- Research Organization Registry (ROR) importer -->
+    <bean id="rorDataProvider" class="org.dspace.external.provider.impl.LiveImportDataProvider" >
+        <property name="metadataSource" ref="rorImportService"/>
+        <property name="sourceIdentifier" value="ror"/>
+        <property name="recordIdMetadata" value="organization.identifier.ror"/>
+        <property name="displayMetadata" value="organization.legalName"/>
+        <property name="supportedEntityTypes">
+            <list>
+                <value>OrgUnit</value>
+            </list>
+        </property>
+    </bean>
+
+    <!-- SciELO importer -->
+    <bean id="scieloLiveImportDataProvider" class="org.dspace.external.provider.impl.LiveImportDataProvider">
+        <property name="metadataSource" ref="ScieloImportService"/>
+        <property name="sourceIdentifier" value="scielo"/>
+        <property name="recordIdMetadata" value="dc.identifier.other"/>
+        <property name="supportedEntityTypes">
+            <list>
+                <value>Publication</value>
+                <value>none</value>
+            </list>
+        </property>
+    </bean>
+
+    <!-- Scopus importer -->
+    <bean id="scopusLiveImportDataProvider" class="org.dspace.external.provider.impl.LiveImportDataProvider">
+        <property name="metadataSource" ref="ScopusImportService"/>
+        <property name="sourceIdentifier" value="scopus"/>
+        <property name="recordIdMetadata" value="dc.identifier.other"/>
+        <property name="supportedEntityTypes">
+            <list>
+                <value>Publication</value>
+                <value>none</value>
+            </list>
+        </property>
+    </bean>
+
+    <!-- Sherpa importers -->
+    <bean class="org.dspace.external.provider.impl.SHERPAv2JournalISSNDataProvider" init-method="init">
+        <property name="sherpaService">
+            <bean class="org.dspace.app.sherpa.SHERPAService">
+                <property name="maxNumberOfTries" value="3"/>
+                <property name="sleepBetweenTimeouts" value="2000"/>
+                <property name="timeout" value="5000"/>
+            </bean>
+        </property>
+        <property name="sourceIdentifier" value="sherpaJournalIssn"/>
+        <property name="supportedEntityTypes">
+            <list>
+                <value>Journal</value>
+            </list>
+        </property>
+    </bean>
+    <bean class="org.dspace.external.provider.impl.SHERPAv2JournalDataProvider" init-method="init">
+        <property name="sourceIdentifier" value="sherpaJournal"/>
+        <property name="sherpaService">
+            <bean class="org.dspace.app.sherpa.SHERPAService">
+                <property name="maxNumberOfTries" value="3"/>
+                <property name="sleepBetweenTimeouts" value="2000"/>
+                <property name="timeout" value="5000"/>
+            </bean>
+        </property>
+        <property name="supportedEntityTypes">
+            <list>
+                <value>Journal</value>
+            </list>
+        </property>
+    </bean>
+    <bean class="org.dspace.external.provider.impl.SHERPAv2PublisherDataProvider" init-method="init">
+        <property name="sourceIdentifier" value="sherpaPublisher"/>
+        <property name="sherpaService">
+            <bean class="org.dspace.app.sherpa.SHERPAService">
+                <property name="maxNumberOfTries" value="3"/>
+                <property name="sleepBetweenTimeouts" value="2000"/>
+                <property name="timeout" value="5000"/>
+            </bean>
+        </property>
+        <property name="supportedEntityTypes">
+            <list>
+                <value>OrgUnit</value>
+            </list>
+        </property>
+    </bean>
+
+    <!-- VuFind importer -->
+    <bean id="vufindLiveImportDataProvider" class="org.dspace.external.provider.impl.LiveImportDataProvider">
+        <property name="metadataSource" ref="vufindImportService"/>
+        <property name="sourceIdentifier" value="vufind"/>
+        <property name="recordIdMetadata" value="dc.identifier.other"/>
+        <property name="supportedEntityTypes">
+            <list>
+                <value>Publication</value>
+                <value>none</value>
+            </list>
+        </property>
+    </bean>
+
+    <!-- Web of Science importer -->
+    <bean id="wosLiveImportDataProvider" class="org.dspace.external.provider.impl.LiveImportDataProvider">
+        <property name="metadataSource" ref="WosImportService"/>
+        <property name="sourceIdentifier" value="wos"/>
+        <property name="recordIdMetadata" value="dc.identifier.other"/>
+        <property name="supportedEntityTypes">
+            <list>
+                <value>Publication</value>
                 <value>none</value>
             </list>
         </property>


### PR DESCRIPTION
## Description

This small PR reorders the configurations in our `external-services.xml`, so that they are listed **alphabetically** by the name of the service.  This ensures that our large dropdown of import services ends up ordered alphabetically like this:

![importers](https://github.com/user-attachments/assets/598a5439-cee8-4406-a763-4f7e03e44d0b)

If you look at this dropdown on current https://sandbox.dspace.org, you'll see the list is in a very random order, starting with OpenAIRE, Pubmed, arXiv, ORCID, etc.

## Instructions for Reviewers
* Verify order is alphabetical by service name.  No changes in behavior should exist because this PR simply reorders the existing configurations.
