### PR TITLE
add PATCH request on /metadata now supports multiple values

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataAddOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataAddOperation.java
@@ -8,12 +8,16 @@
 package org.dspace.app.rest.repository.patch.operation;
 
 import java.sql.SQLException;
+import java.util.List;
 
 import org.dspace.app.rest.exception.DSpaceBadRequestException;
+import org.dspace.app.rest.exception.UnprocessableEntityException;
 import org.dspace.app.rest.model.MetadataValueRest;
 import org.dspace.app.rest.model.patch.Operation;
 import org.dspace.content.DSpaceObject;
+import org.dspace.content.Item;
 import org.dspace.content.MetadataField;
+import org.dspace.content.MetadataValue;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.DSpaceObjectService;
 import org.dspace.core.Context;
@@ -40,7 +44,8 @@ public class DSpaceObjectMetadataAddOperation<R extends DSpaceObject> extends Pa
     @Override
     public R perform(Context context, R resource, Operation operation) throws SQLException {
         DSpaceObjectService dsoService = ContentServiceFactory.getInstance().getDSpaceObjectService(resource);
-        MetadataValueRest metadataValueToAdd = metadataPatchUtils.extractMetadataValueFromOperation(operation);
+        List<MetadataValueRest> metadataValueToAdd = metadataPatchUtils
+            .extractMetadataValueListFromOperation(operation);
         MetadataField metadataField = metadataPatchUtils.getMetadataField(context, operation);
         String indexInPath = metadataPatchUtils.getIndexFromPath(operation.getPath());
 
@@ -60,16 +65,61 @@ public class DSpaceObjectMetadataAddOperation<R extends DSpaceObject> extends Pa
      */
     private void add(Context context, DSpaceObject dso, DSpaceObjectService dsoService, MetadataField metadataField,
                      MetadataValueRest metadataValue, String index) {
+        add(context, dso, dsoService, metadataField, List.of(metadataValue), index);
+    }
+
+    /**
+     * Adds metadata to the dso (appending if index is 0 or left out, prepending if -)
+     *
+     * @param context           context patch is being performed in
+     * @param dso               dso being patched
+     * @param dsoService        service doing the patch in db
+     * @param metadataField     md field being patched
+     * @param metadataValueList list of md element values
+     * @param index             determines whether we're prepending (-) or appending (0) md value (if one value in list)
+     */
+    private void add(Context context, DSpaceObject dso, DSpaceObjectService dsoService, MetadataField metadataField,
+                     List<MetadataValueRest> metadataValueList, String index) {
         metadataPatchUtils.checkMetadataFieldNotNull(metadataField);
         int indexInt = 0;
+        if (index != null && metadataValueList.size() > 1) {
+            throw new DSpaceBadRequestException("Cannot add multiple metadata values with an index in the path.");
+        }
         if (index != null && index.equals("-")) {
             indexInt = -1;
+        } else if (index != null) {
+            try {
+                indexInt = Integer.parseInt(index);
+            } catch (NumberFormatException e) {
+                throw new DSpaceBadRequestException("Invalid index to add metadata value");
+            }
+            // Check that index is within bounds of existing metadata values
+            List<MetadataValue> metadataValues = dsoService.getMetadata(dso,
+                    metadataField.getMetadataSchema().getName(), metadataField.getElement(),
+                    metadataField.getQualifier(), Item.ANY);
+            if (indexInt > metadataValues.size()) {
+                throw new UnprocessableEntityException("There is no metadata of this type at that index");
+            }
         }
         try {
-            dsoService.addAndShiftRightSecuredMetadata(context, dso, metadataField.getMetadataSchema().getName(),
-                    metadataField.getElement(), metadataField.getQualifier(), metadataValue.getLanguage(),
-                    metadataValue.getValue(), metadataValue.getAuthority(), metadataValue.getConfidence(), indexInt,
-                    metadataValue.getSecurityLevel());
+            if (index == null) {
+                // no index => adding/replacing values from the list
+                dsoService.clearMetadata(context, dso, metadataField.getMetadataSchema().getName(),
+                        metadataField.getElement(), metadataField.getQualifier(), Item.ANY);
+                for (MetadataValueRest metadataValue : metadataValueList) {
+                    dsoService.addAndShiftRightSecuredMetadata(context, dso,
+                        metadataField.getMetadataSchema().getName(), metadataField.getElement(),
+                        metadataField.getQualifier(), metadataValue.getLanguage(),
+                        metadataValue.getValue(), metadataValue.getAuthority(), metadataValue.getConfidence(), -1,
+                        metadataValue.getSecurityLevel());
+                }
+            } else {
+                dsoService.addAndShiftRightSecuredMetadata(context, dso, metadataField.getMetadataSchema().getName(),
+                    metadataField.getElement(), metadataField.getQualifier(), metadataValueList.get(0).getLanguage(),
+                    metadataValueList.get(0).getValue(), metadataValueList.get(0).getAuthority(),
+                    metadataValueList.get(0).getConfidence(), indexInt,
+                    metadataValueList.get(0).getSecurityLevel());
+            }
         } catch (SQLException e) {
             throw new DSpaceBadRequestException("SQLException in DspaceObjectMetadataAddOperation.add trying to add " +
                     "metadata to dso.", e);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataAddOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataAddOperation.java
@@ -56,21 +56,6 @@ public class DSpaceObjectMetadataAddOperation<R extends DSpaceObject> extends Pa
     /**
      * Adds metadata to the dso (appending if index is 0 or left out, prepending if -)
      *
-     * @param context       context patch is being performed in
-     * @param dso           dso being patched
-     * @param dsoService    service doing the patch in db
-     * @param metadataField md field being patched
-     * @param metadataValue value of md element
-     * @param index         determines whether we're prepending (-) or appending (0) md value
-     */
-    private void add(Context context, DSpaceObject dso, DSpaceObjectService dsoService, MetadataField metadataField,
-                     MetadataValueRest metadataValue, String index) {
-        add(context, dso, dsoService, metadataField, List.of(metadataValue), index);
-    }
-
-    /**
-     * Adds metadata to the dso (appending if index is 0 or left out, prepending if -)
-     *
      * @param context           context patch is being performed in
      * @param dso               dso being patched
      * @param dsoService        service doing the patch in db
@@ -81,24 +66,25 @@ public class DSpaceObjectMetadataAddOperation<R extends DSpaceObject> extends Pa
     private void add(Context context, DSpaceObject dso, DSpaceObjectService dsoService, MetadataField metadataField,
                      List<MetadataValueRest> metadataValueList, String index) {
         metadataPatchUtils.checkMetadataFieldNotNull(metadataField);
-        int indexInt = 0;
+        int indexInt = -1; // -1 is used if no index is provided, or if index is "-" (meaning last)
         if (index != null && metadataValueList.size() > 1) {
             throw new DSpaceBadRequestException("Cannot add multiple metadata values with an index in the path.");
         }
-        if (index != null && index.equals("-")) {
-            indexInt = -1;
-        } else if (index != null) {
+        if ((index != null) && !index.equals("-")) {
             try {
                 indexInt = Integer.parseInt(index);
             } catch (NumberFormatException e) {
                 throw new DSpaceBadRequestException("Invalid index to add metadata value");
+            }
+            if (indexInt < 0) {
+                throw new DSpaceBadRequestException("Negative index to add metadata value cannot be used");
             }
             // Check that index is within bounds of existing metadata values
             List<MetadataValue> metadataValues = dsoService.getMetadata(dso,
                     metadataField.getMetadataSchema().getName(), metadataField.getElement(),
                     metadataField.getQualifier(), Item.ANY);
             if (indexInt > metadataValues.size()) {
-                throw new UnprocessableEntityException("There is no metadata of this type at that index");
+                throw new UnprocessableEntityException("Index out of bounds for this metadata field");
             }
         }
         try {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataPatchUtils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataPatchUtils.java
@@ -9,6 +9,8 @@ package org.dspace.app.rest.repository.patch.operation;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -52,21 +54,35 @@ public final class DSpaceObjectMetadataPatchUtils {
      * @return MetadataValueRest extracted from json in operation value
      */
     protected MetadataValueRest extractMetadataValueFromOperation(Operation operation) {
-        MetadataValueRest metadataValue = null;
+        return extractMetadataValueListFromOperation(operation).get(0);
+    }
+
+    /**
+     * Extract metadataValue from Operation by parsing the json and mapping it to a MetadataValueRest
+     * @param operation     Operation whose value is begin parsed
+     * @return MetadataValueRest extracted from json in operation value
+     */
+    protected List<MetadataValueRest> extractMetadataValueListFromOperation(Operation operation) {
+        List<MetadataValueRest> metadataValueList = new ArrayList<>();
         try {
             if (operation.getValue() != null) {
                 if (operation.getValue() instanceof JsonValueEvaluator) {
                     JsonNode valueNode = ((JsonValueEvaluator) operation.getValue()).getValueNode();
                     if (valueNode.isArray()) {
-                        metadataValue = mapper.treeToValue(valueNode.get(0), MetadataValueRest.class);
+                        for (JsonNode node : valueNode) {
+                            MetadataValueRest metadataValue = mapper.treeToValue(node, MetadataValueRest.class);
+                            metadataValueList.add(metadataValue);
+                        }
                     } else {
-                        metadataValue = mapper.treeToValue(valueNode, MetadataValueRest.class);
+                        MetadataValueRest metadataValue = mapper.treeToValue(valueNode, MetadataValueRest.class);
+                        metadataValueList.add(metadataValue);
                     }
                 }
                 if (operation.getValue() instanceof String) {
                     String valueString = (String) operation.getValue();
-                    metadataValue = new MetadataValueRest();
+                    MetadataValueRest metadataValue = new MetadataValueRest();
                     metadataValue.setValue(valueString);
+                    metadataValueList.add(metadataValue);
                 }
             }
         } catch (IOException e) {
@@ -74,10 +90,10 @@ public final class DSpaceObjectMetadataPatchUtils {
                     "DspaceObjectMetadataOperation.extractMetadataValueFromOperation trying to map json from " +
                     "operation.value to MetadataValue class.", e);
         }
-        if (metadataValue == null) {
+        if (metadataValueList.isEmpty()) {
             throw new DSpaceBadRequestException("Could not extract MetadataValue Object from Operation");
         }
-        return metadataValue;
+        return metadataValueList;
     }
 
     /**

--- a/dspace-server-webapp/src/test/resources/org/dspace/app/rest/test/metadata-patch-suite.json
+++ b/dspace-server-webapp/src/test/resources/org/dspace/app/rest/test/metadata-patch-suite.json
@@ -139,6 +139,44 @@
       }
     },
     {
+      "name": "replace titles by adding two with one list",
+      "patch": [
+        {
+          "op": "add",
+          "path": "/metadata/dc.title",
+          "value": [
+            { "value": "title 1 (from list)" },
+            { "value": "title 2 (from list)" }
+          ]
+        }
+      ],
+      "expect": {
+        "dc.title": [
+          { "value": "title 1 (from list)", "language": null, "authority": null, "confidence": -1, "place": 0},
+          { "value": "title 2 (from list)", "language": null, "authority": null, "confidence": -1, "place": 1}
+        ]
+      }
+    },
+    {
+      "name": "insert title in between existing ones",
+      "patch": [
+        {
+          "op": "add",
+          "path": "/metadata/dc.title/1",
+          "value": [
+            { "value": "appended title" }
+          ]
+        }
+      ],
+      "expect": {
+        "dc.title": [
+          { "value": "title 1 (from list)", "language": null, "authority": null, "confidence": -1, "place": 0},
+          { "value": "appended title", "language": null, "authority": null, "confidence": -1, "place": 1},
+          { "value": "title 2 (from list)", "language": null, "authority": null, "confidence": -1, "place": 2}
+        ]
+      }
+    },
+    {
       "name": "remove all titles",
       "patch": [
         {

--- a/dspace-server-webapp/src/test/resources/org/dspace/app/rest/test/metadata-patch-suite.json
+++ b/dspace-server-webapp/src/test/resources/org/dspace/app/rest/test/metadata-patch-suite.json
@@ -177,6 +177,41 @@
       }
     },
     {
+      "name": "insert title to the end of list with explicit index",
+      "patch": [
+        {
+          "op": "add",
+          "path": "/metadata/dc.title/3",
+          "value": [
+            { "value": "title at the end" }
+          ]
+        }
+      ],
+      "expect": {
+        "dc.title": [
+          { "value": "title 1 (from list)", "language": null, "authority": null, "confidence": -1, "place": 0},
+          { "value": "appended title", "language": null, "authority": null, "confidence": -1, "place": 1},
+          { "value": "title 2 (from list)", "language": null, "authority": null, "confidence": -1, "place": 2},
+          { "value": "title at the end", "language": null, "authority": null, "confidence": -1, "place": 3}
+        ]
+      }
+    },
+    {
+      "name": "replace titles by adding just one value",
+      "patch": [
+        {
+          "op": "add",
+          "path": "/metadata/dc.title",
+          "value": { "value": "new singular title" }
+        }
+      ],
+      "expect": {
+        "dc.title": [
+          { "value": "new singular title", "language": null, "authority": null, "confidence": -1, "place": 0}
+        ]
+      }
+    },
+    {
       "name": "remove all titles",
       "patch": [
         {


### PR DESCRIPTION
## References

* Related to DSpace/dspace-angular#2056 (and fixes it if [DSpace/dspace-angular/#3078](https://github.com/DSpace/dspace-angular/pull/3078) was implemented with PATCH add instead of PATCH replace)
* Related to DSpace/RestContract#304

## Description

PATCH add to /metadata currently supports adding only one value at time. If values are already present new value is appended only to the start or end of value list (not between, even if /metadata/field.name/n index is given.

In addition, if multiple values are given as a list (to initialize a metadata field without a given index), only one value of the list is picked, conflicting [RFC section 4.1](https://tools.ietf.org/html/rfc6902#section-4.1) and REST contract. This PR - partially based on #9610 by @MMilosz (applied to PATCH replace) - should bring the behaviour in line with the REST contract, providing additional error checks.

## Instructions for Reviewers

List of changes in this PR:
* New method extractMetadataValueListFromOperation has been added to helper class  DSpaceObjectMetadataPatchUtils.java. This is a generalization to earlier method extractMetadataValueFromOperation (used by both add and replace operations) that can handle both individual values or arrays.
* DSpaceObjectMetadataAddOperation.java now handles lists (with one-value-list as special case to handle individual values). Multivaluelist is accepted only if no index is given (i.e. you can add a list with `/metadata/dc.title` but not with `/metadata/dc.title/0`), otherwise this is considered a 400 Bad request.
* Logic and related to metadata additions with indexes are improved. Earlier, unless `-1` value was given, new metadata value was always added to the start of the list (i.e. index `0` - even if PATCH called given with another index number parseInt was not present). Now the new value is appended to position w.r.t. given index. For example, if two different dc.titles are present, call `/metadata/dc.title/1` would append the new value between the first and last values.
* The following checks to handling index values have been added: index number should not be greater that the total number of existing metadata values and it should be a number. I.e. call  `/metadata/dc.title/20` would result to 422 Unprocessable entity and call  `/metadata/dc.title/asdf` would result to 400 Bad request.

This PR can be tested with any entity that uses metadata. For example, updating metadata to an existing community (as in #9610 but applied to add operation) with curl. 

`$ curl http://localhost:8080/server/api/core/communities/:UUID -X PATCH --data-raw '[{"op":add", ... }
`

Simple example tests to try with https://github.com/the-library-code/dspace-rest-python :

```python
d = DSpaceClient(api_endpoint=URL, username=USERNAME, password=PASSWORD, fake_user_agent=False)

#...

dso = d.resolve_identifier_to_dso(handle)

# error 400 - multiple values with place
d.api_patch(url=dso.links["self"]["href"],operation=DSpaceClient.PatchOperation.ADD, path='/metadata/dc.description.abstract/0', value= [ { "value": "Kuvaus suomeksi", "language": "fi" }, { "value": "Description in English", "language": "en" }])

#success - single value in list
d.api_patch(url=dso.links["self"]["href"],operation=DSpaceClient.PatchOperation.ADD, path='/metadata/dc.description.abstract/0', value= [ { "value": "single value"} ])

#original dc.description.abstract values are replaced
d.api_patch(url=dso.links["self"]["href"],operation=DSpaceClient.PatchOperation.ADD, path='/metadata/dc.description.abstract', value= [ { "value": "Kuvaus suomeksi", "language": "fi" }, { "value": "Description in English", "language": "en" }])

#replace existing values as one (as no place is given)
d.add_metadata(dso,'dc.description.abstract','replaced',language='en')

#single value to start of list
d.add_metadata(dso,'dc.description.abstract','Description in English',language='en',place='0')

#single value to end of list
d.add_metadata(dso,'dc.description.abstract','Kuvaus suomeksi',language='fi',place='-1')

#single value in between
d.add_metadata(dso,'dc.description.abstract','intermediate value',place='1')

#results to error 422, out of bounds
d.add_metadata(dso,'dc.description.abstract','erroneous place',language='fi',place='10')

#results to error 400, invalid place
d.add_metadata(dso,'dc.description.abstract','erroneous place',language='fi',place='adsf')

#fails (metadatafield does not exist)
d.add_metadata(dso,'dc.newfield','uninitialized new field')
```

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
