### PR TITLE
Revert "fixed shared memory warnings on Solr startup (when Solr is running in Docker container)"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,8 +86,6 @@ services:
   # DSpace Solr container
   dspacesolr:
     container_name: dspacesolr
-    environment:
-      SOLR_OPTS: -XX:-UseLargePages
     image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-solr:${DSPACE_VER:-latest}"
     build:
       context: ./dspace/src/main/docker/dspace-solr/


### PR DESCRIPTION
Reverts DSpace/DSpace#10357 from `main` (and `dspace-9_x`).  This setting doesn't appear to work properly with Solr 9, as it's resulting in failures in our `dspace-deploy` script (the backend cannot be deployed on Docker without errors).

However, DSpace/DSpace#10357 seems to work fine with Solr 8, which is what is used on `dspace-8_x` and `dspace-7_x`.