### PR TITLE
ORCID Push: Fix SELF and PART_OF external identifier handling

### DIFF
--- a/dspace-api/src/main/java/org/dspace/orcid/model/OrcidWorkFieldMapping.java
+++ b/dspace-api/src/main/java/org/dspace/orcid/model/OrcidWorkFieldMapping.java
@@ -39,6 +39,7 @@ public class OrcidWorkFieldMapping {
      * The metadata fields related to the work external identifiers.
      */
     private Map<String, String> externalIdentifierFields = new HashMap<>();
+    private Map<String, List<String>> externalIdentifierPartOfMap = new HashMap<>();
 
     /**
      * The metadata field related to the work publication date.
@@ -127,6 +128,15 @@ public class OrcidWorkFieldMapping {
 
     public void setExternalIdentifierFields(String externalIdentifierFields) {
         this.externalIdentifierFields = parseConfigurations(externalIdentifierFields);
+    }
+
+    public Map<String, List<String>> getExternalIdentifierPartOfMap() {
+        return this.externalIdentifierPartOfMap;
+    }
+
+    public void setExternalIdentifierPartOfMap(
+            HashMap<String, List<String>> externalIdentifierPartOfMap) {
+        this.externalIdentifierPartOfMap = externalIdentifierPartOfMap;
     }
 
     public String getPublicationDateField() {

--- a/dspace-api/src/main/java/org/dspace/orcid/model/factory/impl/OrcidWorkFactory.java
+++ b/dspace-api/src/main/java/org/dspace/orcid/model/factory/impl/OrcidWorkFactory.java
@@ -149,6 +149,10 @@ public class OrcidWorkFactory implements OrcidEntityFactory {
             .orElse(null);
     }
 
+    /**
+     * Returns a list of external work IDs constructed in the org.orcid.jaxb
+     * ExternalIDs object
+     */
     private ExternalIDs getWorkExternalIds(Context context, Item item, Work work) {
         ExternalIDs externalIDs = new ExternalIDs();
         externalIDs.getExternalIdentifier().addAll(getWorkExternalIdList(context, item, work));
@@ -157,7 +161,7 @@ public class OrcidWorkFactory implements OrcidEntityFactory {
 
     /**
      * Creates a list of ExternalID, one for orcid.mapping.funding.external-ids
-     * value, taking the values from the given item.
+     * value, taking the values from the given item and work type.
      */
     private List<ExternalID> getWorkExternalIdList(Context context, Item item, Work work) {
 

--- a/dspace-api/src/test/java/org/dspace/builder/ItemBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/ItemBuilder.java
@@ -113,6 +113,14 @@ public class ItemBuilder extends AbstractDSpaceObjectBuilder<Item> {
         return addMetadataValue(item, "dc", "identifier", "scopus", scopus);
     }
 
+    public ItemBuilder withISSN(String issn) {
+        return addMetadataValue(item, "dc", "identifier", "issn", issn);
+    }
+
+    public ItemBuilder withISBN(String isbn) {
+        return addMetadataValue(item, "dc", "identifier", "isbn", isbn);
+    }
+
     public ItemBuilder withRelationFunding(String funding) {
         return addMetadataValue(item, "dc", "relation", "funding", funding);
     }

--- a/dspace-api/src/test/java/org/dspace/orcid/service/OrcidEntityFactoryServiceIT.java
+++ b/dspace-api/src/test/java/org/dspace/orcid/service/OrcidEntityFactoryServiceIT.java
@@ -73,6 +73,9 @@ public class OrcidEntityFactoryServiceIT extends AbstractIntegrationTestWithData
 
     private Collection projects;
 
+    private static final String isbn = "978-0-439-02348-1";
+    private static final String issn = "1234-1234X";
+
     @Before
     public void setup() {
 
@@ -117,6 +120,7 @@ public class OrcidEntityFactoryServiceIT extends AbstractIntegrationTestWithData
             .withLanguage("en_US")
             .withType("Book")
             .withIsPartOf("Journal")
+            .withISBN(isbn)
             .withDoiIdentifier("doi-id")
             .withScopusIdentifier("scopus-id")
             .build();
@@ -149,11 +153,100 @@ public class OrcidEntityFactoryServiceIT extends AbstractIntegrationTestWithData
         assertThat(work.getExternalIdentifiers(), notNullValue());
 
         List<ExternalID> externalIds = work.getExternalIdentifiers().getExternalIdentifier();
-        assertThat(externalIds, hasSize(3));
+        assertThat(externalIds, hasSize(4));
         assertThat(externalIds, has(selfExternalId("doi", "doi-id")));
         assertThat(externalIds, has(selfExternalId("eid", "scopus-id")));
         assertThat(externalIds, has(selfExternalId("handle", publication.getHandle())));
+        // Book type should have SELF rel for ISBN
+        assertThat(externalIds, has(selfExternalId("isbn", isbn)));
 
+    }
+
+    @Test
+    public void testJournalArticleAndISSN() {
+        context.turnOffAuthorisationSystem();
+
+        Item publication = ItemBuilder.createItem(context, publications)
+            .withTitle("Test publication")
+            .withAuthor("Walter White")
+            .withAuthor("Jesse Pinkman")
+            .withEditor("Editor")
+            .withIssueDate("2021-04-30")
+            .withDescriptionAbstract("Publication description")
+            .withLanguage("en_US")
+            .withType("Article")
+            .withIsPartOf("Journal")
+            .withISSN(issn)
+            .withDoiIdentifier("doi-id")
+            .withScopusIdentifier("scopus-id")
+            .build();
+
+        context.restoreAuthSystemState();
+
+        Activity activity = entityFactoryService.createOrcidObject(context, publication);
+        assertThat(activity, instanceOf(Work.class));
+
+        Work work = (Work) activity;
+        assertThat(work.getJournalTitle(), notNullValue());
+        assertThat(work.getJournalTitle().getContent(), is("Journal"));
+        assertThat(work.getLanguageCode(), is("en"));
+        assertThat(work.getPublicationDate(), matches(date("2021", "04", "30")));
+        assertThat(work.getShortDescription(), is("Publication description"));
+        assertThat(work.getPutCode(), nullValue());
+        assertThat(work.getWorkType(), is(WorkType.JOURNAL_ARTICLE));
+        assertThat(work.getWorkTitle(), notNullValue());
+        assertThat(work.getWorkTitle().getTitle(), notNullValue());
+        assertThat(work.getWorkTitle().getTitle().getContent(), is("Test publication"));
+        assertThat(work.getWorkContributors(), notNullValue());
+        assertThat(work.getUrl(), matches(urlEndsWith(publication.getHandle())));
+
+        List<Contributor> contributors = work.getWorkContributors().getContributor();
+        assertThat(contributors, hasSize(3));
+        assertThat(contributors, has(contributor("Walter White", AUTHOR, FIRST)));
+        assertThat(contributors, has(contributor("Editor", EDITOR, FIRST)));
+        assertThat(contributors, has(contributor("Jesse Pinkman", AUTHOR, ADDITIONAL)));
+
+        assertThat(work.getExternalIdentifiers(), notNullValue());
+
+        List<ExternalID> externalIds = work.getExternalIdentifiers().getExternalIdentifier();
+        assertThat(externalIds, hasSize(4));
+        assertThat(externalIds, has(selfExternalId("doi", "doi-id")));
+        assertThat(externalIds, has(selfExternalId("eid", "scopus-id")));
+        assertThat(externalIds, has(selfExternalId("handle", publication.getHandle())));
+        // journal-article should have PART_OF rel for ISSN
+        assertThat(externalIds, has(externalId("issn", issn, Relationship.PART_OF)));
+    }
+
+    @Test
+    public void testJournalWithISSN() {
+        context.turnOffAuthorisationSystem();
+
+        Item publication = ItemBuilder.createItem(context, publications)
+            .withTitle("Test journal")
+            .withEditor("Editor")
+            .withType("Journal")
+            .withISSN(issn)
+            .build();
+
+        context.restoreAuthSystemState();
+
+        Activity activity = entityFactoryService.createOrcidObject(context, publication);
+        assertThat(activity, instanceOf(Work.class));
+
+        Work work = (Work) activity;
+        assertThat(work.getWorkType(), is(WorkType.JOURNAL_ISSUE));
+        assertThat(work.getWorkTitle(), notNullValue());
+        assertThat(work.getWorkTitle().getTitle(), notNullValue());
+        assertThat(work.getWorkTitle().getTitle().getContent(), is("Test journal"));
+        assertThat(work.getUrl(), matches(urlEndsWith(publication.getHandle())));
+
+        assertThat(work.getExternalIdentifiers(), notNullValue());
+
+        List<ExternalID> externalIds = work.getExternalIdentifiers().getExternalIdentifier();
+        assertThat(externalIds, hasSize(2));
+        // journal-issue should have SELF rel for ISSN
+        assertThat(externalIds, has(selfExternalId("issn", issn)));
+        assertThat(externalIds, has(selfExternalId("handle", publication.getHandle())));
     }
 
     @Test
@@ -163,6 +256,7 @@ public class OrcidEntityFactoryServiceIT extends AbstractIntegrationTestWithData
 
         Item publication = ItemBuilder.createItem(context, publications)
             .withType("TYPE")
+            .withISSN(issn)
             .build();
 
         context.restoreAuthSystemState();
@@ -183,8 +277,9 @@ public class OrcidEntityFactoryServiceIT extends AbstractIntegrationTestWithData
         assertThat(work.getExternalIdentifiers(), notNullValue());
 
         List<ExternalID> externalIds = work.getExternalIdentifiers().getExternalIdentifier();
-        assertThat(externalIds, hasSize(1));
+        assertThat(externalIds, hasSize(2));
         assertThat(externalIds, has(selfExternalId("handle", publication.getHandle())));
+        assertThat(externalIds, has(externalId("issn", issn, Relationship.PART_OF)));
     }
 
     @Test

--- a/dspace/config/crosswalks/orcid/mapConverter-dspace-to-orcid-publication-type.properties
+++ b/dspace/config/crosswalks/orcid/mapConverter-dspace-to-orcid-publication-type.properties
@@ -7,6 +7,7 @@ Dataset = data-set
 Learning\ Object = other
 Image = other
 Image,\ 3-D = other
+Journal = journal-issue
 Map = other
 Musical\ Score = other
 Plan\ or\ blueprint = other

--- a/dspace/config/modules/orcid.cfg
+++ b/dspace/config/modules/orcid.cfg
@@ -1,4 +1,3 @@
-
 #------------------------------------------------------------------#
 #--------------------ORCID GENERIC CONFIGURATIONS------------------#
 #------------------------------------------------------------------#
@@ -61,12 +60,18 @@ orcid.mapping.work.contributors = dc.contributor.editor::editor
 
 ##orcid.mapping.work.external-ids syntax is <metadatafield>::<type> or $simple-handle::<type>
 ##The full list of available external identifiers is available here https://pub.orcid.org/v3.0/identifiers
+# The identifiers need to have a relationship of SELF, PART_OF, VERSION_OF or FUNDED_BY.
+# The default for most identifiers is SELF. The default for identifiers more commonly
+# associated with 'parent' publciations (ISSN, ISBN) is PART_OF.
+# See the map in `orcid-services.xml`
+# VERSION_OF and FUNDED_BY are not currently implemented.
 orcid.mapping.work.external-ids = dc.identifier.doi::doi
 orcid.mapping.work.external-ids = dc.identifier.scopus::eid
 orcid.mapping.work.external-ids = dc.identifier.pmid::pmid
 orcid.mapping.work.external-ids = $simple-handle::handle
 orcid.mapping.work.external-ids = dc.identifier.isi::wosuid
 orcid.mapping.work.external-ids = dc.identifier.issn::issn
+orcid.mapping.work.external-ids = dc.identifier.isbn::isbn
 
 ### Funding mapping ###
 orcid.mapping.funding.title = dc.title
@@ -145,6 +150,9 @@ orcid.bulk-synchronization.max-attempts = 5
 #------------------------------------------------------------------#
 #--------------------ORCID EXTERNAL DATA MAPPING-------------------#
 #------------------------------------------------------------------#
+
+# Note - the below mapping is for ORCID->DSpace imports, not for
+# DSpace->ORCID exports (see orcid.mapping.work.*)
 
 ### Work (Publication) external-data.mapping ###
 orcid.external-data.mapping.publication.title = dc.title

--- a/dspace/config/spring/api/orcid-services.xml
+++ b/dspace/config/spring/api/orcid-services.xml
@@ -55,24 +55,45 @@
 	<bean id="orcidWorkFactoryFieldMapping" class="org.dspace.orcid.model.OrcidWorkFieldMapping" >
 		<property name="contributorFields" value="${orcid.mapping.work.contributors}" />
 		<property name="externalIdentifierFields" value="${orcid.mapping.work.external-ids}" />
-		<property name="publicationDateField" value="${orcid.mapping.work.publication-date}" />
-		<property name="titleField" value="${orcid.mapping.work.title}" />
-		<property name="journalTitleField" value="${orcid.mapping.work.journal-title}" />
-		<property name="shortDescriptionField" value="${orcid.mapping.work.short-description}" />
-		<property name="subTitleField" value="${orcid.mapping.work.sub-title}" />
-		<property name="languageField" value="${orcid.mapping.work.language}" />
-		<property name="languageConverter" ref="${orcid.mapping.work.language.converter}" />
-		<property name="typeField" value="${orcid.mapping.work.type}" />
-		<property name="typeConverter" ref="${orcid.mapping.work.type.converter}" />
-	</bean>
-	
-	<bean id="orcidFundingFactoryFieldMapping" class="org.dspace.orcid.model.OrcidFundingFieldMapping" >
-		<property name="contributorFields" value="${orcid.mapping.funding.contributors}" />
-		<property name="externalIdentifierFields" value="${orcid.mapping.funding.external-ids}" />
-		<property name="titleField" value="${orcid.mapping.funding.title}" />
-		<property name="typeField" value="${orcid.mapping.funding.type}" />
-		<property name="typeConverter" ref="${orcid.mapping.funding.type.converter}" />
-		<property name="amountField" value="${orcid.mapping.funding.amount}" />
+            <property name="externalIdentifierPartOfMap">
+                <map>
+                    <entry key="issn">
+                        <list>
+                            <value>journal-article</value>
+                            <value>magazine-article</value>
+                            <value>newspaper-article</value>
+                            <value>data-set</value>
+                            <value>learning-object</value>
+                            <value>other</value>
+                        </list>
+                    </entry>
+                    <entry key="isbn">
+                        <list>
+                            <value>book-chapter</value>
+                            <value>book-review</value>
+                            <value>other</value>
+                        </list>
+                    </entry>
+                </map>
+            </property>
+            <property name="publicationDateField" value="${orcid.mapping.work.publication-date}" />
+            <property name="titleField" value="${orcid.mapping.work.title}" />
+            <property name="journalTitleField" value="${orcid.mapping.work.journal-title}" />
+            <property name="shortDescriptionField" value="${orcid.mapping.work.short-description}" />
+            <property name="subTitleField" value="${orcid.mapping.work.sub-title}" />
+            <property name="languageField" value="${orcid.mapping.work.language}" />
+            <property name="languageConverter" ref="${orcid.mapping.work.language.converter}" />
+            <property name="typeField" value="${orcid.mapping.work.type}" />
+            <property name="typeConverter" ref="${orcid.mapping.work.type.converter}" />
+        </bean>
+        
+        <bean id="orcidFundingFactoryFieldMapping" class="org.dspace.orcid.model.OrcidFundingFieldMapping" >
+            <property name="contributorFields" value="${orcid.mapping.funding.contributors}" />
+            <property name="externalIdentifierFields" value="${orcid.mapping.funding.external-ids}" />
+            <property name="titleField" value="${orcid.mapping.funding.title}" />
+            <property name="typeField" value="${orcid.mapping.funding.type}" />
+            <property name="typeConverter" ref="${orcid.mapping.funding.type.converter}" />
+            <property name="amountField" value="${orcid.mapping.funding.amount}" />
 		<property name="amountCurrencyField" value="${orcid.mapping.funding.amount.currency}" />
 		<property name="amountCurrencyConverter" ref="${orcid.mapping.funding.amount.currency.converter}" />
 		<property name="descriptionField" value="${orcid.mapping.funding.description}" />


### PR DESCRIPTION
Handle SELF and PART_OF identifiers properly based on configuration, work type, and identifier type

## References
* Fixes #10738 

## Description

See #10738 for an explanation of the problem and other notes.

* Adds a new map to the orcid-services.xml bean to allow configured identifer type + work type combinations to use `part-of` identifier relationship type for an identifier, instead, of the default `self`.
* Simplifies the `OrcidWorkFactory` to remove some explicit references to "SelfExternalId", instead trying to figure out the correct relationship type as the external ID is added
* Updates integration tests

**Update**: We have had this running in production for a week now in one instance, with good results. Update pushes fixed the original articles or chapters submitted with 'self' ISSN and ISBNs, and now all these items have "Part Of" clearly indicated in the ORCID record for their parent ISSN or ISBN identifiers. Still looking for independent testers to help verify. 

## To test

### Without PR applied

* Using sandbox member account, try to push two publications with the same ISSN

### With PR applied

 * Using sandbox member account, repeat the test above and/or update the test publications already pushed

## Notes

I am open to the idea of shifting the XML mapping to a properties file and then referencing it from the XML bean, to try and keep the config all in the same place, but I actually find the XML map easier to follow.

Note I use ORCID work types, not dc.type or entity types as the map value,  so it doesn't make more work for repositories making type mapping changes. Identifiers are processed after work type mapping when converting to the ORCID Work object.

```xml
            <property name="externalIdentifierPartOfMap">
                <map>
                    <entry key="issn">
                        <list>
                            <value>journal-article</value>
                            <value>magazine-article</value>
                            <value>newspaper-article</value>
                            <value>data-set</value>
                            <value>learning-object</value>
                            <value>other</value>
                        </list>
                    </entry>
                    <entry key="isbn">
                        <list>
                            <value>book-chapter</value>
                            <value>book-review</value>
                            <value>other</value>
                        </list>
                    </entry>
                </map>
            </property>
```

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
