### PR TITLE
Add familyName and givenName when creating profile author and fix EPe…

### DIFF
--- a/dspace-api/src/main/java/org/dspace/eperson/EPerson.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/EPerson.java
@@ -366,7 +366,7 @@ public class EPerson extends CacheableDSpaceObject implements DSpaceObjectLegacy
 
     @Override
     public String getName() {
-        return getEmail();
+        return this.getFullName();
     }
 
     String getDigestAlgorithm() {

--- a/dspace-api/src/main/java/org/dspace/profile/ResearcherProfileServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/profile/ResearcherProfileServiceImpl.java
@@ -283,6 +283,8 @@ public class ResearcherProfileServiceImpl implements ResearcherProfileService {
         itemService.addMetadata(context, item, "dc", "title", null, null, fullName);
         itemService.addMetadata(context, item, "person", "email", null, null, ePerson.getEmail());
         itemService.addMetadata(context, item, "dspace", "object", "owner", null, fullName, id, CF_ACCEPTED);
+        itemService.addMetadata(context, item, "person", "familyName", null, null, ePerson.getLastName());
+        itemService.addMetadata(context, item, "person", "givenName", null, null, ePerson.getFirstName());
 
         item = installItemService.installItem(context, workspaceItem);
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResearcherProfileRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResearcherProfileRestRepositoryIT.java
@@ -144,6 +144,7 @@ public class ResearcherProfileRestRepositoryIT extends AbstractControllerIntegra
 
         user = EPersonBuilder.createEPerson(context)
             .withEmail("user@example.com")
+            .withNameInMetadata("Example", "User")
             .withPassword(password)
             .build();
 
@@ -323,7 +324,7 @@ public class ResearcherProfileRestRepositoryIT extends AbstractControllerIntegra
     public void testCreateAndReturn() throws Exception {
 
         String id = user.getID().toString();
-        String name = user.getName();
+        String name = user.getFullName();
 
         String authToken = getAuthToken(user.getEmail(), password);
 
@@ -342,6 +343,8 @@ public class ResearcherProfileRestRepositoryIT extends AbstractControllerIntegra
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.type", is("item")))
             .andExpect(jsonPath("$.metadata", matchMetadata("dspace.object.owner", name, id, 0)))
+            .andExpect(jsonPath("$.metadata", matchMetadata("person.givenName", user.getFirstName(), 0)))
+            .andExpect(jsonPath("$.metadata", matchMetadata("person.familyName", user.getLastName(), 0)))
             .andExpect(jsonPath("$.metadata", matchMetadata("dspace.entity.type", "Person", 0)));
 
         getClient(authToken).perform(get("/api/eperson/profiles/{id}/eperson", id))
@@ -391,7 +394,7 @@ public class ResearcherProfileRestRepositoryIT extends AbstractControllerIntegra
     public void testCreateAndReturnWithAdmin() throws Exception {
 
         String id = user.getID().toString();
-        String name = user.getName();
+        String name = user.getFullName();
 
         configurationService.setProperty("researcher-profile.collection.uuid", null);
 
@@ -412,6 +415,8 @@ public class ResearcherProfileRestRepositoryIT extends AbstractControllerIntegra
         getClient(authToken).perform(get("/api/eperson/profiles/{id}/item", id))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.type", is("item")))
+            .andExpect(jsonPath("$.metadata", matchMetadata("person.givenName", user.getFirstName(), 0)))
+            .andExpect(jsonPath("$.metadata", matchMetadata("person.familyName", user.getLastName(), 0)))
             .andExpect(jsonPath("$.metadata", matchMetadata("dspace.object.owner", name, id, 0)))
             .andExpect(jsonPath("$.metadata", matchMetadata("dspace.entity.type", "Person", 0)));
 


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/dspace-angular/issues/4648
* Fixes #11262

## Description
Adds `givenName` and `familyName` metadata when creating a profile author from the profile menu, and updates `EPerson#getName()` to return the full name instead of the email. Also updates integration tests to verify these metadata fields.

## Instructions for Reviewers
1. Log in with a user who has a Researcher Profile.
2. Access the profile menu.
3. Create a Researcher Profile.
4. Click on “View Profile.”
5. Go to the full item page and verify that givenName and familyName are displayed.
6. Add a new Publication Entity item.
7. Select the recently created Researcher Profile as an author and verify that it works correctly.

#### List of changes in this PR:

- `EPerson.java` – Updated the getName() method to return `getFullName()` instead of `getEmail()`.
- `ResearcherProfileServiceImpl.java` – Added creation of `givenName` and `familyName` metadata in the `createProfileItem` method.
- `ResearcherProfileRestRepositoryIT.java` – Updated the integration test to verify that the `givenName` and `familyName` metadata are correctly saved when creating a profile.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
