### PR TITLE
Minor Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,6 +45,7 @@ updates:
         applies-to: version-updates
         patterns:
         - "junit:*"
+        - "com.adobe.testing:*"
         - "com.github.stefanbirker:system-rules"
         - "com.h2database:*"
         - "io.findify:s3mock*"
@@ -53,6 +54,7 @@ updates:
         - "org.hamcrest:*"
         - "org.mock-server:*"
         - "org.mockito:*"
+        - "org.testcontainers:*"
         - "org.xmlunit:*"
         update-types:
         - "minor"
@@ -178,6 +180,7 @@ updates:
         applies-to: version-updates
         patterns:
           - "junit:*"
+          - "com.adobe.testing:*"
           - "com.github.stefanbirker:system-rules"
           - "com.h2database:*"
           - "io.findify:s3mock*"
@@ -186,6 +189,7 @@ updates:
           - "org.hamcrest:*"
           - "org.mock-server:*"
           - "org.mockito:*"
+          - "org.testcontainers:*"
           - "org.xmlunit:*"
         update-types:
           - "minor"
@@ -311,6 +315,7 @@ updates:
         applies-to: version-updates
         patterns:
           - "junit:*"
+          - "com.adobe.testing:*"
           - "com.github.stefanbirker:system-rules"
           - "com.h2database:*"
           - "io.findify:s3mock*"
@@ -319,6 +324,7 @@ updates:
           - "org.hamcrest:*"
           - "org.mock-server:*"
           - "org.mockito:*"
+          - "org.testcontainers:*"
           - "org.xmlunit:*"
         update-types:
           - "minor"
@@ -444,6 +450,7 @@ updates:
         applies-to: version-updates
         patterns:
           - "junit:*"
+          - "com.adobe.testing:*"
           - "com.github.stefanbirker:system-rules"
           - "com.h2database:*"
           - "io.findify:s3mock*"
@@ -451,6 +458,7 @@ updates:
           - "org.hamcrest:*"
           - "org.mock-server:*"
           - "org.mockito:*"
+          - "org.testcontainers:*"
           - "org.xmlunit:*"
         update-types:
           - "minor"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,6 +57,14 @@ updates:
         update-types:
         - "minor"
         - "patch"
+      # Group together all Amazon S3 deps in a single PR
+      amazon-s3:
+        applies-to: version-updates
+        patterns:
+          - "software.amazon.*:*"
+        update-types:
+          - "minor"
+          - "patch"
       # Group together all Apache Commons deps in a single PR
       apache-commons:
         applies-to: version-updates
@@ -179,6 +187,14 @@ updates:
           - "org.mock-server:*"
           - "org.mockito:*"
           - "org.xmlunit:*"
+        update-types:
+          - "minor"
+          - "patch"
+      # Group together all Amazon S3 deps in a single PR
+      amazon-s3:
+        applies-to: version-updates
+        patterns:
+          - "software.amazon.*:*"
         update-types:
           - "minor"
           - "patch"
@@ -307,6 +323,14 @@ updates:
         update-types:
           - "minor"
           - "patch"
+      # Group together all Amazon S3 deps in a single PR
+      amazon-s3:
+        applies-to: version-updates
+        patterns:
+          - "software.amazon.*:*"
+        update-types:
+          - "minor"
+          - "patch"
       # Group together all Apache Commons deps in a single PR
       apache-commons:
         applies-to: version-updates
@@ -428,6 +452,14 @@ updates:
           - "org.mock-server:*"
           - "org.mockito:*"
           - "org.xmlunit:*"
+        update-types:
+          - "minor"
+          - "patch"
+      # Group together all Amazon S3 deps in a single PR
+      amazon-s3:
+        applies-to: version-updates
+        patterns:
+          - "software.amazon.*:*"
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
## Description
Two very minor updates to dependabot configuration to add/enhance our PR groups:
* First, added a new `amazon-s3` group for Amazon S3 related dependencies to be grouped in a single PR
* Second, updated our `test-group` group with some newer test-related dependencies.  This keeps them all together in one PR.
