### PR TITLE
Centralized IIIF checks cleanup

### DIFF
--- a/dspace-iiif/src/main/java/org/dspace/app/iiif/service/utils/IIIFUtils.java
+++ b/dspace-iiif/src/main/java/org/dspace/app/iiif/service/utils/IIIFUtils.java
@@ -48,14 +48,8 @@ public class IIIFUtils {
 
     // The DSpace bundle for other content related to item.
     protected static final String OTHER_CONTENT_BUNDLE = "OtherContent";
-
     // The canvas position will be appended to this string.
     private static final String CANVAS_PATH_BASE = "/canvas/c";
-
-    // metadata used to enable the iiif features on the item
-    public static final String METADATA_IIIF_ENABLED = "dspace.iiif.enabled";
-    // metadata used to enable the iiif search service on the item
-    public static final String METADATA_IIIF_SEARCH_ENABLED = "iiif.search.enabled";
     // metadata used to override the title/name exposed as label to iiif client
     public static final String METADATA_IIIF_LABEL = "iiif.label";
     // metadata used to override the description/abstract exposed as label to iiif client
@@ -138,9 +132,8 @@ public class IIIFUtils {
      * @return true if the bitstream can be used as IIIF resource
      */
     public boolean isIIIFBitstream(Context context, Bitstream b) {
-        return checkImageMimeType(getBitstreamMimeType(b, context)) && b.getMetadata().stream()
-                .filter(m -> m.getMetadataField().toString('.').contentEquals(METADATA_IIIF_ENABLED))
-                .noneMatch(m -> m.getValue().equalsIgnoreCase("false") || m.getValue().equalsIgnoreCase("no"));
+        return checkImageMimeType(getBitstreamMimeType(b, context)) &&
+                IIIFSharedUtils.isNotIIIFDisabled(b);
     }
 
     /**


### PR DESCRIPTION
## Description
Cleans up duplicate code, centralizing the IIIF enabled / disabled checks to one place

We still need both the `hasIIIFEnabledFlag` and `isNotIIIFDisabled` as items are default opt-out, but bitstreams by default are opt-in.

## Instructions for Reviewers

Can be tested by checking all basic IIIF functionality related to enabling / disabling via metadata on both item and bitstream level still works the same as before.

Should be a quick win!


## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
