### PR TITLE
Fix (#9694): Change Solr dynamic field *.year to *_year

### DIFF
--- a/dspace/solr/search/conf/schema.xml
+++ b/dspace/solr/search/conf/schema.xml
@@ -326,7 +326,7 @@
     <dynamicField name="*_mlt" type="text" indexed="true" stored="true" multiValued="true" omitNorms="true" termVectors="true" termPositions="true" termOffsets="true"/>
 
     <!--Date matching-->
-    <dynamicField name="*.year" type="sint" indexed="true" stored="true" multiValued="true" omitNorms="true" />
+    <dynamicField name="*_year" type="sint" indexed="true" stored="true" multiValued="true" omitNorms="true" />
     <dynamicField name="*_dt" type="date" indexed="true" stored="true" multiValued="false" omitNorms="true"  docValues="true"/>
 
     <!--Used for matching on all other fields -->


### PR DESCRIPTION
## References
* Fixes #9694

## Description
This resolves an indexing failure caused by a conflict between DSpace metadata fields using `.year` as a qualifier and a broad Solr dynamic field definition (`*.year`) that incorrectly expected an integer value.

The fix changes the Solr dynamic field definition from `*.year` to `*_year` to prevent this conflict, ensuring items with such metadata can be indexed successfully without errors.

## Instructions for Reviewers
This PR modifies a single line in the Solr schema to resolve an indexing bug.

**List of changes in this PR:**
* In `dspace/solr/search/conf/schema.xml`, the dynamic field definition for year matching was changed:
    * **Before:** `<dynamicField name="*.year" type="sint" ... />`
    * **After:** `<dynamicField name="*_year" type="sint" ... />`

**How to test this PR:**

To fully test and verify the fix, it's recommended to first reproduce the original bug and then confirm the fix works as expected.

**1. Reproduce the bug (on a clean `main` branch):**
   1.  On your DSpace site, go to the Metadata Registry (`/admin/registries/metadata`).
   2.  Create a new metadata field in any schema, with `year` as the qualifier (e.g., `local.test.year`).
   3.  Create or edit an item in DSpace.
   4.  Add the new `local.test.year` field to this item and give it a **non-integer value** (e.g., "AY2024/25" or "Test Year").
   5.  Save the item.
   6.  **Observe that the item disappears from all search results.** This confirms the bug. The item becomes unsearchable due to a Solr indexing failure.

**2. Test the fix (with this PR applied):**
   1.  Apply the changes from this PR.
   2.  Build the project (`mvn clean package`) and deploy the DSpace changes (`ant update`). This will place the corrected Solr configurations in your `[dspace]` installation directory.
   3.  Stop your Solr instance.
   4.  Copy the updated Solr configurations from your DSpace installation directory to your running Solr instance. This ensures Solr uses the corrected schema.
       ```bash
       # This copies all DSpace Solr configs, ensuring consistency.
       cp -R [dspace]/solr/* [solr_install_dir]/server/solr/configsets/
       ```
   5.  **Crucially, you must completely clean the Solr `search` index.** The old index contains an inconsistent data structure.
       ```bash
       # This permanently deletes the old search index data.
       rm -rf [solr_install_dir]/server/solr/configsets/search/data
       ```
   6.  Restart Solr. It will create a new, clean index based on the corrected schema.
   7.  Run a full reindex to rebuild the index from scratch: `[dspace]/bin/dspace index-discovery -f`
   8.  Repeat the test steps from Part 1 (create the `local.test.year` field, add it to an item with a non-integer value, and save).
   9.  **Observe that the item now remains visible and searchable.** This confirms the fix.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. (N/A - XML configuration change)
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide). (N/A - Manual testing instructions provided as this configuration change is difficult to cover with automated tests).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).