### PR TITLE
Fix database connection leak on failed login attempts

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/OrcidLoginFilter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/OrcidLoginFilter.java
@@ -87,6 +87,7 @@ public class OrcidLoginFilter extends StatelessLoginFilter {
             String baseRediredirectUrl = configurationService.getProperty("dspace.ui.url");
             String redirectUrl = baseRediredirectUrl + "/error?status=401&code=orcid.generic-error";
             response.sendRedirect(redirectUrl); // lgtm [java/unvalidated-url-redirection]
+            this.closeOpenContext(request);
         } else {
             super.unsuccessfulAuthentication(request, response, failed);
         }


### PR DESCRIPTION
## References
* Fixes #11202
* Related to #10599

## Description
Currently when you enter an incorrect email/password combination, the open `Context` is not closed properly. This leads to a dangling DB connection, which can cause a DB connection exhaustion.

## Instructions for Reviewers
List of changes in this PR:
* Created new method in `StatelessLoginFilter` to close open `Context`s
* Updated the `StatelessLoginFilter#unsuccessfulAuthentication` & `OrcidLoginFilter#unsuccessfulAuthentication` to use this new method

**Guidance for how to test or review this PR.**
- Run the following query in your database:
  ```sql
  SELECT datname, backend_start, state, query
  FROM pg_stat_activity
  WHERE query != 'ROLLBACK' AND query != 'COMMIT' AND datname is not null AND datname != 'postgres'
  ORDER BY backend_start;
  ```
- Perform an invalid authentication attempt without the fix and verify that a new "idle in transaction" connection appears
- Perform an invalid authentication attempt with the fix and verify that no new connection is created anymore

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
