### PR TITLE
Feature/branded-preview-filter

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/BrandedPreviewJPEGFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/BrandedPreviewJPEGFilter.java
@@ -1,13 +1,25 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package org.dspace.app.mediafilter;
 
 import java.awt.image.BufferedImage;
-import java.io.FileInputStream;
 import java.io.InputStream;
+
+import javax.imageio.ImageIO;
 
 import org.dspace.content.Item;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 
+/**
+ * BrandedPreviewJPEGFilter generates JPEG previews with branding. Extends
+ * JPEGFilter to reuse thumbnail generation methods.
+ */
 public class BrandedPreviewJPEGFilter extends JPEGFilter {
 
     @Override
@@ -28,10 +40,15 @@ public class BrandedPreviewJPEGFilter extends JPEGFilter {
     @Override
     public InputStream getDestinationStream(Item currentItem, InputStream source, boolean verbose)
             throws Exception {
-        BufferedImage buf = javax.imageio.ImageIO.read(source);
 
-        ConfigurationService configurationService
-                = DSpaceServicesFactory.getInstance().getConfigurationService();
+        // Read the source image
+        BufferedImage buf = ImageIO.read(source);
+
+        // Get configuration parameters
+        ConfigurationService configurationService = DSpaceServicesFactory
+                .getInstance()
+                .getConfigurationService();
+
         float xmax = (float) configurationService.getIntProperty("webui.preview.maxwidth");
         float ymax = (float) configurationService.getIntProperty("webui.preview.maxheight");
         boolean blurring = configurationService.getBooleanProperty("webui.preview.blurring");
@@ -40,17 +57,8 @@ public class BrandedPreviewJPEGFilter extends JPEGFilter {
         String brandFont = configurationService.getProperty("webui.preview.brand.font");
         int brandFontPoint = configurationService.getIntProperty("webui.preview.brand.fontpoint");
 
+        // Use JPEGFilter's method directly
         return getThumbDim(currentItem, buf, verbose, xmax, ymax, blurring, hqscaling,
                 brandHeight, brandFontPoint, brandFont);
-    }
-
-    // Temporary main method for local testing
-    public static void main(String[] args) throws Exception {
-        BrandedPreviewJPEGFilter filter = new BrandedPreviewJPEGFilter();
-        InputStream in = new FileInputStream("test.jpg"); // make sure test.jpg exists
-        Item item = null; // dummy item
-
-        InputStream out = filter.getDestinationStream(item, in, true);
-        System.out.println("Filter ran successfully: " + (out != null));
     }
 }

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/BrandedPreviewJPEGFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/BrandedPreviewJPEGFilter.java
@@ -1,89 +1,56 @@
-/**
- * The contents of this file are subject to the license and copyright
- * detailed in the LICENSE and NOTICE files at the root of the source
- * tree and available online at
- *
- * http://www.dspace.org/license/
- */
 package org.dspace.app.mediafilter;
 
 import java.awt.image.BufferedImage;
+import java.io.FileInputStream;
 import java.io.InputStream;
-import javax.imageio.ImageIO;
 
 import org.dspace.content.Item;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 
-/**
- * Filter image bitstreams, scaling the image to be within the bounds of
- * thumbnail.maxwidth, thumbnail.maxheight, the size we want our thumbnail to be
- * no bigger than. Creates only JPEGs.
- *
- * @author Jason Sherman jsherman@usao.edu
- */
-public class BrandedPreviewJPEGFilter extends MediaFilter {
+public class BrandedPreviewJPEGFilter extends JPEGFilter {
+
     @Override
     public String getFilteredName(String oldFilename) {
         return oldFilename + ".preview.jpg";
     }
 
-    /**
-     * @return String bundle name
-     */
     @Override
     public String getBundleName() {
         return "BRANDED_PREVIEW";
     }
 
-    /**
-     * @return String bitstreamformat
-     */
-    @Override
-    public String getFormatString() {
-        return "JPEG";
-    }
-
-    /**
-     * @return String description
-     */
     @Override
     public String getDescription() {
         return "Generated Branded Preview";
     }
 
-
-    /**
-     * @param currentItem item
-     * @param source      source input stream
-     * @param verbose     verbose mode
-     * @return InputStream the resulting input stream
-     * @throws Exception if error
-     */
     @Override
     public InputStream getDestinationStream(Item currentItem, InputStream source, boolean verbose)
-        throws Exception {
-        // read in bitstream's image
-        BufferedImage buf = ImageIO.read(source);
+            throws Exception {
+        BufferedImage buf = javax.imageio.ImageIO.read(source);
 
-        // get config params
         ConfigurationService configurationService
                 = DSpaceServicesFactory.getInstance().getConfigurationService();
-        float xmax = (float) configurationService
-            .getIntProperty("webui.preview.maxwidth");
-        float ymax = (float) configurationService
-            .getIntProperty("webui.preview.maxheight");
-        boolean blurring = (boolean) configurationService
-            .getBooleanProperty("webui.preview.blurring");
-        boolean hqscaling = (boolean) configurationService
-            .getBooleanProperty("webui.preview.hqscaling");
+        float xmax = (float) configurationService.getIntProperty("webui.preview.maxwidth");
+        float ymax = (float) configurationService.getIntProperty("webui.preview.maxheight");
+        boolean blurring = configurationService.getBooleanProperty("webui.preview.blurring");
+        boolean hqscaling = configurationService.getBooleanProperty("webui.preview.hqscaling");
         int brandHeight = configurationService.getIntProperty("webui.preview.brand.height");
         String brandFont = configurationService.getProperty("webui.preview.brand.font");
         int brandFontPoint = configurationService.getIntProperty("webui.preview.brand.fontpoint");
 
-        JPEGFilter jpegFilter = new JPEGFilter();
-        return jpegFilter
-            .getThumbDim(currentItem, buf, verbose, xmax, ymax, blurring, hqscaling, brandHeight, brandFontPoint,
-                         brandFont);
+        return getThumbDim(currentItem, buf, verbose, xmax, ymax, blurring, hqscaling,
+                brandHeight, brandFontPoint, brandFont);
+    }
+
+    // Temporary main method for local testing
+    public static void main(String[] args) throws Exception {
+        BrandedPreviewJPEGFilter filter = new BrandedPreviewJPEGFilter();
+        InputStream in = new FileInputStream("test.jpg"); // make sure test.jpg exists
+        Item item = null; // dummy item
+
+        InputStream out = filter.getDestinationStream(item, in, true);
+        System.out.println("Filter ran successfully: " + (out != null));
     }
 }

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/BrandedPreviewJPEGFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/BrandedPreviewJPEGFilter.java
@@ -9,7 +9,6 @@ package org.dspace.app.mediafilter;
 
 import java.awt.image.BufferedImage;
 import java.io.InputStream;
-
 import javax.imageio.ImageIO;
 
 import org.dspace.content.Item;

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/BrandedPreviewJPEGFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/BrandedPreviewJPEGFilter.java
@@ -37,6 +37,15 @@ public class BrandedPreviewJPEGFilter extends JPEGFilter {
         return "Generated Branded Preview";
     }
 
+    /**
+     * Generates a branded JPEG preview of the given item's image.
+     *
+     * @param currentItem the item associated with the bitstream
+     * @param source the source InputStream
+     * @param verbose whether verbose logging is enabled
+     * @return InputStream the resulting branded JPEG preview
+     * @throws Exception if an error occurs during processing
+     */
     @Override
     public InputStream getDestinationStream(Item currentItem, InputStream source, boolean verbose)
             throws Exception {


### PR DESCRIPTION
## References
Fixes #8913

## Description
This PR refactors the BrandedPreviewJPEGFilter class to extend JPEGFilter instead of MediaFilter. This allows direct reuse of the thumbnail generation methods in JPEGFilter and eliminates unnecessary duplication of logic.

## Instructions for Reviewers

**List of changes in this PR:**
- BrandedPreviewJPEGFilter now extends JPEGFilter rather than MediaFilter.
- Removed creation of a separate JPEGFilter instance inside getDestinationStream().
- Simplified imports and removed unused local testing code (no FileInputStream or main method).
- The filter now directly uses JPEGFilter’s getThumbDim() method to generate branded previews.

**Testing instructions:**
1. Ensure your DSpace instance is compiled with the updated BrandedPreviewJPEGFilter.
2. Add a sample image bitstream to an item.
3. Run the media filter (or upload via the web UI) and verify a branded preview JPEG is created in the BRANDED_PREVIEW bundle.
4. Confirm the image dimensions respect the webui.preview.maxwidth and webui.preview.maxheight properties.
