### PR TITLE
`./dspace healthcheck` fixes for a few bugs

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/statistics/LogAnalyser.java
+++ b/dspace-api/src/main/java/org/dspace/app/statistics/LogAnalyser.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
@@ -1083,13 +1084,13 @@ public class LogAnalyser {
 
 
     /**
-     * Take the date object and convert it into a string of the form YYYY-MM-DD
+     * Take the date object and convert it into an Instant datetime object of the form YYYY-MM-DDTHH:MM:SSZ
      *
      * @param date the date to be converted
-     * @return A string of the form YYYY-MM-DD
+     * @return An Instant datetime object of the form YYYY-MM-DDTHH:MM:SSZ
      */
-    public static String unParseDate(LocalDate date) {
-        return DateTimeFormatter.ISO_LOCAL_DATE.format(date);
+    public static Instant convertDate(LocalDate date) {
+        return date.atStartOfDay(ZoneId.systemDefault()).toInstant();
     }
 
 
@@ -1219,13 +1220,13 @@ public class LogAnalyser {
         StringBuilder accessionedQuery = new StringBuilder();
         accessionedQuery.append("dc.date.accessioned_dt:[");
         if (startDate != null) {
-            accessionedQuery.append(unParseDate(startDate));
+            accessionedQuery.append(convertDate(startDate));
         } else {
             accessionedQuery.append("*");
         }
         accessionedQuery.append(" TO ");
         if (endDate != null) {
-            accessionedQuery.append(unParseDate(endDate));
+            accessionedQuery.append(convertDate(endDate));
         } else {
             accessionedQuery.append("*");
         }

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/BitstreamDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/BitstreamDAOImpl.java
@@ -178,7 +178,7 @@ public class BitstreamDAOImpl extends AbstractHibernateDSODAO<Bitstream> impleme
     @Override
     public int countWithNoPolicy(Context context) throws SQLException {
         Query query = createQuery(context,
-                                  "SELECT count(bit.id) from Bitstream bit where bit.deleted<>true and bit.id not in" +
+                                  "SELECT count(bit.id) from Bitstream bit where bit.deleted<>true and bit not in" +
                                       " (select res.dSpaceObject from ResourcePolicy res where res.resourceTypeId = " +
                                       ":typeId )");
         query.setParameter("typeId", Constants.BITSTREAM);

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/CollectionDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/CollectionDAOImpl.java
@@ -159,7 +159,7 @@ public class CollectionDAOImpl extends AbstractHibernateDSODAO<Collection> imple
 
     @Override
     public List<Collection> findCollectionsWithSubscribers(Context context) throws SQLException {
-        return list(createQuery(context, "SELECT DISTINCT c FROM Collection c JOIN Subscription s ON c.id = " +
+        return list(createQuery(context, "SELECT DISTINCT c FROM Collection c JOIN Subscription s ON c = " +
                 "s.dSpaceObject"));
     }
 

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/CollectionDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/CollectionDAOImpl.java
@@ -12,6 +12,7 @@ import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import jakarta.persistence.Query;
 import jakarta.persistence.criteria.CriteriaBuilder;
@@ -19,6 +20,7 @@ import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
+import org.apache.logging.log4j.Logger;
 import org.dspace.authorize.ResourcePolicy;
 import org.dspace.authorize.ResourcePolicy_;
 import org.dspace.content.Collection;
@@ -40,6 +42,8 @@ import org.dspace.eperson.Group;
  * @author kevinvandevelde at atmire.com
  */
 public class CollectionDAOImpl extends AbstractHibernateDSODAO<Collection> implements CollectionDAO {
+    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(CollectionDAOImpl.class);
+
     protected CollectionDAOImpl() {
         super();
     }
@@ -172,14 +176,25 @@ public class CollectionDAOImpl extends AbstractHibernateDSODAO<Collection> imple
     @SuppressWarnings("unchecked")
     public List<Map.Entry<Collection, Long>> getCollectionsWithBitstreamSizesTotal(Context context)
         throws SQLException {
-        String q = "select col as collection, sum(bit.sizeBytes) as totalBytes from Item i join i.collections col " +
-            "join i.bundles bun join bun.bitstreams bit group by col";
+        String q = "select col.id, sum(bit.sizeBytes) as totalBytes from Item i join i.collections col " +
+            "join i.bundles bun join bun.bitstreams bit group by col.id";
         Query query = createQuery(context, q);
+
+        CriteriaBuilder criteriaBuilder = getCriteriaBuilder(context);
 
         List<Object[]> list = query.getResultList();
         List<Map.Entry<Collection, Long>> returnList = new ArrayList<>(list.size());
         for (Object[] o : list) {
-            returnList.add(new AbstractMap.SimpleEntry<>((Collection) o[0], (Long) o[1]));
+            CriteriaQuery<Collection> criteriaQuery = criteriaBuilder.createQuery(Collection.class);
+            Root<Collection> collectionRoot = criteriaQuery.from(Collection.class);
+            criteriaQuery.select(collectionRoot).where(criteriaBuilder.equal(collectionRoot.get("id"), (UUID) o[0]));
+            Query collectionQuery = createQuery(context, criteriaQuery);
+            Collection collection = (Collection) collectionQuery.getSingleResult();
+            if (collection != null) {
+                returnList.add(new AbstractMap.SimpleEntry<>(collection, (Long) o[1]));
+            } else {
+                log.warn("Unable to find Collection with UUID: {}", o[0]);
+            }
         }
         return returnList;
     }

--- a/dspace-api/src/main/java/org/dspace/health/ChecksumCheck.java
+++ b/dspace-api/src/main/java/org/dspace/health/ChecksumCheck.java
@@ -49,7 +49,7 @@ public class ChecksumCheck extends Check {
             }
         }
 
-        if (collector.arr.size() > 0) {
+        if (!collector.arr.isEmpty()) {
             ret = String.format("Checksum performed on [%d] items:\n",
                                 collector.arr.size());
             int ok_items = 0;

--- a/dspace-api/src/main/java/org/dspace/health/UserCheck.java
+++ b/dspace-api/src/main/java/org/dspace/health/UserCheck.java
@@ -50,26 +50,26 @@ public class UserCheck extends Check {
             info.put("Self registered", 0);
 
             for (EPerson e : epersons) {
-                if (e.getEmail() != null && e.getEmail().length() > 0) {
+                if (e.getEmail() != null && !e.getEmail().isEmpty()) {
                     info.put("Have email", info.get("Have email") + 1);
                 }
                 if (e.canLogIn()) {
                     info.put("Can log in (password)",
                              info.get("Can log in (password)") + 1);
                 }
-                if (e.getFirstName() != null && e.getFirstName().length() > 0) {
+                if (e.getFirstName() != null && !e.getFirstName().isEmpty()) {
                     info.put("Have 1st name", info.get("Have 1st name") + 1);
                 }
-                if (e.getLastName() != null && e.getLastName().length() > 0) {
+                if (e.getLastName() != null && !e.getLastName().isEmpty()) {
                     info.put("Have 2nd name", info.get("Have 2nd name") + 1);
                 }
-                if (e.getLanguage() != null && e.getLanguage().length() > 0) {
+                if (e.getLanguage() != null && !e.getLanguage().isEmpty()) {
                     info.put("Have lang", info.get("Have lang") + 1);
                 }
-                if (e.getNetid() != null && e.getNetid().length() > 0) {
+                if (e.getNetid() != null && !e.getNetid().isEmpty()) {
                     info.put("Have netid", info.get("Have netid") + 1);
                 }
-                if (e.getNetid() != null && e.getNetid().length() > 0) {
+                if (e.getNetid() != null && !e.getNetid().isEmpty()) {
                     info.put("Self registered", info.get("Self registered") + 1);
                 }
             }


### PR DESCRIPTION
## References
* Fixes #10805 

## Description
This PR fixes a few bugs in the `./dspace healthcheck` command. They are detailed below.

## Instructions for Reviewers
There are five checks in the healthcheck configuration (below), and a failure in any one can cause others to fail. So the changes in this PR should be tested individually by including only the check fixed by the particular commit.

https://github.com/DSpace/DSpace/blob/243eb3cb844f91f10b892352b7b7b45479da1dc7/dspace/config/modules/healthcheck.cfg#L7-L11

# Fixes

1. https://github.com/DSpace/DSpace/commit/32903551d237f5f0eb20886e0b22b5ba6ce97d54 fixes a bug in the "User summary" check. Remove the other checks and test the `./dspace healthcheck` command with this PR to see the following Hibernate error go away.

> #### User summary [took: 0s] [# lines: 54]
> Exception occurred when processing report - java.lang.IllegalArgumentException: org.hibernate.query.SemanticException: Cannot compare left expression of type 'java.util.UUID' with right expression of type 'org.dspace.content.DSpaceObject'
> 	at org.hibernate.internal.ExceptionConverterImpl.convert(ExceptionConverterImpl.java:143)
> 	at org.hibernate.internal.ExceptionConverterImpl.convert(ExceptionConverterImpl.java:167)
> 	at org.hibernate.internal.ExceptionConverterImpl.convert(ExceptionConverterImpl.java:173)
> 	at org.hibernate.internal.AbstractSharedSessionContract.createQuery(AbstractSharedSessionContract.java:848)
> 	at org.hibernate.internal.AbstractSharedSessionContract.createQuery(AbstractSharedSessionContract.java:753)
> 	at org.hibernate.internal.AbstractSharedSessionContract.createQuery(AbstractSharedSessionContract.java:136)
> 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
> 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
> 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
> 	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
> 	at org.hibernate.context.internal.ThreadLocalSessionContext$TransactionProtectionWrapper.invoke(ThreadLocalSessionContext.java:343)
> 	at jdk.proxy2/jdk.proxy2.$Proxy160.createQuery(Unknown Source)
> 	at org.dspace.core.AbstractHibernateDAO.createQuery(AbstractHibernateDAO.java:147)
> 	at org.dspace.content.dao.impl.CollectionDAOImpl.findCollectionsWithSubscribers(CollectionDAOImpl.java:162)
> 	at org.dspace.content.CollectionServiceImpl.findCollectionsWithSubscribers(CollectionServiceImpl.java:848)
> 	at org.dspace.health.UserCheck.run(UserCheck.java:109)
> 	at org.dspace.health.Check.report(Check.java:33)
> 	at org.dspace.health.Report.run(Report.java:67)
> 	at org.dspace.health.Report.main(Report.java:194)
> 	... 22 more

2. https://github.com/DSpace/DSpace/commit/f4f540f758bcb4961a5e7ea2eecfc58cea1baafe fixes an issue in the "Log Analyser Check" related to the date range query for new items in Solr 9 by converting it to an Instant datetime object. Test and observe the following bug go away.

> 2025-05-30 17:16:33,255 INFO  unknown unknown org.dspace.health.Report @ #3. Processing [Log Analyser Check] at [2025-05-30T22:16:33.255679Z]
> 2025-05-30 17:16:33,315 ERROR unknown unknown org.dspace.health.Check @ Exception during healthcheck:
> org.dspace.discovery.SearchServiceException: Error from server at http://localhost:8983/solr/search: Invalid Date String:'2025-05-23'
>         at org.dspace.discovery.SolrServiceImpl.search(SolrServiceImpl.java:714) ~[dspace-api-10.0-SNAPSHOT.jar:10.0-SNAPSHOT]
>         at org.dspace.app.statistics.LogAnalyser.getNumItems(LogAnalyser.java:1237) ~[dspace-api-10.0-SNAPSHOT.jar:10.0-SNAPSHOT]
>         at org.dspace.app.statistics.LogAnalyser.getNumItems(LogAnalyser.java:1253) ~[dspace-api-10.0-SNAPSHOT.jar:10.0-SNAPSHOT]
>         at org.dspace.app.statistics.LogAnalyser.processLogs(LogAnalyser.java:615) ~[dspace-api-10.0-SNAPSHOT.jar:10.0-SNAPSHOT]
>         at org.dspace.health.LogAnalyserCheck.run(LogAnalyserCheck.java:43) [dspace-api-10.0-SNAPSHOT.jar:10.0-SNAPSHOT]
>         at org.dspace.health.Check.report(Check.java:33) [dspace-api-10.0-SNAPSHOT.jar:10.0-SNAPSHOT]
>         at org.dspace.health.Report.run(Report.java:67) [dspace-api-10.0-SNAPSHOT.jar:10.0-SNAPSHOT]
>         at org.dspace.health.Report.main(Report.java:193) [dspace-api-10.0-SNAPSHOT.jar:10.0-SNAPSHOT]
> Caused by: org.apache.solr.client.solrj.impl.HttpSolrClient$RemoteSolrException: Error from server at http://localhost:8983/solr/search: Invalid Date String:'2025-05-23'
>         at org.apache.solr.client.solrj.impl.HttpSolrClient.executeMethod(HttpSolrClient.java:681) ~[solr-solrj-8.11.4.jar:8.11.4 e27f44e3d78dfcec230c97e0a1240e3751daeff9 - houstonputman - 2024-09-19 12:33:28]


3. https://github.com/DSpace/DSpace/pull/10831/commits/6e6b3c510e46b89e444f5b4fcb09caf90bd284a8 and https://github.com/DSpace/DSpace/pull/10831/commits/19349e22c5683d94dcb820fa7f285fe0e5cc28a6 fix the following two errors in the "Item summary" check.

> Item summary [took: 0s] [# lines: 51]
> Exception occurred when processing report - org.hibernate.exception.SQLGrammarException: JDBC exception executing SQL [select c1_1.uuid,c1_2.uuid,c1_1.admin,c1_1.collection_id,c1_1.logo_bitstream_id,c1_1.submitter,c1_1.template_item_id,sum(b2_1.size_bytes) from public.item i1_0 join public.collection2item c1_0 on i1_0.uuid=c1_0.item_id join (public.collection c1_1 join public.dspaceobject c1_2 on c1_1.uuid=c1_2.uuid) on c1_1.uuid=c1_0.collection_id join public.item2bundle b1_0 on i1_0.uuid=b1_0.item_id join public.bundle b1_1 on b1_1.uuid=b1_0.bundle_id join public.bundle2bitstream b2_0 on b1_1.uuid=b2_0.bundle_id join public.bitstream b2_1 on b2_1.uuid=b2_0.bitstream_id group by c1_1.uuid,case when c1_1.uuid is not null then 3 end,c1_1.admin,c1_1.collection_id,c1_1.logo_bitstream_id,c1_1.submitter,c1_1.template_item_id] [ERROR: column "c1_2.uuid" must appear in the GROUP BY clause or be used in an aggregate function
> Position: 18] [n/a]
> at org.hibernate.exception.internal.SQLStateConversionDelegate.convert(SQLStateConversionDelegate.java:91)
> at org.hibernate.exception.internal.StandardSQLExceptionConverter.convert(StandardSQLExceptionConverter.java:58)
> at org.hibernate.engine.jdbc.spi.SqlExceptionHelper.convert(SqlExceptionHelper.java:108)
> at org.hibernate.engine.jdbc.spi.SqlExceptionHelper.convert(SqlExceptionHelper.java:94)

and

> Item summary [took: 0s] [# lines: 56]
> Exception occurred when processing report - java.lang.IllegalArgumentException: org.hibernate.query.SemanticException: Cannot compare left expression of type 'java.util.UUID' with right expression of type 'org.dspace.content.DSpaceObject'
> 	at org.dspace.core.AbstractHibernateDAO.createQuery(AbstractHibernateDAO.java:147)
> 	at org.dspace.content.dao.impl.BitstreamDAOImpl.countWithNoPolicy(BitstreamDAOImpl.java:180)
> 	at org.dspace.content.BitstreamServiceImpl.countBitstreamsWithoutPolicy(BitstreamServiceImpl.java:488)
> 	at org.dspace.health.ItemCheck.getCollectionSizesInfo(ItemCheck.java:174)
> 	at org.dspace.health.ItemCheck.run(ItemCheck.java:77)
> 	at org.dspace.health.Check.report(Check.java:33)
> 	at org.dspace.health.Report.run(Report.java:67)
> 	at org.dspace.health.Report.main(Report.java:194)
> 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
> 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
> 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
> 	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
> 	at org.dspace.app.launcher.ScriptLauncher.runOneCommand(ScriptLauncher.java:283)
> 	at org.dspace.app.launcher.ScriptLauncher.handleScript(ScriptLauncher.java:134)
> 	at org.dspace.app.launcher.ScriptLauncher.main(ScriptLauncher.java:99)
> Caused by: org.hibernate.query.SemanticException: Cannot compare left expression of type 'java.util.UUID' with right expression of type 'org.dspace.content.DSpaceObject'
> 	at org.hibernate.query.sqm.internal.TypecheckUtil.assertComparable(TypecheckUtil.java:358)



## Checklist
- [X] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [X] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [X] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [X] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
