### PR TITLE
Improve performance for entities when obtaining metadata by not fetching unneeded relationship metadata

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/Item.java
+++ b/dspace-api/src/main/java/org/dspace/content/Item.java
@@ -113,7 +113,13 @@ public class Item extends DSpaceObject implements DSpaceObjectLegacySupport {
     private boolean modifiedMetadataCache = true;
 
     @Transient
+    private boolean modifiedRelationshipMetadataCache = true;
+
+    @Transient
     private List<MetadataValue> cachedMetadata = new ArrayList<>();
+
+    @Transient
+    private List<RelationshipMetadataValue> cachedRelationshipMetadata = new ArrayList<>();
 
     /**
      * Protected constructor, create object using:
@@ -401,5 +407,23 @@ public class Item extends DSpaceObject implements DSpaceObjectLegacySupport {
     protected void setCachedMetadata(List<MetadataValue> cachedMetadata) {
         this.cachedMetadata = cachedMetadata;
         modifiedMetadataCache = false;
+    }
+
+    public boolean isModifiedRelationshipMetadataCache() {
+        return modifiedRelationshipMetadataCache;
+    }
+
+    protected void setRelationshipMetadataModified() {
+        super.setMetadataModified();
+        modifiedRelationshipMetadataCache = true;
+    }
+
+    protected List<RelationshipMetadataValue> getCachedRelationshipMetadata() {
+        return cachedRelationshipMetadata;
+    }
+
+    protected void setCachedRelationshipMetadata(List<RelationshipMetadataValue> cachedRelationshipMetadata) {
+        this.cachedRelationshipMetadata = cachedRelationshipMetadata;
+        modifiedRelationshipMetadataCache = false;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -1650,29 +1650,31 @@ prevent the generation of resource policy entry values with null dspace_object a
             log.debug("Called getMetadata for " + item.getID() + " without enableVirtualMetadata");
             return super.getMetadata(item, schema, element, qualifier, lang);
         }
-        if (item.isModifiedMetadataCache()) {
-            log.debug("Called getMetadata for " + item.getID() + " with invalid cache");
-            //rebuild cache
-            List<MetadataValue> dbMetadataValues = item.getMetadata();
 
-            List<MetadataValue> fullMetadataValueList = new LinkedList<>();
-            fullMetadataValueList.addAll(relationshipMetadataService.getRelationshipMetadata(item, true));
-            fullMetadataValueList.addAll(dbMetadataValues);
+        List<MetadataValue> fullMetadataValueList = new LinkedList<>();
+        boolean metadataModified = item.isModifiedMetadataCache();
+        boolean relationshipMetadataModified = item.isModifiedRelationshipMetadataCache();
 
-            item.setCachedMetadata(MetadataValueComparators.sort(fullMetadataValueList));
+        if (metadataModified) {
+            log.debug("Called getMetadata for " + item.getID() + " with invalid metadata cache");
+            List<MetadataValue> metadata = item.getMetadata();
+            item.setCachedMetadata(MetadataValueComparators.sort(metadata));
+            fullMetadataValueList.addAll(metadata);
+        } else {
+            fullMetadataValueList.addAll(item.getCachedMetadata());
         }
 
-        log.debug("Called getMetadata for " + item.getID() + " based on cache");
-        // Build up list of matching values based on the cache
-        List<MetadataValue> values = new ArrayList<>();
-        for (MetadataValue dcv : item.getCachedMetadata()) {
-            if (match(schema, element, qualifier, lang, dcv)) {
-                values.add(dcv);
-            }
+        if (relationshipMetadataModified) {
+            log.debug("Called getMetadata for " + item.getID() + " with invalid relationship metadata cache");
+            List<RelationshipMetadataValue> relationshipMetadata =
+                    relationshipMetadataService.getRelationshipMetadata(item, true);
+            item.setCachedRelationshipMetadata(MetadataValueComparators.sort(relationshipMetadata));
+            fullMetadataValueList.addAll(relationshipMetadata);
+        } else {
+            fullMetadataValueList.addAll(item.getCachedRelationshipMetadata());
         }
 
-        // Create an array of matching values
-        return values;
+        return fullMetadataValueList;
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -1674,7 +1674,15 @@ prevent the generation of resource policy entry values with null dspace_object a
             fullMetadataValueList.addAll(item.getCachedRelationshipMetadata());
         }
 
-        return fullMetadataValueList;
+        // Build up list of matching values based on the cache
+        List<MetadataValue> values = new ArrayList<>();
+        for (MetadataValue dcv : fullMetadataValueList) {
+            if (match(schema, element, qualifier, lang, dcv)) {
+                values.add(dcv);
+            }
+        }
+
+        return values;
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -1668,12 +1668,13 @@ prevent the generation of resource policy entry values with null dspace_object a
             log.debug("Called getMetadata for " + item.getID() + " with invalid relationship metadata cache");
             List<RelationshipMetadataValue> relationshipMetadata =
                     relationshipMetadataService.getRelationshipMetadata(item, true);
-            item.setCachedRelationshipMetadata(MetadataValueComparators.sort(relationshipMetadata));
+            item.setCachedRelationshipMetadata(relationshipMetadata);
             fullMetadataValueList.addAll(relationshipMetadata);
         } else {
             fullMetadataValueList.addAll(item.getCachedRelationshipMetadata());
         }
 
+        fullMetadataValueList = MetadataValueComparators.sort(fullMetadataValueList);
         // Build up list of matching values based on the cache
         List<MetadataValue> values = new ArrayList<>();
         for (MetadataValue dcv : fullMetadataValueList) {

--- a/dspace-api/src/main/java/org/dspace/content/MetadataValueComparators.java
+++ b/dspace-api/src/main/java/org/dspace/content/MetadataValueComparators.java
@@ -41,10 +41,10 @@ public final class MetadataValueComparators {
      * @param metadataValues
      * @return {@code List<MetadataValue>} ordered copy list using stream.
      */
-    public static final List<MetadataValue> sort(List<MetadataValue> metadataValues) {
+    public static final <T extends MetadataValue> List<T> sort(List<T> metadataValues) {
         return metadataValues
                 .stream()
-                .sorted(MetadataValueComparators.defaultComparator)
+                .sorted(defaultComparator)
                 .collect(Collectors.toList());
     }
 

--- a/dspace-api/src/main/java/org/dspace/content/Relationship.java
+++ b/dspace-api/src/main/java/org/dspace/content/Relationship.java
@@ -173,7 +173,7 @@ public class Relationship implements ReloadableEntity<Integer> {
      */
     public void setLeftPlace(int leftPlace) {
         this.leftPlace = leftPlace;
-        leftItem.setMetadataModified();
+        leftItem.setRelationshipMetadataModified();
     }
 
     /**
@@ -190,7 +190,7 @@ public class Relationship implements ReloadableEntity<Integer> {
      */
     public void setRightPlace(int rightPlace) {
         this.rightPlace = rightPlace;
-        rightItem.setMetadataModified();
+        rightItem.setRelationshipMetadataModified();
     }
 
     /**
@@ -246,8 +246,8 @@ public class Relationship implements ReloadableEntity<Integer> {
 
         // on one item, relation.* fields will change
         // on the other item, relation.*.latestForDiscovery will change
-        leftItem.setMetadataModified();
-        rightItem.setMetadataModified();
+        leftItem.setRelationshipMetadataModified();
+        rightItem.setRelationshipMetadataModified();
     }
 
     public enum LatestVersionStatus {

--- a/dspace-api/src/main/java/org/dspace/content/RelationshipServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/RelationshipServiceImpl.java
@@ -183,13 +183,13 @@ public class RelationshipServiceImpl implements RelationshipService {
             // metadata on the next update.
             // Set the Relationship's Items to the new ones, appending to the end
             if (newLeftItem != null) {
-                relationship.getLeftItem().setMetadataModified();
+                relationship.getLeftItem().setRelationshipMetadataModified();
                 relationship.setLeftItem(newLeftItem);
                 relationship.setLeftPlace(-1);
                 insertLeft = true;
             }
             if (newRightItem != null) {
-                relationship.getRightItem().setMetadataModified();
+                relationship.getRightItem().setRelationshipMetadataModified();
                 relationship.setRightItem(newRightItem);
                 relationship.setRightPlace(-1);
                 insertRight = true;
@@ -523,7 +523,7 @@ public class RelationshipServiceImpl implements RelationshipService {
     @Override
     public void updateItem(Context context, Item relatedItem)
         throws SQLException, AuthorizeException {
-        relatedItem.setMetadataModified();
+        relatedItem.setRelationshipMetadataModified();
         itemService.update(context, relatedItem);
     }
 


### PR DESCRIPTION
## Description
The idea of these changes are to split the cache of regular metadata and relationship metadata. This is useful for performance reasons as there's no reason to fetch relationships when altering regular metadata.

## Instructions for Reviewers

List of changes in this PR:
* Introduced a `List<RelationshipMetadataValue> cachedRelationshipMetadata` on the `Item` object and a `boolean modifiedRelationshipMetadataCache` flag to indicate if cache is modified, just as was present before for all metadata
* In `ItemServiceImpl#getMetadata()` split the cache logic up for our 'regular' metadata cache and our new relationship metadata cache, only updating the one needed

Testing can be done by enabling the author entities in the submission & then adding a mix of plain metadata & author relationships.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).