### PR TITLE
Add basic logging tests to our docker deployment script in GitHub actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -220,6 +220,19 @@ jobs:
           result=$(wget -O- -q http://127.0.0.1:8080/server/api/core/collections)
           echo "$result"
           echo "$result" |  grep -oE "\"Dog in Yard\","
+      # Verify basic backend logging is working.
+      # 1. Access the top communities list. Verify that the "Before request" INFO statement is logged
+      # 2. Access an invalid endpoint (and ignore 404 response). Verify that a "status:404" WARN statement is logged
+      - name: Verify backend is logging properly
+        run: |
+          wget -O/dev/null -q http://127.0.0.1:8080/server/api/core/communities/search/top
+          logs=$(docker compose -f docker-compose.yml logs -n 5 dspace)
+          echo "$logs"
+          echo "$logs" | grep -o "Before request \[GET /server/api/core/communities/search/top\]"
+          wget -O/dev/null -q http://127.0.0.1:8080/server/api/does/not/exist || true
+          logs=$(docker compose -f docker-compose.yml logs -n 5 dspace)
+          echo "$logs"
+          echo "$logs" | grep -o "status:404 exception: The repository type does.not was not found"
       # Verify Handle Server can be stared and is working properly
       # 1. First generate the "[dspace]/handle-server" folder with the sitebndl.zip
       # 2. Start the Handle Server (and wait 20 seconds to let it start up)


### PR DESCRIPTION
## References
* Relates to #11046 - Attempts to avoid this scenario in the future
* Alternative to, or perhaps complementary to, #11067

## Description
This small PR adds some Bash commands to our `docker-deploy` step in our GitHub actions to do the following:
1. Call a valid endpoint, and ensure that the corresponding `INFO` statement is logged
2. Call an invalid endpoint, and ensure that the corresponding `WARN` statement is logged

**Why implement this test via Bash scripts?**  Essentially, from all my testing, I've been unable to reproduce #11046 **in integration tests** (which is why #11067 isn't a full solution).  With everything I've tried, log4j version 2.25.0 seems to work fine in our IT layer (INFO logs are visible for all ITs).  The only way I've been able to easily reproduce #11046 is via a full deployment of the backend.

## Instructions for Reviewers
* Review code for sanity
* This is only fully testable in GitHub actions.  But, it's possible to run a manual test by spinning up the backend in Docker, and running the `wget` calls on your own machine, followed by verifying that the `grep` calls work in your Docker logs.      
    * I ran this manual test locally and verified that with log4j 2.25.1, these commands all succeed.  But, with log4j 2.25.0, the `grep` calls fail because neither the `INFO` nor `WARN` statement is logged.