### PR TITLE
Fix bean initialization with citation-page.enabled_communities

### DIFF
--- a/dspace-api/src/main/java/org/dspace/disseminate/CitationDocumentServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/disseminate/CitationDocumentServiceImpl.java
@@ -126,7 +126,7 @@ public class CitationDocumentServiceImpl implements CitationDocumentService, Ini
         //Load enabled collections
         String[] citationEnabledCollections = configurationService
                 .getArrayProperty("citation-page.enabled_collections");
-        citationEnabledCollectionsList = Arrays.asList(citationEnabledCollections);
+        citationEnabledCollectionsList = new ArrayList<String>(Arrays.asList(citationEnabledCollections));
 
         //Load enabled communities, and add to collection-list
         String[] citationEnabledCommunities = configurationService


### PR DESCRIPTION
## References

* Fixes #11167

## Description

if _citation-page.enabled_communities_ configuration option is set (=nonempty value), Tomcat (or standalone server-boot.jar) fails to start. Startup fails becaus an immutable list is currently used as a base for collection list, and thus, it cannot be modified when collections for the configured communit(ies) are added to the list on startup. The issue is not present with related configuration option _citation-page.enabled_communities_ because the list is created instantly.

## Instructions for Reviewers

List of changes in this PR:
* Arrays.asList that produces initial list for citationEnabledCollectionsList is immutable. To make it mutable (=this is needed if communities-related property if processed), an ArrayList is constructed based on String array.

Testing the issue involves trying different values for citation-page.enabled_communities and checking that Tomcat startup succeeds and CoverPages are generated to correct collections.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
