### PR TITLE
[Port dspace-7_x] dspace-api: improve date parsing for Solr sort indexes

### DIFF
--- a/dspace-api/src/main/java/org/dspace/sort/OrderFormatDate.java
+++ b/dspace-api/src/main/java/org/dspace/sort/OrderFormatDate.java
@@ -7,31 +7,28 @@
  */
 package org.dspace.sort;
 
+import java.util.Date;
+
+import org.dspace.util.MultiFormatDateParser;
+
 /**
- * Standard date ordering delegate implementation. The only "special" need is
- * to treat dates with less than 4-digit year.
+ * Standard date ordering delegate implementation using date format
+ * parsing from o.d.u.MultiFormatDateParser.
  *
  * @author Andrea Bollini
+ * @author Alan Orth
  */
 public class OrderFormatDate implements OrderFormatDelegate {
     @Override
     public String makeSortString(String value, String language) {
-        int padding = 0;
-        int endYearIdx = value.indexOf('-');
+        Date result = MultiFormatDateParser.parse(value);
 
-        if (endYearIdx >= 0 && endYearIdx < 4) {
-            padding = 4 - endYearIdx;
-        } else if (value.length() < 4) {
-            padding = 4 - value.length();
-        }
-
-        if (padding > 0) {
-            // padding the value from left with 0 so that 87 -> 0087, 687-11-24
-            // -> 0687-11-24
-            return String.format("%1$0" + padding + "d", 0)
-                + value;
+        // If parsing was successful we return the value as an ISO instant,
+        // otherwise we return null so Solr does not index this date value.
+        if (result != null) {
+            return result.toInstant().toString();
         } else {
-            return value;
+            return null;
         }
     }
 }


### PR DESCRIPTION
Manual port of https://github.com/DSpace/DSpace/pull/10874 by @alanorth to `dspace-7_x`. DSpace 7 and DSpace 8 use legacy Java date classes, while DSpace 9+ uses `java.time.*`.