### PR TITLE
Implement authentication-oidc.login.specialgroup configuration option

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authenticate/OidcAuthenticationBean.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/OidcAuthenticationBean.java
@@ -16,6 +16,7 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import java.io.UnsupportedEncodingException;
 import java.sql.SQLException;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -31,7 +32,9 @@ import org.dspace.authenticate.oidc.model.OidcTokenResponseDTO;
 import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
+import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.eperson.service.EPersonService;
+import org.dspace.eperson.service.GroupService;
 import org.dspace.services.ConfigurationService;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -48,6 +51,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 public class OidcAuthenticationBean implements AuthenticationMethod {
 
     public static final String OIDC_AUTH_ATTRIBUTE = "oidc";
+
+    protected GroupService groupService
+            = EPersonServiceFactory.getInstance().getGroupService();
 
     private final static String LOGIN_PAGE_URL_FORMAT = "%s?client_id=%s&response_type=code&scope=%s&redirect_uri=%s";
 
@@ -85,6 +91,26 @@ public class OidcAuthenticationBean implements AuthenticationMethod {
 
     @Override
     public List<Group> getSpecialGroups(Context context, HttpServletRequest request) throws SQLException {
+        // Check if authentication-oidc.login.specialgroup config has a group defined
+        try {
+            // without a logged in user, this method should return an empty list
+            if (context.getCurrentUser() == null) {
+                return List.of();
+            }
+            String groupName = configurationService.getProperty("authentication-oidc.login.specialgroup");
+            if ((groupName != null) && (!groupName.trim().equals(""))) {
+                Group group = groupService.findByName(context, groupName);
+                if (group == null) {
+                    // Group not found
+                    LOGGER.warn("Group defined in authentication-oidc.login.specialgroup does not exist");
+                    return List.of();
+                } else {
+                    return Arrays.asList(group);
+                }
+            }
+        } catch (SQLException ex) {
+            // Database error, ignore
+        }
         return List.of();
     }
 
@@ -141,9 +167,16 @@ public class OidcAuthenticationBean implements AuthenticationMethod {
         if (! canSelfRegister()) {
             LOGGER.warn("Self registration is currently disabled for OIDC, and no ePerson could be found for email: {}",
                 email);
+            return NO_SUCH_USER;
+        } else {
+            int result = registerNewEPerson(context, userInfo, email);
+            if (result == SUCCESS) {
+                // It is important to set this attribute so the new user
+                // can be granted permissions of the special group in the first login
+                request.setAttribute(OIDC_AUTHENTICATED, true);
+            }
+            return result;
         }
-
-        return canSelfRegister() ? registerNewEPerson(context, userInfo, email) : NO_SUCH_USER;
     }
 
     @Override

--- a/dspace/config/modules/authentication-oidc.cfg
+++ b/dspace/config/modules/authentication-oidc.cfg
@@ -46,3 +46,7 @@ authentication-oidc.user-info.first-name = given_name
 
 #Specify the attribute present in the user info json related to the user's last name
 authentication-oidc.user-info.last-name = family_name
+
+# If required, a group name can be given here, and all users who log in
+# using OIDC will automatically become members of this group.
+#authentication-oidc.login.specialgroup = group-name


### PR DESCRIPTION
## References
* Fixes #11039
* Fixes #11570

## Description
Implements a new configuration option called `authentication-oidc.login.specialgroup` identical to the one provided by LDAP and Password plugins.

## Instructions for Reviewers
List of changes:
- Modifies the `getSpecialGroup` function in `OidcAuthenticationBean` class to return an EPerson Group considering the `authentication-oidc.login.specialgroup` configuration.
- Modifies the `authenticateWithOidc` function in `OidcAuthenticationBean` to set an attribute indicating OIDC Authentication when user is self registering. Otherwise the special group configured won't be available when user first logs in.

In order to test:
* Enable and configure OIDC Authentication
* Create an EPerson Group or choose an existing one and define any policy related to it (Ex: READ permission on a collection).
* Add the group name to the `authentication-oidc.login.specialgroup` option in the configuration file `local.cfg`
* Log in with OIDC and test the policy defined previously (Ex: try to access the restricted collection).

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
