### PR TITLE
Parse Solr facet range date and time with proper format

### DIFF
--- a/dspace-api/src/main/java/org/dspace/util/SolrImportExport.java
+++ b/dspace-api/src/main/java/org/dspace/util/SolrImportExport.java
@@ -556,7 +556,7 @@ public class SolrImportExport {
             YearMonth monthStartDate;
             String monthStart = monthFacet.getValue();
             try {
-                monthStartDate = YearMonth.parse(monthStart);
+                monthStartDate = YearMonth.parse(monthStart, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
             } catch (DateTimeParseException e) {
                 throw new SolrImportExportException("Could not read start of month batch as date: " + monthStart, e);
             }


### PR DESCRIPTION
## References
* Fixes #11192

## Description
When running `solr-export-statistics` CLI command with no arguments, it queries Solr to get the available date ranges in the index. When parsing these date values, an exception is being thrown due to a format mismatch. This PR fixes this bug.

## Instructions for Reviewers
Changes were made to the command on [this commit](https://github.com/DSpace/DSpace/commit/3accb4d7d6b48698ca911282d660d596d2b3e505#diff-b6d5ef0debc84fce6d6a4e15357da526ff57194ba7717e03dcbb6e123f1e4407).
Now I just added an explicit `DateTimeFormatter` to the `YearMonth.parse` method call.

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
