### PR TITLE
Enhance SWORDv1 Integration Tests & fix WRITE Permissions error for submitters

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/packager/AbstractMETSIngester.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/AbstractMETSIngester.java
@@ -498,8 +498,11 @@ public abstract class AbstractMETSIngester extends AbstractPackageIngester {
                 // Finish creating the item. This actually assigns the handle,
                 // and will either install item immediately or start a workflow, based on params
                 PackageUtils.finishCreateItem(context, wsi, handle, params);
+            } else {
+                // We should have a workspace item during ingest, so this code is only here for safety.
+                // Update the object to make sure all changes are committed
+                PackageUtils.updateDSpaceObject(context, dso);
             }
-
         } else if (type == Constants.COLLECTION || type == Constants.COMMUNITY) {
             // Add logo if one is referenced from manifest
             addContainerLogo(context, dso, manifest, pkgFile, params);
@@ -513,6 +516,9 @@ public abstract class AbstractMETSIngester extends AbstractPackageIngester {
             // (this allows subclasses to do some final validation / changes as
             // necessary)
             finishObject(context, dso, params);
+
+            // Update the object to make sure all changes are committed
+            PackageUtils.updateDSpaceObject(context, dso);
         } else if (type == Constants.SITE) {
             // Do nothing by default -- Crosswalks will handle anything necessary to ingest at Site-level
 
@@ -520,17 +526,14 @@ public abstract class AbstractMETSIngester extends AbstractPackageIngester {
             // (this allows subclasses to do some final validation / changes as
             // necessary)
             finishObject(context, dso, params);
+
+            // Update the object to make sure all changes are committed
+            PackageUtils.updateDSpaceObject(context, dso);
         } else {
             throw new PackageValidationException(
                 "Unknown DSpace Object type in package, type="
                     + String.valueOf(type));
         }
-
-        // -- Step 6 --
-        // Finish things up!
-
-        // Update the object to make sure all changes are committed
-        PackageUtils.updateDSpaceObject(context, dso);
 
         return dso;
     }


### PR DESCRIPTION
## References
* Fixes #8647

## Description
This PR enhances the existing `SWORDv1IT` by adding a new deposit test (based on the similar test already in `SWORDv2IT`).  This improves our test coverage for SWORD v1.

While creating this deposit test, I also rediscovered the #8647 bug.  Using the new deposit test, I was able to figure out a solution to the bug which required a small refactor in `AbstractMETSIngester`
* When `AbstractMETSIngester.ingestObject()` is called to ingest a new Item from a METS file, the code was improperly calling an `update()` on that Item object _after_ the WorkspaceItem already had `installItem()` called.   The error was occurring because the `installItem()` call will turn the WorkspaceItem into an archived Item and **remove all submitter privileges**.  Because privileges were removed, the `update()` call was throwing an error when the user only had submitter privileges.  The solution was to remove the additional `update()` call in that scenario because it's unnecessary (the Item has already been saved by `installItem()`).

## Instructions for Reviewers
* Review the code
* Verify all ITs pass.  This is especially important because of the small change to `AbstractMETSIngester`.  This class has good test coverage as we have `ITDSpaceAIP` which performs a full restore of various AIPs (that process will also use `AbstractMETSIngester`).
