### PR TITLE
.github/dependabot.yml: update hibernate group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -120,6 +120,9 @@ updates:
       # Don't try to auto-update any DSpace dependencies
       - dependency-name: "org.dspace:*"
       - dependency-name: "org.dspace.*:*"
+      # Ignore major/minor updates for Hibernate. Only patch updates can be automated.
+      - dependency-name: "org.hibernate.*:*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
       # Ignore all major version updates for all dependencies. We'll only automate minor/patch updates.
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
@@ -238,6 +241,9 @@ updates:
       # Don't try to auto-update any DSpace dependencies
       - dependency-name: "org.dspace:*"
       - dependency-name: "org.dspace.*:*"
+      # Ignore major/minor updates for Hibernate. Only patch updates can be automated.
+      - dependency-name: "org.hibernate.*:*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
       # Ignore all major version updates for all dependencies. We'll only automate minor/patch updates.
       - dependency-name: "*"
         update-types: [ "version-update:semver-major" ]
@@ -356,6 +362,9 @@ updates:
       # Don't try to auto-update any DSpace dependencies
       - dependency-name: "org.dspace:*"
       - dependency-name: "org.dspace.*:*"
+      # Ignore major/minor updates for Hibernate. Only patch updates can be automated.
+      - dependency-name: "org.hibernate.*:*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
       # Ignore all major version updates for all dependencies. We'll only automate minor/patch updates.
       - dependency-name: "*"
         update-types: [ "version-update:semver-major" ]
@@ -493,6 +502,9 @@ updates:
       # See https://github.com/DSpace/DSpace/pull/9888#issuecomment-2408165545
       - dependency-name: "org.springframework.security:*"
         versions: [">=5.8.0"]
+      # Ignore major/minor updates for Hibernate. Only patch updates can be automated.
+      - dependency-name: "org.hibernate.*:*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
       # Ignore all major version updates for all dependencies. We'll only automate minor/patch updates.
       - dependency-name: "*"
         update-types: [ "version-update:semver-major" ]


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Related to https://github.com/DSpace/DSpace/pull/10834

## Description
Tell dependabot to also consider `hibernate.version` placeholder in `pom.xml` as part of the hibernate group so we only get patch updates.

## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* Add `hibernate.version` to the pattern matching the hibernate group in `.github/dependabot.yml`