### PR TITLE
Update dependabot to run monthly instead of weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,9 @@ updates:
   # So, only this first section can include "applies-to: security-updates"
   - package-ecosystem: "maven"
     directory: "/"
+    # Monthly dependency updates (NOTE: "schedule" doesn't apply to security updates)
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       time: "02:00"
     # Allow up to 10 open PRs for dependencies
     open-pull-requests-limit: 10
@@ -133,7 +134,7 @@ updates:
     directory: "/"
     target-branch: dspace-9_x
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       time: "02:00"
     # Allow up to 10 open PRs for dependencies
     open-pull-requests-limit: 10
@@ -254,7 +255,7 @@ updates:
     directory: "/"
     target-branch: dspace-8_x
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       time: "02:00"
     # Allow up to 10 open PRs for dependencies
     open-pull-requests-limit: 10
@@ -375,7 +376,7 @@ updates:
     directory: "/"
     target-branch: dspace-7_x
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       time: "02:00"
     # Allow up to 10 open PRs for dependencies
     open-pull-requests-limit: 10


### PR DESCRIPTION
## References
* Related to https://github.com/DSpace/dspace-angular/pull/4610 (This is the same PR on the frontend)

## Description
This PR comes out of a Slack discussion between @alanorth , @kshepherd and I.  We were talking about ways to improve our dependabot configs to be less "noisy" (with PRs) and less "busywork" (minor updates that don't matter much).

So, this is the first attempt of just changing the `dependabot` schedule to only create dependency PRs once per month.

## Instructions for Reviewers
* No changes to DSpace.  This is only a change to dependabot.