### PR TITLE
[Port dspace-8_x] Store date of last filter-media run on Items to limit re-filtering unchanged Items (revised)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScript.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScript.java
@@ -117,7 +117,8 @@ public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfigura
             skipIds = commandLine.getOptionValues('s');
         }
 
-        if (commandLine.hasOption('d')) {
+        // isForce overrides fromDate
+        if (!isForce && commandLine.hasOption('d')) {
             fromDate = LocalDate.parse(commandLine.getOptionValue('d'));
         }
 

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScript.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScript.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.app.mediafilter;
 
+import java.sql.SQLException;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.ArrayList;
@@ -25,6 +26,9 @@ import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
+import org.dspace.content.MetadataField;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.MetadataFieldService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.core.SelfNamedPlugin;
@@ -65,6 +69,8 @@ public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfigura
     private String[] skipIds = null;
     private Map<String, List<String>> filterFormats = new HashMap<>();
     private LocalDate fromDate = null;
+
+    private MetadataFieldService metadataFieldService = ContentServiceFactory.getInstance().getMetadataFieldService();;
 
     public MediaFilterScriptConfiguration getScriptConfiguration() {
         return new DSpace().getServiceManager()
@@ -233,6 +239,14 @@ public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfigura
 
         try {
             c = new Context();
+
+            MetadataField field = metadataFieldService.findByElement(c, "dspace", "filtermedia", "lastdate");
+            if (field == null) {
+                throw new SQLException("Cannot find field dspace.filtermedia.lastdate from the Metadata "
+                                          + "Registry. Please update the registry by running\n"
+                                          + "./dspace registry-loader -metadata ../config/registries/dspace-types.xml\n"
+                                          + "in the [dspace]/bin/ directory.");
+            }
 
             // have to be super-user to do the filtering
             c.turnOffAuthorisationSystem();

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScript.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScript.java
@@ -45,7 +45,7 @@ import org.dspace.utils.DSpace;
  * bitstreams to be processed, even if they have been before; -n noindex does not
  * recreate index after processing bitstreams; -i [identifier] limits processing
  * scope to a community, collection or item; -m [max] limits processing to a
- * maximum number of items; -fd [fromdate] takes only items starting from this date,
+ * maximum number of items; -d [fromdate] takes only items starting from this date,
  * filtering by last_modified in the item table.
  */
 public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfiguration> {
@@ -70,7 +70,7 @@ public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfigura
     private Map<String, List<String>> filterFormats = new HashMap<>();
     private LocalDate fromDate = null;
 
-    private MetadataFieldService metadataFieldService = ContentServiceFactory.getInstance().getMetadataFieldService();;
+    private MetadataFieldService metadataFieldService = ContentServiceFactory.getInstance().getMetadataFieldService();
 
     public MediaFilterScriptConfiguration getScriptConfiguration() {
         return new DSpace().getServiceManager()

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScript.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScript.java
@@ -8,8 +8,10 @@
 package org.dspace.app.mediafilter;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -223,7 +225,7 @@ public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfigura
         }
 
         if (fromDate != null) {
-            mediaFilterService.setFromDate(fromDate);
+            mediaFilterService.setFromDate(Date.from(fromDate.atStartOfDay(ZoneId.systemDefault()).toInstant()));
         }
 
         Context c = null;

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScript.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScript.java
@@ -39,15 +39,15 @@ import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.utils.DSpace;
 
 /**
- * MediaFilterManager is the class that invokes the media/format filters over the
+ * MediaFilterScript is the class that invokes the media/format filters over the
  * repository's content. A few command line flags affect the operation of the
- * MFM: -v verbose outputs all extracted text to STDOUT; -f force forces all
- * bitstreams to be processed, even if they have been before; -n noindex does not
- * recreate index after processing bitstreams; -i [identifier] limits processing
- * scope to a community, collection or item; -m [maximum] limits processing to a
- * maximum number of items; -d [fromdate] takes only items starting from this date,
- * filtering by last_modified in the item table; -a [autodate] will store the start
- * time of the run and use that as fromdate for the next run.
+ * script: -v verbose outputs all extracted text to STDOUT; -f force forces all
+ * bitstreams (accounting for date limit) to be processed, even if they have
+ * been before; -i [identifier] limits processing scope to a community,
+ * collection or item; -m [maximum] limits processing to a maximum number of items;
+ * -d [fromdate] takes only items starting from this date, filtering by last_modified
+ * in the item table; -a [autodate] will store the start time of the run and use
+ * that as fromdate for the next run.
  */
 public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfiguration> {
 
@@ -125,8 +125,7 @@ public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfigura
             skipIds = commandLine.getOptionValues('s');
         }
 
-        // isForce overrides fromDate
-        if (!isForce && commandLine.hasOption('d')) {
+        if (commandLine.hasOption('d')) {
             fromDate = LocalDate.parse(commandLine.getOptionValue('d'));
         }
 

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScript.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScript.java
@@ -127,6 +127,8 @@ public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfigura
 
         if (commandLine.hasOption('d')) {
             fromDate = LocalDate.parse(commandLine.getOptionValue('d'));
+        } else {
+            fromDate = null;
         }
 
         if (commandLine.hasOption('a')) {
@@ -156,11 +158,15 @@ public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfigura
         mediaFilterService.setQuiet(isQuiet);
         mediaFilterService.setVerbose(isVerbose);
         mediaFilterService.setMax2Process(max2Process);
+        if (fromDate != null) {
+            mediaFilterService.setFromDate(Date.from(fromDate.atStartOfDay(ZoneId.systemDefault()).toInstant()));
+        } else {
+            mediaFilterService.setFromDate(null);
+        }
         mediaFilterService.setUseAutoDate(useAutoDate);
 
         //initialize an array of our enabled filters
         List<FormatFilter> filterList = new ArrayList<>();
-
 
         //set up each filter
         for (int i = 0; i < filterNames.length; i++) {
@@ -243,11 +249,6 @@ public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfigura
         if (skipIds != null && skipIds.length > 0) {
             //save to a global skip list
             mediaFilterService.setSkipList(Arrays.asList(skipIds));
-        }
-
-        if (fromDate != null) {
-            mediaFilterService.setFromDate(Date.from(fromDate.atStartOfDay(ZoneId.systemDefault()).toInstant()));
-            handler.logInfo("Using manually supplied fromdate " + fromDate);
         }
 
         Context c = null;

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScript.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScript.java
@@ -44,9 +44,10 @@ import org.dspace.utils.DSpace;
  * MFM: -v verbose outputs all extracted text to STDOUT; -f force forces all
  * bitstreams to be processed, even if they have been before; -n noindex does not
  * recreate index after processing bitstreams; -i [identifier] limits processing
- * scope to a community, collection or item; -m [max] limits processing to a
+ * scope to a community, collection or item; -m [maximum] limits processing to a
  * maximum number of items; -d [fromdate] takes only items starting from this date,
- * filtering by last_modified in the item table.
+ * filtering by last_modified in the item table; -a [autodate] will store the start
+ * time of the run and use that as fromdate for the next run.
  */
 public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfiguration> {
 
@@ -69,6 +70,7 @@ public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfigura
     private String[] skipIds = null;
     private Map<String, List<String>> filterFormats = new HashMap<>();
     private LocalDate fromDate = null;
+    private boolean useAutoDate = false;
 
     private MetadataFieldService metadataFieldService = ContentServiceFactory.getInstance().getMetadataFieldService();
 
@@ -128,12 +130,24 @@ public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfigura
             fromDate = LocalDate.parse(commandLine.getOptionValue('d'));
         }
 
-
+        if (commandLine.hasOption('a')) {
+            useAutoDate = true;
+        }
     }
 
     public void internalRun() throws Exception {
         if (help) {
             printHelp();
+            return;
+        }
+
+        if (useAutoDate && max2Process != Integer.MAX_VALUE) {
+            handler.logWarning("WARNING: using --maximum option with --autodate may result to saved date even though " +
+                                "not all items have been processed. Continuing anyway.");
+        }
+
+        if (useAutoDate && identifier != null) {
+            handler.logError("--identifier option cannot be used with --autodate");
             return;
         }
 
@@ -143,6 +157,7 @@ public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfigura
         mediaFilterService.setQuiet(isQuiet);
         mediaFilterService.setVerbose(isVerbose);
         mediaFilterService.setMax2Process(max2Process);
+        mediaFilterService.setUseAutoDate(useAutoDate);
 
         //initialize an array of our enabled filters
         List<FormatFilter> filterList = new ArrayList<>();
@@ -233,6 +248,7 @@ public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfigura
 
         if (fromDate != null) {
             mediaFilterService.setFromDate(Date.from(fromDate.atStartOfDay(ZoneId.systemDefault()).toInstant()));
+            handler.logInfo("Using manually supplied fromdate " + fromDate);
         }
 
         Context c = null;
@@ -240,12 +256,14 @@ public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfigura
         try {
             c = new Context();
 
-            MetadataField field = metadataFieldService.findByElement(c, "dspace", "filtermedia", "lastdate");
-            if (field == null) {
-                throw new SQLException("Cannot find field dspace.filtermedia.lastdate from the Metadata "
-                                          + "Registry. Please update the registry by running\n"
-                                          + "./dspace registry-loader -metadata ../config/registries/dspace-types.xml\n"
-                                          + "in the [dspace]/bin/ directory.");
+            if (useAutoDate) {
+                MetadataField field = metadataFieldService.findByElement(c, "dspace", "filtermedia", "lastdate");
+                if (field == null) {
+                    throw new SQLException("Cannot find field dspace.filtermedia.lastdate from the Metadata "
+                                        + "Registry. Please update the registry by running\n"
+                                        + "./dspace registry-loader -metadata ../config/registries/dspace-types.xml\n"
+                                        + "in the [dspace]/bin/ directory.");
+                }
             }
 
             // have to be super-user to do the filtering

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScriptConfiguration.java
@@ -32,7 +32,7 @@ public class MediaFilterScriptConfiguration<T extends MediaFilterScript> extends
         Options options = new Options();
         options.addOption("v", "verbose", false, "print all extracted text and other details to STDOUT");
         options.addOption("q", "quiet", false, "do not print anything except in the event of errors.");
-        options.addOption("f", "force", false, "force all bitstreams to be processed");
+        options.addOption("f", "force", false, "force all bitstreams to be processed (overrides fromdate)");
         options.addOption("i", "identifier", true,
             "ONLY process bitstreams belonging to the provided handle identifier");
         options.addOption("m", "maximum", true, "process no more than maximum items");

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScriptConfiguration.java
@@ -30,13 +30,14 @@ public class MediaFilterScriptConfiguration<T extends MediaFilterScript> extends
     @Override
     public Options getOptions() {
         Options options = new Options();
-        options.addOption("v", "verbose", false, "print all extracted text and other details to STDOUT");
-        options.addOption("q", "quiet", false, "do not print anything except in the event of errors.");
-        options.addOption("f", "force", false, "force all bitstreams to be processed (overrides fromdate)");
+        options.addOption("v", "verbose", false, "Print all extracted text and other details to STDOUT");
+        options.addOption("q", "quiet", false, "Do not print anything except in the event of errors");
+        options.addOption("f", "force", false, "Force all bitstreams (can be restricted with -d or -i) " +
+                                                                    "to be processed");
         options.addOption("i", "identifier", true,
             "ONLY process bitstreams belonging to the provided handle identifier");
-        options.addOption("m", "maximum", true, "process no more than maximum items");
-        options.addOption("h", "help", false, "help");
+        options.addOption("m", "maximum", true, "Process no more than maximum items");
+        options.addOption("h", "help", false, "Help");
 
         Option pluginOption = Option.builder("p")
                                     .longOpt("plugins")
@@ -47,18 +48,16 @@ public class MediaFilterScriptConfiguration<T extends MediaFilterScript> extends
                                             "ONLY run the specified Media Filter plugin(s)\n" +
                                                     "listed from '" + MEDIA_FILTER_PLUGINS_KEY + "' in dspace.cfg.\n" +
                                                     "Separate multiple with a comma (,)\n" +
-                                                    "(e.g. MediaFilterManager -p \n\"Word Text Extractor\",\"PDF Text" +
+                                                    "(e.g. filter-media -p \n\"Word Text Extractor\",\"PDF Text" +
                                                     " Extractor\")")
                                     .build();
         options.addOption(pluginOption);
 
-        options.addOption("d", "fromdate", true, "Process only items modified after specified date (YYYY-MM-DD)\n" +
-                                                    "Can be combined with -i to restrict run a community/collection.");
+        options.addOption("d", "fromdate", true, "Process only items modified after specified date (YYYY-MM-DD)");
 
         options.addOption("a", "autodate", false, "Process items updated after the last --autodate -based site-wide " +
-                                                    "run (stores the time at the start of the run regardless of the " +
-                                                    "filters used)\n Can be combined with -d to set a custom date " +
-                                                    "for processing or with -f to store the date after full run.");
+                                    "run (stores the time at the start of the run regardless of the filters used),\n" +
+                                    "can be combined with -d to set a custom date");
 
         Option skipOption = Option.builder("s")
                                   .longOpt("skip")
@@ -68,7 +67,7 @@ public class MediaFilterScriptConfiguration<T extends MediaFilterScript> extends
                                   .desc(
                                           "SKIP the bitstreams belonging to identifier\n" +
                                                   "Separate multiple identifiers with a comma (,)\n" +
-                                                  "(e.g. MediaFilterManager -s \n 123456789/34,123456789/323)")
+                                                  "(e.g. filter-media -s \n 123456789/34,123456789/323)")
                                   .build();
         options.addOption(skipOption);
 

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScriptConfiguration.java
@@ -52,7 +52,13 @@ public class MediaFilterScriptConfiguration<T extends MediaFilterScript> extends
                                     .build();
         options.addOption(pluginOption);
 
-        options.addOption("d", "fromdate", true, "Process only item from specified last modified date");
+        options.addOption("d", "fromdate", true, "Process only items modified after specified date (YYYY-MM-DD)\n" +
+                                                    "Can be combined with -i to restrict run a community/collection.");
+
+        options.addOption("a", "autodate", false, "Process items updated after the last --autodate -based site-wide " +
+                                                    "run (stores the time at the start of the run regardless of the " +
+                                                    "filters used)\n Can be combined with -d to set a custom date " +
+                                                    "for processing or with -f to store the date after full run.");
 
         Option skipOption = Option.builder("s")
                                   .longOpt("skip")

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
@@ -118,9 +118,15 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
     @Override
     public void applyFiltersAllItems(Context context) throws Exception {
         boolean storeLastDate = false;
+        String timeToStore = null;
         if (fromDate == null) {
             storeLastDate = true;
+            // dspace.filtermedia.lastdate is saved as datetime. If new items are added while running
+            // the script, storing time at the start of script to ensure that these items are processed
+            // in the next run.
+            timeToStore = DCDate.getCurrent().toString();
             String lastDate = siteService.getMetadata(siteService.findSite(context), "dspace.filtermedia.lastdate");
+            logInfo("Last date retrieved from db for media filter processing: " + lastDate);
             if ((lastDate != null) && (isForce == false)) {
                 fromDate = new DCDate(lastDate).toDate();
             }
@@ -134,6 +140,7 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
                 applyFiltersCommunity(context, topLevelCommunity);
             }
         } else if (fromDate != null) {
+            logInfo("Using fromDate " + fromDate);
             Iterator<Item> itemIterator =
                     itemService.findByLastModifiedSince(
                             context,
@@ -150,11 +157,12 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
             }
         }
         if (storeLastDate) {
+            logInfo("Setting new last date to db for media filter processing: " + timeToStore);
             siteService.clearMetadata(context, siteService.findSite(context),
                 "dspace", "filtermedia", "lastdate", Item.ANY);
             siteService.addMetadata(context, siteService.findSite(context),
                 "dspace", "filtermedia", "lastdate", null,
-                new DCDate(new Date()).toString());
+                timeToStore);
             siteService.update(context, siteService.findSite(context));
         }
     }

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
@@ -120,7 +120,7 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
         boolean storeLastDate = false;
         if (fromDate == null) {
             storeLastDate = true;
-            String lastDate = siteService.getMetadata(siteService.findSite(context), "dc.filtermedia.lastdate");
+            String lastDate = siteService.getMetadata(siteService.findSite(context), "dspace.filtermedia.lastdate");
             if (lastDate != null) {
                 fromDate = new DCDate(lastDate).toDate();
             }
@@ -151,9 +151,9 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
         }
         if (storeLastDate) {
             siteService.clearMetadata(context, siteService.findSite(context),
-                "dc", "filtermedia", "lastdate", Item.ANY);
+                "dspace", "filtermedia", "lastdate", Item.ANY);
             siteService.addMetadata(context, siteService.findSite(context),
-                "dc", "filtermedia", "lastdate", null,
+                "dspace", "filtermedia", "lastdate", null,
                 new DCDate(new Date()).toString());
             siteService.update(context, siteService.findSite(context));
         }

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
@@ -9,8 +9,6 @@ package org.dspace.app.mediafilter;
 
 import java.io.InputStream;
 import java.sql.SQLException;
-import java.time.LocalDate;
-import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -37,6 +35,7 @@ import org.dspace.content.service.BundleService;
 import org.dspace.content.service.CollectionService;
 import org.dspace.content.service.CommunityService;
 import org.dspace.content.service.ItemService;
+import org.dspace.content.service.SiteService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.core.SelfNamedPlugin;
@@ -75,6 +74,8 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
     @Autowired(required = true)
     protected ItemService itemService;
     @Autowired(required = true)
+    protected SiteService siteService;
+    @Autowired(required = true)
     protected ConfigurationService configurationService;
 
     protected DSpaceRunnableHandler handler;
@@ -96,7 +97,7 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
     protected boolean isVerbose = false;
     protected boolean isQuiet = false;
     protected boolean isForce = false; // default to not forced
-    protected LocalDate fromDate = null;
+    protected Date fromDate = null;
 
     protected MediaFilterServiceImpl() {
 
@@ -116,6 +117,14 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
 
     @Override
     public void applyFiltersAllItems(Context context) throws Exception {
+        boolean storeLastDate = false;
+        if (fromDate == null) {
+            storeLastDate = true;
+            String lastDate = siteService.getMetadata(siteService.findSite(context), "dc.filtermedia.lastdate");
+            if (lastDate != null) {
+                fromDate = new DCDate(lastDate).toDate();
+            }
+        }
         if (skipList != null) {
             //if a skip-list exists, we need to filter community-by-community
             //so we can respect what is in the skip-list
@@ -128,7 +137,7 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
             Iterator<Item> itemIterator =
                     itemService.findByLastModifiedSince(
                             context,
-                            Date.from(fromDate.atStartOfDay(ZoneId.systemDefault()).toInstant())
+                            fromDate
                     );
             while (itemIterator.hasNext() && processed < max2Process) {
                 applyFiltersItem(context, itemIterator.next());
@@ -139,6 +148,14 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
             while (itemIterator.hasNext() && processed < max2Process) {
                 applyFiltersItem(context, itemIterator.next());
             }
+        }
+        if (storeLastDate) {
+            siteService.clearMetadata(context, siteService.findSite(context),
+                "dc", "filtermedia", "lastdate", Item.ANY);
+            siteService.addMetadata(context, siteService.findSite(context),
+                "dc", "filtermedia", "lastdate", null,
+                new DCDate(new Date()).toString());
+            siteService.update(context, siteService.findSite(context));
         }
     }
 
@@ -172,7 +189,12 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
         collection = context.reloadEntity(collection);
         //only apply filters if collection not in skip-list
         if (!inSkipList(collection.getHandle())) {
-            Iterator<Item> itemIterator = itemService.findAllByCollection(context, collection);
+            Iterator<Item> itemIterator;
+            if (fromDate != null) {
+                itemIterator = itemService.findByCollectionLastModifiedSince(context, collection, fromDate);
+            } else {
+                itemIterator = itemService.findAllByCollection(context, collection);
+            }
             while (itemIterator.hasNext() && processed < max2Process) {
                 applyFiltersItem(context, itemIterator.next());
             }
@@ -603,7 +625,7 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
     }
 
     @Override
-    public void setFromDate(LocalDate fromDate) {
+    public void setFromDate(Date fromDate) {
         this.fromDate = fromDate;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
@@ -121,7 +121,7 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
         if (fromDate == null) {
             storeLastDate = true;
             String lastDate = siteService.getMetadata(siteService.findSite(context), "dspace.filtermedia.lastdate");
-            if (lastDate != null) {
+            if ((lastDate != null) && (isForce == false)) {
                 fromDate = new DCDate(lastDate).toDate();
             }
         }

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
@@ -29,6 +29,7 @@ import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.DCDate;
 import org.dspace.content.Item;
+import org.dspace.content.Site;
 import org.dspace.content.service.BitstreamFormatService;
 import org.dspace.content.service.BitstreamService;
 import org.dspace.content.service.BundleService;
@@ -127,7 +128,7 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
             timeToStore = DCDate.getCurrent().toString();
             String lastDate = siteService.getMetadata(siteService.findSite(context), "dspace.filtermedia.lastdate");
             logInfo("Last date retrieved from db for media filter processing: " + lastDate);
-            if ((lastDate != null) && (isForce == false)) {
+            if ((lastDate != null) && (!isForce)) {
                 fromDate = new DCDate(lastDate).toDate();
             }
         }
@@ -157,13 +158,14 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
             }
         }
         if (storeLastDate) {
+            Site site = siteService.findSite(context);
             logInfo("Setting new last date to db for media filter processing: " + timeToStore);
-            siteService.clearMetadata(context, siteService.findSite(context),
+            siteService.clearMetadata(context, site,
                 "dspace", "filtermedia", "lastdate", Item.ANY);
-            siteService.addMetadata(context, siteService.findSite(context),
+            siteService.addMetadata(context, site,
                 "dspace", "filtermedia", "lastdate", null,
                 timeToStore);
-            siteService.update(context, siteService.findSite(context));
+            siteService.update(context, site);
         }
     }
 

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
@@ -130,7 +130,7 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
         }
         if (fromDate == null && useAutoDate) {
             String lastDate = siteService.getMetadata(siteService.findSite(context), "dspace.filtermedia.lastdate");
-            if ((lastDate != null) && (!isForce)) {
+            if (lastDate != null) {
                 logInfo("Using fromdate " + lastDate + " retrieved from db");
                 fromDate = new DCDate(lastDate).toDate();
             }

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
@@ -99,6 +99,7 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
     protected boolean isQuiet = false;
     protected boolean isForce = false; // default to not forced
     protected Date fromDate = null;
+    protected boolean useAutoDate = false;
 
     protected MediaFilterServiceImpl() {
 
@@ -120,28 +121,31 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
     public void applyFiltersAllItems(Context context) throws Exception {
         boolean storeLastDate = false;
         String timeToStore = null;
-        if (fromDate == null) {
+        if (useAutoDate) {
             storeLastDate = true;
             // dspace.filtermedia.lastdate is saved as datetime. If new items are added while running
             // the script, storing time at the start of script to ensure that these items are processed
             // in the next run.
             timeToStore = DCDate.getCurrent().toString();
+        }
+        if (fromDate == null && useAutoDate) {
             String lastDate = siteService.getMetadata(siteService.findSite(context), "dspace.filtermedia.lastdate");
-            logInfo("Last date retrieved from db for media filter processing: " + lastDate);
             if ((lastDate != null) && (!isForce)) {
+                logInfo("Using fromdate " + lastDate + " retrieved from db");
                 fromDate = new DCDate(lastDate).toDate();
             }
         }
         if (skipList != null) {
             //if a skip-list exists, we need to filter community-by-community
             //so we can respect what is in the skip-list
+            //(handles also fromDate filtering if the option is present)
             List<Community> topLevelCommunities = communityService.findAllTop(context);
 
             for (Community topLevelCommunity : topLevelCommunities) {
                 applyFiltersCommunity(context, topLevelCommunity);
             }
         } else if (fromDate != null) {
-            logInfo("Using fromDate " + fromDate);
+            //no skip-list, search all items based on last modified date
             Iterator<Item> itemIterator =
                     itemService.findByLastModifiedSince(
                             context,
@@ -638,4 +642,10 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
     public void setFromDate(Date fromDate) {
         this.fromDate = fromDate;
     }
+
+    @Override
+    public void setUseAutoDate(boolean useAutoDate) {
+        this.useAutoDate = useAutoDate;
+    }
+
 }

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
@@ -641,11 +641,18 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
     @Override
     public void setFromDate(Date fromDate) {
         this.fromDate = fromDate;
+        if (fromDate != null) {
+            logInfo("Using manually supplied fromdate " + fromDate);
+        }
     }
+
 
     @Override
     public void setUseAutoDate(boolean useAutoDate) {
         this.useAutoDate = useAutoDate;
+        if (useAutoDate) {
+            logInfo("Stored lastdate functionality activated.");
+        }
     }
 
 }

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/service/MediaFilterService.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/service/MediaFilterService.java
@@ -151,5 +151,9 @@ public interface MediaFilterService {
      */
     public void setLogHandler(DSpaceRunnableHandler handler);
 
+    /** 
+     * Used to set start date (or time, if no specific date of force parameter is given) for filtering items
+     * @param fromDate the datetime from which to filter items
+    */
     public void setFromDate(Date fromDate);
 }

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/service/MediaFilterService.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/service/MediaFilterService.java
@@ -8,7 +8,7 @@
 package org.dspace.app.mediafilter.service;
 
 import java.sql.SQLException;
-import java.time.LocalDate;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -151,5 +151,5 @@ public interface MediaFilterService {
      */
     public void setLogHandler(DSpaceRunnableHandler handler);
 
-    public void setFromDate(LocalDate fromDate);
+    public void setFromDate(Date fromDate);
 }

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/service/MediaFilterService.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/service/MediaFilterService.java
@@ -156,4 +156,12 @@ public interface MediaFilterService {
      * @param fromDate the datetime from which to filter items
     */
     public void setFromDate(Date fromDate);
+
+    /**
+     * If true, the MediaFilter will store the start time (site metadata dspace.filtermedia.lastdate)
+     * when the script is run and use that as the fromDate for filtering items in the next run.
+     * This allows running the script multiple times a day, restricting the run only to new or modified items.
+     * @param useAutoDate true to use autoDate (default is false)
+    */
+    public void setUseAutoDate(boolean useAutoDate);
 }

--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -1613,6 +1613,12 @@ prevent the generation of resource policy entry values with null dspace_object a
     }
 
     @Override
+    public Iterator<Item> findByCollectionLastModifiedSince(Context context, Collection collection, Date last)
+        throws SQLException {
+        return itemDAO.findAllByCollectionLastModifiedSince(context, collection, last);
+    }
+
+    @Override
     public int countTotal(Context context) throws SQLException {
         return itemDAO.countRows(context);
     }

--- a/dspace-api/src/main/java/org/dspace/content/dao/ItemDAO.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/ItemDAO.java
@@ -132,6 +132,9 @@ public interface ItemDAO extends DSpaceObjectLegacySupportDAO<Item> {
 
     Iterator<Item> findAllByCollection(Context context, Collection collection) throws SQLException;
 
+    Iterator<Item> findAllByCollectionLastModifiedSince(Context context, Collection collection, Date last)
+        throws SQLException;
+
     Iterator<Item> findAllByCollection(Context context, Collection collection, Integer limit, Integer offset)
         throws SQLException;
 

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/ItemDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/ItemDAOImpl.java
@@ -463,15 +463,17 @@ public class ItemDAOImpl extends AbstractHibernateDSODAO<Item> implements ItemDA
         CriteriaQuery<UUID> criteriaQuery = criteriaBuilder.createQuery(UUID.class);
         Root<Item> itemRoot = criteriaQuery.from(Item.class);
         criteriaQuery.select(itemRoot.get(Item_.id));
-        criteriaQuery.where(criteriaBuilder.isMember(collection, itemRoot.get(Item_.collections)));
-        criteriaQuery.where(criteriaBuilder.greaterThan(itemRoot.get(Item_.lastModified), last));
+        criteriaQuery.where(criteriaBuilder.and(
+            criteriaBuilder.isMember(collection, itemRoot.get(Item_.collections)),
+            criteriaBuilder.greaterThan(itemRoot.get(Item_.lastModified), last)));
         criteriaQuery.orderBy(criteriaBuilder.asc(itemRoot.get((Item_.id))));
 
         // Transform into a query object to execute
         Query query = createQuery(context, criteriaQuery);
         @SuppressWarnings("unchecked")
         List<UUID> uuids = query.getResultList();
-        log.info("Retrieved " + uuids.size() + " items from collection " + collection.getID() + " modified since " + last);
+        log.info("Retrieved " + uuids.size() + " items from collection " + collection.getID() +
+                 " modified since " + last);
         return new UUIDIterator<Item>(context, uuids, Item.class, this);
     }
 

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/ItemDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/ItemDAOImpl.java
@@ -440,9 +440,34 @@ public class ItemDAOImpl extends AbstractHibernateDSODAO<Item> implements ItemDA
     @Override
     public Iterator<Item> findByLastModifiedSince(Context context, Date since)
         throws SQLException {
-        Query query = createQuery(context,
-                "SELECT i.id FROM Item i WHERE lastModified > :last_modified ORDER BY id");
-        query.setParameter("last_modified", since, TemporalType.TIMESTAMP);
+        CriteriaBuilder criteriaBuilder = getCriteriaBuilder(context);
+        CriteriaQuery<UUID> criteriaQuery = criteriaBuilder.createQuery(UUID.class);
+        Root<Item> itemRoot = criteriaQuery.from(Item.class);
+        criteriaQuery.select(itemRoot.get(Item_.id));
+        criteriaQuery.where(criteriaBuilder.greaterThan(itemRoot.get(Item_.lastModified), since));
+        criteriaQuery.orderBy(criteriaBuilder.asc(itemRoot.get((Item_.id))));
+
+        // Transform into a query object to execute
+        Query query = createQuery(context, criteriaQuery);
+        @SuppressWarnings("unchecked")
+        List<UUID> uuids = query.getResultList();
+        return new UUIDIterator<Item>(context, uuids, Item.class, this);
+    }
+
+    @Override
+    public Iterator<Item> findAllByCollectionLastModifiedSince(Context context, Collection collection,
+                                                               Date last) throws SQLException {
+        // Select UUID of all items which have this "collection" in their list of collections
+        CriteriaBuilder criteriaBuilder = getCriteriaBuilder(context);
+        CriteriaQuery<UUID> criteriaQuery = criteriaBuilder.createQuery(UUID.class);
+        Root<Item> itemRoot = criteriaQuery.from(Item.class);
+        criteriaQuery.select(itemRoot.get(Item_.id));
+        criteriaQuery.where(criteriaBuilder.isMember(collection, itemRoot.get(Item_.collections)));
+        criteriaQuery.where(criteriaBuilder.greaterThan(itemRoot.get(Item_.lastModified), last));
+        criteriaQuery.orderBy(criteriaBuilder.asc(itemRoot.get((Item_.id))));
+
+        // Transform into a query object to execute
+        Query query = createQuery(context, criteriaQuery);
         @SuppressWarnings("unchecked")
         List<UUID> uuids = query.getResultList();
         return new UUIDIterator<Item>(context, uuids, Item.class, this);

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/ItemDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/ItemDAOImpl.java
@@ -451,6 +451,7 @@ public class ItemDAOImpl extends AbstractHibernateDSODAO<Item> implements ItemDA
         Query query = createQuery(context, criteriaQuery);
         @SuppressWarnings("unchecked")
         List<UUID> uuids = query.getResultList();
+        log.info("Retrieved " + uuids.size() + " items modified since " + since);
         return new UUIDIterator<Item>(context, uuids, Item.class, this);
     }
 
@@ -470,6 +471,7 @@ public class ItemDAOImpl extends AbstractHibernateDSODAO<Item> implements ItemDA
         Query query = createQuery(context, criteriaQuery);
         @SuppressWarnings("unchecked")
         List<UUID> uuids = query.getResultList();
+        log.info("Retrieved " + uuids.size() + " items from collection " + collection.getID() + " modified since " + last);
         return new UUIDIterator<Item>(context, uuids, Item.class, this);
     }
 

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/ItemDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/ItemDAOImpl.java
@@ -440,18 +440,12 @@ public class ItemDAOImpl extends AbstractHibernateDSODAO<Item> implements ItemDA
     @Override
     public Iterator<Item> findByLastModifiedSince(Context context, Date since)
         throws SQLException {
-        CriteriaBuilder criteriaBuilder = getCriteriaBuilder(context);
-        CriteriaQuery<UUID> criteriaQuery = criteriaBuilder.createQuery(UUID.class);
-        Root<Item> itemRoot = criteriaQuery.from(Item.class);
-        criteriaQuery.select(itemRoot.get(Item_.id));
-        criteriaQuery.where(criteriaBuilder.greaterThan(itemRoot.get(Item_.lastModified), since));
-        criteriaQuery.orderBy(criteriaBuilder.asc(itemRoot.get((Item_.id))));
-
-        // Transform into a query object to execute
-        Query query = createQuery(context, criteriaQuery);
+        Query query = createQuery(context,
+                "SELECT i.id FROM Item i WHERE lastModified > :last_modified ORDER BY id");
+        query.setParameter("last_modified", since, TemporalType.TIMESTAMP);
         @SuppressWarnings("unchecked")
         List<UUID> uuids = query.getResultList();
-        log.info("Retrieved " + uuids.size() + " items modified since " + since);
+        log.debug("Retrieved " + uuids.size() + " items modified since " + since);
         return new UUIDIterator<Item>(context, uuids, Item.class, this);
     }
 
@@ -472,7 +466,7 @@ public class ItemDAOImpl extends AbstractHibernateDSODAO<Item> implements ItemDA
         Query query = createQuery(context, criteriaQuery);
         @SuppressWarnings("unchecked")
         List<UUID> uuids = query.getResultList();
-        log.info("Retrieved " + uuids.size() + " items from collection " + collection.getID() +
+        log.debug("Retrieved " + uuids.size() + " items from collection " + collection.getID() +
                  " modified since " + last);
         return new UUIDIterator<Item>(context, uuids, Item.class, this);
     }

--- a/dspace-api/src/main/java/org/dspace/content/service/ItemService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/ItemService.java
@@ -857,6 +857,18 @@ public interface ItemService
         throws SQLException;
 
     /**
+     * Get all the archived items in this collection, last modified since a given Date. The order is indeterminate.
+     *
+     * @param context    DSpace context object
+     * @param collection Collection (parent)
+     * @param last       Earliest interesting last-modified date.
+     * @return an iterator over the items in the collection.
+     * @throws SQLException if database error
+     */
+    Iterator<Item> findByCollectionLastModifiedSince(Context context, Collection collection, Date last)
+        throws SQLException;
+
+    /**
      * counts items in the given community
      *
      * @param context   DSpace context object

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexEventConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexEventConsumer.java
@@ -138,22 +138,26 @@ public class IndexEventConsumer implements Consumer {
                                  + ", perhaps it has been deleted.");
                     }
                 } else {
-                    log.debug("consume() adding event to update queue: " + event.toString());
-                    if (event.getSubjectType() == Constants.ITEM) {
-                    // if it is an item we cannot know about its previous state, so it could be a
-                    // workspaceitem that has been deposited right now or an approved/reject
-                    // workflowitem.
-                    // As the workflow is not necessary enabled it can happen than a workspaceitem
-                    // became directly an item without giving us the chance to retrieve a
-                    // workflowitem... so we need to force the unindex of all the related data
-                    // before to index it again to be sure to don't leave any zombie in solr
-                        IndexFactory indexableObjectService = IndexObjectFactoryFactory.getInstance()
-                                              .getIndexFactoryByType(Constants.typeText[event.getSubjectType()]);
-                        String detail = indexableObjectService.getType() + "-" + event.getSubjectID().toString();
-                        uniqueIdsToDelete.add(detail);
-                    }
+                    if (event.getSubjectType() == Constants.SITE) {
+                        log.debug(event.getEventTypeAsString() + " event triggered for Site object. Skipping it.");
+                    } else {
+                        log.debug("consume() adding event to update queue: " + event.toString());
+                        if (event.getSubjectType() == Constants.ITEM) {
+                        // if it is an item we cannot know about its previous state, so it could be a
+                        // workspaceitem that has been deposited right now or an approved/reject
+                        // workflowitem.
+                        // As the workflow is not necessary enabled it can happen than a workspaceitem
+                        // became directly an item without giving us the chance to retrieve a
+                        // workflowitem... so we need to force the unindex of all the related data
+                        // before to index it again to be sure to don't leave any zombie in solr
+                            IndexFactory indexableObjectService = IndexObjectFactoryFactory.getInstance()
+                                                  .getIndexFactoryByType(Constants.typeText[event.getSubjectType()]);
+                            String detail = indexableObjectService.getType() + "-" + event.getSubjectID().toString();
+                            uniqueIdsToDelete.add(detail);
+                        }
 
-                    objectsToUpdate.addAll(indexObjectServiceFactory.getIndexableObjects(ctx, subject));
+                        objectsToUpdate.addAll(indexObjectServiceFactory.getIndexableObjects(ctx, subject));
+                    }
                 }
                 break;
 

--- a/dspace-api/src/test/java/org/dspace/app/mediafilter/MediaFilterIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/mediafilter/MediaFilterIT.java
@@ -7,11 +7,19 @@
  */
 package org.dspace.app.mediafilter;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.sql.SQLException;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 
@@ -32,6 +40,7 @@ import org.dspace.content.Item;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.BitstreamService;
 import org.dspace.content.service.ItemService;
+import org.dspace.content.service.SiteService;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -44,6 +53,7 @@ public class MediaFilterIT extends AbstractIntegrationTestWithDatabase {
 
     private ItemService itemService = ContentServiceFactory.getInstance().getItemService();
     private BitstreamService bitstreamService = ContentServiceFactory.getInstance().getBitstreamService();
+    private SiteService siteService = ContentServiceFactory.getInstance().getSiteService();
     protected Community topComm1;
     protected Community topComm2;
     protected Community childComm1_1;
@@ -186,6 +196,78 @@ public class MediaFilterIT extends AbstractIntegrationTestWithDatabase {
         checkItemHasBeenProcessed(item1_2_2_b);
     }
 
+    @Test
+    public void mediaFilterScriptFromDateTest() throws Exception {
+
+        // setting earlier last modified so date-based filtering will not be applied here
+        Date oldModifiedTime = Date.from(Instant.now().minus(2, ChronoUnit.DAYS));
+        item1_1_a.setLastModified(oldModifiedTime);
+        performMediaFilterScript(null, new String[] {"-d",LocalDate.now().toString()}); // setting to start of day
+        checkItemHasBeenNotProcessed(item1_1_a);
+        checkItemHasBeenProcessed(item1_1_b);
+
+        String lastDate = siteService.getMetadata(siteService.findSite(context), "dspace.filtermedia.lastdate");
+        assertTrue("Last date should be null before first autodate run", lastDate == null);
+
+        // should not update, because -a option cannot be used with -i
+        performMediaFilterScript(col1_1, new String[] {"-a"});
+        checkItemHasBeenNotProcessed(item1_1_a);
+        assertEquals("The item " + item1_1_a.getName() + " should NOT have been modified",
+            oldModifiedTime, item1_1_a.getLastModified());
+
+        lastDate = siteService.getMetadata(siteService.findSite(context), "dspace.filtermedia.lastdate");
+        assertTrue("Last date should still be null", lastDate == null);
+
+        // should work with full run, as well as update the last modified date
+        performMediaFilterScript(null, new String[] {"-a"});
+
+        lastDate = siteService.getMetadata(siteService.findSite(context), "dspace.filtermedia.lastdate");
+        Date lastDateValue = Date.from(Instant.parse(lastDate));
+        assertTrue("Last date should be set after autodate run", lastDateValue != null);
+
+        // all items (esp. item1_1_a) should have been processed by now
+        Item[] items = {item1_1_a,item1_1_b,item1_2_a,item1_2_b,item1_1_1_a,
+            item1_1_1_b,item1_1_2_a,item1_1_2_b,item1_2_1_a,item1_2_1_b,
+            item1_2_2_a,item1_2_2_b,item2_1_a,item2_1_b};
+        Date latestModified = item1_1_a.getLastModified();
+        for (Item i: items) {
+            checkItemHasBeenProcessed(i);
+            if (i.getLastModified().after(latestModified)) {
+                latestModified = i.getLastModified();
+            }
+        }
+        assertNotEquals("The item " + item1_1_a.getName() + " should have been modified",
+            oldModifiedTime, item1_1_a.getLastModified());
+        // TODO: check site metadata
+
+        context.turnOffAuthorisationSystem();
+        // add new item with modified date, to verify that it will be skipped in next run
+        Item item2_1_c = ItemBuilder.createItem(context, col2_1).withTitle("Item 2_1_c").
+            withIssueDate("2017-10-17").build();
+        addBitstream(item2_1_c, "test.txt");
+        item2_1_c.setLastModified(oldModifiedTime);
+        context.restoreAuthSystemState();
+
+        // new run: should not update items anymore, including item2_1_c based on modification date
+        performMediaFilterScript(null, new String[] {"-a"});
+        item2_1_c = context.reloadEntity(item2_1_c); // needs to reloaded separately because created in this method
+
+        lastDate = siteService.getMetadata(siteService.findSite(context), "dspace.filtermedia.lastdate");
+        lastDateValue = Date.from(Instant.parse(lastDate));
+        assertTrue("Last date should be modified after autodate run", lastDateValue.after(oldModifiedTime));
+
+        for (Item i: items) {
+            assertFalse("Item should not have been modified on second run",i.getLastModified().after(latestModified));
+        }
+        checkItemHasBeenNotProcessed(item2_1_c);
+
+        // finally, perform a full run without -a to verify that item2_1_c will be processed as well
+        performMediaFilterScript(null);
+        item2_1_c = context.reloadEntity(item2_1_c);
+
+        checkItemHasBeenProcessed(item2_1_c);
+    }
+
     private void checkItemHasBeenNotProcessed(Item item) throws IOException, SQLException, AuthorizeException {
         List<Bundle> textBundles = item.getBundles("TEXT");
         assertTrue("The item " + item.getName() + " should NOT have the TEXT bundle", textBundles.size() == 0);
@@ -212,11 +294,22 @@ public class MediaFilterIT extends AbstractIntegrationTestWithDatabase {
     }
 
     private void performMediaFilterScript(DSpaceObject dso) throws Exception {
+        performMediaFilterScript(dso, null);
+    }
+
+    private void performMediaFilterScript(DSpaceObject dso, String[] moreArgs) throws Exception {
+        ArrayList<String> argsList = new ArrayList<String>();
+        argsList.add("filter-media");
         if (dso != null) {
-            runDSpaceScript("filter-media", "-i", dso.getHandle());
-        } else {
-            runDSpaceScript("filter-media");
+            argsList.add("-i");
+            argsList.add(dso.getHandle());
         }
+        if (moreArgs != null) {
+            for (String arg : moreArgs) {
+                argsList.add(arg);
+            }
+        }
+        runDSpaceScript(argsList.toArray(new String[0]));
         // reload our items to see the changes
         item1_1_a = context.reloadEntity(item1_1_a);
         item1_1_b = context.reloadEntity(item1_1_b);
@@ -232,6 +325,6 @@ public class MediaFilterIT extends AbstractIntegrationTestWithDatabase {
         item1_2_2_b = context.reloadEntity(item1_2_2_b);
         item2_1_a = context.reloadEntity(item2_1_a);
         item2_1_b = context.reloadEntity(item2_1_b);
-
     }
+
 }

--- a/dspace/config/registries/dspace-types.xml
+++ b/dspace/config/registries/dspace-types.xml
@@ -101,4 +101,11 @@
     </dc-type>
 
 
+    <dc-type>
+        <schema>dspace</schema>
+        <element>filtermedia</element>
+        <qualifier>lastdate</qualifier>
+        <scope_note>Last date filter-media was run</scope_note>
+    </dc-type>
+
 </dspace-dc-types>

--- a/dspace/config/registries/dublin-core-types.xml
+++ b/dspace/config/registries/dublin-core-types.xml
@@ -197,13 +197,6 @@
   </dc-type>
 
   <dc-type>
-    <schema>dc</schema>
-    <element>filtermedia</element>
-    <qualifier>lastdate</qualifier>
-    <scope_note>Last date filter-media was run</scope_note>
-  </dc-type>
-
-  <dc-type>
 	<schema>dc</schema>
     <element>identifier</element>
     <!-- unqualified -->

--- a/dspace/config/registries/dublin-core-types.xml
+++ b/dspace/config/registries/dublin-core-types.xml
@@ -197,6 +197,13 @@
   </dc-type>
 
   <dc-type>
+    <schema>dc</schema>
+    <element>filtermedia</element>
+    <qualifier>lastdate</qualifier>
+    <scope_note>Last date filter-media was run</scope_note>
+  </dc-type>
+
+  <dc-type>
 	<schema>dc</schema>
     <element>identifier</element>
     <!-- unqualified -->


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
 * Fixes [MediaFilter does not take into account that some bitstreams/items are not altered since the previous run #9782](https://github.com/DSpace/DSpace/issues/9782)
 * Expands upon [New parameter fromdate for media-filter script #9653](https://github.com/DSpace/DSpace/pull/9653)
 * Replaces #9819
 * Related to #9272
 * main version (compatible with Dspace 9.x) of this PR: #11010

## Description

This is a replacement patch for MediaFilter performance fix my @Atmire-Kristof applied to DSpace 8 with fixes (filtering collection by last modified date, `-f` behaviour, adjustment to IndexEventConsumer) and additional functionality (logging, setting store date of filter-media run based on the start time of script) discussed in 7.x version of the original PR #9818 (and additional testing with newer DSpace version). In revised version added new `-a` parameter that triggers date storing functionality and new integration test adapted from main version PR.

## Instructions for Reviewers

Please see details on PR applied to main branch #11010. The functionality here should be similar with the exception that this PR still uses old java.util.Date-based classes as the newer ones were adopted for DSpace 9 code.