### PR TITLE
Solr-based suggestion / autocomplete

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/DCInput.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/DCInput.java
@@ -132,6 +132,12 @@ public class DCInput {
     private boolean closedVocabulary = false;
 
     /**
+     * The type of vocabulary (source)
+     * xml, authority, suggest
+     */
+    private String vocabularyType = null;
+
+    /**
      * the regex in ECMAScript standard format, usable also by rests.
      */
     private String regex = null;
@@ -152,6 +158,11 @@ public class DCInput {
     private String searchConfiguration = null;
     private final String filter;
     private final List<String> externalSources;
+
+    /**
+     * validation dictionary
+     */
+    private String validationDictionary = null;
 
     /**
      * The scope of the input sets, this restricts hidden metadata fields from
@@ -217,6 +228,9 @@ public class DCInput {
         String closedVocabularyStr = fieldMap.get("closedVocabulary");
         closedVocabulary = "true".equalsIgnoreCase(closedVocabularyStr)
             || "yes".equalsIgnoreCase(closedVocabularyStr);
+
+        vocabularyType = fieldMap.get("vocabularyType");
+        validationDictionary = fieldMap.get("validation-dictionary");
 
         // parsing of the <type-bind> element (using the colon as split separator)
         typeBind = new ArrayList<>();
@@ -459,6 +473,20 @@ public class DCInput {
     }
 
     /**
+     * @return type of vocabulary source (xml, authority, suggest)
+     */
+    public String getVocabularyType() {
+        return vocabularyType;
+    }
+
+    /**
+     * @param vocabularyType type of vocabulary source (xml, authority, suggest)
+     */
+    public void setVocabularyType(String vocabularyType) {
+        this.vocabularyType = vocabularyType;
+    }
+
+    /**
      * Gets the display string that corresponds to the passed storage string in
      * a particular display-storage pair set.
      *
@@ -567,6 +595,10 @@ public class DCInput {
             return true;
         }
         return false;
+    }
+
+    public String getValidationDictionary() {
+        return validationDictionary;
     }
 
     public boolean validate(String value) {

--- a/dspace-api/src/main/java/org/dspace/app/util/DCInputsReader.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/DCInputsReader.java
@@ -408,6 +408,8 @@ public class DCInputsReader {
                 } else if (tagName.equals("vocabulary")) {
                     String closedVocabularyString = getAttribute(nd, "closed");
                     field.put("closedVocabulary", closedVocabularyString);
+                    String vocabularyTypeString = getAttribute(nd, "type");
+                    field.put("vocabularyType", vocabularyTypeString);
                 } else if (tagName.equals("language")) {
                     if (Boolean.valueOf(value)) {
                         String pairTypeName = getAttribute(nd, PAIR_TYPE_NAME);

--- a/dspace-api/src/main/java/org/dspace/app/util/MetadataExposureServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/MetadataExposureServiceImpl.java
@@ -159,4 +159,16 @@ public class MetadataExposureServiceImpl implements MetadataExposureService {
             }
         }
     }
+
+    /**
+     * Put state back into "not initialzed" and call init()
+     * This should be safe because isHidden also checks this state
+     * and calls init, and they'll both block until complete and the configuration
+     * is in place
+     */
+    public synchronized void reload() {
+        hiddenElementSets = null;
+        hiddenElementMaps = null;
+        init();
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/app/util/service/MetadataExposureService.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/service/MetadataExposureService.java
@@ -62,4 +62,11 @@ public interface MetadataExposureService {
      */
     public boolean isHidden(Context context, String schema, String element, String qualifier)
         throws SQLException;
+
+    /**
+     * Reloads hidden configuration. Useful if an urgent live change needs to be made
+     * and for testing (where we may prefer to add new hidden field config directly
+     * for a given test and not keep overloading cfg files for read at startup)
+     */
+    public void reload();
 }

--- a/dspace-api/src/main/java/org/dspace/content/authority/ChoiceAuthorityServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/ChoiceAuthorityServiceImpl.java
@@ -45,6 +45,7 @@ import org.dspace.submit.factory.SubmissionServiceFactory;
 import org.dspace.submit.model.UploadConfiguration;
 import org.dspace.submit.model.UploadConfigurationService;
 import org.dspace.submit.service.SubmissionConfigService;
+import org.dspace.vocabulary.ControlledVocabulary;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -444,19 +445,22 @@ public final class ChoiceAuthorityServiceImpl implements ChoiceAuthorityService 
                         authorityName = dcinput.getVocabulary();
                     }
 
-                    // do we have an authority?
-                    if (StringUtils.isNotBlank(authorityName)) {
-                        String fieldKey = makeFieldKey(dcinput.getSchema(), dcinput.getElement(),
-                                dcinput.getQualifier());
-                        ChoiceAuthority ca = controller.get(authorityName);
-                        if (ca == null) {
-                            ca = (ChoiceAuthority) pluginService.getNamedPlugin(ChoiceAuthority.class, authorityName);
-                            if (ca == null) {
-                                throw new IllegalStateException("Invalid configuration for " + fieldKey
-                                        + " in submission definition " + submissionName + ", form definition "
-                                        + dcinputSet.getFormName() + " no named plugin found: " + authorityName);
-                            }
-                        }
+                            // do we have a vocabulary that is NOT configured for solr 'suggest' type?
+                            if (StringUtils.isNotBlank(authorityName)
+                                    && !ControlledVocabulary.SUGGEST.equals(dcinput.getVocabularyType())) {
+                                String fieldKey = makeFieldKey(dcinput.getSchema(), dcinput.getElement(),
+                                                               dcinput.getQualifier());
+                                ChoiceAuthority ca = controller.get(authorityName);
+                                if (ca == null) {
+                                    ca = (ChoiceAuthority) pluginService
+                                        .getNamedPlugin(ChoiceAuthority.class, authorityName);
+                                    if (ca == null) {
+                                        throw new IllegalStateException("Invalid configuration for " + fieldKey
+                                                + " in submission definition " + submissionName
+                                                + ", form definition " + dcinputSet.getFormName()
+                                                + " no named plugin found: " + authorityName);
+                                    }
+                                }
 
                         addAuthorityToFormCacheMap(dsoType, submissionName, fieldKey, ca);
                         addFormDetailsToAuthorityCacheMap(submissionName, authorityName, fieldKey);

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexClient.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexClient.java
@@ -48,6 +48,8 @@ public class IndexClient extends DSpaceRunnable<IndexDiscoveryScriptConfiguratio
     private Context context;
     private IndexingService indexer = DSpaceServicesFactory.getInstance().getServiceManager()
             .getServiceByName(IndexingService.class.getName(), IndexingService.class);
+    private SolrSuggestService solrSuggestService = DSpaceServicesFactory.getInstance()
+        .getServiceManager().getServiceByName(SolrSuggestService.class.getName(), SolrSuggestService.class);
 
     private IndexClientOptions indexClientOptions;
 
@@ -84,14 +86,23 @@ public class IndexClient extends DSpaceRunnable<IndexDiscoveryScriptConfiguratio
             case REMOVE:
                 handler.logInfo("Removing " + commandLine.getOptionValue("r") + " from Index");
                 indexer.unIndexContent(context, indexableObject.get().getUniqueIndexID());
+                if (commandLine.hasOption("suggest")) {
+                    rebuildSuggestDictionaries();
+                }
                 break;
             case CLEAN:
                 handler.logInfo("Cleaning Index");
                 indexer.cleanIndex();
+                if (commandLine.hasOption("suggest")) {
+                    rebuildSuggestDictionaries();
+                }
                 break;
             case DELETE:
                 handler.logInfo("Deleting Index");
                 indexer.deleteIndex();
+                if (commandLine.hasOption("suggest")) {
+                    rebuildSuggestDictionaries();
+                }
                 break;
             case BUILD:
             case BUILDANDSPELLCHECK:
@@ -107,13 +118,25 @@ public class IndexClient extends DSpaceRunnable<IndexDiscoveryScriptConfiguratio
                 if (indexClientOptions == IndexClientOptions.BUILDANDSPELLCHECK) {
                     checkRebuildSpellCheck(commandLine, indexer);
                 }
+                if (commandLine.hasOption("suggest")) {
+                    rebuildSuggestDictionaries();
+                }
                 break;
             case OPTIMIZE:
                 handler.logInfo("Optimizing search core.");
                 indexer.optimize();
+                if (commandLine.hasOption("suggest")) {
+                    rebuildSuggestDictionaries();
+                }
                 break;
             case SPELLCHECK:
                 checkRebuildSpellCheck(commandLine, indexer);
+                if (commandLine.hasOption("suggest")) {
+                    rebuildSuggestDictionaries();
+                }
+                break;
+            case SUGGEST:
+                rebuildSuggestDictionaries();
                 break;
             case INDEX:
                 handler.logInfo("Indexing " + commandLine.getOptionValue('i') + " force " + commandLine.hasOption("f"));
@@ -123,6 +146,9 @@ public class IndexClient extends DSpaceRunnable<IndexDiscoveryScriptConfiguratio
                 final long seconds = (Instant.now().toEpochMilli() - startTimeMillis) / 1000;
                 handler.logInfo("Indexed " + count + " object" + (count > 1 ? "s" : "") +
                                 " in " + seconds + " seconds");
+                if (commandLine.hasOption("suggest")) {
+                    rebuildSuggestDictionaries();
+                }
                 break;
             case UPDATE:
             case UPDATEANDSPELLCHECK:
@@ -131,6 +157,9 @@ public class IndexClient extends DSpaceRunnable<IndexDiscoveryScriptConfiguratio
                 if (indexClientOptions == IndexClientOptions.UPDATEANDSPELLCHECK) {
                     checkRebuildSpellCheck(commandLine, indexer);
                 }
+                if (commandLine.hasOption("suggest")) {
+                    rebuildSuggestDictionaries();
+                }
                 break;
             case FORCEUPDATE:
             case FORCEUPDATEANDSPELLCHECK:
@@ -138,6 +167,9 @@ public class IndexClient extends DSpaceRunnable<IndexDiscoveryScriptConfiguratio
                 indexer.updateIndex(context, true, type);
                 if (indexClientOptions == IndexClientOptions.FORCEUPDATEANDSPELLCHECK) {
                     checkRebuildSpellCheck(commandLine, indexer);
+                }
+                if (commandLine.hasOption("suggest")) {
+                    rebuildSuggestDictionaries();
                 }
                 break;
             default:
@@ -268,4 +300,15 @@ public class IndexClient extends DSpaceRunnable<IndexDiscoveryScriptConfiguratio
         indexer.buildSpellCheck();
     }
 
+    /**
+     * Rebuild all Solr suggest dictionaries
+     *
+     * @throws SearchServiceException in case of a solr exception
+     * @throws IOException            If I/O error occurs.
+     */
+    protected void rebuildSuggestDictionaries()
+            throws SearchServiceException, IOException {
+        handler.logInfo("Rebuilding all suggest dictionaries.");
+        solrSuggestService.rebuildAllDictionaries();
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexClientOptions.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexClientOptions.java
@@ -32,6 +32,7 @@ public enum IndexClientOptions {
     FORCEUPDATE,
     UPDATEANDSPELLCHECK,
     FORCEUPDATEANDSPELLCHECK,
+    SUGGEST,
     HELP;
 
     public static final String TYPE_OPTION = "t";
@@ -70,6 +71,9 @@ public enum IndexClientOptions {
                 return IndexClientOptions.FORCEUPDATE;
             } else if (commandLine.hasOption("s")) {
                 return IndexClientOptions.UPDATEANDSPELLCHECK;
+            } else if (commandLine.hasOption("suggest")
+                    && commandLine.getOptions().length == 1) {
+                return IndexClientOptions.SUGGEST;
             } else {
                 return IndexClientOptions.UPDATE;
             }
@@ -93,6 +97,8 @@ public enum IndexClientOptions {
                 "delete all records from existing index");
         options.addOption("b", "build", false, "(re)build index, wiping out current one if it exists");
         options.addOption("s", "spellchecker", false, "Rebuild the spellchecker, can be combined with -b and -f.");
+        options.addOption(null, "suggest", false, "Rebuild all suggest dictionaries. " +
+                "Can be used in combination with any other option that changes the index.");
         options.addOption("f", "force", false,
                           "if updating existing index, force each handle to be reindexed even if up-to-date");
         options.addOption("h", "help", false, "print this help message");

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceIndexSuggestFieldPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceIndexSuggestFieldPlugin.java
@@ -1,0 +1,69 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.discovery;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.solr.common.SolrInputDocument;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.content.Item;
+import org.dspace.content.MetadataValue;
+import org.dspace.content.service.ItemService;
+import org.dspace.core.Context;
+import org.dspace.discovery.indexobject.IndexableItem;
+import org.dspace.services.ConfigurationService;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Index values for each configured solr suggestion field to a _suggest solr field
+ *
+ * @author Kim Shepherd
+ */
+public class SolrServiceIndexSuggestFieldPlugin implements SolrServiceIndexPlugin {
+    private static final Logger log = org.apache.logging.log4j.LogManager
+            .getLogger();
+
+    @Autowired(required = true)
+    protected AuthorizeService authorizeService;
+    @Autowired(required = true)
+    protected ConfigurationService configurationService;
+    @Autowired(required = true)
+    protected ItemService itemService;
+
+    @Override
+    public void additionalIndex(Context context, IndexableObject idxObj, SolrInputDocument document) {
+        if (idxObj instanceof IndexableItem) {
+            Item item = ((IndexableItem) idxObj).getIndexedObject();
+            log.debug("Looking for suggestion fields in item {}.", item.getID());
+            if (item != null) {
+                try {
+                    // Index all metadata fields configured as suggestion fields
+                    String[] suggestionFields = configurationService.getArrayProperty("discovery.suggest.field");
+                    for (String suggestionField : suggestionFields) {
+                        log.debug("Checking suggestion field {}.", suggestionField);
+                        List<MetadataValue> suggestionValues =
+                                itemService.getMetadataByMetadataString(item, suggestionField);
+                        List<String> sv = new ArrayList<String>();
+                        for (MetadataValue v : suggestionValues) {
+                            log.debug("Add value {} for suggestion field {}.", v.getValue(), suggestionField);
+                            sv.add(v.getValue());
+                        }
+                        String docField = suggestionField + "_suggest";
+                        document.addField(docField, sv);
+                    }
+                } catch (Exception e) {
+                    log.error("Error while indexing suggestion fields," +
+                            "Item: (id " + item.getID() + " name " + item.getName() + ")");
+                }
+            }
+        }
+    }
+}
+

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceIndexSuggestFieldPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceIndexSuggestFieldPlugin.java
@@ -12,10 +12,13 @@ import java.util.List;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.solr.common.SolrInputDocument;
+import org.dspace.app.util.service.MetadataExposureService;
 import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.content.Item;
+import org.dspace.content.MetadataFieldName;
 import org.dspace.content.MetadataValue;
 import org.dspace.content.service.ItemService;
+import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.discovery.indexobject.IndexableItem;
 import org.dspace.services.ConfigurationService;
@@ -36,32 +39,70 @@ public class SolrServiceIndexSuggestFieldPlugin implements SolrServiceIndexPlugi
     protected ConfigurationService configurationService;
     @Autowired(required = true)
     protected ItemService itemService;
+    @Autowired(required = true)
+    protected MetadataExposureService metadataExposureService;
 
     @Override
     public void additionalIndex(Context context, IndexableObject idxObj, SolrInputDocument document) {
-        if (idxObj instanceof IndexableItem) {
-            Item item = ((IndexableItem) idxObj).getIndexedObject();
+
+        if (!(idxObj instanceof IndexableItem)) {
+            return;
+        }
+        if (!(((IndexableItem) idxObj).getIndexedObject() instanceof Item item)) {
+            return;
+        }
+
+        if (!item.isDiscoverable() || item.isWithdrawn() || !item.isArchived()) {
+            log.debug("Skipping suggestion term index from non-discoverable / non-archived item {}",
+                    item.getID());
+            return;
+        }
+
+        boolean contextAuthWasIgnored = context.ignoreAuthorization();
+        try {
+            // Most index and plugins want to ignore authorisation, so they can simply build the docs
+            // and let Solr / Discovery endpoints / Auth service decide who can see them. In this case
+            // we are adding a field which will be read directly by the Solr Suggest Handler so
+            // we need to be more restrictive here. Restore authorisation so context is acting as
+            // an anonymous user (public READ check, etc)
+            if (contextAuthWasIgnored) {
+                context.restoreAuthSystemState();
+            }
+            // Don't index values from items without public READ access
+            if (!authorizeService.authorizeActionBoolean(context, item, Constants.READ)) {
+                log.debug("Skipping suggestion term index from non-public item {}",
+                        item.getID());
+                return;
+            }
             log.debug("Looking for suggestion fields in item {}.", item.getID());
-            if (item != null) {
-                try {
-                    // Index all metadata fields configured as suggestion fields
-                    String[] suggestionFields = configurationService.getArrayProperty("discovery.suggest.field");
-                    for (String suggestionField : suggestionFields) {
-                        log.debug("Checking suggestion field {}.", suggestionField);
-                        List<MetadataValue> suggestionValues =
-                                itemService.getMetadataByMetadataString(item, suggestionField);
-                        List<String> sv = new ArrayList<String>();
-                        for (MetadataValue v : suggestionValues) {
-                            log.debug("Add value {} for suggestion field {}.", v.getValue(), suggestionField);
-                            sv.add(v.getValue());
-                        }
-                        String docField = suggestionField + "_suggest";
-                        document.addField(docField, sv);
-                    }
-                } catch (Exception e) {
-                    log.error("Error while indexing suggestion fields," +
-                            "Item: (id " + item.getID() + " name " + item.getName() + ")");
+            // Index all metadata fields configured as suggestion fields
+            String[] suggestionFields = configurationService.getArrayProperty("discovery.suggest.field");
+            for (String suggestionField : suggestionFields) {
+                MetadataFieldName field = new MetadataFieldName(suggestionField);
+                // Don't index metadata fields configured with metadata.hide.* in dspace.cfg
+                if (metadataExposureService.isHidden(context,
+                            field.schema, field.element, field.qualifier)) {
+                    log.debug("Skipping suggestion term index of hidden field {}", field);
+                    continue;
                 }
+                log.debug("Checking suggestion field {}.", suggestionField);
+                List<MetadataValue> suggestionValues =
+                    itemService.getMetadataByMetadataString(item, suggestionField);
+                List<String> sv = new ArrayList<String>();
+                for (MetadataValue v : suggestionValues) {
+                    log.debug("Add value {} for suggestion field {}.", v.getValue(), suggestionField);
+                    sv.add(v.getValue());
+                }
+                String docField = suggestionField + "_suggest";
+                document.addField(docField, sv);
+            }
+        } catch (Exception e) {
+            log.error("Error while indexing suggestion fields," +
+                    "Item: (id " + item.getID() + " name " + item.getName() + ")");
+        } finally {
+            // Put context authZ state back the way we found it
+            if (contextAuthWasIgnored) {
+                context.turnOffAuthorisationSystem();
             }
         }
     }

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrSuggestService.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrSuggestService.java
@@ -1,0 +1,76 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.discovery;
+
+import java.io.IOException;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.logging.log4j.Logger;
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.dspace.services.ConfigurationService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+/**
+ * Query the /suggest Solr search request handler to provide
+ * weighted suggestions from dictionaries based on search index
+ * documents and/or file-based word lists
+ *
+ * @author Kim Shepherd
+ */
+@Service
+public class SolrSuggestService {
+
+    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
+
+    @Autowired
+    protected SolrSearchCore solrSearchCore;
+    @Autowired
+    protected ConfigurationService configurationService;
+
+    protected SolrSuggestService() {
+
+    }
+
+    /**
+     * Get a list of suggested terms from the Solr suggest request handler
+     *
+     * @param query      the current text input
+     * @param dictionary the name of the Solr suggest dictionary to search
+     * @return simple serialised JSON containing Solr suggest results
+     */
+    public Map getSuggestions(String query, String dictionary) {
+
+        SolrClient solrClient = solrSearchCore.getSolr();
+
+        try {
+            SolrQuery solrQuery = new SolrQuery();
+            solrQuery.set("suggest", true);
+            solrQuery.set("suggest.q", query);
+            solrQuery.set("suggest.dictionary", dictionary);
+            solrQuery.setRequestHandler("/suggest");
+
+            QueryResponse response = solrClient.query(solrQuery);
+            ObjectMapper mapper = new ObjectMapper();
+            String json = response.jsonStr();
+            return mapper.readValue(json, new TypeReference<Map<String, Object>>() {});
+
+        } catch (SolrServerException | IOException e) {
+            throw new RuntimeException("Unable to retrieve suggest response.", e);
+        }
+    }
+
+
+
+
+}

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrSuggestService.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrSuggestService.java
@@ -35,6 +35,8 @@ public class SolrSuggestService {
 
     private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
+    private static final String WILDCARD_ALL = "*";
+
     @Autowired
     protected SolrSearchCore solrSearchCore;
     @Autowired
@@ -46,7 +48,9 @@ public class SolrSuggestService {
 
     /**
      * Check whether the given dictionary name is in the configured allowlist.
-     * If no allowlist is configured, all dictionaries are allowed.
+     * If no allowlist is configured (empty or null), no dictionaries are allowed.
+     * If the allowlist contains "*", all dictionaries are allowed.
+     * Otherwise, only explicitly listed dictionary names are allowed.
      *
      * @param dictionary the dictionary name to check
      * @return true if allowed, false otherwise
@@ -55,9 +59,15 @@ public class SolrSuggestService {
         String[] allowed = configurationService.getArrayProperty(
                 "discovery.suggest.allowed-dictionaries");
         if (allowed == null || allowed.length == 0) {
+            return false;
+        }
+        List<String> allowedList = Arrays.stream(allowed)
+                .map(String::trim)
+                .toList();
+        if (allowedList.contains(WILDCARD_ALL)) {
             return true;
         }
-        return Arrays.asList(allowed).contains(dictionary);
+        return allowedList.contains(dictionary);
     }
 
     /**
@@ -72,11 +82,8 @@ public class SolrSuggestService {
         SolrClient solrClient = solrSearchCore.getSolr();
 
         try {
-            SolrQuery solrQuery = new SolrQuery();
-            solrQuery.set("suggest", true);
+            SolrQuery solrQuery = createSuggestQuery(dictionary);
             solrQuery.set("suggest.q", query);
-            solrQuery.set("suggest.dictionary", dictionary);
-            solrQuery.setRequestHandler("/suggest");
 
             QueryResponse response = solrClient.query(solrQuery);
             ObjectMapper mapper = new ObjectMapper();
@@ -90,26 +97,47 @@ public class SolrSuggestService {
 
     public void rebuildDictionary(String dictionary) {
         if (isAllowedDictionary(dictionary)) {
-            SolrClient solrClient = solrSearchCore.getSolr();
-            try {
-                SolrQuery solrQuery = new SolrQuery();
-                solrQuery.set("suggest", true);
-                solrQuery.set("suggest.dictionary", dictionary);
-                solrQuery.set("suggest.build", true);
-                solrQuery.setRequestHandler("/suggest");
-                QueryResponse response = solrClient.query(solrQuery);
-            } catch (SolrServerException | IOException e) {
-                log.error("Unable to rebuild dictionary {}: {}", dictionary, e.getMessage());
-            }
+            sendBuildRequest(dictionary);
         }
     }
 
     public void rebuildAllDictionaries() {
         log.debug("Rebuilding all dictionaries");
-        List<String> allowedDictionaries = List.of(
-                configurationService.getArrayProperty("discovery.suggest.allowed-dictionaries"));
+        String[] allowed = configurationService.getArrayProperty("discovery.suggest.allowed-dictionaries");
+        if (allowed == null || allowed.length == 0) {
+            log.debug("No allowed dictionaries configured, skipping rebuild");
+            return;
+        }
+        List<String> allowedDictionaries = Arrays.stream(allowed)
+                .map(String::trim)
+                .toList();
+        if (allowedDictionaries.contains(WILDCARD_ALL)) {
+            sendBuildRequest(null);
+            return;
+        }
         for (String dictionary : allowedDictionaries) {
             rebuildDictionary(dictionary);
+        }
+    }
+
+    private SolrQuery createSuggestQuery(String dictionary) {
+        SolrQuery solrQuery = new SolrQuery();
+        solrQuery.set("suggest", true);
+        if (dictionary != null) {
+            solrQuery.set("suggest.dictionary", dictionary);
+        }
+        solrQuery.setRequestHandler("/suggest");
+        return solrQuery;
+    }
+
+    private void sendBuildRequest(String dictionary) {
+        SolrClient solrClient = solrSearchCore.getSolr();
+        try {
+            SolrQuery solrQuery = createSuggestQuery(dictionary);
+            solrQuery.set("suggest.build", true);
+            solrClient.query(solrQuery);
+        } catch (SolrServerException | IOException e) {
+            log.error("Unable to rebuild dictionary {}: {}", dictionary != null ? dictionary : WILDCARD_ALL, e.getMessage());
         }
     }
 

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrSuggestService.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrSuggestService.java
@@ -9,6 +9,7 @@ package org.dspace.discovery;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -84,6 +85,31 @@ public class SolrSuggestService {
 
         } catch (SolrServerException | IOException e) {
             throw new RuntimeException("Unable to retrieve suggest response.", e);
+        }
+    }
+
+    public void rebuildDictionary(String dictionary) {
+        if (isAllowedDictionary(dictionary)) {
+            SolrClient solrClient = solrSearchCore.getSolr();
+            try {
+                SolrQuery solrQuery = new SolrQuery();
+                solrQuery.set("suggest", true);
+                solrQuery.set("suggest.dictionary", dictionary);
+                solrQuery.set("suggest.build", true);
+                solrQuery.setRequestHandler("/suggest");
+                QueryResponse response = solrClient.query(solrQuery);
+            } catch (SolrServerException | IOException e) {
+                log.error("Unable to rebuild dictionary {}: {}", dictionary, e.getMessage());
+            }
+        }
+    }
+
+    public void rebuildAllDictionaries() {
+        log.debug("Rebuilding all dictionaries");
+        List<String> allowedDictionaries = List.of(
+                configurationService.getArrayProperty("discovery.suggest.allowed-dictionaries"));
+        for (String dictionary : allowedDictionaries) {
+            rebuildDictionary(dictionary);
         }
     }
 

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrSuggestService.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrSuggestService.java
@@ -9,7 +9,6 @@ package org.dspace.discovery;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -35,8 +34,6 @@ public class SolrSuggestService {
 
     private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
-    private static final String WILDCARD_ALL = "*";
-
     @Autowired
     protected SolrSearchCore solrSearchCore;
     @Autowired
@@ -49,7 +46,6 @@ public class SolrSuggestService {
     /**
      * Check whether the given dictionary name is in the configured allowlist.
      * If no allowlist is configured (empty or null), no dictionaries are allowed.
-     * If the allowlist contains "*", all dictionaries are allowed.
      * Otherwise, only explicitly listed dictionary names are allowed.
      *
      * @param dictionary the dictionary name to check
@@ -61,13 +57,7 @@ public class SolrSuggestService {
         if (allowed == null || allowed.length == 0) {
             return false;
         }
-        List<String> allowedList = Arrays.stream(allowed)
-                .map(String::trim)
-                .toList();
-        if (allowedList.contains(WILDCARD_ALL)) {
-            return true;
-        }
-        return allowedList.contains(dictionary);
+        return Arrays.asList(allowed).contains(dictionary);
     }
 
     /**
@@ -108,24 +98,15 @@ public class SolrSuggestService {
             log.debug("No allowed dictionaries configured, skipping rebuild");
             return;
         }
-        List<String> allowedDictionaries = Arrays.stream(allowed)
-                .map(String::trim)
-                .toList();
-        if (allowedDictionaries.contains(WILDCARD_ALL)) {
-            sendBuildRequest(null);
-            return;
-        }
-        for (String dictionary : allowedDictionaries) {
-            rebuildDictionary(dictionary);
+        for (String dictionary : allowed) {
+            sendBuildRequest(dictionary);
         }
     }
 
     private SolrQuery createSuggestQuery(String dictionary) {
         SolrQuery solrQuery = new SolrQuery();
         solrQuery.set("suggest", true);
-        if (dictionary != null) {
-            solrQuery.set("suggest.dictionary", dictionary);
-        }
+        solrQuery.set("suggest.dictionary", dictionary);
         solrQuery.setRequestHandler("/suggest");
         return solrQuery;
     }
@@ -137,7 +118,7 @@ public class SolrSuggestService {
             solrQuery.set("suggest.build", true);
             solrClient.query(solrQuery);
         } catch (SolrServerException | IOException e) {
-            log.error("Unable to rebuild dictionary {}: {}", dictionary != null ? dictionary : WILDCARD_ALL, e.getMessage());
+            log.error("Unable to rebuild dictionary {}: {}", dictionary, e.getMessage());
         }
     }
 

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrSuggestService.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrSuggestService.java
@@ -8,6 +8,7 @@
 package org.dspace.discovery;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Map;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -43,6 +44,22 @@ public class SolrSuggestService {
     }
 
     /**
+     * Check whether the given dictionary name is in the configured allowlist.
+     * If no allowlist is configured, all dictionaries are allowed.
+     *
+     * @param dictionary the dictionary name to check
+     * @return true if allowed, false otherwise
+     */
+    public boolean isAllowedDictionary(String dictionary) {
+        String[] allowed = configurationService.getArrayProperty(
+                "discovery.suggest.allowed-dictionaries");
+        if (allowed == null || allowed.length == 0) {
+            return true;
+        }
+        return Arrays.asList(allowed).contains(dictionary);
+    }
+
+    /**
      * Get a list of suggested terms from the Solr suggest request handler
      *
      * @param query      the current text input
@@ -69,8 +86,5 @@ public class SolrSuggestService {
             throw new RuntimeException("Unable to retrieve suggest response.", e);
         }
     }
-
-
-
 
 }

--- a/dspace-api/src/main/java/org/dspace/validation/MetadataValidator.java
+++ b/dspace-api/src/main/java/org/dspace/validation/MetadataValidator.java
@@ -61,8 +61,6 @@ public class MetadataValidator implements SubmissionStepValidator {
 
     private static final String ERROR_VALIDATION_DICTIONARY = "error.validation.dictionary";
 
-    public static final String WORKSPACE_ITEM_OPERATION_PATH_SECTIONS = "sections";
-
     private static final Logger log = LogManager.getLogger(MetadataValidator.class);
 
     private DCInputsReader inputReader;
@@ -270,8 +268,8 @@ public class MetadataValidator implements SubmissionStepValidator {
                         } else {
                             addError(errors,
                                     ERROR_VALIDATION_DICTIONARY + "." + input.getValidationDictionary(),
-                                    "/" + WORKSPACE_ITEM_OPERATION_PATH_SECTIONS
-                                            + "/" + config.getId() + "/" + input.getFieldName() + "/" + md.getPlace());
+                                    "/" + OPERATION_PATH_SECTIONS + "/" + config.getId()
+                                    + "/" + input.getFieldName() + "/" + md.getPlace());
                         }
                     }
                 } catch (ClassCastException e) {

--- a/dspace-api/src/main/java/org/dspace/vocabulary/ControlledVocabulary.java
+++ b/dspace-api/src/main/java/org/dspace/vocabulary/ControlledVocabulary.java
@@ -39,6 +39,10 @@ public class ControlledVocabulary {
     private String value;
     private List<ControlledVocabulary> childNodes;
 
+    public static final String AUTHORITY = "authority";
+    public static final String XML = "xml";
+    public static final String SUGGEST = "suggest";
+
     public ControlledVocabulary(String id, String label, String value, List<ControlledVocabulary> childNodes) {
         this.id = id;
         this.label = label;

--- a/dspace-api/src/test/data/dspaceFolder/config/item-submission.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/item-submission.xml
@@ -34,6 +34,7 @@
         <name-map collection-handle="123456789/collection-test-patch" submission-name="publicationTestPatch"/>
         <name-map collection-handle="123456789/enforced-relation" submission-name="enforcedRelation"/>
         <name-map collection-handle="123456789/person" submission-name="person-submission"/>
+        <name-map collection-handle="123456789/test-suggestion-vocabulary" submission-name="testSuggestionVocabulary"/>
     </submission-map>
 
 
@@ -229,6 +230,12 @@
             <type>custom-url</type>
         </step-definition>
 
+        <step-definition id="vocabulary-suggest-test" mandatory="true">
+            <heading>submit.progressbar.describe.stepone</heading>
+            <processing-class>org.dspace.app.rest.submit.step.DescribeStep</processing-class>
+            <type>submission-form</type>
+        </step-definition>
+
     </step-definitions>
 
     <!-- The submission-definitions map lays out the detailed definition of -->
@@ -356,6 +363,11 @@
         <submission-process name="person-submission">
             <step id="collection"/>
             <step id="personstep"/>
+        </submission-process>
+
+
+        <submission-process name="testSuggestionVocabulary">
+            <step id="vocabulary-suggest-test"></step>
         </submission-process>
 
     </submission-definitions>

--- a/dspace-api/src/test/data/dspaceFolder/config/local.cfg
+++ b/dspace-api/src/test/data/dspaceFolder/config/local.cfg
@@ -214,3 +214,6 @@ assetstore.jcloud.basedir = target/testing/dspace
 webui.submit.upload.required = true
 rest.cors.allowed-origins = http://localhost:4000
 dspace.name = DSpace at My University
+
+##### SUGGEST / AUTOCOMPLETE #####
+discovery.suggest.allowed-dictionaries = subject, authors, countries_file

--- a/dspace-api/src/test/data/dspaceFolder/config/submission-forms.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/submission-forms.xml
@@ -529,6 +529,22 @@ it, please enter the types and the actual numbers or codes.</hint>
      </row>
    </form>
 
+   <form name="vocabulary-suggest-test">
+     <row>
+       <field>
+         <dc-schema>dc</dc-schema>
+         <dc-element>subject</dc-element>
+         <dc-qualifier></dc-qualifier>
+         <repeatable>true</repeatable>
+         <label>Subject Keywords</label>
+         <input-type>tag</input-type>
+         <hint>Enter appropriate subject keywords or phrases. </hint>
+         <required></required>
+         <vocabulary type="suggest">subject</vocabulary>
+       </field>
+     </row>
+   </form>
+
  </form-definitions>
 
 

--- a/dspace-api/src/test/java/org/dspace/discovery/SolrSuggestServiceTest.java
+++ b/dspace-api/src/test/java/org/dspace/discovery/SolrSuggestServiceTest.java
@@ -24,7 +24,6 @@ import org.mockito.junit.MockitoJUnitRunner;
  *
  * The allowed-dictionaries config behavior should be:
  * - Empty/null list: no dictionaries are allowed (deny all)
- * - "*" in list: all dictionaries are allowed (allow all)
  * - Explicit list: only those named dictionaries are allowed
  *
  * @author Milan Majchrak (dspace at dataquest.sk)
@@ -72,18 +71,6 @@ public class SolrSuggestServiceTest {
     }
 
     /**
-     * When the allowed-dictionaries config contains "*", all dictionaries should be allowed.
-     */
-    @Test
-    public void wildcardConfigShouldAllowAll() {
-        when(configurationService.getArrayProperty(CONFIG_KEY)).thenReturn(new String[]{"*"});
-
-        assertThat(solrSuggestService.isAllowedDictionary("subject"), is(true));
-        assertThat(solrSuggestService.isAllowedDictionary("authors"), is(true));
-        assertThat(solrSuggestService.isAllowedDictionary("any_random_name"), is(true));
-    }
-
-    /**
      * When the allowed-dictionaries config contains explicit names,
      * only those names should be allowed.
      */
@@ -96,30 +83,5 @@ public class SolrSuggestServiceTest {
         assertThat(solrSuggestService.isAllowedDictionary("countries_file"), is(true));
         assertThat(solrSuggestService.isAllowedDictionary("authors"), is(false));
         assertThat(solrSuggestService.isAllowedDictionary("not_in_list"), is(false));
-    }
-
-    /**
-     * When the wildcard "*" is mixed with explicit names, all dictionaries should still be allowed.
-     */
-    @Test
-    public void wildcardMixedWithExplicitShouldAllowAll() {
-        when(configurationService.getArrayProperty(CONFIG_KEY))
-                .thenReturn(new String[]{"subject", "*", "countries_file"});
-
-        assertThat(solrSuggestService.isAllowedDictionary("subject"), is(true));
-        assertThat(solrSuggestService.isAllowedDictionary("anything_else"), is(true));
-    }
-
-    /**
-     * Whitespace-trimmed names should still match.
-     */
-    @Test
-    public void trimmedNamesShouldMatch() {
-        when(configurationService.getArrayProperty(CONFIG_KEY))
-                .thenReturn(new String[]{" subject ", " countries_file "});
-
-        assertThat(solrSuggestService.isAllowedDictionary("subject"), is(true));
-        assertThat(solrSuggestService.isAllowedDictionary("countries_file"), is(true));
-        assertThat(solrSuggestService.isAllowedDictionary("authors"), is(false));
     }
 }

--- a/dspace-api/src/test/java/org/dspace/discovery/SolrSuggestServiceTest.java
+++ b/dspace-api/src/test/java/org/dspace/discovery/SolrSuggestServiceTest.java
@@ -1,0 +1,125 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.discovery;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
+
+import org.dspace.services.ConfigurationService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * Unit tests for SolrSuggestService, specifically the isAllowedDictionary logic.
+ *
+ * The allowed-dictionaries config behavior should be:
+ * - Empty/null list: no dictionaries are allowed (deny all)
+ * - "*" in list: all dictionaries are allowed (allow all)
+ * - Explicit list: only those named dictionaries are allowed
+ *
+ * @author dataquest-dev
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class SolrSuggestServiceTest {
+
+    @InjectMocks
+    private SolrSuggestService solrSuggestService;
+
+    @Mock
+    private ConfigurationService configurationService;
+
+    @Mock
+    private SolrSearchCore solrSearchCore;
+
+    private static final String CONFIG_KEY = "discovery.suggest.allowed-dictionaries";
+
+    @Before
+    public void setUp() {
+    }
+
+    /**
+     * When the allowed-dictionaries config is null (not set), no dictionaries should be allowed.
+     */
+    @Test
+    public void nullConfigShouldDenyAll() {
+        when(configurationService.getArrayProperty(CONFIG_KEY)).thenReturn(null);
+
+        assertThat(solrSuggestService.isAllowedDictionary("subject"), is(false));
+        assertThat(solrSuggestService.isAllowedDictionary("authors"), is(false));
+        assertThat(solrSuggestService.isAllowedDictionary("anything"), is(false));
+    }
+
+    /**
+     * When the allowed-dictionaries config is empty, no dictionaries should be allowed.
+     */
+    @Test
+    public void emptyConfigShouldDenyAll() {
+        when(configurationService.getArrayProperty(CONFIG_KEY)).thenReturn(new String[]{});
+
+        assertThat(solrSuggestService.isAllowedDictionary("subject"), is(false));
+        assertThat(solrSuggestService.isAllowedDictionary("authors"), is(false));
+        assertThat(solrSuggestService.isAllowedDictionary("anything"), is(false));
+    }
+
+    /**
+     * When the allowed-dictionaries config contains "*", all dictionaries should be allowed.
+     */
+    @Test
+    public void wildcardConfigShouldAllowAll() {
+        when(configurationService.getArrayProperty(CONFIG_KEY)).thenReturn(new String[]{"*"});
+
+        assertThat(solrSuggestService.isAllowedDictionary("subject"), is(true));
+        assertThat(solrSuggestService.isAllowedDictionary("authors"), is(true));
+        assertThat(solrSuggestService.isAllowedDictionary("any_random_name"), is(true));
+    }
+
+    /**
+     * When the allowed-dictionaries config contains explicit names,
+     * only those names should be allowed.
+     */
+    @Test
+    public void explicitConfigShouldAllowOnlyListed() {
+        when(configurationService.getArrayProperty(CONFIG_KEY))
+                .thenReturn(new String[]{"subject", "countries_file"});
+
+        assertThat(solrSuggestService.isAllowedDictionary("subject"), is(true));
+        assertThat(solrSuggestService.isAllowedDictionary("countries_file"), is(true));
+        assertThat(solrSuggestService.isAllowedDictionary("authors"), is(false));
+        assertThat(solrSuggestService.isAllowedDictionary("not_in_list"), is(false));
+    }
+
+    /**
+     * When the wildcard "*" is mixed with explicit names, all dictionaries should still be allowed.
+     */
+    @Test
+    public void wildcardMixedWithExplicitShouldAllowAll() {
+        when(configurationService.getArrayProperty(CONFIG_KEY))
+                .thenReturn(new String[]{"subject", "*", "countries_file"});
+
+        assertThat(solrSuggestService.isAllowedDictionary("subject"), is(true));
+        assertThat(solrSuggestService.isAllowedDictionary("anything_else"), is(true));
+    }
+
+    /**
+     * Whitespace-trimmed names should still match.
+     */
+    @Test
+    public void trimmedNamesShouldMatch() {
+        when(configurationService.getArrayProperty(CONFIG_KEY))
+                .thenReturn(new String[]{" subject ", " countries_file "});
+
+        assertThat(solrSuggestService.isAllowedDictionary("subject"), is(true));
+        assertThat(solrSuggestService.isAllowedDictionary("countries_file"), is(true));
+        assertThat(solrSuggestService.isAllowedDictionary("authors"), is(false));
+    }
+}

--- a/dspace-api/src/test/java/org/dspace/discovery/SolrSuggestServiceTest.java
+++ b/dspace-api/src/test/java/org/dspace/discovery/SolrSuggestServiceTest.java
@@ -27,7 +27,7 @@ import org.mockito.junit.MockitoJUnitRunner;
  * - "*" in list: all dictionaries are allowed (allow all)
  * - Explicit list: only those named dictionaries are allowed
  *
- * @author dataquest-dev
+ * @author Milan Majchrak (dspace at dataquest.sk)
  */
 @RunWith(MockitoJUnitRunner.class)
 public class SolrSuggestServiceTest {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/DiscoveryRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/DiscoveryRestController.java
@@ -11,6 +11,7 @@ import static org.apache.commons.collections4.ListUtils.emptyIfNull;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import org.apache.commons.lang3.StringUtils;
@@ -33,6 +34,8 @@ import org.dspace.app.rest.model.hateoas.SearchSupportResource;
 import org.dspace.app.rest.parameter.SearchFilter;
 import org.dspace.app.rest.repository.DiscoveryRestRepository;
 import org.dspace.app.rest.utils.Utils;
+import org.dspace.discovery.SolrSuggestService;
+import org.dspace.services.factory.DSpaceServicesFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
@@ -233,4 +236,19 @@ public class DiscoveryRestController implements InitializingBean {
         }
     }
 
+    /**
+     * Return serialized map of Solr search suggest handler results
+     * for use in autocomplete and term suggestion lookups
+     * @param dictionary dictionary as configured in search/solrconfig.xml
+     * @param query term query
+     * @return Map (to be serialized to JSON)
+     */
+    @RequestMapping(method = RequestMethod.GET, value = "/suggest", produces = "application/json")
+    public Map<String, Object> suggest(
+        @RequestParam(name = "dict") String dictionary,
+        @RequestParam(name = "q") String query) {
+        SolrSuggestService solrSuggestService = DSpaceServicesFactory.getInstance().getServiceManager()
+            .getServicesByType(SolrSuggestService.class).get(0);
+        return solrSuggestService.getSuggestions(query, dictionary);
+    }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/DiscoveryRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/DiscoveryRestController.java
@@ -274,4 +274,42 @@ public class DiscoveryRestController implements InitializingBean {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
     }
+
+    /**
+     * Build one or all Solr suggest dictionaries. Helpful to force rebuilds
+     * if metadata has changed significantly.
+     *
+     * @param dictionary the name of the suggest dictionary to rebuild
+     *                   of, if blank, indicator to rebuild all dictionaries
+     * @return ResponseEntity with suggestion results in Solr suggest response format
+     */
+    @PreAuthorize("hasAuthority('ADMIN')")
+    @RequestMapping(method = RequestMethod.GET, value = "/suggest/build")
+    public ResponseEntity<RepresentationModel<?>> buildSuggestDictionary(
+        @RequestParam(name = "dict", required = false) String dictionary) {
+
+        if (StringUtils.isBlank(dictionary)) {
+            try {
+                solrSuggestService.rebuildAllDictionaries();
+                return ResponseEntity.status(HttpStatus.OK).build();
+            } catch (Exception e) {
+                log.error("Error building suggest dictionaries", e);
+                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+            }
+        }
+
+        if (!solrSuggestService.isAllowedDictionary(dictionary)) {
+            log.warn("Suggest request for non-allowed dictionary: {}", dictionary);
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+
+        try {
+            solrSuggestService.rebuildDictionary(dictionary);
+            return ResponseEntity.status(HttpStatus.OK).build();
+        } catch (Exception e) {
+            log.error("Error building suggest dictionary={}", dictionary, e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
 }
+

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/DiscoveryRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/DiscoveryRestController.java
@@ -35,12 +35,14 @@ import org.dspace.app.rest.parameter.SearchFilter;
 import org.dspace.app.rest.repository.DiscoveryRestRepository;
 import org.dspace.app.rest.utils.Utils;
 import org.dspace.discovery.SolrSuggestService;
-import org.dspace.services.factory.DSpaceServicesFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.RepresentationModel;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -72,6 +74,9 @@ public class DiscoveryRestController implements InitializingBean {
 
     @Autowired
     private ConverterService converter;
+
+    @Autowired
+    private SolrSuggestService solrSuggestService;
 
     @Override
     public void afterPropertiesSet() throws Exception {
@@ -237,18 +242,36 @@ public class DiscoveryRestController implements InitializingBean {
     }
 
     /**
-     * Return serialized map of Solr search suggest handler results
-     * for use in autocomplete and term suggestion lookups
-     * @param dictionary dictionary as configured in search/solrconfig.xml
-     * @param query term query
-     * @return Map (to be serialized to JSON)
+     * Endpoint for autocomplete suggestions. Queries the Solr suggest handler.
+     * Protected by a configurable dictionary allowlist and authentication.
+     *
+     * @param dictionary the name of the suggest dictionary to query
+     * @param query      the current text input for autocomplete
+     * @return ResponseEntity with suggestion results in Solr suggest response format
      */
-    @RequestMapping(method = RequestMethod.GET, value = "/suggest", produces = "application/json")
-    public Map<String, Object> suggest(
-        @RequestParam(name = "dict") String dictionary,
-        @RequestParam(name = "q") String query) {
-        SolrSuggestService solrSuggestService = DSpaceServicesFactory.getInstance().getServiceManager()
-            .getServicesByType(SolrSuggestService.class).get(0);
-        return solrSuggestService.getSuggestions(query, dictionary);
+    @PreAuthorize("hasAuthority('AUTHENTICATED')")
+    @RequestMapping(method = RequestMethod.GET, value = "/suggest",
+            produces = "application/json")
+    public ResponseEntity<Map<String, Object>> suggest(
+            @RequestParam(name = "dict") String dictionary,
+            @RequestParam(name = "q") String query) {
+
+        if (StringUtils.isBlank(dictionary) || StringUtils.isBlank(query)) {
+            return ResponseEntity.badRequest().build();
+        }
+
+        if (!solrSuggestService.isAllowedDictionary(dictionary)) {
+            log.warn("Suggest request for non-allowed dictionary: {}", dictionary);
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+
+        try {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> suggestions = solrSuggestService.getSuggestions(query, dictionary);
+            return ResponseEntity.ok(suggestions);
+        } catch (RuntimeException e) {
+            log.error("Error retrieving suggestions for dictionary={}, query={}", dictionary, query, e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionFormConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionFormConverter.java
@@ -14,8 +14,6 @@ import java.util.List;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.model.ScopeEnum;
 import org.dspace.app.rest.model.SubmissionFormFieldRest;
 import org.dspace.app.rest.model.SubmissionFormInputTypeRest;
@@ -51,8 +49,6 @@ public class SubmissionFormConverter implements DSpaceConverter<DCInputSet, Subm
     private static final String INPUT_TYPE_LOOKUP_NAME = "lookup-name";
     private static final String INPUT_TYPE_DROPDOWN = "dropdown";
 
-    private static final Logger log = LogManager.getLogger();
-
     @Autowired
     private AuthorityUtils authorityUtils;
 
@@ -82,7 +78,6 @@ public class SubmissionFormConverter implements DSpaceConverter<DCInputSet, Subm
             rowRest.setFields(fields);
             rows.add(rowRest);
             for (DCInput dcinput : row) {
-                log.warn(dcinput.getFieldName() + ": " + dcinput.getVocabularyType());
                 fields.add(getField(dcinput, formName));
             }
         }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionFormConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionFormConverter.java
@@ -14,6 +14,8 @@ import java.util.List;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.model.ScopeEnum;
 import org.dspace.app.rest.model.SubmissionFormFieldRest;
 import org.dspace.app.rest.model.SubmissionFormInputTypeRest;
@@ -30,6 +32,7 @@ import org.dspace.app.util.DCInput;
 import org.dspace.app.util.DCInputSet;
 import org.dspace.services.RequestService;
 import org.dspace.submit.model.LanguageFormField;
+import org.dspace.vocabulary.ControlledVocabulary;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -47,6 +50,8 @@ public class SubmissionFormConverter implements DSpaceConverter<DCInputSet, Subm
     private static final String INPUT_TYPE_LOOKUP = "lookup";
     private static final String INPUT_TYPE_LOOKUP_NAME = "lookup-name";
     private static final String INPUT_TYPE_DROPDOWN = "dropdown";
+
+    private static final Logger log = LogManager.getLogger();
 
     @Autowired
     private AuthorityUtils authorityUtils;
@@ -77,6 +82,7 @@ public class SubmissionFormConverter implements DSpaceConverter<DCInputSet, Subm
             rowRest.setFields(fields);
             rows.add(rowRest);
             for (DCInput dcinput : row) {
+                log.warn(dcinput.getFieldName() + ": " + dcinput.getVocabularyType());
                 fields.add(getField(dcinput, formName));
             }
         }
@@ -94,8 +100,8 @@ public class SubmissionFormConverter implements DSpaceConverter<DCInputSet, Subm
         inputField.setMandatory(dcinput.isRequired());
         inputField.setScope(ScopeEnum.fromString(dcinput.getScope()));
         inputField.setVisibility(new SubmissionVisibilityRest(
-            VisibilityEnum.fromString(dcinput.isReadOnly("submission") ? "read-only" : null),
-            VisibilityEnum.fromString(dcinput.isReadOnly("workflow") ? "read-only" : null)));
+                VisibilityEnum.fromString(dcinput.isReadOnly("submission") ? "read-only" : null),
+                VisibilityEnum.fromString(dcinput.isReadOnly("workflow") ? "read-only" : null)));
         inputField.setRepeatable(dcinput.isRepeatable());
         if (dcinput.getLanguage()) {
             int idx = 1;
@@ -122,21 +128,27 @@ public class SubmissionFormConverter implements DSpaceConverter<DCInputSet, Subm
                 String inputType = dcinput.getInputType();
 
                 SelectableMetadata selMd = new SelectableMetadata();
-                if (isChoice(dcinput.getSchema(), dcinput.getElement(), dcinput.getQualifier(),
-                             dcinput.getPairsType(), dcinput.getVocabulary(), formName)) {
+                if (ControlledVocabulary.SUGGEST.equals(dcinput.getVocabularyType())) {
+                    inputRest.setType(INPUT_TYPE_ONEBOX);
+                    selMd.setControlledVocabulary(dcinput.getVocabulary());
+                    selMd.setClosed(dcinput.isClosedVocabulary());
+                    selMd.setVocabularyType(dcinput.getVocabularyType());
+                } else if (isChoice(dcinput.getSchema(), dcinput.getElement(), dcinput.getQualifier(),
+                        dcinput.getPairsType(), dcinput.getVocabulary(), formName)) {
                     inputRest.setType(getPresentation(dcinput.getSchema(), dcinput.getElement(),
-                                                      dcinput.getQualifier(), inputType));
+                            dcinput.getQualifier(), inputType));
                     selMd.setControlledVocabulary(getAuthorityName(dcinput.getSchema(), dcinput.getElement(),
-                                                        dcinput.getQualifier(), dcinput.getPairsType(),
-                                                                   dcinput.getVocabulary(), formName));
+                            dcinput.getQualifier(), dcinput.getPairsType(),
+                            dcinput.getVocabulary(), formName));
                     selMd.setClosed(
                             isClosed(dcinput.getSchema(), dcinput.getElement(), dcinput.getQualifier(),
                                     dcinput.getPairsType(), dcinput.getVocabulary(), dcinput.isClosedVocabulary()));
+                    selMd.setVocabularyType(dcinput.getVocabularyType());
                 } else {
                     inputRest.setType(inputType);
                 }
                 selMd.setMetadata(org.dspace.core.Utils
-                    .standardize(dcinput.getSchema(), dcinput.getElement(), dcinput.getQualifier(), "."));
+                        .standardize(dcinput.getSchema(), dcinput.getElement(), dcinput.getQualifier(), "."));
                 selectableMetadata.add(selMd);
             } else {
                 // if the field is a qualdrop_value
@@ -147,19 +159,23 @@ public class SubmissionFormConverter implements DSpaceConverter<DCInputSet, Subm
                     selMd.setLabel((String) pairs.get(idx));
                     selMd.setMetadata(org.dspace.core.Utils
                             .standardize(dcinput.getSchema(), dcinput.getElement(), pairs.get(idx + 1), "."));
-                    if (authorityUtils.isChoice(dcinput.getSchema(), dcinput.getElement(), dcinput.getQualifier(),
-                                                formName)) {
+                    if (ControlledVocabulary.SUGGEST.equals(dcinput.getVocabularyType())) {
+                        selMd.setControlledVocabulary(dcinput.getVocabulary());
+                        selMd.setClosed(dcinput.isClosedVocabulary());
+                        selMd.setVocabularyType(dcinput.getVocabularyType());
+                    } else if (authorityUtils.isChoice(
+                            dcinput.getSchema(), dcinput.getElement(), dcinput.getQualifier(), formName)) {
                         selMd.setControlledVocabulary(getAuthorityName(dcinput.getSchema(), dcinput.getElement(),
-                                                                       pairs.get(idx + 1), dcinput.getPairsType(),
-                                                                       dcinput.getVocabulary(), formName));
+                                pairs.get(idx + 1), dcinput.getPairsType(), dcinput.getVocabulary(), formName));
                         selMd.setClosed(isClosed(dcinput.getSchema(), dcinput.getElement(),
-                                dcinput.getQualifier(), null, dcinput.getVocabulary(), dcinput.isClosedVocabulary()));
+                                dcinput.getQualifier(), null, dcinput.getVocabulary(),
+                                dcinput.isClosedVocabulary()));
+                        selMd.setVocabularyType(dcinput.getVocabularyType());
                     }
                     selectableMetadata.add(selMd);
                 }
             }
         }
-
         inputField.setInput(inputRest);
         if (dcinput.isMetadataField()) {
             inputField.setSelectableMetadata(selectableMetadata);
@@ -176,7 +192,7 @@ public class SubmissionFormConverter implements DSpaceConverter<DCInputSet, Subm
      * This method will create a SelectableRelationship object
      * The DCInput will be used to define all the properties of the SelectableRelationship object
      * @param dcinput                   The parsed input from submission-forms.xml
-     * @return                          The SelectableRelationship object based on the dcinput
+     * @return The SelectableRelationship object based on the dcinput
      */
     private SelectableRelationship getSelectableRelationships(DCInput dcinput) {
         SelectableRelationship selectableRelationship = new SelectableRelationship();
@@ -222,7 +238,7 @@ public class SubmissionFormConverter implements DSpaceConverter<DCInputSet, Subm
     }
 
     private boolean isClosed(String schema, String element, String qualifier, String valuePairsName,
-            String vocabularyName, boolean isClosedVocabulary) {
+                             String vocabularyName, boolean isClosedVocabulary) {
         if (StringUtils.isNotBlank(valuePairsName)) {
             return true;
         } else if (StringUtils.isNotBlank(vocabularyName)) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/submit/SelectableMetadata.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/submit/SelectableMetadata.java
@@ -31,6 +31,8 @@ public class SelectableMetadata {
     private String controlledVocabulary;
     @JsonInclude(Include.NON_NULL)
     private Boolean closed = false;
+    @JsonInclude(Include.NON_NULL)
+    private String vocabularyType;
 
     public String getMetadata() {
         return metadata;
@@ -62,5 +64,13 @@ public class SelectableMetadata {
 
     public void setClosed(Boolean closed) {
         this.closed = closed;
+    }
+
+    public String getVocabularyType() {
+        return vocabularyType;
+    }
+
+    public void setVocabularyType(String vocabularyType) {
+        this.vocabularyType = vocabularyType;
     }
 }

--- a/dspace-server-webapp/src/test/data/dspaceFolder/config/spring/api/test-discovery.xml
+++ b/dspace-server-webapp/src/test/data/dspaceFolder/config/spring/api/test-discovery.xml
@@ -40,6 +40,9 @@
     <bean id="solrServiceBestMatchIndexingPlugin" class="org.dspace.discovery.SolrServiceBestMatchIndexingPlugin"/>
     <bean id="solrServiceBestMatchStrictIndexingPlugin"
           class="org.dspace.discovery.SolrServiceStrictBestMatchIndexingPlugin"/>
+
+    <bean id="SolrServiceIndexSuggestFieldPlugin" class="org.dspace.discovery.SolrServiceIndexSuggestFieldPlugin" scope="prototype"/>
+
     <!--Bean that is used for mapping communities/collections to certain discovery configurations.-->
     <bean id="org.dspace.discovery.configuration.DiscoveryConfigurationService" class="org.dspace.discovery.configuration.DiscoveryConfigurationService">
         <property name="map">

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/AutocompleteSuggestionIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/AutocompleteSuggestionIT.java
@@ -1,0 +1,113 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.dspace.app.rest.matcher.SubmissionFormFieldMatcher;
+import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.ItemBuilder;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.Item;
+import org.dspace.discovery.SolrSearchCore;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class AutocompleteSuggestionIT extends AbstractControllerIntegrationTest {
+    // Items with subject metadata, commit, test REST method for expected results
+    // Test test submission for expected vocabulary type
+    @Autowired
+    private SolrSearchCore solrSearchCore;
+
+    Logger log = LogManager.getLogger(this.getClass());
+
+    @Test
+    public void findFieldWithValuePairsConfig() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+        String submissionFormName = "vocabulary-suggest-test";
+
+        getClient(token).perform(get("/api/config/submissionforms/" + submissionFormName))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(contentType))
+                .andExpect(jsonPath("$.id", is(submissionFormName)))
+                .andExpect(jsonPath("$.name", is(submissionFormName)))
+                .andExpect(jsonPath("$.type", is("submissionform")))
+                .andExpect(jsonPath("$._links.self.href", Matchers
+                        .startsWith(REST_SERVER_URL + "config/submissionforms/" + submissionFormName)))
+                .andExpect(jsonPath("$.rows[0].fields", contains(
+                        SubmissionFormFieldMatcher.matchFormFieldDefinition("onebox", "Subject", null,
+                                null, true,
+                                "Enter appropriate subject keywords or phrases.",
+                                null, "dc.subject", "subject", "suggest")
+                )))
+        ;
+    }
+
+    @Test
+    public void findSubjectTermSuggestions() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                .withName("Sub Community")
+                .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+
+        Item publicItem1 = ItemBuilder.createItem(context, col1)
+                .withTitle("Public item 1")
+                .withIssueDate("2017-10-17")
+                .withAuthor("Smith, Donald")
+                .withAuthor("Doe, John")
+                .withSubject("Totora Grove")
+                .withSubject("Punga Grove")
+                .withSubject("Kowhai Flower")
+                .withSubject("Flower Arranging")
+                .build();
+
+        context.restoreAuthSystemState();
+
+        String token = getAuthToken(eperson.getEmail(), password);
+
+        // Expect two terms for "grove"
+        getClient(token).perform(get("/api/discover/suggest")
+                        .queryParam("dict", "subject")
+                        .queryParam("q", "grove")
+                )
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andExpect(jsonPath("$.suggest.subject.grove.numFound", is(2)))
+                .andExpect(jsonPath("$.suggest.subject.grove.suggestions[*].term",
+                        containsInAnyOrder("Punga <b>Grove</b>", "Totora <b>Grove</b>"
+                        )));
+
+        // Expect zero terms for "test"
+        getClient(token).perform(get("/api/discover/suggest")
+                        .queryParam("dict", "subject")
+                        .queryParam("q", "test")
+                )
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andExpect(jsonPath("$.suggest.subject.test.numFound", is(0)));
+    }
+
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/AutocompleteSuggestionIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/AutocompleteSuggestionIT.java
@@ -461,4 +461,89 @@ public class AutocompleteSuggestionIT extends AbstractControllerIntegrationTest 
                                 .param("q", "test"))
                 .andExpect(status().isBadRequest());
     }
+
+    /**
+     * Test that when discovery.suggest.allowed-dictionaries is empty (not configured),
+     * ALL dictionaries are denied (HTTP 403).
+     */
+    @Test
+    public void emptyAllowedDictionariesShouldDenyAll() throws Exception {
+        // Set the allowed-dictionaries to an empty value
+        configurationService.setProperty("discovery.suggest.allowed-dictionaries", new String[]{});
+
+        String userToken = getAuthToken(eperson.getEmail(), password);
+
+        // Even a previously-allowed dictionary like "subject" should now be forbidden
+        getClient(userToken).perform(
+                        get("/api/discover/suggest")
+                                .param("dict", "subject")
+                                .param("q", "test"))
+                .andExpect(status().isForbidden());
+
+        // Another dictionary should also be forbidden
+        getClient(userToken).perform(
+                        get("/api/discover/suggest")
+                                .param("dict", "countries_file")
+                                .param("q", "test"))
+                .andExpect(status().isForbidden());
+    }
+
+    /**
+     * Test that when discovery.suggest.allowed-dictionaries contains the wildcard "*",
+     * ALL dictionaries are allowed (HTTP 200).
+     */
+    @Test
+    public void wildcardAllowedDictionariesShouldAllowAll() throws Exception {
+        // Set the allowed-dictionaries to wildcard
+        configurationService.setProperty("discovery.suggest.allowed-dictionaries", new String[]{"*"});
+
+        String userToken = getAuthToken(eperson.getEmail(), password);
+
+        // Any dictionary name should be allowed (returns 200, not 403)
+        getClient(userToken).perform(
+                        get("/api/discover/suggest")
+                                .param("dict", "subject")
+                                .param("q", "test"))
+                .andExpect(status().isOk());
+
+        // Even an arbitrary dictionary name should be allowed with wildcard
+        getClient(userToken).perform(
+                        get("/api/discover/suggest")
+                                .param("dict", "any_dictionary_name")
+                                .param("q", "test"))
+                .andExpect(status().isOk());
+    }
+
+    /**
+     * Test that the /suggest/build endpoint also respects empty allowed-dictionaries
+     * by returning 403 when the list is empty.
+     */
+    @Test
+    public void emptyAllowedDictionariesBuildShouldDenyAll() throws Exception {
+        configurationService.setProperty("discovery.suggest.allowed-dictionaries", new String[]{});
+
+        String adminToken = getAuthToken(admin.getEmail(), password);
+
+        // Building a specific dictionary should be forbidden when allowlist is empty
+        getClient(adminToken).perform(
+                        get("/api/discover/suggest/build")
+                                .param("dict", "subject"))
+                .andExpect(status().isForbidden());
+    }
+
+    /**
+     * Test that the /suggest/build endpoint works with wildcard "*" for any dictionary.
+     */
+    @Test
+    public void wildcardAllowedDictionariesBuildShouldAllowAll() throws Exception {
+        configurationService.setProperty("discovery.suggest.allowed-dictionaries", new String[]{"*"});
+
+        String adminToken = getAuthToken(admin.getEmail(), password);
+
+        // Building any specific dictionary should be allowed
+        getClient(adminToken).perform(
+                        get("/api/discover/suggest/build")
+                                .param("dict", "subject"))
+                .andExpect(status().isOk());
+    }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/AutocompleteSuggestionIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/AutocompleteSuggestionIT.java
@@ -20,24 +20,98 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.matcher.SubmissionFormFieldMatcher;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.app.util.service.MetadataExposureService;
 import org.dspace.builder.CollectionBuilder;
 import org.dspace.builder.CommunityBuilder;
 import org.dspace.builder.ItemBuilder;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.Item;
+import org.dspace.content.service.ItemService;
+import org.dspace.discovery.IndexingService;
 import org.dspace.discovery.SolrSearchCore;
+import org.dspace.discovery.SolrSuggestService;
+import org.dspace.eperson.Group;
+import org.dspace.eperson.service.GroupService;
+import org.dspace.services.ConfigurationService;
 import org.hamcrest.Matchers;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+/**
+ * Tests for suggestion dictionaries
+ * Note: Dictionaries are "snapshots" and won't apply incremenetal updates
+ * if data is deleted / removed from the main search document of a given object.
+ * Build must be run by an administrator with/without other reindex commands or a GET
+ * to /discover/suggest/build
+ * In this test, we call rebuildAllDictionaries directly to simulate that behaviour
+ * so we can at least test that the subsequent dictionary will not contain values
+ * we expect to be missing, after a change to data or configuration.
+ */
 public class AutocompleteSuggestionIT extends AbstractControllerIntegrationTest {
     // Items with subject metadata, commit, test REST method for expected results
     // Test test submission for expected vocabulary type
     @Autowired
     private SolrSearchCore solrSearchCore;
+    @Autowired
+    private ConfigurationService configurationService;
+    @Autowired
+    private GroupService groupService;
+    @Autowired
+    private ItemService itemService;
+    @Autowired
+    private IndexingService indexingService;
+    @Autowired
+    private SolrSuggestService solrSuggestService;
+    @Autowired
+    private MetadataExposureService metadataExposureService;
 
     Logger log = LogManager.getLogger(this.getClass());
+
+    Group adminGroup;
+    String handle = "autocomplete/test";
+
+    /**
+     * Reset configuration back to its pre-test state
+     */
+    private void resetConfiguration() {
+        configurationService.reloadConfig();
+    }
+
+    /*
+     * Reindex item
+     * Because of the way the mock solr search core works
+     * we have to commit "extra hard" here...
+     */
+    private void reindexItem(Item item) throws Exception {
+        indexingService.updateIndex(context, true);
+        indexingService.commit();
+        solrSearchCore.getSolr().commit(true, true);
+    }
+
+    @BeforeClass
+    public static void beforeAll() throws Exception {
+
+    }
+
+    @Before
+    public void beforeEach() throws Exception {
+        configurationService.setProperty("discovery.suggest.field",
+                new String[]{"dc.subject", "dc.contributor.author"});
+        configurationService.setProperty("discovery.suggest.allowed-dictionaries",
+                new String[]{"subject", "authors", "countries_file"});
+        adminGroup = groupService.findByName(context, Group.ADMIN);
+        solrSuggestService.rebuildAllDictionaries();
+    }
+
+    @After
+    public void afterEach() {
+        resetConfiguration();
+        metadataExposureService.reload();
+    }
 
     @Test
     public void findFieldWithValuePairsConfig() throws Exception {
@@ -62,7 +136,7 @@ public class AutocompleteSuggestionIT extends AbstractControllerIntegrationTest 
     }
 
     @Test
-    public void findSubjectTermSuggestions() throws Exception {
+    public void findTermSuggestionsFromMetadata() throws Exception {
         context.turnOffAuthorisationSystem();
 
         parentCommunity = CommunityBuilder.createCommunity(context)
@@ -73,7 +147,7 @@ public class AutocompleteSuggestionIT extends AbstractControllerIntegrationTest 
                 .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
 
-        Item publicItem1 = ItemBuilder.createItem(context, col1)
+        Item item1 = ItemBuilder.createItem(context, col1)
                 .withTitle("Public item 1")
                 .withIssueDate("2017-10-17")
                 .withAuthor("Smith, Donald")
@@ -108,6 +182,238 @@ public class AutocompleteSuggestionIT extends AbstractControllerIntegrationTest 
                 .andExpect(status().isOk())
                 .andDo(print())
                 .andExpect(jsonPath("$.suggest.subject.test.numFound", is(0)));
+
+        context.ignoreAuthorization();
+        solrSuggestService.rebuildAllDictionaries();
+        context.restoreAuthSystemState();
+    }
+
+    @Test
+    public void findTermSuggestionsFromFlatFile() throws Exception {
+        String token = getAuthToken(eperson.getEmail(), password);
+        getClient(token).perform(get("/api/discover/suggest")
+                        .queryParam("dict", "countries_file")
+                        .queryParam("q", "madagascar")
+                )
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andExpect(jsonPath("$.suggest.countries_file.madagascar.numFound", is(1)));
+    }
+
+    @Test
+    public void dontFindHiddenMetadatTermSuggestions() throws Exception {
+        context.turnOffAuthorisationSystem();
+        configurationService.addPropertyValue("metadata.hide.dc.subject", true);
+        metadataExposureService.reload();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                .withName("Sub Community")
+                .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+
+        Item item1 = ItemBuilder.createItem(context, col1)
+                .withTitle("Public item 1")
+                .withIssueDate("2017-10-17")
+                .withAuthor("Smith, Donald")
+                .withAuthor("Doe, John")
+                .withSubject("Totora Grove")
+                .withSubject("Punga Grove")
+                .withSubject("Kowhai Flower")
+                .withSubject("Flower Arranging")
+                .build();
+        reindexItem(item1);
+        solrSuggestService.rebuildAllDictionaries();
+        context.restoreAuthSystemState();
+
+        String token = getAuthToken(eperson.getEmail(), password);
+
+        // Expect ZERO terms for "grove" - this field is hidden
+        getClient(token).perform(get("/api/discover/suggest")
+                        .queryParam("dict", "subject")
+                        .queryParam("q", "grove")
+                )
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andExpect(jsonPath("$.suggest.subject.grove.numFound", is(0)));
+
+        resetConfiguration();
+    }
+
+    @Test
+    public void testSuggestTermsFromRestrictedItem() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                .withName("Sub Community")
+                .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+
+        Item restrictedItem = ItemBuilder.createItem(context, col1)
+                .withTitle("Restricted item 1")
+                .withIssueDate("2017-10-17")
+                .withAuthor("Smith, Donald")
+                .withAuthor("Doe, John")
+                .withSubject("Totara Grove")
+                .withSubject("Punga Grove")
+                .withReaderGroup(adminGroup)
+                .build();
+
+        context.restoreAuthSystemState();
+
+        reindexItem(restrictedItem);
+        solrSuggestService.rebuildAllDictionaries();
+
+        String token = getAuthToken(eperson.getEmail(), password);
+
+        // Expect ZERO terms - this item is not publicly readable
+        getClient(token).perform(get("/api/discover/suggest")
+                        .queryParam("dict", "subject")
+                        .queryParam("q", "grove")
+                )
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andExpect(jsonPath("$.suggest.subject.grove.numFound", is(0)));
+    }
+
+    @Test
+    public void testSuggestTermsFromWithdrawnItem() throws Exception {
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                .withName("Sub Community")
+                .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+
+        Item item1 = ItemBuilder.createItem(context, col1)
+                .withTitle("Public item 1")
+                .withIssueDate("2017-10-17")
+                .withAuthor("Smith, Donald")
+                .withAuthor("Doe, John")
+                .withSubject("Totora Grove")
+                .withSubject("Kowhai Grove")
+                .withSubject("Punga Grove")
+                .withSubject("Kowhai Flower")
+                .withSubject("Flower Arranging")
+                .withdrawn()
+                .build();
+        itemService.withdraw(context, item1);
+        reindexItem(item1);
+        solrSuggestService.rebuildAllDictionaries();
+        context.restoreAuthSystemState();
+
+        String token = getAuthToken(eperson.getEmail(), password);
+
+        // Expect ZERO terms for "grove" - this item is withdrawn
+        getClient(token).perform(get("/api/discover/suggest")
+                        .queryParam("dict", "subject")
+                        .queryParam("q", "grove")
+                )
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andExpect(jsonPath("$.suggest.subject.grove.numFound", is(0)));
+
+    }
+
+    @Test
+    public void testSuggestTermsFromNonDiscoverableItem() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                .withName("Sub Community")
+                .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+
+        Item item1 = ItemBuilder.createItem(context, col1)
+                .withTitle("Public item 1")
+                .withIssueDate("2017-10-17")
+                .withAuthor("Smith, Donald")
+                .withAuthor("Doe, John")
+                .withSubject("Totora Grove")
+                .withSubject("Punga Grove")
+                .withSubject("Kowhai Flower")
+                .withSubject("Flower Arranging")
+                .build();
+        item1.setDiscoverable(false);
+        itemService.update(context, item1);
+        reindexItem(item1);
+        context.restoreAuthSystemState();
+
+        String token = getAuthToken(eperson.getEmail(), password);
+
+        // Expect ZERO terms for "grove" - this item is set as undiscoverable
+        getClient(token).perform(get("/api/discover/suggest")
+                        .queryParam("dict", "subject")
+                        .queryParam("q", "grove")
+                )
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andExpect(jsonPath("$.suggest.subject.grove.numFound", is(0)));
+    }
+
+    @Test
+    public void testSuggestTermsFromNonArchivedItem() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+                .withName("Sub Community")
+                .build();
+        Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
+
+        Item item1 = ItemBuilder.createItem(context, col1)
+                .withTitle("Public item 1")
+                .withIssueDate("2017-10-17")
+                .withAuthor("Smith, Donald")
+                .withAuthor("Doe, John")
+                .withSubject("Totora Grove")
+                .withSubject("Punga Grove")
+                .withSubject("Kowhai Flower")
+                .withSubject("Flower Arranging")
+                .build();
+        item1.setArchived(false);
+        itemService.update(context, item1);
+        reindexItem(item1);
+        solrSuggestService.rebuildAllDictionaries();
+        context.restoreAuthSystemState();
+
+        String token = getAuthToken(eperson.getEmail(), password);
+
+        // Expect ZERO terms for "grove" - this item is set as 'not archived'
+        // (wrapped by in-progress item, withdrawn, etc)
+        getClient(token).perform(get("/api/discover/suggest")
+                        .queryParam("dict", "subject")
+                        .queryParam("q", "grove")
+                )
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andExpect(jsonPath("$.suggest.subject.grove.numFound", is(0)));
+    }
+
+    /**
+     * Test that a non-admin request to /build (rebuild dictionaries)
+     * fails with 401, with or without a parameter
+     */
+    @Test
+    public void nonAdminDictionaryBuildShouldFail() throws Exception {
+        getClient().perform(
+                get("/api/discover/suggest/build")
+        ).andExpect(status().isUnauthorized());
+        getClient().perform(
+                get("/api/discover/suggest/build").param("dict", "subject")
+        ).andExpect(status().isUnauthorized());
     }
 
     /**
@@ -116,9 +422,9 @@ public class AutocompleteSuggestionIT extends AbstractControllerIntegrationTest 
     @Test
     public void unauthenticatedRequestShouldReturn401() throws Exception {
         getClient().perform(
-                get("/api/discover/suggest")
-                        .param("dict", "subject")
-                        .param("q", "test"))
+                        get("/api/discover/suggest")
+                                .param("dict", "subject")
+                                .param("q", "test"))
                 .andExpect(status().isUnauthorized());
     }
 
@@ -130,9 +436,9 @@ public class AutocompleteSuggestionIT extends AbstractControllerIntegrationTest 
         String userToken = getAuthToken(eperson.getEmail(), password);
 
         getClient(userToken).perform(
-                get("/api/discover/suggest")
-                        .param("dict", "not_in_allowlist")
-                        .param("q", "test"))
+                        get("/api/discover/suggest")
+                                .param("dict", "not_in_allowlist")
+                                .param("q", "test"))
                 .andExpect(status().isForbidden());
     }
 
@@ -145,14 +451,14 @@ public class AutocompleteSuggestionIT extends AbstractControllerIntegrationTest 
 
         // Missing 'q' parameter
         getClient(userToken).perform(
-                get("/api/discover/suggest")
-                        .param("dict", "subject"))
+                        get("/api/discover/suggest")
+                                .param("dict", "subject"))
                 .andExpect(status().isBadRequest());
 
         // Missing 'dict' parameter
         getClient(userToken).perform(
-                get("/api/discover/suggest")
-                        .param("q", "test"))
+                        get("/api/discover/suggest")
+                                .param("q", "test"))
                 .andExpect(status().isBadRequest());
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/AutocompleteSuggestionIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/AutocompleteSuggestionIT.java
@@ -489,32 +489,6 @@ public class AutocompleteSuggestionIT extends AbstractControllerIntegrationTest 
     }
 
     /**
-     * Test that when discovery.suggest.allowed-dictionaries contains the wildcard "*",
-     * ALL dictionaries are allowed (HTTP 200).
-     */
-    @Test
-    public void wildcardAllowedDictionariesShouldAllowAll() throws Exception {
-        // Set the allowed-dictionaries to wildcard
-        configurationService.setProperty("discovery.suggest.allowed-dictionaries", new String[]{"*"});
-
-        String userToken = getAuthToken(eperson.getEmail(), password);
-
-        // Any dictionary name should be allowed (returns 200, not 403)
-        getClient(userToken).perform(
-                        get("/api/discover/suggest")
-                                .param("dict", "subject")
-                                .param("q", "test"))
-                .andExpect(status().isOk());
-
-        // Even an arbitrary dictionary name should be allowed with wildcard
-        getClient(userToken).perform(
-                        get("/api/discover/suggest")
-                                .param("dict", "any_dictionary_name")
-                                .param("q", "test"))
-                .andExpect(status().isOk());
-    }
-
-    /**
      * Test that the /suggest/build endpoint also respects empty allowed-dictionaries
      * by returning 403 when the list is empty.
      */
@@ -531,19 +505,4 @@ public class AutocompleteSuggestionIT extends AbstractControllerIntegrationTest 
                 .andExpect(status().isForbidden());
     }
 
-    /**
-     * Test that the /suggest/build endpoint works with wildcard "*" for any dictionary.
-     */
-    @Test
-    public void wildcardAllowedDictionariesBuildShouldAllowAll() throws Exception {
-        configurationService.setProperty("discovery.suggest.allowed-dictionaries", new String[]{"*"});
-
-        String adminToken = getAuthToken(admin.getEmail(), password);
-
-        // Building any specific dictionary should be allowed
-        getClient(adminToken).perform(
-                        get("/api/discover/suggest/build")
-                                .param("dict", "subject"))
-                .andExpect(status().isOk());
-    }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/AutocompleteSuggestionIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/AutocompleteSuggestionIT.java
@@ -110,4 +110,49 @@ public class AutocompleteSuggestionIT extends AbstractControllerIntegrationTest 
                 .andExpect(jsonPath("$.suggest.subject.test.numFound", is(0)));
     }
 
+    /**
+     * Test that an unauthenticated request returns HTTP 401 Unauthorized.
+     */
+    @Test
+    public void unauthenticatedRequestShouldReturn401() throws Exception {
+        getClient().perform(
+                get("/api/discover/suggest")
+                        .param("dict", "subject")
+                        .param("q", "test"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    /**
+     * Test that a non-allowed dictionary request returns HTTP 403 Forbidden.
+     */
+    @Test
+    public void nonAllowedDictionaryShouldReturn403() throws Exception {
+        String userToken = getAuthToken(eperson.getEmail(), password);
+
+        getClient(userToken).perform(
+                get("/api/discover/suggest")
+                        .param("dict", "not_in_allowlist")
+                        .param("q", "test"))
+                .andExpect(status().isForbidden());
+    }
+
+    /**
+     * Test that missing required parameters return HTTP 400 Bad Request.
+     */
+    @Test
+    public void missingParametersShouldReturn400() throws Exception {
+        String userToken = getAuthToken(eperson.getEmail(), password);
+
+        // Missing 'q' parameter
+        getClient(userToken).perform(
+                get("/api/discover/suggest")
+                        .param("dict", "subject"))
+                .andExpect(status().isBadRequest());
+
+        // Missing 'dict' parameter
+        getClient(userToken).perform(
+                get("/api/discover/suggest")
+                        .param("q", "test"))
+                .andExpect(status().isBadRequest());
+    }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionFormsControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionFormsControllerIT.java
@@ -62,20 +62,19 @@ public class SubmissionFormsControllerIT extends AbstractControllerIntegrationTe
 
         //When we call the root endpoint
         getClient(token).perform(get("/api/config/submissionforms"))
-                        //The status has to be 200 OK
-                        .andExpect(status().isOk())
-                        //We expect the content type to be "application/hal+json;charset=UTF-8"
-                        .andExpect(content().contentType(contentType))
-                        //The configuration file for the test env includes 6 forms
-                        .andExpect(jsonPath("$.page.size", is(20)))
-                        .andExpect(jsonPath("$.page.totalElements", equalTo(12)))
-                        .andExpect(jsonPath("$.page.totalPages", equalTo(1)))
-                        .andExpect(jsonPath("$.page.number", is(0)))
-                        .andExpect(
-                            jsonPath("$._links.self.href",
-                                     Matchers.startsWith(REST_SERVER_URL + "config/submissionforms")))
-                        //The array of submissionforms should have a size of 12
-                        .andExpect(jsonPath("$._embedded.submissionforms", hasSize(equalTo(12))))
+                   //The status has to be 200 OK
+                   .andExpect(status().isOk())
+                   //We expect the content type to be "application/hal+json;charset=UTF-8"
+                   .andExpect(content().contentType(contentType))
+                   //The configuration file for the test env includes 6 forms
+                   .andExpect(jsonPath("$.page.size", is(20)))
+                   .andExpect(jsonPath("$.page.totalElements", equalTo(11)))
+                   .andExpect(jsonPath("$.page.totalPages", equalTo(1)))
+                   .andExpect(jsonPath("$.page.number", is(0)))
+                   .andExpect(
+                       jsonPath("$._links.self.href", Matchers.startsWith(REST_SERVER_URL + "config/submissionforms")))
+                   //The array of submissionforms should have a size of 11
+                   .andExpect(jsonPath("$._embedded.submissionforms", hasSize(equalTo(11))))
         ;
     }
 
@@ -83,15 +82,15 @@ public class SubmissionFormsControllerIT extends AbstractControllerIntegrationTe
     public void findAllWithNewlyCreatedAccountTest() throws Exception {
         String token = getAuthToken(eperson.getEmail(), password);
         getClient(token).perform(get("/api/config/submissionforms"))
-                        .andExpect(status().isOk())
-                        .andExpect(content().contentType(contentType))
-                        .andExpect(jsonPath("$.page.size", is(20)))
-                        .andExpect(jsonPath("$.page.totalElements", equalTo(12)))
-                        .andExpect(jsonPath("$.page.totalPages", equalTo(1)))
-                        .andExpect(jsonPath("$.page.number", is(0)))
-                        .andExpect(jsonPath("$._links.self.href", Matchers.startsWith(REST_SERVER_URL
-                                                                                          + "config/submissionforms")))
-                        .andExpect(jsonPath("$._embedded.submissionforms", hasSize(equalTo(12))));
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(contentType))
+                .andExpect(jsonPath("$.page.size", is(20)))
+                .andExpect(jsonPath("$.page.totalElements", equalTo(11)))
+                .andExpect(jsonPath("$.page.totalPages", equalTo(1)))
+                .andExpect(jsonPath("$.page.number", is(0)))
+                .andExpect(jsonPath("$._links.self.href", Matchers.startsWith(REST_SERVER_URL
+                           + "config/submissionforms")))
+                .andExpect(jsonPath("$._embedded.submissionforms", hasSize(equalTo(11))));
     }
 
     @Test
@@ -681,113 +680,111 @@ public class SubmissionFormsControllerIT extends AbstractControllerIntegrationTe
     public void findAllPaginationTest() throws Exception {
         String tokenAdmin = getAuthToken(admin.getEmail(), password);
         getClient(tokenAdmin).perform(get("/api/config/submissionforms")
-                                          .param("size", "2")
-                                          .param("page", "0"))
-                             .andExpect(status().isOk())
-                             .andExpect(content().contentType(contentType))
-                             .andExpect(jsonPath("$._embedded.submissionforms[0].id", is("personstep")))
-                             .andExpect(jsonPath("$._embedded.submissionforms[1].id", is("bitstream-metadata")))
-                             .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=0"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=0"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$._links.next.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=1"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=5"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$.page.size", is(2)))
-                             .andExpect(jsonPath("$.page.totalElements", equalTo(12)))
-                             .andExpect(jsonPath("$.page.totalPages", equalTo(6)))
-                             .andExpect(jsonPath("$.page.number", is(0)));
+                 .param("size", "2")
+                 .param("page", "0"))
+                 .andExpect(status().isOk())
+                 .andExpect(content().contentType(contentType))
+                 .andExpect(jsonPath("$._embedded.submissionforms[0].id", is("bitstream-metadata")))
+                 .andExpect(jsonPath("$._embedded.submissionforms[1].id", is("journalVolumeStep")))
+                 .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
+                         Matchers.containsString("/api/config/submissionforms?"),
+                         Matchers.containsString("page=0"), Matchers.containsString("size=2"))))
+                 .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
+                         Matchers.containsString("/api/config/submissionforms?"),
+                         Matchers.containsString("page=0"), Matchers.containsString("size=2"))))
+                 .andExpect(jsonPath("$._links.next.href", Matchers.allOf(
+                         Matchers.containsString("/api/config/submissionforms?"),
+                         Matchers.containsString("page=1"), Matchers.containsString("size=2"))))
+                 .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
+                         Matchers.containsString("/api/config/submissionforms?"),
+                         Matchers.containsString("page=5"), Matchers.containsString("size=2"))))
+                 .andExpect(jsonPath("$.page.size", is(2)))
+                 .andExpect(jsonPath("$.page.totalElements", equalTo(11)))
+                 .andExpect(jsonPath("$.page.totalPages", equalTo(6)))
+                 .andExpect(jsonPath("$.page.number", is(0)));
 
         getClient(tokenAdmin).perform(get("/api/config/submissionforms")
-                                          .param("size", "2")
-                                          .param("page", "1"))
-                             .andExpect(status().isOk())
-                             .andExpect(content().contentType(contentType))
-                             .andExpect(jsonPath("$._embedded.submissionforms[0].id", is("journalVolumeStep")))
-                             .andExpect(jsonPath("$._embedded.submissionforms[1].id",
-                                                 is("test-outside-workflow-hidden")))
-                             .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=0"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$._links.prev.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=0"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=1"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$._links.next.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=2"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=5"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$.page.size", is(2)))
-                             .andExpect(jsonPath("$.page.totalElements", equalTo(12)))
-                             .andExpect(jsonPath("$.page.totalPages", equalTo(6)))
-                             .andExpect(jsonPath("$.page.number", is(1)));
+                 .param("size", "2")
+                 .param("page", "1"))
+                 .andExpect(status().isOk())
+                 .andExpect(content().contentType(contentType))
+                 .andExpect(jsonPath("$._embedded.submissionforms[0].id", is("test-outside-workflow-hidden")))
+                 .andExpect(jsonPath("$._embedded.submissionforms[1].id", is("languagetest")))
+                 .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
+                         Matchers.containsString("/api/config/submissionforms?"),
+                         Matchers.containsString("page=0"), Matchers.containsString("size=2"))))
+                 .andExpect(jsonPath("$._links.prev.href", Matchers.allOf(
+                         Matchers.containsString("/api/config/submissionforms?"),
+                         Matchers.containsString("page=0"), Matchers.containsString("size=2"))))
+                 .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
+                         Matchers.containsString("/api/config/submissionforms?"),
+                         Matchers.containsString("page=1"), Matchers.containsString("size=2"))))
+                 .andExpect(jsonPath("$._links.next.href", Matchers.allOf(
+                         Matchers.containsString("/api/config/submissionforms?"),
+                         Matchers.containsString("page=2"), Matchers.containsString("size=2"))))
+                 .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
+                         Matchers.containsString("/api/config/submissionforms?"),
+                         Matchers.containsString("page=5"), Matchers.containsString("size=2"))))
+                 .andExpect(jsonPath("$.page.size", is(2)))
+                 .andExpect(jsonPath("$.page.totalElements", equalTo(11)))
+                 .andExpect(jsonPath("$.page.totalPages", equalTo(6)))
+                 .andExpect(jsonPath("$.page.number", is(1)));
 
         getClient(tokenAdmin).perform(get("/api/config/submissionforms")
-                                          .param("size", "2")
-                                          .param("page", "2"))
-                             .andExpect(status().isOk())
-                             .andExpect(content().contentType(contentType))
-                             .andExpect(jsonPath("$._embedded.submissionforms[0].id", is("languagetest")))
-                             .andExpect(jsonPath("$._embedded.submissionforms[1].id", is("publicationStep")))
-                             .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=0"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$._links.prev.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=1"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=2"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=5"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$.page.size", is(2)))
-                             .andExpect(jsonPath("$.page.totalElements", equalTo(12)))
-                             .andExpect(jsonPath("$.page.totalPages", equalTo(6)))
-                             .andExpect(jsonPath("$.page.number", is(2)));
+                .param("size", "2")
+                .param("page", "2"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(contentType))
+                .andExpect(jsonPath("$._embedded.submissionforms[0].id", is("publicationStep")))
+                .andExpect(jsonPath("$._embedded.submissionforms[1].id", is("test-outside-submission-hidden")))
+                .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
+                        Matchers.containsString("/api/config/submissionforms?"),
+                        Matchers.containsString("page=0"), Matchers.containsString("size=2"))))
+                .andExpect(jsonPath("$._links.prev.href", Matchers.allOf(
+                        Matchers.containsString("/api/config/submissionforms?"),
+                        Matchers.containsString("page=1"), Matchers.containsString("size=2"))))
+                .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
+                        Matchers.containsString("/api/config/submissionforms?"),
+                        Matchers.containsString("page=2"), Matchers.containsString("size=2"))))
+                .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
+                        Matchers.containsString("/api/config/submissionforms?"),
+                        Matchers.containsString("page=5"), Matchers.containsString("size=2"))))
+                .andExpect(jsonPath("$.page.size", is(2)))
+                .andExpect(jsonPath("$.page.totalElements", equalTo(11)))
+                .andExpect(jsonPath("$.page.totalPages", equalTo(6)))
+                .andExpect(jsonPath("$.page.number", is(2)));
 
         getClient(tokenAdmin).perform(get("/api/config/submissionforms")
-                                          .param("size", "2")
-                                          .param("page", "3"))
-                             .andExpect(status().isOk())
-                             .andExpect(content().contentType(contentType))
-                             .andExpect(jsonPath("$._embedded.submissionforms[0].id",
-                                                 is("test-outside-submission-hidden")))
-                             .andExpect(jsonPath("$._embedded.submissionforms[1].id", is("qualdroptest")))
-                             .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=0"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$._links.prev.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=2"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=3"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=5"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$.page.size", is(2)))
-                             .andExpect(jsonPath("$.page.totalElements", equalTo(12)))
-                             .andExpect(jsonPath("$.page.totalPages", equalTo(6)))
-                             .andExpect(jsonPath("$.page.number", is(3)));
+            .param("size", "2")
+            .param("page", "3"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._embedded.submissionforms[0].id", is("qualdroptest")))
+            .andExpect(jsonPath("$._embedded.submissionforms[1].id", is("traditionalpagetwo")))
+            .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissionforms?"),
+                Matchers.containsString("page=0"), Matchers.containsString("size=2"))))
+            .andExpect(jsonPath("$._links.prev.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissionforms?"),
+                Matchers.containsString("page=2"), Matchers.containsString("size=2"))))
+            .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissionforms?"),
+                Matchers.containsString("page=3"), Matchers.containsString("size=2"))))
+            .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissionforms?"),
+                Matchers.containsString("page=5"), Matchers.containsString("size=2"))))
+            .andExpect(jsonPath("$.page.size", is(2)))
+            .andExpect(jsonPath("$.page.totalElements", equalTo(11)))
+            .andExpect(jsonPath("$.page.totalPages", equalTo(6)))
+            .andExpect(jsonPath("$.page.number", is(3)));
 
         getClient(tokenAdmin).perform(get("/api/config/submissionforms")
-                                          .param("size", "2")
-                                          .param("page", "4"))
+                                 .param("size", "2")
+                                 .param("page", "4"))
                              .andExpect(status().isOk())
                              .andExpect(content().contentType(contentType))
-                             .andExpect(jsonPath("$._embedded.submissionforms[0].id", is("traditionalpagetwo")))
-                             .andExpect(jsonPath("$._embedded.submissionforms[1].id", is("sampleauthority")))
+                             .andExpect(jsonPath("$._embedded.submissionforms[0].id", is("sampleauthority")))
+                             .andExpect(jsonPath("$._embedded.submissionforms[1].id", is("traditionalpageone")))
                              .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
                                  Matchers.containsString("/api/config/submissionforms?"),
                                  Matchers.containsString("page=0"), Matchers.containsString("size=2"))))
@@ -801,32 +798,31 @@ public class SubmissionFormsControllerIT extends AbstractControllerIntegrationTe
                                  Matchers.containsString("/api/config/submissionforms?"),
                                  Matchers.containsString("page=5"), Matchers.containsString("size=2"))))
                              .andExpect(jsonPath("$.page.size", is(2)))
-                             .andExpect(jsonPath("$.page.totalElements", equalTo(12)))
+                             .andExpect(jsonPath("$.page.totalElements", equalTo(11)))
                              .andExpect(jsonPath("$.page.totalPages", equalTo(6)))
                              .andExpect(jsonPath("$.page.number", is(4)));
 
         getClient(tokenAdmin).perform(get("/api/config/submissionforms")
-                                          .param("size", "2")
-                                          .param("page", "5"))
-                             .andExpect(status().isOk())
-                             .andExpect(content().contentType(contentType))
-                             .andExpect(jsonPath("$._embedded.submissionforms[0].id", is("traditionalpageone")))
-                             .andExpect(jsonPath("$._embedded.submissionforms[1].id", is("typebindtest")))
-                             .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=0"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$._links.prev.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=4"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=5"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=5"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$.page.size", is(2)))
-                             .andExpect(jsonPath("$.page.totalElements", equalTo(12)))
-                             .andExpect(jsonPath("$.page.totalPages", equalTo(6)))
-                             .andExpect(jsonPath("$.page.number", is(5)));
+                .param("size", "2")
+                .param("page", "5"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._embedded.submissionforms[0].id", is("typebindtest")))
+            .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissionforms?"),
+                Matchers.containsString("page=0"), Matchers.containsString("size=2"))))
+            .andExpect(jsonPath("$._links.prev.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissionforms?"),
+                Matchers.containsString("page=4"), Matchers.containsString("size=2"))))
+            .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissionforms?"),
+                Matchers.containsString("page=5"), Matchers.containsString("size=2"))))
+            .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
+                Matchers.containsString("/api/config/submissionforms?"),
+                Matchers.containsString("page=5"), Matchers.containsString("size=2"))))
+            .andExpect(jsonPath("$.page.size", is(2)))
+            .andExpect(jsonPath("$.page.totalElements", equalTo(11)))
+            .andExpect(jsonPath("$.page.totalPages", equalTo(6)))
+            .andExpect(jsonPath("$.page.number", is(5)));
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/SubmissionFormFieldMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/SubmissionFormFieldMatcher.java
@@ -30,7 +30,7 @@ public class SubmissionFormFieldMatcher {
     public static Matcher<? super Object> matchFormFieldDefinition(String type, String label, String mandatoryMessage,
         boolean repeatable, String hints, String metadata) {
         return matchFormFieldDefinition(type, label, null, mandatoryMessage, repeatable, hints, null, metadata,
-            null);
+            null, null);
     }
 
     public static Matcher<? super Object> matchFormFieldDefinition(String type, String label, String mandatoryMessage,
@@ -43,7 +43,42 @@ public class SubmissionFormFieldMatcher {
                                                                    boolean repeatable, String hints, String style,
                                                                    String metadata, String controlledVocabulary) {
         return matchFormFieldDefinition(type, label, null, mandatoryMessage, repeatable, hints, style, metadata,
-            controlledVocabulary);
+            controlledVocabulary, null);
+    }
+
+    /**
+     * Shortcut for the
+     * {@link SubmissionFormFieldMatcher#matchFormFieldDefinition(String, String, String, String, boolean, String, String, String, String, String)}
+     * with a null vocabularyType
+     *
+     * @param type
+     *            the expected input type
+     * @param label
+     *            the expected label
+     * @param typeBind
+     *            the expected type-bind field(s)
+     * @param mandatoryMessage
+     *            the expected mandatoryMessage, can be null. If not empty the field is expected to be flagged as
+     *            mandatory
+     * @param repeatable
+     *            the expected repeatable flag
+     * @param hints
+     *            the expected hints message
+     * @param style
+     *            the expected style for the field, can be null. If null the corresponding json path is expected to be
+     *            missing
+     * @param metadata
+     *            the expected metadata
+     * @param controlledVocabulary
+     *            the expected controlled vocabulary, can be null. If null the corresponding json path is expected to be
+     *            missing
+     * @return a Matcher for all the condition above
+     */
+    public static Matcher<? super Object> matchFormFieldDefinition(String type, String label, String typeBind,
+                                                                   String mandatoryMessage, boolean repeatable, String hints, String style, String metadata,
+                                                                   String controlledVocabulary) {
+        return matchFormFieldDefinition(type, label, typeBind, mandatoryMessage, repeatable, hints, style, metadata,
+                controlledVocabulary, null);
     }
 
     /**

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/SubmissionFormFieldMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/SubmissionFormFieldMatcher.java
@@ -48,7 +48,7 @@ public class SubmissionFormFieldMatcher {
 
     /**
      * Shortcut for the
-     * {@link SubmissionFormFieldMatcher#matchFormFieldDefinition(String, String, String, String, boolean, String, String, String, String)}
+     * {@link SubmissionFormFieldMatcher#matchFormFieldDefinition(String, String, String, String, boolean,String, String, String, String, String)}
      * with a null style and vocabulary name
      *
      * @param type
@@ -76,7 +76,7 @@ public class SubmissionFormFieldMatcher {
 
     /**
      * Shortcut for the
-     * {@link SubmissionFormFieldMatcher#matchFormFieldDefinition(String, String, String, String, boolean, String, String, String, String)}
+     * {@link SubmissionFormFieldMatcher#matchFormFieldDefinition(String, String, String, String, boolean, String, String, String)}
      * with a null controlled vocabulary
      *
      * @param type
@@ -102,7 +102,7 @@ public class SubmissionFormFieldMatcher {
     public static Matcher<? super Object> matchFormFieldDefinition(String type, String label, String typeBind,
             String mandatoryMessage, boolean repeatable, String hints, String style, String metadata) {
         return matchFormFieldDefinition(type, label, typeBind, mandatoryMessage, repeatable, hints, style, metadata,
-                null);
+                null, null);
     }
 
     /**
@@ -129,12 +129,15 @@ public class SubmissionFormFieldMatcher {
      * @param controlledVocabulary
      *            the expected controlled vocabulary, can be null. If null the corresponding json path is expected to be
      *            missing
+     * @param vocabularyType
+     *            the expected vocabulary type, can be null. If null the corresopnding json path is expected to be
+     *            missing
      * @return a Matcher for all the condition above
      */
     public static Matcher<? super Object> matchFormFieldDefinition(String type, String label, String typeBind,
                                                                    String mandatoryMessage, boolean repeatable,
                                                                    String hints, String style, String metadata,
-                                                                   String controlledVocabulary) {
+                                                                   String controlledVocabulary, String vocabularyType) {
         return allOf(
             // check each field definition
             hasJsonPath("$.input.type", is(type)),
@@ -143,6 +146,8 @@ public class SubmissionFormFieldMatcher {
             hasJsonPath("$.selectableMetadata[0].metadata", is(metadata)),
             controlledVocabulary != null ? hasJsonPath("$.selectableMetadata[0].controlledVocabulary",
                     is(controlledVocabulary)) : hasNoJsonPath("$.selectableMetadata[0].controlledVocabulary"),
+            vocabularyType != null ? hasJsonPath("$.selectableMetadata[0].vocabularyType",
+                    is(vocabularyType)) : hasNoJsonPath("$.selectableMetadata[0].vocabularyType"),
             mandatoryMessage != null ? hasJsonPath("$.mandatoryMessage", containsString(mandatoryMessage)) :
                 hasNoJsonPath("$.mandatoryMessage"),
             hasJsonPath("$.mandatory", is(mandatoryMessage != null)),

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1284,6 +1284,8 @@ webui.licence_bundle.show = false
 #  3. OAI (every where as there is currently no possibility to authenticate)
 #     Attention: You need to rebuild the OAI SOLR index after every change of
 #     this property. Run [dspace-install]/bin/dspace oai import -c to do so.
+#  4. 'Suggest' Autocomplete plugin that adds *_suggest fields to be used by the
+#     Solr suggest handler for the search core.
 #
 # To designate a field as hidden, add a property here in the form:
 #    metadata.hide.SCHEMA.ELEMENT.QUALIFIER = true

--- a/dspace/config/log4j2-cli.xml
+++ b/dspace/config/log4j2-cli.xml
@@ -92,6 +92,8 @@
                 level='ERROR'/>
         <Logger name='org.dspace.utils'
                 level='ERROR'/>
+        <Logger name='org.dspace.discovery'
+                level='DEBUG'/>
 
         <!-- Block passwords from being exposed in Axis logs. (DEBUG exposes passwords in Basic Auth) -->
         <Logger name='org.apache.axis.handlers.http.HTTPAuthHandler'

--- a/dspace/config/log4j2-cli.xml
+++ b/dspace/config/log4j2-cli.xml
@@ -92,8 +92,6 @@
                 level='ERROR'/>
         <Logger name='org.dspace.utils'
                 level='ERROR'/>
-        <Logger name='org.dspace.discovery'
-                level='DEBUG'/>
 
         <!-- Block passwords from being exposed in Axis logs. (DEBUG exposes passwords in Basic Auth) -->
         <Logger name='org.apache.axis.handlers.http.HTTPAuthHandler'

--- a/dspace/config/modules/discovery.cfg
+++ b/dspace/config/modules/discovery.cfg
@@ -139,5 +139,8 @@ discovery.highlights.escape-html = true
 #discovery.suggest.field = dc.subject
 
 # Allowlist of dictionary names that the /suggest endpoint will accept.
-# If empty, all dictionaries are allowed. Separate multiple values with commas.
+# If empty or not set, no dictionaries are allowed (endpoint is effectively disabled).
+# Use * to allow all configured dictionaries.
+# Separate multiple values with commas.
+#discovery.suggest.allowed-dictionaries = *
 #discovery.suggest.allowed-dictionaries = subject, authors, countries_file

--- a/dspace/config/modules/discovery.cfg
+++ b/dspace/config/modules/discovery.cfg
@@ -137,3 +137,7 @@ discovery.highlights.escape-html = true
 # in submission-forms.xml
 #discovery.suggest.field = dc.contributor.author
 #discovery.suggest.field = dc.subject
+
+# Allowlist of dictionary names that the /suggest endpoint will accept.
+# If empty, all dictionaries are allowed. Separate multiple values with commas.
+#discovery.suggest.allowed-dictionaries = subject, authors, countries_file

--- a/dspace/config/modules/discovery.cfg
+++ b/dspace/config/modules/discovery.cfg
@@ -124,3 +124,16 @@ discovery.highlights.escape-html = true
 # - "GONZALEZ RODRIGUEZ" (case insensitive, no punctuation)
 # - "dr maria" (title + first name)
 # - "phd rodriguez" (degree + last name)
+
+#---------------------------------------------------------------#
+#------------- SOLR AUTOCOMPLETE SUGGESTION CONFIGURATION ------#
+#---------------------------------------------------------------#
+# Set fields to index as *_suggest Solr fields for use with the suggest request handler
+# (autocomplete, search suggestion)
+# a field like dc.contributor.author will be indexed as dc.contributor.author_suggest
+# with field type suggestAutoComplete (see search/conf/schema.xml)
+# These fields must be referenced in search/conf/solrconfig.xml with a suggest dictionary
+# definition. Each dictionary name can then be used as a controlled vocabulary name
+# in submission-forms.xml
+#discovery.suggest.field = dc.contributor.author
+#discovery.suggest.field = dc.subject

--- a/dspace/config/modules/discovery.cfg
+++ b/dspace/config/modules/discovery.cfg
@@ -140,7 +140,5 @@ discovery.highlights.escape-html = true
 
 # Allowlist of dictionary names that the /suggest endpoint will accept.
 # If empty or not set, no dictionaries are allowed (endpoint is effectively disabled).
-# Use * to allow all configured dictionaries.
 # Separate multiple values with commas.
-#discovery.suggest.allowed-dictionaries = *
 #discovery.suggest.allowed-dictionaries = subject, authors, countries_file

--- a/dspace/config/spring/api/core-services.xml
+++ b/dspace/config/spring/api/core-services.xml
@@ -182,5 +182,6 @@
     <bean id="org.dspace.app.customurl.consumer.CustomUrlConsumerConfig"
           class="org.dspace.app.customurl.consumer.CustomUrlConsumerConfig"/>
 
+    <bean class="org.dspace.discovery.SolrSuggestService" autowire-candidate="true" />
 </beans>
 

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -32,6 +32,7 @@
     <bean id="SolrServiceParentObjectIndexingPlugin" class="org.dspace.discovery.SolrServiceParentObjectIndexingPlugin" scope="prototype"/>
     <bean id="solrServiceCrisValuePairsIndexPlugin" class="org.dspace.discovery.SolrServiceValuePairsIndexPlugin"/>
     <bean id="solrServiceCustomUrlIndexPlugin" class="org.dspace.discovery.SolrServiceCustomUrlIndexPlugin"/>
+    <bean id="SolrServiceIndexSuggestFieldPlugin" class="org.dspace.discovery.SolrServiceIndexSuggestFieldPlugin" scope="prototype"/>
     <bean id="itemAuthorityLookupIndexPlugin" class="org.dspace.discovery.ItemAuthorityLookupIndexPlugin">
         <property name="additionalFields">
             <list>

--- a/dspace/config/submission-forms.dtd
+++ b/dspace/config/submission-forms.dtd
@@ -8,7 +8,7 @@
  <!ELEMENT row (field|relation-field)+ >
  <!ATTLIST form name NMTOKEN #REQUIRED>
 
- <!ELEMENT field (dc-schema, dc-element, dc-qualifier?, language?, repeatable?, label, style?, type-bind?, input-type, hint, required?, regex?, vocabulary?, visibility?, readonly?) >
+ <!ELEMENT field (dc-schema, dc-element, dc-qualifier?, language?, repeatable?, label, style?, type-bind?, input-type, hint, required?, regex?, vocabulary?, validation-dictionary?, visibility?, readonly?) >
  <!ELEMENT dc-schema (#PCDATA) >
  <!ELEMENT dc-element (#PCDATA) >
  <!ELEMENT dc-qualifier (#PCDATA) >
@@ -47,19 +47,23 @@
 
  <!ATTLIST input-type value-pairs-name CDATA  #IMPLIED>
 
- <!ELEMENT vocabulary (#PCDATA) >
+ <!ELEMENT vocabulary (#PCDATA)>
 
- <!ATTLIST vocabulary closed (true|false) "false">
+ <!ATTLIST vocabulary
+     closed (true|false) "false"
+     type (xml|authority|suggest) "xml">
 
- <!ELEMENT visibility (#PCDATA) >
+ <!ELEMENT validation-dictionary (#PCDATA)>
 
- <!ATTLIST language value-pairs-name CDATA  #IMPLIED>
+ <!ELEMENT visibility (#PCDATA)>
 
- <!ELEMENT readonly (#PCDATA) >
+ <!ATTLIST language value-pairs-name CDATA #IMPLIED>
 
-<!ELEMENT relationship-type (#PCDATA) >
-<!ELEMENT search-configuration (#PCDATA) >
-<!ELEMENT filter (#PCDATA) >
-<!ELEMENT externalsources (#PCDATA) >
+ <!ELEMENT readonly (#PCDATA)>
+
+<!ELEMENT relationship-type (#PCDATA)>
+<!ELEMENT search-configuration (#PCDATA)>
+<!ELEMENT filter (#PCDATA)>
+<!ELEMENT externalsources (#PCDATA)>
 <!ELEMENT relation-field (relationship-type, search-configuration, filter?, repeatable?, name-variants?, label, type-bind?, hint, linked-metadata-field?, externalsources?, required?, regex?, visibility?)>
 <!ELEMENT linked-metadata-field (dc-schema, dc-element, dc-qualifier?, input-type)>

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -59,6 +59,7 @@
                     <repeatable>true</repeatable>
                     <label>Author</label>
                     <input-type>onebox</input-type>
+                    <vocabulary closed="false" type="suggest">authors</vocabulary>
                     <hint>Enter the author's name (Family name, Given names).</hint>
                     <required></required>
                 </field>
@@ -197,7 +198,12 @@
                     <input-type>tag</input-type>
                     <hint>Enter appropriate subject keywords or phrases.</hint>
                     <required></required>
-                    <vocabulary>srsc</vocabulary>
+                    <!-- Uncomment the below line to have this field offer autocomplete
+                         suggestions based on existing dc.subject metadata.
+                         You must have a solrconfig.xml "subject" dictionary defined (available by default)
+                         and dc.subject configured in discovery.cfg in discovery.suggest.field (enabled by default)
+                    -->
+                    <!--<vocabulary type="suggest">subject</vocabulary>-->
                 </field>
             </row>
             <row>

--- a/dspace/solr/search/conf/schema.xml
+++ b/dspace/solr/search/conf/schema.xml
@@ -190,6 +190,19 @@
         </analyzer>
     </fieldType>
 
+    <fieldType name="suggestAutoComplete" class="solr.TextField" sortMissingLast="true" omitNorms="true">
+        <analyzer type="index">
+            <tokenizer class="solr.KeywordTokenizerFactory"/>
+            <filter class="solr.TrimFilterFactory"/>
+        </analyzer>
+        <analyzer type="query">
+            <tokenizer class="solr.KeywordTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.TrimFilterFactory"/>
+
+        </analyzer>
+    </fieldType>
+
     <!--This field is used for ItemAuthority lookup -->
     <fieldType name="itemLookup" class="solr.TextField" sortMissingLast="true" omitNorms="true">
         <analyzer>
@@ -374,6 +387,8 @@
 
     <field name="customurl" type="string" indexed="true" stored="true" required="false" multiValued="true"/>
 
+     <!-- Dynamic field used in the suggestion index plugin to store tokens -->
+     <dynamicField name="*_suggest" type="suggestAutoComplete" indexed="true" stored="true" multiValued="true"/>
  </fields>
 
  <uniqueKey>search.uniqueid</uniqueKey>

--- a/dspace/solr/search/conf/solrconfig.xml
+++ b/dspace/solr/search/conf/solrconfig.xml
@@ -165,4 +165,36 @@
             <str>spellcheck</str>
         </arr>
     </requestHandler>
+
+    <searchComponent name="suggest" class="solr.SuggestComponent">
+        <lst name="suggester">
+            <str name="name">subject</str>
+            <str name="lookupImpl">AnalyzingInfixLookupFactory</str>
+            <str name="dictionaryImpl">HighFrequencyDictionaryFactory</str>
+            <str name="field">dc.subject_suggest</str>
+            <str name="suggestAnalyzerFieldType">textgen</str>
+            <str name="buildOnCommit">true</str>
+            <str name="buildOnOptimize">true</str>
+        </lst>
+        <lst name="suggester">
+            <str name="name">authors</str>
+            <str name="lookupImpl">AnalyzingInfixLookupFactory</str>
+            <str name="dictionaryImpl">HighFrequencyDictionaryFactory</str>
+            <str name="field">dc.contributor.author_suggest</str>
+            <str name="suggestAnalyzerFieldType">textgen</str>
+            <str name="buildOnCommit">true</str>
+            <str name="buildOnOptimize">true</str>
+        </lst>
+    </searchComponent>
+
+    <requestHandler name="/suggest" class="solr.SearchHandler" startup="lazy">
+        <lst name="defaults">
+            <str name="suggest">true</str>
+            <str name="suggest.count">10</str>
+        </lst>
+        <arr name="components">
+            <str>suggest</str>
+        </arr>
+    </requestHandler>
+
 </config>

--- a/dspace/solr/search/conf/solrconfig.xml
+++ b/dspace/solr/search/conf/solrconfig.xml
@@ -166,6 +166,8 @@
         </arr>
     </requestHandler>
 
+    <!-- Suggest dictionaries here should either use a field ending in _suggest
+         as configured in discovery.cfg, or flat files -->
     <searchComponent name="suggest" class="solr.SuggestComponent">
         <lst name="suggester">
             <str name="name">subject</str>
@@ -184,6 +186,16 @@
             <str name="suggestAnalyzerFieldType">textgen</str>
             <str name="buildOnCommit">true</str>
             <str name="buildOnOptimize">true</str>
+        </lst>
+        <lst name="suggester">
+            <str name="name">countries_file</str>
+            <str name="lookupImpl">FuzzyLookupFactory</str>
+            <str name="dictionaryImpl">FileDictionaryFactory</str>
+            <str name="sourceLocation">countries.txt</str>
+            <str name="suggestAnalyzerFieldType">textgen</str>
+            <str name="buildOnCommit">true</str>
+            <str name="buildOnOptimize">true</str>
+            <str name="buildOnStartup">true</str>
         </lst>
     </searchComponent>
 

--- a/dspace/solr/search/countries.txt
+++ b/dspace/solr/search/countries.txt
@@ -1,0 +1,196 @@
+Afghanistan
+Albania
+Algeria
+Andorra
+Angola
+Antigua & Deps
+Argentina
+Armenia
+Australia
+Austria
+Azerbaijan
+Bahamas
+Bahrain
+Bangladesh
+Barbados
+Belarus
+Belgium
+Belize
+Benin
+Bhutan
+Bolivia
+Bosnia Herzegovina
+Botswana
+Brazil
+Brunei
+Bulgaria
+Burkina
+Burundi
+Cambodia
+Cameroon
+Canada
+Cape Verde
+Central African Rep
+Chad
+Chile
+China
+Colombia
+Comoros
+Congo
+Congo {Democratic Rep}
+Costa Rica
+Croatia
+Cuba
+Cyprus
+Czech Republic
+Denmark
+Djibouti
+Dominica
+Dominican Republic
+East Timor
+Ecuador
+Egypt
+El Salvador
+Equatorial Guinea
+Eritrea
+Estonia
+Ethiopia
+Fiji
+Finland
+France
+Gabon
+Gambia
+Georgia
+Germany
+Ghana
+Greece
+Grenada
+Guatemala
+Guinea
+Guinea-Bissau
+Guyana
+Haiti
+Honduras
+Hungary
+Iceland
+India
+Indonesia
+Iran
+Iraq
+Ireland {Republic}
+Israel
+Italy
+Ivory Coast
+Jamaica
+Japan
+Jordan
+Kazakhstan
+Kenya
+Kiribati
+Korea North
+Korea South
+Kosovo
+Kuwait
+Kyrgyzstan
+Laos
+Latvia
+Lebanon
+Lesotho
+Liberia
+Libya
+Liechtenstein
+Lithuania
+Luxembourg
+Macedonia
+Madagascar
+Malawi
+Malaysia
+Maldives
+Mali
+Malta
+Marshall Islands
+Mauritania
+Mauritius
+Mexico
+Micronesia
+Moldova
+Monaco
+Mongolia
+Montenegro
+Morocco
+Mozambique
+Myanmar, {Burma}
+Namibia
+Nauru
+Nepal
+Netherlands
+New Zealand
+Nicaragua
+Niger
+Nigeria
+Norway
+Oman
+Pakistan
+Palau
+Panama
+Papua New Guinea
+Paraguay
+Peru
+Philippines
+Poland
+Portugal
+Qatar
+Romania
+Russian Federation
+Rwanda
+St Kitts & Nevis
+St Lucia
+Saint Vincent & the Grenadines
+Samoa
+San Marino
+Sao Tome & Principe
+Saudi Arabia
+Senegal
+Serbia
+Seychelles
+Sierra Leone
+Singapore
+Slovakia
+Slovenia
+Solomon Islands
+Somalia
+South Africa
+South Sudan
+Spain
+Sri Lanka
+Sudan
+Suriname
+Swaziland
+Sweden
+Switzerland
+Syria
+Taiwan
+Tajikistan
+Tanzania
+Thailand
+Togo
+Tonga
+Trinidad & Tobago
+Tunisia
+Turkey
+Turkmenistan
+Tuvalu
+Uganda
+Ukraine
+United Arab Emirates
+United Kingdom
+United States
+Uruguay
+Uzbekistan
+Vanuatu
+Vatican City
+Venezuela
+Vietnam
+Yemen
+Zambia
+Zimbabwe


### PR DESCRIPTION
## Solr suggest handler and discovery method

* Requires https://github.com/DSpace/dspace-angular/pull/4439
* Rest Contract doc: https://github.com/DSpace/RestContract/pull/328
* Related to #10237 
* (they solve similar issues in slightly different ways)

This pull request adds the ability to use the Solr suggest request handler to generate search suggestions, input suggestions using the `HighFrequencyDictionaryFactory` for weighted (by freq) terms from the search Solr core, or `FileDictionaryFactory` for text-file based vocabularies.

This allows for flexible use in a few different ways, and currently is added into Submission / Edit Item forms for input field suggestions using typeahead, using the following approach:

**Vocabulary**
* The vocabulary model and services are extended to provide a 'type' so "suggest" can be treated differently without affecting other usage

**Solr and discovery**
* The suggest handler is enabled for Solr search, with some `_suggest` fields - each suggest "dictionary" config needs to be added to `solrconfig.xml` with field name and other options set
* Configuration tells a Solr index plugin which fields to copy into `_suggest` dynamic Solr fields

**REST**
* A new /suggest method on the DiscoveryRestRepository is added to take a query and dictionary, and will return plain JSON with suggestions - the suggestions are not strongly modelled as this is intended to be a light-weight solution that does not involve addressable objects
* (new corresponding functions are added to the angular search service)

**Submission**
The submission-form XML is extended to take a "vocabulary type" when declaring a field to be controlled by a vocabulary:
```
 <!ATTLIST vocabulary
     closed (true|false) "false"
     type (xml|authority|suggest) "xml">
```
* XML should indicate the plain, legacy XML files (maybe obsolete since I think most just use the ChoiceAuthority plugin now anyway?
* Authority indicates to use the authority plugin (this could allow for #10237 to be referenced for facet autocomplete, or the existing tree lookups, etc.)
* Suggest indicates that the Discovery suggest method should be used, with the vocabulary name as the dictionary

There is also a new `validation-dictionary` element which can reference a suggest dictionary to validate saved values against.

**UI**
In the `dynamic-onebox` Angular component which traditionally handles vocabulary / authority display like tree lookup or autocomplete, if the vocabulary type is "suggest", it will use a different search method and display template for the suggest terms. If not, the current behaviour is used (lookup / suggest from XML / etc)

![f31100b4-99df-4f9e-91cb-341cb6b66c3b](https://github.com/user-attachments/assets/82d4cb4e-d8c5-4a23-a679-4b94b1dbcb03)

The fuzzy search can match multiple terms, highlight the matching term parts and sort the matches by frequency which is useful for suggesting the most common metadata values first.


Developed by The Library Code with the support of Universität Bremen and GESIS.

## How to Test

* See the top of this issue for the required frontend PR
* It is recommended to use the solrconfig.xml and schema.xml as supplied in the search core in this PR. Depending on how you deploy/use solr, you may need to recreate the search core and fully reindex, to ensure the new schema is active
* In order to test dc.subject as a metadata dictionary, you should have a decent number of values (unique and non-unique) in dc.subject fields
* `dc.subject` is enabled for indexing to `dc.subject_suggest` by default, you can check this in `discovery.cfg`
* The example `<vocabulary type="suggest"....` usage is available in a comment in `traditionalpagetwo` of `submission-forms.xml` - for the quickest test, simply uncomment this line and try out submissions of a standard item that uses the traditionalpagetwo submission step / form.
* You can also try out the "countries_file" vocabulary name instead of "subject" to see how the feature works by indexing a flat txt file instead of metadata values from the search core

## Open questions

* Should we leave discovery.suggest.fields and discovery.suggest.allowed-dictionaries blank by default with commented examples? If so we would need to override the test dspaceFolder with another discovery.cfg that enabled them, or modify our test suite to programmatically add/set those values. Right now they make reviewing a bit easier so I've left them as is.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).