### PR TITLE
Fixed QAEventRestRepositoryIT#recordDecisionNotifyTest failure in certain regions 

### DIFF
--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/QAEventMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/QAEventMatcher.java
@@ -77,10 +77,11 @@ public class QAEventMatcher {
     public static Matcher<? super Object> matchQAEventNotifyEntry(QAEvent event) {
         try {
             ObjectMapper jsonMapper = new JsonMapper();
+            DecimalFormat decimalFormat = new DecimalFormat("0.000", new DecimalFormatSymbols(Locale.ENGLISH));
             return allOf(hasJsonPath("$.id", is(event.getEventId())),
                     hasJsonPath("$.originalId", is(event.getOriginalId())),
                     hasJsonPath("$.title", is(event.getTitle())),
-                    hasJsonPath("$.trust", is(new DecimalFormat("0.000").format(event.getTrust()))),
+                    hasJsonPath("$.trust", is(decimalFormat.format(event.getTrust()))),
                     hasJsonPath("$.status", Matchers.equalToIgnoringCase(event.getStatus())),
                     hasJsonPath("$.message",
                             matchMessage(event.getTopic(), jsonMapper.readValue(event.getMessage(),


### PR DESCRIPTION
## Description
Fixed an issue with the `QAEventRestRepositoryIT#recordDecisionNotifyTest` test that failed for certain regions who use commas as decimal separators (for example Belgium)

## Instructions for Reviewers
List of changes in this PR:
* Forced the `Local.ENGLISH` `DecimalFormatSymbols` to be used when formatting the decimal values in `matchQAEventNotifyEntry`

**Include guidance for how to test or review your PR:**
- Verify the tests still succeed

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
