### PR TITLE
Make UploadValidation force MetadataValidation of each bitstream in submission

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/validation/UploadValidation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/validation/UploadValidation.java
@@ -20,13 +20,13 @@ import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.model.ErrorRest;
 import org.dspace.app.rest.repository.WorkspaceItemRestRepository;
 import org.dspace.app.rest.submit.SubmissionService;
-import org.dspace.app.rest.utils.ContextUtil;
 import org.dspace.app.util.DCInput;
 import org.dspace.app.util.DCInputSet;
 import org.dspace.app.util.DCInputsReader;
 import org.dspace.app.util.DCInputsReaderException;
 import org.dspace.app.util.SubmissionStepConfig;
 import org.dspace.content.Bitstream;
+import org.dspace.content.Bundle;
 import org.dspace.content.InProgressSubmission;
 import org.dspace.content.MetadataValue;
 import org.dspace.content.authority.service.MetadataAuthorityService;
@@ -67,10 +67,11 @@ public class UploadValidation extends AbstractValidation {
                          + config.getId());
         }
         if (itemService.hasUploadedFiles(obj.getItem())) {
-            List<Bitstream> bitstreams =
-                    itemService.getNonInternalBitstreams(ContextUtil.obtainCurrentRequestContext(), obj.getItem());
-            for (Bitstream bitstream : bitstreams) {
-                errors.addAll(metadataValidate(bitstream, config, uploadConfig));
+            List<Bundle> bundles = itemService.getBundles(obj.getItem(), "ORIGINAL");
+            for (Bundle bundle : bundles) {
+                for (Bitstream bitstream : bundle.getBitstreams()) {
+                    errors.addAll(metadataValidate(bitstream, config, uploadConfig));
+                }
             }
         }
         return errors;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/validation/UploadValidation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/validation/UploadValidation.java
@@ -7,23 +7,33 @@
  */
 package org.dspace.app.rest.submit.step.validation;
 
+import static org.dspace.app.rest.submit.step.validation.MetadataValidation.ERROR_VALIDATION_AUTHORITY_REQUIRED;
+import static org.dspace.app.rest.submit.step.validation.MetadataValidation.ERROR_VALIDATION_REGEX;
+import static org.dspace.app.rest.submit.step.validation.MetadataValidation.ERROR_VALIDATION_REQUIRED;
+
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.model.ErrorRest;
 import org.dspace.app.rest.repository.WorkspaceItemRestRepository;
 import org.dspace.app.rest.submit.SubmissionService;
 import org.dspace.app.rest.utils.ContextUtil;
+import org.dspace.app.util.DCInput;
+import org.dspace.app.util.DCInputSet;
+import org.dspace.app.util.DCInputsReader;
 import org.dspace.app.util.DCInputsReaderException;
 import org.dspace.app.util.SubmissionStepConfig;
 import org.dspace.content.Bitstream;
 import org.dspace.content.InProgressSubmission;
+import org.dspace.content.MetadataValue;
+import org.dspace.content.authority.service.MetadataAuthorityService;
+import org.dspace.content.service.BitstreamService;
 import org.dspace.content.service.ItemService;
 import org.dspace.submit.model.UploadConfiguration;
 import org.dspace.submit.model.UploadConfigurationService;
-import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * Execute file required check validation
@@ -36,12 +46,15 @@ public class UploadValidation extends AbstractValidation {
 
     private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(UploadValidation.class);
 
+    private DCInputsReader inputReader;
+
     private ItemService itemService;
 
     private UploadConfigurationService uploadConfigurationService;
 
-    @Autowired
-    private MetadataValidation metadataValidation;
+    private MetadataAuthorityService metadataAuthorityService;
+
+    private BitstreamService bitstreamService;
 
     @Override
     public List<ErrorRest> validate(SubmissionService submissionService, InProgressSubmission obj,
@@ -57,10 +70,108 @@ public class UploadValidation extends AbstractValidation {
             List<Bitstream> bitstreams =
                     itemService.getNonInternalBitstreams(ContextUtil.obtainCurrentRequestContext(), obj.getItem());
             for (Bitstream bitstream : bitstreams) {
-                errors.addAll(metadataValidation.validate(submissionService, bitstream, config));
+                errors.addAll(metadataValidate(bitstream, config, uploadConfig));
             }
         }
         return errors;
+    }
+
+    private List<ErrorRest> metadataValidate(Bitstream obj, SubmissionStepConfig config,
+                                             UploadConfiguration uploadConfig)
+            throws DCInputsReaderException {
+        List<ErrorRest> errors = new ArrayList<>();
+        String documentTypeValue = "";
+        DCInputSet inputConfig;
+        inputConfig = getInputReader().getInputsByFormName(uploadConfig.getMetadata());
+
+
+        // Begin the actual validation loop
+        for (DCInput[] row : inputConfig.getFields()) {
+            for (DCInput input : row) {
+                String fieldKey =
+                        metadataAuthorityService.makeFieldKey(input.getSchema(), input.getElement(),
+                                input.getQualifier());
+                boolean isAuthorityControlled = metadataAuthorityService.isAuthorityControlled(fieldKey);
+
+                List<String> fieldsName = new ArrayList<String>();
+
+                if (input.isQualdropValue()) {
+                    boolean foundResult = false;
+                    List<Object> inputPairs = input.getPairs();
+                    for (int i = 1; i < inputPairs.size(); i += 2) {
+                        String fullFieldname = input.getFieldName() + "." + (String) inputPairs.get(i);
+                        List<MetadataValue> mdv = bitstreamService.getMetadataByMetadataString(obj, fullFieldname);
+
+                        validateMetadataValues(mdv, input, config, isAuthorityControlled, fieldKey, errors);
+                        if (!mdv.isEmpty() && input.isVisible(DCInput.SUBMISSION_SCOPE)) {
+                            foundResult = true;
+                        }
+                    }
+                    if (input.isRequired() && !foundResult) {
+                        // for this required qualdrop no value was found, add to the list of error fields
+                        addError(errors, ERROR_VALIDATION_REQUIRED,
+                                "/" + WorkspaceItemRestRepository.OPERATION_PATH_SECTIONS + "/" + config.getId() + "/" +
+                                        input.getFieldName());
+                    }
+                } else {
+                    String name = input.getFieldName();
+                    if (name != null) {
+                        fieldsName.add(name);
+                    }
+                }
+
+                for (String fieldName : fieldsName) {
+                    boolean valuesRemoved = false;
+                    List<MetadataValue> mdv = bitstreamService.getMetadataByMetadataString(obj, fieldName);
+                    validateMetadataValues(mdv, input, config, isAuthorityControlled, fieldKey, errors);
+                    if ((input.isRequired() && mdv.isEmpty()) && input.isVisible(DCInput.SUBMISSION_SCOPE)
+                            && !valuesRemoved) {
+                        // Is the input required for *this* type? In other words, are we looking at a required
+                        // input that is also allowed for this document type
+                        if (input.isAllowedFor(documentTypeValue)) {
+                            // since this field is missing add to list of error
+                            // fields
+                            addError(errors, ERROR_VALIDATION_REQUIRED, "/"
+                                    + WorkspaceItemRestRepository.OPERATION_PATH_SECTIONS + "/" + config.getId() + "/" +
+                                    input.getFieldName());
+                        }
+                    }
+                }
+            }
+        }
+        return errors;
+    }
+
+    private void validateMetadataValues(List<MetadataValue> mdv, DCInput input, SubmissionStepConfig config,
+                                        boolean isAuthorityControlled, String fieldKey,
+                                        List<ErrorRest> errors) {
+        for (MetadataValue md : mdv) {
+            if (! (input.validate(md.getValue()))) {
+                addError(errors, ERROR_VALIDATION_REGEX,
+                        "/" + WorkspaceItemRestRepository.OPERATION_PATH_SECTIONS + "/" + config.getId() + "/" +
+                                input.getFieldName() + "/" + md.getPlace());
+            }
+            if (isAuthorityControlled) {
+                String authKey = md.getAuthority();
+                if (metadataAuthorityService.isAuthorityRequired(fieldKey) &&
+                        StringUtils.isBlank(authKey)) {
+                    addError(errors, ERROR_VALIDATION_AUTHORITY_REQUIRED,
+                            "/" + WorkspaceItemRestRepository.OPERATION_PATH_SECTIONS + "/" + config.getId() +
+                                    "/" + input.getFieldName() + "/" + md.getPlace());
+                }
+            }
+        }
+    }
+
+    public DCInputsReader getInputReader() {
+        if (inputReader == null) {
+            try {
+                inputReader = new DCInputsReader();
+            } catch (DCInputsReaderException e) {
+                log.error(e.getMessage(), e);
+            }
+        }
+        return inputReader;
     }
 
     public ItemService getItemService() {
@@ -77,6 +188,26 @@ public class UploadValidation extends AbstractValidation {
 
     public void setUploadConfigurationService(UploadConfigurationService uploadConfigurationService) {
         this.uploadConfigurationService = uploadConfigurationService;
+    }
+
+    public void setInputReader(DCInputsReader inputReader) {
+        this.inputReader = inputReader;
+    }
+
+    public MetadataAuthorityService getMetadataAuthorityService() {
+        return metadataAuthorityService;
+    }
+
+    public void setMetadataAuthorityService(MetadataAuthorityService metadataAuthorityService) {
+        this.metadataAuthorityService = metadataAuthorityService;
+    }
+
+    public BitstreamService getBitstreamService() {
+        return bitstreamService;
+    }
+
+    public void setBitstreamService(BitstreamService bitstreamService) {
+        this.bitstreamService = bitstreamService;
     }
 
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/validation/UploadValidation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/validation/UploadValidation.java
@@ -9,7 +9,6 @@ package org.dspace.app.rest.submit.step.validation;
 
 import static org.dspace.app.rest.submit.step.validation.MetadataValidation.ERROR_VALIDATION_AUTHORITY_REQUIRED;
 import static org.dspace.app.rest.submit.step.validation.MetadataValidation.ERROR_VALIDATION_REGEX;
-import static org.dspace.app.rest.submit.step.validation.MetadataValidation.ERROR_VALIDATION_REQUIRED;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -43,6 +42,8 @@ import org.dspace.submit.model.UploadConfigurationService;
 public class UploadValidation extends AbstractValidation {
 
     private static final String ERROR_VALIDATION_FILEREQUIRED = "error.validation.filerequired";
+
+    public static final String ERROR_VALIDATION_METADATA_PENDING = "error.validation.metadata.pending";
 
     private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(UploadValidation.class);
 
@@ -110,7 +111,7 @@ public class UploadValidation extends AbstractValidation {
                     }
                     if (input.isRequired() && !foundResult) {
                         // for this required qualdrop no value was found, add to the list of error fields
-                        addError(errors, ERROR_VALIDATION_REQUIRED,
+                        addError(errors, ERROR_VALIDATION_METADATA_PENDING,
                                 "/" + WorkspaceItemRestRepository.OPERATION_PATH_SECTIONS + "/" + config.getId() + "/" +
                                         input.getFieldName());
                     }
@@ -132,7 +133,7 @@ public class UploadValidation extends AbstractValidation {
                         if (input.isAllowedFor(documentTypeValue)) {
                             // since this field is missing add to list of error
                             // fields
-                            addError(errors, ERROR_VALIDATION_REQUIRED, "/"
+                            addError(errors, ERROR_VALIDATION_METADATA_PENDING, "/"
                                     + WorkspaceItemRestRepository.OPERATION_PATH_SECTIONS + "/" + config.getId() + "/" +
                                     input.getFieldName());
                         }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/validation/UploadValidation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/validation/UploadValidation.java
@@ -25,7 +25,6 @@ import org.dspace.app.util.DCInputsReader;
 import org.dspace.app.util.DCInputsReaderException;
 import org.dspace.app.util.SubmissionStepConfig;
 import org.dspace.content.Bitstream;
-import org.dspace.content.Bundle;
 import org.dspace.content.InProgressSubmission;
 import org.dspace.content.MetadataValue;
 import org.dspace.content.authority.service.MetadataAuthorityService;
@@ -68,11 +67,9 @@ public class UploadValidation extends AbstractValidation {
                          + config.getId());
         }
         if (itemService.hasUploadedFiles(obj.getItem())) {
-            List<Bundle> bundles = itemService.getBundles(obj.getItem(), "ORIGINAL");
-            for (Bundle bundle : bundles) {
-                for (Bitstream bitstream : bundle.getBitstreams()) {
-                    errors.addAll(metadataValidate(bitstream, config, uploadConfig));
-                }
+            List<Bitstream> bitstreams = itemService.getBundles(obj.getItem(), "ORIGINAL").get(0).getBitstreams();
+            for (Bitstream bitstream : bitstreams) {
+                errors.addAll(metadataValidate(bitstream, config, uploadConfig));
             }
         }
         return errors;

--- a/dspace-server-webapp/src/main/resources/spring/spring-dspace-addon-validation-services.xml
+++ b/dspace-server-webapp/src/main/resources/spring/spring-dspace-addon-validation-services.xml
@@ -17,7 +17,6 @@
           scope="prototype">
         <property name="name" value="submission-form"/>
         <property name="configurationService" ref="org.dspace.services.ConfigurationService"/>
-        <property name="itemService" ref="org.dspace.content.ItemServiceImpl"/>
         <property name="metadataAuthorityService" ref="org.dspace.content.authority.MetadataAuthorityServiceImpl"/>
     </bean>
 

--- a/dspace-server-webapp/src/main/resources/spring/spring-dspace-addon-validation-services.xml
+++ b/dspace-server-webapp/src/main/resources/spring/spring-dspace-addon-validation-services.xml
@@ -17,6 +17,7 @@
           scope="prototype">
         <property name="name" value="submission-form"/>
         <property name="configurationService" ref="org.dspace.services.ConfigurationService"/>
+        <property name="itemService" ref="org.dspace.content.ItemServiceImpl"/>
         <property name="metadataAuthorityService" ref="org.dspace.content.authority.MetadataAuthorityServiceImpl"/>
     </bean>
 
@@ -24,6 +25,8 @@
         <property name="name" value="upload"/>
         <property name="itemService" ref="org.dspace.content.ItemServiceImpl"/>
         <property name="uploadConfigurationService" ref="uploadConfigurationService"/>
+        <property name="metadataAuthorityService" ref="org.dspace.content.authority.MetadataAuthorityServiceImpl"/>
+        <property name="bitstreamService" ref="org.dspace.content.BitstreamServiceImpl"/>
     </bean>
 
     <bean name="cclicenseValidation" class="org.dspace.app.rest.submit.step.validation.CclicenseValidator">

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkflowItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkflowItemRestRepositoryIT.java
@@ -9,6 +9,7 @@ package org.dspace.app.rest;
 
 import static com.jayway.jsonpath.JsonPath.read;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.dspace.app.rest.submit.step.validation.UploadValidation.ERROR_VALIDATION_METADATA_PENDING;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
@@ -2323,7 +2324,7 @@ public class WorkflowItemRestRepositoryIT extends AbstractControllerIntegrationT
         // check that the errors returned mentions that the dc.title is missing from upload section
         getClient(epersonToken).perform(get("/api/workflow/workflowitems/" + workflowItem.getID()))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.errors[?(@.message=='error.validation.required')]",
+                .andExpect(jsonPath("$.errors[?(@.message=='" + ERROR_VALIDATION_METADATA_PENDING + "')]",
                         Matchers.contains(
                                 hasJsonPath("$.paths", Matchers.contains(
                                         hasJsonPath("$", Matchers.is("/sections/upload/dc.title"))

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkflowItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkflowItemRestRepositoryIT.java
@@ -2264,4 +2264,70 @@ public class WorkflowItemRestRepositoryIT extends AbstractControllerIntegrationT
             .andExpect(jsonPath("$.sections.upload-no-required-metadata.files",hasSize(0)));
     }
 
+    @Test
+    public void verifyMetadataOfBitstreamsIsChecked()
+            throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+
+        Collection collection1 = CollectionBuilder.createCollection(context, parentCommunity)
+                .withName("Collection 1")
+                .build();
+
+        Collection collection2 = CollectionBuilder.createCollection(context, parentCommunity).withName("Collection 2")
+                .withWorkflowGroup(1, eperson).build();
+
+        WorkspaceItem witem = null;
+
+        String bitstreamContent = "0123456789";
+
+        //3. a workflow item will all the required fields
+        XmlWorkflowItem workflowItem = WorkflowItemBuilder.createWorkflowItem(context, collection2)
+                .withTitle("Workflow Item 1")
+                .withIssueDate("2017-10-17")
+                .build();
+
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, Charset.defaultCharset())) {
+
+            context.setCurrentUser(admin);
+            witem = WorkspaceItemBuilder.createWorkspaceItem(context, collection1)
+                    .withTitle("Test WorkspaceItem")
+                    .withIssueDate("2019-10-01")
+                    .grantLicense()
+                    .build();
+
+            BitstreamBuilder.createBitstream(context, witem.getItem(), is)
+                    .withDescription("This is a bitstream to test range requests")
+                    .withMimeType("text/plain")
+                    .build();
+
+            BitstreamBuilder.createBitstream(context, workflowItem.getItem(), is)
+                    .withDescription("This is a bitstream to test range requests")
+                    .withMimeType("text/plain")
+                    .build();
+
+        }
+
+        context.restoreAuthSystemState();
+        String adminToken = getAuthToken(admin.getEmail(), password);
+        String epersonToken = getAuthToken(eperson.getEmail(), password);
+        // check that the item can't be submitted due to not having dc.title on the bitstream
+        getClient(adminToken).perform(post(BASE_REST_SERVER_URL + "/api/workflow/workflowitems")
+                        .content("/api/submission/workspaceitems/" + witem.getID())
+                        .contentType(textUriContentType))
+                .andExpect(status().is4xxClientError());
+
+        // check that the errors returned mentions that the dc.title is missing from upload section
+        getClient(epersonToken).perform(get("/api/workflow/workflowitems/" + workflowItem.getID()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.errors[?(@.message=='error.validation.required')]",
+                        Matchers.contains(
+                                hasJsonPath("$.paths", Matchers.contains(
+                                        hasJsonPath("$", Matchers.is("/sections/upload/dc.title"))
+                                )))));
+    }
+
 }


### PR DESCRIPTION
## References
* Fixes #10957
* Requires #4655

## Description
Changed UploadValidation step to check for each bitstreams MetadataValidation. This causes the submission form to be aware of required fields present in bitstreams.

## Instructions for Reviewers

- Adjusts UploadValidation to check if the item has bitstreams attached
- If it does runs the MetadataValidation on the bitstream object and adds the returned errors to the list
- Changes MetadataValidation to on the fly decide which Dspace Object Service to use, and allows validate to be called with a dspace object instead of a InProgressSubmission

To test: 
- Create a submission
- Upload a file
- Fill in all required fields but those in the bitstreams metadata
- Try to submit (should fail)
- Try to submit after filling in bitstreams metadata (should succeed) 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
