### PR TITLE
[Port dspace-7_x] Fix several unit/integration test failures that only occur on Windows

### DIFF
--- a/dspace-api/src/main/java/org/dspace/importer/external/metadatamapping/MetadatumDTO.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/metadatamapping/MetadatumDTO.java
@@ -105,4 +105,13 @@ public class MetadatumDTO {
     public void setValue(String value) {
         this.value = value;
     }
+
+    /**
+     * Return string representation of MetadatumDTO
+     * @return string representation of format "[schema].[element].[qualifier]=[value]"
+     */
+    @Override
+    public String toString() {
+        return schema + "." + element + "." + qualifier + "=" + value;
+    }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/AbstractLiveImportIntegrationTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/AbstractLiveImportIntegrationTest.java
@@ -16,12 +16,12 @@ import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.ProtocolVersion;
 import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.entity.BasicHttpEntity;
-import org.apache.tools.ant.filters.StringInputStream;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
 import org.dspace.importer.external.datamodel.ImportRecord;
 import org.dspace.importer.external.metadatamapping.MetadatumDTO;
@@ -43,7 +43,8 @@ public class AbstractLiveImportIntegrationTest extends AbstractControllerIntegra
     private void checkMetadataValue(List<MetadatumDTO> list, List<MetadatumDTO> list2) {
         assertEquals(list.size(), list2.size());
         for (int i = 0; i < list.size(); i++) {
-            assertTrue(sameMetadatum(list.get(i), list2.get(i)));
+            assertTrue("'" + list.get(i).toString() + "' should be equal to '" + list2.get(i).toString() + "'",
+                       sameMetadatum(list.get(i), list2.get(i)));
         }
     }
 
@@ -70,7 +71,7 @@ public class AbstractLiveImportIntegrationTest extends AbstractControllerIntegra
             throws UnsupportedEncodingException {
         BasicHttpEntity basicHttpEntity = new BasicHttpEntity();
         basicHttpEntity.setChunked(true);
-        basicHttpEntity.setContent(new StringInputStream(xmlExample));
+        basicHttpEntity.setContent(IOUtils.toInputStream(xmlExample));
 
         CloseableHttpResponse response = mock(CloseableHttpResponse.class);
         when(response.getStatusLine()).thenReturn(statusLine(statusCode, reason));

--- a/pom.xml
+++ b/pom.xml
@@ -515,10 +515,10 @@
     </build>
 
     <profiles>
-        <!-- Allow for passing extra memory to Unit/Integration tests.
-             By default this gives unit tests 1GB of memory max (when tests are enabled),
-             unless tweaked on commandline (e.g. "-Dtest.argLine=-Xmx512m"). Since
-             m-surefire-p and m-failsafe-p both fork a new JVM for testing, they ignores MAVEN_OPTS. -->
+        <!-- Profile which sets our default system properties for all Unit/Integration tests.
+             By default, this sets UTF-8 encoding for all tests and gives tests 1GB of memory max.
+             Both m-surefire-p and m-failsafe-p are unable to use MAVEN_OPTS because they fork a new JVM for testing.
+             These default settings may be overridden via the commandline (e.g. "-Dtest.argLine=-Xmx512m"). -->
         <profile>
             <id>test-argLine</id>
             <activation>
@@ -527,7 +527,7 @@
                 </property>
             </activation>
             <properties>
-                <test.argLine>-Xmx1024m</test.argLine>
+                <test.argLine>-Xmx1024m -Dfile.encoding=UTF-8</test.argLine>
             </properties>
         </profile>
 


### PR DESCRIPTION
Manual port of #11063 to `dspace-7_x`.  Includes all commits which are valid for 7.x