### PR TITLE
Extend org.dspace.content.virtual.VirtualMetadataConfiguration.getVal…ues(context, item) method to accept the concrete RelationShip as parameter

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/RelationshipMetadataServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/RelationshipMetadataServiceImpl.java
@@ -285,7 +285,7 @@ public class RelationshipMetadataServiceImpl implements RelationshipMetadataServ
             Context context, Item item, Item otherItem, Relationship relationship, int place,
             String key, VirtualMetadataConfiguration virtualBean) throws SQLException {
         List<RelationshipMetadataValue> resultingMetadataValueList = new LinkedList<>();
-        for (String value : virtualBean.getValues(context, otherItem)) {
+        for (String value : virtualBean.getValues(context, otherItem, relationship)) {
             RelationshipMetadataValue relationshipMetadataValue = constructRelationshipMetadataValue(context, item,
                                                                                                      relationship
                                                                                                          .getID(),

--- a/dspace-api/src/main/java/org/dspace/content/virtual/VirtualMetadataConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/content/virtual/VirtualMetadataConfiguration.java
@@ -11,6 +11,7 @@ import java.sql.SQLException;
 import java.util.List;
 
 import org.dspace.content.Item;
+import org.dspace.content.Relationship;
 import org.dspace.core.Context;
 
 /**
@@ -30,6 +31,20 @@ public interface VirtualMetadataConfiguration {
      * @throws SQLException If something goes wrong
      */
     List<String> getValues(Context context, Item item) throws SQLException;
+
+    /**
+     * This method will return a list filled with String values which will be determine by the bean that's responsible
+     * of handling the metadata fields when fully traversed through all the {@link Related} beans
+     * @param context      The relevant DSpace context
+     * @param item         The item that will be used to either retrieve metadata values from or to find
+     *                     the related item through its relationships
+     * @param relationship The concrete relationship that was identified
+     * @return The list of String values of all the metadata values as constructed by the responsible bean
+     * @throws SQLException If something goes wrong
+     */
+    default List<String> getValues(Context context, Item item, Relationship relationship) throws SQLException {
+        return getValues(context, item);
+    }
 
     /**
      * Generic setter for the useForPlace property


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #11013 

## Description
To support the use case described in the referenced issue, we had to extend the method getValues(context, item) from the VirtualMetadataConfiguration interface to accept the specific relationship as an additional parameter. 

## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* Extended the org.dspace.content.virtual.VirtualMetadataConfiguration.getValues(context, item) method to accept the concrete relationship as parameter. used a default interface implementation to provide a fallback to the old interface method
* Changed the findRelationshipMetadataValueFromBean method of org.dspace.content.RelationshipMetadataServiceImpl to pass the already present relationship to the getValues method. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
