### PR TITLE
Removing unused collection conversion - fixes #10750

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionDefinitionConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionDefinitionConverter.java
@@ -75,21 +75,6 @@ public class SubmissionDefinitionConverter implements DSpaceConverter<Submission
                         e);
             }
         }
-
-        HttpServletRequest request = requestService.getCurrentRequest().getHttpServletRequest();
-        Context context = null;
-        try {
-            context = ContextUtil.obtainContext(request);
-            List<Collection> collections = panelConverter.getSubmissionConfigService()
-                                                         .getCollectionsBySubmissionConfig(context,
-                                                                                           obj.getSubmissionName());
-            DSpaceConverter<Collection, CollectionRest> cc = converter.getConverter(Collection.class);
-            List<CollectionRest> collectionsRest = collections.stream().map((collection) ->
-                    cc.convert(collection, projection)).collect(Collectors.toList());
-            sd.setCollections(collectionsRest);
-        } catch (SQLException | IllegalStateException | SubmissionConfigReaderException e) {
-            log.error(e.getMessage(), e);
-        }
         sd.setPanels(panels);
         return sd;
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionDefinitionConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionDefinitionConverter.java
@@ -7,24 +7,16 @@
  */
 package org.dspace.app.rest.converter;
 
-import java.sql.SQLException;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.stream.Collectors;
 
-import jakarta.servlet.http.HttpServletRequest;
 import org.apache.logging.log4j.Logger;
-import org.dspace.app.rest.model.CollectionRest;
 import org.dspace.app.rest.model.SubmissionDefinitionRest;
 import org.dspace.app.rest.model.SubmissionSectionRest;
 import org.dspace.app.rest.projection.Projection;
 import org.dspace.app.rest.submit.DataProcessingStep;
-import org.dspace.app.rest.utils.ContextUtil;
 import org.dspace.app.util.SubmissionConfig;
-import org.dspace.app.util.SubmissionConfigReaderException;
 import org.dspace.app.util.SubmissionStepConfig;
-import org.dspace.content.Collection;
-import org.dspace.core.Context;
 import org.dspace.services.RequestService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionDefinitionsControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionDefinitionsControllerIT.java
@@ -190,8 +190,7 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
         //Match only that a section exists with a submission configuration behind
         getClient(token).perform(get("/api/config/submissiondefinitions/traditional/collections")
                    .param("projection", "full"))
-                   .andExpect(status().isNoContent())
-                   .andExpect(jsonPath("$.page.totalElements", is(0)));
+                   .andExpect(status().isNoContent());
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionDefinitionsControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionDefinitionsControllerIT.java
@@ -190,7 +190,7 @@ public class SubmissionDefinitionsControllerIT extends AbstractControllerIntegra
         //Match only that a section exists with a submission configuration behind
         getClient(token).perform(get("/api/config/submissiondefinitions/traditional/collections")
                    .param("projection", "full"))
-                   .andExpect(status().isOk())
+                   .andExpect(status().isNoContent())
                    .andExpect(jsonPath("$.page.totalElements", is(0)));
     }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/SubmissionDefinitionsMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/SubmissionDefinitionsMatcher.java
@@ -35,7 +35,7 @@ public class SubmissionDefinitionsMatcher {
      */
     public static Matcher<? super Object> matchFullEmbeds() {
         return matchEmbeds(
-                "collections[]",
+                "collections",
                 "sections"
         );
     }


### PR DESCRIPTION
## References
* Fixes #10750
* NEW PR was created for RestContract changes https://github.com/DSpace/RestContract/pull/316

## Description
This tiny PR removes an unused part of the SubmissionDefinitionConverter code that is loading all item submission configured collections, for each listed item, by adding extra unwanted processing.

## Instructions for Reviewers
We've tested this locally and didn't see any changes besides the greater performance improvement. We also applied this PR into our DS9 setup and in few production repositories. We expect to have feedback until the end of this week.

List of changes in this PR:
* Just removes a code part from SubmissionDefinitionConverter 

This PR should be also backported to DS7 and DS8.