### PR TITLE
Fix several unit/integration test failures that only occur on Windows

### DIFF
--- a/dspace-api/src/main/java/org/dspace/importer/external/metadatamapping/MetadatumDTO.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/metadatamapping/MetadatumDTO.java
@@ -105,4 +105,13 @@ public class MetadatumDTO {
     public void setValue(String value) {
         this.value = value;
     }
+
+    /**
+     * Return string representation of MetadatumDTO
+     * @return string representation of format "[schema].[element].[qualifier]=[value]"
+     */
+    @Override
+    public String toString() {
+        return schema + "." + element + "." + qualifier + "=" + value;
+    }
 }

--- a/dspace-api/src/test/java/org/dspace/storage/bitstore/JCloudBitStoreServiceTest.java
+++ b/dspace-api/src/test/java/org/dspace/storage/bitstore/JCloudBitStoreServiceTest.java
@@ -16,6 +16,9 @@ import static org.mockito.Mockito.when;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 
 import com.google.common.io.ByteSource;
 import org.dspace.AbstractUnitTest;
@@ -143,7 +146,7 @@ public class JCloudBitStoreServiceTest extends AbstractUnitTest {
         String computedPath = this.jCloudBitStoreService.getIntermediatePath(path.toString());
         int slashes = computeSlashes(path.toString());
         assertThat(computedPath, Matchers.endsWith(File.separator));
-        assertThat(computedPath.split(File.separator).length, Matchers.equalTo(slashes));
+        assertThat(countPathElements(computedPath), Matchers.equalTo(slashes));
 
         path.append("2");
         computedPath = this.jCloudBitStoreService.getIntermediatePath(path.toString());
@@ -168,31 +171,31 @@ public class JCloudBitStoreServiceTest extends AbstractUnitTest {
         String computedPath = this.jCloudBitStoreService.getIntermediatePath(path.toString());
         int slashes = computeSlashes(path.toString());
         assertThat(computedPath, Matchers.endsWith(File.separator));
-        assertThat(computedPath.split(File.separator).length, Matchers.equalTo(slashes));
+        assertThat(countPathElements(computedPath), Matchers.equalTo(slashes));
 
         path.append("2");
         computedPath = this.jCloudBitStoreService.getIntermediatePath(path.toString());
         slashes = computeSlashes(path.toString());
         assertThat(computedPath, Matchers.endsWith(File.separator));
-        assertThat(computedPath.split(File.separator).length, Matchers.equalTo(slashes));
+        assertThat(countPathElements(computedPath), Matchers.equalTo(slashes));
 
         path.append("3");
         computedPath = this.jCloudBitStoreService.getIntermediatePath(path.toString());
         slashes = computeSlashes(path.toString());
         assertThat(computedPath, Matchers.endsWith(File.separator));
-        assertThat(computedPath.split(File.separator).length, Matchers.equalTo(slashes));
+        assertThat(countPathElements(computedPath), Matchers.equalTo(slashes));
 
         path.append("4");
         computedPath = this.jCloudBitStoreService.getIntermediatePath(path.toString());
         slashes = computeSlashes(path.toString());
         assertThat(computedPath, Matchers.endsWith(File.separator));
-        assertThat(computedPath.split(File.separator).length, Matchers.equalTo(slashes));
+        assertThat(countPathElements(computedPath), Matchers.equalTo(slashes));
 
         path.append("56789");
         computedPath = this.jCloudBitStoreService.getIntermediatePath(path.toString());
         slashes = computeSlashes(path.toString());
         assertThat(computedPath, Matchers.endsWith(File.separator));
-        assertThat(computedPath.split(File.separator).length, Matchers.equalTo(slashes));
+        assertThat(countPathElements(computedPath), Matchers.equalTo(slashes));
     }
 
     @Test
@@ -217,6 +220,14 @@ public class JCloudBitStoreServiceTest extends AbstractUnitTest {
         int odd = Math.min(1, minimum % S3BitStoreService.digitsPerLevel);
         int slashes = slashesPerLevel + odd;
         return Math.min(slashes, S3BitStoreService.directoryLevels);
+    }
+
+    // Count the number of elements in a Unix or Windows path.
+    // We use 'Paths' instead of splitting on slashes because these OSes use different path separators.
+    private int countPathElements(String stringPath) {
+        List<String> pathElements = new ArrayList<>();
+        Paths.get(stringPath).forEach(p -> pathElements.add(p.toString()));
+        return pathElements.size();
     }
 
 }

--- a/dspace-saml2/src/test/java/org/dspace/saml2/DSpaceRelyingPartyRegistrationRepositoryTest.java
+++ b/dspace-saml2/src/test/java/org/dspace/saml2/DSpaceRelyingPartyRegistrationRepositoryTest.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.saml2;
 
+import static org.apache.commons.lang3.SystemUtils.IS_OS_WINDOWS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -376,11 +377,14 @@ public class DSpaceRelyingPartyRegistrationRepositoryTest extends AbstractDSpace
         configurationService.setProperty(
             "saml-relying-party.auth0.asserting-party.metadata-uri", "classpath:auth0-ap-metadata.xml");
 
+        // Windows requires three slashes in a file URL.  Linux/unix does not.
+        String fileUrlPrefix = IS_OS_WINDOWS ? "file:///" : "file://";
+
         configurationService.setProperty("saml-relying-party.auth0.signing.credentials.0.private-key-location",
-            "file://" + new ClassPathResource("auth0-rp-private.key").getFile().getAbsolutePath());
+            fileUrlPrefix + new ClassPathResource("auth0-rp-private.key").getFile().getAbsolutePath());
 
         configurationService.setProperty("saml-relying-party.auth0.signing.credentials.0.certificate-location",
-            "file://" + new ClassPathResource("auth0-rp-certificate.crt").getFile().getAbsolutePath());
+            fileUrlPrefix + new ClassPathResource("auth0-rp-certificate.crt").getFile().getAbsolutePath());
 
         DSpaceRelyingPartyRegistrationRepository repo = new DSpaceRelyingPartyRegistrationRepository();
         RelyingPartyRegistration registration = repo.findByRegistrationId("auth0");

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/AbstractLiveImportIntegrationTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/AbstractLiveImportIntegrationTest.java
@@ -16,12 +16,12 @@ import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.ProtocolVersion;
 import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.entity.BasicHttpEntity;
-import org.apache.tools.ant.filters.StringInputStream;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
 import org.dspace.importer.external.datamodel.ImportRecord;
 import org.dspace.importer.external.metadatamapping.MetadatumDTO;
@@ -43,7 +43,8 @@ public class AbstractLiveImportIntegrationTest extends AbstractControllerIntegra
     private void checkMetadataValue(List<MetadatumDTO> list, List<MetadatumDTO> list2) {
         assertEquals(list.size(), list2.size());
         for (int i = 0; i < list.size(); i++) {
-            assertTrue(sameMetadatum(list.get(i), list2.get(i)));
+            assertTrue("'" + list.get(i).toString() + "' should be equal to '" + list2.get(i).toString() + "'",
+                       sameMetadatum(list.get(i), list2.get(i)));
         }
     }
 
@@ -70,7 +71,7 @@ public class AbstractLiveImportIntegrationTest extends AbstractControllerIntegra
             throws UnsupportedEncodingException {
         BasicHttpEntity basicHttpEntity = new BasicHttpEntity();
         basicHttpEntity.setChunked(true);
-        basicHttpEntity.setContent(new StringInputStream(xmlExample));
+        basicHttpEntity.setContent(IOUtils.toInputStream(xmlExample));
 
         CloseableHttpResponse response = mock(CloseableHttpResponse.class);
         when(response.getStatusLine()).thenReturn(statusLine(statusCode, reason));

--- a/pom.xml
+++ b/pom.xml
@@ -531,10 +531,10 @@
     </build>
 
     <profiles>
-        <!-- Allow for passing extra memory to Unit/Integration tests.
-             By default this gives unit tests 1GB of memory max (when tests are enabled),
-             unless tweaked on commandline (e.g. "-Dtest.argLine=-Xmx512m"). Since
-             m-surefire-p and m-failsafe-p both fork a new JVM for testing, they ignores MAVEN_OPTS. -->
+        <!-- Profile which sets our default system properties for all Unit/Integration tests.
+             By default, this sets UTF-8 encoding for all tests and gives tests 1GB of memory max.
+             Both m-surefire-p and m-failsafe-p are unable to use MAVEN_OPTS because they fork a new JVM for testing.
+             These default settings may be overridden via the commandline (e.g. "-Dtest.argLine=-Xmx512m"). -->
         <profile>
             <id>test-argLine</id>
             <activation>
@@ -543,7 +543,7 @@
                 </property>
             </activation>
             <properties>
-                <test.argLine>-Xmx1024m</test.argLine>
+                <test.argLine>-Xmx1024m -Dfile.encoding=UTF-8</test.argLine>
             </properties>
         </profile>
 


### PR DESCRIPTION
## Description

When running tests on Windows via the commandline, there are a number of unit & integration tests that will consistently fail because of Windows incompatibility.  These have become a pain (for me at least), as it means it's difficult to determine on Windows whether tests are accurately passing or not.

After a lot of debugging, I've narrowed down that there are two main reasons that this occurs:
1. First, most importantly, our tests do NOT force UTF-8 encoding.  This results in some test failures because Windows attempts to use its own encoding -- causing string comparisons to fail when strings include UTF-8 characters.  This occurs most frequently in the Live Import tests (any that extend `AbstractLiveImportIntegrationTest`.  _(Fixed by forcing UTF-8 in our `pom.xml`)_
2. Several other tests make assumptions that are only guaranteed on Linux/Unix.  Examples include:
    * `JCloudBitStoreServiceTest` and `S3BitStoreServiceIT` both assume that paths can be split on the `/` (forward slash), but Windows paths use `\` (backward slash).   _(Fixed by splitting paths in a programmatic way by using `java.nio.file.Paths`)_
    * `DSpaceHttpClientFactoryTest` assumes that `127.0.0.1` will always respond as `localhost`.  But, when using Docker Desktop on Windows, `127.0.0.1` may respond as `kubernetes.docker.internal`  _(Fixed by ensuring tests do not hardcode checks for "localhost", but instead use `java.net.InetAddress` to obtain the actual hostname.)_
    * `S3BitStoreServiceIT` also used `S3Mock` with a filesystem storage.  On Windows, this passes tests but cleanup of the files written to the filesystem always fails. _(Fixed by switching S3Mock to use in-memory storage)_
    * SAML2 tests assume that all File URLs begin with prefix `file://`.  But, on Windows, three slashes are needed (i.e. `file:///`).  _(Fixed by checking OS and determining which file URL prefix to use.)_


## Instructions for Reviewers
* Check the code to make sure no changes in behavior.  All code changes are to testing framework (with one exception: added a new `MetadatumDTO.toString()` method just for logging purposes in tests)
* Verify tests pass in GitHub CI
* I've already verified that these tests now pass on Windows.  So, no additional tests are necessary there.

NOTE: Ideally, this should also be backported to `dspace-8_x` and `dspace-7_x`.  But, it would require a manual backport because some of the modified tests (e.g. SAML2) didn't exist in those releases.  I can backport these changes once this original PR is approved.