### PR TITLE
[Dependabot] Pin Google's `errorprone` to v2.42.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -135,6 +135,10 @@ updates:
       # Don't try to auto-update any DSpace dependencies
       - dependency-name: "org.dspace:*"
       - dependency-name: "org.dspace.*:*"
+      # Last version of errorprone to support JDK 17 is 2.42.0
+      # TODO: Remove this after this ticket is resolved https://github.com/DSpace/DSpace/issues/11621
+      - dependency-name: "com.google.errorprone:*"
+        versions: [ ">=2.43.0" ]
       # Ignore major/minor updates for Hibernate. Only patch updates can be automated.
       - dependency-name: "org.hibernate.*:*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
@@ -270,6 +274,9 @@ updates:
       # Don't try to auto-update any DSpace dependencies
       - dependency-name: "org.dspace:*"
       - dependency-name: "org.dspace.*:*"
+      # Last version of errorprone to support JDK 17 is 2.42.0
+      - dependency-name: "com.google.errorprone:*"
+        versions: [ ">=2.43.0" ]
       # Ignore major/minor updates for Hibernate. Only patch updates can be automated.
       - dependency-name: "org.hibernate.*:*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
@@ -405,6 +412,9 @@ updates:
       # Don't try to auto-update any DSpace dependencies
       - dependency-name: "org.dspace:*"
       - dependency-name: "org.dspace.*:*"
+      # Last version of errorprone to support JDK 17 is 2.42.0
+      - dependency-name: "com.google.errorprone:*"
+        versions: [ ">=2.43.0" ]
       # Ignore major/minor updates for Hibernate. Only patch updates can be automated.
       - dependency-name: "org.hibernate.*:*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]


### PR DESCRIPTION
## Description
This small PR to dependabot rules pins the version of Google's errorprone that we are using to 2.42.0. This is necessary because [v2.43.0 and later require JDK 21](https://github.com/google/error-prone/releases/tag/v2.43.0).

At this time, we still use JDK 17 as a minimum java version.  See #11621 for discussion about moving to JDK 21.