### PR TITLE
Replace deprecated StringUtils usages with Strings equivalent

### DIFF
--- a/dspace-api/src/test/java/org/dspace/app/itemexport/ItemExportCLIIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/itemexport/ItemExportCLIIT.java
@@ -20,7 +20,6 @@ import java.util.stream.Collectors;
 import org.apache.commons.codec.CharEncoding;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.file.PathUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.dspace.AbstractIntegrationTestWithDatabase;
 import org.dspace.builder.BitstreamBuilder;

--- a/dspace-api/src/test/java/org/dspace/app/itemexport/ItemExportCLIIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/itemexport/ItemExportCLIIT.java
@@ -21,6 +21,7 @@ import org.apache.commons.codec.CharEncoding;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.file.PathUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.dspace.AbstractIntegrationTestWithDatabase;
 import org.dspace.builder.BitstreamBuilder;
 import org.dspace.builder.CollectionBuilder;
@@ -335,7 +336,7 @@ public class ItemExportCLIIT extends AbstractIntegrationTestWithDatabase {
     private void checkZip(String zipFileName) throws Exception {
         assertEquals(1,
                 Files.list(tempDir)
-                .filter(b -> StringUtils.equals(b.getFileName().toString(), zipFileName))
+                .filter(b -> Strings.CS.equals(b.getFileName().toString(), zipFileName))
                 .count());
     }
 

--- a/dspace-api/src/test/java/org/dspace/app/mediafilter/MediaFilterIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/mediafilter/MediaFilterIT.java
@@ -16,7 +16,6 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.dspace.AbstractIntegrationTestWithDatabase;
 import org.dspace.authorize.AuthorizeException;

--- a/dspace-api/src/test/java/org/dspace/app/mediafilter/MediaFilterIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/mediafilter/MediaFilterIT.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.dspace.AbstractIntegrationTestWithDatabase;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.builder.BitstreamBuilder;
@@ -192,17 +193,17 @@ public class MediaFilterIT extends AbstractIntegrationTestWithDatabase {
     }
 
     private void checkItemHasBeenProcessed(Item item) throws IOException, SQLException, AuthorizeException {
-        String expectedFileName = StringUtils.endsWith(item.getName(), "_a") ? "test.csv.txt" : "test.txt.txt";
-        String expectedContent = StringUtils.endsWith(item.getName(), "_a") ? "data3,3" : "quick brown fox";
+        String expectedFileName = Strings.CS.endsWith(item.getName(), "_a") ? "test.csv.txt" : "test.txt.txt";
+        String expectedContent = Strings.CS.endsWith(item.getName(), "_a") ? "data3,3" : "quick brown fox";
         List<Bundle> textBundles = item.getBundles("TEXT");
         assertTrue("The item " + item.getName() + " has NOT the TEXT bundle", textBundles.size() == 1);
         List<Bitstream> bitstreams = textBundles.get(0).getBitstreams();
         assertTrue("The item " + item.getName() + " has NOT exactly 1 bitstream in the TEXT bundle",
                 bitstreams.size() == 1);
         assertTrue("The text bitstream in the " + item.getName() + " is NOT named properly [" + expectedFileName + "]",
-                StringUtils.equals(bitstreams.get(0).getName(), expectedFileName));
+                Strings.CS.equals(bitstreams.get(0).getName(), expectedFileName));
         assertTrue("The text bitstream in the " + item.getName() + " doesn't contain the proper content ["
-                + expectedContent + "]", StringUtils.contains(getContent(bitstreams.get(0)), expectedContent));
+                + expectedContent + "]", Strings.CS.contains(getContent(bitstreams.get(0)), expectedContent));
     }
 
     private CharSequence getContent(Bitstream bitstream) throws IOException, SQLException, AuthorizeException {

--- a/dspace-api/src/test/java/org/dspace/eperson/EPersonTest.java
+++ b/dspace-api/src/test/java/org/dspace/eperson/EPersonTest.java
@@ -26,6 +26,7 @@ import jakarta.mail.MessagingException;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.Logger;
 import org.dspace.AbstractUnitTest;
 import org.dspace.authorize.AuthorizeException;
@@ -985,7 +986,7 @@ public class EPersonTest extends AbstractUnitTest {
         Iterator<String> iterator = tableList.iterator();
         while (iterator.hasNext()) {
             String tableName = iterator.next();
-            if (StringUtils.equalsIgnoreCase(tableName, "item")) {
+            if (Strings.CI.equals(tableName, "item")) {
                 return;
             }
         }

--- a/dspace-api/src/test/java/org/dspace/eperson/EPersonTest.java
+++ b/dspace-api/src/test/java/org/dspace/eperson/EPersonTest.java
@@ -25,7 +25,6 @@ import java.util.Set;
 import jakarta.mail.MessagingException;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.Logger;
 import org.dspace.AbstractUnitTest;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/CollectionGroupRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/CollectionGroupRestController.java
@@ -17,6 +17,7 @@ import java.util.UUID;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.dspace.app.rest.converter.ConverterService;
 import org.dspace.app.rest.exception.UnprocessableEntityException;
 import org.dspace.app.rest.model.GroupRest;
@@ -233,7 +234,7 @@ public class CollectionGroupRestController {
             .getAuthorizedGroups(context, collection, Constants.DEFAULT_ITEM_READ);
         if (itemGroups != null && !itemGroups.isEmpty()) {
             Group itemReadGroup = itemGroups.get(0);
-            if (itemReadGroup != null && !StringUtils.equalsIgnoreCase(itemReadGroup.getName(), Group.ANONYMOUS)) {
+            if (itemReadGroup != null && !Strings.CI.equals(itemReadGroup.getName(), Group.ANONYMOUS)) {
                 throw new UnprocessableEntityException(
                     "Unable to create a new default read group because either the group already exists or multiple " +
                         "groups are assigned the default privileges.");
@@ -273,7 +274,7 @@ public class CollectionGroupRestController {
         List<Group> itemGroups = authorizeService.getAuthorizedGroups(context, collection, Constants.DEFAULT_ITEM_READ);
         if (itemGroups != null && !itemGroups.isEmpty()) {
             Group itemReadGroup = itemGroups.get(0);
-            if (itemReadGroup == null || StringUtils.equalsIgnoreCase(itemReadGroup.getName(), Group.ANONYMOUS)) {
+            if (itemReadGroup == null || Strings.CI.equals(itemReadGroup.getName(), Group.ANONYMOUS)) {
                 throw new UnprocessableEntityException(
                     "Unable to delete the default read group because it's the default");
             }
@@ -315,7 +316,7 @@ public class CollectionGroupRestController {
             .getAuthorizedGroups(context, collection, Constants.DEFAULT_BITSTREAM_READ);
         if (bitstreamGroups != null && !bitstreamGroups.isEmpty()) {
             Group bitstreamGroup = bitstreamGroups.get(0);
-            if (bitstreamGroup != null && !StringUtils.equalsIgnoreCase(bitstreamGroup.getName(), Group.ANONYMOUS)) {
+            if (bitstreamGroup != null && !Strings.CI.equals(bitstreamGroup.getName(), Group.ANONYMOUS)) {
                 throw new UnprocessableEntityException(
                     "Unable to create a new default read group because either the group already exists or multiple " +
                         "groups are assigned the default privileges.");
@@ -357,8 +358,8 @@ public class CollectionGroupRestController {
             .getAuthorizedGroups(context, collection, Constants.DEFAULT_BITSTREAM_READ);
         if (bitstreamGroups != null && !bitstreamGroups.isEmpty()) {
             Group bitstreamReadGroup = bitstreamGroups.get(0);
-            if (bitstreamReadGroup == null || StringUtils
-                .equalsIgnoreCase(bitstreamReadGroup.getName(), Group.ANONYMOUS)) {
+            if (bitstreamReadGroup == null || Strings
+                .CI.equals(bitstreamReadGroup.getName(), Group.ANONYMOUS)) {
                 throw new UnprocessableEntityException(
                     "Unable to delete the default read group because it's the default");
             }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/CollectionGroupRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/CollectionGroupRestController.java
@@ -16,7 +16,6 @@ import java.util.UUID;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.dspace.app.rest.converter.ConverterService;
 import org.dspace.app.rest.exception.UnprocessableEntityException;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/OidcRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/OidcRestController.java
@@ -14,6 +14,7 @@ import java.util.List;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.model.AuthnRest;
@@ -65,7 +66,7 @@ public class OidcRestController {
             allowedHostNames.add(Utils.getHostName(url));
         }
 
-        if (StringUtils.equalsAnyIgnoreCase(redirectHostName, allowedHostNames.toArray(new String[0]))) {
+        if (Strings.CI.equalsAny(redirectHostName, allowedHostNames.toArray(new String[0]))) {
             log.debug("OIDC redirecting to {}", redirectUrl);
             response.sendRedirect(redirectUrl); // lgtm [java/unvalidated-url-redirection]
         } else {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/RestResourceController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/RestResourceController.java
@@ -30,6 +30,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.converter.ConverterService;
 import org.dspace.app.rest.converter.JsonPatchConverter;
@@ -1003,7 +1004,7 @@ public class RestResourceController implements InitializingBean {
      * @param model
      */
     private void checkModelPluralForm(String apiCategory, String model) {
-        if (StringUtils.equals(utils.makeSingular(model), model)) {
+        if (Strings.CS.equals(utils.makeSingular(model), model)) {
             throw new RepositoryNotFoundException(apiCategory, model);
         }
     }
@@ -1090,7 +1091,7 @@ public class RestResourceController implements InitializingBean {
         UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.newInstance();
 
         for (String key : parameters.keySet()) {
-            if (!StringUtils.equals(key, "embed") && !StringUtils.startsWith(key, "embed.")) {
+            if (!Strings.CS.equals(key, "embed") && !Strings.CS.startsWith(key, "embed.")) {
                 uriComponentsBuilder.queryParam(key, parameters.get(key));
             }
         }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/RestResourceController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/RestResourceController.java
@@ -29,7 +29,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.converter.ConverterService;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/SubmissionCCLicenseUrlRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/SubmissionCCLicenseUrlRepository.java
@@ -13,6 +13,7 @@ import java.util.Map;
 
 import jakarta.servlet.ServletRequest;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.dspace.app.rest.converter.ConverterService;
 import org.dspace.app.rest.exception.DSpaceBadRequestException;
 import org.dspace.app.rest.exception.RepositoryMethodNotImplementedException;
@@ -79,7 +80,7 @@ public class SubmissionCCLicenseUrlRepository extends DSpaceRestRepository<Submi
         // Loop through parameters to find answer parameters, adding them to the parameterMap. Zero or more answers
         // may exist, as some CC licenses do not require answers
         for (String parameter : requestParameterMap.keySet()) {
-            if (StringUtils.startsWith(parameter, "answer_")) {
+            if (Strings.CS.startsWith(parameter, "answer_")) {
                 String field = StringUtils.substringAfter(parameter, "answer_");
                 String answer = "";
                 if (requestParameterMap.get(parameter).length > 0) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/AuthorizationFeatureServiceImpl.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/AuthorizationFeatureServiceImpl.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.ArrayUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.dspace.app.rest.authorization.AuthorizationFeature;
 import org.dspace.app.rest.authorization.AuthorizationFeatureService;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/AuthorizationFeatureServiceImpl.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/AuthorizationFeatureServiceImpl.java
@@ -13,6 +13,7 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.dspace.app.rest.authorization.AuthorizationFeature;
 import org.dspace.app.rest.authorization.AuthorizationFeatureService;
 import org.dspace.app.rest.model.BaseObjectRest;
@@ -61,7 +62,7 @@ public class AuthorizationFeatureServiceImpl implements AuthorizationFeatureServ
     @Override
     public AuthorizationFeature find(String name) {
         for (AuthorizationFeature feature : features) {
-            if (StringUtils.equals(name, feature.getName())) {
+            if (Strings.CS.equals(name, feature.getName())) {
                 return feature;
             }
         }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/CanSynchronizeWithORCID.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/CanSynchronizeWithORCID.java
@@ -14,6 +14,7 @@ import java.util.UUID;
 import java.util.function.Predicate;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.dspace.app.rest.authorization.AuthorizationFeature;
 import org.dspace.app.rest.authorization.AuthorizationFeatureDocumentation;
 import org.dspace.app.rest.model.BaseObjectRest;
@@ -85,7 +86,7 @@ public class CanSynchronizeWithORCID implements AuthorizationFeature {
             return false;
         }
         List<MetadataValue> owners = itemService.getMetadataByMetadataString(item, "dspace.object.owner");
-        Predicate<MetadataValue> checkOwner = v -> StringUtils.equals(v.getAuthority(), eperson.getID().toString());
+        Predicate<MetadataValue> checkOwner = v -> Strings.CS.equals(v.getAuthority(), eperson.getID().toString());
         return owners.stream().anyMatch(checkOwner);
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/CanSynchronizeWithORCID.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/CanSynchronizeWithORCID.java
@@ -13,7 +13,6 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Predicate;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.dspace.app.rest.authorization.AuthorizationFeature;
 import org.dspace.app.rest.authorization.AuthorizationFeatureDocumentation;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/LoginOnBehalfOfFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/LoginOnBehalfOfFeature.java
@@ -9,7 +9,6 @@ package org.dspace.app.rest.authorization.impl;
 
 import java.sql.SQLException;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.dspace.app.rest.authorization.AuthorizationFeature;
 import org.dspace.app.rest.authorization.AuthorizationFeatureDocumentation;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/LoginOnBehalfOfFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/LoginOnBehalfOfFeature.java
@@ -10,6 +10,7 @@ package org.dspace.app.rest.authorization.impl;
 import java.sql.SQLException;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.dspace.app.rest.authorization.AuthorizationFeature;
 import org.dspace.app.rest.authorization.AuthorizationFeatureDocumentation;
 import org.dspace.app.rest.model.BaseObjectRest;
@@ -51,8 +52,8 @@ public class LoginOnBehalfOfFeature implements AuthorizationFeature {
 
     @Override
     public boolean isAuthorized(Context context, BaseObjectRest object) throws SQLException {
-        if (!StringUtils.equals(object.getType(), SiteRest.NAME) &&
-            !StringUtils.equals(object.getType(), EPersonRest.NAME)) {
+        if (!Strings.CS.equals(object.getType(), SiteRest.NAME) &&
+            !Strings.CS.equals(object.getType(), EPersonRest.NAME)) {
             return false;
         }
         if (!authorizeService.isAdmin(context)) {
@@ -61,10 +62,10 @@ public class LoginOnBehalfOfFeature implements AuthorizationFeature {
         if (!configurationService.getBooleanProperty("webui.user.assumelogin")) {
             return false;
         }
-        if (StringUtils.equals(object.getType(), EPersonRest.NAME)) {
+        if (Strings.CS.equals(object.getType(), EPersonRest.NAME)) {
             EPersonRest ePersonRest = (EPersonRest) object;
             EPerson currentUser = context.getCurrentUser();
-            if (StringUtils.equalsIgnoreCase(currentUser.getEmail(), ePersonRest.getEmail())) {
+            if (Strings.CI.equals(currentUser.getEmail(), ePersonRest.getEmail())) {
                 return false;
             }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/ManageGroupFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/ManageGroupFeature.java
@@ -10,6 +10,7 @@ package org.dspace.app.rest.authorization.impl;
 import java.sql.SQLException;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.dspace.app.rest.authorization.AuthorizationFeature;
 import org.dspace.app.rest.authorization.AuthorizationFeatureDocumentation;
 import org.dspace.app.rest.model.BaseObjectRest;
@@ -61,8 +62,8 @@ public class ManageGroupFeature implements AuthorizationFeature {
 
         // Community/Collection admins cannot manage groups that are not COMMUNITY/COLLECTION bound
         // This check is required until https://github.com/DSpace/DSpace/issues/3323 is fixed.
-        if (!(StringUtils.startsWith(group.getName(), "COLLECTION_")
-              || StringUtils.startsWith(group.getName(), "COMMUNITY_"))) {
+        if (!(Strings.CS.startsWith(group.getName(), "COLLECTION_")
+              || Strings.CS.startsWith(group.getName(), "COMMUNITY_"))) {
             return false;
         }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/ManageGroupFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/ManageGroupFeature.java
@@ -9,7 +9,6 @@ package org.dspace.app.rest.authorization.impl;
 
 import java.sql.SQLException;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.dspace.app.rest.authorization.AuthorizationFeature;
 import org.dspace.app.rest.authorization.AuthorizationFeatureDocumentation;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/RequestCopyFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/RequestCopyFeature.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.UUID;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.authorization.AuthorizationFeature;
@@ -75,12 +76,12 @@ public class RequestCopyFeature implements AuthorizationFeature {
         String requestType = configurationService.getProperty("request.item.type");
         if (StringUtils.isBlank(requestType)) {
             return false;
-        } else if (StringUtils.equalsIgnoreCase(requestType, "logged")) {
+        } else if (Strings.CI.equals(requestType, "logged")) {
             EPerson currentUser = context.getCurrentUser();
             if (currentUser == null) {
                 return false;
             }
-        } else if (!StringUtils.equalsIgnoreCase(requestType, "all")) {
+        } else if (!Strings.CI.equals(requestType, "all")) {
             log.warn("The configuration parameter \"request.item.type\" contains an invalid value.");
             return false;
         }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ConverterService.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ConverterService.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import jakarta.annotation.Nullable;
 import jakarta.annotation.PostConstruct;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.link.HalLinkFactory;
@@ -156,7 +157,7 @@ public class ConverterService {
         int maxDepth = 0;
         // DS-4530 exclude the AOP Proxy from determining the annotations
         for (Method m : AopUtils.getTargetClass(repositoryToUse).getMethods()) {
-            if (StringUtils.equalsIgnoreCase(m.getName(), "findOne")) {
+            if (Strings.CI.equals(m.getName(), "findOne")) {
                 int depth = howManySuperclass(m.getDeclaringClass());
                 if (depth > maxDepth) {
                     preAuthorize = AnnotationUtils.findAnnotation(m, PreAuthorize.class);
@@ -179,7 +180,7 @@ public class ConverterService {
 
     private Annotation getDefaultFindOnePreAuthorize() {
         for (Method m : DSpaceRestRepository.class.getMethods()) {
-            if (StringUtils.equalsIgnoreCase(m.getName(), "findOne")) {
+            if (Strings.CI.equals(m.getName(), "findOne")) {
                 Annotation annotation = AnnotationUtils.findAnnotation(m, PreAuthorize.class);
                 if (annotation != null) {
                     return annotation;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ConverterService.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ConverterService.java
@@ -19,7 +19,6 @@ import java.util.Set;
 
 import jakarta.annotation.Nullable;
 import jakarta.annotation.PostConstruct;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionFormConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionFormConverter.java
@@ -13,6 +13,7 @@ import java.util.List;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.dspace.app.rest.model.ScopeEnum;
 import org.dspace.app.rest.model.SubmissionFormFieldRest;
 import org.dspace.app.rest.model.SubmissionFormInputTypeRest;
@@ -110,7 +111,7 @@ public class SubmissionFormConverter implements DSpaceConverter<DCInputSet, Subm
 
         if (dcinput.isMetadataField()) {
             // only try to process the metadata input type if there's a metadata field
-            if (!StringUtils.equalsIgnoreCase(dcinput.getInputType(), "qualdrop_value")) {
+            if (!Strings.CI.equals(dcinput.getInputType(), "qualdrop_value")) {
 
                 // value-pair and vocabulary are a special kind of authorities
                 String inputType = dcinput.getInputType();

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/query/SearchQueryConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/query/SearchQueryConverter.java
@@ -13,7 +13,6 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.dspace.app.rest.model.query.RestSearchOperator;
 import org.dspace.app.rest.parameter.SearchFilter;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/query/SearchQueryConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/query/SearchQueryConverter.java
@@ -14,6 +14,7 @@ import java.util.List;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.dspace.app.rest.model.query.RestSearchOperator;
 import org.dspace.app.rest.parameter.SearchFilter;
 
@@ -34,7 +35,7 @@ public class SearchQueryConverter {
 
         List<SearchFilter> transformedSearchFilters = new LinkedList<>();
         for (SearchFilter searchFilter : CollectionUtils.emptyIfNull(searchFilters)) {
-            if (StringUtils.equals(searchFilter.getOperator(), OPERATOR_QUERY)) {
+            if (Strings.CS.equals(searchFilter.getOperator(), OPERATOR_QUERY)) {
                 SearchFilter transformedSearchFilter = convertQuerySearchFilterIntoStandardSearchFilter(searchFilter);
                 transformedSearchFilters.add(transformedSearchFilter);
             } else {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/hateoas/HALResource.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/hateoas/HALResource.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.Link;
 
@@ -56,7 +57,7 @@ public abstract class HALResource<T> extends EntityModel<T> {
             if (StringUtils.isNotBlank(name)) {
                 List<Link> list = this.getLinks(link.getRel());
                 // If a link of this name doesn't already exist in the list, add it
-                if (!list.stream().anyMatch((l -> StringUtils.equalsIgnoreCase(l.getName(), name)))) {
+                if (!list.stream().anyMatch((l -> Strings.CI.equals(l.getName(), name)))) {
                     super.add(link);
                 }
             }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/parameter/SearchFilter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/parameter/SearchFilter.java
@@ -7,7 +7,6 @@
  */
 package org.dspace.app.rest.parameter;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 
 /**

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/parameter/SearchFilter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/parameter/SearchFilter.java
@@ -8,6 +8,7 @@
 package org.dspace.app.rest.parameter;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 
 /**
  * Custom request parameter used in the Discovery search REST endpoint.
@@ -38,7 +39,7 @@ public class SearchFilter {
     }
 
     public boolean hasAuthorityOperator() {
-        return StringUtils.equals(operator, "authority");
+        return Strings.CS.equals(operator, "authority");
     }
 
     public String toString() {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/projection/EmbedRelsProjection.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/projection/EmbedRelsProjection.java
@@ -11,7 +11,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.dspace.app.rest.model.LinkRest;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/projection/EmbedRelsProjection.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/projection/EmbedRelsProjection.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.dspace.app.rest.model.LinkRest;
 import org.dspace.app.rest.model.RestAddressableModel;
@@ -50,7 +51,7 @@ public class EmbedRelsProjection extends AbstractProjection {
     public EmbedRelsProjection(Set<String> embedRels, Set<String> embedSizes) {
         this.embedRels = embedRels;
         this.embedSizes = embedSizes.stream()
-                                    .filter(embedSize -> StringUtils.contains(embedSize, "="))
+                                    .filter(embedSize -> Strings.CS.contains(embedSize, "="))
                                     .map(embedSize -> embedSize.split("="))
                                     .collect(Collectors.toMap(
                                         split -> split[0],

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamRestRepository.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.dspace.app.rest.Parameter;
 import org.dspace.app.rest.SearchRestMethod;
 import org.dspace.app.rest.converter.JsonPatchConverter;
@@ -210,7 +211,7 @@ public class BitstreamRestRepository extends DSpaceObjectRestRepository<Bitstrea
         }
         if (StringUtils.isNotBlank(filename)) {
             for (Bitstream bitstream : bitstreams) {
-                if (StringUtils.equals(bitstream.getName(), filename)) {
+                if (Strings.CS.equals(bitstream.getName(), filename)) {
                     return bitstream;
                 }
             }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BrowseItemLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BrowseItemLinkRepository.java
@@ -14,6 +14,7 @@ import java.util.List;
 
 import jakarta.servlet.http.HttpServletRequest;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.dspace.app.rest.model.BrowseIndexRest;
 import org.dspace.app.rest.model.ItemRest;
 import org.dspace.app.rest.projection.Projection;
@@ -99,7 +100,7 @@ public class BrowseItemLinkRepository extends AbstractDSpaceRestRepository
                 Order order = orders.next();
                 bs.setOrder(order.getDirection().name());
                 String sortBy;
-                if (!StringUtils.equals("default", order.getProperty())) {
+                if (!Strings.CS.equals("default", order.getProperty())) {
                     sortBy = order.getProperty();
                 } else {
                     sortBy = bi.getDefaultOrder();

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/EPersonRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/EPersonRestRepository.java
@@ -16,6 +16,7 @@ import java.util.UUID;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.DiscoverableEndpointsService;
@@ -180,7 +181,7 @@ public class EPersonRestRepository extends DSpaceObjectRestRepository<EPerson, E
         }
         String emailFromJson = epersonRest.getEmail();
         if (StringUtils.isNotBlank(emailFromJson)) {
-            if (!StringUtils.equalsIgnoreCase(registrationData.getEmail(), emailFromJson)) {
+            if (!Strings.CI.equals(registrationData.getEmail(), emailFromJson)) {
                 throw new DSpaceBadRequestException("The email resulting from the token does not match the email given"
                                                         + " in the json body. Email from token: " +
                                                     registrationData.getEmail() + " email from the json body: "
@@ -232,7 +233,7 @@ public class EPersonRestRepository extends DSpaceObjectRestRepository<EPerson, E
 
     private boolean canRegisterExternalAccount(RegistrationData registration, EPersonRest epersonRest) {
         return accountService.isTokenValidForCreation(registration) &&
-            StringUtils.equals(registration.getNetId(), epersonRest.getNetid());
+            Strings.CS.equals(registration.getNetId(), epersonRest.getNetid());
     }
 
     @Override
@@ -347,7 +348,7 @@ public class EPersonRestRepository extends DSpaceObjectRestRepository<EPerson, E
                          Patch patch) throws AuthorizeException, SQLException {
         boolean passwordChangeFound = false;
         for (Operation operation : patch.getOperations()) {
-            if (StringUtils.equalsIgnoreCase(operation.getPath(), "/password")) {
+            if (Strings.CI.equals(operation.getPath(), "/password")) {
                 passwordChangeFound = true;
             }
         }
@@ -357,7 +358,7 @@ public class EPersonRestRepository extends DSpaceObjectRestRepository<EPerson, E
                                                     "changing the password");
             }
         } else {
-            if (passwordChangeFound && !StringUtils.equals(context.getAuthenticationMethod(), "password")) {
+            if (passwordChangeFound && !Strings.CS.equals(context.getAuthenticationMethod(), "password")) {
                 throw new AccessDeniedException("Refused to perform the EPerson patch based to change the password " +
                                                         "for non \"password\" authentication");
             }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ItemRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ItemRestRepository.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.http.HttpServletRequest;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.converter.MetadataConverter;
@@ -324,7 +325,7 @@ public class ItemRestRepository extends DSpaceObjectRestRepository<Item, ItemRes
             throw new ResourceNotFoundException(apiCategory + "." + model + " with id: " + uuid + " not found");
         }
 
-        if (StringUtils.equals(uuid.toString(), itemRest.getId())) {
+        if (Strings.CS.equals(uuid.toString(), itemRest.getId())) {
             metadataConverter.setMetadata(context, item, itemRest.getMetadata());
         } else {
             throw new IllegalArgumentException("The UUID in the Json and the UUID in the url do not match: "

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ProcessRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ProcessRestRepository.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 
 import jakarta.annotation.PostConstruct;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.Parameter;
@@ -231,13 +232,13 @@ public class ProcessRestRepository extends DSpaceRestRepository<ProcessRest, Int
             Iterator<Sort.Order> iterator = sort.iterator();
             if (iterator.hasNext()) {
                 Sort.Order order = iterator.next();
-                if (StringUtils.equalsIgnoreCase(order.getProperty(), "startTime")) {
+                if (Strings.CI.equals(order.getProperty(), "startTime")) {
                     processQueryParameterContainer.setSortProperty(Process_.START_TIME);
                     processQueryParameterContainer.setSortOrder(order.getDirection().name());
-                } else if (StringUtils.equalsIgnoreCase(order.getProperty(), "endTime")) {
+                } else if (Strings.CI.equals(order.getProperty(), "endTime")) {
                     processQueryParameterContainer.setSortProperty(Process_.FINISHED_TIME);
                     processQueryParameterContainer.setSortOrder(order.getDirection().name());
-                } else if (StringUtils.equalsIgnoreCase(order.getProperty(), "creationTime")) {
+                } else if (Strings.CI.equals(order.getProperty(), "creationTime")) {
                     processQueryParameterContainer.setSortProperty(Process_.CREATION_TIME);
                     processQueryParameterContainer.setSortOrder(order.getDirection().name());
                 } else {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/SearchEventRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/SearchEventRestRepository.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.http.HttpServletRequest;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.dspace.app.rest.converter.SearchEventConverter;
 import org.dspace.app.rest.exception.DSpaceBadRequestException;
 import org.dspace.app.rest.exception.UnprocessableEntityException;
@@ -70,8 +71,8 @@ public class SearchEventRestRepository extends AbstractDSpaceRestRepository {
         if (sort == null) {
             return false;
         }
-        if (!(StringUtils.equalsIgnoreCase(sort.getOrder(), "asc") ||
-            StringUtils.equalsIgnoreCase(sort.getOrder(), "desc"))) {
+        if (!(Strings.CI.equals(sort.getOrder(), "asc") ||
+            Strings.CI.equals(sort.getOrder(), "desc"))) {
             return false;
         }
         return true;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/SearchEventRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/SearchEventRestRepository.java
@@ -12,7 +12,6 @@ import java.io.IOException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.http.HttpServletRequest;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.dspace.app.rest.converter.SearchEventConverter;
 import org.dspace.app.rest.exception.DSpaceBadRequestException;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/SubscriptionRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/SubscriptionRestRepository.java
@@ -27,6 +27,7 @@ import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.http.HttpServletRequest;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.dspace.app.rest.DiscoverableEndpointsService;
 import org.dspace.app.rest.Parameter;
 import org.dspace.app.rest.SearchRestMethod;
@@ -211,7 +212,7 @@ public class SubscriptionRestRepository extends DSpaceRestRepository<Subscriptio
             SubscriptionParameter subscriptionParameter = new SubscriptionParameter();
             var name = subscriptionParameterRest.getName();
             var value = subscriptionParameterRest.getValue();
-            if (!StringUtils.equals("frequency", name) || !FrequencyType.isSupportedFrequencyType(value)) {
+            if (!Strings.CS.equals("frequency", name) || !FrequencyType.isSupportedFrequencyType(value)) {
                 throw new UnprocessableEntityException("Provided SubscriptionParameter name:" + name +
                                                        " or value: " + value + " is not supported!");
             }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/handler/ExternalSourceEntryItemUriListHandler.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/handler/ExternalSourceEntryItemUriListHandler.java
@@ -18,6 +18,7 @@ import java.util.regex.Pattern;
 
 import jakarta.servlet.http.HttpServletRequest;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.model.ExternalSourceRest;
 import org.dspace.authorize.AuthorizeException;
@@ -55,8 +56,8 @@ public abstract class ExternalSourceEntryItemUriListHandler<T> implements UriLis
             return false;
         }
         for (String string : uriList) {
-            if (!(StringUtils.contains(string, ExternalSourceRest.CATEGORY + "/" + ExternalSourceRest.PLURAL_NAME) &&
-                StringUtils.contains(string, "entryValues"))) {
+            if (!(Strings.CS.contains(string, ExternalSourceRest.CATEGORY + "/" + ExternalSourceRest.PLURAL_NAME) &&
+                Strings.CS.contains(string, "entryValues"))) {
                 return false;
             }
         }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/QAEventStatusReplaceOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/QAEventStatusReplaceOperation.java
@@ -9,7 +9,6 @@ package org.dspace.app.rest.repository.patch.operation;
 
 import java.sql.SQLException;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.dspace.app.rest.model.patch.Operation;
 import org.dspace.content.QAEvent;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/QAEventStatusReplaceOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/QAEventStatusReplaceOperation.java
@@ -10,6 +10,7 @@ package org.dspace.app.rest.repository.patch.operation;
 import java.sql.SQLException;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.dspace.app.rest.model.patch.Operation;
 import org.dspace.content.QAEvent;
 import org.dspace.core.Context;
@@ -35,11 +36,11 @@ public class QAEventStatusReplaceOperation extends PatchOperation<QAEvent> {
     @Override
     public QAEvent perform(Context context, QAEvent qaevent, Operation operation) throws SQLException {
         String value = (String) operation.getValue();
-        if (StringUtils.equalsIgnoreCase(value, QAEvent.ACCEPTED)) {
+        if (Strings.CI.equals(value, QAEvent.ACCEPTED)) {
             qaEventActionService.accept(context, qaevent);
-        } else if (StringUtils.equalsIgnoreCase(value, QAEvent.REJECTED)) {
+        } else if (Strings.CI.equals(value, QAEvent.REJECTED)) {
             qaEventActionService.reject(context, qaevent);
-        } else if (StringUtils.equalsIgnoreCase(value, QAEvent.DISCARDED)) {
+        } else if (Strings.CI.equals(value, QAEvent.DISCARDED)) {
             qaEventActionService.discard(context, qaevent);
         } else {
             throw new IllegalArgumentException(
@@ -53,8 +54,8 @@ public class QAEventStatusReplaceOperation extends PatchOperation<QAEvent> {
 
     @Override
     public boolean supports(Object objectToMatch, Operation operation) {
-        return StringUtils.equals(operation.getOp(), "replace") && objectToMatch instanceof QAEvent && StringUtils
-                .containsAny(operation.getValue().toString().toLowerCase(), QAEvent.ACCEPTED, QAEvent.DISCARDED,
+        return Strings.CS.equals(operation.getOp(), "replace") && objectToMatch instanceof QAEvent && Strings
+            .CS.containsAny(operation.getValue().toString().toLowerCase(), QAEvent.ACCEPTED, QAEvent.DISCARDED,
                         QAEvent.REJECTED);
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/ResearcherProfileReplaceOrcidSyncPreferencesOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/ResearcherProfileReplaceOrcidSyncPreferencesOperation.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.dspace.app.rest.exception.RESTAuthorizationException;
 import org.dspace.app.rest.exception.UnprocessableEntityException;
 import org.dspace.app.rest.model.patch.Operation;
@@ -76,7 +77,7 @@ public class ResearcherProfileReplaceOrcidSyncPreferencesOperation extends Patch
     public ResearcherProfile perform(Context context, ResearcherProfile profile, Operation operation)
         throws SQLException {
 
-        String path = StringUtils.removeStart(operation.getPath(), OPERATION_ORCID_SYNCH);
+        String path = Strings.CS.removeStart(operation.getPath(), OPERATION_ORCID_SYNCH);
         String value = getNewValueFromOperation(operation);
 
         Item profileItem = profile.getItem();

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/ClaimedTaskRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/ClaimedTaskRestPermissionEvaluatorPlugin.java
@@ -11,6 +11,7 @@ import java.io.Serializable;
 import java.sql.SQLException;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.model.ClaimedTaskRest;
@@ -50,7 +51,7 @@ public class ClaimedTaskRestPermissionEvaluatorPlugin extends RestObjectPermissi
     public boolean hasDSpacePermission(Authentication authentication, Serializable targetId,
                                  String targetType, DSpaceRestPermission permission) {
 
-        if (!StringUtils.equalsIgnoreCase(ClaimedTaskRest.NAME, targetType)) {
+        if (!Strings.CI.equals(ClaimedTaskRest.NAME, targetType)) {
             return false;
         }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/ClaimedTaskRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/ClaimedTaskRestPermissionEvaluatorPlugin.java
@@ -10,7 +10,6 @@ package org.dspace.app.rest.security;
 import java.io.Serializable;
 import java.sql.SQLException;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/DSpaceObjectAdminPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/DSpaceObjectAdminPermissionEvaluatorPlugin.java
@@ -12,6 +12,7 @@ import java.sql.SQLException;
 import java.util.UUID;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.utils.ContextUtil;
@@ -53,7 +54,7 @@ public class DSpaceObjectAdminPermissionEvaluatorPlugin extends RestObjectPermis
         DSpaceRestPermission restPermission = DSpaceRestPermission.convert(permission);
 
         if (!DSpaceRestPermission.ADMIN.equals(restPermission)
-                || !StringUtils.equalsIgnoreCase(targetType, DSPACE_OBJECT)) {
+                || !Strings.CI.equals(targetType, DSPACE_OBJECT)) {
             return false;
         }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/DSpaceObjectAdminPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/DSpaceObjectAdminPermissionEvaluatorPlugin.java
@@ -11,7 +11,6 @@ import java.io.Serializable;
 import java.sql.SQLException;
 import java.util.UUID;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/EPersonRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/EPersonRestPermissionEvaluatorPlugin.java
@@ -14,6 +14,7 @@ import java.util.UUID;
 
 import jakarta.servlet.http.HttpServletRequest;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.model.patch.Operation;
@@ -104,8 +105,8 @@ public class EPersonRestPermissionEvaluatorPlugin extends RestObjectPermissionEv
         if (currentRequest != null) {
             HttpServletRequest httpServletRequest = currentRequest.getHttpServletRequest();
             if (!operations.isEmpty()
-                && StringUtils.equalsIgnoreCase(operations.get(0).getOp(), PatchOperation.OPERATION_ADD)
-                && StringUtils.equalsIgnoreCase(operations.get(0).getPath(),
+                && Strings.CI.equals(operations.get(0).getOp(), PatchOperation.OPERATION_ADD)
+                && Strings.CI.equals(operations.get(0).getPath(),
                 EPersonPasswordAddOperation.OPERATION_PASSWORD_CHANGE)
                 && StringUtils.isNotBlank(httpServletRequest.getParameter("token"))) {
                 return true;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/OidcLoginFilter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/OidcLoginFilter.java
@@ -17,6 +17,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.core.Utils;
@@ -88,7 +89,7 @@ public class OidcLoginFilter extends StatelessLoginFilter {
             allowedHostNames.add(Utils.getHostName(url));
         }
 
-        if (StringUtils.equalsAnyIgnoreCase(redirectHostName, allowedHostNames.toArray(new String[0]))) {
+        if (Strings.CI.equalsAny(redirectHostName, allowedHostNames.toArray(new String[0]))) {
             log.debug("OIDC redirecting to " + redirectUrl);
             response.sendRedirect(redirectUrl);
         } else {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/OrcidLoginFilter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/OrcidLoginFilter.java
@@ -20,6 +20,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.authenticate.OrcidAuthentication;
@@ -144,7 +145,7 @@ public class OrcidLoginFilter extends StatelessLoginFilter {
             allowedHostNames.add(Utils.getHostName(url));
         }
 
-        if (StringUtils.equalsAnyIgnoreCase(redirectHostName, allowedHostNames.toArray(new String[0]))) {
+        if (Strings.CI.equalsAny(redirectHostName, allowedHostNames.toArray(new String[0]))) {
             log.debug("Orcid redirecting to " + redirectUrl);
             response.sendRedirect(redirectUrl);
         } else {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/PoolTaskRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/PoolTaskRestPermissionEvaluatorPlugin.java
@@ -12,6 +12,7 @@ import java.io.Serializable;
 import java.sql.SQLException;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.model.PoolTaskRest;
@@ -52,7 +53,7 @@ public class PoolTaskRestPermissionEvaluatorPlugin extends RestObjectPermissionE
     public boolean hasDSpacePermission(Authentication authentication, Serializable targetId,
                                  String targetType, DSpaceRestPermission permission) {
 
-        if (!StringUtils.equalsIgnoreCase(PoolTaskRest.NAME, targetType)) {
+        if (!Strings.CI.equals(PoolTaskRest.NAME, targetType)) {
             return false;
         }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/PoolTaskRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/PoolTaskRestPermissionEvaluatorPlugin.java
@@ -11,7 +11,6 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.sql.SQLException;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/ProcessRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/ProcessRestPermissionEvaluatorPlugin.java
@@ -11,6 +11,7 @@ import java.io.Serializable;
 import java.sql.SQLException;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.model.ProcessRest;
@@ -48,7 +49,7 @@ public class ProcessRestPermissionEvaluatorPlugin extends RestObjectPermissionEv
     public boolean hasDSpacePermission(Authentication authentication, Serializable targetId, String targetType,
                                        DSpaceRestPermission restPermission) {
 
-        if (!StringUtils.equalsIgnoreCase(targetType, ProcessRest.NAME)) {
+        if (!Strings.CI.equals(targetType, ProcessRest.NAME)) {
             return false;
         }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/ProcessRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/ProcessRestPermissionEvaluatorPlugin.java
@@ -10,7 +10,6 @@ package org.dspace.app.rest.security;
 import java.io.Serializable;
 import java.sql.SQLException;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/QAEventRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/QAEventRestPermissionEvaluatorPlugin.java
@@ -11,6 +11,7 @@ import java.io.Serializable;
 import java.util.Objects;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.model.QAEventRest;
@@ -54,7 +55,7 @@ public class QAEventRestPermissionEvaluatorPlugin extends RestObjectPermissionEv
     @Override
     public boolean hasDSpacePermission(Authentication authentication, Serializable targetId, String targetType,
             DSpaceRestPermission restPermission) {
-        if (StringUtils.equalsIgnoreCase(QAEventRest.NAME, targetType)) {
+        if (Strings.CI.equals(QAEventRest.NAME, targetType)) {
             log.debug("Checking permission for targetId {}", targetId);
             Request request = requestService.getCurrentRequest();
             Context context = ContextUtil.obtainContext(request.getHttpServletRequest());

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/QAEventRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/QAEventRestPermissionEvaluatorPlugin.java
@@ -10,7 +10,6 @@ package org.dspace.app.rest.security;
 import java.io.Serializable;
 import java.util.Objects;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/QASourceRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/QASourceRestPermissionEvaluatorPlugin.java
@@ -11,6 +11,7 @@ import java.io.Serializable;
 import java.util.Objects;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.model.QASourceRest;
@@ -51,8 +52,8 @@ public class QASourceRestPermissionEvaluatorPlugin extends RestObjectPermissionE
     @Override
     public boolean hasDSpacePermission(Authentication authentication, Serializable targetId, String targetType,
                                        DSpaceRestPermission restPermission) {
-        if (StringUtils.equalsIgnoreCase(QASourceRest.NAME, targetType)
-                || StringUtils.equalsIgnoreCase(QATopicRest.NAME, targetType)) {
+        if (Strings.CI.equals(QASourceRest.NAME, targetType)
+                || Strings.CI.equals(QATopicRest.NAME, targetType)) {
             log.debug("Checking permission for targetId {}", targetId);
             Request request = requestService.getCurrentRequest();
             Context context = ContextUtil.obtainContext(request.getHttpServletRequest());

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/QASourceRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/QASourceRestPermissionEvaluatorPlugin.java
@@ -10,7 +10,6 @@ package org.dspace.app.rest.security;
 import java.io.Serializable;
 import java.util.Objects;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/ReadAuthorizationPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/ReadAuthorizationPermissionEvaluatorPlugin.java
@@ -10,7 +10,6 @@ package org.dspace.app.rest.security;
 import java.io.Serializable;
 import java.sql.SQLException;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/ReadAuthorizationPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/ReadAuthorizationPermissionEvaluatorPlugin.java
@@ -11,6 +11,7 @@ import java.io.Serializable;
 import java.sql.SQLException;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.authorization.AuthorizationRestUtil;
@@ -51,7 +52,7 @@ public class ReadAuthorizationPermissionEvaluatorPlugin extends RestObjectPermis
         DSpaceRestPermission restPermission = DSpaceRestPermission.convert(permission);
 
         if (!DSpaceRestPermission.READ.equals(restPermission)
-                || !StringUtils.equalsIgnoreCase(targetType, AuthorizationRest.NAME)) {
+                || !Strings.CI.equals(targetType, AuthorizationRest.NAME)) {
             return false;
         }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/ResearcherProfileRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/ResearcherProfileRestPermissionEvaluatorPlugin.java
@@ -15,7 +15,6 @@ import java.io.Serializable;
 import java.util.UUID;
 
 import jakarta.servlet.http.HttpServletRequest;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.dspace.app.rest.model.ResearcherProfileRest;
 import org.dspace.app.rest.utils.ContextUtil;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/ResearcherProfileRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/ResearcherProfileRestPermissionEvaluatorPlugin.java
@@ -16,6 +16,7 @@ import java.util.UUID;
 
 import jakarta.servlet.http.HttpServletRequest;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.dspace.app.rest.model.ResearcherProfileRest;
 import org.dspace.app.rest.utils.ContextUtil;
 import org.dspace.core.Context;
@@ -49,7 +50,7 @@ public class ResearcherProfileRestPermissionEvaluatorPlugin extends RestObjectPe
             return false;
         }
 
-        if (!StringUtils.equalsIgnoreCase(targetType, ResearcherProfileRest.NAME)) {
+        if (!Strings.CI.equals(targetType, ResearcherProfileRest.NAME)) {
             return false;
         }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/ResourcePolicyAdminPermissionEvalutatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/ResourcePolicyAdminPermissionEvalutatorPlugin.java
@@ -12,7 +12,6 @@ import java.sql.SQLException;
 import java.util.UUID;
 
 import org.apache.commons.lang.math.NumberUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/ResourcePolicyAdminPermissionEvalutatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/ResourcePolicyAdminPermissionEvalutatorPlugin.java
@@ -13,6 +13,7 @@ import java.util.UUID;
 
 import org.apache.commons.lang.math.NumberUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.model.ResourcePolicyRest;
@@ -60,7 +61,7 @@ public class ResourcePolicyAdminPermissionEvalutatorPlugin extends RestObjectPer
 
         if (!DSpaceRestPermission.ADMIN.equals(restPermission) &&
             !DSpaceRestPermission.WRITE.equals(restPermission) ||
-            !StringUtils.equalsIgnoreCase(targetType, RESOURCE_POLICY_TYPE)) {
+            !Strings.CI.equals(targetType, RESOURCE_POLICY_TYPE)) {
             return false;
         }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/ResourcePolicyRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/ResourcePolicyRestPermissionEvaluatorPlugin.java
@@ -10,7 +10,6 @@ package org.dspace.app.rest.security;
 import java.io.Serializable;
 import java.sql.SQLException;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/ResourcePolicyRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/ResourcePolicyRestPermissionEvaluatorPlugin.java
@@ -11,6 +11,7 @@ import java.io.Serializable;
 import java.sql.SQLException;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.model.ResourcePolicyRest;
@@ -56,7 +57,7 @@ public class ResourcePolicyRestPermissionEvaluatorPlugin extends RestObjectPermi
 
         if (!DSpaceRestPermission.READ.equals(restPermission)
                 && !DSpaceRestPermission.DELETE.equals(restPermission)
-                || !StringUtils.equalsIgnoreCase(targetType, ResourcePolicyRest.NAME)) {
+                || !Strings.CI.equals(targetType, ResourcePolicyRest.NAME)) {
             return false;
         }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/ShibbolethLoginFilter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/ShibbolethLoginFilter.java
@@ -15,6 +15,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.authenticate.ShibAuthentication;
@@ -126,7 +127,7 @@ public class ShibbolethLoginFilter extends StatelessLoginFilter {
             allowedHostNames.add(Utils.getHostName(url));
         }
 
-        if (StringUtils.equalsAnyIgnoreCase(redirectHostName, allowedHostNames.toArray(new String[0]))) {
+        if (Strings.CI.equalsAny(redirectHostName, allowedHostNames.toArray(new String[0]))) {
             log.debug("Shibboleth redirecting to " + redirectUrl);
             response.sendRedirect(redirectUrl);
         } else {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/SubmissionCCLicenseRestEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/SubmissionCCLicenseRestEvaluatorPlugin.java
@@ -10,6 +10,7 @@ package org.dspace.app.rest.security;
 import java.io.Serializable;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.dspace.app.rest.model.SubmissionCCLicenseRest;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
@@ -20,7 +21,7 @@ public class SubmissionCCLicenseRestEvaluatorPlugin extends RestObjectPermission
     @Override
     public boolean hasDSpacePermission(Authentication authentication, Serializable targetId, String targetType,
                                        DSpaceRestPermission restPermission) {
-        if (!StringUtils.equalsIgnoreCase(SubmissionCCLicenseRest.NAME, targetType)) {
+        if (!Strings.CI.equals(SubmissionCCLicenseRest.NAME, targetType)) {
             return false;
         }
         return true;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/SubmissionCCLicenseRestEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/SubmissionCCLicenseRestEvaluatorPlugin.java
@@ -9,7 +9,6 @@ package org.dspace.app.rest.security;
 
 import java.io.Serializable;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.dspace.app.rest.model.SubmissionCCLicenseRest;
 import org.springframework.security.core.Authentication;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/SubmissionCCLicenseUrlRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/SubmissionCCLicenseUrlRestPermissionEvaluatorPlugin.java
@@ -9,7 +9,6 @@ package org.dspace.app.rest.security;
 
 import java.io.Serializable;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.dspace.app.rest.model.SubmissionCCLicenseUrlRest;
 import org.springframework.security.core.Authentication;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/SubmissionCCLicenseUrlRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/SubmissionCCLicenseUrlRestPermissionEvaluatorPlugin.java
@@ -10,6 +10,7 @@ package org.dspace.app.rest.security;
 import java.io.Serializable;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.dspace.app.rest.model.SubmissionCCLicenseUrlRest;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
@@ -23,7 +24,7 @@ public class SubmissionCCLicenseUrlRestPermissionEvaluatorPlugin extends RestObj
     @Override
     public boolean hasDSpacePermission(Authentication authentication, Serializable targetId, String targetType,
                                        DSpaceRestPermission restPermission) {
-        if (!StringUtils.equalsIgnoreCase(SubmissionCCLicenseUrlRest.NAME, targetType)) {
+        if (!Strings.CI.equals(SubmissionCCLicenseUrlRest.NAME, targetType)) {
             return false;
         }
         return true;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/SubscriptionRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/SubscriptionRestPermissionEvaluatorPlugin.java
@@ -17,6 +17,7 @@ import java.sql.SQLException;
 import java.util.Objects;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.utils.ContextUtil;
@@ -55,7 +56,7 @@ public class SubscriptionRestPermissionEvaluatorPlugin extends RestObjectPermiss
         DSpaceRestPermission restPermission = DSpaceRestPermission.convert(permission);
 
         if (!READ.equals(restPermission) && !WRITE.equals(restPermission) && !DELETE.equals(restPermission)
-            || !StringUtils.equalsIgnoreCase(targetType, NAME)) {
+            || !Strings.CI.equals(targetType, NAME)) {
             return false;
         }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/SubscriptionRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/SubscriptionRestPermissionEvaluatorPlugin.java
@@ -16,7 +16,6 @@ import java.io.Serializable;
 import java.sql.SQLException;
 import java.util.Objects;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/SuggestionRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/SuggestionRestPermissionEvaluatorPlugin.java
@@ -15,7 +15,6 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.UUID;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.dspace.app.rest.model.SuggestionRest;
 import org.dspace.app.rest.utils.ContextUtil;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/SuggestionRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/SuggestionRestPermissionEvaluatorPlugin.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.UUID;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.dspace.app.rest.model.SuggestionRest;
 import org.dspace.app.rest.utils.ContextUtil;
 import org.dspace.content.Item;
@@ -51,8 +52,8 @@ public class SuggestionRestPermissionEvaluatorPlugin extends RestObjectPermissio
             return false;
         }
 
-        if (!StringUtils.equalsIgnoreCase(targetType, SuggestionRest.NAME)
-                && !StringUtils.startsWithIgnoreCase(targetType, SuggestionRest.NAME)) {
+        if (!Strings.CI.equals(targetType, SuggestionRest.NAME)
+                && !Strings.CI.startsWith(targetType, SuggestionRest.NAME)) {
             return false;
         }
 
@@ -79,7 +80,7 @@ public class SuggestionRestPermissionEvaluatorPlugin extends RestObjectPermissio
                 List<MetadataValue> mvalues = itemService.getMetadataByMetadataString(item, "dspace.object.owner");
                 if (mvalues != null) {
                     for (MetadataValue mv : mvalues) {
-                        if (StringUtils.equals(mv.getAuthority(), currentUser.getID().toString())) {
+                        if (Strings.CS.equals(mv.getAuthority(), currentUser.getID().toString())) {
                             return true;
                         }
                     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/SuggestionTargetRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/SuggestionTargetRestPermissionEvaluatorPlugin.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.UUID;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.dspace.app.rest.model.SuggestionTargetRest;
 import org.dspace.app.rest.utils.ContextUtil;
 import org.dspace.content.Item;
@@ -52,8 +53,8 @@ public class SuggestionTargetRestPermissionEvaluatorPlugin extends RestObjectPer
             return false;
         }
 
-        if (!StringUtils.equalsIgnoreCase(targetType, SuggestionTargetRest.NAME)
-                && !StringUtils.startsWithIgnoreCase(targetType, SuggestionTargetRest.NAME)) {
+        if (!Strings.CI.equals(targetType, SuggestionTargetRest.NAME)
+                && !Strings.CI.startsWith(targetType, SuggestionTargetRest.NAME)) {
             return false;
         }
 
@@ -80,7 +81,7 @@ public class SuggestionTargetRestPermissionEvaluatorPlugin extends RestObjectPer
                 List<MetadataValue> mvalues = itemService.getMetadataByMetadataString(item, "dspace.object.owner");
                 if (mvalues != null) {
                     for (MetadataValue mv : mvalues) {
-                        if (StringUtils.equals(mv.getAuthority(), currentUser.getID().toString())) {
+                        if (Strings.CS.equals(mv.getAuthority(), currentUser.getID().toString())) {
                             return true;
                         }
                     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/SuggestionTargetRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/SuggestionTargetRestPermissionEvaluatorPlugin.java
@@ -15,7 +15,6 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.UUID;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.dspace.app.rest.model.SuggestionTargetRest;
 import org.dspace.app.rest.utils.ContextUtil;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/TemplateItemRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/TemplateItemRestPermissionEvaluatorPlugin.java
@@ -12,6 +12,7 @@ import java.sql.SQLException;
 import java.util.UUID;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.model.TemplateItemRest;
@@ -55,7 +56,7 @@ public class TemplateItemRestPermissionEvaluatorPlugin extends RestObjectPermiss
                 !DSpaceRestPermission.DELETE.equals(restPermission)) {
             return false;
         }
-        if (!StringUtils.equalsIgnoreCase(targetType, TemplateItemRest.NAME)) {
+        if (!Strings.CI.equals(targetType, TemplateItemRest.NAME)) {
             return false;
         }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/TemplateItemRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/TemplateItemRestPermissionEvaluatorPlugin.java
@@ -11,7 +11,6 @@ import java.io.Serializable;
 import java.sql.SQLException;
 import java.util.UUID;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/UsageReportRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/UsageReportRestPermissionEvaluatorPlugin.java
@@ -13,6 +13,7 @@ import java.util.Objects;
 import java.util.UUID;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.model.UsageReportRest;
@@ -63,8 +64,8 @@ public class UsageReportRestPermissionEvaluatorPlugin extends RestObjectPermissi
     @Override
     public boolean hasDSpacePermission(Authentication authentication, Serializable targetId, String targetType,
                                        DSpaceRestPermission restPermission) {
-        if (StringUtils.equalsIgnoreCase(UsageReportRest.NAME, targetType)
-                || StringUtils.equalsIgnoreCase(UsageReportRest.NAME + "search", targetType)) {
+        if (Strings.CI.equals(UsageReportRest.NAME, targetType)
+                || Strings.CI.equals(UsageReportRest.NAME + "search", targetType)) {
             Request request = requestService.getCurrentRequest();
             Context context = ContextUtil.obtainContext(request.getHttpServletRequest());
             UUID uuidObject = null;
@@ -74,14 +75,14 @@ public class UsageReportRestPermissionEvaluatorPlugin extends RestObjectPermissi
                 }
                 if (configurationService.getBooleanProperty("usage-statistics.authorization.admin.usage", false)) {
                     return authorizeService.isAdmin(context);
-                } else  if (StringUtils.equalsIgnoreCase(UsageReportRest.NAME, targetType)) {
+                } else  if (Strings.CI.equals(UsageReportRest.NAME, targetType)) {
                     if (StringUtils.countMatches(targetId.toString(), "_") != 1) {
                         throw new IllegalArgumentException("Must end in objectUUID_reportId, example: "
                                 + "1911e8a4-6939-490c-b58b-a5d70f8d91fb_TopCountries");
                     }
                     // Get uuid from uuidDSO_reportId pathParam
                     uuidObject = UUID.fromString(StringUtils.substringBefore(targetId.toString(), "_"));
-                } else if (StringUtils.equalsIgnoreCase(UsageReportRest.NAME + "search", targetType)) {
+                } else if (Strings.CI.equals(UsageReportRest.NAME + "search", targetType)) {
                     // Get uuid from url (selfLink of dso) queryParam
                     uuidObject = UUID.fromString(StringUtils.substringAfterLast(targetId.toString(), "/"));
                 } else {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/VersionHistoryRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/VersionHistoryRestPermissionEvaluatorPlugin.java
@@ -10,7 +10,6 @@ package org.dspace.app.rest.security;
 import java.io.Serializable;
 import java.sql.SQLException;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/VersionHistoryRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/VersionHistoryRestPermissionEvaluatorPlugin.java
@@ -11,6 +11,7 @@ import java.io.Serializable;
 import java.sql.SQLException;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.model.VersionHistoryRest;
@@ -48,7 +49,7 @@ public class VersionHistoryRestPermissionEvaluatorPlugin extends RestObjectPermi
                                        DSpaceRestPermission restPermission) {
 
 
-        if (!StringUtils.equalsIgnoreCase(targetType, VersionHistoryRest.NAME)) {
+        if (!Strings.CI.equals(targetType, VersionHistoryRest.NAME)) {
             return false;
         }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/VersionRestPatchPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/VersionRestPatchPermissionEvaluatorPlugin.java
@@ -12,6 +12,7 @@ import java.sql.SQLException;
 import java.util.UUID;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.model.VersionRest;
@@ -52,7 +53,7 @@ public class VersionRestPatchPermissionEvaluatorPlugin extends RestObjectPermiss
         DSpaceRestPermission restPermission = DSpaceRestPermission.convert(permission);
 
         if (!DSpaceRestPermission.ADMIN.equals(restPermission) ||
-            !StringUtils.equalsIgnoreCase(targetType, VersionRest.NAME)) {
+            !Strings.CI.equals(targetType, VersionRest.NAME)) {
             return false;
         }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/VersionRestPatchPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/VersionRestPatchPermissionEvaluatorPlugin.java
@@ -11,7 +11,6 @@ import java.io.Serializable;
 import java.sql.SQLException;
 import java.util.UUID;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/VersionRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/VersionRestPermissionEvaluatorPlugin.java
@@ -11,7 +11,6 @@ import java.io.Serializable;
 import java.sql.SQLException;
 import java.util.Objects;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/VersionRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/VersionRestPermissionEvaluatorPlugin.java
@@ -12,6 +12,7 @@ import java.sql.SQLException;
 import java.util.Objects;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.model.VersionRest;
@@ -54,7 +55,7 @@ public class VersionRestPermissionEvaluatorPlugin extends RestObjectPermissionEv
                                        DSpaceRestPermission restPermission) {
 
 
-        if (!StringUtils.equalsIgnoreCase(targetType, VersionRest.NAME) || Objects.isNull(targetId)) {
+        if (!Strings.CI.equals(targetType, VersionRest.NAME) || Objects.isNull(targetId)) {
             return false;
         }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/WorkflowRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/WorkflowRestPermissionEvaluatorPlugin.java
@@ -11,7 +11,6 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.sql.SQLException;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/WorkflowRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/WorkflowRestPermissionEvaluatorPlugin.java
@@ -12,6 +12,7 @@ import java.io.Serializable;
 import java.sql.SQLException;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.model.WorkflowItemRest;
@@ -67,7 +68,7 @@ public class WorkflowRestPermissionEvaluatorPlugin extends RestObjectPermissionE
         //This plugin currently only evaluates READ access
         DSpaceRestPermission restPermission = DSpaceRestPermission.convert(permission);
         if (!DSpaceRestPermission.READ.equals(restPermission)
-                || !StringUtils.equalsIgnoreCase(WorkflowItemRest.NAME, targetType)) {
+                || !Strings.CI.equals(WorkflowItemRest.NAME, targetType)) {
             return false;
         }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/WorkspaceItemRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/WorkspaceItemRestPermissionEvaluatorPlugin.java
@@ -11,6 +11,7 @@ import java.io.Serializable;
 import java.sql.SQLException;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.model.WorkspaceItemRest;
@@ -59,7 +60,7 @@ public class WorkspaceItemRestPermissionEvaluatorPlugin extends RestObjectPermis
                 && !DSpaceRestPermission.DELETE.equals(restPermission)) {
             return false;
         }
-        if (!StringUtils.equalsIgnoreCase(targetType, WorkspaceItemRest.NAME)) {
+        if (!Strings.CI.equals(targetType, WorkspaceItemRest.NAME)) {
             return false;
         }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/WorkspaceItemRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/WorkspaceItemRestPermissionEvaluatorPlugin.java
@@ -10,7 +10,6 @@ package org.dspace.app.rest.security;
 import java.io.Serializable;
 import java.sql.SQLException;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/ItemMetadataValueAddPatchOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/ItemMetadataValueAddPatchOperation.java
@@ -14,7 +14,6 @@ import java.util.Map;
 import java.util.Optional;
 
 import jakarta.servlet.http.HttpServletRequest;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.exception.UnprocessableEntityException;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/ItemMetadataValueAddPatchOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/ItemMetadataValueAddPatchOperation.java
@@ -15,6 +15,7 @@ import java.util.Optional;
 
 import jakarta.servlet.http.HttpServletRequest;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.exception.UnprocessableEntityException;
 import org.dspace.app.rest.model.MetadataValueRest;
@@ -165,10 +166,10 @@ public class ItemMetadataValueAddPatchOperation extends MetadataValueAddPatchOpe
         // (with this operator virtual value can only be moved or deleted).
         int idx = 0;
         for (MetadataValueRest ll : list) {
-            if (StringUtils.startsWith(ll.getAuthority(), Constants.VIRTUAL_AUTHORITY_PREFIX)) {
+            if (Strings.CS.startsWith(ll.getAuthority(), Constants.VIRTUAL_AUTHORITY_PREFIX)) {
 
                 Optional<MetadataValue> preExistentMv = preExistentMetadata.stream().filter(mvr ->
-                    StringUtils.equals(ll.getAuthority(), mvr.getAuthority())).findFirst();
+                    Strings.CS.equals(ll.getAuthority(), mvr.getAuthority())).findFirst();
 
                 if (!preExistentMv.isPresent()) {
                     throw new UnprocessableEntityException(

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/DescribeStep.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/DescribeStep.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import jakarta.servlet.http.HttpServletRequest;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.exception.UnprocessableEntityException;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/DescribeStep.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/DescribeStep.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 import jakarta.servlet.http.HttpServletRequest;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.exception.UnprocessableEntityException;
 import org.dspace.app.rest.model.MetadataValueRest;
@@ -185,8 +186,8 @@ public class DescribeStep extends AbstractProcessingStep {
                     for (Object qualifier : input.getPairs()) {
                         fieldsName.add(input.getFieldName() + "." + (String) qualifier);
                     }
-                } else if (StringUtils.equalsIgnoreCase(input.getInputType(), "group") ||
-                        StringUtils.equalsIgnoreCase(input.getInputType(), "inline-group")) {
+                } else if (Strings.CI.equals(input.getInputType(), "group") ||
+                        Strings.CI.equals(input.getInputType(), "inline-group")) {
                     log.info("Called child form:" + configId + "-" +
                         Utils.standardize(input.getSchema(), input.getElement(), input.getQualifier(), "-"));
                     DCInputSet inputConfigChild = inputReader.getInputsByFormName(configId + "-" + Utils

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/ExtractMetadataStep.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/ExtractMetadataStep.java
@@ -20,6 +20,7 @@ import java.util.StringJoiner;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.Equator;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.model.ErrorRest;
 import org.dspace.app.rest.submit.ListenerProcessingStep;
@@ -132,8 +133,8 @@ public class ExtractMetadataStep implements ListenerProcessingStep, UploadableSt
                     if (!CollectionUtils.isEqualCollection(prevMetadata, currMetadata, new Equator<MetadataValue>() {
                         @Override
                         public boolean equate(MetadataValue o1, MetadataValue o2) {
-                            return StringUtils.equals(o1.getValue(), o2.getValue())
-                                    && StringUtils.equals(o1.getAuthority(), o2.getAuthority());
+                            return Strings.CS.equals(o1.getValue(), o2.getValue())
+                                    && Strings.CS.equals(o1.getAuthority(), o2.getAuthority());
                         }
                         @Override
                         public int hash(MetadataValue o) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/ApplicationConfig.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/ApplicationConfig.java
@@ -7,7 +7,6 @@
  */
 package org.dspace.app.rest.utils;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.ComponentScan;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/ApplicationConfig.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/ApplicationConfig.java
@@ -8,6 +8,7 @@
 package org.dspace.app.rest.utils;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -93,7 +94,7 @@ public class ApplicationConfig {
             // http://example.org and http://example.org/ to be different Origins.
             for (int i = 0; i < corsOrigins.length; i++) {
                 if (corsOrigins[i].endsWith("/")) {
-                    corsOrigins[i] = StringUtils.removeEnd(corsOrigins[i], "/");
+                    corsOrigins[i] = Strings.CS.removeEnd(corsOrigins[i], "/");
                 }
             }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/CollectionRestEqualityUtils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/CollectionRestEqualityUtils.java
@@ -7,7 +7,6 @@
  */
 package org.dspace.app.rest.utils;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.dspace.app.rest.model.CollectionRest;
 import org.springframework.stereotype.Component;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/CollectionRestEqualityUtils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/CollectionRestEqualityUtils.java
@@ -8,6 +8,7 @@
 package org.dspace.app.rest.utils;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.dspace.app.rest.model.CollectionRest;
 import org.springframework.stereotype.Component;
 
@@ -26,8 +27,8 @@ public class CollectionRestEqualityUtils extends DSpaceObjectRestEqualityUtils {
      */
     public boolean isCollectionRestEqualWithoutMetadata(CollectionRest original, CollectionRest updated) {
         return super.isDSpaceObjectEqualsWithoutMetadata(original, updated) &&
-            StringUtils.equals(original.getCategory(), updated.getCategory()) &&
-            StringUtils.equals(original.getType(), updated.getType());
+            Strings.CS.equals(original.getCategory(), updated.getCategory()) &&
+            Strings.CS.equals(original.getType(), updated.getType());
 
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/CommunityRestEqualityUtils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/CommunityRestEqualityUtils.java
@@ -7,7 +7,6 @@
  */
 package org.dspace.app.rest.utils;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.dspace.app.rest.model.CommunityRest;
 import org.springframework.stereotype.Component;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/CommunityRestEqualityUtils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/CommunityRestEqualityUtils.java
@@ -8,6 +8,7 @@
 package org.dspace.app.rest.utils;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.dspace.app.rest.model.CommunityRest;
 import org.springframework.stereotype.Component;
 
@@ -26,8 +27,8 @@ public class CommunityRestEqualityUtils extends DSpaceObjectRestEqualityUtils {
      */
     public boolean isCommunityRestEqualWithoutMetadata(CommunityRest original, CommunityRest updated) {
         return super.isDSpaceObjectEqualsWithoutMetadata(original, updated) &&
-            StringUtils.equals(original.getCategory(), updated.getCategory()) &&
-            StringUtils.equals(original.getType(), updated.getType());
+            Strings.CS.equals(original.getCategory(), updated.getCategory()) &&
+            Strings.CS.equals(original.getType(), updated.getType());
 
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/DSpaceObjectRestEqualityUtils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/DSpaceObjectRestEqualityUtils.java
@@ -8,6 +8,7 @@
 package org.dspace.app.rest.utils;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.dspace.app.rest.model.DSpaceObjectRest;
 import org.springframework.stereotype.Component;
 
@@ -25,9 +26,9 @@ public class DSpaceObjectRestEqualityUtils {
      * @return          A boolean indicating whether they're equal or not
      */
     public boolean isDSpaceObjectEqualsWithoutMetadata(DSpaceObjectRest original, DSpaceObjectRest updated) {
-        return StringUtils.equals(original.getId(), updated.getId()) &&
-            StringUtils.equals(original.getCategory(), updated.getCategory()) &&
-            StringUtils.equals(original.getHandle(), updated.getHandle());
+        return Strings.CS.equals(original.getId(), updated.getId()) &&
+            Strings.CS.equals(original.getCategory(), updated.getCategory()) &&
+            Strings.CS.equals(original.getHandle(), updated.getHandle());
 
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/DSpaceObjectRestEqualityUtils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/DSpaceObjectRestEqualityUtils.java
@@ -7,7 +7,6 @@
  */
 package org.dspace.app.rest.utils;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.dspace.app.rest.model.DSpaceObjectRest;
 import org.springframework.stereotype.Component;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/RestRepositoryUtils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/RestRepositoryUtils.java
@@ -12,6 +12,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.Parameter;
@@ -119,7 +120,7 @@ public class RestRepositoryUtils {
                 if (name.isEmpty()) {
                     name = method.getName();
                 }
-                if (StringUtils.equals(name, searchMethodName)) {
+                if (Strings.CS.equals(name, searchMethodName)) {
                     searchMethod = method;
                     break;
                 }
@@ -268,7 +269,7 @@ public class RestRepositoryUtils {
         Method linkMethod = null;
         Method[] methods = linkRepository.getClass().getMethods();
         for (Method m : methods) {
-            if (StringUtils.equals(m.getName(), methodName)) {
+            if (Strings.CS.equals(m.getName(), methodName)) {
                 linkMethod = m;
                 break;
             }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/URLUtils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/URLUtils.java
@@ -14,6 +14,7 @@ import java.net.URLDecoder;
 import java.net.URLEncoder;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.dspace.core.Constants;
 
 /**
@@ -89,8 +90,8 @@ public class URLUtils {
         }
 
         boolean isPrefix;
-        isPrefix = StringUtils.equals(candidateURL.getProtocol(), patternURL.getProtocol());
-        isPrefix &= StringUtils.equals(candidateURL.getHost(), patternURL.getHost());
+        isPrefix = Strings.CS.equals(candidateURL.getProtocol(), patternURL.getProtocol());
+        isPrefix &= Strings.CS.equals(candidateURL.getHost(), patternURL.getHost());
         isPrefix &= candidatePort == patternPort;
 
         String[] candidateElements = StringUtils.split(candidateURL.getPath(), '/');

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/Utils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/Utils.java
@@ -48,6 +48,7 @@ import jakarta.annotation.Nullable;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.http.HttpServletRequest;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.converter.ConverterService;
@@ -308,25 +309,25 @@ public class Utils {
         if (modelPlural.equals("resourcepolicies")) {
             return ResourcePolicyRest.NAME;
         }
-        if (StringUtils.equals(modelPlural, "processes")) {
+        if (Strings.CS.equals(modelPlural, "processes")) {
             return ProcessRest.NAME;
         }
-        if (StringUtils.equals(modelPlural, "versionhistories")) {
+        if (Strings.CS.equals(modelPlural, "versionhistories")) {
             return VersionHistoryRest.NAME;
         }
-        if (StringUtils.equals(modelPlural, "properties")) {
+        if (Strings.CS.equals(modelPlural, "properties")) {
             return PropertyRest.NAME;
         }
-        if (StringUtils.equals(modelPlural, "vocabularies")) {
+        if (Strings.CS.equals(modelPlural, "vocabularies")) {
             return VocabularyRest.NAME;
         }
-        if (StringUtils.equals(modelPlural, OrcidQueueRest.PLURAL_NAME)) {
+        if (Strings.CS.equals(modelPlural, OrcidQueueRest.PLURAL_NAME)) {
             return OrcidQueueRest.NAME;
         }
-        if (StringUtils.equals(modelPlural, "orcidhistories")) {
+        if (Strings.CS.equals(modelPlural, "orcidhistories")) {
             return OrcidHistoryRest.NAME;
         }
-        if (StringUtils.equals(modelPlural, "supervisionorders")) {
+        if (Strings.CS.equals(modelPlural, "supervisionorders")) {
             return SupervisionOrderRest.NAME;
         }
         return modelPlural.replaceAll("s$", "");


### PR DESCRIPTION
## References
Fixes #11162

## Description
Replaced deprecated usages of org.apache.commons.lang3.StringUtils with the recommended alternatives from org.apache.commons.lang3.Strings to remove compiler warnings introduced after upgrading to Commons Lang 3.18.

## Instructions for Reviewers
This PR focuses on cleaning up deprecation warnings only. No functional changes were introduced. Reviewers should verify that the replacements are correct equivalents and that existing unit tests continue to pass.

List of changes in this PR:
* Replaced deprecated StringUtils methods with the appropriate Strings.CS (case-sensitive) or Strings.CI (case-insensitive) equivalents.
* Added import statements for org.apache.commons.lang3.Strings.
* Removed unused import statements for org.apache.commons.lang3.StringUtils

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
