### PR TITLE
[Port dspace-7_x] fixed shared memory warnings on Solr startup (when Solr is running in Docker container)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,6 +86,8 @@ services:
   # DSpace Solr container
   dspacesolr:
     container_name: dspacesolr
+    environment:
+      SOLR_OPTS: -XX:-UseLargePages
     image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-solr:${DSPACE_VER:-dspace-7_x}"
     build:
       context: ./dspace/src/main/docker/dspace-solr/


### PR DESCRIPTION
Manual port of #10357 by @saschaszott to `dspace-7_x`