### PR TITLE
set locale to English for this test and restore the default after test

### DIFF
--- a/dspace-api/src/test/java/org/dspace/util/DefaultLocaleForTestRule.java
+++ b/dspace-api/src/test/java/org/dspace/util/DefaultLocaleForTestRule.java
@@ -14,40 +14,40 @@ import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 
 public class DefaultLocaleForTestRule extends TestWatcher {
-	
-	private Locale originalDefault;
+
+    private Locale originalDefault;
     private Locale testDefault;
-    
+
     public DefaultLocaleForTestRule() {
         this(null);
     }
-    
+
     public DefaultLocaleForTestRule(Locale testDefault) {
-    	this.testDefault = testDefault;
+        this.testDefault = testDefault;
     }
-    
+
     @Override
     protected void starting(Description description) {
-    	 originalDefault = Locale.getDefault();
-         
-         if(null != testDefault) {
-             Locale.setDefault(testDefault);
-         };
+        originalDefault = Locale.getDefault();
+
+        if (null != testDefault) {
+            Locale.setDefault(testDefault);
+        }
     }
-    
+
     @Override
     protected void succeeded(Description description) {
-    	Locale.setDefault(originalDefault);
+        Locale.setDefault(originalDefault);
     }
-    
+
     public void setDefault(Locale locale) {
-        if(null == locale) {
+        if (null == locale) {
             locale = originalDefault;
         }
-        
+
         Locale.setDefault(locale);
     }
-    
+
     public static DefaultLocaleForTestRule en() {
         return new DefaultLocaleForTestRule(Locale.ENGLISH);
     }

--- a/dspace-api/src/test/java/org/dspace/util/DefaultLocaleForTestRule.java
+++ b/dspace-api/src/test/java/org/dspace/util/DefaultLocaleForTestRule.java
@@ -1,3 +1,11 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+
 package org.dspace.util;
 
 import java.util.Locale;

--- a/dspace-api/src/test/java/org/dspace/util/DefaultLocaleForTestRule.java
+++ b/dspace-api/src/test/java/org/dspace/util/DefaultLocaleForTestRule.java
@@ -1,0 +1,46 @@
+package org.dspace.util;
+
+import java.util.Locale;
+
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+
+public class DefaultLocaleForTestRule extends TestWatcher {
+	
+	private Locale originalDefault;
+    private Locale testDefault;
+    
+    public DefaultLocaleForTestRule() {
+        this(null);
+    }
+    
+    public DefaultLocaleForTestRule(Locale testDefault) {
+    	this.testDefault = testDefault;
+    }
+    
+    @Override
+    protected void starting(Description description) {
+    	 originalDefault = Locale.getDefault();
+         
+         if(null != testDefault) {
+             Locale.setDefault(testDefault);
+         };
+    }
+    
+    @Override
+    protected void succeeded(Description description) {
+    	Locale.setDefault(originalDefault);
+    }
+    
+    public void setDefault(Locale locale) {
+        if(null == locale) {
+            locale = originalDefault;
+        }
+        
+        Locale.setDefault(locale);
+    }
+    
+    public static DefaultLocaleForTestRule en() {
+        return new DefaultLocaleForTestRule(Locale.ENGLISH);
+    }
+}

--- a/dspace-api/src/test/java/org/dspace/util/MultiFormatDateParserTest.java
+++ b/dspace-api/src/test/java/org/dspace/util/MultiFormatDateParserTest.java
@@ -15,12 +15,12 @@ import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -33,8 +33,7 @@ import org.junit.runners.Parameterized;
  */
 @RunWith(Parameterized.class)
 public class MultiFormatDateParserTest {
-    private static Locale vmLocale;
-    private final String toParseDate;
+	private final String toParseDate;
     private final String expectedFormat;
     private final String expectedResult;
 
@@ -82,10 +81,18 @@ public class MultiFormatDateParserTest {
             {"1957/01/2720:06:20", "yyyy/MM/ddHH:mm:ss", ""}
         });
     }
+    
+    // 
+    /**
+     * Rule for setting the locale to english. This is necessary to test with the english month names.
+     * The rule restore the default locale after test.
+     */
+    @ClassRule
+    public static DefaultLocaleForTestRule defaultLocaleRule = DefaultLocaleForTestRule.en();
 
     @BeforeClass
     public static void setUpClass() {
-        Map<String, String> formats = new HashMap<>(32);
+    	Map<String, String> formats = new HashMap<>(32);
         formats.put("\\d{8}", "yyyyMMdd");
         formats.put("\\d{1,2}-\\d{1,2}-\\d{4}", "dd-MM-yyyy");
         formats.put("\\d{4}-\\d{1,2}-\\d{1,2}", "yyyy-MM-dd");
@@ -130,7 +137,7 @@ public class MultiFormatDateParserTest {
     /**
      * Test of parse method, of class MultiFormatDateParser.
      */
-    @Test
+    @Test    
     public void testParse() {
         ZonedDateTime result = MultiFormatDateParser.parse(toParseDate);
         // Verify that the parsed ZonedDateTime is equal to the expected String result (or null if result is empty)
@@ -139,5 +146,5 @@ public class MultiFormatDateParserTest {
         } else {
             assertNull("Should not parse: " + expectedFormat, result);
         }
-    }
+    }    
 }

--- a/dspace-api/src/test/java/org/dspace/util/MultiFormatDateParserTest.java
+++ b/dspace-api/src/test/java/org/dspace/util/MultiFormatDateParserTest.java
@@ -33,7 +33,7 @@ import org.junit.runners.Parameterized;
  */
 @RunWith(Parameterized.class)
 public class MultiFormatDateParserTest {
-	private final String toParseDate;
+    private final String toParseDate;
     private final String expectedFormat;
     private final String expectedResult;
 
@@ -81,18 +81,17 @@ public class MultiFormatDateParserTest {
             {"1957/01/2720:06:20", "yyyy/MM/ddHH:mm:ss", ""}
         });
     }
-    
-    // 
+
     /**
-     * Rule for setting the locale to english. This is necessary to test with the english month names.
-     * The rule restore the default locale after test.
+     * Rule for setting the locale to English. This is necessary to test with the English month
+     * names. The rule restore the default locale after test.
      */
     @ClassRule
     public static DefaultLocaleForTestRule defaultLocaleRule = DefaultLocaleForTestRule.en();
 
     @BeforeClass
     public static void setUpClass() {
-    	Map<String, String> formats = new HashMap<>(32);
+        Map<String, String> formats = new HashMap<>(32);
         formats.put("\\d{8}", "yyyyMMdd");
         formats.put("\\d{1,2}-\\d{1,2}-\\d{4}", "dd-MM-yyyy");
         formats.put("\\d{4}-\\d{1,2}-\\d{1,2}", "yyyy-MM-dd");
@@ -137,7 +136,7 @@ public class MultiFormatDateParserTest {
     /**
      * Test of parse method, of class MultiFormatDateParser.
      */
-    @Test    
+    @Test
     public void testParse() {
         ZonedDateTime result = MultiFormatDateParser.parse(toParseDate);
         // Verify that the parsed ZonedDateTime is equal to the expected String result (or null if result is empty)
@@ -146,5 +145,5 @@ public class MultiFormatDateParserTest {
         } else {
             assertNull("Should not parse: " + expectedFormat, result);
         }
-    }    
+    }
 }


### PR DESCRIPTION
## References
* Fixes #11157 

## Description
Set the locale for the MultiFormatDateParserTest to english. Restore the old default after test

## Instructions for Reviewers
Run the test with non-english-system...

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
