### PR TITLE
Simple Log4j tests with in-memory log appender

### DIFF
--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/test/WebappLoggingIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/test/WebappLoggingIT.java
@@ -1,0 +1,101 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.test;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.config.Property;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * Test basic log4j logging functionality, extending AbstractControllerIntegrationTest
+ * purely to make sure we are testing the *web application* and not just the kernel
+ * as that is where logging has broken in the past.
+ *
+ * @author Kim Shepherd
+ */
+public class WebappLoggingIT extends AbstractControllerIntegrationTest {
+
+    private static final Logger logger = LogManager.getLogger(WebappLoggingIT.class);
+    private static final String APPENDER_NAME = "DSpaceTestAppender";
+
+    static class InMemoryAppender extends AbstractAppender {
+        private final List<String> messages = new ArrayList<>();
+
+        protected InMemoryAppender(String name) {
+            super(
+                name,
+                null,
+                PatternLayout.newBuilder().withPattern("%m").build(),
+                false,
+                Property.EMPTY_ARRAY
+            );
+            start();
+        }
+
+        @Override
+        public void append(LogEvent event) {
+            messages.add(event.getMessage().getFormattedMessage());
+        }
+
+        public List<String> getMessages() {
+            return messages;
+        }
+    }
+
+    @Test
+    public void testLogging() throws Exception {
+        LoggerContext context = (LoggerContext) LogManager.getContext(false);
+        Configuration config = context.getConfiguration();
+
+        InMemoryAppender appender = new InMemoryAppender(APPENDER_NAME);
+        config.addAppender(appender);
+
+        LoggerConfig testLoggerConfig = new LoggerConfig(logger.getName(), Level.INFO, false);
+        testLoggerConfig.addAppender(appender, null, null);
+        config.addLogger(logger.getName(), testLoggerConfig);
+        context.updateLoggers();
+
+        logger.info("DSPACE TEST LOG ENTRY");
+
+        List<String> messages = appender.getMessages();
+        assertTrue(messages.stream().anyMatch(msg -> msg.contains("DSPACE TEST LOG ENTRY")));
+    }
+
+    @After
+    public void cleanupAppender() {
+        LoggerContext context = (LoggerContext) LogManager.getContext(false);
+        Configuration config = context.getConfiguration();
+
+        config.removeLogger(logger.getName());
+
+        Appender appender = config.getAppender(APPENDER_NAME);
+        if (appender != null) {
+            appender.stop();
+            config.getAppenders().remove(APPENDER_NAME);
+        }
+
+        context.updateLoggers();
+}
+
+}
+


### PR DESCRIPTION
Related to https://github.com/DSpace/DSpace/issues/11046

This integration test creates and attaches an in-memory log appender, writes an INFO line, and tests for expected output.

It is a controller integration test rather than a simple abstract test, not to test any specific REST webapp functionality but to force it to be run in that environment, as earlier log4j bugs appeared to affect logging from Tomcat but not the CLI (plain kernel).

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
