### PR TITLE
Fix #11074 export simple archive format when item has no collection (dspace-8_x)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExportServiceImpl.java
@@ -352,7 +352,7 @@ public class ItemExportServiceImpl implements ItemExportService {
 
     /**
      * Create the 'collections' file.  List handles of all Collections which
-     * contain this Item.  The "owning" Collection is listed first.
+     * contain this Item. The "owning" Collection is listed first.
      *
      * @param item list collections holding this Item.
      * @param destDir write the file here.
@@ -363,12 +363,14 @@ public class ItemExportServiceImpl implements ItemExportService {
         File outFile = new File(destDir, "collections");
         if (outFile.createNewFile()) {
             try (PrintWriter out = new PrintWriter(new FileWriter(outFile))) {
-                String ownerHandle = item.getOwningCollection().getHandle();
-                out.println(ownerHandle);
+                Collection owningCollection = item.getOwningCollection();
+                // The owning collection is null for workspace and workflow items
+                if (owningCollection != null) {
+                    out.println(owningCollection.getHandle());
+                }
                 for (Collection collection : item.getCollections()) {
-                    String collectionHandle = collection.getHandle();
-                    if (!collectionHandle.equals(ownerHandle)) {
-                        out.println(collectionHandle);
+                    if (!collection.equals(owningCollection)) {
+                        out.println(collection.getHandle());
                     }
                 }
             }


### PR DESCRIPTION
## References
* Fixes #11074

## Description
Tiny changes to `writeCollections` in `ItemExportServiceImpl.java`:
- Add a check for null, in case there is no "owning" collection to an item yet. That happens if the item is in workspace or workflow and not yet archived.
- Compare collections directly, instead of comparing their handles. I think this communicates more clearly the intent and simplifies the code.
- Fix a typo in the method comment.

## Instructions for Reviewers
- Export an item that's in workspace and an item that's in workflow to simple archive format. Use this command:
```./dspace export -t ITEM -i <ID or handle of item to export> -d <destination where you want items to go> -n 1```
- As opposed to before the fix, you should now see no more error messages
- As before, an empty `collections` file is written to the export
- You could also test exporting a regular, archived item to confirm, that everything still works well for archived items.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
👉 My pull request is against the 8.x branch, but it should and can be ported to 9.x and main probably automatically.
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
