### PR TITLE
fix(#10721): Sanitize non-characters during OAI indexing

### DIFF
--- a/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
@@ -18,6 +18,8 @@ import java.util.List;
 import com.lyncode.xoai.dataprovider.xml.xoai.Element;
 import com.lyncode.xoai.dataprovider.xml.xoai.Metadata;
 import com.lyncode.xoai.util.Base64Utils;
+
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.util.factory.UtilServiceFactory;
@@ -166,8 +168,8 @@ public class ItemUtils {
     }
 
     /**
-     * Sanitizes a string to remove characters that are invalid in XML 1.0.
-     * Currently targets the non-characters U+FFFE and U+FFFF.
+     * Sanitizes a string to remove characters that are invalid 
+     * in XML 1.0 using the Apache Commons Text library.
      * @param value The string to sanitize.
      * @return A sanitized string, or null if the input was null.
      */
@@ -175,7 +177,7 @@ public class ItemUtils {
         if (value == null) {
             return null;
         }
-        return value.replace("\ufffe", "").replace("\uffff", "");
+        return StringEscapeUtils.escapeXml10(value);
     }
 
     /**

--- a/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
@@ -166,6 +166,19 @@ public class ItemUtils {
     }
 
     /**
+     * Sanitizes a string to remove characters that are invalid in XML 1.0.
+     * Currently targets the non-characters U+FFFE and U+FFFF.
+     * @param value The string to sanitize.
+     * @return A sanitized string, or null if the input was null.
+     */
+    private static String sanitize(String value) {
+        if (value == null) {
+            return null;
+        }
+        return value.replace("\ufffe", "").replace("\uffff", "");
+    }
+
+    /**
      * This method will add metadata information about associated resource policies for a give bitstream.
      * It will parse of relevant policies and add metadata information
      * @param context
@@ -281,7 +294,7 @@ public class ItemUtils {
             valueElem = language;
         }
 
-        valueElem.getField().add(createValue("value", val.getValue()));
+        valueElem.getField().add(createValue("value", sanitize(val.getValue())));
         if (val.getAuthority() != null) {
             valueElem.getField().add(createValue("authority", val.getAuthority()));
             if (val.getConfidence() != Choices.CF_NOVALUE) {

--- a/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
@@ -18,7 +18,6 @@ import java.util.List;
 import com.lyncode.xoai.dataprovider.xml.xoai.Element;
 import com.lyncode.xoai.dataprovider.xml.xoai.Metadata;
 import com.lyncode.xoai.util.Base64Utils;
-
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
@@ -167,7 +167,7 @@ public class ItemUtils {
     }
 
     /**
-     * Sanitizes a string to remove characters that are invalid 
+     * Sanitizes a string to remove characters that are invalid
      * in XML 1.0 using the Apache Commons Text library.
      * @param value The string to sanitize.
      * @return A sanitized string, or null if the input was null.


### PR DESCRIPTION
## References
* Fixes #10721 

## Description
This pull request prevents OAI-PMH harvesting from crashing when encountering items with invalid XML non-characters (like U+FFFE and U+FFFF) in their metadata. The fix sanitizes metadata values during the OAI indexing process, ensuring that the generated XML is always well-formed.

## Instructions for Reviewers
This PR introduces a sanitization step within the OAI indexing process to solve a fatal SAXParseException caused by invalid XML characters in item metadata. The core change is in dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java.

List of changes in this PR:
* A new private static String sanitize(String value) method has been added to ItemUtils.java. This method removes the XML 1.0 non-characters U+FFFE and U+FFFF.
* The existing public static Element.Field createValue(String name, String value) method in the same class has been modified to use this sanitize function on all values before creating a metadata field. This ensures all metadata processed for OAI is clean, preventing the XML parser from crashing.
* The original item data in the PostgreSQL database remains untouched.

### 1 - How to reproduce the bug (before this fix):
* Create an item and, through the UI or directly in the database, add a U+FFFE or U+FFFF character to a metadata field (e.g., dc.title).
* Run a full OAI re-index: [dspace]/bin/dspace oai -c import.
* Attempt to harvest all records via OAI-PMH: curl -v "[dspace.server.url]/oai/request?verb=ListRecords&metadataPrefix=oai_dc".
* Expected result (without fix): An HTTP 500 error is returned, and the dspace.log shows a SAXParseException for an invalid XML character.

### 2 - How to verify the fix:
* Apply this PR, rebuild DSpace (mvn package), and update your installation (ant update).
* With the "dirty" data still in the database, run a full OAI re-index again: [dspace]/bin/dspace oai -c import.
* Attempt to harvest all records again: curl -v "[dspace.server.url]/oai/request?verb=ListRecords&metadataPrefix=oai_dc".
* Expected result (with fix): The command returns HTTP 200 OK. The OAI-PMH XML response is displayed successfully, and the metadata for the problematic item appears with the invalid characters removed. The dspace.log shows no errors.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is created against the main branch of code.
- [x] My PR is small in size (it's a change to a single file).
- [x] My PR passes Checkstyle validation (I've followed the existing style of the file).
- [x] My PR includes Javadoc for the new sanitize method.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR includes details on how to test it.
- [x] My PR does not include new libraries/dependencies.
- [x] My PR does not modify REST API endpoints.
- [x] My PR does not include new configurations.
- [x] My PR fixes an issue ticket and I've linked them together.
