### PR TITLE
[Port dspace-7_x] LDAP Authentication fails when user has no email despite netid_email_domain configuration

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
@@ -322,7 +322,7 @@ public class LDAPAuthentication implements AuthenticationMethod {
                             log.info(LogHelper.getHeader(context,
                                                           "type=ldap-login", "type=ldap_but_already_email"));
                             context.turnOffAuthorisationSystem();
-                            setEpersonAttributes(context, eperson, ldap, Optional.of(netid));
+                            setEpersonAttributes(context, eperson, ldap, Optional.of(netid), email);
                             ePersonService.update(context, eperson);
                             context.dispatchEvents();
                             context.restoreAuthSystemState();
@@ -339,7 +339,7 @@ public class LDAPAuthentication implements AuthenticationMethod {
                                 try {
                                     context.turnOffAuthorisationSystem();
                                     eperson = ePersonService.create(context);
-                                    setEpersonAttributes(context, eperson, ldap, Optional.of(netid));
+                                    setEpersonAttributes(context, eperson, ldap, Optional.of(netid), email);
                                     eperson.setCanLogIn(true);
                                     authenticationService.initEPerson(context, request, eperson);
                                     ePersonService.update(context, eperson);
@@ -381,11 +381,24 @@ public class LDAPAuthentication implements AuthenticationMethod {
      * Update eperson's attributes
      */
     private void setEpersonAttributes(Context context, EPerson eperson, SpeakerToLDAP ldap, Optional<String> netid)
-        throws SQLException {
+            throws SQLException {
+        setEpersonAttributes(context, eperson, ldap, netid, null);
+    }
 
+    /**
+     * Update eperson's attributes
+     */
+    private void setEpersonAttributes(Context context, EPerson eperson, SpeakerToLDAP ldap, Optional<String> netid,
+                                      String email)
+            throws SQLException {
+
+        // Set email address: first try LDAP email, then fallback to provided email parameter
         if (StringUtils.isNotEmpty(ldap.ldapEmail)) {
             eperson.setEmail(ldap.ldapEmail);
+        } else if (StringUtils.isNotEmpty(email)) {
+            eperson.setEmail(email);
         }
+
         if (StringUtils.isNotEmpty(ldap.ldapGivenName)) {
             eperson.setFirstName(context, ldap.ldapGivenName);
         }


### PR DESCRIPTION
## References
Fixes #11292
`main` version of this PR: #11331

## Description
Fix LDAP authentication failure when users have no email field in LDAP directory despite `netid_email_domain` fallback configuration.

I couldn’t find any integration test class for LDAP authentication—did I overlook it? If not, I can create one.

## Instructions for Reviewers
This PR fixes a bug where LDAP users without email attributes in their LDAP entry cannot authenticate, even when `authentication-ldap.netid_email_domain` is properly configured as a fallback.

List of changes in this PR:
* Added overloaded `setEpersonAttributes()` method that accepts calculated email as parameter
* Updated existing `setEpersonAttributes()` to delegate to new method with null email
* Modified calls to `setEpersonAttributes()` in new user creation path to pass calculated fallback email
* Modified calls to `setEpersonAttributes()` in existing user update path to pass calculated fallback email
* Added logic to set email from parameter when LDAP email is empty

**How to test:**
1. Configure DSpace with LDAP authentication and set `authentication-ldap.netid_email_domain = @example.com`
2. Create/find an LDAP user that has no `mail` attribute in their LDAP entry
3. Before the fix: Login fails with "No eperson with an non-blank e-mail address found"
4. After the fix: Login succeeds and user gets email `username@example.com`
5. Verify in database that EPerson has correct email address set

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
