### PR TITLE
Allow setting invalid domains for self registration

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authenticate/PasswordAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/PasswordAuthentication.java
@@ -66,6 +66,7 @@ public class PasswordAuthentication
      * <p>
      * Example - aber.ac.uk domain : @aber.ac.uk
      * Example - MIT domain and all .ac.uk domains: @mit.edu, .ac.uk
+     * Example - MIT domain and NOT example.org: @mit.edu, !example.org
      *
      * @param email email
      * @throws SQLException if database error
@@ -87,7 +88,7 @@ public class PasswordAuthentication
             email = email.trim().toLowerCase();
             for (int i = 0; i < domains.length; i++) {
                 check = domains[i].trim().toLowerCase();
-                if (email.endsWith(check)) {
+                if (email.endsWith(check) || (check.startsWith("!") && !email.endsWith(check.substring(1)))) {
                     // A match, so we can register this user
                     return true;
                 }

--- a/dspace-api/src/main/java/org/dspace/authenticate/PasswordAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/PasswordAuthentication.java
@@ -31,7 +31,7 @@ import org.dspace.services.factory.DSpaceServicesFactory;
  * See the <code>AuthenticationMethod</code> interface for more details.
  * <p>
  * The <em>username</em> is the E-Person's email address,
- * and and the <em>password</em> (given to the <code>authenticate()</code>
+ * and the <em>password</em> (given to the <code>authenticate()</code>
  * method) must match the EPerson password.
  * <p>
  * This is the default method for a new DSpace configuration.

--- a/dspace-api/src/main/java/org/dspace/authenticate/PasswordAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/PasswordAuthentication.java
@@ -79,7 +79,7 @@ public class PasswordAuthentication
         // Is there anything set in domain.valid?
         String[] domains = DSpaceServicesFactory.getInstance().getConfigurationService()
                                                 .getArrayProperty("authentication-password.domain.valid");
-        if ((domains == null) || (domains.length == 0)) {
+        if (domains == null || domains.length == 0) {
             // No conditions set, so must be able to self register
             return true;
         } else {


### PR DESCRIPTION
# References
* Fixes https://github.com/DSpace/DSpace/issues/9675

# Description
Allow setting domains that are NOT allowed for self registration by using a "!" to negate the pattern. This is useful for example if an organization uses Active Directory or LDAP and would prefer that users log in directly instead of registering so that institutional password policies are respected.

# Instructions for Reviewers

List of changes in this PR:
* First, adjust logic in `dspace-api/src/main/java/org/dspace/authenticate/PasswordAuthentication.java` to make it possible to specify domains that are _not_ allowed to self register
* Second, fix a minor syntax issue in the boolean expression of a conditional
* Third, fix a minor grammatical error in the Javadoc

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes.

Set the `authentication-password.domain.valid` key in your backend configuration with a negated domain, for example:

```ini
authentication-password.domain.valid = !example.org
```

Try to self register using an email address with the domain that is not valid, for example `test@example.org`.

# Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
