### PR TITLE
Fix for #9589 Incorrect Export of Search Results with Double Quotation Marks in DSpace 7. Reference PR #10103

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExportSearch.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExportSearch.java
@@ -14,6 +14,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
 
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.DefaultParser.Builder;
 import org.apache.commons.cli.ParseException;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataDSpaceCsvExportServiceImpl;
@@ -166,5 +168,15 @@ public class MetadataExportSearch extends DSpaceRunnable<MetadataExportSearchScr
             scopeObj = new IndexableCollection(collectionService.find(context, uuid));
         }
         return scopeObj;
+    }
+
+    @Override
+    protected StepResult parse(String[] args) throws ParseException {
+        commandLine = new DefaultParser().parse(getScriptConfiguration().getOptions(), args);
+        Builder builder = new DefaultParser().builder();
+        builder.setStripLeadingAndTrailingQuotes(false);
+        commandLine = builder.build().parse(getScriptConfiguration().getOptions(), args);
+        setup();
+        return StepResult.Continue;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/scripts/DSpaceRunnable.java
+++ b/dspace-api/src/main/java/org/dspace/scripts/DSpaceRunnable.java
@@ -117,7 +117,7 @@ public abstract class DSpaceRunnable<T extends ScriptConfiguration> implements R
      * @param args              The primitive array of Strings representing the parameters
      * @throws ParseException   If something goes wrong
      */
-    private StepResult parse(String[] args) throws ParseException {
+    protected StepResult parse(String[] args) throws ParseException {
         commandLine = new DefaultParser().parse(getScriptConfiguration().getOptions(), args);
         setup();
         return StepResult.Continue;


### PR DESCRIPTION
## References
* Fixes #9589 
* Previous PR #10103

## Description
When exporting search results in DSpace 7 that include double quotation marks in the search query, the export does not reflect the original search query with double quotation marks. Instead, it exports the results of the search query without the double quotation marks.

## Instructions for Reviewers
Export the search results after performing a search in DSpace using a query that includes double quotation marks, for example: "search term". The export of search result bringing extra results in it which are not there in the result of original double quoted search query results.

## List of changes in this PR:
* Added minor change inside DSpaceRunnable class to change the parse method visibility as protected. 
* Override the parse method inside MetadataExportSearch class to handle the custom behaviour needed in DefaultParser. 
* Added test cases in MetadataExportSearchIT class against MetadataExportSearch class changes.

## Guidance for how to test or review this PR 
1. Login with any user
2. Perform a search in DSpace using a query that includes double quotation marks, for example: "dengue vaccination".
3. Export the search results by clicking on Export search results as CSV.
4. Observe the export does not reflect the original search query result and instead exports the results without the double quotation marks also.