### PR TITLE
Fix patching metadata on unknown field clears all DSO metadata

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataPatchUtils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataPatchUtils.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.StringUtils;
 import org.dspace.app.rest.exception.DSpaceBadRequestException;
+import org.dspace.app.rest.exception.UnprocessableEntityException;
 import org.dspace.app.rest.model.MetadataValueRest;
 import org.dspace.app.rest.model.patch.JsonValueEvaluator;
 import org.dspace.app.rest.model.patch.Operation;
@@ -135,10 +136,20 @@ public final class DSpaceObjectMetadataPatchUtils {
      * @param context       Context the retrieve metadataField from service with string
      * @param operation     Operation of the patch
      * @return              The metadataField corresponding to the md element string of the operation
+     *                      Null if no metadata field is passed in the operation
+     * @throws UnprocessableEntityException if an invalid metadata field is passed in the operation
      */
-    protected MetadataField getMetadataField(Context context, Operation operation) throws SQLException {
+    protected MetadataField getMetadataField(Context context, Operation operation)
+        throws SQLException, UnprocessableEntityException {
         String mdElement = this.extractMdFieldStringFromOperation(operation);
-        return metadataFieldService.findByString(context, mdElement, '.');
+        if (StringUtils.isBlank(mdElement)) {
+            return null;
+        }
+        MetadataField metadataField = metadataFieldService.findByString(context, mdElement, '.');
+        if (metadataField == null) {
+            throw new UnprocessableEntityException("Metadata field does not exist");
+        }
+        return metadataField;
     }
 
     /**

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataReplaceOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataReplaceOperation.java
@@ -80,7 +80,8 @@ public class DSpaceObjectMetadataReplaceOperation<R extends DSpaceObject> extend
                          MetadataValueRest metadataValue, String index, String propertyOfMd, String valueMdProperty) {
         // replace entire set of metadata
         if (metadataField == null) {
-            throw new UnprocessableEntityException("Metadata field does not exist");
+            this.replaceAllMetadata(context, dso, dsoService);
+            return;
         }
 
         // replace all metadata for existing key

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataReplaceOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataReplaceOperation.java
@@ -80,8 +80,7 @@ public class DSpaceObjectMetadataReplaceOperation<R extends DSpaceObject> extend
                          MetadataValueRest metadataValue, String index, String propertyOfMd, String valueMdProperty) {
         // replace entire set of metadata
         if (metadataField == null) {
-            this.replaceAllMetadata(context, dso, dsoService);
-            return;
+            throw new UnprocessableEntityException("Metadata field does not exist");
         }
 
         // replace all metadata for existing key

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/PatchMetadataIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/PatchMetadataIT.java
@@ -1429,7 +1429,7 @@ public class PatchMetadataIT extends AbstractEntityIntegrationTest {
     @Test
     public void replaceInvalidMetadataShouldFailTest() throws Exception {
         initSimplePublicationItem();
-        assertEquals(12, publicationItem.getMetadata().size());
+        assertEquals(11, publicationItem.getMetadata().size());
 
         String patchBody = getPatchContent(List.of(
             new ReplaceOperation("/metadata/dc.contributor.invalid/0", "some value")
@@ -1442,7 +1442,7 @@ public class PatchMetadataIT extends AbstractEntityIntegrationTest {
 
         publicationItem = context.reloadEntity(publicationItem);
 
-        assertEquals(12, publicationItem.getMetadata().size());
+        assertEquals(11, publicationItem.getMetadata().size());
         assertEquals(0,
             itemService.getMetadata(publicationItem, "dc", "contributor", "invalid", Item.ANY, false).size());
     }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/PatchMetadataIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/PatchMetadataIT.java
@@ -1426,6 +1426,27 @@ public class PatchMetadataIT extends AbstractEntityIntegrationTest {
         moveMetadataAuthorTest(moves, expectedOrder);
     }
 
+    @Test
+    public void replaceInvalidMetadataShouldFailTest() throws Exception {
+        initSimplePublicationItem();
+        assertEquals(12, publicationItem.getMetadata().size());
+
+        String patchBody = getPatchContent(List.of(
+            new ReplaceOperation("/metadata/dc.contributor.invalid/0", "some value")
+        ));
+        String token = getAuthToken(admin.getEmail(), password);
+        getClient(token).perform(patch("/api/core/items/" + publicationItem.getID())
+            .content(patchBody)
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isUnprocessableEntity());
+
+        publicationItem = context.reloadEntity(publicationItem);
+
+        assertEquals(12, publicationItem.getMetadata().size());
+        assertEquals(0,
+            itemService.getMetadata(publicationItem, "dc", "contributor", "invalid", Item.ANY, false).size());
+    }
+
     /**
      * This method moves an author (dc.contributor.author) within a workspace publication's "traditionalpageone"
      * section from position "from" to "path" using a PATCH request and verifies the order of the authors within the


### PR DESCRIPTION
## References
Fixes #10817 

## Description
`DSpaceObjectMetadataReplaceOperation` would clear all the metadata on an Item if submitted with an unknown metadata field and return 200. This is changed to return 422 now.

## Instructions for Reviewers

List of changes in this PR:
* `DSpaceObjectMetadataReplaceOperation#replace` updated to throw `UnprocessableEntityException` for unknown metadata fields
* A test case added to `PatchMetadataIT` 

As mentioned in the Issue, this can be tested my manually editing the patch request from the network tab. This will now return 422 and the original metadata will remain unchanged.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
