### PR TITLE
[Docker] Update Dockerfiles to be "standalone" and have valid ENTRYPOINT defaults.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,11 +55,13 @@ RUN ant init_installation update_configs update_code update_webapps
 
 # Step 3 - Start up DSpace via Runnable JAR
 FROM docker.io/eclipse-temurin:${JDK_VERSION}
-# NOTE: DSPACE_INSTALL must align with the "dspace.dir" default configuration.
-ENV DSPACE_INSTALL=/dspace
+# Below syntax may look odd, but it is how to override dspace.cfg settings via env variables.
+# See https://github.com/DSpace/DSpace/blob/main/dspace/config/config-definition.xml
+# "dspace__P__dir" is setting the value of the "dspace.dir" configuration. This is our installation directory.
+ENV dspace__P__dir=/dspace
 # Copy the /dspace directory from 'ant_build' container to /dspace in this container
-COPY --from=ant_build /dspace $DSPACE_INSTALL
-WORKDIR $DSPACE_INSTALL
+COPY --from=ant_build /dspace $dspace__P__dir
+WORKDIR $dspace__P__dir
 # Need host command for "[dspace]/bin/make-handle-config"
 RUN apt-get update \
     && apt-get install -y --no-install-recommends host \
@@ -69,5 +71,5 @@ RUN apt-get update \
 EXPOSE 8080 8000
 # Give java extra memory (2GB)
 ENV JAVA_OPTS=-Xmx2000m
-# On startup, run DSpace Runnable JAR
-ENTRYPOINT ["java", "-jar", "webapps/server-boot.jar", "--dspace.dir=$DSPACE_INSTALL"]
+# On startup, run DSpace Runnable JAR (uses the "dspace.dir" setting defined in "dspace__P__dir" env variable)
+ENTRYPOINT ["java", "-jar", "webapps/server-boot.jar"]

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -49,10 +49,13 @@ RUN ant init_installation update_configs update_code
 
 # Step 3 - Run jdk
 FROM docker.io/eclipse-temurin:${JDK_VERSION}
-# NOTE: DSPACE_INSTALL must align with the "dspace.dir" default configuration.
-ENV DSPACE_INSTALL=/dspace
+# Below syntax may look odd, but it is how to override dspace.cfg settings via env variables.
+# See https://github.com/DSpace/DSpace/blob/main/dspace/config/config-definition.xml
+# "dspace__P__dir" is setting the value of the "dspace.dir" configuration. This is our installation directory.
+ENV dspace__P__dir=/dspace
 # Copy the /dspace directory from 'ant_build' container to /dspace in this container
-COPY --from=ant_build /dspace $DSPACE_INSTALL
+COPY --from=ant_build /dspace $dspace__P__dir
+WORKDIR $dspace__P__dir
 # Give java extra memory (1GB)
 ENV JAVA_OPTS=-Xmx1000m
 # Install unzip for AIPs
@@ -60,3 +63,8 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends unzip \
     && apt-get purge -y --auto-remove \
     && rm -rf /var/lib/apt/lists/*
+
+# On startup, run DSpace commandline script
+ENTRYPOINT ["./bin/dspace"]
+# By default just pass 'help' command to ./bin/dspace
+CMD ["help"]

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -54,11 +54,13 @@ RUN ant init_installation update_configs update_code update_webapps
 
 # Step 3 - Start up DSpace via Runnable JAR
 FROM docker.io/eclipse-temurin:${JDK_VERSION}
-# NOTE: DSPACE_INSTALL must align with the "dspace.dir" default configuration.
-ENV DSPACE_INSTALL=/dspace
+# Below syntax may look odd, but it is how to override dspace.cfg settings via env variables.
+# See https://github.com/DSpace/DSpace/blob/main/dspace/config/config-definition.xml
+# "dspace__P__dir" is setting the value of the "dspace.dir" configuration. This is our installation directory.
+ENV dspace__P__dir=/dspace
 # Copy the /dspace directory from 'ant_build' container to /dspace in this container
-COPY --from=ant_build /dspace $DSPACE_INSTALL
-WORKDIR $DSPACE_INSTALL
+COPY --from=ant_build /dspace $dspace__P__dir
+WORKDIR $dspace__P__dir
 # Need host command for "[dspace]/bin/make-handle-config"
 RUN apt-get update \
     && apt-get install -y --no-install-recommends host \
@@ -70,5 +72,5 @@ EXPOSE 8080 8000
 ENV JAVA_OPTS=-Xmx2000m
 # enable JVM debugging via JDWP
 ENV JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8000
-# On startup, run DSpace Runnable JAR
-ENTRYPOINT ["java", "-jar", "webapps/server-boot.jar", "--dspace.dir=$DSPACE_INSTALL"]
+# On startup, run DSpace Runnable JAR (uses the "dspace.dir" setting defined in "dspace__P__dir" env variable)
+ENTRYPOINT ["java", "-jar", "webapps/server-boot.jar"]

--- a/docker-compose-cli.yml
+++ b/docker-compose-cli.yml
@@ -16,8 +16,6 @@ services:
       # See https://github.com/DSpace/DSpace/blob/main/dspace/config/config-definition.xml
       # __P__ => "." (e.g. dspace__P__dir => dspace.dir)
       # __D__ => "-" (e.g. google__D__metadata => google-metadata)
-      # dspace.dir: Must match with Dockerfile's DSPACE_INSTALL directory.
-      dspace__P__dir: /dspace
       # db.url: Ensure we are using the 'dspacedb' image for our database
       db__P__url: 'jdbc:postgresql://dspacedb:5432/dspace'
       # solr.server: Ensure we are using the 'dspacesolr' image for Solr
@@ -28,8 +26,6 @@ services:
     # Mount local [src]/dspace/config/ to container. This syncs your local configs with container
     # NOTE: Environment variables specified above will OVERRIDE any configs in local.cfg or dspace.cfg
     - ./dspace/config:/dspace/config
-    entrypoint: /dspace/bin/dspace
-    command: help
     tty: true
     stdin_open: true
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,9 +14,8 @@ services:
       # See https://github.com/DSpace/DSpace/blob/main/dspace/config/config-definition.xml
       # __P__ => "." (e.g. dspace__P__dir => dspace.dir)
       # __D__ => "-" (e.g. google__D__metadata => google-metadata)
-      # dspace.dir: Must match with Dockerfile's DSPACE_INSTALL directory.
-      dspace__P__dir: /dspace
-      # Uncomment to set a non-default value for dspace.server.url or dspace.ui.url
+      # Uncomment to set a non-default value for dspace.dir, dspace.server.url or dspace.ui.url
+      # dspace__P__dir: /dspace
       # dspace__P__server__P__url: http://localhost:8080/server
       # dspace__P__ui__P__url: http://localhost:4000
       dspace__P__name: 'DSpace Started with Docker Compose'
@@ -61,7 +60,7 @@ services:
     - |
       while (!</dev/tcp/dspacedb/5432) > /dev/null 2>&1; do sleep 1; done;
       /dspace/bin/dspace database migrate
-      java -jar /dspace/webapps/server-boot.jar --dspace.dir=/dspace
+      java -jar /dspace/webapps/server-boot.jar
   # DSpace PostgreSQL database container
   dspacedb:
     container_name: dspacedb

--- a/dspace/src/main/docker-compose/db.entities.yml
+++ b/dspace/src/main/docker-compose/db.entities.yml
@@ -24,4 +24,4 @@ services:
       - |
         while (!</dev/tcp/dspacedb/5432) > /dev/null 2>&1; do sleep 1; done;
         /dspace/bin/dspace database migrate ignored
-        java -jar /dspace/webapps/server-boot.jar --dspace.dir=/dspace
+        java -jar /dspace/webapps/server-boot.jar


### PR DESCRIPTION
## References
* Fixes #10493 
* Replaces #10541

## Description
After moving to using `server-boot.jar` (in v8.0) in our Dockerfiles, we've accidentally had invalid `ENTRYPOINT` settings in our `Dockerfile` and `Dockerfile.test` files as described in #10493    Essentially, we were assuming that everyone would use the `docker-compose.yml` (and similar), but some people may want to use the `Dockerfile` directly.

This PR fixes that bug by using environment variables instead of relying on passing the `--dspace.dir` flag to the `server-boot.jar`.  This has the additional advantage of simplifying our docker-compose scripts.

Changes in this PR:
* Replaces usage of `--dspace.dir` flag with specifying `dspace__P__dir` environment variable in our main Dockerfiles.  
    * This removes the usage of a custom `DSPACE_INSTALL` environment variable in these Dockerfiles, as it's replaced by `dspace__P__dir`
    * This also simplifies the corresponding `docker-compose` scripts as they no longer need to specify the `dspace__P__dir` environment variable (as it's "inherited" from the Dockerfile).
* Updates the `Dockerfile.cli` (command-line Dockerfile) to have a valid `ENTRYPOINT` and `CMD`.  Previously, both were only specified in the `docker-compose-cli.yml`.

## Instructions for Reviewers
* Verify no changes in behavior from normal Docker or Docker Compose commands.
* I've already verified the commands that I use heavily all still work, including these:
    * Spinning up backend with Entities: `docker compose -p d9 -f docker-compose.yml -f dspace/src/main/docker-compose/db.entities.yml up -d`
    * Importing assetstore for those Entities: `docker compose -p d9 -f docker-compose-cli.yml -f dspace/src/main/docker-compose/cli.assetstore.yml run dspace-cli`
    * Testing creating a new Administrator from commandline: `docker compose -p d9 -f docker-compose-cli.yml run --rm dspace-cli create-administrator -e test@test.edu -f admin -l user -p admin -c en`
    * Other basic docker compose commands.