### PR TITLE
[DSpace-CRIS] Fixed Recipients Email Feature

### DIFF
--- a/dspace-api/src/main/java/org/dspace/core/Email.java
+++ b/dspace-api/src/main/java/org/dspace/core/Email.java
@@ -368,8 +368,9 @@ public class Email {
      */
     private static boolean isValidEmail() {
         ConfigurationService config = DSpaceServicesFactory.getInstance().getConfigurationService();
+        boolean disabled = isMailServerDisabled(config);
         String[] fixedRecipient = config.getArrayProperty("mail.server.fixedRecipient", new String[] { });
-        return fixedRecipient.length > 0 && isMailServerDisabled(config);
+        return !disabled || fixedRecipient.length > 0;
     }
 
     /**

--- a/dspace-api/src/test/java/org/dspace/core/EmailTest.java
+++ b/dspace-api/src/test/java/org/dspace/core/EmailTest.java
@@ -89,7 +89,7 @@ public class EmailTest
         assertThat("Exactly one 'To:' recipient expected.", recipients.length, is(1));
         assertThat("CatchAll recipient should receive the email", recipients[0].getAddress(), is("fixed@example.com"));
 
-        // Check that original recipient is included in the body
+        // Check that original recipient marker is included in the body
         String messageBody = message.getContent().toString();
         assertThat("Original recipient should be included in email body",
                 messageBody, containsString("original@example.com"));
@@ -121,7 +121,7 @@ public class EmailTest
     }
 
     @Test
-    public void testDisabledServerWithoutCatchAllRecipient()
+    public void testEmailWithoutCatchAllRecipient()
             throws MessagingException, IOException {
         config.setProperty("mail.server.disabled", "false");
         config.setProperty("mail.server.catchAll.enabled", "true");
@@ -142,9 +142,9 @@ public class EmailTest
         assertThat("Original recipient should receive the email", recipients[0].getAddress(),
                    is("original@example.com"));
 
-        // Check that original recipient is NOT included in the body (normal behavior)
+        // Check that real recipient marker is NOT included in the body (normal behavior)
         String messageBody = message.getContent().toString();
-        assertThat("Original recipient should NOT be included in email body for normal disabled behavior",
+        assertThat("Real recipient marker should NOT be included in email body for normal disabled behavior",
                 messageBody, not(containsString("===REAL RECIPIENT===")));
     }
 
@@ -168,9 +168,9 @@ public class EmailTest
         assertThat("Original recipient should receive the email",
                    recipients[0].getAddress(), is("original@example.com"));
 
-        // Check that original recipient is NOT included in the body (normal behavior)
+        // Check that real recipient marker is NOT included in the body (normal behavior)
         String messageBody = message.getContent().toString();
-        assertThat("Original recipient should NOT be included in email body for normal sending",
+        assertThat("Real recipient marker should NOT be included in email body for normal sending",
                 messageBody, not(containsString("===REAL RECIPIENT===")));
     }
 
@@ -226,7 +226,7 @@ public class EmailTest
         assertThat("CC field should be null for catchAll recipient", ccRecipients, Matchers.nullValue());
 
         assertThat(
-            "Original recipient should NOT be included in email body for normal disabled behavior",
+            "Real recipient marker should NOT be included in email body",
             message.getContent().toString(),
             not(containsString("===REAL RECIPIENT==="))
         );

--- a/dspace-api/src/test/java/org/dspace/core/EmailTest.java
+++ b/dspace-api/src/test/java/org/dspace/core/EmailTest.java
@@ -9,11 +9,14 @@ package org.dspace.core;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
 import java.io.IOException;
 
 import jakarta.mail.MessagingException;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
 import org.dspace.AbstractDSpaceTest;
 import org.dspace.services.ConfigurationService;
 import org.junit.Before;
@@ -64,5 +67,167 @@ public class EmailTest
         String message = email.getMessage();
         assertThat("Null message parameter should be transformed to empty",
                 message, containsString(testParam));
+    }
+
+    @Test
+    public void testFixedRecipientWithDisabledServer()
+            throws MessagingException, IOException {
+        // Configure mail server as disabled with fixed recipient
+        config.setProperty("mail.server.disabled", "true");
+        config.setProperty("mail.server.fixedRecipient", "fixed@example.com");
+
+        Email email = new Email();
+        email.setContent("fixed recipient test",
+                "This is a test email that should go to fixed recipient.");
+        email.addRecipient("original@example.com");
+        email.build();
+
+        MimeMessage message = email.message;
+        InternetAddress[] recipients = (InternetAddress[]) message.getRecipients(MimeMessage.RecipientType.TO);
+
+        assertThat("Email should be sent to fixed recipient", recipients.length, is(1));
+        assertThat("Fixed recipient should receive the email", recipients[0].getAddress(), is("fixed@example.com"));
+
+        // Check that original recipient is included in the body
+        String messageBody = message.getContent().toString();
+        assertThat("Original recipient should be included in email body",
+                messageBody, containsString("original@example.com"));
+        assertThat("Email body should contain REAL RECIPIENT marker",
+                messageBody, containsString("===REAL RECIPIENT==="));
+    }
+
+    @Test
+    public void testMultipleFixedRecipients()
+            throws MessagingException, IOException {
+        // Configure mail server as disabled with multiple fixed recipients
+        config.setProperty("mail.server.disabled", "true");
+        config.setProperty("mail.server.fixedRecipient", "fixed1@example.com,fixed2@example.com");
+
+        Email email = new Email();
+        email.setContent("multiple fixed recipients test",
+                "This is a test email that should go to multiple fixed recipients.");
+        email.addRecipient("original@example.com");
+        email.build();
+
+        MimeMessage message = email.message;
+        InternetAddress[] recipients = (InternetAddress[]) message.getRecipients(MimeMessage.RecipientType.TO);
+
+        assertThat("Email should be sent to both fixed recipients", recipients.length, is(2));
+        assertThat("First fixed recipient should receive the email", recipients[0].getAddress(),
+                   is("fixed1@example.com"));
+        assertThat("Second fixed recipient should receive the email", recipients[1].getAddress(),
+                   is("fixed2@example.com"));
+    }
+
+    @Test
+    public void testDisabledServerWithoutFixedRecipient()
+            throws MessagingException, IOException {
+        // Configure mail server as disabled but without fixed recipient
+        config.setProperty("mail.server.disabled", "true");
+        config.setProperty("mail.server.fixedRecipient", "");
+
+        Email email = new Email();
+        email.setContent("disabled server test",
+                "This is a test email that should not be sent.");
+        email.addRecipient("original@example.com");
+        email.build();
+
+        // When disabled and no fixed recipient, message is still created but sent to original recipient
+        MimeMessage message = email.message;
+        InternetAddress[] recipients = (InternetAddress[]) message.getRecipients(MimeMessage.RecipientType.TO);
+
+        assertThat("Message should be created", message, is(not((MimeMessage) null)));
+        assertThat("Email should be sent to original recipient when no fixed recipient configured",
+                recipients.length, is(1));
+        assertThat("Original recipient should receive the email", recipients[0].getAddress(),
+                   is("original@example.com"));
+
+        // Check that original recipient is NOT included in the body (normal behavior)
+        String messageBody = message.getContent().toString();
+        assertThat("Original recipient should NOT be included in email body for normal disabled behavior",
+                messageBody, not(containsString("===REAL RECIPIENT===")));
+    }
+
+    @Test
+    public void testNormalEmailSendingWithFixedRecipientConfigured()
+            throws MessagingException, IOException {
+        // Configure mail server as enabled but with fixed recipient configured
+        config.setProperty("mail.server.disabled", "false");
+        config.setProperty("mail.server.fixedRecipient", "fixed@example.com");
+
+        Email email = new Email();
+        email.setContent("normal sending test",
+                "This is a test email that should go to original recipient.");
+        email.addRecipient("original@example.com");
+        email.build();
+
+        MimeMessage message = email.message;
+        InternetAddress[] recipients = (InternetAddress[]) message.getRecipients(MimeMessage.RecipientType.TO);
+
+        assertThat("Email should be sent to original recipient when server is enabled",
+                   recipients.length, is(1));
+        assertThat("Original recipient should receive the email",
+                   recipients[0].getAddress(), is("original@example.com"));
+
+        // Check that original recipient is NOT included in the body (normal behavior)
+        String messageBody = message.getContent().toString();
+        assertThat("Original recipient should NOT be included in email body for normal sending",
+                messageBody, not(containsString("===REAL RECIPIENT===")));
+    }
+
+    @Test
+    public void testFixedRecipientWithCCRecipients()
+            throws MessagingException, IOException {
+        // Configure mail server as disabled with fixed recipient
+        config.setProperty("mail.server.disabled", "true");
+        config.setProperty("mail.server.fixedRecipient", "fixed@example.com");
+
+        Email email = new Email();
+        email.setContent("CC recipients test",
+                "This is a test email with CC recipients.");
+        email.addRecipient("original@example.com");
+        // Note: In the current implementation, CC addresses need to be added via the message directly
+        // For this test, we'll verify the structure is ready for CC handling
+        email.build();
+
+        MimeMessage message = email.message;
+        InternetAddress[] recipients = (InternetAddress[]) message.getRecipients(MimeMessage.RecipientType.TO);
+        InternetAddress[] ccRecipients = (InternetAddress[]) message.getRecipients(MimeMessage.RecipientType.CC);
+
+        assertThat("Email should be sent to fixed recipient", recipients.length, is(1));
+        assertThat("Fixed recipient should receive the email", recipients[0].getAddress(), is("fixed@example.com"));
+        assertThat("CC field should be null for fixed recipient", ccRecipients, is((InternetAddress[]) null));
+
+
+        // Check that original recipient is included in the body
+        String messageBody = message.getContent().toString();
+        assertThat("Original recipient should be included in email body",
+                messageBody, containsString("original@example.com"));
+    }
+
+    @Test
+    public void testFixedRecipientLogging()
+            throws MessagingException, IOException {
+        // Configure mail server as disabled with fixed recipient
+        config.setProperty("mail.server.disabled", "true");
+        config.setProperty("mail.server.fixedRecipient", "fixed@example.com");
+
+        Email email = new Email();
+        email.setContent("logging test",
+                "This is a test email for logging verification.");
+        email.addRecipient("original@example.com");
+        email.build();
+
+        // Get the logged message (this simulates what would be logged)
+        String loggedMessage = email.getMessage();
+
+        assertThat("Logged message should contain fixed recipient info",
+                loggedMessage, containsString("fixed@example.com"));
+        assertThat("Logged message should contain original recipient info",
+                loggedMessage, containsString("original@example.com"));
+        assertThat("Logged message should indicate disabled server",
+                loggedMessage, containsString("Message not sent due to mail.server.disabled"));
+        assertThat("Logged message should contain REAL RECIPIENT section",
+                loggedMessage, containsString("===REAL RECIPIENT==="));
     }
 }

--- a/dspace-api/src/test/java/org/dspace/core/EmailTest.java
+++ b/dspace-api/src/test/java/org/dspace/core/EmailTest.java
@@ -222,7 +222,8 @@ public class EmailTest
         InternetAddress[] ccRecipients = (InternetAddress[]) message.getRecipients(MimeMessage.RecipientType.CC);
 
         assertThat("Message should have exactly one recipient.", recipients.length, is(1));
-        assertThat("Original recipient should receive the email", recipients[0].getAddress(), is("original@example.com"));
+        assertThat("Original recipient should receive the email", recipients[0].getAddress(),
+                   is("original@example.com"));
         assertThat("CC field should be null for catchAll recipient", ccRecipients, Matchers.nullValue());
 
         assertThat(

--- a/dspace-api/src/test/java/org/dspace/core/EmailTest.java
+++ b/dspace-api/src/test/java/org/dspace/core/EmailTest.java
@@ -70,23 +70,22 @@ public class EmailTest
     }
 
     @Test
-    public void testFixedRecipientWithDisabledServer()
+    public void testCatchAllRecipientWithDisabledServer()
             throws MessagingException, IOException {
-        // Configure mail server as disabled with fixed recipient
-        config.setProperty("mail.server.disabled", "true");
-        config.setProperty("mail.server.fixedRecipient", "fixed@example.com");
+        config.setProperty("mail.server.catchAll.enabled", "true");
+        config.setProperty("mail.server.catchAll.recipient", "fixed@example.com");
 
         Email email = new Email();
         email.setContent("fixed recipient test",
-                "This is a test email that should go to fixed recipient.");
+                "This is a test email that should go to catchAll recipient.");
         email.addRecipient("original@example.com");
         email.build();
 
         MimeMessage message = email.message;
         InternetAddress[] recipients = (InternetAddress[]) message.getRecipients(MimeMessage.RecipientType.TO);
 
-        assertThat("Email should be sent to fixed recipient", recipients.length, is(1));
-        assertThat("Fixed recipient should receive the email", recipients[0].getAddress(), is("fixed@example.com"));
+        assertThat("Email should be sent to catchAll recipient", recipients.length, is(1));
+        assertThat("CatchAll recipient should receive the email", recipients[0].getAddress(), is("fixed@example.com"));
 
         // Check that original recipient is included in the body
         String messageBody = message.getContent().toString();
@@ -97,34 +96,32 @@ public class EmailTest
     }
 
     @Test
-    public void testMultipleFixedRecipients()
+    public void testMultipleCatchAllRecipients()
             throws MessagingException, IOException {
-        // Configure mail server as disabled with multiple fixed recipients
         config.setProperty("mail.server.disabled", "true");
-        config.setProperty("mail.server.fixedRecipient", "fixed1@example.com,fixed2@example.com");
+        config.setProperty("mail.server.catchAll.recipient", "fixed1@example.com,fixed2@example.com");
 
         Email email = new Email();
-        email.setContent("multiple fixed recipients test",
-                "This is a test email that should go to multiple fixed recipients.");
+        email.setContent("multiple catchAll recipients test",
+                "This is a test email that should go to multiple catchAll recipients.");
         email.addRecipient("original@example.com");
         email.build();
 
         MimeMessage message = email.message;
         InternetAddress[] recipients = (InternetAddress[]) message.getRecipients(MimeMessage.RecipientType.TO);
 
-        assertThat("Email should be sent to both fixed recipients", recipients.length, is(2));
-        assertThat("First fixed recipient should receive the email", recipients[0].getAddress(),
+        assertThat("Email should be sent to both catchAll recipients", recipients.length, is(2));
+        assertThat("First catchAll recipient should receive the email", recipients[0].getAddress(),
                    is("fixed1@example.com"));
-        assertThat("Second fixed recipient should receive the email", recipients[1].getAddress(),
+        assertThat("Second catchAll recipient should receive the email", recipients[1].getAddress(),
                    is("fixed2@example.com"));
     }
 
     @Test
-    public void testDisabledServerWithoutFixedRecipient()
+    public void testDisabledServerWithoutCatchAllRecipient()
             throws MessagingException, IOException {
-        // Configure mail server as disabled but without fixed recipient
         config.setProperty("mail.server.disabled", "true");
-        config.setProperty("mail.server.fixedRecipient", "");
+        config.setProperty("mail.server.catchAll.recipient", "");
 
         Email email = new Email();
         email.setContent("disabled server test",
@@ -132,12 +129,11 @@ public class EmailTest
         email.addRecipient("original@example.com");
         email.build();
 
-        // When disabled and no fixed recipient, message is still created but sent to original recipient
         MimeMessage message = email.message;
         InternetAddress[] recipients = (InternetAddress[]) message.getRecipients(MimeMessage.RecipientType.TO);
 
         assertThat("Message should be created", message, is(not((MimeMessage) null)));
-        assertThat("Email should be sent to original recipient when no fixed recipient configured",
+        assertThat("Email should be sent to original recipient when no catchAll recipient configured",
                 recipients.length, is(1));
         assertThat("Original recipient should receive the email", recipients[0].getAddress(),
                    is("original@example.com"));
@@ -149,11 +145,10 @@ public class EmailTest
     }
 
     @Test
-    public void testNormalEmailSendingWithFixedRecipientConfigured()
+    public void testNormalEmailSendingWithCatchAllRecipientConfigured()
             throws MessagingException, IOException {
-        // Configure mail server as enabled but with fixed recipient configured
-        config.setProperty("mail.server.disabled", "false");
-        config.setProperty("mail.server.fixedRecipient", "fixed@example.com");
+        config.setProperty("mail.server.catchAll.enabled", "false");
+        config.setProperty("mail.server.catchAll.recipient", "fixed@example.com");
 
         Email email = new Email();
         email.setContent("normal sending test",
@@ -176,11 +171,10 @@ public class EmailTest
     }
 
     @Test
-    public void testFixedRecipientWithCCRecipients()
+    public void testCatchAllRecipientWithCCRecipients()
             throws MessagingException, IOException {
-        // Configure mail server as disabled with fixed recipient
-        config.setProperty("mail.server.disabled", "true");
-        config.setProperty("mail.server.fixedRecipient", "fixed@example.com");
+        config.setProperty("mail.server.catchAll.enabled", "true");
+        config.setProperty("mail.server.catchAll.recipient", "fixed@example.com");
 
         Email email = new Email();
         email.setContent("CC recipients test",
@@ -194,9 +188,9 @@ public class EmailTest
         InternetAddress[] recipients = (InternetAddress[]) message.getRecipients(MimeMessage.RecipientType.TO);
         InternetAddress[] ccRecipients = (InternetAddress[]) message.getRecipients(MimeMessage.RecipientType.CC);
 
-        assertThat("Email should be sent to fixed recipient", recipients.length, is(1));
-        assertThat("Fixed recipient should receive the email", recipients[0].getAddress(), is("fixed@example.com"));
-        assertThat("CC field should be null for fixed recipient", ccRecipients, is((InternetAddress[]) null));
+        assertThat("Email should be sent to catchAll recipient", recipients.length, is(1));
+        assertThat("CatchAll recipient should receive the email", recipients[0].getAddress(), is("fixed@example.com"));
+        assertThat("CC field should be null for catchAll recipient", ccRecipients, is((InternetAddress[]) null));
 
 
         // Check that original recipient is included in the body
@@ -206,11 +200,10 @@ public class EmailTest
     }
 
     @Test
-    public void testFixedRecipientLogging()
+    public void testCatchAllRecipientsLogging()
             throws MessagingException, IOException {
-        // Configure mail server as disabled with fixed recipient
-        config.setProperty("mail.server.disabled", "true");
-        config.setProperty("mail.server.fixedRecipient", "fixed@example.com");
+        config.setProperty("mail.server.catchAll.enabled", "true");
+        config.setProperty("mail.server.catchAll.recipient", "fixed@example.com");
 
         Email email = new Email();
         email.setContent("logging test",
@@ -221,12 +214,10 @@ public class EmailTest
         // Get the logged message (this simulates what would be logged)
         String loggedMessage = email.getMessage();
 
-        assertThat("Logged message should contain fixed recipient info",
+        assertThat("Logged message should contain catchAllrecipient info",
                 loggedMessage, containsString("fixed@example.com"));
         assertThat("Logged message should contain original recipient info",
                 loggedMessage, containsString("original@example.com"));
-        assertThat("Logged message should indicate disabled server",
-                loggedMessage, containsString("Message not sent due to mail.server.disabled"));
         assertThat("Logged message should contain REAL RECIPIENT section",
                 loggedMessage, containsString("===REAL RECIPIENT==="));
     }

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -205,8 +205,11 @@ mail.charset = UTF-8
 # It will instead log the subject of the email which should have been sent
 # This is especially useful for development and test environments where production data is used when testing functionality.
 #mail.server.disabled = false
-# If the mail.server.fixedRecipient is not empty then only in the case mail.server.disabled = true all email will be sent to this email address.
-#mail.server.fixedRecipient =
+# Enables the catchAll system, more details downer.
+#mail.server.catchAll.enabled = true
+# If the mail.server.catchAll.recipient is set and has been enabled with mail.server.catchAll.enabled all the emails will
+# be sent to these recipients ( comma separated list ), instead of original ones.
+#mail.server.catchAll.recipient =
 
 # Message headers which may be set within a message template by assigning values
 # to Velocity properties.  Only the properties named here will be interpreted as

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -205,6 +205,8 @@ mail.charset = UTF-8
 # It will instead log the subject of the email which should have been sent
 # This is especially useful for development and test environments where production data is used when testing functionality.
 #mail.server.disabled = false
+# If the mail.server.fixedRecipient is not empty then only in the case mail.server.disabled = true all email will be sent to this email address.
+#mail.server.fixedRecipient =
 
 # Message headers which may be set within a message template by assigning values
 # to Velocity properties.  Only the properties named here will be interpreted as

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -205,7 +205,7 @@ mail.charset = UTF-8
 # It will instead log the subject of the email which should have been sent
 # This is especially useful for development and test environments where production data is used when testing functionality.
 #mail.server.disabled = false
-# Enables the catchAll system, more details downer.
+# Enables the catchAll system
 #mail.server.catchAll.enabled = true
 # If the mail.server.catchAll.recipient is set and has been enabled with mail.server.catchAll.enabled all the emails will
 # be sent to these recipients ( comma separated list ), instead of original ones.

--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -134,6 +134,14 @@ db.password = dspace
 # Recipient for new user registration emails (defaults to unspecified)
 #registration.notify =
 
+# An option is added to disable the mailserver. By default, this property is set to false
+# By setting mail.server.disabled = true, DSpace will not send out emails.
+# It will instead log the subject of the email which should have been sent
+# This is especially useful for development and test environments where production data is used when testing functionality.
+#mail.server.disabled = false
+# If the mail.server.fixedRecipient is not empty then only in the case mail.server.disabled = true all email will be sent to this email address.
+#mail.server.fixedRecipient =
+
 
 ########################
 # HANDLE CONFIGURATION #

--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -139,7 +139,7 @@ db.password = dspace
 # It will instead log the subject of the email which should have been sent
 # This is especially useful for development and test environments where production data is used when testing functionality.
 #mail.server.disabled = false
-# Enables the catchAll system, more details downer.
+# Enables the catchAll system
 #mail.server.catchAll.enabled = true
 # If the mail.server.catchAll.recipient is set and has been enabled with mail.server.catchAll.enabled all the emails will
 # be sent to these recipients ( comma separated list ), instead of original ones.

--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -139,8 +139,11 @@ db.password = dspace
 # It will instead log the subject of the email which should have been sent
 # This is especially useful for development and test environments where production data is used when testing functionality.
 #mail.server.disabled = false
-# If the mail.server.fixedRecipient is not empty then only in the case mail.server.disabled = true all email will be sent to this email address.
-#mail.server.fixedRecipient =
+# Enables the catchAll system, more details downer.
+#mail.server.catchAll.enabled = true
+# If the mail.server.catchAll.recipient is set and has been enabled with mail.server.catchAll.enabled all the emails will
+# be sent to these recipients ( comma separated list ), instead of original ones.
+#mail.server.catchAll.recipient =
 
 
 ########################

--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -134,17 +134,6 @@ db.password = dspace
 # Recipient for new user registration emails (defaults to unspecified)
 #registration.notify =
 
-# An option is added to disable the mailserver. By default, this property is set to false
-# By setting mail.server.disabled = true, DSpace will not send out emails.
-# It will instead log the subject of the email which should have been sent
-# This is especially useful for development and test environments where production data is used when testing functionality.
-#mail.server.disabled = false
-# Enables the catchAll system
-#mail.server.catchAll.enabled = true
-# If the mail.server.catchAll.recipient is set and has been enabled with mail.server.catchAll.enabled all the emails will
-# be sent to these recipients ( comma separated list ), instead of original ones.
-#mail.server.catchAll.recipient =
-
 
 ########################
 # HANDLE CONFIGURATION #


### PR DESCRIPTION
## Description
This PR introduces a new feature that will allow to send all the emails to a given list of emails ( `catchAllRecipients` ).
- When `mail.server.catchAll.enabled=true` and `mail.server.catchAll.recipient` is configured:  
  - * All emails are sent to catchAll recipients instead of original recipients
  - * Original recipients are logged and appended to email body for reference
  - * Useful for development and test environments

## Instructions for Reviewers
Try to configure the following properties:
-  `mail.server.catchAll.recipient = youremail`
-  `mail.server.catchAll.enabled=true`
Then try to sent an email, you should verify that the email will be sent to that specified email address.

List of changes in this PR:
- Added support for catchAll.recipient in Email.java
- Added catchAll configurations in dspace.cfg and local.cfg.EXAMPLE
- Added Arrays import and ccAddresses field to Email.java
- Implemented fixedRecipient logic in build() method
- When `mail.server.disabled=true` and `mail.server.catchAll.enabled=true` is configured:  
  - * All emails are sent to catchAll recipients instead of original recipients
  - * Original recipients are logged and appended to email body for reference
  - * Useful for development and test environments

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
