### PR TITLE
Fix for bitstreams with old style embargo lift date in metadata not rendering on simple item pages #8640

### DIFF
--- a/dspace-api/src/main/java/org/dspace/embargo/DefaultEmbargoSetter.java
+++ b/dspace-api/src/main/java/org/dspace/embargo/DefaultEmbargoSetter.java
@@ -94,7 +94,6 @@ public class DefaultEmbargoSetter implements EmbargoSetter {
             if (!(bnn.equals(Constants.LICENSE_BUNDLE_NAME) || bnn.equals(Constants.METADATA_BUNDLE_NAME) || bnn
                 .equals(CreativeCommonsServiceImpl.CC_BUNDLE_NAME))) {
                 //AuthorizeManager.removePoliciesActionFilter(context, bn, Constants.READ);
-                generatePolicies(context, liftDate.toDate(), null, bn, item.getOwningCollection());
                 for (Bitstream bs : bn.getBitstreams()) {
                     //AuthorizeManager.removePoliciesActionFilter(context, bs, Constants.READ);
                     generatePolicies(context, liftDate.toDate(), null, bs, item.getOwningCollection());


### PR DESCRIPTION
# References
* Fixes DSpace/DSpace#8640

# Description
Fix Original bundle embargo in DSpace 7_x: apply embargo only to bitstreams, leaving Original bundle readable. Anonymous users can see bundles; admin users retain full access.

# Instructions for Reviewers
Verify that anonymous users can see the ORIGINAL bundle but cannot access embargoed bitstreams, while admins can access both. Review changes in DefaultEmbargoSetter.java for correct policy handling. 

# List of changes in this PR:
•	Updated DefaultEmbargoSetter.java to only set embargo to bitstreams only and not to bundles.
 
# How to Test
1.	Log in as a site admin.
2.	Submit a new item using the submission form.
3.	Ensure the metadata field configured for embargo lift (e.g., dc.embargo.lift) is filled out.
4.	Attach a bitstream to the item and edit the bitstream and configure an embargo, then deposit the item.
5.	View the item as an admin: both ORIGINAL and LICENSE bundles should be visible, and embargoed bitstreams accessible.
6.	Log out and view the item as an anonymous user: bundles should be visible, but embargoed bitstreams in the ORIGINAL bundle should not be accessible until the embargo expires.