### PR TITLE
Performance improvement for 10084

### DIFF
--- a/dspace-api/src/test/java/org/dspace/discovery/SolrServiceResourceRestrictionPluginTest.java
+++ b/dspace-api/src/test/java/org/dspace/discovery/SolrServiceResourceRestrictionPluginTest.java
@@ -1,0 +1,293 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.discovery;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.solr.client.solrj.SolrQuery;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.core.Context;
+import org.dspace.eperson.EPerson;
+import org.dspace.eperson.Group;
+import org.dspace.eperson.service.GroupService;
+import org.dspace.kernel.ServiceManager;
+import org.dspace.services.RequestService;
+import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.services.model.Request;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * Unit tests for {@link SolrServiceResourceRestrictionPlugin}
+ * Focuses on the role gate and memoization logic for admin scope queries.
+ *
+ * @author Bram Luyten (bram at atmire dot com)
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class SolrServiceResourceRestrictionPluginTest {
+
+    @InjectMocks
+    private SolrServiceResourceRestrictionPlugin plugin;
+
+    @Mock
+    private AuthorizeService authorizeService;
+
+    @Mock
+    private GroupService groupService;
+
+    @Mock
+    private Context context;
+
+    @Mock
+    private DiscoverQuery discoverQuery;
+
+    @Mock
+    private SolrQuery solrQuery;
+
+    @Mock
+    private EPerson currentUser;
+
+    @Mock
+    private Group anonymousGroup;
+
+    @Mock
+    private SearchService searchService;
+
+    @Mock
+    private RequestService requestService;
+
+    @Mock
+    private Request request;
+
+    @Before
+    public void setUp() throws Exception {
+        // Setup common mocks
+        when(groupService.findByName(any(Context.class), eq(Group.ANONYMOUS))).thenReturn(anonymousGroup);
+        when(anonymousGroup.getID()).thenReturn(java.util.UUID.randomUUID());
+        when(context.getCurrentUser()).thenReturn(currentUser);
+        when(currentUser.getID()).thenReturn(java.util.UUID.randomUUID());
+
+        Set<Group> emptyGroups = new HashSet<>();
+        when(groupService.allMemberGroupsSet(any(Context.class), any(EPerson.class))).thenReturn(emptyGroups);
+    }
+
+    /**
+     * Test that when user is NOT a C/C admin, createLocationQueryForAdministrableItems is NOT called
+     */
+    @Test
+    public void testNonAdminUser_DoesNotCallAdminScopeQuery() throws Exception {
+        // Arrange: user is not a site admin, not a C/C admin
+        when(authorizeService.isAdmin(context)).thenReturn(false);
+        when(authorizeService.isCommunityAdmin(context)).thenReturn(false);
+        when(authorizeService.isCollectionAdmin(context)).thenReturn(false);
+
+        try (MockedStatic<DSpaceServicesFactory> mockedFactory = Mockito.mockStatic(DSpaceServicesFactory.class)) {
+            DSpaceServicesFactory factory = mock(DSpaceServicesFactory.class);
+            mockedFactory.when(DSpaceServicesFactory::getInstance).thenReturn(factory);
+            when(factory.getRequestService()).thenReturn(requestService);
+            when(requestService.getCurrentRequest()).thenReturn(request);
+
+            ServiceManager serviceManager = mock(ServiceManager.class);
+            when(factory.getServiceManager()).thenReturn(serviceManager);
+            when(serviceManager.getServiceByName(eq(SearchService.class.getName()), 
+                                                 eq(SearchService.class))).thenReturn(searchService);
+
+            // Act
+            plugin.additionalSearchParameters(context, discoverQuery, solrQuery);
+
+            // Assert: createLocationQueryForAdministrableItems should NOT be called
+            verify(searchService, never()).createLocationQueryForAdministrableItems(any(Context.class));
+        }
+    }
+
+    /**
+     * Test that when user IS a community admin, createLocationQueryForAdministrableItems IS called
+     */
+    @Test
+    public void testCommunityAdmin_CallsAdminScopeQuery() throws Exception {
+        // Arrange: user is a community admin but not site admin
+        when(authorizeService.isAdmin(context)).thenReturn(false);
+        when(authorizeService.isCommunityAdmin(context)).thenReturn(true);
+        when(authorizeService.isCollectionAdmin(context)).thenReturn(false);
+
+        try (MockedStatic<DSpaceServicesFactory> mockedFactory = Mockito.mockStatic(DSpaceServicesFactory.class)) {
+            DSpaceServicesFactory factory = mock(DSpaceServicesFactory.class);
+            mockedFactory.when(DSpaceServicesFactory::getInstance).thenReturn(factory);
+            when(factory.getRequestService()).thenReturn(requestService);
+            when(requestService.getCurrentRequest()).thenReturn(request);
+            when(request.getAttribute("dspace.discovery.adminScopeLocations")).thenReturn(null);
+
+            ServiceManager serviceManager = mock(ServiceManager.class);
+            when(factory.getServiceManager()).thenReturn(serviceManager);
+            when(serviceManager.getServiceByName(eq(SearchService.class.getName()), 
+                                                 eq(SearchService.class))).thenReturn(searchService);
+            when(searchService.createLocationQueryForAdministrableItems(context))
+                .thenReturn("location:(m123 OR l456)");
+
+            // Act
+            plugin.additionalSearchParameters(context, discoverQuery, solrQuery);
+
+            // Assert: createLocationQueryForAdministrableItems should be called once
+            verify(searchService, times(1)).createLocationQueryForAdministrableItems(context);
+            verify(request, times(1)).setAttribute(eq("dspace.discovery.adminScopeLocations"), 
+                                                   eq("location:(m123 OR l456)"));
+        }
+    }
+
+    /**
+     * Test that when user IS a collection admin, createLocationQueryForAdministrableItems IS called
+     */
+    @Test
+    public void testCollectionAdmin_CallsAdminScopeQuery() throws Exception {
+        // Arrange: user is a collection admin but not site admin
+        when(authorizeService.isAdmin(context)).thenReturn(false);
+        when(authorizeService.isCommunityAdmin(context)).thenReturn(false);
+        when(authorizeService.isCollectionAdmin(context)).thenReturn(true);
+
+        try (MockedStatic<DSpaceServicesFactory> mockedFactory = Mockito.mockStatic(DSpaceServicesFactory.class)) {
+            DSpaceServicesFactory factory = mock(DSpaceServicesFactory.class);
+            mockedFactory.when(DSpaceServicesFactory::getInstance).thenReturn(factory);
+            when(factory.getRequestService()).thenReturn(requestService);
+            when(requestService.getCurrentRequest()).thenReturn(request);
+            when(request.getAttribute("dspace.discovery.adminScopeLocations")).thenReturn(null);
+
+            ServiceManager serviceManager = mock(ServiceManager.class);
+            when(factory.getServiceManager()).thenReturn(serviceManager);
+            when(serviceManager.getServiceByName(eq(SearchService.class.getName()), 
+                                                 eq(SearchService.class))).thenReturn(searchService);
+            when(searchService.createLocationQueryForAdministrableItems(context))
+                .thenReturn("location:(l789)");
+
+            // Act
+            plugin.additionalSearchParameters(context, discoverQuery, solrQuery);
+
+            // Assert: createLocationQueryForAdministrableItems should be called once
+            verify(searchService, times(1)).createLocationQueryForAdministrableItems(context);
+            verify(request, times(1)).setAttribute(eq("dspace.discovery.adminScopeLocations"), 
+                                                   eq("location:(l789)"));
+        }
+    }
+
+    /**
+     * Test memoization: when called twice in same request, DB query should only happen once
+     */
+    @Test
+    public void testMemoization_CallsAdminScopeQueryOnlyOnce() throws Exception {
+        // Arrange: user is a community admin
+        when(authorizeService.isAdmin(context)).thenReturn(false);
+        when(authorizeService.isCommunityAdmin(context)).thenReturn(true);
+        when(authorizeService.isCollectionAdmin(context)).thenReturn(false);
+
+        try (MockedStatic<DSpaceServicesFactory> mockedFactory = Mockito.mockStatic(DSpaceServicesFactory.class)) {
+            DSpaceServicesFactory factory = mock(DSpaceServicesFactory.class);
+            mockedFactory.when(DSpaceServicesFactory::getInstance).thenReturn(factory);
+            when(factory.getRequestService()).thenReturn(requestService);
+            when(requestService.getCurrentRequest()).thenReturn(request);
+
+            ServiceManager serviceManager = mock(ServiceManager.class);
+            when(factory.getServiceManager()).thenReturn(serviceManager);
+            when(serviceManager.getServiceByName(eq(SearchService.class.getName()), 
+                                                 eq(SearchService.class))).thenReturn(searchService);
+
+            String cachedLocations = "location:(m123 OR l456)";
+            
+            // First call: cache miss
+            when(request.getAttribute("dspace.discovery.adminScopeLocations")).thenReturn(null);
+            when(searchService.createLocationQueryForAdministrableItems(context))
+                .thenReturn(cachedLocations);
+
+            // Act: First call
+            plugin.additionalSearchParameters(context, discoverQuery, solrQuery);
+
+            // Now simulate the cache hit for the second call
+            when(request.getAttribute("dspace.discovery.adminScopeLocations")).thenReturn(cachedLocations);
+
+            // Act: Second call
+            plugin.additionalSearchParameters(context, discoverQuery, solrQuery);
+
+            // Assert: createLocationQueryForAdministrableItems should be called only ONCE
+            verify(searchService, times(1)).createLocationQueryForAdministrableItems(context);
+            // setAttribute should also be called only once (during first call)
+            verify(request, times(1)).setAttribute(eq("dspace.discovery.adminScopeLocations"), 
+                                                   eq(cachedLocations));
+        }
+    }
+
+    /**
+     * Test that site admin does not trigger the admin scope query (they already have full access)
+     */
+    @Test
+    public void testSiteAdmin_DoesNotCallAdminScopeQuery() throws Exception {
+        // Arrange: user is a site admin
+        when(authorizeService.isAdmin(context)).thenReturn(true);
+
+        try (MockedStatic<DSpaceServicesFactory> mockedFactory = Mockito.mockStatic(DSpaceServicesFactory.class)) {
+            DSpaceServicesFactory factory = mock(DSpaceServicesFactory.class);
+            mockedFactory.when(DSpaceServicesFactory::getInstance).thenReturn(factory);
+            when(factory.getRequestService()).thenReturn(requestService);
+
+            ServiceManager serviceManager = mock(ServiceManager.class);
+            when(factory.getServiceManager()).thenReturn(serviceManager);
+            when(serviceManager.getServiceByName(eq(SearchService.class.getName()), 
+                                                 eq(SearchService.class))).thenReturn(searchService);
+
+            // Act
+            plugin.additionalSearchParameters(context, discoverQuery, solrQuery);
+
+            // Assert: For site admins, the entire resource query is skipped, so no admin scope query
+            verify(searchService, never()).createLocationQueryForAdministrableItems(any(Context.class));
+        }
+    }
+
+    /**
+     * Test handling when there's no current request (e.g., CLI context)
+     */
+    @Test
+    public void testNoCurrentRequest_StillCallsAdminScopeQuery() throws Exception {
+        // Arrange: user is a community admin, but there's no HTTP request
+        when(authorizeService.isAdmin(context)).thenReturn(false);
+        when(authorizeService.isCommunityAdmin(context)).thenReturn(true);
+        when(authorizeService.isCollectionAdmin(context)).thenReturn(false);
+
+        try (MockedStatic<DSpaceServicesFactory> mockedFactory = Mockito.mockStatic(DSpaceServicesFactory.class)) {
+            DSpaceServicesFactory factory = mock(DSpaceServicesFactory.class);
+            mockedFactory.when(DSpaceServicesFactory::getInstance).thenReturn(factory);
+            when(factory.getRequestService()).thenReturn(requestService);
+            when(requestService.getCurrentRequest()).thenReturn(null); // No current request
+
+            ServiceManager serviceManager = mock(ServiceManager.class);
+            when(factory.getServiceManager()).thenReturn(serviceManager);
+            when(serviceManager.getServiceByName(eq(SearchService.class.getName()), 
+                                                 eq(SearchService.class))).thenReturn(searchService);
+            when(searchService.createLocationQueryForAdministrableItems(context))
+                .thenReturn("location:(m999)");
+
+            // Act
+            plugin.additionalSearchParameters(context, discoverQuery, solrQuery);
+
+            // Assert: Should still call the method, but won't cache (no request to cache in)
+            verify(searchService, times(1)).createLocationQueryForAdministrableItems(context);
+        }
+    }
+}
+


### PR DESCRIPTION
## References

* Fixes #10084
* Related to #9471

## Description

This PR adds a role gate and per-request memoization to prevent unnecessary database queries for collection/community admin resource policies during Discovery searches, significantly improving performance for non-admin users.

## Instructions for Reviewers

This PR addresses a performance regression where every Discovery search query was executing two expensive database queries against `resourcepolicy` to compute administrable collections/communities scope, even for users who are not collection or community admins.

List of changes in this PR:

* **Added role gate** in `SolrServiceResourceRestrictionPlugin.additionalSearchParameters()` to only compute administrable scope when the user is actually a collection or community admin (checked via `authorizeService.isCommunityAdmin()` or `authorizeService.isCollectionAdmin()`)
* **Implemented per-request memoization** using `RequestService` to cache the administrable scope query result within a single HTTP request, avoiding redundant DB calls when multiple Solr queries occur during the same page render
* **Added comprehensive unit tests** in new `SolrServiceResourceRestrictionPluginTest.java` with mock-based tests verifying the role gate and memoization logic
* **Added integration test** in `DiscoveryIT.java` (`testAdminScopeOnlyAppliedForCollectionCommunityAdmins`) to verify correct behavior for regular users, collection admins, community admins, and site admins

### How to test

1. **Performance verification (manual)**:
   - Log in as a non-admin user
   - Browse various search and facet pages
   - Check DSpace logs - the WARN message "We have a collection or community admin with ID: X without any administrable collection or community!" should no longer appear
   - Performance should improve noticeably for non-admin users on high-traffic sites

2. **Functional verification (automated)**:
   - Run the new unit test: `mvn test -Dtest=SolrServiceResourceRestrictionPluginTest`
   - Run the new integration test: `mvn test -Dtest=DiscoveryIT#testAdminScopeOnlyAppliedForCollectionCommunityAdmins`
   - Both should pass, verifying that:
     - Non-admins don't trigger admin scope queries
     - C/C admins do trigger the query (once per request with memoization)
     - All user roles see appropriate search results

3. **Regression verification**:
   - Run full test suite: `mvn clean test`
   - Verify no existing tests are broken
   - Test with different user roles (anonymous, regular user, collection admin, community admin, site admin) to ensure search results remain correct

### Expected outcomes

✅ No database queries to compute admin scope for non-admin users  
✅ Admin scope computed at most once per HTTP request for C/C admins  
✅ Elimination of spurious WARN logs for regular users  
✅ No change in search results or authorization behavior for any user role  
✅ Performance improvement on sites with many concurrent non-admin users

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation. _(N/A - no new dependencies)_
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change. _(N/A - no REST API changes)_
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself. _(N/A - no new configurations)_
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).