### PR TITLE
Optimize SQL query in findByEPerson to enhance performance

### DIFF
--- a/dspace-api/src/main/java/org/dspace/eperson/dao/impl/GroupDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/dao/impl/GroupDAOImpl.java
@@ -92,7 +92,7 @@ public class GroupDAOImpl extends AbstractHibernateDSODAO<Group> implements Grou
     @Override
     public List<Group> findByEPerson(Context context, EPerson ePerson) throws SQLException {
         Query query = createQuery(context,
-                                  "from Group where (from EPerson e where e.id = :eperson_id) in elements(epeople)");
+            "select distinct g from Group g join g.epeople ep where ep.id = :eperson_id");
         query.setParameter("eperson_id", ePerson.getID());
         query.setHint("org.hibernate.cacheable", Boolean.TRUE);
 


### PR DESCRIPTION
## Description
It updates the `findByEPerson` method in the `GroupDAOImpl` class to improve SQL query performance.
The previous HQL statement has been rewritten to use a more efficient JOIN query when retrieving groups linked to a specific EPerson.

This issue was discovered recently during a period of high user activity in an instance with a large number of users and groups, where multiple concurrent connections were observed. While monitoring the database, I noticed many active and slow-running queries similar to the following:

```
select g1_0.uuid, g1_1.uuid, g1_0.eperson_group_id, g1_0.name, g1_0.permanent
from public.epersongroup g1_0
join public.dspaceobject g1_1 on g1_0.uuid = g1_1.uuid
where (
    select e1_0.uuid
    from public.eperson e1_0
    join public.dspaceobject e1_1 on e1_0.uuid = e1_1.uuid
    where e1_0.uuid = $1
) in (
    select e2_0.eperson_id
    from public.epersongroup2eperson e2_0
    join (public.eperson e2_1
          join public.dspaceobject e2_2 on e2_1.uuid = e2_2.uuid)
      on e2_1.uuid = e2_0.eperson_id
    where g1_0.uuid = e2_0.eperson_group_id
)
```

These subquery-based statements caused unnecessary overhead and contributed to poor performance during peak load.

## Instructions for Reviewers

List of changes in this PR:
* Replaced the old subquery-based HQL:
```
from Group where (from EPerson e where e.id = :eperson_id) in elements(epeople)
```
with a more performant join-based query:
```
select distinct g from Group g join g.epeople ep where ep.id = :eperson_id
```

There is no straightforward way to test this query on its own. It is usually called as part of another function that retrieves all groups for the currently logged-in non-admin user (for example, before a Solr search).

To verify correctness:
- Compare the results returned by the old and new queries for the same user.
- Both should return the same set of groups, confirming that the new query is equivalent to the old one.

The following SQL query is the actual query generated by Hibernate (with `show_sql` enabled):

```
select distinct g1_0.uuid, g1_1.uuid, g1_0.eperson_group_id, g1_0.name, g1_0.permanent 
from public.epersongroup g1_0 
join public.dspaceobject g1_1 on g1_0.uuid = g1_1.uuid 
join public.epersongroup2eperson e1_0 on g1_0.uuid = e1_0.eperson_group_id 
where e1_0.eperson_id = ?
```

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
