### PR TITLE
Add an option to index-discovery to index by solr query

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/IndexClientOptions.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexClientOptions.java
@@ -32,6 +32,7 @@ public enum IndexClientOptions {
     FORCEUPDATE,
     UPDATEANDSPELLCHECK,
     FORCEUPDATEANDSPELLCHECK,
+    INDEXBYQUERY,
     HELP;
 
     public static final String TYPE_OPTION = "t";
@@ -63,6 +64,8 @@ public enum IndexClientOptions {
             return IndexClientOptions.SPELLCHECK;
         } else if (commandLine.hasOption("i")) {
             return IndexClientOptions.INDEX;
+        } else if (commandLine.hasOption("q")) {
+            return IndexClientOptions.INDEXBYQUERY;
         } else {
             if (commandLine.hasOption("f") && commandLine.hasOption("s")) {
                 return IndexClientOptions.FORCEUPDATEANDSPELLCHECK;
@@ -95,6 +98,8 @@ public enum IndexClientOptions {
         options.addOption("s", "spellchecker", false, "Rebuild the spellchecker, can be combined with -b and -f.");
         options.addOption("f", "force", false,
                           "if updating existing index, force each handle to be reindexed even if up-to-date");
+        options.addOption("q", "query", true,
+                "reindex by query, reindexing all objects matching the provided solr query");
         options.addOption("h", "help", false, "print this help message");
         return options;
     }

--- a/dspace-api/src/test/java/org/dspace/discovery/IndexClientIT.java
+++ b/dspace-api/src/test/java/org/dspace/discovery/IndexClientIT.java
@@ -1,0 +1,155 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.discovery;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.common.SolrDocument;
+import org.apache.solr.common.SolrDocumentList;
+import org.dspace.AbstractIntegrationTestWithDatabase;
+import org.dspace.app.launcher.ScriptLauncher;
+import org.dspace.app.scripts.handler.impl.TestDSpaceRunnableHandler;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.ItemBuilder;
+import org.dspace.content.Collection;
+import org.dspace.content.Item;
+import org.dspace.content.MetadataValue;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.CollectionService;
+import org.dspace.content.service.WorkspaceItemService;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * This class will aim to test the index client
+ */
+public class IndexClientIT extends AbstractIntegrationTestWithDatabase {
+
+    protected WorkspaceItemService workspaceItemService = ContentServiceFactory.getInstance().getWorkspaceItemService();
+    protected SearchService searchService;
+
+    CollectionService collectionService = ContentServiceFactory.getInstance().getCollectionService();
+
+    ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
+
+    MockSolrSearchCore solrSearchCore = DSpaceServicesFactory.getInstance().getServiceManager()
+            .getServiceByName(null, MockSolrSearchCore.class);
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        searchService = SearchUtils.getSearchService();
+    }
+
+    /**
+     * Test if index by query works by updating two items (without reindexing)
+     * and updating only one of them using the --query parameter in index-discovery.
+     * @throws Exception Thrown if it's not possible to fetch items from Solr.
+     */
+    @Test
+    public void verifyIndexByQuery() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        // Create two items - one will be indexed by query, the other one will not
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+
+        Collection col1 = CollectionBuilder.createCollection(context, parentCommunity)
+                .withName("Collection 1").build();
+
+        Item item1 = ItemBuilder.createItem(context, col1)
+                .withTitle("Indexed item 1")
+                .withIssueDate("2017-10-17")
+                .withAuthor("Smith, Donald")
+                .withSubject("Entry to reindex")
+                .build();
+
+        Item item2 = ItemBuilder.createItem(context, col1)
+                .withTitle("Indexed item 2")
+                .withIssueDate("2016-02-13")
+                .withAuthor("Smith, Maria")
+                .withSubject("Do not reindex")
+                .build();
+
+        context.setDispatcher("noindex");
+        configurationService.setProperty("discovery.removestale.attempts", 0);
+
+        // Change the items without indexing
+        List<MetadataValue> metadata = item1.getMetadata();
+        for (MetadataValue mdv1 : metadata) {
+            if (
+                    mdv1.getMetadataField().getElement().equals("contributor") &&
+                            mdv1.getMetadataField().getQualifier().equals("author")
+            ) {
+                mdv1.setValue("Doe, Jane (indexed)");
+            }
+        }
+        item1.setMetadata(metadata);
+
+        List<MetadataValue> metadata2 = item2.getMetadata();
+        for (MetadataValue mdv2 : metadata2) {
+            if (
+                    mdv2.getMetadataField().getElement().equals("contributor") &&
+                            mdv2.getMetadataField().getQualifier().equals("author")
+            ) {
+                mdv2.setValue("Kowalski, Jan (indexed)");
+            }
+        }
+        item2.setMetadata(metadata2);
+
+        // Run indexing by query only on the first item
+        TestDSpaceRunnableHandler testDSpaceRunnableHandler = new TestDSpaceRunnableHandler();
+
+        String[] args = new String[] { "index-discovery", "-f", "-q", "dc.subject:(\"Entry to reindex\")" };
+        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), testDSpaceRunnableHandler, kernelImpl);
+
+        // Confirm only the first item has been indexed
+        List<String> infoMessages = testDSpaceRunnableHandler.getInfoMessages();
+        assertThat(infoMessages, hasItem(containsString("Indexing object: " + item1.getID().toString() + " [1 / 1]")));
+        assertThat(infoMessages, not(hasItem(containsString("Indexing object: " + item2.getID().toString()))));
+
+        // Fetch both items from Solr index
+        QueryResponse result;
+        try {
+            result = solrSearchCore.getSolr().query(new SolrQuery("search.resourcetype:\"Item\""));
+        } catch (SolrServerException | IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        SolrDocumentList results = result.getResults();
+        assertEquals(2, results.size());
+
+        // Confirm that the second item's author name has not changed in solr
+        for (SolrDocument entries : results) {
+            if (entries.get("dc.subject").equals(List.of("Entry to reindex"))) {
+                assertEquals(List.of("Doe, Jane (indexed)"), entries.get("dc.contributor.author"));
+            } else {
+                assertEquals(List.of("Smith, Maria"), entries.get("dc.contributor.author"));
+            }
+        }
+
+        // Cleanup
+        collectionService.delete(context, col1);
+        context.restoreAuthSystemState();
+    }
+}


### PR DESCRIPTION
## Description
This is a PR that proposes an addition to the `index-discovery` script that allows the user to select objects to reindex using a Solr query, thanks to the `-q` or `--query` parameter.
Suppose I have a database with millions of objects. I am making a change in the database to a few of them (since API can be slow if the system is under stress - and the systems with this many objects often are). I could technically write a script to extract UUIDs that have been changed, or I could just run:
`/dspace/bin/dspace index-discovery -q "solr query"`.
This is useful for large migrations from old university systems to new ones, where metadata mapping is often volatile and changes frequently.
My colleagues and I have been using it quite frequently, and it has helped us up speed up the process of updates on the client's demand, so we would like to propose adding it to the DSpace standard, should the community agree on its usefulness.

## Instructions for Reviewers
This PR adds a new option to the `index-discovery` script: `-q` or `--query`, which will fetch objects from Solr and run indexing on those objects.

List of changes in this PR:
* Add a new option to the `index-discovery` script: `-q` or `--query`
* Add an option to index objects that match a Solr query

**How to test:** a simple test can be performed on an existing Solr and PostgreSQL instance. Simply pick an item, edit its metadata in the PostgreSQL database (it should exist in Solr, but will now be outdated). Then, create a Solr query that will match this item and run the command. For example, let's say you changed an item that had `dc.contributor.author` set to `Someone` to `Someone else`. Then you run:
`/dspace/bin/dspace index-discovery -q "dc.contributor.author:(Someone)"`
And then check Solr if the value of that metadata has been changed to `Someone else`.

## Checklist

- [X] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [X] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [X] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [X] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
