### PR TITLE
DS-8943: adds limit to number of typed links to bitstreams in header 

### DIFF
--- a/dspace/config/modules/signposting.cfg
+++ b/dspace/config/modules/signposting.cfg
@@ -34,5 +34,10 @@ signposting.describedby.crosswalk-name = DataCite
 # Mime-type of response of handling of 'describedby' links.
 signposting.describedby.mime-type = application/vnd.datacite.datacite+xml
 
+# Limit to the number of an item's bitstreams to return as typed links.
+# If there are more bitstreams than this limit then only the typed links to the Link Sets are added to the header. 
+# Defaults to 10 if the value is unspecified
+# signposting.item.bitstreams.limit = 10
+
 # Optional, to expose the profile attribute, required by PCI workflow ()
 # signposting.describedby.profile = http://datacite.org/schema/kernel-4


### PR DESCRIPTION
## References
* Fixes #8943 

## Description
This pull request modifies the Signposting code by adding a limit to the number of an item's bitstreams that will be added to the list of typed links in the header of an item. The limit is necessary to make sure the header does not get so large that it causes an error. 

## Instructions for Reviewers
List of changes in this PR:
* Adds a limit to the number of bitstreams an item can have before only the typed links to the Link Sets will be returned
* Makes this limit configurable in the Spring configuration so repository admins can increase it if they want

To test, ingest an item with fewer bitstreams than the limit (10) and observe typed links for every bitstream in the HTTP response. Then test with another item that has more bitstreams than the limit and observe that only the typed links for the Link Sets are present.

To test that this PR fixes the Apache gateway timeout in the issue cited above you will need to use an item with a large number of bitstreams.

One final note: there is a trade-off in this PR in that the function `countItemBitstreams()` counts all of an item's bitstreams and not just those that the user is authorized to read, but the function `addBitstreamLinksets()` only adds typed links for authorized bitstreams. So it is possible that an item could have a few authorized bitstreams and many unauthorized bitstreams, which would result in only the Link Sets being returned. Because that scenario still complies with the Level 2 implementation of FAIR Signposting (https://signposting.org/FAIR/#level2) I thought it was beneficial to avoid the performance hit of iterating over all of the bitstreams twice.

## Checklist
- [X] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [X] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [X] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [X] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
