### PR TITLE
[dspace-7_x] Remove `commons-fileupload` as it is no longer used.

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -475,10 +475,6 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-dbcp2</artifactId>
         </dependency>
-        <dependency>
-            <groupId>commons-fileupload</groupId>
-            <artifactId>commons-fileupload</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>commons-io</groupId>

--- a/dspace-sword/pom.xml
+++ b/dspace-sword/pom.xml
@@ -54,11 +54,6 @@
             </exclusions>
         </dependency>
 
-        <!-- additional dependencies for the sword-common code -->
-        <dependency>
-            <groupId>commons-fileupload</groupId>
-            <artifactId>commons-fileupload</artifactId>
-        </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1498,11 +1498,6 @@
                 <version>2.13.0</version>
             </dependency>
             <dependency>
-                <groupId>commons-fileupload</groupId>
-                <artifactId>commons-fileupload</artifactId>
-                <version>1.5</version>
-            </dependency>
-            <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
                 <version>2.19.0</version>


### PR DESCRIPTION
## References
* Replaces #10859 , which is no longer needed

## Description
Removes `commons-fileupload` dependency from `dspace-7_x` as it is no longer used.  This dependency has already been removed from `dspace-8_x`, `dspace-9_x` and `main`.  

I believe it was used in the SWORD v1 client code, but that has been removed in #10568.  It's not used anywhere else.  While we already removed this dependency from all other branches, it was left around on 7.x

## Instructions for Reviewers
* Verify code builds and tests all pass.   If you want, search for "org.apache.commons.fileupload" (or just "fileupload") to verify that it's unused.