### PR TITLE
[GitHub Actions] Fix Docker build bug by installing regctl manually instead of using a plugin

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -78,6 +78,8 @@ env:
   # Registry used during building of Docker images. (All images are later copied to docker.io registry)
   # We use GitHub's Container Registry to avoid aggressive rate limits at DockerHub.
   DOCKER_BUILD_REGISTRY: ghcr.io
+  # Version of 'regctl' to use for copying images to DOCKER_BUILD_REGISTRY
+  REGCTL_VERSION: 'v0.9.2'
 
 jobs:
   docker-build:
@@ -298,9 +300,9 @@ jobs:
       # 'regctl' is used to more easily copy the image to DockerHub and obtain the digest from DockerHub
       # See https://github.com/regclient/regclient/blob/main/docs/regctl.md
       - name: Install regctl for Docker registry tools
-        uses: regclient/actions/regctl-installer@main
-        with:
-          release: 'v0.8.0'
+        run: |
+          curl -L https://github.com/regclient/regclient/releases/download/${REGCTL_VERSION}/regctl-linux-amd64 > /usr/bin/regctl
+          chmod 755 /usr/bin/regctl
 
       # This recreates Docker tags for DockerHub
       - name: Add Docker metadata for image


### PR DESCRIPTION
## Description
Currently, all of our Docker build processes in our CI because our GitHub Action is unable to properly install `regctl`, which is used to copy the images to DockerHub.  Here's an example:
https://github.com/DSpace/dspace-angular/actions/runs/19310594321/job/55231392562

The problem appears to be that the `regctl-installer` action we were using was modified in an incompatible way.   Because that action doesn't do versioned releases, they don't have a way to rollback to a prior version.  

Therefore, this PR removes usage of `regctl-installer` and just performs a manual installation of `regctl` instead.

## Instructions for Reviewers
* The only way to test this is via GitHub actions.