### PR TITLE
[dspace-7_x] fix authority separator handling in metadata import

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
@@ -90,7 +90,7 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
     /**
      * The authority controlled fields
      */
-    protected static Set<String> authorityControlled;
+    protected Set<String> authorityControlled;
 
     /**
      * The prefix of the authority controlled field
@@ -1386,7 +1386,7 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
     /**
      * is the field is defined as authority controlled
      */
-    private static boolean isAuthorityControlledField(String md) {
+    private boolean isAuthorityControlledField(String md) {
         String mdf = StringUtils.substringAfter(md, ":");
         mdf = StringUtils.substringBefore(mdf, "[");
         return authorityControlled.contains(mdf) || authorityControlled.contains(md);

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
@@ -1166,10 +1166,18 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
     }
 
     private void resolveValueAndAuthority(String value, BulkEditMetadataValue dcv) {
+        // Cells with valid authority are composed of three parts ~ <value>, <authority>, <confidence>
+        // The value itself may also include the authority separator though
         String[] parts = value.split(csv.getEscapedAuthoritySeparator());
 
+        // If we don't have enough parts, assume the whole string is the value
+        if (parts.length < 3) {
+            simplyCopyValue(value, dcv);
+            return;
+        }
+
         try {
-            // If an authority value is present, require a confidence value to be present as well
+            // The last part of the cell must be a confidence value (integer)
             int confidence = Integer.parseInt(parts[parts.length - 1]);
             String authority = parts[parts.length - 2];
             String plainValue = String.join(
@@ -1182,7 +1190,7 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
             dcv.setConfidence(confidence);
         } catch (NumberFormatException e) {
             // Otherwise assume the whole string is the value
-            dcv.setValue(value);
+            simplyCopyValue(value, dcv);
         }
     }
 

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import java.util.UUID;
 import javax.annotation.Nullable;
 
+import com.ibm.icu.impl.Pair;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -406,9 +407,16 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
                         // Remove authority unless the md is not authority controlled
                         if (!isAuthorityControlledField(md)) {
                             for (int i = 0; i < fromCSV.length; i++) {
-                                int pos = fromCSV[i].indexOf(csv.getAuthoritySeparator());
-                                if (pos > -1) {
-                                    fromCSV[i] = fromCSV[i].substring(0, pos);
+
+                                Pair<String, String> authorityAndConfidence = getAuthorityAndConfidence(fromCSV[i]);
+
+                                if (authorityAndConfidence != null) {
+                                    // Calculate the length of the authority + confidence part of the value
+                                    int authLength = authorityAndConfidence.first.length()
+                                        + authorityAndConfidence.second.length()
+                                        + csv.getAuthoritySeparator().length() * 2;
+
+                                    fromCSV[i] = fromCSV[i].substring(0, fromCSV[i].length() - authLength);
                                 }
                             }
                         }
@@ -1171,21 +1179,42 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
         dcv.setConfidence(Choices.CF_UNSET);
     }
 
-    private void resolveValueAndAuthority(String value, BulkEditMetadataValue dcv) {
+
+
+    private Pair<String, String> getAuthorityAndConfidence(String value) {
         // Cells with valid authority are composed of three parts ~ <value>, <authority>, <confidence>
         // The value itself may also include the authority separator though
-        String[] parts = value.split(csv.getEscapedAuthoritySeparator());
+        String[] parts = value.split(csv.getAuthoritySeparator());
 
-        // If we don't have enough parts, assume the whole string is the value
         if (parts.length < 3) {
+            return null;
+        }
+
+        // Check that confidence is an integer
+        try {
+            Integer.parseInt(parts[parts.length - 1]);
+        } catch (NumberFormatException e) {
+            return null; // confidence isn't an integer
+        }
+
+        return Pair.of(parts[parts.length - 2], parts[parts.length - 1]);
+    }
+
+    private void resolveValueAndAuthority(String value, BulkEditMetadataValue dcv) {
+        Pair<String, String> authorityAndConfidence = getAuthorityAndConfidence(value);
+
+        // If no authority & confidence is found, assume the whole string is the value
+        if (authorityAndConfidence == null) {
             simplyCopyValue(value, dcv);
             return;
         }
 
         try {
             // The last part of the cell must be a confidence value (integer)
-            int confidence = Integer.parseInt(parts[parts.length - 1]);
-            String authority = parts[parts.length - 2];
+            int confidence = Integer.parseInt(authorityAndConfidence.second);
+            String authority = authorityAndConfidence.first;
+
+            String[] parts = value.split(csv.getEscapedAuthoritySeparator());
             String plainValue = String.join(
                 csv.getAuthoritySeparator(),
                 ArrayUtils.subarray(parts, 0, parts.length - 2)

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -22,10 +23,9 @@ import java.util.Set;
 import java.util.UUID;
 import javax.annotation.Nullable;
 
-import com.ibm.icu.impl.Pair;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Triple;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.util.RelationshipUtils;
 import org.dspace.authority.AuthorityValue;
@@ -408,15 +408,11 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
                         if (!isAuthorityControlledField(md)) {
                             for (int i = 0; i < fromCSV.length; i++) {
 
-                                Pair<String, String> authorityAndConfidence = getAuthorityAndConfidence(fromCSV[i]);
+                                Triple<String, String, String> valueAndauthorityAndConfidence =
+                                    getValueAndAuthorityAndConfidence(fromCSV[i]);
 
-                                if (authorityAndConfidence != null) {
-                                    // Calculate the length of the authority + confidence part of the value
-                                    int authLength = authorityAndConfidence.first.length()
-                                        + authorityAndConfidence.second.length()
-                                        + csv.getAuthoritySeparator().length() * 2;
-
-                                    fromCSV[i] = fromCSV[i].substring(0, fromCSV[i].length() - authLength);
+                                if (valueAndauthorityAndConfidence.getMiddle() != null) {
+                                    fromCSV[i] = valueAndauthorityAndConfidence.getLeft();
                                 }
                             }
                         }
@@ -489,9 +485,11 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
                         // Remove authority unless the md is not authority controlled
                         if (!isAuthorityControlledField(md)) {
                             for (int i = 0; i < fromCSV.length; i++) {
-                                int pos = fromCSV[i].indexOf(csv.getAuthoritySeparator());
-                                if (pos > -1) {
-                                    fromCSV[i] = fromCSV[i].substring(0, pos);
+                                Triple<String, String, String> valueAndauthorityAndConfidence =
+                                    getValueAndAuthorityAndConfidence(fromCSV[i]);
+
+                                if (valueAndauthorityAndConfidence.getMiddle() != null) {
+                                    fromCSV[i] = valueAndauthorityAndConfidence.getLeft();
                                 }
                             }
                         }
@@ -1181,44 +1179,45 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
 
 
 
-    private Pair<String, String> getAuthorityAndConfidence(String value) {
+    private Triple<String, String, String> getValueAndAuthorityAndConfidence(String value) {
         // Cells with valid authority are composed of three parts ~ <value>, <authority>, <confidence>
         // The value itself may also include the authority separator though
         String[] parts = value.split(csv.getAuthoritySeparator());
 
         if (parts.length < 3) {
-            return null;
+            return Triple.of(String.join(csv.getAuthoritySeparator(),
+                Arrays.copyOfRange(parts, 0, parts.length)), null, null);
         }
 
         // Check that confidence is an integer
         try {
             Integer.parseInt(parts[parts.length - 1]);
         } catch (NumberFormatException e) {
-            return null; // confidence isn't an integer
+            return Triple.of(String.join(csv.getAuthoritySeparator(),
+                Arrays.copyOfRange(parts, 0, parts.length)), null, null);
+
         }
 
-        return Pair.of(parts[parts.length - 2], parts[parts.length - 1]);
+        return Triple.of(String.join(csv.getAuthoritySeparator(),
+            Arrays.copyOfRange(parts, 0, parts.length - 2)),
+            parts[parts.length - 2], parts[parts.length - 1]);
     }
 
     private void resolveValueAndAuthority(String value, BulkEditMetadataValue dcv) {
-        Pair<String, String> authorityAndConfidence = getAuthorityAndConfidence(value);
+        Triple<String, String, String> valueAndauthorityAndConfidence = getValueAndAuthorityAndConfidence(value);
 
         // If no authority & confidence is found, assume the whole string is the value
-        if (authorityAndConfidence == null) {
+        if (valueAndauthorityAndConfidence == null) {
             simplyCopyValue(value, dcv);
             return;
         }
 
         try {
             // The last part of the cell must be a confidence value (integer)
-            int confidence = Integer.parseInt(authorityAndConfidence.second);
-            String authority = authorityAndConfidence.first;
+            int confidence = Integer.parseInt(valueAndauthorityAndConfidence.getRight());
+            String authority = valueAndauthorityAndConfidence.getMiddle();
 
-            String[] parts = value.split(csv.getEscapedAuthoritySeparator());
-            String plainValue = String.join(
-                csv.getAuthoritySeparator(),
-                ArrayUtils.subarray(parts, 0, parts.length - 2)
-            );
+            String plainValue = valueAndauthorityAndConfidence.getLeft();
 
             dcv.setValue(plainValue);
             dcv.setAuthority(authority);

--- a/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataEditControlledVocabularyIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataEditControlledVocabularyIT.java
@@ -72,7 +72,6 @@ public class MetadataEditControlledVocabularyIT extends AbstractIntegrationTestW
         configurationService.setProperty("vocabulary.plugin.srsc.delimiter", "::");
         configurationService.setProperty("authority.controlled.dc.subject", "true");
         configurationService.setProperty("choices.plugin.dc.subject", "DSpaceControlledVocabulary");
-        configurationService.setProperty("authority.controlled.dc.subject", "true");
         configurationService.setProperty("plugin.named.org.dspace.content.authority.ChoiceAuthority",
                                          new String[] {
                                              "org.dspace.content.authority.SolrAuthority = SolrAuthorAuthority",

--- a/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataEditControlledVocabularyIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataEditControlledVocabularyIT.java
@@ -1,0 +1,257 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+
+package org.dspace.app.bulkedit;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNull;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.commons.io.IOUtils;
+import org.dspace.AbstractIntegrationTestWithDatabase;
+import org.dspace.app.scripts.handler.impl.TestDSpaceRunnableHandler;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.ItemBuilder;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.Item;
+import org.dspace.content.MetadataValue;
+import org.dspace.content.authority.DCInputAuthority;
+import org.dspace.content.authority.factory.ContentAuthorityServiceFactory;
+import org.dspace.content.authority.service.MetadataAuthorityService;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.ItemService;
+import org.dspace.core.factory.CoreServiceFactory;
+import org.dspace.core.service.PluginService;
+import org.dspace.scripts.DSpaceRunnable;
+import org.dspace.scripts.configuration.ScriptConfiguration;
+import org.dspace.scripts.factory.ScriptServiceFactory;
+import org.dspace.scripts.service.ScriptService;
+import org.dspace.services.ConfigurationService;
+import org.dspace.utils.DSpace;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class MetadataEditControlledVocabularyIT extends AbstractIntegrationTestWithDatabase {
+    ConfigurationService configurationService = new DSpace().getConfigurationService();
+    PluginService pluginService = CoreServiceFactory.getInstance().getPluginService();
+    MetadataAuthorityService mas = ContentAuthorityServiceFactory.getInstance().getMetadataAuthorityService();
+    ItemService itemService = ContentServiceFactory.getInstance().getItemService();
+
+    private Collection collection;
+
+    private TestDSpaceRunnableHandler handler;
+
+    private File file;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        configurationService.setProperty("vocabulary.plugin.srsc.hierarchy.store", true);
+        configurationService.setProperty("vocabulary.plugin.srsc.hierarchy.suggest", true);
+        configurationService.setProperty("vocabulary.plugin.srsc.delimiter", "::");
+        configurationService.setProperty("authority.controlled.dc.subject", "true");
+        configurationService.setProperty("choices.plugin.dc.subject", "DSpaceControlledVocabulary");
+        configurationService.setProperty("authority.controlled.dc.subject", "true");
+        configurationService.setProperty("plugin.named.org.dspace.content.authority.ChoiceAuthority",
+                                         new String[] {
+                                             "org.dspace.content.authority.SolrAuthority = SolrAuthorAuthority",
+                                             "org.dspace.content.authority.SolrAuthority = SolrEditorAuthority",
+                                             "org.dspace.content.authority.SolrAuthority = SolrSubjectAuthority",
+                                             "org.dspace.content.authority.DSpaceControlledVocabulary = DCV"
+                                         });
+
+        // These clears have to happen so that the config is actually reloaded in those classes. This is needed for
+        // the properties that we're altering above and this is only used within the tests
+        DCInputAuthority.reset();
+        pluginService.clearNamedPluginClasses();
+        mas.clearCache();
+
+        handler = new TestDSpaceRunnableHandler();
+        file = File.createTempFile("edit", ".csv");
+
+        context.turnOffAuthorisationSystem();
+
+        Community community = CommunityBuilder.createCommunity(context).build();
+        collection = CollectionBuilder.createCollection(context, community).build();
+
+        context.restoreAuthSystemState();
+    }
+
+    @After
+    @Override
+    public void destroy() throws Exception {
+        super.destroy();
+
+        configurationService.reloadConfig();
+
+        // These clears have to happen so that the config is actually reloaded in those classes. This is needed for
+        // the properties that we're altering above and this is only used within the tests
+        DCInputAuthority.reset();
+        pluginService.clearNamedPluginClasses();
+        mas.clearCache();
+    }
+
+    @Test
+    public void testEditVocabularySubject() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Item item = ItemBuilder
+            .createItem(context, collection)
+            .withTitle("Test Export")
+            .withSubject("Church studies", "VR110103", 600)
+            .withSubject("History of religion", "VR110102", 600)
+            .build();
+        context.restoreAuthSystemState();
+
+        runExport(item);
+        assertNull(
+            "Export should succeed",
+            handler.getException()
+        );
+
+        String exportedContent = readFile();
+        assertThat(exportedContent, containsString("Church studies::VR110103::600"));
+        assertThat(exportedContent, containsString("History of religion::VR110102::600"));
+
+        writeFile(exportedContent.replace(
+            "History of religion::VR110102::600",
+            "Missionary studies::VR110104::600"
+        ));
+
+        runImport();
+        assertNull(
+            "Re-import should succeed",
+            handler.getException()
+        );
+
+        // Note: we need to re-retrieve the Item to see the newly updated metadata
+        item = itemService.find(context, item.getID());
+
+        List<MetadataValue> subjects = itemService.getMetadata(item, "dc", "subject", null, Item.ANY);
+        assertEquals(2, subjects.size());
+
+        List<String> values = subjects.stream().map(MetadataValue::getValue).collect(Collectors.toList());
+        List<String> authorities = subjects.stream().map(MetadataValue::getAuthority).collect(Collectors.toList());
+
+        assertThat(values, containsInAnyOrder("Church studies", "Missionary studies"));
+        assertThat(authorities, containsInAnyOrder("VR110103", "VR110104"));
+    }
+
+    @Test
+    public void testEditVocabularySubjectHierarchy() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        Item item = ItemBuilder
+            .createItem(context, collection)
+            .withTitle("Test Export")
+            .withSubject("HUMANITIES and RELIGION::Religion/Theology::Psychology of religion", "VR110109", 600)
+            .withSubject("HUMANITIES and RELIGION::Religion/Theology::Philosophy of religion", "VR110110", 600)
+            .build();
+        context.restoreAuthSystemState();
+
+        runExport(item);
+        assertNull(
+            "Export should succeed",
+            handler.getException()
+        );
+
+        String exportedContent = readFile();
+        assertThat(exportedContent, containsString(
+            "HUMANITIES and RELIGION::Religion/Theology::Psychology of religion::VR110109::600"));
+        assertThat(exportedContent, containsString(
+            "HUMANITIES and RELIGION::Religion/Theology::Philosophy of religion::VR110110::600"));
+
+        writeFile(exportedContent.replace(
+            "HUMANITIES and RELIGION::Religion/Theology::Psychology of religion::VR110109::600",
+            "HUMANITIES and RELIGION::Religion/Theology::New Testament exegesis::VR110111::600"
+        ));
+
+        runImport();
+        assertNull(
+            "Re-import should succeed",
+            handler.getException()
+        );
+
+        // Note: we need to re-retrieve the Item to see the newly updated metadata
+        item = itemService.find(context, item.getID());
+
+        List<MetadataValue> subjects = itemService.getMetadata(item, "dc", "subject", null, Item.ANY);
+        assertEquals(2, subjects.size());
+
+        List<String> values = subjects.stream().map(MetadataValue::getValue).collect(Collectors.toList());
+        List<String> authorities = subjects.stream().map(MetadataValue::getAuthority).collect(Collectors.toList());
+
+        assertThat(values, containsInAnyOrder(
+            "HUMANITIES and RELIGION::Religion/Theology::Philosophy of religion",
+            "HUMANITIES and RELIGION::Religion/Theology::New Testament exegesis"
+        ));
+        assertThat(authorities, containsInAnyOrder("VR110110", "VR110111"));
+    }
+
+    private void runExport(Item item) throws Exception {
+        runScript(new String[] {
+            "metadata-export",
+            "-i", String.valueOf(item.getHandle()),
+            "-f", file.getAbsolutePath()
+        });
+    }
+
+    private void runImport() throws Exception {
+        runScript(new String[] {
+            "metadata-import", "-s",
+            "-e", eperson.getEmail(),
+            "-f", file.getAbsolutePath(),
+        });
+    }
+
+    private void runScript(String[] args) throws Exception {
+        ScriptService scriptService = ScriptServiceFactory.getInstance().getScriptService();
+        ScriptConfiguration scriptConfiguration = scriptService.getScriptConfiguration(args[0]);
+
+        DSpaceRunnable script = null;
+        if (scriptConfiguration != null) {
+            script = scriptService.createDSpaceRunnableForScriptConfiguration(scriptConfiguration);
+        }
+        if (script != null) {
+            script.initialize(args, handler, null);
+            script.run();
+        }
+    }
+
+    private String readFile() throws Exception {
+        return IOUtils.toString(new FileInputStream(file), StandardCharsets.UTF_8);
+    }
+
+    private void writeFile(String content) throws Exception {
+        try (
+            BufferedWriter out = new BufferedWriter(
+                new OutputStreamWriter(
+                    new FileOutputStream(file), StandardCharsets.UTF_8
+                )
+            )
+        ) {
+            out.write(content);
+            out.flush();
+        }
+    }
+}

--- a/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataImportIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataImportIT.java
@@ -377,11 +377,10 @@ public class MetadataImportIT extends AbstractIntegrationTestWithDatabase {
                 .build();
             context.restoreAuthSystemState();
 
-            final String testAbstract = "The double colon '::' has many purposes, like: ...";
-            final String authority = "::authority::nonint";
+            final String testAbstract = "The double colon '::' has many purposes, like: ...::authority::nonint";
 
             String[] csv = {"id,dc.description.abstract",
-                item.getID().toString() + ",\"" + testAbstract + authority + "\""};
+                item.getID().toString() + ",\"" + testAbstract + "\""};
             performImportScript(csv);
             item = findItemByName(itemTitle);
 

--- a/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataImportIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataImportIT.java
@@ -378,7 +378,7 @@ public class MetadataImportIT extends AbstractIntegrationTestWithDatabase {
             context.restoreAuthSystemState();
 
             final String testAbstract = "The double colon '::' has many purposes, like: ...";
-            final String authority = "::authority::123";
+            final String authority = "::authority::nonint";
 
             String[] csv = {"id,dc.description.abstract",
                 item.getID().toString() + ",\"" + testAbstract + authority + "\""};


### PR DESCRIPTION
## References

- Fixes #9896
- Similar problem: https://github.com/DSpace/DSpace/pull/9753

## Description

Solving the problem for metadata-imports, were a value of a field includes the authority seperator `::` but as actual part of the value, not to add an authority.
Example mentioned in [#9896](https://github.com/DSpace/DSpace/issues/9896): `To test our hypothesis, we created mutant strains R20291::licB and R20291:: cd2781 using ClosTron mutagenesis system.`


## Instructions for Reviewers

This PR solves the problem by adding a rule, that expects the value to follow this format: `{value}::{authirty}::{confidence}` (atleast seperated in 3 parts) and the confidence must be an integer and be positioned directly after the authority. Otherwise it is seen as part of the value.

List of changes in this PR:
* First, `MetadataImport#getAuthorityAndConfidence` updated to `getValueAndAuthorityAndConfidence` returning a Triple of `<value>, <authority>, <confidence>`. If the initial value doesn't follow the above rules a Triple of `<value>, null, null` is returned.
* Second, `MetadataImportIT` updated to add test-cases for:
    - Value `The double colon '::' has many purposes, like: ...::authority::123`
    - Value `The double colon '::' has many purposes, like: ...::authority::nonint`


**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 



Enable:
```
authority.controlled.dc.description.abstract = true
```


As admin, navigate to `/admin/metadata-import` & disable `Validate Only` upload the [abstract-authority-test.csv](https://github.com/user-attachments/files/20774867/abstract-authority-test.csv) file. **Make sure to change the UUID in the file to your target item**



Navigate to the generated process; process output should contain:
```
The double colon '::' has many purposes, like: ...
 , authority = authority
 , confidence = 123
```

This can also be checked in the database:
```
select authority, confidence from metadatavalue where dspace_object_id = '{UUID}';
```
Should have a row

```
authority |        123
```


Disable:
```
authority.controlled.dc.description.abstract = false
```

As admin, navigate to `/admin/metadata-import` & disable `Validate Only` upload the [abstract-authority-test.csv](https://github.com/user-attachments/files/20774867/abstract-authority-test.csv) file. **Make sure to change the UUID in the file to your target item**


check:
```
select authority, confidence from metadatavalue where dspace_object_id = '{UUID}';
```

Navigate to the generated process; process output should contain:
```
The double colon '::' has many purposes, like: ...
```
without:
```
 , authority = authority
 , confidence = 123
```

does not contain:
```
authority |        123
```


## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
