### PR TITLE
Fixes build on VSCode and other m2e plugins issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -531,6 +531,45 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>m2e-fix</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>m2e.version</name>
+                </property>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.eclipse.m2e</groupId>
+                            <artifactId>lifecycle-mapping</artifactId>
+                            <version>1.0.0</version>
+                            <configuration>
+                                <lifecycleMappingMetadata>
+                                    <pluginExecutions>
+                                        <pluginExecution>
+                                            <pluginExecutionFilter>
+                                                <groupId>org.apache.maven.plugins</groupId>
+                                                <artifactId>maven-dependency-plugin</artifactId>
+                                                <versionRange>(3.3.0,)</versionRange>
+                                                <goals>
+                                                    <goal>unpack-dependencies</goal>
+                                                </goals>
+                                            </pluginExecutionFilter>
+                                            <action>
+                                                <ignore />
+                                            </action>
+                                        </pluginExecution>
+                                    </pluginExecutions>
+                                </lifecycleMappingMetadata>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
         <!-- Profile which sets our default system properties for all Unit/Integration tests.
              By default, this sets UTF-8 encoding for all tests and gives tests 1GB of memory max.
              Both m-surefire-p and m-failsafe-p are unable to use MAVEN_OPTS because they fork a new JVM for testing.


### PR DESCRIPTION
## References
* https://github.com/apache/maven-dependency-plugin/issues/639

## Description
This profile resolves Eclipse m2e integration issues by configuring lifecycle mapping to ignore the maven-dependency-plugin's unpack-dependencies goal, preventing build errors in IDE environments.


## Instructions for Reviewers
Try to compile the project with VScode, and other IDE that have m2e plugin.

List of changes in this PR:
* Adds an extra plugin that is enabled only when the build is done using an m2e environment 

You should be able to import the project inside VSCode and also on new version of eclipse.

This error would appear for the pom.xml of the server module:

```log
Failed to execute mojo org.apache.maven.plugins:maven-dependency-plugin:3.8.1:unpack-dependencies {execution: unpack-additions} (org.apache.maven.plugins:maven-dependency-plugin:3.8.1:unpack-dependencies:unpack-additions:prepare-package)

org.eclipse.core.runtime.CoreException: Failed to execute mojo org.apache.maven.plugins:maven-dependency-plugin:3.8.1:unpack-dependencies {execution: unpack-additions}
	at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.executeMojo(MavenExecutionContext.java:404)
	at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.lambda$2(MavenExecutionContext.java:355)
	at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.executeBare(MavenExecutionContext.java:458)
	at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.execute(MavenExecutionContext.java:339)
	at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.execute(MavenExecutionContext.java:354)
	at org.eclipse.m2e.core.project.configurator.MojoExecutionBuildParticipant.build(MojoExecutionBuildParticipant.java:57)
	at org.eclipse.m2e.core.internal.builder.MavenBuilderImpl.lambda$2(MavenBuilderImpl.java:159)
	at java.base/java.util.LinkedHashMap.forEach(Unknown Source)
	at org.eclipse.m2e.core.internal.builder.MavenBuilderImpl.build(MavenBuilderImpl.java:139)
	at org.eclipse.m2e.core.internal.builder.MavenBuilder$1.method(MavenBuilder.java:164)
	at org.eclipse.m2e.core.internal.builder.MavenBuilder$1.method(MavenBuilder.java:1)
	at org.eclipse.m2e.core.internal.builder.MavenBuilder$BuildMethod.lambda$1(MavenBuilder.java:109)
	at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.executeBare(MavenExecutionContext.java:458)
	at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.execute(MavenExecutionContext.java:292)
	at org.eclipse.m2e.core.internal.builder.MavenBuilder$BuildMethod.lambda$0(MavenBuilder.java:100)
	at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.executeBare(MavenExecutionContext.java:458)
	at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.execute(MavenExecutionContext.java:339)
	at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.execute(MavenExecutionContext.java:278)
	at org.eclipse.m2e.core.internal.builder.MavenBuilder$BuildMethod.execute(MavenBuilder.java:83)
	at org.eclipse.m2e.core.internal.builder.MavenBuilder.build(MavenBuilder.java:192)
	at org.eclipse.core.internal.events.BuildManager$2.run(BuildManager.java:1109)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:47)
	at org.eclipse.core.internal.events.BuildManager.basicBuild(BuildManager.java:299)
	at org.eclipse.core.internal.events.BuildManager.basicBuild(BuildManager.java:355)
	at org.eclipse.core.internal.events.BuildManager$1.run(BuildManager.java:449)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:47)
	at org.eclipse.core.internal.events.BuildManager.basicBuild(BuildManager.java:452)
	at org.eclipse.core.internal.events.BuildManager.basicBuildLoop(BuildManager.java:564)
	at org.eclipse.core.internal.events.BuildManager.basicBuildLoop(BuildManager.java:512)
	at org.eclipse.core.internal.events.BuildManager.build(BuildManager.java:594)
	at org.eclipse.core.internal.events.AutoBuildJob.doBuild(AutoBuildJob.java:208)
	at org.eclipse.core.internal.events.AutoBuildJob.run(AutoBuildJob.java:309)
	at org.eclipse.core.internal.jobs.Worker.run(Worker.java:63)
Caused by: org.apache.maven.plugin.MojoExecutionException: Artifact has not been packaged yet. When used on reactor artifact, unpack should be executed after packaging: see MDEP-98.
	at org.apache.maven.plugins.dependency.utils.UnpackUtil.unpack(UnpackUtil.java:104)
	at org.apache.maven.plugins.dependency.fromDependencies.UnpackDependenciesMojo.doExecute(UnpackDependenciesMojo.java:121)
	at org.apache.maven.plugins.dependency.AbstractDependencyMojo.execute(AbstractDependencyMojo.java:114)
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:126)
	at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.executeMojo(MavenExecutionContext.java:402)
	... 32 more
```

Tested out with various version of that plugin, and is broken with our configuration starting from the 3.4.0 version ( that's because I placed the (3.3.0, ) range inside the plugin ).

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
