### PR TITLE
Error in file upload after security fixes

### DIFF
--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/DSBitStoreService.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/DSBitStoreService.java
@@ -19,9 +19,11 @@ import java.security.NoSuchAlgorithmException;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.dspace.content.Bitstream;
 import org.dspace.core.Utils;
+import org.dspace.services.factory.DSpaceServicesFactory;
 
 /**
  * Native DSpace (or "Directory Scatter" if you prefer) asset store.
@@ -252,7 +254,10 @@ public class DSBitStoreService extends BaseBitStoreService {
         }
         File bitstreamFile = new File(bufFilename.toString());
         Path normalizedPath = bitstreamFile.toPath().normalize();
-        if (!normalizedPath.startsWith(baseDir.getAbsolutePath())) {
+        String[] allowedAssetstoreRoots = DSpaceServicesFactory.getInstance().getConfigurationService()
+                .getArrayProperty("assetstore.allowed.roots", new String[]{});
+        if (!normalizedPath.startsWith(baseDir.getAbsolutePath())
+            && !StringUtils.startsWithAny(normalizedPath.toString(), allowedAssetstoreRoots)) {
             log.error("Bitstream path outside of assetstore root requested:" +
                     "bitstream={}, path={}, assetstore={}",
                     bitstream.getID(), normalizedPath, baseDir.getAbsolutePath());

--- a/dspace/config/modules/assetstore.cfg
+++ b/dspace/config/modules/assetstore.cfg
@@ -12,10 +12,10 @@ assetstore.dir = ${dspace.dir}/assetstore
 # This value will be used as `incoming` default store inside the `bitstore.xml`
 # Possible values are:
 #     - 0: to use the `localStore`;
-#     - 1: to use the `s3Store`. 
+#     - 1: to use the `s3Store`.
 # If you want to add additional assetstores, they must be added to that bitstore.xml
 # and new values should be provided as key-value pairs in the `stores` map of the
-# `bitstore.xml` configuration. 
+# `bitstore.xml` configuration.
 assetstore.index.primary = 0
 
 #---------------------------------------------------------------#
@@ -102,3 +102,5 @@ assetstore.s3.awsRegionName =
 # The maximum counter value for S3 operations.
 # Default: -1 (unlimited) connection is never manualy closed in BitstoreService
 # assetstore.jcloud.maxCounter = -1
+
+#assetstore.allowed.roots = /data/assetstore

--- a/dspace/config/modules/assetstore.cfg
+++ b/dspace/config/modules/assetstore.cfg
@@ -18,6 +18,9 @@ assetstore.dir = ${dspace.dir}/assetstore
 # `bitstore.xml` configuration.
 assetstore.index.primary = 0
 
+#if the assetstore path is symbolic link, use this configuration to allow that path.
+#assetstore.allowed.roots = /data/assetstore
+
 #---------------------------------------------------------------#
 #-------------- Amazon S3 Specific Configurations --------------#
 #---------------------------------------------------------------#
@@ -102,5 +105,3 @@ assetstore.s3.awsRegionName =
 # The maximum counter value for S3 operations.
 # Default: -1 (unlimited) connection is never manualy closed in BitstoreService
 # assetstore.jcloud.maxCounter = -1
-
-#assetstore.allowed.roots = /data/assetstore


### PR DESCRIPTION
## References
* Fixes #11169

## Description
after applying the security fixes the resulting code is https://github.com/DSpace/DSpace/blob/main/dspace-api/src/main/java/org/dspace/storage/bitstore/DSBitStoreService.java#L253-L255
This code is fine if the configured basepath is a "standard" path making no usage of symbolic link.
On many on-prem installations admins tend to configure path using symbolic link or any other solution which is currently broken by the usage of getCanonicalPath
The result is that the user is no longer allowed to upload files anywhere it should be allowed and an exception is throw at the backend

## Instructions for Reviewers
List of changes in this PR:
* Additional control is implemented on the bitstream path to avoid errors caused by the symbolic link configuration.

## To Reproduce
Steps to reproduce the behavior:

Configure the bean for the localstore to use a symbolic link by using the property assetstore.dir
try to upload files in the submission or anywhere else (process creation has the same error for instance)
When uploading files it actually might seem everything is working fine but the error pops out during the process creation or the save being triggered

## Expected behavior
File upload should be uploaded successfully

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [X] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
