### PR TITLE
Fix CVE-2025-53622 by improving SAF manifest path handling

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
@@ -1003,6 +1003,34 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
     }
 
     /**
+     * Ensures a file path does not attempt to access files outside the designated parent directory.
+     *
+     * @param parentDir          The absolute path to the parent directory that should contain the file
+     * @param fileName           The name or path of the file to validate
+     * @throws IOException       If an error occurs while resolving canonical paths, or the file path attempts
+     *                           to access a location outside the parent directory
+     */
+    private void validateFilePath(String parentDir, String fileName) throws IOException {
+        File parent = new File(parentDir);
+        File file = new File(fileName);
+
+        // If the fileName is not an absolute path, we resolve it against the parentDir
+        if (!file.isAbsolute()) {
+            file = new File(parent, fileName);
+        }
+
+        String parentCanonicalPath = parent.getCanonicalPath();
+        String fileCanonicalPath = file.getCanonicalPath();
+
+        if (!fileCanonicalPath.startsWith(parentCanonicalPath)) {
+            log.error("File path outside of canonical root requested: fileCanonicalPath={} does not begin " +
+                "with parentCanonicalPath={}", fileCanonicalPath, parentCanonicalPath);
+            throw new IOException("Illegal file path '" + fileName + "' encountered. This references a path " +
+                "outside of the import package. Please see the system logs for more details.");
+        }
+    }
+
+    /**
      * Read the collections file inside the item directory. If there
      * is one and it is not empty return a list of collections in
      * which the item should be inserted. If it does not exist or it
@@ -1202,6 +1230,7 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
                             sDescription = sDescription.replaceFirst("description:", "");
                         }
 
+                        validateFilePath(path, sFilePath);
                         registerBitstream(c, i, iAssetstore, sFilePath, sBundle, sDescription);
                         logInfo("\tRegistering Bitstream: " + sFilePath
                             + "\tAssetstore: " + iAssetstore
@@ -1415,6 +1444,7 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
             return;
         }
 
+        validateFilePath(path, fileName);
         String fullpath = path + File.separatorChar + fileName;
 
         // get an input stream

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/DSBitStoreService.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/DSBitStoreService.java
@@ -12,6 +12,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Path;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -248,6 +249,12 @@ public class DSBitStoreService extends BaseBitStoreService {
         if (log.isDebugEnabled()) {
             log.debug("Local filename for " + sInternalId + " is "
                           + bufFilename.toString());
+        }
+        File bitstreamFile = new File(bufFilename.toString());
+        Path normalizedPath = bitstreamFile.toPath().normalize();
+        if (!normalizedPath.startsWith(baseDir.getAbsolutePath())) {
+            log.error("Bitstream path outside of assetstore root requested: bitstream={}, path={}, assetstore={}", bitstream.getID(), normalizedPath, baseDir.getAbsolutePath());
+            throw new IOException("Illegal bitstream path constructed");
         }
         return new File(bufFilename.toString());
     }

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/DSBitStoreService.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/DSBitStoreService.java
@@ -253,7 +253,9 @@ public class DSBitStoreService extends BaseBitStoreService {
         File bitstreamFile = new File(bufFilename.toString());
         Path normalizedPath = bitstreamFile.toPath().normalize();
         if (!normalizedPath.startsWith(baseDir.getAbsolutePath())) {
-            log.error("Bitstream path outside of assetstore root requested: bitstream={}, path={}, assetstore={}", bitstream.getID(), normalizedPath, baseDir.getAbsolutePath());
+            log.error("Bitstream path outside of assetstore root requested:" +
+                    "bitstream={}, path={}, assetstore={}",
+                    bitstream.getID(), normalizedPath, baseDir.getAbsolutePath());
             throw new IOException("Illegal bitstream path constructed");
         }
         return bitstreamFile;

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/DSBitStoreService.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/DSBitStoreService.java
@@ -256,7 +256,7 @@ public class DSBitStoreService extends BaseBitStoreService {
             log.error("Bitstream path outside of assetstore root requested: bitstream={}, path={}, assetstore={}", bitstream.getID(), normalizedPath, baseDir.getAbsolutePath());
             throw new IOException("Illegal bitstream path constructed");
         }
-        return new File(bufFilename.toString());
+        return bitstreamFile;
     }
 
     public boolean isRegisteredBitstream(String internalId) {


### PR DESCRIPTION
## References
* Fixes CVE-2025-53622 . See security advisory: https://github.com/DSpace/DSpace/security/advisories/GHSA-vhvx-8xgc-99wf

## Description

This pull request fixes a path traversal vulnerability in the Simple Archive Format (SAF) contents manifest file, and in the file-based bitstore services handling of [registered] bitstream internal IDs.

Changes in this PR:
* Relative path is enforced on all file entries (including using the -r flag for registered file locations) in the contents manifest. All resolved, normalized file paths must be relative to the SAF item directory.
  * This works for registered files, even though they are not part of the SAF package, as they must also be relative to an assetstore and therefore must not be absolute paths or contain any traversal possibilities
* The bitstream path constructed from internal ID, intermediate path, and assetstore root is resolved, normalized and enforced by the DSBitstoreService#get method. An exception is thrown if the path is not within the correct assetstore root.
  * Some path segment sanitization was already done for ingested (not registered) internal IDs, but registered bitstreams could still traverse outside of assetstore root, and some other possibilities following manipulation of the intermediate path or internal IDs existed.
