### PR TITLE
[Port dspace-9_x] Fix for bitstreams with old style embargo lift date in metadata not rendering on simple item pages #8640

### DIFF
--- a/dspace-api/src/main/java/org/dspace/embargo/DefaultEmbargoSetter.java
+++ b/dspace-api/src/main/java/org/dspace/embargo/DefaultEmbargoSetter.java
@@ -94,7 +94,6 @@ public class DefaultEmbargoSetter implements EmbargoSetter {
             if (!(bnn.equals(Constants.LICENSE_BUNDLE_NAME) || bnn.equals(Constants.METADATA_BUNDLE_NAME) || bnn
                 .equals(CreativeCommonsServiceImpl.CC_BUNDLE_NAME))) {
                 //AuthorizeManager.removePoliciesActionFilter(context, bn, Constants.READ);
-                generatePolicies(context, liftDate.toDate().toLocalDate(), null, bn, item.getOwningCollection());
                 for (Bitstream bs : bn.getBitstreams()) {
                     //AuthorizeManager.removePoliciesActionFilter(context, bs, Constants.READ);
                     generatePolicies(context, liftDate.toDate().toLocalDate(), null, bs, item.getOwningCollection());


### PR DESCRIPTION
Manual port of #11324 by @im-shivamb to `dspace-9_x`.