### PR TITLE
Fixes authentication issues involving Special Groups and various Authentication Methods 

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authenticate/AuthenticationMethod.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/AuthenticationMethod.java
@@ -166,7 +166,7 @@ public interface AuthenticationMethod {
      *                 otherwise
      */
     public default boolean areSpecialGroupsApplicable(Context context, HttpServletRequest request) {
-        return getName().equals(context.getAuthenticationMethod());
+        return getName().equals(context.getAuthenticationMethod()) || isUsed(context,request);
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/authenticate/AuthenticationMethod.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/AuthenticationMethod.java
@@ -166,7 +166,7 @@ public interface AuthenticationMethod {
      *                 otherwise
      */
     public default boolean areSpecialGroupsApplicable(Context context, HttpServletRequest request) {
-        return getName().equals(context.getAuthenticationMethod()) || isUsed(context,request);
+        return getName().equals(context.getAuthenticationMethod()) || isUsed(context, request);
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/authenticate/AuthenticationServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/AuthenticationServiceImpl.java
@@ -110,6 +110,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
                 }
                 if (ret == AuthenticationMethod.SUCCESS) {
                     updateLastActiveDate(context);
+                    context.setAuthenticationMethod(aMethodStack.getName());
                     return ret;
                 }
                 if (ret < bestRet) {


### PR DESCRIPTION
## References
Fixes https://github.com/DSpace/DSpace/issues/9226
Fixes https://github.com/DSpace/DSpace/issues/9498
Fixes https://github.com/DSpace/DSpace/issues/9726

Improves upon work started in https://github.com/DSpace/DSpace/pull/11462

## Description
This PR addresses an issue where the authentication method was not being correctly set in the context upon successful login. It also relaxes the check for special groups applicability to include cases where the authentication method is currently in use, ensuring that special groups are correctly resolved during the authentication process.

## Improvements over PR #11462
This PR offers a significant improvement over the approach taken in PR #11462 in terms of **clearness, readability, and testability**:

*   **Clearness**: Instead of complex logic involving servlet path enumeration and iterating through the authentication stack to guess the method, this solution simply sets the authentication method in the `Context` at the exact moment of successful login in `AuthenticationServiceImpl`. This reduces the change to essentially two lines of logic.
*   **Readability**: The changes are minimal and located exactly where one would expect the authentication state to be managed (in the service implementation and the method interface), making the code easy to follow and maintain.
*   **Testability**: Unlike the previous attempt, this PR includes comprehensive integration tests (`AuthenticationRestControllerIT`) that verify:
    *   The authentication method is correctly set in the response.
    *   Special groups are correctly mapped and returned *only* for the active authentication method.
    *   Scenarios for both Shibboleth and Password authentication are covered to ensure no regression or cross-contamination of special groups.

## Instructions for Reviewers
List of changes in this PR:
*   **`AuthenticationServiceImpl.java`**: Explicitly set the authentication method in the `Context` when authentication is successful.
*   **`AuthenticationMethod.java`**: Updated `areSpecialGroupsApplicable` to return `true` if the authentication method `isUsed` by the current request.
*   **`AuthenticationRestControllerIT.java`**: Added integration tests to verify that the authentication method is correctly set and that special groups are applied only when the corresponding authentication method is used.

**Include guidance for how to test or review your PR.**
Reviewers should verify that logging in with an authentication method (e.g., Shibboleth or Password) correctly sets the authentication method in the context and that special groups associated with that method are correctly applied. The new integration tests cover these scenarios.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).