### PR TITLE
Fix dspace 7 tag input type doesn't support value-pairs-name

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/DCInput.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/DCInput.java
@@ -203,7 +203,7 @@ public class DCInput {
         inputType = fieldMap.get("input-type");
         // these types are list-controlled
         if ("dropdown".equals(inputType) || "qualdrop_value".equals(inputType)
-            || "list".equals(inputType)) {
+            || "list".equals(inputType) || "tag".equals(inputType)) {
             valueListName = fieldMap.get("value-pairs-name");
             valueList = listMap.get(valueListName);
         }

--- a/dspace-api/src/main/java/org/dspace/app/util/DCInputsReader.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/DCInputsReader.java
@@ -463,9 +463,14 @@ public class DCInputsReader {
         throws SAXException {
         if (value.equals("dropdown")
             || value.equals("qualdrop_value")
-            || value.equals("list")) {
+            || value.equals("list")
+            || value.equals("tag")) {
             String pairTypeName = getAttribute(nd, PAIR_TYPE_NAME);
             if (pairTypeName == null) {
+                if (value.equals("tag")) {
+                    // Optional value pair key for tag inputs
+                    return;
+                }
                 throw new SAXException("Form " + formName + ", field " +
                                            field.get("dc-element") +
                                            "." + field.get("dc-qualifier") +


### PR DESCRIPTION
## References
- Fixes DSpace/dspace-angular#2485

## Description
This PR adds support for `value-pairs-name` to tag input fields.

## Instructions for Reviewers
List of changes in this PR:

1. Added tag support to `DCInput` when checking for `value-pairs-name` values. 
2. Added tag support to `DCInputsReader` when setting the value pair name field.

How to test or review the PR:

Configure a tag input field in `submission-forms.xml` with a `value-pairs-name` key. E.g.
```
<field>
    <dc-schema>dc</dc-schema>
    <dc-element>type</dc-element>
    <dc-qualifier></dc-qualifier>
    <repeatable>true</repeatable>
    <label>Type</label>
    <input-type value-pairs-name="common_types">tag</input-type>
</field>
```
Verify that the values from the configured `value-pairs-name` show up in the input field's autocomplete during submission.

## Checklist

- [x] PRs _should_ be smaller in size (ideally less than 1,000 lines of code, not including comments & tests)
- [x] PRs **must** pass Checkstyle validation based on our [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] PRs **must** include Javadoc for _all new/modified public methods and classes_. Larger private methods should also have Javadoc
- [x] PRs **must** pass all automated tests and include new/updated Unit or Integration tests based on our [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] Details on how to test the PR **must** be provided. Reviewers must be aware of any steps they need to take to successfully test your fix or feature.
- [x] If a PR includes new libraries/dependencies (in any `pom.xml`), then their software licenses **must** align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] Basic technical documentation _should_ be provided for any new features or changes to the REST API. REST API changes should be documented in our [Rest Contract](https://github.com/DSpace/RestContract).
- [x] If a PR fixes an issue ticket, please [link them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).