### PR TITLE
Fixing issue #10530 excluding latestForDiscovery element from processing

### DIFF
--- a/dspace/config/crosswalks/oai/metadataFormats/oai_openaire.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/oai_openaire.xsl
@@ -5,7 +5,7 @@
     detailed in the LICENSE and NOTICE files at the root of the source
     tree and available online at
 
-    Developed by Paulo Graça <paulo.graca@fccn.pt>
+    Developed by paulo-graca
     
     > https://www.openaire.eu/schema/repo-lit/4.0/openaire.xsd
 
@@ -303,7 +303,7 @@
     <!-- This template will create a type of identifier exclusive for DSpace
          which is a resolver for that record and, at same time, the REST API end point
      -->
-    <xsl:template match="doc:field[starts-with(@name,'relation.isAuthorOfPublication')]"
+    <xsl:template match="doc:field[starts-with(@name,'relation.isAuthorOfPublication') and not(contains(@name,'latestForDiscovery'))]"
         mode="entity_author">
         <xsl:variable name="url">
             <xsl:call-template name="getDSpaceURL"/>


### PR DESCRIPTION
## References
* Fixes #10530

## Description
This PR fixes issue #10530 with having duplicated entries like:
```
<datacite:nameIdentifier nameIdentifierScheme="DSpace" schemeURI="http://dspace.org">/items/62e8c1d8-8ec3-423c-be3a-df179c91d85f</datacite:nameIdentifier>
<datacite:nameIdentifier nameIdentifierScheme="DSpace" schemeURI="http://dspace.org">/items/62e8c1d8-8ec3-423c-be3a-df179c91d85f</datacite:nameIdentifier>
```

The responsible was the element:
```
<element name="latestForDiscovery">
```
that, along with `isAuthorOfPublication` added the duplication.

## Instructions for Reviewers
To test this you should do a full OAI reindexing and follow Pierre's instructions on the issue ticket.

List of changes in this PR:
* An exception was added to exclude the `latestForDiscovery` element from processing.

