### PR TITLE
Fix/9698 add configuration to disable usage statistics

### DIFF
--- a/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerUsageEventListener.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerUsageEventListener.java
@@ -37,6 +37,14 @@ public class SolrLoggerUsageEventListener extends AbstractUsageEventListener {
     @Autowired
     private ConfigurationService configurationService;
 
+    /**
+     * Setter for ConfigurationService, primarily for dependency injection.
+     * @param configurationService the configuration service
+     */
+    public void setConfigurationService(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
+    }
+
     @Autowired
     public void setSolrLoggerService(SolrLoggerService solrLoggerService) {
         this.solrLoggerService = solrLoggerService;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/CanViewUsageStatisticsFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/CanViewUsageStatisticsFeature.java
@@ -49,6 +49,11 @@ public class CanViewUsageStatisticsFeature implements AuthorizationFeature {
     @Override
     @SuppressWarnings("rawtypes")
     public boolean isAuthorized(Context context, BaseObjectRest object) throws SQLException {
+
+        if (!configurationService.getBooleanProperty("usage-statistics.enabled", true)) {
+            return false;
+        }
+
         if (object instanceof SiteRest
             || object instanceof CommunityRest
             || object instanceof CollectionRest

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/ViewUsageStatisticsFeatureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/ViewUsageStatisticsFeatureIT.java
@@ -378,4 +378,36 @@ public class ViewUsageStatisticsFeatureIT extends AbstractControllerIntegrationT
                                .andExpect(jsonPath("$.page.totalElements", greaterThan(0)))
                                .andExpect(jsonPath("$._embedded").exists());
     }
+
+    @Test
+    public void adminSiteWhenStatsDisabled() throws Exception {
+    configurationService.setProperty("usage-statistics.enabled", false);
+    configurationService.setProperty("usage-statistics.authorization.admin.usage", true);
+
+    String adminToken = getAuthToken(admin.getEmail(), password);
+    getClient(adminToken).perform(
+        get("/api/authz/authorizations/search/object")
+            .param("embed", "feature")
+            .param("feature", feature)
+            .param("uri", utils.linkToSingleResource(siteRest, "self").getHref()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.page.totalElements", is(0)))
+        .andExpect(jsonPath("$._embedded").doesNotExist());
+    }
+
+    @Test
+    public void adminSiteWhenStatsEnabled() throws Exception {
+    configurationService.setProperty("usage-statistics.enabled", true);
+    configurationService.setProperty("usage-statistics.authorization.admin.usage", true);
+
+    String adminToken = getAuthToken(admin.getEmail(), password);
+    getClient(adminToken).perform(
+        get("/api/authz/authorizations/search/object")
+            .param("embed", "feature")
+            .param("feature", feature)
+            .param("uri", utils.linkToSingleResource(siteRest, "self").getHref()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.page.totalElements", greaterThan(0)))
+        .andExpect(jsonPath("$._embedded").exists());
+    }
 }

--- a/dspace/config/modules/usage-statistics.cfg
+++ b/dspace/config/modules/usage-statistics.cfg
@@ -6,6 +6,11 @@
 # See also: solr-statistics.cfg                                 #
 #---------------------------------------------------------------#
 
+# Whether to track/display DSpace's usage statistics.
+# When set to "false", DSpace will no longer track usage statistics and
+# the "Statistics" menu will no longer be available in the User Interface. (Default = true)
+#usage-statistics.enabled = true
+
 # The location for the database used to map client addresses to approximate
 # physical locations.  This MUST BE CONFIGURED if you want statistics with
 # location data.  A typical path is shown:


### PR DESCRIPTION
## References
* Fixes #9698

## Description
Adds a new configuration `usage-statistics.enabled` to `usage-statistics.cfg` allowing administrators to easily disable the tracking and display of Solr usage statistics via a single setting.

## Instructions for Reviewers
This PR introduces a boolean configuration property `usage-statistics.enabled` (defaulting to `true`) in `usage-statistics.cfg`. When set to `false`, DSpace will stop logging usage events to Solr and hide the "Statistics" link/page from the user interface.

List of changes in this PR:
* Added the `usage-statistics.enabled` property to `config/modules/usage-statistics.cfg`.
* Modified `SolrLoggerUsageEventListener.java` to check the new property before logging usage events. It now ignores events if `usage-statistics.enabled` is `false`.
* Modified `CanViewUsageStatisticsFeature.java` to check the new property. It now immediately returns `false` (unauthorized) if `usage-statistics.enabled` is `false`, effectively hiding the statistics link/page.
* Added integration tests to `ViewUsageStatisticsFeatureIT.java` to verify the authorization check respects the new setting.
* Added integration tests to `SolrLoggerServiceImplIT.java` to verify that usage events are not logged to Solr when the feature is disabled.

**How to test:**

1.  **Test Case 1: Statistics Disabled**
    * Edit `[dspace]/config/modules/usage-statistics.cfg`.
    * Set `usage-statistics.enabled = false`.
    * Restart your DSpace backend (Tomcat).
    * Access the DSpace UI (`http://localhost:4000` or your UI URL).
    * **Verify:** The "Statistics" link should **NOT** appear in the main navigation menu.
    * **Verify:** Trying to access the statistics page directly (e.g., `/statistics`) should redirect you (likely to the login page if not logged in, or homepage/404 if logged in but unauthorized).
    * *(Optional Backend Check):* Browse some pages/items. Check your Solr `statistics` core logs or query the core directly. **Verify:** No new view events should be logged while the setting is `false`.

2.  **Test Case 2: Statistics Enabled (Default)**
    * Edit `[dspace]/config/modules/usage-statistics.cfg`.
    * Set `usage-statistics.enabled = true` (or comment out the line to use the default).
    * Restart your DSpace backend (Tomcat).
    * Access the DSpace UI.
    * **Verify:** The "Statistics" link **SHOULD** appear in the main navigation menu (assuming the user has permissions based on `usage-statistics.authorization.admin.usage`).
    * **Verify:** Clicking the "Statistics" link should load the statistics page successfully.
    * *(Optional Backend Check):* Browse some pages/items. Check your Solr `statistics` core logs or query the core. **Verify:** New view events **SHOULD** be logged.

3.  **Automated Tests:**
    * Run the specific integration tests added/modified:
        ```bash
        mvn clean verify -pl dspace-server-webapp -Dit.test=ViewUsageStatisticsFeatureIT -DskipUnitTests=true
        mvn clean verify -pl dspace-api -Dit.test=SolrLoggerServiceImplIT -DskipUnitTests=true
        ```
    * **Verify:** All tests should pass.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods. (No new public methods were added)
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide). (Manual testing instructions provided, as this is difficult to unit test).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).