### PR TITLE
[GitHub Actions] Decrease cache size of our Docker images in GitHub Actions

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -164,7 +164,7 @@ jobs:
           # Use GitHub cache to load cached Docker images and cache the results of this build
           # This decreases the number of images we need to fetch from DockerHub
           cache-from: type=gha,scope=${{ inputs.build_id }}
-          cache-to: type=gha,scope=${{ inputs.build_id }},mode=max
+          cache-to: type=gha,scope=${{ inputs.build_id }},mode=min
 
       # Export the digest of Docker build locally
       - name: Export Docker build digest
@@ -216,7 +216,7 @@ jobs:
           # Use GitHub cache to load cached Docker images and cache the results of this build
           # This decreases the number of images we need to fetch from DockerHub
           cache-from: type=gha,scope=${{ inputs.build_id }}
-          cache-to: type=gha,scope=${{ inputs.build_id }},mode=max
+          cache-to: type=gha,scope=${{ inputs.build_id }},mode=min
           # Export image to a local TAR file
           outputs: type=docker,dest=/tmp/${{ inputs.build_id }}.tar
 


### PR DESCRIPTION
## Description
This small PR attempts to decrease the size of our caches in GitHub Actions by changing the Docker image caching `mode` from `max` to `min`.  The `max` mode will cache **all layers**, while the `min` mode will only cache the resulting image's layers.  See docs at https://docs.docker.com/build/cache/backends/#cache-mode

The reason for this change in behavior is because GitHub has changed its caching policies as of October 15, and will strictly apply a 10GB limit per GitHub repository.  The size of our cache in `DSpace/DSpace` seems highly dependent on how frequently PRs are being created/rebuilt...and a large portion of that content _seems to_ be coming from Docker cached layers.  In the last few days though, we've been at about 30-50GB of cached content.

So, the goal of this PR is to minimize what we cache in our Docker builds and see if that helps to keep us closer to the new 10GB limit.  Otherwise, we'd have to investigate whether to [pay for additional caching](https://github.com/orgs/community/discussions/42506).

More information on viewing cache sizes is at https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manage-caches#viewing-cache-entries

## Instructions for Reviewers

This PR cannot be manually tested.  It must be merged so that we can watch the behavior and see if it brings down the cache size closer to the 10GB range.
