### PR TITLE
Fix Hibernate syntax bugs in the CollectionDAO and BitstreamDAO

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/BitstreamDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/BitstreamDAOImpl.java
@@ -178,7 +178,7 @@ public class BitstreamDAOImpl extends AbstractHibernateDSODAO<Bitstream> impleme
     @Override
     public int countWithNoPolicy(Context context) throws SQLException {
         Query query = createQuery(context,
-                                  "SELECT count(bit.id) from Bitstream bit where bit.deleted<>true and bit.id not in" +
+                                  "SELECT count(bit.id) from Bitstream bit where bit.deleted<>true and bit not in" +
                                       " (select res.dSpaceObject from ResourcePolicy res where res.resourceTypeId = " +
                                       ":typeId )");
         query.setParameter("typeId", Constants.BITSTREAM);

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/CollectionDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/CollectionDAOImpl.java
@@ -12,6 +12,7 @@ import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import jakarta.persistence.Query;
 import jakarta.persistence.criteria.CriteriaBuilder;
@@ -19,6 +20,7 @@ import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
+import org.apache.logging.log4j.Logger;
 import org.dspace.authorize.ResourcePolicy;
 import org.dspace.authorize.ResourcePolicy_;
 import org.dspace.content.Collection;
@@ -40,6 +42,11 @@ import org.dspace.eperson.Group;
  * @author kevinvandevelde at atmire.com
  */
 public class CollectionDAOImpl extends AbstractHibernateDSODAO<Collection> implements CollectionDAO {
+    /**
+     * log4j logger
+     */
+    private static Logger log = org.apache.logging.log4j.LogManager.getLogger(CollectionDAOImpl.class);
+
     protected CollectionDAOImpl() {
         super();
     }
@@ -172,14 +179,25 @@ public class CollectionDAOImpl extends AbstractHibernateDSODAO<Collection> imple
     @SuppressWarnings("unchecked")
     public List<Map.Entry<Collection, Long>> getCollectionsWithBitstreamSizesTotal(Context context)
         throws SQLException {
-        String q = "select col as collection, sum(bit.sizeBytes) as totalBytes from Item i join i.collections col " +
-            "join i.bundles bun join bun.bitstreams bit group by col";
+        String q = "select col.id, sum(bit.sizeBytes) as totalBytes from Item i join i.collections col " +
+            "join i.bundles bun join bun.bitstreams bit group by col.id";
         Query query = createQuery(context, q);
+
+        CriteriaBuilder criteriaBuilder = getCriteriaBuilder(context);
 
         List<Object[]> list = query.getResultList();
         List<Map.Entry<Collection, Long>> returnList = new ArrayList<>(list.size());
         for (Object[] o : list) {
-            returnList.add(new AbstractMap.SimpleEntry<>((Collection) o[0], (Long) o[1]));
+            CriteriaQuery<Collection> criteriaQuery = criteriaBuilder.createQuery(Collection.class);
+            Root<Collection> collectionRoot = criteriaQuery.from(Collection.class);
+            criteriaQuery.select(collectionRoot).where(criteriaBuilder.equal(collectionRoot.get("id"), (UUID) o[0]));
+            Query collectionQuery = createQuery(context, criteriaQuery);
+            Collection collection = (Collection) collectionQuery.getSingleResult();
+            if (collection != null) {
+                returnList.add(new AbstractMap.SimpleEntry<>(collection, (Long) o[1]));
+            } else {
+                log.warn("Unable to find Collection with UUID: {}", o[0]);
+            }
         }
         return returnList;
     }


### PR DESCRIPTION
## References
* Related to #10805 

## Description
This small PR fixes a few Hibernate syntax bugs that occur during the Item summary in the Healthcheck module.

## Instructions for Reviewers
1. Remove all of the other checks in `[dspace]/modules/healthcheck.cfg`, leaving only the Item summary:
> healthcheck.checks = Item summary
2. Run `bin/dspace healthcheck` and observe the following error:
> #### Item summary [took: 0s] [# lines: 56]
> Exception occurred when processing report - java.lang.IllegalArgumentException: org.hibernate.query.SemanticException: Cannot compare left expression of type 'java.util.UUID' with right expression of type 'org.dspace.content.DSpaceObject'
> 	at org.hibernate.internal.ExceptionConverterImpl.convert(ExceptionConverterImpl.java:143)
> 	at org.hibernate.internal.ExceptionConverterImpl.convert(ExceptionConverterImpl.java:167)
> 	at org.hibernate.internal.ExceptionConverterImpl.convert(ExceptionConverterImpl.java:173)
> 	at org.hibernate.internal.AbstractSharedSessionContract.createQuery(AbstractSharedSessionContract.java:848)
> 	at org.hibernate.internal.AbstractSharedSessionContract.createQuery(AbstractSharedSessionContract.java:753)
> 	at org.hibernate.internal.AbstractSharedSessionContract.createQuery(AbstractSharedSessionContract.java:136)
> 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
> 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
> 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
> 	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
> 	at org.hibernate.context.internal.ThreadLocalSessionContext$TransactionProtectionWrapper.invoke(ThreadLocalSessionContext.java:343)
> 	at jdk.proxy2/jdk.proxy2.$Proxy160.createQuery(Unknown Source)
> 	at org.dspace.core.AbstractHibernateDAO.createQuery(AbstractHibernateDAO.java:147)
> 	at org.dspace.content.dao.impl.BitstreamDAOImpl.countWithNoPolicy(BitstreamDAOImpl.java:180)
> 	at org.dspace.content.BitstreamServiceImpl.countBitstreamsWithoutPolicy(BitstreamServiceImpl.java:488)
> 	at org.dspace.health.ItemCheck.getCollectionSizesInfo(ItemCheck.java:172)
> 	at org.dspace.health.ItemCheck.run(ItemCheck.java:75)
> 	at org.dspace.health.Check.report(Check.java:33)
> 	at org.dspace.health.Report.run(Report.java:67)
> 	at org.dspace.health.Report.main(Report.java:194)
> 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
> 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
> 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
> 	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
> 	at org.dspace.app.launcher.ScriptLauncher.runOneCommand(ScriptLauncher.java:284)
> 	at org.dspace.app.launcher.ScriptLauncher.handleScript(ScriptLauncher.java:135)
> 	at org.dspace.app.launcher.ScriptLauncher.main(ScriptLauncher.java:100)
> Caused by: org.hibernate.query.SemanticException: Cannot compare left expression of type 'java.util.UUID' with right expression of type 'org.dspace.content.DSpaceObject'
> 	at org.hibernate.query.sqm.internal.TypecheckUtil.assertComparable(TypecheckUtil.java:358)
> 	at org.hibernate.query.sqm.tree.predicate.SqmInSubQueryPredicate.<init>(SqmInSubQueryPredicate.java:45)
> 	at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitInPredicate(SemanticQueryBuilder.java:2642)
> 	at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitInPredicate(SemanticQueryBuilder.java:269)
> 	at org.hibernate.grammars.hql.HqlParser$InPredicateContext.accept(HqlParser.java:6139)
> 	at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitAndPredicate(SemanticQueryBuilder.java:2262)
> 	at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitAndPredicate(SemanticQueryBuilder.java:269)
> 	at org.hibernate.grammars.hql.HqlParser$AndPredicateContext.accept(HqlParser.java:6040)
> 	at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitWhereClause(SemanticQueryBuilder.java:2244)
> 	at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitWhereClause(SemanticQueryBuilder.java:269)
> 	at org.hibernate.grammars.hql.HqlParser$WhereClauseContext.accept(HqlParser.java:5906)
> 	at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitQuery(SemanticQueryBuilder.java:1159)
> 	at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitQuerySpecExpression(SemanticQueryBuilder.java:941)
> 	at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitQuerySpecExpression(SemanticQueryBuilder.java:269)
> 	at org.hibernate.grammars.hql.HqlParser$QuerySpecExpressionContext.accept(HqlParser.java:1869)
> 	at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitSimpleQueryGroup(SemanticQueryBuilder.java:926)
> 	at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitSimpleQueryGroup(SemanticQueryBuilder.java:269)
> 	at org.hibernate.grammars.hql.HqlParser$SimpleQueryGroupContext.accept(HqlParser.java:1740)
> 	at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitSelectStatement(SemanticQueryBuilder.java:443)
> 	at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitStatement(SemanticQueryBuilder.java:402)
> 	at org.hibernate.query.hql.internal.SemanticQueryBuilder.buildSemanticModel(SemanticQueryBuilder.java:311)
> 	at org.hibernate.query.hql.internal.StandardHqlTranslator.translate(StandardHqlTranslator.java:71)
> 	at org.hibernate.query.internal.QueryInterpretationCacheStandardImpl.createHqlInterpretation(QueryInterpretationCacheStandardImpl.java:165)
> 	at org.hibernate.query.internal.QueryInterpretationCacheStandardImpl.resolveHqlInterpretation(QueryInterpretationCacheStandardImpl.java:147)
> 	at org.hibernate.internal.AbstractSharedSessionContract.interpretHql(AbstractSharedSessionContract.java:790)
> 	at org.hibernate.internal.AbstractSharedSessionContract.createQuery(AbstractSharedSessionContract.java:840)
> 	... 23 more
> 
> ###############################
4. Deploy this PR and run the `bin/dspace healthcheck` command again.
5. Observe that the Item summary finishes successfully.


## Checklist
- [X] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [X] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [X] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [X] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).