### PR TITLE
fix: correct date formatting in DateUtils and add unit test

### DIFF
--- a/dspace-oai/src/main/java/org/dspace/xoai/util/DateUtils.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/util/DateUtils.java
@@ -8,7 +8,6 @@
 package org.dspace.xoai.util;
 
 import java.time.Instant;
-import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
@@ -36,13 +35,8 @@ public class DateUtils {
      * @return UTC date string
      */
     public static String format(Instant date) {
-        // NOTE: OAI-PMH REQUIRES that all dates be expressed in UTC format
-        // as YYYY-MM-DDThh:mm:ssZ  For more details, see
-        // http://www.openarchives.org/OAI/openarchivesprotocol.html#DatestampsResponses
-
         Instant truncated = date.truncatedTo(ChronoUnit.SECONDS);
         return DateTimeFormatter.ISO_INSTANT.format(truncated);
-        
     }
 
     /**

--- a/dspace-oai/src/main/java/org/dspace/xoai/util/DateUtils.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/util/DateUtils.java
@@ -8,8 +8,10 @@
 package org.dspace.xoai.util;
 
 import java.time.Instant;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoUnit;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -38,8 +40,9 @@ public class DateUtils {
         // as YYYY-MM-DDThh:mm:ssZ  For more details, see
         // http://www.openarchives.org/OAI/openarchivesprotocol.html#DatestampsResponses
 
-        // toString returns the correct format
-        return date.toString();
+        Instant truncated = date.truncatedTo(ChronoUnit.SECONDS);
+        return DateTimeFormatter.ISO_INSTANT.format(truncated);
+        
     }
 
     /**

--- a/dspace-oai/src/test/java/org/dspace/xoai/tests/unit/util/DateUtilsTest.java
+++ b/dspace-oai/src/test/java/org/dspace/xoai/tests/unit/util/DateUtilsTest.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package org.dspace.xoai.tests.unit.util;
 
 import org.dspace.xoai.util.DateUtils;

--- a/dspace-oai/src/test/java/org/dspace/xoai/tests/unit/util/DateUtilsTest.java
+++ b/dspace-oai/src/test/java/org/dspace/xoai/tests/unit/util/DateUtilsTest.java
@@ -7,13 +7,12 @@
  */
 package org.dspace.xoai.tests.unit.util;
 
+import static org.junit.Assert.assertEquals;
+
 import java.time.Instant;
 
-import org.junit.Test;
-
 import org.dspace.xoai.util.DateUtils;
-
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
 
 public class DateUtilsTest {
 

--- a/dspace-oai/src/test/java/org/dspace/xoai/tests/unit/util/DateUtilsTest.java
+++ b/dspace-oai/src/test/java/org/dspace/xoai/tests/unit/util/DateUtilsTest.java
@@ -7,16 +7,18 @@
  */
 package org.dspace.xoai.tests.unit.util;
 
-import org.dspace.xoai.util.DateUtils;
+import java.time.Instant;
+
 import org.junit.Test;
 
-import java.time.Instant;
+import org.dspace.xoai.util.DateUtils;
+
 import static org.junit.Assert.assertEquals;
 
 public class DateUtilsTest {
 
     @Test
-    public void testFormatOaiDate(){
+    public void testFormatOaiDate() {
         Instant date = Instant.parse("2025-10-09T18:53:58.376565922Z");
         String formatted = DateUtils.format(date);
         assertEquals("2025-10-09T18:53:58Z", formatted);

--- a/dspace-oai/src/test/java/org/dspace/xoai/tests/unit/util/DateUtilsTest.java
+++ b/dspace-oai/src/test/java/org/dspace/xoai/tests/unit/util/DateUtilsTest.java
@@ -1,0 +1,17 @@
+package org.dspace.xoai.tests.unit.util;
+
+import org.dspace.xoai.util.DateUtils;
+import org.junit.Test;
+
+import java.time.Instant;
+import static org.junit.Assert.assertEquals;
+
+public class DateUtilsTest {
+
+    @Test
+    public void testFormatOaiDate(){
+        Instant date = Instant.parse("2025-10-09T18:53:58.376565922Z");
+        String formatted = DateUtils.format(date);
+        assertEquals("2025-10-09T18:53:58Z", formatted);
+    }
+}


### PR DESCRIPTION
Ensure OAI date formatting truncates nanoseconds and matches expected ISO pattern.

## References
* Fixes #11129 — DSpace 9 fails validation at Open Archives (responseDate includes decimal seconds)

## Description
This PR fixes `DateUtils.format(Instant)` so OAI-PMH `<responseDate>` values do not include fractional seconds (nanoseconds/milliseconds). Previously timestamps like `2025-10-09T18:53:58.376565922Z` were produced, which fail OAI-PMH validation. The formatting now matches the required ISO pattern `YYYY-MM-DDThh:mm:ssZ`.

## Instructions for Reviewers

### List of changes
* Modify `org.dspace.xoai.util.DateUtils.format(Instant)` to produce timestamps without fractional seconds, using the UTC pattern yyyy-MM-dd'T'HH:mm:ss'Z'. 
* Add unit test `src/test/java/org/dspace/xoai/tests/unit/util/DateUtilsTest.java` which verifies that an `Instant` containing nanoseconds is formatted to `YYYY-MM-DDThh:mm:ssZ`.

### How to test / review

#### 1) Unit test (fast, recommended)
From repository root run:
```
mvn test -pl dspace-oai -Dtest=org.dspace.xoai.tests.unit.util.DateUtilsTest -DskipUnitTests=false
```

Or run all `dspace-oai` unit tests:
```
mvn clean test -pl dspace-oai -DskipUnitTests=false -DskipIntegrationTests=true
```

#### Notes for reviewers
* I ran unit tests locally only for the `dspace-oai` module. CI should run the project-wide test suite and integration tests.
* Implementation note: the `DateTimeFormatter` may be promoted to a `private static final` formatter if maintainers prefer that micro-optimization — happy to adjust if requested.

## Checklist
- [x] My PR is **created against the `main` branch**.
- [x] My PR is **small in size** (fix + unit test).
- [x] My PR **passes Checkstyle** validation (not run locally; CI will verify).
- [ ] My PR **includes Javadoc** for new/modified public APIs (not applicable — internal util change).
- [x] My PR **adds/updates unit tests** for the change (`DateUtilsTest`).
- [x] I have provided **clear testing instructions** in this PR.
- [ ] If my PR includes new libraries/dependencies, licenses align (not applicable).
- [ ] If my PR modifies REST API endpoints, REST Contract PR exists (not applicable).
- [ ] If my PR includes new configurations, basic technical documentation provided (not applicable).
- [x] If my PR fixes an issue ticket, it is **linked** (`Fixes #11129`).
