### PR TITLE
[Port dspace-7_x] [GitHub Actions] Fix Docker build bug by installing regctl manually instead of using a plugin

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -79,8 +79,6 @@ env:
   # Registry used during building of Docker images. (All images are later copied to docker.io registry)
   # We use GitHub's Container Registry to avoid aggressive rate limits at DockerHub.
   DOCKER_BUILD_REGISTRY: ghcr.io
-  # Version of 'regctl' to use for copying images to DOCKER_BUILD_REGISTRY
-  REGCTL_VERSION: 'v0.9.2'
 
 jobs:
   docker-build:
@@ -302,8 +300,11 @@ jobs:
       # See https://github.com/regclient/regclient/blob/main/docs/regctl.md
       - name: Install regctl for Docker registry tools
         run: |
-          curl -L https://github.com/regclient/regclient/releases/download/${REGCTL_VERSION}/regctl-linux-amd64 > /usr/bin/regctl
-          chmod 755 /usr/bin/regctl
+          export REGCTL_VERSION=v0.9.2
+          mkdir -p bin
+          curl -sSLo bin/regctl https://github.com/regclient/regclient/releases/download/${REGCTL_VERSION}/regctl-linux-amd64
+          chmod a+x bin/regctl
+          echo "$(pwd)/bin" >> $GITHUB_PATH
 
       # This recreates Docker tags for DockerHub
       - name: Add Docker metadata for image

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -79,6 +79,8 @@ env:
   # Registry used during building of Docker images. (All images are later copied to docker.io registry)
   # We use GitHub's Container Registry to avoid aggressive rate limits at DockerHub.
   DOCKER_BUILD_REGISTRY: ghcr.io
+  # Version of 'regctl' to use for copying images to DOCKER_BUILD_REGISTRY
+  REGCTL_VERSION: 'v0.9.2'
 
 jobs:
   docker-build:
@@ -299,9 +301,9 @@ jobs:
       # 'regctl' is used to more easily copy the image to DockerHub and obtain the digest from DockerHub
       # See https://github.com/regclient/regclient/blob/main/docs/regctl.md
       - name: Install regctl for Docker registry tools
-        uses: regclient/actions/regctl-installer@main
-        with:
-          release: 'v0.8.0'
+        run: |
+          curl -L https://github.com/regclient/regclient/releases/download/${REGCTL_VERSION}/regctl-linux-amd64 > /usr/bin/regctl
+          chmod 755 /usr/bin/regctl
 
       # This recreates Docker tags for DockerHub
       - name: Add Docker metadata for image


### PR DESCRIPTION
Manual port of #11541 and a later bug fix to `dspace-7_x`