### PR TITLE
Change default behavior of BibTeX mapping for extractionstep

### DIFF
--- a/dspace-api/src/main/java/org/dspace/importer/external/bibtex/service/BibtexImportMetadataSourceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/bibtex/service/BibtexImportMetadataSourceServiceImpl.java
@@ -71,7 +71,7 @@ public class BibtexImportMetadataSourceServiceImpl extends AbstractPlainMetadata
                 keyValueItem.setValue(entry.getKey().getValue());
                 keyValues.add(keyValueItem);
                 PlainMetadataKeyValueItem typeItem = new PlainMetadataKeyValueItem();
-                typeItem.setKey("type");
+                typeItem.setKey("@type");
                 typeItem.setValue(entry.getValue().getType().getValue());
                 keyValues.add(typeItem);
                 if (entry.getValue().getFields() != null) {

--- a/dspace-api/src/main/java/org/dspace/importer/external/metadatamapping/contributor/FirstProductiveContributorMetadataContributor.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/metadatamapping/contributor/FirstProductiveContributorMetadataContributor.java
@@ -1,0 +1,43 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.importer.external.metadatamapping.contributor;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.dspace.importer.external.metadatamapping.MetadataFieldMapping;
+import org.dspace.importer.external.metadatamapping.MetadatumDTO;
+
+/**
+ * Apply the first {@link MetadataContributor} that contributes at least one {@link MetadatumDTO}.
+ */
+public class FirstProductiveContributorMetadataContributor<T> implements MetadataContributor<T> {
+    final private List<MetadataContributor<T>> contributors;
+    public FirstProductiveContributorMetadataContributor(List<MetadataContributor<T>> contributors) {
+        this.contributors = contributors;
+    }
+
+    @Override
+    public void setMetadataFieldMapping(MetadataFieldMapping<T, MetadataContributor<T>> rt) {
+        for (var contributor : this.contributors) {
+            contributor.setMetadataFieldMapping(rt);
+        }
+    }
+
+    @Override
+    public Collection<MetadatumDTO> contributeMetadata(T t) {
+        // Find the first subcontributor that produces anything, and pass on what it produces.
+        return contributors.stream()
+            .map(con -> con.contributeMetadata(t))
+            .filter(coll -> !coll.isEmpty())
+            .findFirst()
+
+            // If every subcontributor produces nothing, produce nothing.
+            .orElse(List.of());
+    }
+}

--- a/dspace/config/spring/api/bibtex-integration.xml
+++ b/dspace/config/spring/api/bibtex-integration.xml
@@ -55,9 +55,19 @@
         <property name="key" value="title" />
     </bean>
 
-    <bean id="bibtexTypeContrib" class="org.dspace.importer.external.metadatamapping.contributor.SimpleMetadataContributor">
-        <property name="field" ref="dcType"/>
-        <property name="key" value="type" />
+    <bean id="bibtexTypeContrib" class="org.dspace.importer.external.metadatamapping.contributor.FirstProductiveContributorMetadataContributor">
+        <constructor-arg name="contributors">
+            <util:list>
+                <bean class="org.dspace.importer.external.metadatamapping.contributor.SimpleMetadataContributor">
+                    <property name="field" ref="dcType"/>
+                    <property name="key" value="type"/>
+                </bean>
+                <bean class="org.dspace.importer.external.metadatamapping.contributor.SimpleMetadataContributor">
+                    <property name="field" ref="dcType"/>
+                    <property name="key" value="@type"/>
+                </bean>
+            </util:list>
+        </constructor-arg>
     </bean>
 
 </beans>


### PR DESCRIPTION
## References
https://github.com/DSpace/DSpace/issues/10982

## Description
Changes the default behavior of the extraction step wrt BibTeX import where the entry has both an "entry type" (for example, `@misc`) and an explicit `type` field (for example `type = {note}`).
Pre-PR, DSpace produces two `dc.type` values, one for each field.
Post-PR, DSpace by default produces only one `dc.type` value, preferring the explicit `type` field if it exists.

## Instructions for Reviewers
List of changes in this PR:
* In `BibtexImportMetadataSourceServiceImpl`, changed the key for the entry type from `type` to `@type`, making it distinct from the `type` field.
* Added a new `MetadataContributor` implementation `FirstProductiveContributorMetadataContributor`. It is constructed with a list of `MetadataContributor`s, and it applies the first one that produces at least one metadata value.
* Redefined `bibtexTypeContrib` bean in `bibtex-integration.xml` as a `FirstProductiveContributorMetadataContributor`, which first tries to apply the contributor for `type`, and only if that contributor produces nothing, tries `@type`.

### Testing instructions
Follow the bug reproduction steps in the linked issue. After the PR is applied, you should see only one `dc.type`, corresponding to the explicit `type` field if it exists, and otherwise using the entry type.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [X] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [X] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [X] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
