### PR TITLE
fix(#11191): Align Content-Disposition with RFC 5987/6266

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/HttpHeadersInitializer.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/HttpHeadersInitializer.java
@@ -7,11 +7,13 @@
  */
 package org.dspace.app.rest.utils;
 
-import static jakarta.mail.internet.MimeUtility.encodeText;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.text.Normalizer;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
@@ -172,9 +174,16 @@ public class HttpHeadersInitializer {
 
         // distposition may be null here if contentType is null
         if (!isNullOrEmpty(disposition)) {
-            httpHeaders.put(CONTENT_DISPOSITION, Collections.singletonList(String.format(CONTENT_DISPOSITION_FORMAT,
-                                                                                         disposition,
-                                                                                         encodeText(fileName))));
+            String fallbackAsciiName = createFallbackAsciiName(this.fileName);
+            String encodedUtf8Name = createEncodedUtf8Name(this.fileName);
+
+            String headerValue = String.format(
+                "%s; filename=\"%s\"; filename*=UTF-8''%s",
+                disposition,
+                fallbackAsciiName,
+                encodedUtf8Name
+            );
+            httpHeaders.put(CONTENT_DISPOSITION, Collections.singletonList(headerValue));
         }
         log.debug("Content-Disposition : {}", disposition);
 
@@ -260,6 +269,43 @@ public class HttpHeadersInitializer {
         String[] matchValues = matchHeader.split("\\s*,\\s*");
         Arrays.sort(matchValues);
         return Arrays.binarySearch(matchValues, toMatch) > -1 || Arrays.binarySearch(matchValues, "*") > -1;
+    }
+
+    /**
+     * Creates a safe ASCII-only fallback filename by removing diacritics (accents)
+     * and replacing any remaining non-ASCII characters.
+     * E.g., "ä-ö-é.pdf" becomes "a-o-e.pdf".
+     * @param originalFilename The original filename.
+     * @return A string containing only ASCII characters.
+     */
+    private String createFallbackAsciiName(String originalFilename) {
+        if (originalFilename == null) {
+            return "";
+        }
+        String normalized = Normalizer.normalize(originalFilename, Normalizer.Form.NFD);
+        String withoutAccents = normalized.replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
+        return withoutAccents.replaceAll("[^\\x00-\\x7F]", "");
+    }
+
+    /**
+     * Creates a percent-encoded UTF-8 filename according to RFC 5987.
+     * This is for the `filename*` parameter.
+     * E.g., "ä ö é.pdf" becomes "%C3%A4%20%C3%B6%20%C3%A9.pdf".
+     * @param originalFilename The original filename.
+     * @return A percent-encoded string.
+     */
+    private String createEncodedUtf8Name(String originalFilename) {
+        if (originalFilename == null) {
+            return "";
+        }
+        try {
+            String encoded = URLEncoder.encode(originalFilename, StandardCharsets.UTF_8.toString());
+            return encoded.replace("+", "%20");
+        } catch (java.io.UnsupportedEncodingException e) {
+            // Fallback to a simple ASCII name if encoding fails.
+            log.error("UTF-8 encoding not supported, which should not happen.", e);
+            return createFallbackAsciiName(originalFilename);
+        }
     }
 
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
@@ -8,7 +8,6 @@
 package org.dspace.app.rest;
 
 import static com.jayway.jsonpath.JsonPath.read;
-import static jakarta.mail.internet.MimeUtility.encodeText;
 import static java.util.UUID.randomUUID;
 import static org.apache.commons.codec.CharEncoding.UTF_8;
 import static org.apache.commons.collections.CollectionUtils.isEmpty;
@@ -368,7 +367,11 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
         //2. A public item with a bitstream
 
         String bitstreamContent = "0123456789";
-        String bitstreamName = "ภาษาไทย";
+        String bitstreamName = "ภาษาไทย-com-acentuação.pdf";
+        String expectedAscii = "-com-acentuacao.pdf";
+        String expectedUtf8Encoded =
+        "%E0%B8%A0%E0%B8%B2%E0%B8%A9%E0%B8%B2%E0%B9%84%E0%B8%97%E0%B8%A2-"
+        + "com-acentua%C3%A7%C3%A3o.pdf";
 
         try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
 
@@ -392,7 +395,9 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
             //We expect the content disposition to have the encoded bitstream name
             .andExpect(header().string(
                 "Content-Disposition",
-                "attachment;filename=\"" + encodeText(bitstreamName) + "\""
+                String.format("attachment; filename=\"%s\"; filename*=UTF-8''%s",
+                              expectedAscii,
+                              expectedUtf8Encoded)
             ));
     }
 


### PR DESCRIPTION
## References
* Fixes #11191

## Description
This pull request updates the `Content-Disposition` header to correctly encode non-ASCII filenames, following the RFC5987/6266 standards. This resolves an issue where browsers like Safari would display garbled filenames for downloads containing special characters.

## Instructions for Reviewers
This PR addresses a bug in how bitstream filenames are encoded in the `Content-Disposition` HTTP header. The previous implementation used RFC 2047 encoding (`MimeUtility.encodeText`), which is intended for email headers and is not correctly interpreted by all browsers, notably Safari on macOS and iOS.

The fix implements the modern, web-standard approach recommended by RFC5987/6266.

### List of changes in this PR:
* Modified `HttpHeadersInitializer.java` to stop using `MimeUtility.encodeText` for the `Content-Disposition` header.
* A new header value is now generated, which includes a `filename` parameter with a safe, ASCII-only version of the filename for backward compatibility and a `filename*` parameter with the full, percent-encoded UTF-8 filename.
* Added two private helper methods, `createFallbackAsciiName` and `createEncodedUtf8Name`, to handle the filename transformations.
* Updated the integration test `BitstreamRestControllerIT.java` (`testBitstreamName` method) to validate the new, correct header format, ensuring the fix is verified and preventing future regressions. The test now uses a complex filename with both non-Latin (Thai) and accented Latin characters to ensure robust coverage.

### How to test this PR:

1. Ingest a bitstream with a filename containing non-ASCII characters (e.g., ä ö é.pdf, Teste-com-acentuação.pdf or ภาษาไทย.pdf).
2. Open the item page and download the bitstream.
3. On Safari (macOS/iOS): Verify that the "Save As" dialog now shows the correct filename with accents and special characters preserved.
4. On any browser (Chrome, Firefox):
Open the Developer Tools (F12) and go to the "Network" tab. Make sure to preserve the log.
Download the file and inspect the response headers for the download request.
Verify the `Content-Disposition` header has the correct format. Like in this `ä ö é.pdf` example: <img width="899" height="25" alt="image" src="https://github.com/user-attachments/assets/3de9970d-edee-485a-b70e-93c4b70f60b5" /> Which now follows the pattern:
`attachment; filename="[ascii-version].pdf"; filename*=UTF-8''[percent-encoded-version].pdf`
5. Run the backend unit tests to confirm that **BitstreamRestControllerIT** passes successfully.
``mvn clean install -Dtest=BitstreamRestControllerIT``

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods. (No new public methods were added)
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide). (Manual testing instructions provided, as this is difficult to unit test).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).