### PR TITLE
fix(#8852): Statistics event processor now uses oaiPrefix instead of getHost

### DIFF
--- a/dspace-api/src/main/java/org/dspace/statistics/export/processor/ExportEventProcessor.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/export/processor/ExportEventProcessor.java
@@ -137,9 +137,10 @@ public abstract class ExportEventProcessor {
             .append(URLEncoder.encode(clientUA, UTF_8));
 
         String hostName = Utils.getHostName(configurationService.getProperty("dspace.ui.url"));
+        String oaiPrefix = configurationService.getProperty("oai.identifier.prefix");
 
         data.append("&").append(URLEncoder.encode("rft.artnum", UTF_8)).append("=").
-                append(URLEncoder.encode("oai:" + hostName + ":" + item
+                append(URLEncoder.encode("oai:" + oaiPrefix + ":" + item
                         .getHandle(), UTF_8));
         data.append("&").append(URLEncoder.encode("rfr_dat", UTF_8)).append("=")
             .append(URLEncoder.encode(referer, UTF_8));

--- a/dspace-api/src/test/java/org/dspace/statistics/export/ITIrusExportUsageEventListener.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/export/ITIrusExportUsageEventListener.java
@@ -116,6 +116,7 @@ public class ITIrusExportUsageEventListener extends AbstractIntegrationTestWithD
         configurationService.setProperty("irus.statistics.tracker.enabled", true);
         configurationService.setProperty("irus.statistics.tracker.type-field", "dc.type");
         configurationService.setProperty("irus.statistics.tracker.type-value", "Excluded type");
+        configurationService.setProperty("oai.identifier.prefix", "localhost");
 
 
         context.turnOffAuthorisationSystem();

--- a/dspace-api/src/test/java/org/dspace/statistics/export/processor/ExportEventProcessorIT.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/export/processor/ExportEventProcessorIT.java
@@ -62,6 +62,7 @@ public class ExportEventProcessorIT extends AbstractIntegrationTestWithDatabase 
         configurationService.setProperty("irus.statistics.tracker.enabled", true);
         configurationService.setProperty("irus.statistics.tracker.type-field", "dc.type");
         configurationService.setProperty("irus.statistics.tracker.type-value", "Excluded type");
+        configurationService.setProperty("oai.identifier.prefix", "localhost");
 
         context.turnOffAuthorisationSystem();
         publication = EntityTypeBuilder.createEntityTypeBuilder(context, "Publication").build();


### PR DESCRIPTION
## References
* Fixes #8852

## Description
This pull request resolves the statistics event processor removing www prefixes from OAI identifiers. 
The root cause of the bug was that the `ExportEventProcessor` was incorrectly using the `dspace.ui.url` configuration and processing it with `Utils.getHostName()`. This resulted in OAI identifiers being generated with the wrong hostname (e.g., `localhost` in test environments) or having necessary prefixes like `www.` stripped.
This fix ensures the processor uses the dedicated `oai.identifier.prefix` configuration, guaranteeing that the OAI identifier sent in statistics events is always correct and complete.

## Instructions for Reviewers
This PR modifies ExportEventProcessor.java to use the correct configuration property for building the OAI identifier (`rft.artnum` parameter) for statistics events.

### List of changes in this PR:
* The existing logic to determine `hostName` from `dspace.ui.url` is preserved, as it is correctly used for the `rfr_id` parameter.
* A new string variable, `oaiPrefix`, is added to fetch its value directly from the `oai.identifier.prefix` configuration property.
* The `rft.artnum` parameter is now built using this new `oaiPrefix` variable, ensuring the identifier is correct.
* Updated the related integration tests (`ExportEventProcessorIT.java` and `ITIrusExportUsageEventListener.java`) to provide the new `oai.identifier.prefix` configuration, ensuring they align with the new code logic and pass successfully.

### How to test this PR:
**1. Setup your test environment:**
In your `local.cfg`, ensure the following properties are set:
```ini
# Enable the IRUS statistics tracker
irus.statistics.tracker.enabled = true

# Set an OAI prefix that starts with "www"
oai.identifier.prefix = www.my-dspace-repo.com

# Configure the tracker to send events to a local listener
irus.statistics.tracker.environment = test
irus.statistics.tracker.testurl = http://localhost:8000/
```
**2. Start a local HTTP listener:**
In a separate terminal, run the following command to listen for the events sent by DSpace:
```ini
python3 -m http.server 8000
```
**3. How to reproduce the bug (on the main branch):**
* Start DSpace.
* Confirm that the main OAI-PMH module is correctly configured by running the Identify verb. You should see the correct repository identifier as configured in oai.identifier.prefix.
<img width="695" height="93" alt="image" src="https://github.com/user-attachments/assets/79bf3496-a0ed-4022-8a03-46a2ce72aa86" />

* Now, in the UI, navigate to an item page and download a file.
* Observe the output in your Python listener terminal.
* Expected Result (Buggy): Despite the main OAI module being correct, the statistics event will use the wrong identifier. In a local test environment, this will typically be oai:localhost:..., as it is derived from dspace.ui.url.
```ini
...&rft.artnum=oai%3Alocalhost%3A...
or
...&rft.artnum=oai%3Amy-dspace-repo.com%3A...
```
(Note how this contradicts the correct identifier shown in the Identify verb above)


**4. How to verify the fix (on this PR's branch):**
* Apply this PR, recompile DSpace, and restart the backend.
* In the UI, download a file from any item again.
* Observe the new output in your Python listener terminal.
* Expected Result (Fixed): The rft.artnum parameter now correctly uses the full prefix from oai.identifier.prefix.
```ini
...&rft.artnum=oai%3Awww.my-dspace-repo.com%3A...
```
(Note that "www." is now correctly included)

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods. (No new public methods were added)
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide). (Updated the related integration tests (`ExportEventProcessorIT.java` and `ITIrusExportUsageEventListener.java`) to provide the new `oai.identifier.prefix` configuration, ensuring they align with the new code logic and pass successfully.)
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
