### PR TITLE
Fix Hibernate syntax bug in the CollectionDAO

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/CollectionDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/CollectionDAOImpl.java
@@ -159,7 +159,7 @@ public class CollectionDAOImpl extends AbstractHibernateDSODAO<Collection> imple
 
     @Override
     public List<Collection> findCollectionsWithSubscribers(Context context) throws SQLException {
-        return list(createQuery(context, "SELECT DISTINCT c FROM Collection c JOIN Subscription s ON c.id = " +
+        return list(createQuery(context, "SELECT DISTINCT c FROM Collection c JOIN Subscription s ON c = " +
                 "s.dSpaceObject"));
     }
 

--- a/dspace-api/src/main/java/org/dspace/health/UserCheck.java
+++ b/dspace-api/src/main/java/org/dspace/health/UserCheck.java
@@ -50,26 +50,26 @@ public class UserCheck extends Check {
             info.put("Self registered", 0);
 
             for (EPerson e : epersons) {
-                if (e.getEmail() != null && e.getEmail().length() > 0) {
+                if (e.getEmail() != null && !e.getEmail().isEmpty()) {
                     info.put("Have email", info.get("Have email") + 1);
                 }
                 if (e.canLogIn()) {
                     info.put("Can log in (password)",
                              info.get("Can log in (password)") + 1);
                 }
-                if (e.getFirstName() != null && e.getFirstName().length() > 0) {
+                if (e.getFirstName() != null && !e.getFirstName().isEmpty()) {
                     info.put("Have 1st name", info.get("Have 1st name") + 1);
                 }
-                if (e.getLastName() != null && e.getLastName().length() > 0) {
+                if (e.getLastName() != null && !e.getLastName().isEmpty()) {
                     info.put("Have 2nd name", info.get("Have 2nd name") + 1);
                 }
-                if (e.getLanguage() != null && e.getLanguage().length() > 0) {
+                if (e.getLanguage() != null && !e.getLanguage().isEmpty()) {
                     info.put("Have lang", info.get("Have lang") + 1);
                 }
-                if (e.getNetid() != null && e.getNetid().length() > 0) {
+                if (e.getNetid() != null && !e.getNetid().isEmpty()) {
                     info.put("Have netid", info.get("Have netid") + 1);
                 }
-                if (e.getNetid() != null && e.getNetid().length() > 0) {
+                if (e.getNetid() != null && !e.getNetid().isEmpty()) {
                     info.put("Self registered", info.get("Self registered") + 1);
                 }
             }


### PR DESCRIPTION
## References
* Related to #10805 

## Description
This tiny PR fixes a Hibernate syntax bug that happens during the User Summary in the Healthcheck module.

## Instructions for Reviewers
1. Remove all of the other checks in `[dspace]/modules/healthcheck.cfg`, leaving only the User summary:
> healthcheck.checks = User summary
2. Run `bin/dspace healthcheck` and observe the following error:
> #### User summary [took: 0s] [# lines: 54]
> Exception occurred when processing report - java.lang.IllegalArgumentException: org.hibernate.query.SemanticException: Cannot compare left expression of type 'java.util.UUID' with right expression of type 'org.dspace.content.DSpaceObject'
>       at org.hibernate.internal.ExceptionConverterImpl.convert(ExceptionConverterImpl.java:143)
>       at org.hibernate.internal.ExceptionConverterImpl.convert(ExceptionConverterImpl.java:167)
>       at org.hibernate.internal.ExceptionConverterImpl.convert(ExceptionConverterImpl.java:173)
>       at org.hibernate.internal.AbstractSharedSessionContract.createQuery(AbstractSharedSessionContract.java:848)
>       at org.hibernate.internal.AbstractSharedSessionContract.createQuery(AbstractSharedSessionContract.java:753)
>       at org.hibernate.internal.AbstractSharedSessionContract.createQuery(AbstractSharedSessionContract.java:136)
>       at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
>       at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
>       at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
>       at java.base/java.lang.reflect.Method.invoke(Method.java:569)
>       at org.hibernate.context.internal.ThreadLocalSessionContext$TransactionProtectionWrapper.invoke(ThreadLocalSessionContext.java:343)
>       at jdk.proxy2/jdk.proxy2.$Proxy160.createQuery(Unknown Source)
>       at org.dspace.core.AbstractHibernateDAO.createQuery(AbstractHibernateDAO.java:147)
>       at org.dspace.content.dao.impl.CollectionDAOImpl.findCollectionsWithSubscribers(CollectionDAOImpl.java:162)
>       at org.dspace.content.CollectionServiceImpl.findCollectionsWithSubscribers(CollectionServiceImpl.java:848)
>       at org.dspace.health.UserCheck.run(UserCheck.java:109)
>       at org.dspace.health.Check.report(Check.java:33)
>       at org.dspace.health.Report.run(Report.java:67)
>       at org.dspace.health.Report.main(Report.java:194)
>       at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
>       at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
>       at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
>       at java.base/java.lang.reflect.Method.invoke(Method.java:569)
>       at org.dspace.app.launcher.ScriptLauncher.runOneCommand(ScriptLauncher.java:284)
>       at org.dspace.app.launcher.ScriptLauncher.handleScript(ScriptLauncher.java:135)
>       at org.dspace.app.launcher.ScriptLauncher.main(ScriptLauncher.java:100)
> Caused by: org.hibernate.query.SemanticException: Cannot compare left expression of type 'java.util.UUID' with right expression of type 'org.dspace.content.DSpaceObject'
>       at org.hibernate.query.sqm.internal.TypecheckUtil.assertComparable(TypecheckUtil.java:358)
>       at org.hibernate.query.sqm.tree.predicate.SqmComparisonPredicate.<init>(SqmComparisonPredicate.java:48)
>       at org.hibernate.query.sqm.tree.predicate.SqmComparisonPredicate.<init>(SqmComparisonPredicate.java:34)
>       at org.hibernate.query.hql.internal.SemanticQueryBuilder.createComparisonPredicate(SemanticQueryBuilder.java:2448)
>       at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitComparisonPredicate(SemanticQueryBuilder.java:2392)
>       at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitComparisonPredicate(SemanticQueryBuilder.java:269)
>       at org.hibernate.grammars.hql.HqlParser$ComparisonPredicateContext.accept(HqlParser.java:6165)
>       at org.hibernate.query.hql.internal.SemanticQueryBuilder.consumeJoin(SemanticQueryBuilder.java:2130)
>       at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitEntityWithJoins(SemanticQueryBuilder.java:1922)
>       at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitFromClause(SemanticQueryBuilder.java:1901)
>       at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitQuery(SemanticQueryBuilder.java:1148)
>       at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitQuerySpecExpression(SemanticQueryBuilder.java:941)
>       at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitQuerySpecExpression(SemanticQueryBuilder.java:269)
>       at org.hibernate.grammars.hql.HqlParser$QuerySpecExpressionContext.accept(HqlParser.java:1869)
>       at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitSimpleQueryGroup(SemanticQueryBuilder.java:926)
>       at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitSimpleQueryGroup(SemanticQueryBuilder.java:269)
>       at org.hibernate.grammars.hql.HqlParser$SimpleQueryGroupContext.accept(HqlParser.java:1740)
>       at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitSelectStatement(SemanticQueryBuilder.java:443)
>       at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitStatement(SemanticQueryBuilder.java:402)
>       at org.hibernate.query.hql.internal.SemanticQueryBuilder.buildSemanticModel(SemanticQueryBuilder.java:311)
>       at org.hibernate.query.hql.internal.StandardHqlTranslator.translate(StandardHqlTranslator.java:71)
>       at org.hibernate.query.internal.QueryInterpretationCacheStandardImpl.createHqlInterpretation(QueryInterpretationCacheStandardImpl.java:165)
>       at org.hibernate.query.internal.QueryInterpretationCacheStandardImpl.resolveHqlInterpretation(QueryInterpretationCacheStandardImpl.java:147)
>       at org.hibernate.internal.AbstractSharedSessionContract.interpretHql(AbstractSharedSessionContract.java:790)
>       at org.hibernate.internal.AbstractSharedSessionContract.createQuery(AbstractSharedSessionContract.java:840)
>       ... 22 more
> 
> ###############################
4. Deploy this PR and run the `bin/dspace healthcheck` command again.
5. Observe that the User summary finishes successfully.


## Checklist
- [X] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [X] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [X] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [X] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
