### PR TITLE
[dspace-7_x] Fix failing Handle ITs by properly registering/unregistering handle plugin & using better context management

### DIFF
--- a/dspace-api/src/test/java/org/dspace/identifier/VersionedHandleIdentifierProviderIT.java
+++ b/dspace-api/src/test/java/org/dspace/identifier/VersionedHandleIdentifierProviderIT.java
@@ -48,15 +48,21 @@ public class VersionedHandleIdentifierProviderIT extends AbstractIdentifierProvi
         collection = CollectionBuilder.createCollection(context, parentCommunity)
                                       .withName("Collection")
                                       .build();
+
+        context.restoreAuthSystemState();
     }
 
     private void createVersions() throws SQLException, AuthorizeException {
+        context.turnOffAuthorisationSystem();
+
         itemV1 = ItemBuilder.createItem(context, collection)
                 .withTitle("First version")
                 .build();
         firstHandle = itemV1.getHandle();
         itemV2 = VersionBuilder.createVersion(context, itemV1, "Second version").build().getItem();
         itemV3 = VersionBuilder.createVersion(context, itemV1, "Third version").build().getItem();
+
+        context.restoreAuthSystemState();
     }
 
     @Test
@@ -76,8 +82,7 @@ public class VersionedHandleIdentifierProviderIT extends AbstractIdentifierProvi
 
     @Test
     public void testCollectionHandleMetadata() {
-        registerProvider(VersionedHandleIdentifierProvider.class);
-
+        context.turnOffAuthorisationSystem();
         Community testCommunity = CommunityBuilder.createCommunity(context)
                                                   .withName("Test community")
                                                   .build();
@@ -85,6 +90,7 @@ public class VersionedHandleIdentifierProviderIT extends AbstractIdentifierProvi
         Collection testCollection = CollectionBuilder.createCollection(context, testCommunity)
                                                      .withName("Test Collection")
                                                      .build();
+        context.restoreAuthSystemState();
 
         List<MetadataValue> metadata = ContentServiceFactory.getInstance().getDSpaceObjectService(testCollection)
                                                             .getMetadata(testCollection, "dc", "identifier", "uri",
@@ -96,11 +102,11 @@ public class VersionedHandleIdentifierProviderIT extends AbstractIdentifierProvi
 
     @Test
     public void testCommunityHandleMetadata() {
-        registerProvider(VersionedHandleIdentifierProvider.class);
-
+        context.turnOffAuthorisationSystem();
         Community testCommunity = CommunityBuilder.createCommunity(context)
                                                   .withName("Test community")
                                                   .build();
+        context.restoreAuthSystemState();
 
         List<MetadataValue> metadata = ContentServiceFactory.getInstance().getDSpaceObjectService(testCommunity)
                                                             .getMetadata(testCommunity, "dc", "identifier", "uri",


### PR DESCRIPTION
## Description
This PR should fix the IT failures on `dspace-7_x` related to `org.dspace.identifier.VersionedHandleIdentifierProviderIT`.

These failures appear to be caused by an update in GitHub Actions where the ITs are now **running in a different order**.  

Simply put, when `VersionedHandleIdentifierProviderWithCanonicalHandlesIT` runs **before** `VersionedHandleIdentifierProviderIT` **then the tests fail**.  But, if `VersionedHandleIdentifierProviderWithCanonicalHandlesIT` runs **after** `VersionedHandleIdentifierProviderIT` **then the tests pass**.

This PR updates both of these ITs to use the same code that currently exists on other branches, but was accidentally missing from `dspace-7_x`.  the updated code ensures that `VersionedHandleIdentifierProviderWithCanonicalHandlesIT` cleans up after itself (see the new `destroy()`) and both ITs use better Context management (to avoid accidentally caching Handle Service settings between tests).

This PR is essentially a backport of b4f05114c118d91d1ff21a1bcfe4579f2ddd2117 , which did something similar to `main`.  But, it does include parts of a few other related changes in #10656 that are oddly missing from `dspace-7_x` but exist on other branches.

## Instructions for Reviewers
* Ensure ITs now all pass.  If they pass, this is working.
