### PR TITLE
fix(#9663): Add configurable limit to CSV metadata import

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
@@ -360,13 +360,13 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
         // Process each change
         rowCount = 1;
 
-        int maxItems = configurationService.getIntProperty("bulkedit.import.max-items", 1000);
+        int maxItems = configurationService.getIntProperty("bulkedit.import.max.items", 1000);
         int numItems = toImport.size();
         if (numItems > maxItems && maxItems > 0) {
             throw new MetadataImportException(
                 "Import contains " + numItems + " items, which exceeds the configured "
                 + "maximum of " + maxItems + ". You can change this limit by setting "
-                + "'bulkedit.import.max-items' in your local configuration.");
+                + "'bulkedit.import.max.items' in your local configuration.");
         }
 
         for (DSpaceCSVLine line : toImport) {

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
@@ -359,6 +359,16 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
 
         // Process each change
         rowCount = 1;
+
+        int maxItems = configurationService.getIntProperty("bulkedit.import.max-items", 1000);
+        int numItems = toImport.size();
+        if (numItems > maxItems && maxItems > 0) {
+            throw new MetadataImportException(
+                "Import contains " + numItems + " items, which exceeds the configured "
+                + "maximum of " + maxItems + ". You can change this limit by setting "
+                + "'bulkedit.import.max-items' in your local configuration.");
+        }
+
         for (DSpaceCSVLine line : toImport) {
             // Resolve target references to other items
             populateRefAndRowMap(line, line.getID());

--- a/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataImportIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataImportIT.java
@@ -313,7 +313,7 @@ public class MetadataImportIT extends AbstractIntegrationTestWithDatabase {
 
     @Test
     public void metadataImportExceedsLimitTest() throws Exception {
-        configurationService.setProperty("bulkedit.import.max-items", 1);
+        configurationService.setProperty("bulkedit.import.max.items", 1);
         String[] csv = {"id,collection,dc.title",
             "+," + collection.getHandle() + ",\"Title 1\"",
             "+," + collection.getHandle() + ",\"Title 2\""};
@@ -347,7 +347,7 @@ public class MetadataImportIT extends AbstractIntegrationTestWithDatabase {
 
     @Test
     public void metadataImportWithItemCountBelowLimitTest() throws Exception {
-        configurationService.setProperty("bulkedit.import.max-items", 2);
+        configurationService.setProperty("bulkedit.import.max.items", 2);
         String[] csv = {"id,collection,dc.title",
             "+," + collection.getHandle() + ",\"Title 1\"",
             "+," + collection.getHandle() + ",\"Title 2\""};
@@ -360,7 +360,7 @@ public class MetadataImportIT extends AbstractIntegrationTestWithDatabase {
 
     @Test
     public void metadataImportWithLimitDisabledTest() throws Exception {
-        configurationService.setProperty("bulkedit.import.max-items", 0);
+        configurationService.setProperty("bulkedit.import.max.items", 0);
         String[] csv = {"id,collection,dc.title",
             "+," + collection.getHandle() + ",\"Title 1\"",
             "+," + collection.getHandle() + ",\"Title 2\""};

--- a/dspace/config/modules/bulkedit.cfg
+++ b/dspace/config/modules/bulkedit.cfg
@@ -16,7 +16,7 @@
 
 # A hard limit on the number of items allowed to be imported via the UI.
 # To disable this limit, set this value to 0. Defaults to 1000.
-bulkedit.import.max-items = 1000
+bulkedit.import.max.items = 1000
 
 # Metadata elements to exclude when exporting via the user interfaces, or when using the
 # command line version and not using the -a (all) option.

--- a/dspace/config/modules/bulkedit.cfg
+++ b/dspace/config/modules/bulkedit.cfg
@@ -14,10 +14,9 @@
 # The delimiter used to serarate authority data (defaults to a double colon ::)
 # bulkedit.authorityseparator = ::
 
-# A hard limit of the number of items allowed to be edited in one go in the UI
-# (does not apply to the command line version)
-# TODO: UNSUPPORTED in DSpace 7.0
-# bulkedit.gui-item-limit = 20
+# A hard limit on the number of items allowed to be imported via the UI.
+# To disable this limit, set this value to 0. Defaults to 1000.
+bulkedit.import.max-items = 1000
 
 # Metadata elements to exclude when exporting via the user interfaces, or when using the
 # command line version and not using the -a (all) option.


### PR DESCRIPTION
## References
* Fixes #9663

## Description
This PR addresses the issue of the CSV metadata import functionality not having a cap on the maximum number of items. This could lead to performance and stability problems when importing very large CSV files.
A new configuration property, `bulkedit.import.max-items`, has been introduced to allow administrators to set a configurable limit on the number of items that can be added or edited in a single CSV import via the UI.

## Instructions for Reviewers
This change adds a safeguard to the metadata import process. The logic is contained within `MetadataImport.java` and is configurable via `bulkedit.cfg`. A comprehensive set of integration tests has been added to `MetadataImportIT.java` to validate the new behavior.

**List of changes in this PR:**
* **`dspace/config/modules/bulkedit.cfg`**: Added the new configuration property `bulkedit.import.max-items` with a default value of 1000 and comments explaining its usage, including how to disable the limit by setting it to `0`.
* **`dspace-api/.../MetadataImport.java`**: Modified the `runImport()` method to check the number of items in the CSV against the `bulkedit.import.max-items` configuration. If the limit is exceeded, it throws a `MetadataImportException` with a clear error message.
* **`dspace-api/.../MetadataImportIT.java`**: Added four new integration tests to cover the following scenarios:
    * Importing a CSV that exceeds the configured limit (expects an exception).
    * Importing a CSV with an item count below the limit (expects success).
    * Importing a CSV with the limit disabled (`max-items = 0`) (expects success).
    * Importing an empty CSV with only a header (expects success with no items created).

### How to test this PR:

**Automated Testing:**
1.  Run the Maven tests for the `dspace-api` module and confirm that the new tests in `MetadataImportIT` pass successfully.
    ```bash
    # From [dspace-source]/dspace-api directory
    mvn clean install -Dtest=MetadataImportIT
    ```

**Manual Testing (via UI):**
1.  Navigate to your DSpace installation's `[dspace-install]` directory.
2.  Edit your `local.cfg` file and set a low limit for testing, for example:
    ```
    bulkedit.import.max-items = 1
    ```
3.  Restart your DSpace backend (Tomcat).
4.  Log in to the DSpace UI as an administrator.
5.  Navigate to **Import -> Metadata**.
6.  Attempt to upload a CSV file that contains **2 or more items**.
7.  **Expected Result:** The import process should fail immediately, and an error message should be displayed on the screen, similar to: "Import contains 2 items, which exceeds the configured maximum of 1...". The process log should also show this error.
<img width="1042" height="163" alt="image" src="https://github.com/user-attachments/assets/9f43e5ef-ee2b-4447-b0c4-384256b07b38" />

8.  Now, edit your `local.cfg` again and set the limit higher, for example:
    ```
    bulkedit.import.max-items = 5
    ```
9.  Restart the backend.
10. Attempt to upload the same CSV file with 2 items again.
11. **Expected Result:** The import process should now proceed to the validation/confirmation step without any errors related to the limit.
<img width="634" height="163" alt="image" src="https://github.com/user-attachments/assets/771835dd-5668-4e10-90d4-4f12c6a91603" />

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).