### PR TITLE
Update S3 bitstore service to use AWS SDK v2 and CRT client

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -635,7 +635,7 @@
             <version>1.1.1</version>
         </dependency>
 
-        <!-- guava is needed by OAuth, Guice, Mockserver, ORCID, s3mock, Solr, JClouds -->
+        <!-- guava is needed by OAuth, Guice, Mockserver, ORCID, Solr, JClouds -->
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
@@ -718,9 +718,25 @@
 
         <!-- S3 -->
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-s3</artifactId>
-            <version>1.12.792</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+            <version>2.32.31</version>
+            <exclusions>
+              <exclusion>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>netty-nio-client</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>apache-client</artifactId>
+              </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk.crt</groupId>
+            <artifactId>aws-crt</artifactId>
+            <version>0.38.12</version>
         </dependency>
 
         <!-- TODO: This may need to be replaced with the "orcid-model" artifact once this ticket is resolved:
@@ -832,22 +848,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        
+
         <dependency>
-            <groupId>io.findify</groupId>
-            <artifactId>s3mock_2.13</artifactId>
-            <version>0.2.6</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.amazonawsl</groupId>
-                    <artifactId>aws-java-sdk-s3</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.amazonaws</groupId>
-                    <artifactId>aws-java-sdk-s3</artifactId>
-                </exclusion>
-            </exclusions>
+          <groupId>com.adobe.testing</groupId>
+          <artifactId>s3mock-testcontainers</artifactId>
+          <version>4.8.0</version>
+          <scope>test</scope>
         </dependency>
 
         <!-- JClouds Assetstorage Support -->

--- a/dspace-api/src/test/java/org/dspace/storage/bitstore/S3BitStoreServiceIT.java
+++ b/dspace-api/src/test/java/org/dspace/storage/bitstore/S3BitStoreServiceIT.java
@@ -7,13 +7,12 @@
  */
 package org.dspace.storage.bitstore;
 
-import static com.amazonaws.regions.Regions.DEFAULT_REGION;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.dspace.storage.bitstore.S3BitStoreService.CSA;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -26,6 +25,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -34,15 +34,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.AnonymousAWSCredentials;
-import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-import com.amazonaws.services.s3.model.AmazonS3Exception;
-import com.amazonaws.services.s3.model.Bucket;
-import com.amazonaws.services.s3.model.ObjectMetadata;
-import io.findify.s3mock.S3Mock;
+import com.adobe.testing.s3mock.testcontainers.S3MockContainer;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.BooleanUtils;
 import org.dspace.AbstractIntegrationTestWithDatabase;
@@ -60,44 +52,60 @@ import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
-
-
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.Bucket;
+import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 
 /**
  * @author Luca Giamminonni (luca.giamminonni at 4science.com)
  */
 public class S3BitStoreServiceIT extends AbstractIntegrationTestWithDatabase {
+    private static  S3MockContainer s3Mock = new S3MockContainer("4.8.0");
+
+    private static S3AsyncClient s3AsyncClient;
 
     private static final String DEFAULT_BUCKET_NAME = "dspace-asset-localhost";
 
     private S3BitStoreService s3BitStoreService;
 
-    private AmazonS3 amazonS3Client;
-
-    private S3Mock s3Mock;
-
     private Collection collection;
 
     private ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
 
+    @BeforeClass
+    public static void setupS3() {
+        s3Mock.start();
+
+        s3AsyncClient = S3AsyncClient.crtBuilder()
+                .endpointOverride(URI.create("http://127.0.0.1:" + s3Mock.getHttpServerPort()))
+                .credentialsProvider(AnonymousCredentialsProvider.create())
+                .region(Region.US_EAST_1)
+                .build();
+    }
+
+    @AfterClass
+    public static void cleanupS3() {
+        s3Mock.close();
+        s3AsyncClient.close();
+    }
 
     @Before
     public void setup() throws Exception {
-
         configurationService.setProperty("assetstore.s3.enabled", "true");
 
-        s3Mock = new S3Mock.Builder().withPort(8001).withInMemoryBackend().build();
-        s3Mock.start();
-
-        amazonS3Client = createAmazonS3Client();
-
-        s3BitStoreService = new S3BitStoreService(amazonS3Client);
+        s3BitStoreService = new S3BitStoreService(s3AsyncClient);
         s3BitStoreService.setEnabled(BooleanUtils.toBoolean(
                 configurationService.getProperty("assetstore.s3.enabled")));
-        s3BitStoreService.setBufferSize(22);
+        s3BitStoreService.setS3ChecksumAlgorithm(ChecksumAlgorithm.SHA256);
+
         context.turnOffAuthorisationSystem();
 
         parentCommunity = CommunityBuilder.createCommunity(context)
@@ -109,22 +117,17 @@ public class S3BitStoreServiceIT extends AbstractIntegrationTestWithDatabase {
         context.restoreAuthSystemState();
     }
 
-    @After
-    public void cleanUp() {
-        s3Mock.shutdown();
-    }
-
     @Test
     public void testBitstreamPutAndGetWithAlreadyPresentBucket() throws IOException {
 
         String bucketName = "testbucket";
 
-        amazonS3Client.createBucket(bucketName);
+        s3AsyncClient.createBucket(r -> r.bucket(bucketName)).join();
 
         s3BitStoreService.setBucketName(bucketName);
         s3BitStoreService.init();
 
-        assertThat(amazonS3Client.listBuckets(), contains(bucketNamed(bucketName)));
+        assertThat(s3AsyncClient.listBuckets().join().buckets(), hasItem(bucketNamed(bucketName)));
 
         context.turnOffAuthorisationSystem();
         String content                = "Test bitstream content";
@@ -146,7 +149,7 @@ public class S3BitStoreServiceIT extends AbstractIntegrationTestWithDatabase {
 
     private void checkGetPut(String bucketName, String content, Bitstream bitstream) throws IOException {
         s3BitStoreService.put(bitstream, toInputStream(content));
-        String expectedChecksum = Utils.toHex(generateChecksum(content));
+        String expectedChecksum = Utils.toHex(generateChecksum("MD5", content));
 
         assertThat(bitstream.getSizeBytes(), is((long) content.length()));
         assertThat(bitstream.getChecksum(), is(expectedChecksum));
@@ -154,20 +157,16 @@ public class S3BitStoreServiceIT extends AbstractIntegrationTestWithDatabase {
 
         InputStream inputStream = s3BitStoreService.get(bitstream);
         assertThat(IOUtils.toString(inputStream, UTF_8), is(content));
-
-        String key = s3BitStoreService.getFullKey(bitstream.getInternalId());
-        ObjectMetadata objectMetadata = amazonS3Client.getObjectMetadata(bucketName, key);
-        assertThat(objectMetadata.getContentMD5(), is(expectedChecksum));
     }
 
     @Test
-    public void testBitstreamPutAndGetWithoutSpecifingBucket() throws IOException {
+    public void testBitstreamPutAndGetWithoutSpecifyingBucket() throws IOException {
 
         s3BitStoreService.init();
 
         assertThat(s3BitStoreService.getBucketName(), is(DEFAULT_BUCKET_NAME));
 
-        assertThat(amazonS3Client.listBuckets(), contains(bucketNamed(DEFAULT_BUCKET_NAME)));
+        assertThat(s3AsyncClient.listBuckets().join().buckets(), hasItem(bucketNamed(DEFAULT_BUCKET_NAME)));
 
         context.turnOffAuthorisationSystem();
         String content = "Test bitstream content";
@@ -176,7 +175,7 @@ public class S3BitStoreServiceIT extends AbstractIntegrationTestWithDatabase {
 
         s3BitStoreService.put(bitstream, toInputStream(content));
 
-        String expectedChecksum = Utils.toHex(generateChecksum(content));
+        String expectedChecksum = Utils.toHex(generateChecksum("MD5", content));
 
         assertThat(bitstream.getSizeBytes(), is((long) content.length()));
         assertThat(bitstream.getChecksum(), is(expectedChecksum));
@@ -184,11 +183,6 @@ public class S3BitStoreServiceIT extends AbstractIntegrationTestWithDatabase {
 
         InputStream inputStream = s3BitStoreService.get(bitstream);
         assertThat(IOUtils.toString(inputStream, UTF_8), is(content));
-
-        String key = s3BitStoreService.getFullKey(bitstream.getInternalId());
-        ObjectMetadata objectMetadata = amazonS3Client.getObjectMetadata(DEFAULT_BUCKET_NAME, key);
-        assertThat(objectMetadata.getContentMD5(), is(expectedChecksum));
-
     }
 
     @Test
@@ -210,9 +204,9 @@ public class S3BitStoreServiceIT extends AbstractIntegrationTestWithDatabase {
         String key = s3BitStoreService.getFullKey(bitstream.getInternalId());
         assertThat(key, startsWith("test/DSpace7/"));
 
-        ObjectMetadata objectMetadata = amazonS3Client.getObjectMetadata(DEFAULT_BUCKET_NAME, key);
-        assertThat(objectMetadata, notNullValue());
-
+        HeadObjectResponse response = s3AsyncClient.headObject(r ->
+            r.bucket(DEFAULT_BUCKET_NAME).key(key)).join();
+        assertThat(response, notNullValue());
     }
 
     @Test
@@ -232,8 +226,8 @@ public class S3BitStoreServiceIT extends AbstractIntegrationTestWithDatabase {
         s3BitStoreService.remove(bitstream);
 
         IOException exception = assertThrows(IOException.class, () -> s3BitStoreService.get(bitstream));
-        assertThat(exception.getCause(), instanceOf(AmazonS3Exception.class));
-        assertThat(((AmazonS3Exception) exception.getCause()).getStatusCode(), is(404));
+        assertThat(exception.getCause(), instanceOf(AwsServiceException.class));
+        assertThat(((AwsServiceException) exception.getCause()).statusCode(), is(404));
 
     }
 
@@ -261,7 +255,7 @@ public class S3BitStoreServiceIT extends AbstractIntegrationTestWithDatabase {
         assertThat(about, hasEntry(is("modified"), notNullValue()));
         assertThat(about.size(), is(2));
 
-        String expectedChecksum = Utils.toHex(generateChecksum(content));
+        String expectedChecksum = Utils.toHex(generateChecksum("MD5", content));
 
         about = s3BitStoreService.about(bitstream, List.of("size_bytes", "modified", "checksum"));
         assertThat(about, hasEntry("size_bytes", 22L));
@@ -406,28 +400,21 @@ public class S3BitStoreServiceIT extends AbstractIntegrationTestWithDatabase {
     public void testDoNotInitializeConfigured() throws Exception {
         String assetstores3enabledOldValue = configurationService.getProperty("assetstore.s3.enabled");
         configurationService.setProperty("assetstore.s3.enabled", "false");
-        s3BitStoreService = new S3BitStoreService(amazonS3Client);
+        s3BitStoreService = new S3BitStoreService(s3AsyncClient);
         s3BitStoreService.init();
         assertFalse(s3BitStoreService.isInitialized());
         assertFalse(s3BitStoreService.isEnabled());
         configurationService.setProperty("assetstore.s3.enabled", assetstores3enabledOldValue);
     }
 
-    private byte[] generateChecksum(String content) {
+    private byte[] generateChecksum(String algorithm, String content) {
         try {
-            MessageDigest m = MessageDigest.getInstance("MD5");
+            MessageDigest m = MessageDigest.getInstance(algorithm);
             m.update(content.getBytes());
             return m.digest();
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    private AmazonS3 createAmazonS3Client() {
-        return AmazonS3ClientBuilder.standard()
-            .withCredentials(new AWSStaticCredentialsProvider(new AnonymousAWSCredentials()))
-            .withEndpointConfiguration(new EndpointConfiguration("http://127.0.0.1:8001", DEFAULT_REGION.getName()))
-            .build();
     }
 
     private Item createItem() {
@@ -447,7 +434,7 @@ public class S3BitStoreServiceIT extends AbstractIntegrationTestWithDatabase {
     }
 
     private Matcher<? super Bucket> bucketNamed(String name) {
-        return LambdaMatcher.matches(bucket -> bucket.getName().equals(name));
+        return LambdaMatcher.matches(bucket -> bucket.name().equals(name));
     }
 
     private InputStream toInputStream(String content) {

--- a/dspace-server-webapp/pom.xml
+++ b/dspace-server-webapp/pom.xml
@@ -481,6 +481,13 @@
         </dependency>
 
         <!-- DSpace dependencies -->
+
+        <!-- Moved here from optional modules list to ensure that iiif-apis mime.types resource is first in classpath -->
+        <dependency>
+            <groupId>org.dspace</groupId>
+            <artifactId>dspace-iiif</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.dspace</groupId>
             <artifactId>dspace-api</artifactId>
@@ -500,10 +507,6 @@
 
         <!-- DSpace modules to deploy (these modules are all optional, but add features/endpoints to webapp) -->
         <!-- You may choose to comment out any of these modules if you do not want/need its features -->
-        <dependency>
-            <groupId>org.dspace</groupId>
-            <artifactId>dspace-iiif</artifactId>
-        </dependency>
         <dependency>
             <groupId>org.dspace</groupId>
             <artifactId>dspace-oai</artifactId>

--- a/dspace/config/modules/assetstore.cfg
+++ b/dspace/config/modules/assetstore.cfg
@@ -47,6 +47,9 @@ assetstore.s3.bucketName =
 # is shared. Optional, default is root level of bucket
 assetstore.s3.subfolder =
 
+# Optional custom S3 endpoint URI. Leave this blank / commented to use the Amazon default
+# assetstore.s3.endpoint =
+
 # please don't use root credentials in production but rely on the aws credentials default
 # discovery mechanism to configure them (ENV VAR, EC2 Iam role, etc.)
 # The preferred approach for security reason is to use the IAM user credentials, but isn't always possible.
@@ -58,6 +61,20 @@ assetstore.s3.awsSecretKey =
 # If the credentials are left empty,
 # then this setting is ignored and the default AWS region will be used.
 assetstore.s3.awsRegionName =
+
+# The target throughput for transfer requests in Gbps. Higher value means more connections will be established with S3.
+assetstore.s3.targetThroughputGbps = 10.0
+
+# Sets the minimum part size for transfer parts. Decreasing the minimum part size causes multipart transfer to be split
+# into a larger number of smaller parts.
+assetstore.s3.minPartSizeBytes = 8388608
+
+# Specifies the maximum number of S3 connections that should be established during a transfer.
+# If not provided, it will be based on targetThroughputGbps
+assetstore.s3.maxConcurrency = 
+
+# The algorithm the S3 client will use to create a checksum when doing putObject.
+assetstore.s3.s3ChecksumAlgorithm = CRC32
 
 
 ### JCloudSettings

--- a/dspace/config/spring/api/bitstore.xml
+++ b/dspace/config/spring/api/bitstore.xml
@@ -28,6 +28,9 @@
         <!-- S3 bucket name to store assets in. example: longsight-dspace-auk -->
         <property name="bucketName" value="${assetstore.s3.bucketName}"/>
 
+        <!-- S3 endpoint URI if not using Amazon defaults, example: minio.mysite.org -->
+        <property name="endpoint" value="${assetstore.s3.endpoint:}"/>
+
         <!-- AWS S3 Region to use: {us-east-1, us-west-1, eu-west-1, eu-central-1, ap-southeast-1, ... } -->
         <!-- Optional, sdk default is us-east-1 -->
         <property name="awsRegionName" value="${assetstore.s3.awsRegionName}"/>
@@ -35,6 +38,22 @@
         <!-- Subfolder to organize assets within the bucket, in case this bucket is shared  -->
         <!-- Optional, default is root level of bucket -->
         <property name="subfolder" value="${assetstore.s3.subfolder}"/>
+
+        <!-- The target throughput for transfer requests in Gbps. Higher value means more connections will be established with S3.  -->
+        <property name="targetThroughputGbps" value="${assetstore.s3.targetThroughputGbps}"/>
+
+        <!-- Sets the minimum part size for transfer parts. Decreasing the minimum part size causes multipart transfer
+             to be split into a larger number of smaller parts.
+        -->
+        <property name="minPartSizeBytes" value="${assetstore.s3.minPartSizeBytes}"/>
+
+        <!-- Specifies the maximum number of S3 connections that should be established during a transfer.
+             If not provided, it will be based on targetThroughputGbps
+        -->
+        <property name="maxConcurrency" value="${assetstore.s3.maxConcurrency}"/>
+
+        <!-- The algorithm the S3 client will use to create a checksum when doing putObject. -->
+        <property name="s3ChecksumAlgorithm" value="${assetstore.s3.s3ChecksumAlgorithm}"/>
     </bean>
 
     <!-- 


### PR DESCRIPTION
## References
* Fixes #10819

## Description

This pr update to AWS SDK v2 for the S3 bitstore service and also switches to the CRT client .

## Instructions for Reviewers

The CRT client, https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/crt-based-s3-client.html, can do uploads and downloads in parallel as parts. Configuration options are exposed to control how that happens.

The put method no longer creates a temporary file. The upload will occur in parallel chunks according to the configuration. (See the throughput , max concurrency, and part size properties of the CRT client which are exposed as configuration properties.) The get method no longer chunk the S3 objects into temporary files and instead the transfer occurs in parallel according to the configuration.

It turns out s3mock will not work with v2. See for example: findify/s3mock#10. To solve the problem I switched to the adobe S3 mocking library.

Switching to AWS SDK v2 revealed an existing problem. The iiif-apis library loads the resource `mime.types` without a path. Resources of that name are provided by several libraries and it happens to load one it can't parse. This is a reported issue, see: dbmdz/iiif-apis#270. I fixed it temporarily by changing the order of maven dependencies which also changes the classpath order and makes sure the `mime.types` from iiif-apis is found first.

I also made a small change to the github workflow to not run the code coverage tests on forks.

In order to test, run the updated dspace code against S3 and try uploading and downloading files. 
I tested in our dspace staging environment at JH.
But there should be some sort of performance testing under load to make sure it works well and figure out what the default configuration should be.

I tried to avoid doing any code cleanup and kept the structure pretty much the same.

One issue I noticed is the checksum behavior. It seems like all the bitstore services are hard coded to use MD5. If instead there was a switch to something supported by S3 like SHA-256, then an additional checksum calculation could be avoided during the put and about methods.  I did some testing and the the S3 CRT client generated checksums are composite, not full object, so would not make sense for DSpace.

I also wonder if the mostly commented out main method is used or needed. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
