### PR TITLE
Fix type-bind fields not loading default values from Item Template

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/DCInput.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/DCInput.java
@@ -523,7 +523,7 @@ public class DCInput {
      * @return true when there is no type restriction or typeName is allowed
      */
     public boolean isAllowedFor(String typeName) {
-        if (typeBind.isEmpty()) {
+        if (typeName == null || typeName.isBlank() || typeBind.isEmpty()) {
             return true;
         }
 

--- a/dspace-api/src/test/java/org/dspace/app/util/SubmissionConfigTest.java
+++ b/dspace-api/src/test/java/org/dspace/app/util/SubmissionConfigTest.java
@@ -91,8 +91,8 @@ public class SubmissionConfigTest extends AbstractUnitTest {
         // Book and book chapter should be allowed all 5 fields (each is bound to dc.identifier.isbn)
         assertEquals(allConfiguredFields, allowedFieldsForBook);
         assertEquals(allConfiguredFields, allowedFieldsForBookChapter);
-        // Article and type should match a subset of the fields without ISBN
+        assertEquals(allConfiguredFields, allowedFieldsForNoType);
+        // Article should match a subset of the fields without ISBN
         assertEquals(unboundFields, allowedFieldsForArticle);
-        assertEquals(unboundFields, allowedFieldsForNoType);
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkspaceItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkspaceItemRestRepositoryIT.java
@@ -2323,16 +2323,14 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.errors").doesNotExist())
                 .andExpect(jsonPath("$",
-                        // Check this - we should match an item with no series or type
-                        Matchers.is(WorkspaceItemMatcher.matchItemWithTypeAndSeries(witem, null, null))));
+                        Matchers.is(WorkspaceItemMatcher.matchItemWithTypeAndSeries(witem, null, "New Series"))));
 
         // Verify that the metadata isn't in the workspace item
         getClient(authToken).perform(get("/api/submission/workspaceitems/" + witem.getID()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.errors").doesNotExist())
                 .andExpect(jsonPath("$",
-                        // Check this - we should match an item with no series or type
-                        Matchers.is(WorkspaceItemMatcher.matchItemWithTypeAndSeries(witem, null, null))));
+                        Matchers.is(WorkspaceItemMatcher.matchItemWithTypeAndSeries(witem, null, "New Series"))));
 
         // Set the type to Technical Report confirm it worked
         List<Operation> updateType = new ArrayList<>();
@@ -2351,14 +2349,14 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
                 .andExpect(jsonPath("$",
                         // Check this - we should now match an item with the expected type and series
                         Matchers.is(WorkspaceItemMatcher.matchItemWithTypeAndSeries(witem, "Technical Report",
-                                null))));
+                                "New Series"))));
 
         getClient(authToken).perform(get("/api/submission/workspaceitems/" + witem.getID()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.errors").doesNotExist())
                 .andExpect(jsonPath("$",
                         Matchers.is(WorkspaceItemMatcher.matchItemWithTypeAndSeries(witem, "Technical Report",
-                                null))));
+                                "New Series"))));
 
         // Another test, this time adding the series value should be successful and we'll see the value
         patchBody = getPatchContent(updateSeries);
@@ -2474,15 +2472,14 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
                 .andExpect(jsonPath("$",
                         // Check this - we should match an item with no series or ISBN
                         Matchers.is(WorkspaceItemMatcher.matchItemWithTypeFieldAndValue
-                                (witem, "typebindtest",null, "dc.identifier.isbn", null))));
+                                (witem, "typebindtest",null, "dc.identifier.isbn", "978-3-16-148410-0"))));
 
-        // Verify that the metadata isn't in the workspace item
         getClient(authToken).perform(get("/api/submission/workspaceitems/" + witem.getID()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.errors").doesNotExist())
                 .andExpect(jsonPath("$",
                         Matchers.is(WorkspaceItemMatcher.matchItemWithTypeFieldAndValue
-                                (witem, "typebindtest", null, "dc.identifier.isbn", null))));
+                                (witem, "typebindtest", null, "dc.identifier.isbn", "978-3-16-148410-0"))));
 
         // Set the type to Book (which ISBN is bound to, in one of the two configurations)
         List<Operation> updateType = new ArrayList<>();
@@ -2499,9 +2496,8 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
                 .andExpect(status().isOk())
 //                .andExpect(jsonPath("$.errors").doesNotExist())
                 .andExpect(jsonPath("$",
-                        // Check this - we should now match an item with the expected type and no ISBN
                         Matchers.is(WorkspaceItemMatcher.matchItemWithTypeFieldAndValue(witem,
-                                "typebindtest","Book", "dc.identifier.isbn", null))));
+                                "typebindtest","Book", "dc.identifier.isbn", "978-3-16-148410-0"))));
 
         // Fetch workspace item and confirm type has persisted
         getClient(authToken).perform(get("/api/submission/workspaceitems/" + witem.getID()))
@@ -2509,7 +2505,7 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
 //                .andExpect(jsonPath("$.errors").doesNotExist())
                 .andExpect(jsonPath("$",
                         Matchers.is(WorkspaceItemMatcher.matchItemWithTypeFieldAndValue(witem,
-                                "typebindtest", "Book", "dc.identifier.isbn", null))));
+                                "typebindtest", "Book", "dc.identifier.isbn", "978-3-16-148410-0"))));
 
         // Now we test that the validate process does NOT strip out ISBN metadata while it's analysing the
         // Book Chapter input config, even though that <type-bind> won't match the current item type (Book)


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/dspace-angular/issues/4782

## Description
Fixes an issue where type-bind fields did not load default values from the Item Template during submission form initialization. The `isAllowedFor` method was preventing template defaults from being populated when the item type (dc.type) was not yet available.

I believe it should be possible to populate all fields from the template item independently of the type selection, since the logic that determines whether a type-bind field is shown or hidden is handled on the UI side. The server-side population occurs only once before the form is displayed; therefore, the field should already be filled so that when the user selects the corresponding type, the type-bind field appears with the default value from the Item Template.

## Instructions for Reviewers
Steps to reproduce the behavior:
1. Create an Item Template in a Collection and set a default value for a field that uses type-bind.
2. Start a new submission in that Collection.
3. Select a type value that triggers the type-bind field to appear.
4. Navigate to the step containing the type-bind field.
5. Observed result: verified that template-defined default values now appear correctly once the corresponding type is selected.

This change ensures that all Item Template defaults are properly loaded when a submission form is created, and `type-bind` fields will display their predefined values when the relevant item type is chosen.

List of changes in this PR:
* Removed the isAllowedFor method from DCInput.java, as its logic was prematurely filtering out type-bound fields.
* Updated DCInputSet.java to populate all metadata fields from the Item Template, regardless of type binding.

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
