### PR TITLE
fix(#9774): Restore eager loading for CSRF tokens

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/WebSecurityConfiguration.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/WebSecurityConfiguration.java
@@ -92,7 +92,7 @@ public class WebSecurityConfiguration {
         // In DSpace 8+, the upgrade to Spring Security 6 changed the default behavior to "deferred loading",
         // which meant the DSPACE-XSRF-TOKEN was no longer automatically sent on most GET requests.
         // This was a breaking change for REST API clients expecting the DSpace 7.x behavior.
-        // <P>
+        //
         // By setting the csrfRequestAttributeName to null, we explicitly opt-out of deferred loading and
         // force Spring Security to load the token on every request, restoring the old functionality.
         // This resolves https://github.com/DSpace/DSpace/issues/9774

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/WebSecurityConfiguration.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/WebSecurityConfiguration.java
@@ -88,6 +88,17 @@ public class WebSecurityConfiguration {
         // Get the current AuthenticationManager (defined above) to apply filters below
         AuthenticationManager authenticationManager = authenticationManager();
 
+        // Create a custom CsrfTokenRequestHandler to restore the eager loading of the CSRF token.
+        // In DSpace 8+, the upgrade to Spring Security 6 changed the default behavior to "deferred loading",
+        // which meant the DSPACE-XSRF-TOKEN was no longer automatically sent on most GET requests.
+        // This was a breaking change for REST API clients expecting the DSpace 7.x behavior.
+        // <P>
+        // By setting the csrfRequestAttributeName to null, we explicitly opt-out of deferred loading and
+        // force Spring Security to load the token on every request, restoring the old functionality.
+        // This resolves https://github.com/DSpace/DSpace/issues/9774
+        CsrfTokenRequestAttributeHandler requestHandler = new CsrfTokenRequestAttributeHandler();
+        requestHandler.setCsrfRequestAttributeName(null);
+
         // Configure authentication requirements for ${dspace.server.url}/api/ URL only
         // NOTE: REST API is hardcoded to respond on /api/. Other modules (OAI, SWORD, IIIF, etc) use other root paths.
         http.securityMatcher("/api/**", "/iiif/**", actuatorBasePath + "/**", "/signposting/**")
@@ -118,7 +129,7 @@ public class WebSecurityConfiguration {
                 // See https://github.com/DSpace/DSpace/issues/9450
                 // NOTE: DSpace doesn't need BREACH protection as it's only necessary when sending the token via a
                 // request attribute (e.g. "_csrf") which the DSpace UI never does.
-                .csrfTokenRequestHandler(new CsrfTokenRequestAttributeHandler()))
+                .csrfTokenRequestHandler(requestHandler))
             .exceptionHandling((exceptionHandling) -> exceptionHandling
                 // Return 401 on authorization failures with a correct WWWW-Authenticate header
                 .authenticationEntryPoint(new DSpace401AuthenticationEntryPoint(restAuthenticationService))


### PR DESCRIPTION
## References
* Fixes #9774

## Description
This pull request resolves a breaking change introduced in DSpace 8 where the DSPACE-XSRF-TOKEN was no longer automatically generated on most GET requests. The configuration for Spring Security is updated to restore the eager token loading behavior from DSpace 7, ensuring backward compatibility for REST API clients.

## Instructions for Reviewers
This PR modifies WebSecurityConfiguration.java to restore the automatic generation of CSRF tokens on GET requests, a behavior that existed in DSpace 7.x but was altered by the upgrade to Spring Security 6 in DSpace 8.x.

List of changes in this PR:
* In WebSecurityConfiguration.java, a CsrfTokenRequestAttributeHandler instance is now explicitly created and configured.
* By calling requestHandler.setCsrfRequestAttributeName(null), we opt-out of Spring Security's default "deferred loading" behavior.
* This configured handler is then passed to the .csrf() configuration chain, forcing the CSRF token to be eagerly loaded on every request, thus matching the previous, expected behavior.

How to test this PR:
### 1 - Before this change (on the main branch):
* Run DSpace(8, 9 or 10) and execute the following command: curl -i -X GET http://localhost:8080/server/api/core/communities
* Observe that the response headers **don't** contain DSPACE-XSRF-TOKEN.
<img width="791" height="243" alt="image" src="https://github.com/user-attachments/assets/5356433f-ac3d-435b-8e10-0ee9a0026116" />


### 2 - After this change (on the fix/9774-csrf-token-not-generated-spring-security-6 branch):
* Run DSpace and execute the same command: curl -i -X GET http://localhost:8080/server/api/core/communities
* Verify that the response headers **now include** the DSPACE-XSRF-TOKEN and Set-Cookie: DSPACE-XSRF-COOKIE headers, confirming the fix.
<img width="858" height="284" alt="image" src="https://github.com/user-attachments/assets/eab24de5-2b7f-4cdd-af29-f218516ab63a" />


## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
