### PR TITLE
Experimental change to test theory on workflow item list perf cause

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/AInprogressItemConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/AInprogressItemConverter.java
@@ -27,6 +27,7 @@ import org.dspace.content.Item;
 import org.dspace.eperson.EPerson;
 import org.dspace.submit.factory.SubmissionServiceFactory;
 import org.dspace.submit.service.SubmissionConfigService;
+import org.dspace.workflow.WorkflowItem;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 
@@ -70,6 +71,14 @@ public abstract class AInprogressItemConverter<T extends InProgressSubmission,
         submitter = obj.getSubmitter();
 
         witem.setId(obj.getID());
+
+        // Return early if this is a workflow item
+        // TODO - WIP - this is just an experimental change and I expect it
+        // breaks the "Edit Metadata" workflow action for a claimed task since
+        // that requires the form models, errors etc to be loaded
+        if (witem instanceof WorkflowItem) {
+            return;
+        }
 
         // 1. retrieve the submission definition
         // 2. iterate over the submission section to allow to plugin additional


### PR DESCRIPTION
## References
 * Attempts to locate or prove the performance issues in #10750 

A very small change that returns early during the `fillModel` conversion method (used in all "in progress" submission items). WARNING: THIS BREAKS THE EDIT METADATA STEP IN WORKFLOW.

This is NOT an actual suggested fix, but it might be a good first step - if we only need to complete `fillModel` or retrieve it in an additional request when the Editor clicks "Edit" (special parameter to the REST endpoint or something?) then it might gie us some good ideas.

There are of course some bottlenecks in submission config and input form reading/handling that are themselves a problem, but this might be a good start since we are doing so much extra backend work converting workflow items this way, when it's not necessary 99% of the time.

@paulo-graca this should be very easy to cherry-pick or just manully apply to a 7.x or 8.x codebase.