### PR TITLE
Fix for workflow groups are not deleted during the deletion of the associated collection #8063.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
@@ -1165,13 +1165,13 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
                 String roleId = collectionRole.getRoleId();
                 int stepId = -1;
                 switch (roleId) {
-                    case "reviewer":
+                    case CollectionRoleService.LEGACY_WORKFLOW_STEP1_NAME:
                         stepId = 1;
                         break;
-                    case "editor":
+                    case CollectionRoleService.LEGACY_WORKFLOW_STEP2_NAME:
                         stepId = 2;
                         break;
-                    case "finaleditor":
+                    case CollectionRoleService.LEGACY_WORKFLOW_STEP3_NAME:
                         stepId = 3;
                         break;
                     default:


### PR DESCRIPTION
# References
* Fixes DSpace/DSpace#8063

# Description
Remove workflow groups associated with a collection when the collection is deleted.

# Instructions for Reviewers
•	Delete a collection that has one or more workflow groups assigned.
•	Verify that the associated workflow groups are also removed from the database.
•	Confirm that no other collections or unrelated workflow groups are affected.
•	Check for proper handling in both UI and backend.

# List of changes in this PR:
•	Updated CollectionServiceImpl.java to remove workflow groups linked to a collection when the collection is deleted.
 
# How to Test
1.	Log in as a site admin.
2.	Create a new collection and assign roles (reviewer/editor/final-editor) to users.
3.	Deposit items, ensuring some enter the workflow.
4.	Open the Edit Collection panel and delete the collection.
5.	Verify that the workflow groups associated with the deleted collection are removed.
6.	Confirm that other collections and their workflow groups remain unaffected.