### PR TITLE
Store date of last filter-media run on Items to limit re-filtering unchanged Items (revised)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScript.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScript.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.app.mediafilter;
 
+import java.sql.SQLException;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -23,6 +24,9 @@ import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
+import org.dspace.content.MetadataField;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.MetadataFieldService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.core.SelfNamedPlugin;
@@ -63,6 +67,8 @@ public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfigura
     private String[] skipIds = null;
     private Map<String, List<String>> filterFormats = new HashMap<>();
     private LocalDate fromDate = null;
+
+    private MetadataFieldService metadataFieldService = ContentServiceFactory.getInstance().getMetadataFieldService();
 
     public MediaFilterScriptConfiguration getScriptConfiguration() {
         return new DSpace().getServiceManager()
@@ -231,6 +237,14 @@ public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfigura
 
         try {
             c = new Context();
+
+            MetadataField field = metadataFieldService.findByElement(c, "dspace", "filtermedia", "lastdate");
+            if (field == null) {
+                throw new SQLException("Cannot find field dspace.filtermedia.lastdate from the Metadata "
+                                          + "Registry. Please update the registry by running\n"
+                                          + "./dspace registry-loader -metadata ../config/registries/dspace-types.xml\n"
+                                          + "in the [dspace]/bin/ directory.");
+            }
 
             // have to be super-user to do the filtering
             c.turnOffAuthorisationSystem();

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScript.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScript.java
@@ -115,7 +115,8 @@ public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfigura
             skipIds = commandLine.getOptionValues('s');
         }
 
-        if (commandLine.hasOption('d')) {
+        // isForce overrides fromDate
+        if (!isForce && commandLine.hasOption('d')) {
             fromDate = LocalDate.parse(commandLine.getOptionValue('d'));
         }
 

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScript.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScript.java
@@ -8,7 +8,9 @@
 package org.dspace.app.mediafilter;
 
 import java.sql.SQLException;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -43,7 +45,7 @@ import org.dspace.utils.DSpace;
  * bitstreams to be processed, even if they have been before; -n noindex does not
  * recreate index after processing bitstreams; -i [identifier] limits processing
  * scope to a community, collection or item; -m [max] limits processing to a
- * maximum number of items; -fd [fromdate] takes only items starting from this date,
+ * maximum number of items; -d [fromdate] takes only items starting from this date,
  * filtering by last_modified in the item table.
  */
 public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfiguration> {
@@ -66,7 +68,7 @@ public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfigura
     private String[] filterNames;
     private String[] skipIds = null;
     private Map<String, List<String>> filterFormats = new HashMap<>();
-    private LocalDate fromDate = null;
+    private Instant fromDate = null;
 
     private MetadataFieldService metadataFieldService = ContentServiceFactory.getInstance().getMetadataFieldService();
 
@@ -123,7 +125,8 @@ public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfigura
 
         // isForce overrides fromDate
         if (!isForce && commandLine.hasOption('d')) {
-            fromDate = LocalDate.parse(commandLine.getOptionValue('d'));
+            fromDate = LocalDate.parse(commandLine.getOptionValue('d')).atStartOfDay(ZoneId.systemDefault())
+                                                                           .toInstant();
         }
 
 

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScript.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScript.java
@@ -128,6 +128,8 @@ public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfigura
         if (commandLine.hasOption('d')) {
             fromDate = LocalDate.parse(commandLine.getOptionValue('d')).atStartOfDay(ZoneId.systemDefault())
                                                                            .toInstant();
+        } else {
+            fromDate = null;
         }
 
         if (commandLine.hasOption('a')) {
@@ -157,11 +159,11 @@ public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfigura
         mediaFilterService.setQuiet(isQuiet);
         mediaFilterService.setVerbose(isVerbose);
         mediaFilterService.setMax2Process(max2Process);
+        mediaFilterService.setFromDate(fromDate);
         mediaFilterService.setUseAutoDate(useAutoDate);
 
         //initialize an array of our enabled filters
         List<FormatFilter> filterList = new ArrayList<>();
-
 
         //set up each filter
         for (int i = 0; i < filterNames.length; i++) {
@@ -244,11 +246,6 @@ public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfigura
         if (skipIds != null && skipIds.length > 0) {
             //save to a global skip list
             mediaFilterService.setSkipList(Arrays.asList(skipIds));
-        }
-
-        if (fromDate != null) {
-            mediaFilterService.setFromDate(fromDate);
-            handler.logInfo("Using manually supplied fromdate " + fromDate);
         }
 
         Context c = null;

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScript.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScript.java
@@ -39,15 +39,15 @@ import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.utils.DSpace;
 
 /**
- * MediaFilterManager is the class that invokes the media/format filters over the
+ * MediaFilterScript is the class that invokes the media/format filters over the
  * repository's content. A few command line flags affect the operation of the
- * MFM: -v verbose outputs all extracted text to STDOUT; -f force forces all
- * bitstreams to be processed, even if they have been before; -n noindex does not
- * recreate index after processing bitstreams; -i [identifier] limits processing
- * scope to a community, collection or item; -m [maximum] limits processing to a
- * maximum number of items; -d [fromdate] takes only items starting from this date,
- * filtering by last_modified in the item table; -a [autodate] will store the start
- * time of the run and use that as fromdate for the next run.
+ * script: -v verbose outputs all extracted text to STDOUT; -f force forces all
+ * bitstreams (accounting for date limit) to be processed, even if they have
+ * been before; -i [identifier] limits processing scope to a community,
+ * collection or item; -m [maximum] limits processing to a maximum number of items;
+ * -d [fromdate] takes only items starting from this date, filtering by last_modified
+ * in the item table; -a [autodate] will store the start time of the run and use
+ * that as fromdate for the next run.
  */
 public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfiguration> {
 
@@ -125,8 +125,7 @@ public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfigura
             skipIds = commandLine.getOptionValues('s');
         }
 
-        // isForce overrides fromDate
-        if (!isForce && commandLine.hasOption('d')) {
+        if (commandLine.hasOption('d')) {
             fromDate = LocalDate.parse(commandLine.getOptionValue('d')).atStartOfDay(ZoneId.systemDefault())
                                                                            .toInstant();
         }

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScript.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScript.java
@@ -44,9 +44,10 @@ import org.dspace.utils.DSpace;
  * MFM: -v verbose outputs all extracted text to STDOUT; -f force forces all
  * bitstreams to be processed, even if they have been before; -n noindex does not
  * recreate index after processing bitstreams; -i [identifier] limits processing
- * scope to a community, collection or item; -m [max] limits processing to a
+ * scope to a community, collection or item; -m [maximum] limits processing to a
  * maximum number of items; -d [fromdate] takes only items starting from this date,
- * filtering by last_modified in the item table.
+ * filtering by last_modified in the item table; -a [autodate] will store the start
+ * time of the run and use that as fromdate for the next run.
  */
 public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfiguration> {
 
@@ -69,6 +70,7 @@ public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfigura
     private String[] skipIds = null;
     private Map<String, List<String>> filterFormats = new HashMap<>();
     private Instant fromDate = null;
+    private boolean useAutoDate = false;
 
     private MetadataFieldService metadataFieldService = ContentServiceFactory.getInstance().getMetadataFieldService();
 
@@ -129,12 +131,24 @@ public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfigura
                                                                            .toInstant();
         }
 
-
+        if (commandLine.hasOption('a')) {
+            useAutoDate = true;
+        }
     }
 
     public void internalRun() throws Exception {
         if (help) {
             printHelp();
+            return;
+        }
+
+        if (useAutoDate && max2Process != Integer.MAX_VALUE) {
+            handler.logWarning("WARNING: using --maximum option with --autodate may result to saved date even though " +
+                                "not all items have been processed. Continuing anyway.");
+        }
+
+        if (useAutoDate && identifier != null) {
+            handler.logError("--identifier option cannot be used with --autodate");
             return;
         }
 
@@ -144,6 +158,7 @@ public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfigura
         mediaFilterService.setQuiet(isQuiet);
         mediaFilterService.setVerbose(isVerbose);
         mediaFilterService.setMax2Process(max2Process);
+        mediaFilterService.setUseAutoDate(useAutoDate);
 
         //initialize an array of our enabled filters
         List<FormatFilter> filterList = new ArrayList<>();
@@ -234,6 +249,7 @@ public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfigura
 
         if (fromDate != null) {
             mediaFilterService.setFromDate(fromDate);
+            handler.logInfo("Using manually supplied fromdate " + fromDate);
         }
 
         Context c = null;
@@ -241,12 +257,14 @@ public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfigura
         try {
             c = new Context();
 
-            MetadataField field = metadataFieldService.findByElement(c, "dspace", "filtermedia", "lastdate");
-            if (field == null) {
-                throw new SQLException("Cannot find field dspace.filtermedia.lastdate from the Metadata "
-                                          + "Registry. Please update the registry by running\n"
-                                          + "./dspace registry-loader -metadata ../config/registries/dspace-types.xml\n"
-                                          + "in the [dspace]/bin/ directory.");
+            if (useAutoDate) {
+                MetadataField field = metadataFieldService.findByElement(c, "dspace", "filtermedia", "lastdate");
+                if (field == null) {
+                    throw new SQLException("Cannot find field dspace.filtermedia.lastdate from the Metadata "
+                                        + "Registry. Please update the registry by running\n"
+                                        + "./dspace registry-loader -metadata ../config/registries/dspace-types.xml\n"
+                                        + "in the [dspace]/bin/ directory.");
+                }
             }
 
             // have to be super-user to do the filtering

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScriptConfiguration.java
@@ -32,7 +32,7 @@ public class MediaFilterScriptConfiguration<T extends MediaFilterScript> extends
         Options options = new Options();
         options.addOption("v", "verbose", false, "print all extracted text and other details to STDOUT");
         options.addOption("q", "quiet", false, "do not print anything except in the event of errors.");
-        options.addOption("f", "force", false, "force all bitstreams to be processed");
+        options.addOption("f", "force", false, "force all bitstreams to be processed (overrides fromdate)");
         options.addOption("i", "identifier", true,
             "ONLY process bitstreams belonging to the provided handle identifier");
         options.addOption("m", "maximum", true, "process no more than maximum items");

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScriptConfiguration.java
@@ -30,13 +30,14 @@ public class MediaFilterScriptConfiguration<T extends MediaFilterScript> extends
     @Override
     public Options getOptions() {
         Options options = new Options();
-        options.addOption("v", "verbose", false, "print all extracted text and other details to STDOUT");
-        options.addOption("q", "quiet", false, "do not print anything except in the event of errors.");
-        options.addOption("f", "force", false, "force all bitstreams to be processed (overrides fromdate)");
+        options.addOption("v", "verbose", false, "Print all extracted text and other details to STDOUT");
+        options.addOption("q", "quiet", false, "Do not print anything except in the event of errors");
+        options.addOption("f", "force", false, "Force all bitstreams (can be restricted with -d or -i) " +
+                                                                    "to be processed");
         options.addOption("i", "identifier", true,
             "ONLY process bitstreams belonging to the provided handle identifier");
-        options.addOption("m", "maximum", true, "process no more than maximum items");
-        options.addOption("h", "help", false, "help");
+        options.addOption("m", "maximum", true, "Process no more than maximum items");
+        options.addOption("h", "help", false, "Help");
 
         Option pluginOption = Option.builder("p")
                                     .longOpt("plugins")
@@ -47,18 +48,16 @@ public class MediaFilterScriptConfiguration<T extends MediaFilterScript> extends
                                             "ONLY run the specified Media Filter plugin(s)\n" +
                                                     "listed from '" + MEDIA_FILTER_PLUGINS_KEY + "' in dspace.cfg.\n" +
                                                     "Separate multiple with a comma (,)\n" +
-                                                    "(e.g. MediaFilterManager -p \n\"Word Text Extractor\",\"PDF Text" +
+                                                    "(e.g. filter-media -p \n\"Word Text Extractor\",\"PDF Text" +
                                                     " Extractor\")")
                                     .build();
         options.addOption(pluginOption);
 
-        options.addOption("d", "fromdate", true, "Process only items modified after specified date (YYYY-MM-DD)\n" +
-                                                    "Can be combined with -i to restrict run a community/collection.");
+        options.addOption("d", "fromdate", true, "Process only items modified after specified date (YYYY-MM-DD)");
 
         options.addOption("a", "autodate", false, "Process items updated after the last --autodate -based site-wide " +
-                                                    "run (stores the time at the start of the run regardless of the " +
-                                                    "filters used)\n Can be combined with -d to set a custom date " +
-                                                    "for processing or with -f to store the date after full run.");
+                                    "run (stores the time at the start of the run regardless of the filters used),\n" +
+                                    "can be combined with -d to set a custom date");
 
         Option skipOption = Option.builder("s")
                                   .longOpt("skip")
@@ -68,7 +67,7 @@ public class MediaFilterScriptConfiguration<T extends MediaFilterScript> extends
                                   .desc(
                                           "SKIP the bitstreams belonging to identifier\n" +
                                                   "Separate multiple identifiers with a comma (,)\n" +
-                                                  "(e.g. MediaFilterManager -s \n 123456789/34,123456789/323)")
+                                                  "(e.g. filter-media -s \n 123456789/34,123456789/323)")
                                   .build();
         options.addOption(skipOption);
 

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScriptConfiguration.java
@@ -52,7 +52,13 @@ public class MediaFilterScriptConfiguration<T extends MediaFilterScript> extends
                                     .build();
         options.addOption(pluginOption);
 
-        options.addOption("d", "fromdate", true, "Process only item from specified last modified date");
+        options.addOption("d", "fromdate", true, "Process only items modified after specified date (YYYY-MM-DD)\n" +
+                                                    "Can be combined with -i to restrict run a community/collection.");
+
+        options.addOption("a", "autodate", false, "Process items updated after the last --autodate -based site-wide " +
+                                                    "run (stores the time at the start of the run regardless of the " +
+                                                    "filters used)\n Can be combined with -d to set a custom date " +
+                                                    "for processing or with -f to store the date after full run.");
 
         Option skipOption = Option.builder("s")
                                   .longOpt("skip")

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
@@ -37,6 +37,7 @@ import org.dspace.content.service.BundleService;
 import org.dspace.content.service.CollectionService;
 import org.dspace.content.service.CommunityService;
 import org.dspace.content.service.ItemService;
+import org.dspace.content.service.SiteService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.core.SelfNamedPlugin;
@@ -74,6 +75,8 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
     protected GroupService groupService;
     @Autowired(required = true)
     protected ItemService itemService;
+    @Autowired(required = true)
+    protected SiteService siteService;
     @Autowired(required = true)
     protected ConfigurationService configurationService;
 
@@ -116,6 +119,14 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
 
     @Override
     public void applyFiltersAllItems(Context context) throws Exception {
+        boolean storeLastDate = false;
+        if (fromDate == null) {
+            storeLastDate = true;
+            String lastDate = siteService.getMetadata(siteService.findSite(context), "dspace.filtermedia.lastdate");
+            if (lastDate != null) {
+                fromDate = new DCDate(lastDate).toDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+            }
+        }
         if (skipList != null) {
             //if a skip-list exists, we need to filter community-by-community
             //so we can respect what is in the skip-list
@@ -139,6 +150,14 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
             while (itemIterator.hasNext() && processed < max2Process) {
                 applyFiltersItem(context, itemIterator.next());
             }
+        }
+        if (storeLastDate) {
+            siteService.clearMetadata(context, siteService.findSite(context),
+                "dspace", "filtermedia", "lastdate", Item.ANY);
+            siteService.addMetadata(context, siteService.findSite(context),
+                "dspace", "filtermedia", "lastdate", null,
+                DCDate.getCurrent().toString());
+            siteService.update(context, siteService.findSite(context));
         }
     }
 
@@ -172,7 +191,16 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
         collection = context.reloadEntity(collection);
         //only apply filters if collection not in skip-list
         if (!inSkipList(collection.getHandle())) {
-            Iterator<Item> itemIterator = itemService.findAllByCollection(context, collection);
+            Iterator<Item> itemIterator;
+            if (fromDate != null) {
+                itemIterator = itemService.findByCollectionLastModifiedSince(
+                    context,
+                    collection,
+                    fromDate.atStartOfDay(ZoneId.systemDefault()).toInstant()
+                );
+            } else {
+                itemIterator = itemService.findAllByCollection(context, collection);
+            }
             while (itemIterator.hasNext() && processed < max2Process) {
                 applyFiltersItem(context, itemIterator.next());
             }

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
@@ -667,11 +667,18 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
     @Override
     public void setFromDate(Instant fromDate) {
         this.fromDate = fromDate;
+        if (fromDate != null) {
+            logInfo("Using manually supplied fromdate " + fromDate);
+        }
     }
+
 
     @Override
     public void setUseAutoDate(boolean useAutoDate) {
         this.useAutoDate = useAutoDate;
+        if (useAutoDate) {
+            logInfo("Stored lastdate functionality activated.");
+        }
     }
 
 }

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
@@ -30,6 +30,7 @@ import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.DCDate;
 import org.dspace.content.Item;
+import org.dspace.content.Site;
 import org.dspace.content.service.BitstreamFormatService;
 import org.dspace.content.service.BitstreamService;
 import org.dspace.content.service.BundleService;
@@ -125,11 +126,11 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
             // dspace.filtermedia.lastdate is saved as datetime. If new items are added while running
             // the script, storing time at the start of script to ensure that these items are processed
             // in the next run.
-            timeToStore = DCDate.getCurrent().toString();
+            timeToStore = Instant.now().toString();
             String lastDate = siteService.getMetadata(siteService.findSite(context), "dspace.filtermedia.lastdate");
             logInfo("Last date retrieved from db for media filter processing: " + lastDate);
-            if ((lastDate != null) && (isForce == false)) {
-                fromDate = new DCDate(lastDate).toDate().toInstant(); //.atZone(ZoneId.systemDefault()).toLocalDate();
+            if ((lastDate != null) && (!isForce)) {
+                fromDate = Instant.parse(lastDate);
             }
         }
         if (skipList != null) {
@@ -158,13 +159,14 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
             }
         }
         if (storeLastDate) {
+            Site site = siteService.findSite(context);
             logInfo("Setting new last date to db for media filter processing: " + timeToStore);
-            siteService.clearMetadata(context, siteService.findSite(context),
+            siteService.clearMetadata(context, site,
                 "dspace", "filtermedia", "lastdate", Item.ANY);
-            siteService.addMetadata(context, siteService.findSite(context),
+            siteService.addMetadata(context, site,
                 "dspace", "filtermedia", "lastdate", null,
                 timeToStore);
-            siteService.update(context, siteService.findSite(context));
+            siteService.update(context, site);
         }
     }
 

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
@@ -123,7 +123,7 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
         if (fromDate == null) {
             storeLastDate = true;
             String lastDate = siteService.getMetadata(siteService.findSite(context), "dspace.filtermedia.lastdate");
-            if (lastDate != null) {
+            if ((lastDate != null) && (isForce == false)) {
                 fromDate = new DCDate(lastDate).toDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
             }
         }

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
@@ -100,6 +100,7 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
     protected boolean isQuiet = false;
     protected boolean isForce = false; // default to not forced
     protected Instant fromDate = null;
+    protected boolean useAutoDate = false;
 
     protected MediaFilterServiceImpl() {
 
@@ -121,28 +122,31 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
     public void applyFiltersAllItems(Context context) throws Exception {
         boolean storeLastDate = false;
         String timeToStore = null;
-        if (fromDate == null) {
+        if (useAutoDate) {
             storeLastDate = true;
             // dspace.filtermedia.lastdate is saved as datetime. If new items are added while running
             // the script, storing time at the start of script to ensure that these items are processed
             // in the next run.
             timeToStore = Instant.now().toString();
+        }
+        if (fromDate == null && useAutoDate) {
             String lastDate = siteService.getMetadata(siteService.findSite(context), "dspace.filtermedia.lastdate");
-            logInfo("Last date retrieved from db for media filter processing: " + lastDate);
             if ((lastDate != null) && (!isForce)) {
+                logInfo("Using fromdate " + lastDate + " retrieved from db");
                 fromDate = Instant.parse(lastDate);
             }
         }
         if (skipList != null) {
             //if a skip-list exists, we need to filter community-by-community
             //so we can respect what is in the skip-list
+            //(handles also fromDate filtering if the option is present)
             List<Community> topLevelCommunities = communityService.findAllTop(context);
 
             for (Community topLevelCommunity : topLevelCommunities) {
                 applyFiltersCommunity(context, topLevelCommunity);
             }
         } else if (fromDate != null) {
-            logInfo("Using fromDate " + fromDate);
+            //no skip-list, search all items based on last modified date
             Iterator<Item> itemIterator =
                     itemService.findByLastModifiedSince(
                             context,
@@ -664,4 +668,10 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
     public void setFromDate(Instant fromDate) {
         this.fromDate = fromDate;
     }
+
+    @Override
+    public void setUseAutoDate(boolean useAutoDate) {
+        this.useAutoDate = useAutoDate;
+    }
+
 }

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
@@ -9,8 +9,7 @@ package org.dspace.app.mediafilter;
 
 import java.io.InputStream;
 import java.sql.SQLException;
-import java.time.LocalDate;
-import java.time.ZoneId;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -99,7 +98,7 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
     protected boolean isVerbose = false;
     protected boolean isQuiet = false;
     protected boolean isForce = false; // default to not forced
-    protected LocalDate fromDate = null;
+    protected Instant fromDate = null;
 
     protected MediaFilterServiceImpl() {
 
@@ -120,11 +119,17 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
     @Override
     public void applyFiltersAllItems(Context context) throws Exception {
         boolean storeLastDate = false;
+        String timeToStore = null;
         if (fromDate == null) {
             storeLastDate = true;
+            // dspace.filtermedia.lastdate is saved as datetime. If new items are added while running
+            // the script, storing time at the start of script to ensure that these items are processed
+            // in the next run.
+            timeToStore = DCDate.getCurrent().toString();
             String lastDate = siteService.getMetadata(siteService.findSite(context), "dspace.filtermedia.lastdate");
+            logInfo("Last date retrieved from db for media filter processing: " + lastDate);
             if ((lastDate != null) && (isForce == false)) {
-                fromDate = new DCDate(lastDate).toDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+                fromDate = new DCDate(lastDate).toDate().toInstant(); //.atZone(ZoneId.systemDefault()).toLocalDate();
             }
         }
         if (skipList != null) {
@@ -136,10 +141,11 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
                 applyFiltersCommunity(context, topLevelCommunity);
             }
         } else if (fromDate != null) {
+            logInfo("Using fromDate " + fromDate);
             Iterator<Item> itemIterator =
                     itemService.findByLastModifiedSince(
                             context,
-                            fromDate.atStartOfDay(ZoneId.systemDefault()).toInstant()
+                            fromDate
                     );
             while (itemIterator.hasNext() && processed < max2Process) {
                 applyFiltersItem(context, itemIterator.next());
@@ -152,11 +158,12 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
             }
         }
         if (storeLastDate) {
+            logInfo("Setting new last date to db for media filter processing: " + timeToStore);
             siteService.clearMetadata(context, siteService.findSite(context),
                 "dspace", "filtermedia", "lastdate", Item.ANY);
             siteService.addMetadata(context, siteService.findSite(context),
                 "dspace", "filtermedia", "lastdate", null,
-                DCDate.getCurrent().toString());
+                timeToStore);
             siteService.update(context, siteService.findSite(context));
         }
     }
@@ -196,7 +203,7 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
                 itemIterator = itemService.findByCollectionLastModifiedSince(
                     context,
                     collection,
-                    fromDate.atStartOfDay(ZoneId.systemDefault()).toInstant()
+                    fromDate
                 );
             } else {
                 itemIterator = itemService.findAllByCollection(context, collection);
@@ -652,7 +659,7 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
     }
 
     @Override
-    public void setFromDate(LocalDate fromDate) {
+    public void setFromDate(Instant fromDate) {
         this.fromDate = fromDate;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
@@ -131,7 +131,7 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
         }
         if (fromDate == null && useAutoDate) {
             String lastDate = siteService.getMetadata(siteService.findSite(context), "dspace.filtermedia.lastdate");
-            if ((lastDate != null) && (!isForce)) {
+            if (lastDate != null) {
                 logInfo("Using fromdate " + lastDate + " retrieved from db");
                 fromDate = Instant.parse(lastDate);
             }

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/service/MediaFilterService.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/service/MediaFilterService.java
@@ -171,4 +171,12 @@ public interface MediaFilterService {
      * @param fromDate the datetime from which to filter items
     */
     public void setFromDate(Instant fromDate);
+
+    /**
+     * If true, the MediaFilter will store the start time (site metadata dspace.filtermedia.lastdate)
+     * when the script is run and use that as the fromDate for filtering items in the next run.
+     * This allows running the script multiple times a day, restricting the run only to new or modified items.
+     * @param useAutoDate true to use autoDate (default is false)
+    */
+    public void setUseAutoDate(boolean useAutoDate);
 }

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/service/MediaFilterService.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/service/MediaFilterService.java
@@ -8,7 +8,7 @@
 package org.dspace.app.mediafilter.service;
 
 import java.sql.SQLException;
-import java.time.LocalDate;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
@@ -166,5 +166,9 @@ public interface MediaFilterService {
      */
     public void setLogHandler(DSpaceRunnableHandler handler);
 
-    public void setFromDate(LocalDate fromDate);
+    /** 
+     * Used to set start date (or time, if no specific date of force parameter is given) for filtering items
+     * @param fromDate the datetime from which to filter items
+    */
+    public void setFromDate(Instant fromDate);
 }

--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -1823,6 +1823,12 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
     }
 
     @Override
+    public Iterator<Item> findByCollectionLastModifiedSince(Context context, Collection collection, Instant last)
+        throws SQLException {
+        return itemDAO.findAllByCollectionLastModifiedSince(context, collection, last);
+    }
+
+    @Override
     public int countTotal(Context context) throws SQLException {
         return itemDAO.countRows(context);
     }

--- a/dspace-api/src/main/java/org/dspace/content/dao/ItemDAO.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/ItemDAO.java
@@ -179,6 +179,18 @@ public interface ItemDAO extends DSpaceObjectLegacySupportDAO<Item> {
 
     Iterator<Item> findAllByCollection(Context context, Collection collection) throws SQLException;
 
+    /**
+     * Find all Items modified in a collection since a Date.
+     *
+     * @param context Context
+     * @param collection Collection to search in
+     * @param last   Earliest interesting last-modified date.
+     * @return iterator over items
+     * @throws SQLException if database error
+     */
+    Iterator<Item> findAllByCollectionLastModifiedSince(Context context, Collection collection, Instant last)
+        throws SQLException;
+
     Iterator<Item> findAllByCollection(Context context, Collection collection, Integer limit, Integer offset)
         throws SQLException;
 

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/ItemDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/ItemDAOImpl.java
@@ -502,9 +502,34 @@ public class ItemDAOImpl extends AbstractHibernateDSODAO<Item> implements ItemDA
     @Override
     public Iterator<Item> findByLastModifiedSince(Context context, Instant since)
         throws SQLException {
-        Query query = createQuery(context,
-                "SELECT i.id FROM Item i WHERE lastModified > :last_modified ORDER BY id");
-        query.setParameter("last_modified", since);
+        CriteriaBuilder criteriaBuilder = getCriteriaBuilder(context);
+        CriteriaQuery<UUID> criteriaQuery = criteriaBuilder.createQuery(UUID.class);
+        Root<Item> itemRoot = criteriaQuery.from(Item.class);
+        criteriaQuery.select(itemRoot.get(Item_.id));
+        criteriaQuery.where(criteriaBuilder.greaterThan(itemRoot.get(Item_.lastModified), since));
+        criteriaQuery.orderBy(criteriaBuilder.asc(itemRoot.get((Item_.id))));
+
+        // Transform into a query object to execute
+        Query query = createQuery(context, criteriaQuery);
+        @SuppressWarnings("unchecked")
+        List<UUID> uuids = query.getResultList();
+        return new UUIDIterator<Item>(context, uuids, Item.class, this);
+    }
+
+    @Override
+    public Iterator<Item> findAllByCollectionLastModifiedSince(Context context, Collection collection,
+                                                               Instant last) throws SQLException {
+        // Select UUID of all items which have this "collection" in their list of collections
+        CriteriaBuilder criteriaBuilder = getCriteriaBuilder(context);
+        CriteriaQuery<UUID> criteriaQuery = criteriaBuilder.createQuery(UUID.class);
+        Root<Item> itemRoot = criteriaQuery.from(Item.class);
+        criteriaQuery.select(itemRoot.get(Item_.id));
+        criteriaQuery.where(criteriaBuilder.isMember(collection, itemRoot.get(Item_.collections)));
+        criteriaQuery.where(criteriaBuilder.greaterThan(itemRoot.get(Item_.lastModified), last));
+        criteriaQuery.orderBy(criteriaBuilder.asc(itemRoot.get((Item_.id))));
+
+        // Transform into a query object to execute
+        Query query = createQuery(context, criteriaQuery);
         @SuppressWarnings("unchecked")
         List<UUID> uuids = query.getResultList();
         return new UUIDIterator<Item>(context, uuids, Item.class, this);

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/ItemDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/ItemDAOImpl.java
@@ -525,15 +525,17 @@ public class ItemDAOImpl extends AbstractHibernateDSODAO<Item> implements ItemDA
         CriteriaQuery<UUID> criteriaQuery = criteriaBuilder.createQuery(UUID.class);
         Root<Item> itemRoot = criteriaQuery.from(Item.class);
         criteriaQuery.select(itemRoot.get(Item_.id));
-        criteriaQuery.where(criteriaBuilder.isMember(collection, itemRoot.get(Item_.collections)));
-        criteriaQuery.where(criteriaBuilder.greaterThan(itemRoot.get(Item_.lastModified), last));
+        criteriaQuery.where(criteriaBuilder.and(
+            criteriaBuilder.isMember(collection, itemRoot.get(Item_.collections)),
+            criteriaBuilder.greaterThan(itemRoot.get(Item_.lastModified), last)));
         criteriaQuery.orderBy(criteriaBuilder.asc(itemRoot.get((Item_.id))));
 
         // Transform into a query object to execute
         Query query = createQuery(context, criteriaQuery);
         @SuppressWarnings("unchecked")
         List<UUID> uuids = query.getResultList();
-        log.info("Retrieved " + uuids.size() + " items from collection " + collection.getID() + " modified since " + last);
+        log.info("Retrieved " + uuids.size() + " items from collection " + collection.getID() +
+                 " modified since " + last);
         return new UUIDIterator<Item>(context, uuids, Item.class, this);
     }
 

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/ItemDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/ItemDAOImpl.java
@@ -513,6 +513,7 @@ public class ItemDAOImpl extends AbstractHibernateDSODAO<Item> implements ItemDA
         Query query = createQuery(context, criteriaQuery);
         @SuppressWarnings("unchecked")
         List<UUID> uuids = query.getResultList();
+        log.info("Retrieved " + uuids.size() + " items modified since " + since);
         return new UUIDIterator<Item>(context, uuids, Item.class, this);
     }
 
@@ -532,6 +533,7 @@ public class ItemDAOImpl extends AbstractHibernateDSODAO<Item> implements ItemDA
         Query query = createQuery(context, criteriaQuery);
         @SuppressWarnings("unchecked")
         List<UUID> uuids = query.getResultList();
+        log.info("Retrieved " + uuids.size() + " items from collection " + collection.getID() + " modified since " + last);
         return new UUIDIterator<Item>(context, uuids, Item.class, this);
     }
 

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/ItemDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/ItemDAOImpl.java
@@ -502,18 +502,12 @@ public class ItemDAOImpl extends AbstractHibernateDSODAO<Item> implements ItemDA
     @Override
     public Iterator<Item> findByLastModifiedSince(Context context, Instant since)
         throws SQLException {
-        CriteriaBuilder criteriaBuilder = getCriteriaBuilder(context);
-        CriteriaQuery<UUID> criteriaQuery = criteriaBuilder.createQuery(UUID.class);
-        Root<Item> itemRoot = criteriaQuery.from(Item.class);
-        criteriaQuery.select(itemRoot.get(Item_.id));
-        criteriaQuery.where(criteriaBuilder.greaterThan(itemRoot.get(Item_.lastModified), since));
-        criteriaQuery.orderBy(criteriaBuilder.asc(itemRoot.get((Item_.id))));
-
-        // Transform into a query object to execute
-        Query query = createQuery(context, criteriaQuery);
+        Query query = createQuery(context,
+                "SELECT i.id FROM Item i WHERE lastModified > :last_modified ORDER BY id");
+        query.setParameter("last_modified", since);
         @SuppressWarnings("unchecked")
         List<UUID> uuids = query.getResultList();
-        log.info("Retrieved " + uuids.size() + " items modified since " + since);
+        log.debug("Retrieved " + uuids.size() + " items modified since " + since);
         return new UUIDIterator<Item>(context, uuids, Item.class, this);
     }
 
@@ -534,7 +528,7 @@ public class ItemDAOImpl extends AbstractHibernateDSODAO<Item> implements ItemDA
         Query query = createQuery(context, criteriaQuery);
         @SuppressWarnings("unchecked")
         List<UUID> uuids = query.getResultList();
-        log.info("Retrieved " + uuids.size() + " items from collection " + collection.getID() +
+        log.debug("Retrieved " + uuids.size() + " items from collection " + collection.getID() +
                  " modified since " + last);
         return new UUIDIterator<Item>(context, uuids, Item.class, this);
     }

--- a/dspace-api/src/main/java/org/dspace/content/service/ItemService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/ItemService.java
@@ -881,6 +881,18 @@ public interface ItemService
         throws SQLException;
 
     /**
+     * Get all the archived items in this collection, last modified since a given Date. The order is indeterminate.
+     *
+     * @param context    DSpace context object
+     * @param collection Collection (parent)
+     * @param last       Earliest interesting last-modified date.
+     * @return an iterator over the items in the collection.
+     * @throws SQLException if database error
+     */
+    Iterator<Item> findByCollectionLastModifiedSince(Context context, Collection collection, Instant last)
+        throws SQLException;
+
+    /**
      * counts items in the given community
      *
      * @param context   DSpace context object

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexEventConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexEventConsumer.java
@@ -144,22 +144,26 @@ public class IndexEventConsumer implements Consumer {
                                  + ", perhaps it has been deleted.");
                     }
                 } else {
-                    log.debug("consume() adding event to update queue: " + event.toString());
-                    if (event.getSubjectType() == Constants.ITEM) {
-                    // if it is an item we cannot know about its previous state, so it could be a
-                    // workspaceitem that has been deposited right now or an approved/reject
-                    // workflowitem.
-                    // As the workflow is not necessary enabled it can happen than a workspaceitem
-                    // became directly an item without giving us the chance to retrieve a
-                    // workflowitem... so we need to force the unindex of all the related data
-                    // before to index it again to be sure to don't leave any zombie in solr
-                        IndexFactory indexableObjectService = IndexObjectFactoryFactory.getInstance()
-                                              .getIndexFactoryByType(Constants.typeText[event.getSubjectType()]);
-                        String detail = indexableObjectService.getType() + "-" + event.getSubjectID().toString();
-                        uniqueIdsToDelete.add(detail);
-                    }
+                    if (event.getSubjectType() == Constants.SITE) {
+                        log.debug(event.getEventTypeAsString() + " event triggered for Site object. Skipping it.");
+                    } else {
+                        log.debug("consume() adding event to update queue: " + event.toString());
+                        if (event.getSubjectType() == Constants.ITEM) {
+                        // if it is an item we cannot know about its previous state, so it could be a
+                        // workspaceitem that has been deposited right now or an approved/reject
+                        // workflowitem.
+                        // As the workflow is not necessary enabled it can happen than a workspaceitem
+                        // became directly an item without giving us the chance to retrieve a
+                        // workflowitem... so we need to force the unindex of all the related data
+                        // before to index it again to be sure to don't leave any zombie in solr
+                            IndexFactory indexableObjectService = IndexObjectFactoryFactory.getInstance()
+                                                  .getIndexFactoryByType(Constants.typeText[event.getSubjectType()]);
+                            String detail = indexableObjectService.getType() + "-" + event.getSubjectID().toString();
+                            uniqueIdsToDelete.add(detail);
+                        }
 
-                    objectsToUpdate.addAll(indexObjectServiceFactory.getIndexableObjects(ctx, subject));
+                        objectsToUpdate.addAll(indexObjectServiceFactory.getIndexableObjects(ctx, subject));
+                    }
                 }
                 break;
 

--- a/dspace-api/src/test/java/org/dspace/app/mediafilter/MediaFilterIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/mediafilter/MediaFilterIT.java
@@ -7,12 +7,19 @@
  */
 package org.dspace.app.mediafilter;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
@@ -33,6 +40,7 @@ import org.dspace.content.Item;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.BitstreamService;
 import org.dspace.content.service.ItemService;
+import org.dspace.content.service.SiteService;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -45,6 +53,7 @@ public class MediaFilterIT extends AbstractIntegrationTestWithDatabase {
 
     private ItemService itemService = ContentServiceFactory.getInstance().getItemService();
     private BitstreamService bitstreamService = ContentServiceFactory.getInstance().getBitstreamService();
+    private SiteService siteService = ContentServiceFactory.getInstance().getSiteService();
     protected Community topComm1;
     protected Community topComm2;
     protected Community childComm1_1;
@@ -187,6 +196,77 @@ public class MediaFilterIT extends AbstractIntegrationTestWithDatabase {
         checkItemHasBeenProcessed(item1_2_2_b);
     }
 
+    @Test
+    public void mediaFilterScriptFromDateTest() throws Exception {
+
+        // setting earlier last modified so date-based filtering will not be applied here
+        Instant oldModifiedTime = Instant.now().minus(2, ChronoUnit.DAYS);
+        item1_1_a.setLastModified(oldModifiedTime);
+        performMediaFilterScript(null, new String[] {"-d",LocalDate.now().toString()}); // setting to start of day
+        checkItemHasBeenNotProcessed(item1_1_a);
+        checkItemHasBeenProcessed(item1_1_b);
+
+        String lastDate = siteService.getMetadata(siteService.findSite(context), "dspace.filtermedia.lastdate");
+        assertTrue("Last date should be null before first autodate run", lastDate == null);
+
+        // should not update, because -a option cannot be used with -i
+        performMediaFilterScript(col1_1, new String[] {"-a"});
+        checkItemHasBeenNotProcessed(item1_1_a);
+        assertEquals("The item " + item1_1_a.getName() + " should NOT have been modified",
+            oldModifiedTime.truncatedTo(ChronoUnit.MILLIS), item1_1_a.getLastModified().truncatedTo(ChronoUnit.MILLIS));
+
+        lastDate = siteService.getMetadata(siteService.findSite(context), "dspace.filtermedia.lastdate");
+        assertTrue("Last date should still be null", lastDate == null);
+
+        // should work with full run, as well as update the last modified date
+        performMediaFilterScript(null, new String[] {"-a"});
+
+        lastDate = siteService.getMetadata(siteService.findSite(context), "dspace.filtermedia.lastdate");
+        Instant lastInstant = Instant.parse(lastDate);
+        assertTrue("Last date should be set after autodate run", lastInstant != null);
+
+        // all items (esp. item1_1_a) should have been processed by now
+        Item[] items = {item1_1_a,item1_1_b,item1_2_a,item1_2_b,item1_1_1_a,
+            item1_1_1_b,item1_1_2_a,item1_1_2_b,item1_2_1_a,item1_2_1_b,
+            item1_2_2_a,item1_2_2_b,item2_1_a,item2_1_b};
+        Instant latestModified = item1_1_a.getLastModified();
+        for (Item i: items) {
+            checkItemHasBeenProcessed(i);
+            if (i.getLastModified().isAfter(latestModified)) {
+                latestModified = i.getLastModified();
+            }
+        }
+        assertNotEquals("The item " + item1_1_a.getName() + " should have been modified",
+            oldModifiedTime.truncatedTo(ChronoUnit.MILLIS), item1_1_a.getLastModified().truncatedTo(ChronoUnit.MILLIS));
+        // TODO: check site metadata
+
+        context.turnOffAuthorisationSystem();
+        // add new item with modified date, to verify that it will be skipped in next run
+        Item item2_1_c = ItemBuilder.createItem(context, col2_1).withTitle("Item 2_1_c").
+            withIssueDate("2017-10-17").build();
+        addBitstream(item2_1_c, "test.txt");
+        item2_1_c.setLastModified(oldModifiedTime);
+        context.restoreAuthSystemState();
+
+        // new run: should not update items anymore, including item2_1_c based on modification date
+        performMediaFilterScript(null, new String[] {"-a"});
+        item2_1_c = context.reloadEntity(item2_1_c); // needs to reloaded separately because created in this method
+
+        lastDate = siteService.getMetadata(siteService.findSite(context), "dspace.filtermedia.lastdate");
+        assertTrue("Last date should be modified after autodate run", lastInstant.isBefore(Instant.parse(lastDate)));
+
+        for (Item i: items) {
+            assertFalse("Item should not have been modified on second run",i.getLastModified().isAfter(latestModified));
+        }
+        checkItemHasBeenNotProcessed(item2_1_c);
+
+        // finally, perform a full run without -a to verify that item2_1_c will be processed as well
+        performMediaFilterScript(null);
+        item2_1_c = context.reloadEntity(item2_1_c);
+
+        checkItemHasBeenProcessed(item2_1_c);
+    }
+
     private void checkItemHasBeenNotProcessed(Item item) throws IOException, SQLException, AuthorizeException {
         List<Bundle> textBundles = item.getBundles("TEXT");
         assertTrue("The item " + item.getName() + " should NOT have the TEXT bundle", textBundles.size() == 0);
@@ -217,11 +297,22 @@ public class MediaFilterIT extends AbstractIntegrationTestWithDatabase {
     }
 
     private void performMediaFilterScript(DSpaceObject dso) throws Exception {
+        performMediaFilterScript(dso, null);
+    }
+
+    private void performMediaFilterScript(DSpaceObject dso, String[] moreArgs) throws Exception {
+        ArrayList<String> argsList = new ArrayList<String>();
+        argsList.add("filter-media");
         if (dso != null) {
-            runDSpaceScript("filter-media", "-i", dso.getHandle());
-        } else {
-            runDSpaceScript("filter-media");
+            argsList.add("-i");
+            argsList.add(dso.getHandle());
         }
+        if (moreArgs != null) {
+            for (String arg : moreArgs) {
+                argsList.add(arg);
+            }
+        }
+        runDSpaceScript(argsList.toArray(new String[0]));
         // reload our items to see the changes
         item1_1_a = context.reloadEntity(item1_1_a);
         item1_1_b = context.reloadEntity(item1_1_b);
@@ -237,6 +328,6 @@ public class MediaFilterIT extends AbstractIntegrationTestWithDatabase {
         item1_2_2_b = context.reloadEntity(item1_2_2_b);
         item2_1_a = context.reloadEntity(item2_1_a);
         item2_1_b = context.reloadEntity(item2_1_b);
-
     }
+
 }

--- a/dspace/config/registries/dspace-types.xml
+++ b/dspace/config/registries/dspace-types.xml
@@ -444,6 +444,13 @@
 
     <dc-type>
         <schema>dspace</schema>
+        <element>filtermedia</element>
+        <qualifier>lastdate</qualifier>
+        <scope_note>Last date filter-media was run</scope_note>
+    </dc-type>
+
+    <dc-type>
+        <schema>dspace</schema>
         <element>bitstream</element>
         <qualifier>hasCopies</qualifier>
         <scope_note>Stores the UUID's of the copies of this bitstream</scope_note>


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
 * Fixes [MediaFilter does not take into account that some bitstreams/items are not altered since the previous run #9782](https://github.com/DSpace/DSpace/issues/9782)
 * Expands upon [New parameter fromdate for media-filter script #9653](https://github.com/DSpace/DSpace/pull/9653)
 * Replaces #9820
 * Related to #9272
 * 8_x version of this PR (in progress after 04/2026 changes to this PR): #11011

## Description

This is a replacement patch for MediaFilter performance fix my @Atmire-Kristof applied to main branch as the original code does not merge after the migration from java.util.Date -> java.time -based classes in Mar 2025. In addition, some minor discrepancies have been fixed and logging added to ease testing.
 
#9653 Added the ability to provide a "from-date" to the "filter-media" script. This date allows us to only process items that were last changed _after_ the provided date.
 
When **no** date is provided, filter-media would process **all** items. This PR ~aims to change the default logic~ _EDIT 04/2026_: adds additional option `--autodate` to only process items that were modified _after_ the last time the script was ran, based on site-wide metadata field dspace.filtermedia.lastdate. As a consequence, filter-media can be run repeatedly (even during the same day) without specific given date but only processing items that have been modified. _EDIT_: without `--autodate` given the mediafilter logic works more or less the same as before but with improved help texts and messages.
 
Also expanding the earlier functionality, -i option (process only community or collection) can be used in conjunction with -d parameter, processing items in community or collection that have been modified after the specified date. However, this does not affect the site-wide variable that is read and updated only in the context of full run. In addition, the script now fails gracefully if dspace.filtermedia.lastdate does not yet exist in metadata registry, _EDIT_: or `--autodate` option is attempted to be used with `--identitier`.

## Instructions for Reviewers

Changes:
 
* After filter-media is done processing all items (only when no parameters were provided, like an identifier or specific date), it will store the current date in the Site's new "dspace.filtermedia.lastdate" metadata field. The reason we couldn't just use last-modified date and have to compare it to another is because the last-modified date of an item is already updated by filter-media itself. Site seemed like an appropriate place to store this and metadata values allows more control by administrators.

* Even though -d parameter is given as a date, lastdate is stored internally as a timestamp, making it possible to run the script multiple times a day an eventually resulting to zero processed items if no new items are added, making it easier to run repeatedly from cron to e.g. keep thumbnails up to date with short delay. This is also a generalization of behaviour introduced earlier in #9653 as fromDate variable in MediaFilterServiceImpl has been changed to LocalDate (=no hour/minute information) to Instant (=allowing exact timestamp that can be used to such for time-based searches in ItemService)
* Change to original PR: when setting new lastdate to site metadata, timestamp at the _start_ of the script is used instead of the end. This enables that even if new items are added while running the script, they are processed during the next run. As a consequence, items that were filtered in the previous run will be processed one time again (typically as SKIPPED, still resulting to relatively fast run).
* At the start of filter-media (~without any additional parameters~ with `--autodate` parameter), the date stored in Site is checked and if present, only items with a last-modified date _after_ this date are retrieved and processed. If the metadata field is empty, all items are processed (and value will be set at the end of run). Change to original PR: if the metadata field does not exist at all, the script ends before full run and user is given a message about running registry-loader (fix to #8655 would make this detail unnecessary). While testing the original PR (see e.g. comments in #9818), it turned out that while updating DSpace, the field was not always added even after database migrate but registry-loader seems to work.
* Based on discussion in #9818 `-f` argument ~now overrides date handling~ EDIT: originally overrided date handling but with the new `--autodate` parameter `-f` can now be used as standalone or in combination with other filter-media paremeters, as in #9653 implementation. In addition, when testing the functionality (originally in DSpace 7), exception like `ERROR unknown unknown org.dspace.event.BasicDispatcher @ Consumer("discovery").consume threw: java.lang.IllegalArgumentException: The object: org.dspace.content.Site cannot be indexed` appeared during the full run. I compensated this with a modification to IndexEventConsumer, based on logic introduced in #9069.
* A custom date can be provided with the `-d` argument. This will override the date found on the Site, but will NOT update the Site's date (otherwise we could end up with non-processed items that are skipped from then). -d parameter now works properly (fix to criteriaQuery in ItemDAOImpl) in conjunction with `-i` argument, e.g. providing a community or collection to process with regard to last modified date.
* Logging has been added to MediaFilterScript and ItemService to help testing (and overall, help the end user to better understand functionality of the script): last date to be used (and set and the end of script) is logged, as well as amounts of items to be processed (site-wide or per community). With these, it is relatively easy to verify how the number of processed items reduces as the script is run consecutively.

Version notes:

* The code in this PR should be mergeable as such to current main branch and DSpace 9. The first commit is a squash of 3 commits (2 original commits from the original PR and a third that migrates code to java.time-based classes. This eases porting the code to DSpace 8 (and even to 7), as the rest of the commits are virtually the same in different versions. 

How to test:
 
* Create/update some items/bitstreams
* Run filter-media with `--autodate` argument and confirm it processes them all
* Update some of the same items/bitstreams
* Run filter-media again with `--autodate` argument and confirm it only processes the updated ones (possibly with one-time SKIPPED of the items processed the last time). Observe log messages containing "retrieved" and "lastdate" for details and date handling and number of items to be processed.
* Run filter-media with a `-d` argument and confirm it only processes items from the given date
* Run filter-media with both a `-d` and `-i` argument and confirm they function together (only processing items from the given date and within the given object, e.g. collection)
* Run filter-media with `-f` argument and confirm that `-f` ~overrides the date in site metadata (and even additional `-d` parameter~ ignores the date in site metadata. So it's still possible to to a full reindex EDIT: and even force mediafilter to rerun a subset of items, is used in combination with `-a`, `-d`, or `-i` argument
* To test checking dspace.filtermedia.lastdate, delete if from the metadataregistry and run `dspace registry-loader -metadata ../config/registries/dspace-types.xml` in the `[dspace]/bin` directory.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
