### PR TITLE
QAEventService creates a new HttpSolrClient for each Solr request

### DIFF
--- a/dspace-api/src/main/java/org/dspace/qaevent/service/impl/QAEventServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/qaevent/service/impl/QAEventServiceImpl.java
@@ -131,7 +131,7 @@ public class QAEventServiceImpl implements QAEventService {
         if (solr == null) {
             String solrService = DSpaceServicesFactory.getInstance().getConfigurationService()
                     .getProperty("qaevents.solr.server", "http://localhost:8983/solr/qaevent");
-            return new HttpSolrClient.Builder(solrService).build();
+            solr = new HttpSolrClient.Builder(solrService).build();
         }
         return solr;
     }


### PR DESCRIPTION
## Description
This PR fixes an issue in `QAEventServiceImpl` where the Solr client instance was not being assigned to the `solr` field. As a result, a new `HttpSolrClient` was created each time instead of reusing a single instance.

## Instructions for Reviewers

List of changes in this PR:
* Updated the `getSolr()` method in `QAEventServiceImpl` to properly assign the newly created `HttpSolrClient` to the `solr` field.

I discovered this issue after noticing that the Tomcat instance hosting DSpace was creating many "Connection eviction" threads, related to the repeated opening of Solr connections. This can be verified by observing the thread list (e.g., using jstack or a monitoring tool), after performing requests such as:

https://demo.dspace.org/server/api/config/correctiontypes/search/findByItem?uuid=[Item-UUID]

After applying this change, these new threads should no longer be created on each Solr query.
Also verify that the functionality provided by `QAEventService` remains unaffected.

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
