### PR TITLE
Bug Fix: Remove RequestItems referencing deleted Bitstreams (main)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
@@ -301,7 +301,7 @@ public class BitstreamServiceImpl extends DSpaceObjectServiceImpl<Bitstream> imp
         // a deleted bitstream
         List<RequestItem> requestItems = requestItemService.findAll(context);
         for (RequestItem requestItem : requestItems) {
-            if (requestItem.getBitstream().equals(bitstream)) {
+            if (bitstream.equals(requestItem.getBitstream())) {
                 requestItemService.delete(context, requestItem);
             }
         }

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.6_2025.10.29__Fix-request-items-with-deleted-bitstreams.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.6_2025.10.29__Fix-request-items-with-deleted-bitstreams.sql
@@ -1,0 +1,14 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+DELETE
+FROM requestitem
+WHERE bitstream_id IN
+      (SELECT bs.uuid
+       FROM bitstream AS bs
+       WHERE bs.deleted IS TRUE)


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #9674 
* DSpace 7.x version: https://github.com/DSpace/DSpace/pull/11468
* DSpace 8.x version: https://github.com/DSpace/DSpace/pull/11470
* DSpace 9.x version: https://github.com/DSpace/DSpace/pull/11471
* Related to https://github.com/DSpace/DSpace/pull/9106

## Description
Ensures that when a `Bitstream` is deleted, any associated `RequestItem` entities referencing it are also removed, preventing orphaned request records and issues with `cleanup` script.

## Instructions for Reviewers
List of changes in this PR:
* First, added logic in `BitstreamServiceImpl.delete()` to remove any `RequestItem` entities referencing the deleted `bitstream`.
* Second, introduced a SQL migration script to clean up existing database records with deleted bitstreams.
* Third, added new test method to `RequestItemRepositoryIT` to verify that deleting a bitstream automatically removes its associated request items.

How to Test / Review:
- Create a new `item` and attach a **restricted** `bitstream`.
- Submit a **request a copy** for that `bitstream` and verify that a corresponding entry is created in the `requestitem` table.
- Delete the `bitstream`.
- Confirm that the related `RequestItem` entry is automatically removed from the `requestitem` table.
- Run the `dspace cleanup` script and verify that it executes successfully and that no database integrity errors occur, such as: `ERROR: update or delete on table "bitstream" violates foreign key constraint "requestitem_bitstream_id_fkey" on table "requestitem"`.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
