### PR TITLE
Fix/11033 solr logging thumbnail download stats

### DIFF
--- a/dspace-api/src/test/java/org/dspace/statistics/SolrLoggerServiceImplIT.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/SolrLoggerServiceImplIT.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
@@ -27,8 +28,14 @@ import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrInputDocument;
 import org.dspace.AbstractIntegrationTestWithDatabase;
+import org.dspace.builder.BitstreamBuilder;
+import org.dspace.builder.CollectionBuilder;
 import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.ItemBuilder;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Collection;
 import org.dspace.content.Community;
+import org.dspace.content.Item;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.core.Constants;
 import org.dspace.core.factory.CoreServiceFactory;
@@ -302,5 +309,57 @@ public class SolrLoggerServiceImplIT
                     false, isBot);
         }
         assertEquals("Wrong number of documents remaining --", 1, nDocs);
+    }
+
+    @Test
+    public void testPostViewShouldNotLogIgnoredBundles() throws Exception {
+        ContentServiceFactory csf = ContentServiceFactory.getInstance();
+        MockSolrLoggerServiceImpl solrLoggerService = DSpaceServicesFactory.getInstance()
+                .getServiceManager()
+                .getServiceByName("solrLoggerService", MockSolrLoggerServiceImpl.class);
+        solrLoggerService.bitstreamService = csf.getBitstreamService();
+        solrLoggerService.contentServiceFactory = csf;
+        solrLoggerService.configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
+        solrLoggerService.clientInfoService = CoreServiceFactory.getInstance().getClientInfoService();
+        solrLoggerService.afterPropertiesSet();
+        SolrStatisticsCore solrStatisticsCore = DSpaceServicesFactory.getInstance()
+                .getServiceManager()
+                .getServiceByName(SolrStatisticsCore.class.getName(), MockSolrStatisticsCore.class);
+
+        solrStatisticsCore.getSolr().deleteByQuery("*:*");
+        solrStatisticsCore.getSolr().commit();
+
+        context.turnOffAuthorisationSystem();
+        Community community = CommunityBuilder
+                .createCommunity(context)
+                .withName("Test Community").build();
+        Collection collection = CollectionBuilder
+                .createCollection(context, community)
+                .withName("Test Collection").build();
+        Item item = ItemBuilder
+                .createItem(context, collection)
+                .withTitle("Test Item for Logging").build();
+        Bitstream originalBitstream = BitstreamBuilder
+                .createBitstream(context, item, new ByteArrayInputStream("original content".getBytes()), "ORIGINAL")
+                .withName("original.txt")
+                .build();
+        Bitstream thumbnailBitstream = BitstreamBuilder
+                .createBitstream(context, item, new ByteArrayInputStream("thumbnail content".getBytes()), "THUMBNAIL")
+                .withName("thumbnail.jpg")
+                .build();
+
+        context.restoreAuthSystemState();
+        solrLoggerService.postView(originalBitstream, null, eperson);
+        solrLoggerService.postView(thumbnailBitstream, null, eperson);
+
+        solrStatisticsCore.getSolr().commit();
+
+        SolrQuery thumbnailQuery = new SolrQuery("id:" + thumbnailBitstream.getID().toString());
+        QueryResponse thumbnailResponse = solrStatisticsCore.getSolr().query(thumbnailQuery);
+        assertEquals("Thumbnail bundle should NOT be logged", 0, thumbnailResponse.getResults().getNumFound());
+
+        SolrQuery originalQuery = new SolrQuery("id:" + originalBitstream.getID().toString());
+        QueryResponse originalResponse = solrStatisticsCore.getSolr().query(originalQuery);
+        assertEquals("ORIGINAL bundle SHOULD be logged", 1, originalResponse.getResults().getNumFound());
     }
 }


### PR DESCRIPTION
## References
* Fixes #11033

## Description
This PR prevents Solr statistics from logging view/download events for bitstream bundles that are not explicitly configured for tracking (e.g., `THUMBNAIL`). This resolves a performance and storage issue caused by the excessive logging of irrelevant events, including attempts to view non-existent thumbnails.

## Instructions for Reviewers
This pull request addresses the problem of Solr logging statistics for all bitstream bundles, regardless of the `solr-statistics.query.filter.bundles` configuration. This behavior leads to significant database bloat and performance overhead, as a large percentage of statistics can be from non-relevant bundles like `THUMBNAIL`.

The fix ensures that the logging process respects the aforementioned configuration before writing to Solr.

### List of changes in this PR:
* Introduced a new private helper method `isBitstreamLoggable(Bitstream bitstream)` in `SolrLoggerServiceImpl.java`. This method centralizes the logic to check if a bitstream belongs to a bundle that is configured to be logged.
* Modified the two main `postView` methods in `SolrLoggerServiceImpl.java` to call this new helper method at the beginning, preventing the execution of the logging logic for non-loggable bitstreams.
* Added a new integration test, `testPostViewShouldNotLogIgnoredBundles()`, to `SolrLoggerServiceImplIT.java`. This test confirms two things:
  * Bitstreams in ignored bundles (e.g., `THUMBNAIL`) are not logged.
  * Bitstreams in allowed bundles (e.g., `ORIGINAL`) are still correctly logged.

### How to Test or Review
**Automated Test:**
* From the module directory:
```
cd dspace-api
mvn -Dit.test=org.dspace.statistics.SolrLoggerServiceImplIT verify
```
* Or from the repository root (limit reactor to the module):
```
mvn -pl dspace-api -am -Dit.test=org.dspace.statistics.SolrLoggerServiceImplIT verify
```

**Manual Verification:**
These steps demonstrate the behavior before the fix and after the fix.

1. Reproducing the Bug **(Without the Fix)**:
   * Ensure your `dspace/config/modules/solr-statistics.cfg` has the default setting: 
   `solr-statistics.query.filter.bundles=ORIGINAL`.
   * Start DSpace using the `main` branch (**without** this PR's changes).
   * Using a web browser, navigate to an item page and download the primary file (e.g., a PDF in the `ORIGINAL` bundle).
   * Query your Solr statistics core.
      * `curl "http://localhost:8983/solr/statistics/select?q=bundleName:THUMBNAIL&wt=json"`
      * `curl "http://localhost:8983/solr/statistics/select?q=bundleName:ORIGINAL&wt=json"`
   * Expected (**Buggy**) Result: Both queries should return `"numFound":1` (or more), proving that `THUMBNAIL` views are being incorrectly logged.

2. Verifying the Solution (With This Fix)
   * Apply this PR's code.
   * Clean your existing Solr statistics core to start fresh:
`curl "http://localhost:8983/solr/statistics/update?commit=true" -H "Content-Type: text/xml" --data-binary '<delete><query>*:*</query></delete>'`
   * Restart DSpace with the new code.
   * Repeat the same actions: navigate to an item page and download the primary file.
   * Query your Solr statistics core again:
      * `curl "http://localhost:8983/solr/statistics/select?q=bundleName:THUMBNAIL&wt=json"`
      * `curl "http://localhost:8983/solr/statistics/select?q=bundleName:ORIGINAL&wt=json"`
   * Expected (**Corrected**) Result:
      * The query for `THUMBNAIL` must return `"numFound":0`.
      * The query for `ORIGINAL` must return `"numFound":1`.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods. (No new public methods were added)
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide). (Manual testing instructions provided, as this is difficult to unit test).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
