### PR TITLE
dspace-api: improve date parsing for Solr sort indexes

### DIFF
--- a/dspace-api/src/main/java/org/dspace/sort/OrderFormatDate.java
+++ b/dspace-api/src/main/java/org/dspace/sort/OrderFormatDate.java
@@ -7,31 +7,28 @@
  */
 package org.dspace.sort;
 
+import java.time.ZonedDateTime;
+
+import org.dspace.util.MultiFormatDateParser;
+
 /**
- * Standard date ordering delegate implementation. The only "special" need is
- * to treat dates with less than 4-digit year.
+ * Standard date ordering delegate implementation using date format
+ * parsing from o.d.u.MultiFormatDateParser.
  *
  * @author Andrea Bollini
+ * @author Alan Orth
  */
 public class OrderFormatDate implements OrderFormatDelegate {
     @Override
     public String makeSortString(String value, String language) {
-        int padding = 0;
-        int endYearIdx = value.indexOf('-');
+        ZonedDateTime result = MultiFormatDateParser.parse(value);
 
-        if (endYearIdx >= 0 && endYearIdx < 4) {
-            padding = 4 - endYearIdx;
-        } else if (value.length() < 4) {
-            padding = 4 - value.length();
-        }
-
-        if (padding > 0) {
-            // padding the value from left with 0 so that 87 -> 0087, 687-11-24
-            // -> 0687-11-24
-            return String.format("%1$0" + padding + "d", 0)
-                + value;
+        // If parsing was successful we return the value as an ISO instant,
+        // otherwise we return null so Solr does not index this date value.
+        if (result != null) {
+            return result.toInstant().toString();
         } else {
-            return value;
+            return null;
         }
     }
 }


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #9944
* Replaces #9945
* 7.x port: https://github.com/DSpace/DSpace/pull/10875

## Description
Re-use DSpace date parsing from `o.d.util.MultiFormatDateParser` for more robust date format support when creating Solr browse/sort indexes. Successfully parsed dates are now indexed as ISO 8601 instead of as literal text values, and dates which cannot be parsed are not indexed.

Before, certain issue date values would cause unpredictable sort indexes in Solr:

- Date value: `nd`
  - Solr sort index: `"bi_sort_2_sort":"00nd"`
- Date value: `02/12/2024`
  - Solr sort index: `"bi_sort_2_sort":"02/12/2024"`
- Date value: `193604`
  - Solr sort index: `"bi_sort_2_sort":"193604"`
- Date value: `null`
  - Solr sort index: `"bi_sort_2_sort":"0000"`

After, 

- Date value: `nd`
  - Solr sort index: none
- Date value: `02/12/2024`
  - Solr sort index: `"bi_sort_2_sort":"2024-02-12T00:00:00Z"`
- Date value: `193604`
  - Solr sort index: `"bi_sort_2_sort":"1936-04-01T00:00:00Z"`
- Date value: `null`
  - Solr sort index: none

## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* Re-work `o.d.sort.OrderFormatDate` to use date parsing from `o.d.util.MultiFormatDateParser` instead of a custom parser
* Re-work `o.d.sort.OrderFormatDate` to return successfully parsed dates in ISO 8601 format instead of as literal text values
* Re-work `o.d.sort.OrderFormatDate` to not create sort indexes for dates that cannot be parsed
* Remove special handling of dates with less than four-digit year

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes.

There is no need to do a full Discovery reindex—you can simply update one item's issue date and then check the Solr search core to find the appropriate sort index for that `search.resourceid` (item's UUID), for example:

http://localhost:8983/solr/#/search/query?q=search.resourceid:da0641fc-19d4-44e1-b2f8-e1e3a736f7d9&q.op=OR&indent=true

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
