### PR TITLE
[Port dspace-8_x] Ensure DSpace defaults to UTC time zone in all code / tests

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/bulkaccesscontrol/BulkAccessControl.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkaccesscontrol/BulkAccessControl.java
@@ -18,6 +18,7 @@ import java.io.InputStream;
 import java.sql.SQLException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.Iterator;
@@ -154,7 +155,7 @@ public class BulkAccessControl extends DSpaceRunnable<BulkAccessControlScriptCon
         }
 
         ObjectMapper mapper = new ObjectMapper();
-        mapper.setTimeZone(TimeZone.getTimeZone("UTC"));
+        mapper.setTimeZone(TimeZone.getTimeZone(ZoneOffset.UTC));
         BulkAccessControlInput accessControl;
         context = new Context(Context.Mode.BATCH_EDIT);
         setEPerson(context);

--- a/dspace-api/src/main/java/org/dspace/util/DateMathParser.java
+++ b/dspace-api/src/main/java/org/dspace/util/DateMathParser.java
@@ -13,6 +13,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
@@ -107,7 +108,7 @@ public class DateMathParser {
 
     private static final Logger LOG = LogManager.getLogger();
 
-    public static final TimeZone UTC = TimeZone.getTimeZone("UTC");
+    public static final TimeZone UTC = TimeZone.getTimeZone(ZoneOffset.UTC);
 
     /**
      * Default TimeZone for DateMath rounding (UTC)

--- a/dspace-api/src/test/java/org/dspace/AbstractDSpaceIntegrationTest.java
+++ b/dspace-api/src/test/java/org/dspace/AbstractDSpaceIntegrationTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.fail;
 import java.io.IOException;
 import java.net.URL;
 import java.sql.SQLException;
+import java.time.ZoneOffset;
 import java.util.Properties;
 import java.util.TimeZone;
 
@@ -73,8 +74,10 @@ public class AbstractDSpaceIntegrationTest {
             //Stops System.exit(0) throws exception instead of exitting
             System.setSecurityManager(new NoExitSecurityManager());
 
-            //set a standard time zone for the tests
-            TimeZone.setDefault(TimeZone.getTimeZone("Europe/Dublin"));
+            // All tests should assume UTC timezone by default (unless overridden in the test itself)
+            // This ensures that Spring doesn't attempt to change the timezone of dates that are read from the
+            // database (via Hibernate). We store all dates in the database as UTC.
+            TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.UTC));
 
             //load the properties of the tests
             testProps = new Properties();

--- a/dspace-api/src/test/java/org/dspace/AbstractDSpaceTest.java
+++ b/dspace-api/src/test/java/org/dspace/AbstractDSpaceTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.fail;
 import java.io.IOException;
 import java.net.URL;
 import java.sql.SQLException;
+import java.time.ZoneOffset;
 import java.util.Properties;
 import java.util.TimeZone;
 
@@ -82,8 +83,10 @@ public class AbstractDSpaceTest {
     @BeforeClass
     public static void initKernel() {
         try {
-            //set a standard time zone for the tests
-            TimeZone.setDefault(TimeZone.getTimeZone("Europe/Dublin"));
+            // All tests should assume UTC timezone by default (unless overridden in the test itself)
+            // This ensures that Spring doesn't attempt to change the timezone of dates that are read from the
+            // database (via Hibernate). We store all dates in the database as UTC.
+            TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.UTC));
 
             //load the properties of the tests
             testProps = new Properties();

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/WebApplication.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/WebApplication.java
@@ -9,8 +9,11 @@ package org.dspace.app.rest;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.time.ZoneOffset;
 import java.util.List;
+import java.util.TimeZone;
 
+import jakarta.annotation.PostConstruct;
 import jakarta.servlet.Filter;
 import org.dspace.app.ldn.LDNQueueExtractor;
 import org.dspace.app.ldn.LDNQueueTimeoutChecker;
@@ -245,5 +248,13 @@ public class WebApplication {
                 argumentResolvers.add(new SearchFilterResolver());
             }
         };
+    }
+
+    @PostConstruct
+    public void setDefaultTimezone() {
+        // Set the default timezone in Spring Boot to UTC.
+        // This ensures that Spring Boot doesn't attempt to change the timezone of dates that are read from the
+        // database (via Hibernate). We store all dates in the database as UTC.
+        TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.UTC));
     }
 }


### PR DESCRIPTION
## References

* Backport of [UTC default timezone commit](https://github.com/DSpace/DSpace/commit/837f7c993cad9accef3f0493c6385e101d8b812d) from #10432 to `dspace-8_x`
* Fixes issues related to upgrading to Hibernate 6.4.9.Final or later (see test failures in #10876)
* Fixes #10119 for DSpace 8.x (see [this comment](https://github.com/DSpace/DSpace/issues/10119#issuecomment-2715781866))

## Description

This small PR backports code which forces the DSpace backend and all tests to always use the UTC timezone. This is necessary so that Spring / Hibernate don't auto-switch timezones when reading dates from the database.   This behavior seems to only trigger in more recent versions of Hibernate (starting in 6.4.9.Final, it appears).

This same fix was already applied on `main` (and released in 9.0) as part of the larger date refactoring work in #10432.  So, this is backporting the same code to the `dspace-8_x` branch. 

## Instructions for Reviewers
* Verify no tests fail
* Verify running this PR with Hibernate `6.4.10.Final` now results in the `BulkAccessControlIT` passing all tests: `mvn install -DskipIntegrationTests=false -Dit.test=BulkAccessControlIT -DfailIfNoTests=false`  This will prove that the errors in #10876 are now fixed.
    * I've tested this locally and found that it works.
* Optionally, verify that #10119 is also now fixed on the `dspace-8_x` branch.
