### PR TITLE
Fix transitive retrieval of entity metadata using "related" virtualmetadata configuration

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/RelationshipMetadataServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/RelationshipMetadataServiceImpl.java
@@ -285,13 +285,13 @@ public class RelationshipMetadataServiceImpl implements RelationshipMetadataServ
             Context context, Item item, Item otherItem, Relationship relationship, int place,
             String key, VirtualMetadataConfiguration virtualBean) throws SQLException {
         List<RelationshipMetadataValue> resultingMetadataValueList = new LinkedList<>();
-        for (String value : virtualBean.getValues(context, otherItem)) {
+        for (VirtualMetadataConfiguration.ValueResult valueResult : virtualBean.getValues(context, otherItem)) {
             RelationshipMetadataValue relationshipMetadataValue = constructRelationshipMetadataValue(context, item,
-                                                                                                     relationship
-                                                                                                         .getID(),
-                                                                                                     place,
-                                                                                                     key, virtualBean,
-                                                                                                     value);
+                relationship
+                    .getID(),
+                valueResult.getPlace() == null ? place : valueResult.getPlace(),
+                key, virtualBean,
+                valueResult.getValue());
             if (relationshipMetadataValue != null) {
                 resultingMetadataValueList.add(relationshipMetadataValue);
             }

--- a/dspace-api/src/main/java/org/dspace/content/virtual/Collected.java
+++ b/dspace-api/src/main/java/org/dspace/content/virtual/Collected.java
@@ -90,12 +90,13 @@ public class Collected implements VirtualMetadataConfiguration {
     /**
      * this method will retrieve the metadata values from the given item for all the metadata fields listed
      * in the fields property and it'll return all those values as a list
-     * @param context   The relevant DSpace context
-     * @param item      The item that will be used to either retrieve metadata values from
+     *
+     * @param context The relevant DSpace context
+     * @param item    The item that will be used to either retrieve metadata values from
      * @return The String values for all of the retrieved metadatavalues
      */
-    public List<String> getValues(Context context, Item item) {
-        List<String> resultValues = new LinkedList<>();
+    public List<ValueResult> getValues(Context context, Item item) {
+        List<ValueResult> resultValues = new LinkedList<>();
         List<String> value = this.getFields();
         for (String s : value) {
             String[] splittedString = s.split("\\.");
@@ -111,7 +112,7 @@ public class Collected implements VirtualMetadataConfiguration {
 
             for (MetadataValue metadataValue : resultList) {
                 if (StringUtils.isNotBlank(metadataValue.getValue())) {
-                    resultValues.add(metadataValue.getValue());
+                    resultValues.add(new ValueResult(metadataValue.getValue()));
                 }
             }
         }

--- a/dspace-api/src/main/java/org/dspace/content/virtual/Concatenate.java
+++ b/dspace-api/src/main/java/org/dspace/content/virtual/Concatenate.java
@@ -109,12 +109,13 @@ public class Concatenate implements VirtualMetadataConfiguration {
      * this method will retrieve the metadata values from the given item for all the metadata fields listed
      * in the fields property and it'll concatenate all those values together with the separator specified
      * in this class
-     * @param context   The relevant DSpace context
-     * @param item      The item that will be used to either retrieve metadata values from
+     *
+     * @param context The relevant DSpace context
+     * @param item    The item that will be used to either retrieve metadata values from
      * @return The String value for all of the retrieved metadatavalues combined with the separator
      */
     @Override
-    public List<String> getValues(Context context, Item item) {
+    public List<ValueResult> getValues(Context context, Item item) {
 
         List<String> resultValues = new LinkedList<>();
         List<String> value = this.getFields();
@@ -146,8 +147,8 @@ public class Concatenate implements VirtualMetadataConfiguration {
         }
 
         String result = StringUtils.join(resultValues, this.getSeparator());
-        List<String> listToReturn = new LinkedList<>();
-        listToReturn.add(result);
+        List<ValueResult> listToReturn = new LinkedList<>();
+        listToReturn.add(new ValueResult(result));
         return listToReturn;
     }
 

--- a/dspace-api/src/main/java/org/dspace/content/virtual/Related.java
+++ b/dspace-api/src/main/java/org/dspace/content/virtual/Related.java
@@ -145,7 +145,8 @@ public class Related implements VirtualMetadataConfiguration {
      * @throws SQLException If something goes wrong
      */
     @Override
-    public List<String> getValues(Context context, Item item) throws SQLException {
+    public List<ValueResult> getValues(Context context, Item item) throws SQLException {
+        List<ValueResult> values = new LinkedList<>();
         Entity entity = entityService.findByItemId(context, item.getID());
         EntityType entityType = entityService.getType(context, entity);
 
@@ -167,18 +168,23 @@ public class Related implements VirtualMetadataConfiguration {
             if (relationship.getRelationshipType().getLeftType().equals(entityType)) {
                 if (place == null || relationship.getLeftPlace() == place) {
                     Item otherItem = relationship.getRightItem();
-                    return virtualMetadataConfiguration.getValues(context, otherItem);
+                    for (ValueResult valueResult : virtualMetadataConfiguration.getValues(context, otherItem)) {
+                        valueResult.setPlace(relationship.getLeftPlace());
+                        values.add(valueResult);
+                    }
                 }
             } else if (relationship.getRelationshipType().getRightType().equals(entityType)) {
                 if (place == null || relationship.getRightPlace() == place) {
                     Item otherItem = relationship.getLeftItem();
-                    return virtualMetadataConfiguration.getValues(context, otherItem);
+                    for (ValueResult valueResult : virtualMetadataConfiguration.getValues(context, otherItem)) {
+                        valueResult.setPlace(relationship.getRightPlace());
+                        values.add(valueResult);
+                    }
                 }
             }
         }
 
-        //Return an empty list if no relationships were found
-        return new LinkedList<>();
+        return values;
     }
 
 }

--- a/dspace-api/src/main/java/org/dspace/content/virtual/UUIDValue.java
+++ b/dspace-api/src/main/java/org/dspace/content/virtual/UUIDValue.java
@@ -22,8 +22,8 @@ public class UUIDValue implements VirtualMetadataConfiguration {
     private boolean useForPlace;
 
     @Override
-    public List<String> getValues(Context context, Item item) throws SQLException {
-        return List.of(String.valueOf(item.getID()));
+    public List<ValueResult> getValues(Context context, Item item) throws SQLException {
+        return List.of(new ValueResult(String.valueOf(item.getID())));
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/content/virtual/VirtualMetadataConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/content/virtual/VirtualMetadataConfiguration.java
@@ -9,6 +9,7 @@ package org.dspace.content.virtual;
 
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Objects;
 
 import org.dspace.content.Item;
 import org.dspace.core.Context;
@@ -19,27 +20,116 @@ import org.dspace.core.Context;
  * {@link org.dspace.content.ItemServiceImpl}
  */
 public interface VirtualMetadataConfiguration {
+    /**
+     * Represents a metadata value result with an optional placement indicator.
+     * Used by VirtualMetadataConfiguration implementations to return metadata values
+     * along with their position information for ordering purposes.
+     */
+    class ValueResult {
+        /**
+         * The string representation of the metadata value.
+         * This field is immutable once set through the constructor.
+         */
+        private final String value;
+        /**
+         * The placement indicator for this value within a list of metadata values.
+         * Used to maintain or establish ordering of metadata values.
+         * Can be null if placement is not relevant or not yet determined.
+         */
+        private Integer place;
+
+        /**
+         * Compares this ValueResult with another object for equality.
+         * Two ValueResult objects are considered equal if they have the same
+         * value and place properties.
+         *
+         * @param o The object to compare with
+         * @return true if the objects are equal, false otherwise
+         */
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            ValueResult that = (ValueResult) o;
+            return Objects.equals(value, that.value) && Objects.equals(place, that.place);
+        }
+
+        /**
+         * Returns a hash code value for this ValueResult.
+         * The hash code is computed based on both the value and place properties.
+         *
+         * @return A hash code value for this object
+         */
+        @Override
+        public int hashCode() {
+            return Objects.hash(value, place);
+        }
+
+        /**
+         * Creates a new ValueResult with the specified value and no placement information.
+         * The place is initialized to null and can be set later using setPlace().
+         *
+         * @param value The string value of the metadata
+         */
+        public ValueResult(String value) {
+            this.value = value;
+            this.place = null;
+        }
+
+        /**
+         * Sets the placement indicator for this value result.
+         * This method is package-private and intended for internal use, particularly
+         * when placement information needs to be assigned after initial construction.
+         *
+         * @param place The placement indicator to set
+         */
+        void setPlace(Integer place) {
+            this.place = place;
+        }
+
+        /**
+         * Returns the string value of this result.
+         *
+         * @return The metadata value as a string
+         */
+        public String getValue() {
+            return value;
+        }
+
+        /**
+         * Returns the placement indicator for this value result.
+         *
+         * @return The placement indicator, or null if not set
+         */
+        public Integer getPlace() {
+            return place;
+        }
+    }
 
     /**
      * This method will return a list filled with String values which will be determine by the bean that's responsible
      * of handling the metadata fields when fully traversed through all the {@link Related} beans
-     * @param context   The relevant DSpace context
-     * @param item      The item that will be used to either retrieve metadata values from or to find
-     *                  the related item through its relationships
-     * @return The list of String values of all the metadata values as constructed by the responsible bean
+     *
+     * @param context The relevant DSpace context
+     * @param item    The item that will be used to either retrieve metadata values from or to find
+     *                the related item through its relationships
+     * @return The list of the ValueResult values of all metadata values as constructed by the responsible bean
      * @throws SQLException If something goes wrong
      */
-    List<String> getValues(Context context, Item item) throws SQLException;
+    List<ValueResult> getValues(Context context, Item item) throws SQLException;
 
     /**
      * Generic setter for the useForPlace property
-     * @param useForPlace   The boolean value that the useForPlace property will be set to
+     *
+     * @param useForPlace The boolean value that the useForPlace property will be set to
      */
     void setUseForPlace(boolean useForPlace);
 
     /**
      * Generic getter for the useForPlace property
-     * @return  The useForPlace to be used by this bean
+     *
+     * @return The useForPlace to be used by this bean
      */
     boolean getUseForPlace();
 
@@ -47,13 +137,15 @@ public interface VirtualMetadataConfiguration {
      * Generic setter for the populateWithNameVariant
      * This property defines whether the value should be retrieved from the left/rightward on the Relationship (true)
      * or through the configuration and usual way (false)
-     * @param populateWithNameVariant   The boolean value that the populateWithNameVariant property will be set to
+     *
+     * @param populateWithNameVariant The boolean value that the populateWithNameVariant property will be set to
      */
     void setPopulateWithNameVariant(boolean populateWithNameVariant);
 
     /**
      * Generic getter for the populateWithNameVariant property
-     * @return  The populatewithNameVariant to be used by this bean
+     *
+     * @return The populatewithNameVariant to be used by this bean
      */
     boolean getPopulateWithNameVariant();
 }

--- a/dspace-api/src/test/java/org/dspace/content/virtual/CollectedTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/virtual/CollectedTest.java
@@ -79,7 +79,7 @@ public class CollectedTest {
     public void testGetValues() {
         // Setup objects utilized in unit test
         List<String> list = new ArrayList<>();
-        List<String> valueList = new ArrayList<>();
+        List<VirtualMetadataConfiguration.ValueResult> valueList = new ArrayList<>();
         List<MetadataValue> metadataValueList = new ArrayList<>();
         MetadataValue metadataValue = mock(MetadataValue.class);
         Item item = mock(Item.class);
@@ -88,7 +88,7 @@ public class CollectedTest {
         list.add(s);
         List<String> splittedString = Splitter.on('.').splitToList(s);
         collected.setFields(list);
-        valueList.add("TestValue");
+        valueList.add(new VirtualMetadataConfiguration.ValueResult("TestValue"));
 
         // Mock the state of objects utilized in getValues() to meet the success criteria of an invocation
         when(itemService.getMetadata(item, splittedString.size() > 0 ? splittedString.get(0) : null,

--- a/dspace-api/src/test/java/org/dspace/content/virtual/ConcatenateTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/virtual/ConcatenateTest.java
@@ -101,7 +101,7 @@ public class ConcatenateTest {
     public void testGetValues() {
         // Setup objects utilized in unit test
         List<String> list = new ArrayList<>();
-        List<String> valueList = new ArrayList<>();
+        List<VirtualMetadataConfiguration.ValueResult> valueList = new ArrayList<>();
         List<MetadataValue> metadataValueList = new ArrayList<>();
         MetadataValue metadataValue = mock(MetadataValue.class);
         Item item = mock(Item.class);
@@ -110,7 +110,7 @@ public class ConcatenateTest {
         list.add(s);
         List<String> splittedString = Splitter.on(".").splitToList(s);
         concatenate.setFields(list);
-        valueList.add("TestValue");
+        valueList.add(new VirtualMetadataConfiguration.ValueResult("TestValue"));
 
         // Mock the state of objects utilized in getValues() to meet the success criteria of an invocation
         when(itemService.getMetadata(item, splittedString.size() > 0 ? splittedString.get(0) : null,

--- a/dspace-api/src/test/java/org/dspace/content/virtual/UUIDValueTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/virtual/UUIDValueTest.java
@@ -36,11 +36,11 @@ public class UUIDValueTest {
     @Test
     public void testGetValues() throws Exception {
         // Setup objects utilized in unit test
-        List<String> list = new ArrayList<>();
+        List<VirtualMetadataConfiguration.ValueResult> list = new ArrayList<>();
         Item item = mock(Item.class);
         UUID uuid = UUID.randomUUID();
         when(item.getID()).thenReturn(uuid);
-        list.add(String.valueOf(uuid));
+        list.add(new VirtualMetadataConfiguration.ValueResult(String.valueOf(uuid)));
 
         // The reported value(s) should match our defined list
         assertEquals("TestGetValues 0", list, uuidValue.getValues(context, item));


### PR DESCRIPTION
## References
* Fixes #11458 

## Description
This PR is a basis for discussion, covering a fix for the bug decribed in  Issue #11458  

## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:

As stated in the  Issue:

> 1. `dspace-api/src/main/java/org/dspace/content/virtual/Related.java`
> The `getValues` Method returns after finding the first desired `RelationShip`. In case of multiple `ProjectMembers` attached to a `Project` related to the `Publication` - multiple RelationShips must be analysed and the results must all be  returned.

This was fixed.

> 2. `src/main/java/org/dspace/content/RelationshipMetadataServiceImpl.java`
> The `findRelationshipMetadataValueFromBean` method iterates over all results of the current valueBean `getValues` method and uses the same place value for all values during one iteration - this causes a reduction of the value set transferred via REST, based on the used Comparator `Comparator.comparingInt(MetadataValueRest::getPlace)` inside the `convert` method `dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/MetadataConverter.java`. This breaks it for the Related - Values when there is more that one transitive entity (like our `ProjectMember`) To fix that, the `getValues` Method must not only return the related value, but also the actual place that was found inside the concrete `getValues` Method of `Related.java`

This was fixed.

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

This is described in Issue #11458 

Additionally, the test method `testGetTransitiveVirtualMetadata` of `RelationshipMetadataServiceIT` can be used to reproduce the bug and to verify the fix. 
It uses the same entity setup as described in the bug - but using other entity types because I dit not want to mess around with the default DSpace virtual-metadata.xml

So, the entity model:
```
Publication (1)
 └─── (n:1) ───> Project (1)
                   └─── (1:n) ───> Person:ProjectMember (n)
```

was transferred for the test to:

```
JournalIssue (1)
 └─── (n:1) ───> JournalVolume (1)
                   └─── (1:n) ───> Journal (n)
```

To execute this test against old code basis in order to trigger the bug and reproduce it, perform a cherry pick of the test code commit against a new branch created from main:

```
git remote add leuphana https://github.com/leuphana/DSpace/
git fetch leuphana
git checkout -b reproduce-11458
git cherry-pick 9654a392cf...d4dbcfb79f
```

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x]  If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

