### PR TITLE
The email VTL template doesn't allow the creation of headers with ( dash ) character '-'

### DIFF
--- a/dspace-api/src/main/java/org/dspace/core/Email.java
+++ b/dspace-api/src/main/java/org/dspace/core/Email.java
@@ -411,6 +411,7 @@ public class Email {
         VelocityContext vctx = new VelocityContext();
         vctx.put("config", new UnmodifiableConfigurationService(config));
         vctx.put("params", Collections.unmodifiableList(arguments));
+        vctx.put("global", vctx);   
 
         StringWriter writer = new StringWriter();
         try {

--- a/dspace-api/src/main/java/org/dspace/core/Email.java
+++ b/dspace-api/src/main/java/org/dspace/core/Email.java
@@ -411,7 +411,7 @@ public class Email {
         VelocityContext vctx = new VelocityContext();
         vctx.put("config", new UnmodifiableConfigurationService(config));
         vctx.put("params", Collections.unmodifiableList(arguments));
-        vctx.put("global", vctx);   
+        vctx.put("global", vctx);
 
         StringWriter writer = new StringWriter();
         try {

--- a/dspace-api/src/test/java/org/dspace/core/EmailTest.java
+++ b/dspace-api/src/test/java/org/dspace/core/EmailTest.java
@@ -9,14 +9,17 @@ package org.dspace.core;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 
 import java.io.IOException;
 
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;
+import org.apache.velocity.exception.ParseErrorException;
 import org.dspace.AbstractDSpaceTest;
 import org.dspace.services.ConfigurationService;
 import org.hamcrest.Matchers;
@@ -28,8 +31,8 @@ import org.junit.Test;
  *
  * @author mwood
  */
-public class EmailTest
-        extends AbstractDSpaceTest {
+public class EmailTest extends AbstractDSpaceTest {
+
     private ConfigurationService config;
 
     @Before
@@ -255,4 +258,151 @@ public class EmailTest
         assertThat("Logged message should contain REAL RECIPIENT section",
                 loggedMessage, containsString("===REAL RECIPIENT==="));
     }
+
+    /**
+     * Test that verifies the ability to create headers with dashes using $global.put()
+     * without creating a temporary variable.
+     * Syntax: $!global.put("X-Custom-Header", "value")
+     * The $! (silent reference) calls the method without printing anything to the body.
+     */
+    @Test
+    public void testVelocityHeaderWithDashUsingGlobalPutWithoutTempVariable() throws MessagingException, IOException {
+        config.setProperty("mail.server.disabled", "true");
+        config.setProperty("mail.message.headers", "X-Custom-Header, subject");
+
+        var body = "Email body with custom header.";
+        String template = "$!global.put('X-Custom-Header', 'test-value-123')" + body;
+
+        Email email = new Email();
+        email.setContent("test-header-dash", template);
+        email.addRecipient("test@example.com");
+        email.build();
+
+        MimeMessage message = email.message;
+        String[] headerValues = message.getHeader("X-Custom-Header");
+        String messageBody = message.getContent().toString();
+
+        assertThat("Header should contain the correct value", headerValues[0], is("test-value-123"));
+        assertThat("Body should contain only the body text", messageBody, containsString(body));
+        assertThat("Body should NOT contain references to $global.put", messageBody, not(containsString("$global")));
+        assertThat("Body should NOT contain the header name", messageBody, not(containsString("X-Custom-Header")));
+        assertThat("Body should NOT contain the header value", messageBody, not(containsString("test-value-123")));
+    }
+
+    /**
+     * Test with alternative syntax using #if()
+     * to force evaluation of the expression without creating temporary variables.
+     * Syntax: #if($global.put("X-Header", "value"))#end
+     * The #if evaluates the expression (executing .put()), and since .put() returns null,
+     * the condition is always false, but the method is still executed.
+     */
+    @Test
+    public void testVelocityHeaderWithDashUsingIfConstruct() throws MessagingException, IOException {
+        config.setProperty("mail.server.disabled", "true");
+        config.setProperty("mail.message.headers", "X-TEST-TEST,subject");
+
+        var body = "Email body with test header.";
+        String template = "#if($global.put('X-TEST-TEST', $config.get('dspace.name')))#end\n" + body;
+
+        Email email = new Email();
+        email.setContent("test-if-construct", template);
+        email.addRecipient("test@example.com");
+        email.build();
+
+        MimeMessage message = email.message;
+        String[] headerValues = message.getHeader("X-TEST-TEST");
+        String messageBody = message.getContent().toString();
+
+        assertThat("Header X-TEST-TEST should exist", headerValues, notNullValue());
+        assertThat("Header should contain the DSpace name", headerValues[0], equalTo("DSpace at My University"));
+        assertThat("Body should contain only the body text", messageBody, containsString(body));
+        assertThat("Body should NOT contain references to $global.put", messageBody, not(containsString("$global")));
+        assertThat("Body should NOT contain the header name", messageBody, not(containsString("X-TEST-TEST")));
+        assertThat("Body should NOT contain the header value", messageBody,
+                not(containsString("DSpace at My University")));
+    }
+
+    /**
+     * Test of the current syntax (with temporary variable) for comparison.
+     * Syntax: #set($temp = $global.put("X-Header", "value"))
+     * This works but creates an unnecessary temporary variable with null value.
+     * The variable will be rendered as "$test" (literal) if not handled with $!
+     */
+    @Test
+    public void testVelocityHeaderWithDashUsingTempVariable() throws MessagingException, IOException {
+        config.setProperty("mail.server.disabled", "true");
+        config.setProperty("mail.message.headers", "X-Test-ID,subject");
+
+        // Using $!test instead of $test to avoid printing the literal string
+        String template = "#set($test = $global.put('X-Test-ID', 'test-001'))\n" +
+                "Email body. Temp variable value:$!test";
+
+        Email email = new Email();
+        email.setContent("test-temp-var", template);
+        email.addRecipient("test@example.com");
+        email.build();
+
+        MimeMessage message = email.message;
+        String[] headerValues = message.getHeader("X-Test-ID");
+        String messageBody = message.getContent().toString();
+
+        assertThat("Header X-Test-ID should exist", headerValues, is(not((String[]) null)));
+        assertThat("Header should contain the ID", headerValues[0], is("test-001"));
+        // $!test prints nothing when null, so the body should not contain "test"
+        assertThat("Temp variable should render as empty string", messageBody,
+                equalTo("Email body. Temp variable value:"));
+        assertThat("Temp variable should not print literal $test", messageBody, not(containsString("$test")));
+    }
+
+    /**
+     * Test with multiple headers containing dashes using different syntaxes.
+     * Demonstrates that all three approaches work together in the same template.
+     */
+    @Test
+    public void testVelocityMultipleHeadersWithDash() throws MessagingException, IOException {
+        config.setProperty("mail.server.disabled", "true");
+        config.setProperty("mail.message.headers", "X-Header-One,X-Header-Two,X-Header-Three,subject");
+
+        String template = "$!global.put('X-Header-One', 'value1')\n" +
+                "#if($global.put('X-Header-Two', 'value2'))#end\n" +
+                "#set($temp = $global.put('X-Header-Three', 'value3'))\n" +
+                "Email with multiple custom headers.";
+
+        Email email = new Email();
+        email.setContent("test-multiple-headers", template);
+        email.addRecipient("test@example.com");
+        email.build();
+
+        MimeMessage message = email.message;
+
+        assertThat("X-Header-One should exist", message.getHeader("X-Header-One")[0], is("value1"));
+        assertThat("X-Header-Two should exist", message.getHeader("X-Header-Two")[0], is("value2"));
+        assertThat("X-Header-Three should exist", message.getHeader("X-Header-Three")[0], is("value3"));
+    }
+
+    /**
+     * Test that verifies headers with dashes do not work with standard syntax
+     * (without using $global.put()).
+     * This demonstrates the problem that necessitates the $global.put() workaround.
+     *
+     * The standard Velocity syntax {@code #set($X-Header = 'value')} causes a
+     * {@link ParseErrorException} when the template is loaded via {@link Email#setContent},
+     * because Velocity interprets the dash as a subtraction operator (e.g., $X minus Header).
+     *
+     * This test expects the {@link ParseErrorException} to be thrown during template compilation,
+     * proving that the workaround with $global.put() is necessary for headers containing dashes.
+     */
+    @Test(expected = ParseErrorException.class)
+    public void testVelocityHeaderWithDashStandardSyntaxFails() throws IOException {
+        config.setProperty("mail.server.disabled", "true");
+        config.setProperty("mail.message.headers", "X-Will-Not-Work,subject");
+
+        // This syntax does NOT work due to the dash - it causes a parse error at template compilation
+        String template = "#set($X-Will-Not-Work = 'this-will-fail')Email body.";
+
+        Email email = new Email();
+        // This call will throw ParseErrorException because the template cannot be compiled
+        email.setContent("test-standard-syntax", template);
+    }
+
 }


### PR DESCRIPTION
## Description
Velocity officially deprecated the use of dashes in variable identifiers to avoid ambiguity with the subtraction operator.
A backward compatibility property exists, but enabling it forces escaping of the minus operator everywhere, which would break existing templates.

The standard syntax
```
 #set($X-Custom-Header = 'value')
``` 
now causes a `ParseErrorException` because Velocity interprets it as `$X minus Custom minus Header`.

## Solution
To avoid breaking existing templates, I added the VelocityContext itself as a variable (`$global`) in the template scope.
This enables using the context API `context.put(...)` to set variables with any name, including those containing dashes.

**Old (broken) syntax:**
```velocity
#set($X-TEST-ID = $config.get('test.id'))
```

**New syntax options:**
```velocity
# Option 1: Silent reference (recommended - no variable duplication)
$!global.put('X-TEST-ID', $config.get('test.id'))

# Option 2: If construct (clean alternative)
#if($global.put('X-TEST-ID', $config.get('test.id')))#end

# Option 3: With temporary variable (original approach)
#set($test = $global.put('X-TEST-ID', $config.get('test.id')))
```

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
