### PR TITLE
DSBitStoreService - Use canonical path for bitstream path/assetstore path comparisons

### DIFF
--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/DSBitStoreService.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/DSBitStoreService.java
@@ -256,11 +256,11 @@ public class DSBitStoreService extends BaseBitStoreService {
         Path normalizedPath = bitstreamFile.toPath().normalize();
         String[] allowedAssetstoreRoots = DSpaceServicesFactory.getInstance().getConfigurationService()
                 .getArrayProperty("assetstore.allowed.roots", new String[]{});
-        if (!normalizedPath.startsWith(baseDir.getAbsolutePath())
+        if (!normalizedPath.startsWith(baseDir.getCanonicalPath())
             && !StringUtils.startsWithAny(normalizedPath.toString(), allowedAssetstoreRoots)) {
             log.error("Bitstream path outside of assetstore root requested:" +
                     "bitstream={}, path={}, assetstore={}",
-                    bitstream.getID(), normalizedPath, baseDir.getAbsolutePath());
+                    bitstream.getID(), normalizedPath, baseDir.getCanonicalPath());
             throw new IOException("Illegal bitstream path constructed");
         }
         return bitstreamFile;


### PR DESCRIPTION
Replaced `baseDir.getAbsolutePath()` with `baseDir.getCanonicalPath()` in the bitstream path check.

This is necessary because the "normzalizedPath" is generated via the "getCanonicalFile" method. This method resolves symbolic links, unlike the "getAbsolutePath" method, which does not.

Therefore, when comparing the "normalizedPath" to the "baseDir", it is necessary to use "getCanonicalPath" so that any symbolic links are resolved in the same way.

This issue was uncovered by running the
"org.dspace.storage.bitstore.BitstreamStorageServiceImplIT" integration tests on macOS, in which a temporary file asset store is used. On macOS the temporary files are stored in "/var" which is a symbolic link to "/private/var".

## References

* Fixes #11346
* https://github.com/DSpace/DSpace/pull/10490
* https://github.com/DSpace/DSpace/commit/6799660a903bfea985c818654cca3891527780de
* https://github.com/DSpace/DSpace/commit/6c3274630ce081b8395168149756569689153ce0

## Description

Modified "dspace-api/src/main/java/org/dspace/storage/bitstore/DSBitStoreService.java" to use the "getCanonicalPath" method instead of "getAbsolutePath" when comparing the bitstream path and assetstore paths.

## Instructions for Reviewers

The "DSBitStoreService" class has the following check to verify that the "normalizedPath" of the bitstream falls within the expected "baseDir" of the assetstore:

```
if (!normalizedPath.startsWith(baseDir.getAbsolutePath()))
```

The [java.io.File](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/io/File.html) class contains the following methods for determining the filepath for a file:

* getAbsoluteFile
* getAbsolutePath
* getCanonicalFile
* getCanonicalPath

The difference between the "Absolute" and "Canonical" methods is that the "Canonical" methods will resolve symbolic links, while the "Absolute" methods do not.

In "dspace-api/src/main/java/org/dspace/storage/bitstore/DSBitStoreService.java", the "normalizedPath" is generated using "getCanonicalFile" method. Therefore, when it is compared to "baseDir", the comparison should use the "getCanonicalPath" in the check, not "getAbsolutePath" to ensure that symbolic links are handled identically, i.e.:

```
if (!normalizedPath.startsWith(baseDir.getCanonicalPath()))
```

Also modified the error log output to use. `baseDir.getCanonicalPath()` instead of `baseDir.getAbsolutePath()`.

### Verification Steps

This issue was uncovered by running the integration tests on macOS (specifically the "dspace-api/src/test/java/org/dspace/storage/bitstore/BitstreamStorageServiceImplIT.java" tests), see https://github.com/DSpace/DSpace/issues/11346

Therefore to verify this change, on macOs:

1) Checkout the pull request.

2) Build DSpace:

```
$ mvn clean install
```

3) Run the "BitstreamStorageServiceImplIT" integration test:

```
$ cd dspace-api
$ mvn verify -Dit.test=BitstreamStorageServiceImplIT -DskipIntegrationTests=false
```

and verify that the tests pass.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
