### PR TITLE
Refactor authorization-based Solr queries and add new findAddAuthorized/findEditAuthorized endpoints

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authorize/service/AuthorizeService.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/service/AuthorizeService.java
@@ -561,6 +561,20 @@ public interface AuthorizeService {
         throws SearchServiceException, SQLException;
 
     /**
+     *  Finds communities for which the logged in user has the rights specified by the action parameter.
+     *
+     * @param context   the context whose user is checked against
+     * @param query     the optional extra query
+     * @param action    the action to check for
+     * @param offset    the offset for pagination
+     * @param limit     the amount of dso's to return
+     * @return          a list of communities for which the logged in user has the rights specified by the action
+     * @throws SearchServiceException
+     */
+    List<Community> findAuthorizedCommunityByAction(Context context, String query, int action, int offset, int limit)
+        throws SearchServiceException, SQLException;
+
+    /**
      * Counts communities for which the current user is admin, AND which match the query.
      *
      * @param context   context with the current user
@@ -573,6 +587,18 @@ public interface AuthorizeService {
         throws SearchServiceException, SQLException;
 
     /**
+     * Counts communities for which the current user has the rights specified by the action parameter.
+     *
+     * @param context   context with the current user
+     * @param query     the query for which to filter the results more
+     * @param action    the action to check for
+     * @return          the matching communities
+     * @throws SearchServiceException
+     */
+    long countAuthorizedCommunityByAction(Context context, String query, int action)
+        throws SearchServiceException;
+
+    /**
      * Finds collections for which the current user is admin, AND which match the query.
      *
      * @param context   context with the current user
@@ -581,10 +607,24 @@ public interface AuthorizeService {
      * @param limit     used for pagination of the results
      * @return          the matching collections
      * @throws SearchServiceException
-     * @throws SQLException
      */
     List<Collection> findAdminAuthorizedCollection(Context context, String query, int offset, int limit)
-        throws SearchServiceException, SQLException;
+        throws SearchServiceException;
+
+    /**
+     * Finds collections for which the current user has the rights specified by the action parameter.
+     *
+     * @param context   context with the current user
+     * @param query     the query for which to filter the results more
+     * @param action    the action to check for
+     * @param offset    used for pagination of the results
+     * @param limit     used for pagination of the results
+     * @return          the matching collections
+     * @throws SearchServiceException
+     */
+    List<Collection> findAuthorizedCollectionByAction(Context context, String query, int action, int offset,
+                                                      int limit)
+        throws SearchServiceException;
 
     /**
      * Counts collections for which the current user is admin, AND which match the query.
@@ -596,7 +636,19 @@ public interface AuthorizeService {
      * @throws SQLException
      */
     long countAdminAuthorizedCollection(Context context, String query)
-        throws SearchServiceException, SQLException;
+        throws SearchServiceException;
+
+    /**
+     * Counts collections for which the current user has the rights specified by the action parameter.
+     *
+     * @param context   context with the current user
+     * @param query     the query for which to filter the results more
+     * @param action   the action to check for
+     * @return          the number of matching collections
+     * @throws SearchServiceException
+     */
+    long countAuthorizedCollectionByAction(Context context, String query, int action)
+        throws SearchServiceException;
 
     /**
      * Returns true if the current user can manage accounts.

--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -22,7 +22,6 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -1268,43 +1267,38 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
      *
      * @param context                    DSpace context
      * @param discoverQuery
+     * @param q                          query string
      * @return                           discovery search result objects
-     * @throws SQLException              if something goes wrong
      * @throws SearchServiceException    if search error
      */
-    private DiscoverResult retrieveItemsWithEdit(Context context, DiscoverQuery discoverQuery)
-        throws SQLException, SearchServiceException {
-        EPerson currentUser = context.getCurrentUser();
-        if (!authorizeService.isAdmin(context)) {
-            String userId = currentUser != null ? "e" + currentUser.getID().toString() : "e";
-            Stream<String> groupIds = groupService.allMemberGroupsSet(context, currentUser).stream()
-                .map(group -> "g" + group.getID());
-            String query = Stream.concat(Stream.of(userId), groupIds)
-                .collect(Collectors.joining(" OR ", "edit:(", ")"));
-            discoverQuery.addFilterQueries(query);
+    private DiscoverResult retrieveItemsWithEdit(Context context, DiscoverQuery discoverQuery, String q)
+        throws SearchServiceException {
+        if (StringUtils.isNotBlank(q)) {
+            discoverQuery.setQuery(q);
         }
+        discoverQuery.addRequiredAuthorization(Constants.WRITE);
         return searchService.search(context, discoverQuery);
     }
 
     @Override
-    public List<Item> findItemsWithEdit(Context context, int offset, int limit)
-        throws SQLException, SearchServiceException {
+    public List<Item> findItemsWithEdit(Context context, String q, int offset, int limit)
+        throws SearchServiceException {
         DiscoverQuery discoverQuery = new DiscoverQuery();
         discoverQuery.setDSpaceObjectFilter(IndexableItem.TYPE);
         discoverQuery.setStart(offset);
         discoverQuery.setMaxResults(limit);
-        DiscoverResult resp = retrieveItemsWithEdit(context, discoverQuery);
+        DiscoverResult resp = retrieveItemsWithEdit(context, discoverQuery, q);
         return resp.getIndexableObjects().stream()
             .map(solrItems -> ((IndexableItem) solrItems).getIndexedObject())
             .collect(Collectors.toList());
     }
 
     @Override
-    public int countItemsWithEdit(Context context) throws SQLException, SearchServiceException {
+    public int countItemsWithEdit(Context context, String q) throws SearchServiceException {
         DiscoverQuery discoverQuery = new DiscoverQuery();
         discoverQuery.setMaxResults(0);
         discoverQuery.setDSpaceObjectFilter(IndexableItem.TYPE);
-        DiscoverResult resp = retrieveItemsWithEdit(context, discoverQuery);
+        DiscoverResult resp = retrieveItemsWithEdit(context, discoverQuery, q);
         return (int) resp.getTotalSearchResults();
     }
 

--- a/dspace-api/src/main/java/org/dspace/content/service/CollectionService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/CollectionService.java
@@ -391,11 +391,11 @@ public interface CollectionService
      * NOTE: for better performance, this method retrieves its results from an
      *       index (cache) and does not query the database directly.
      *       This means that results may be stale or outdated until https://github.com/DSpace/DSpace/issues/2853 is resolved"
-     * 
+     *
+     * @param context          DSpace Context
      * @param q                limit the returned collection to those with metadata values matching the query terms.
      *                         The terms are used to make also a prefix query on SOLR so it can be used to implement
      *                         an autosuggest feature over the collection name
-     * @param context          DSpace Context
      * @param community        parent community
      * @param entityType       limit the returned collection to those related to given entity type
      * @param offset           the position of the first result to return
@@ -404,7 +404,7 @@ public interface CollectionService
      * @throws SQLException              if something goes wrong
      * @throws SearchServiceException    if search error
      */
-    public List<Collection> findCollectionsWithSubmit(String q, Context context, Community community,
+    public List<Collection> findCollectionsWithSubmit(Context context, String q, Community community,
             String entityType, int offset, int limit) throws SQLException, SearchServiceException;
 
     /**
@@ -422,11 +422,10 @@ public interface CollectionService
      * @param offset           the position of the first result to return
      * @param limit            paging limit
      * @return                 discovery search result objects
-     * @throws SQLException              if something goes wrong
      * @throws SearchServiceException    if search error
      */
     public List<Collection> findCollectionsWithSubmit(String q, Context context, Community community,
-        int offset, int limit) throws SQLException, SearchServiceException;
+        int offset, int limit) throws SearchServiceException;
 
     /**
      * Retrieve the first collection in the community or its descending that support
@@ -462,17 +461,17 @@ public interface CollectionService
      *       and does not query the database directly.
      *       This means that results may be stale or outdated until
      *       https://github.com/DSpace/DSpace/issues/2853 is resolved."
-     * 
+     *
+     * @param context          DSpace Context
      * @param q                limit the returned collection to those with metadata values matching the query terms.
      *                         The terms are used to make also a prefix query on SOLR so it can be used to implement
      *                         an autosuggest feature over the collection name
-     * @param context          DSpace Context
      * @param community        parent community
      * @return                 total collections found
      * @throws SQLException              if something goes wrong
      * @throws SearchServiceException    if search error
      */
-    public int countCollectionsWithSubmit(String q, Context context, Community community)
+    public int countCollectionsWithSubmit(Context context, String q, Community community)
         throws SQLException, SearchServiceException;
 
     /**
@@ -481,18 +480,18 @@ public interface CollectionService
      *       and does not query the database directly.
      *       This means that results may be stale or outdated until
      *       https://github.com/DSpace/DSpace/issues/2853 is resolved."
-     * 
+     *
+     * @param context          DSpace Context
      * @param q                limit the returned collection to those with metadata values matching the query terms.
      *                         The terms are used to make also a prefix query on SOLR so it can be used to implement
      *                         an autosuggest feature over the collection name
-     * @param context          DSpace Context
      * @param community        parent community
      * @param entityType       limit the returned collection to those related to given entity type
      * @return                 total collections found
      * @throws SQLException              if something goes wrong
      * @throws SearchServiceException    if search error
      */
-    public int countCollectionsWithSubmit(String q, Context context, Community community, String entityType)
+    public int countCollectionsWithSubmit(Context context, String q, Community community, String entityType)
         throws SQLException, SearchServiceException;
 
     /**

--- a/dspace-api/src/main/java/org/dspace/content/service/ItemService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/ItemService.java
@@ -933,23 +933,23 @@ public interface ItemService
     /**
       * finds all items for which the current user has editing rights
       * @param context DSpace context object
+      * @param q search query
       * @param offset page offset
       * @param limit  page size limit
       * @return list of items for which the current user has editing rights
-      * @throws SQLException
       * @throws SearchServiceException
       */
-    List<Item> findItemsWithEdit(Context context, int offset, int limit)
-        throws SQLException, SearchServiceException;
+    List<Item> findItemsWithEdit(Context context, String q, int offset, int limit)
+        throws SearchServiceException;
 
     /**
     * counts all items for which the current user has editing rights
     * @param context DSpace context object
+    * @param q search query
     * @return list of items for which the current user has editing rights
-    * @throws SQLException
     * @throws SearchServiceException
     */
-    int countItemsWithEdit(Context context) throws SQLException, SearchServiceException;
+    int countItemsWithEdit(Context context, String q) throws SearchServiceException;
 
     /**
      * Check if the supplied item is an inprogress submission

--- a/dspace-api/src/main/java/org/dspace/discovery/DiscoverQuery.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/DiscoverQuery.java
@@ -73,6 +73,14 @@ public class DiscoverQuery {
 
     private String discoveryConfigurationName;
 
+    /**
+     * The required authorizations user should have for the objects returned by the query.
+     * The READ authorization (Constants.READ) is always required and does not need to be added here.
+     */
+    private List<Integer> requiredAuthorization;
+
+    private boolean inheritAuthorizations = true;
+
     public DiscoverQuery() {
         //Initialize all our lists
         this.filterQueries = new ArrayList<>();
@@ -84,6 +92,7 @@ public class DiscoverQuery {
         this.hitHighlighting = new HashMap<>();
         //Use a linked hashmap since sometimes insertion order might matter
         this.properties = new LinkedHashMap<>();
+        this.requiredAuthorization = new ArrayList<>();
     }
 
 
@@ -420,4 +429,54 @@ public class DiscoverQuery {
     public void setIncludeNotDiscoverableOrWithdrawn(boolean includeNotDiscoverableAndWithdrawn) {
         this.includeNotDiscoverableOrWithdrawn = includeNotDiscoverableAndWithdrawn;
     }
+
+    /**
+     * Return the required authorization user should have for the objects returned by this query
+     *
+     * @return the required authorizations
+     */
+    public List<Integer> getRequiredAuthorizations() {
+        return requiredAuthorization;
+    }
+
+    /**
+     * Add a required authorization user should have for the objects returned by this query.
+     * The READ authorization (Constants.READ) is always required and does not need to be added here.
+     *
+     * @param action
+     *            the required action
+     */
+    public void addRequiredAuthorization(int action) {
+        this.requiredAuthorization.add(action);
+    }
+
+    /**
+     * Remove a required authorization user should have for the objects returned by this query
+     *
+     * @param authorizationAction
+     *            the required action
+     */
+    public void removeRequiredAuthorization(int authorizationAction) {
+        this.requiredAuthorization.removeIf(action -> action == authorizationAction);
+    }
+
+    /**
+     * Return whether authorizations should be inherited from parent objects
+     *
+     * @return true if authorizations should be inherited, false otherwise
+     */
+    public boolean isInheritAuthorizationsEnabled() {
+        return inheritAuthorizations;
+    }
+
+    /**
+     * Set whether authorizations should be inherited from parent objects
+     *
+     * @param inheritAuthorizations
+     *            true if authorizations should be inherited, false otherwise
+     */
+    public void setInheritAuthorizations(boolean inheritAuthorizations) {
+        this.inheritAuthorizations = inheritAuthorizations;
+    }
+
 }

--- a/dspace-api/src/main/java/org/dspace/discovery/SearchService.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SearchService.java
@@ -90,6 +90,8 @@ public interface SearchService {
     List<Item> getRelatedItems(Context context, Item item,
                                DiscoveryMoreLikeThisConfiguration moreLikeThisConfiguration);
 
+    String createLocationQueryForAdministrableDSOs(String epersonAndGroupClause);
+
     /**
      * Method to create a  Query that includes all
      * communities and collections a user may administrate.

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServicePrivateItemPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServicePrivateItemPlugin.java
@@ -45,9 +45,8 @@ public class SolrServicePrivateItemPlugin implements SolrServiceSearchPlugin {
                 solrQuery.addFilterQuery("NOT(discoverable:false)");
                 return;
             }
-            if (!authorizeService.isCommunityAdmin(context) && !authorizeService.isCollectionAdmin(context)) {
+            if (!authorizeService.isComColAdmin(context)) {
                 solrQuery.addFilterQuery("NOT(discoverable:false)");
-
             }
         } catch (SQLException ex) {
             log.error(LogHelper.getHeader(context, "Error looking up authorization rights of current user",

--- a/dspace-api/src/main/java/org/dspace/discovery/indexobject/CommunityIndexFactoryImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/indexobject/CommunityIndexFactoryImpl.java
@@ -126,7 +126,7 @@ public class CommunityIndexFactoryImpl extends DSpaceObjectIndexFactoryImpl<Inde
         final Community target = indexableDSpaceObject.getIndexedObject();
         List<String> locations = new ArrayList<>();
         // build list of community ids
-        List<Community> communities = target.getParentCommunities();
+        List<Community> communities = communityService.getAllParents(context, target);
 
         // now put those into strings
         for (Community community : communities) {

--- a/dspace-api/src/test/java/org/dspace/content/service/ItemServiceIT.java
+++ b/dspace-api/src/test/java/org/dspace/content/service/ItemServiceIT.java
@@ -685,8 +685,8 @@ public class ItemServiceIT extends AbstractIntegrationTestWithDatabase {
     @Test
     public void testFindItemsWithEditNoRights() throws Exception {
         context.setCurrentUser(eperson);
-        List<Item> result = itemService.findItemsWithEdit(context, 0, 10);
-        int count = itemService.countItemsWithEdit(context);
+        List<Item> result = itemService.findItemsWithEdit(context, "", 0, 10);
+        int count = itemService.countItemsWithEdit(context, "");
         assertThat(result.size(), equalTo(0));
         assertThat(count, equalTo(0));
     }
@@ -698,8 +698,8 @@ public class ItemServiceIT extends AbstractIntegrationTestWithDatabase {
             .withAction(Constants.WRITE)
             .build();
         context.setCurrentUser(eperson);
-        List<Item> result = itemService.findItemsWithEdit(context, 0, 10);
-        int count = itemService.countItemsWithEdit(context);
+        List<Item> result = itemService.findItemsWithEdit(context, "", 0, 10);
+        int count = itemService.countItemsWithEdit(context, "");
         assertThat(result.size(), equalTo(1));
         assertThat(count, equalTo(1));
     }
@@ -711,8 +711,8 @@ public class ItemServiceIT extends AbstractIntegrationTestWithDatabase {
             .withAction(Constants.ADMIN)
             .build();
         context.setCurrentUser(eperson);
-        List<Item> result = itemService.findItemsWithEdit(context, 0, 10);
-        int count = itemService.countItemsWithEdit(context);
+        List<Item> result = itemService.findItemsWithEdit(context, "", 0, 10);
+        int count = itemService.countItemsWithEdit(context, "");
         assertThat(result.size(), equalTo(1));
         assertThat(count, equalTo(1));
     }
@@ -730,8 +730,8 @@ public class ItemServiceIT extends AbstractIntegrationTestWithDatabase {
             .withAction(Constants.WRITE)
             .build();
         context.setCurrentUser(eperson);
-        List<Item> result = itemService.findItemsWithEdit(context, 0, 10);
-        int count = itemService.countItemsWithEdit(context);
+        List<Item> result = itemService.findItemsWithEdit(context, "", 0, 10);
+        int count = itemService.countItemsWithEdit(context, "");
         assertThat(result.size(), equalTo(1));
         assertThat(count, equalTo(1));
     }
@@ -749,8 +749,8 @@ public class ItemServiceIT extends AbstractIntegrationTestWithDatabase {
             .withAction(Constants.ADMIN)
             .build();
         context.setCurrentUser(eperson);
-        List<Item> result = itemService.findItemsWithEdit(context, 0, 10);
-        int count = itemService.countItemsWithEdit(context);
+        List<Item> result = itemService.findItemsWithEdit(context, "", 0, 10);
+        int count = itemService.countItemsWithEdit(context, "");
         assertThat(result.size(), equalTo(1));
         assertThat(count, equalTo(1));
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/EditItemFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/EditItemFeature.java
@@ -40,7 +40,7 @@ public class EditItemFeature implements AuthorizationFeature {
     @Override
     public boolean isAuthorized(Context context, BaseObjectRest object) throws SQLException, SearchServiceException {
         if (object instanceof SiteRest) {
-            return itemService.countItemsWithEdit(context) > 0;
+            return itemService.countItemsWithEdit(context, "") > 0;
         } else if (object instanceof ItemRest) {
             Item item = (Item) utils.getDSpaceAPIObjectFromRest(context, object);
             return authService.authorizeActionBoolean(context, item, Constants.WRITE);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/SubmitFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/SubmitFeature.java
@@ -43,7 +43,7 @@ public class SubmitFeature implements AuthorizationFeature {
     public boolean isAuthorized(Context context, BaseObjectRest object) throws SQLException, SearchServiceException {
         if (object instanceof SiteRest) {
             // Check whether the user has permission to add to any collection
-            return collectionService.countCollectionsWithSubmit("", context, null) > 0;
+            return collectionService.countCollectionsWithSubmit(context, "", null) > 0;
         } else if (object instanceof CollectionRest) {
             // Check whether the user has permission to add to the given collection
             Collection collection = (Collection) utils.getDSpaceAPIObjectFromRest(context, object);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CommunityRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/CommunityRestRepository.java
@@ -38,6 +38,7 @@ import org.dspace.content.Bitstream;
 import org.dspace.content.Community;
 import org.dspace.content.service.BitstreamService;
 import org.dspace.content.service.CommunityService;
+import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.discovery.DiscoverQuery;
 import org.dspace.discovery.DiscoverResult;
@@ -222,12 +223,31 @@ public class CommunityRestRepository extends DSpaceObjectRestRepository<Communit
     @SearchRestMethod(name = "findAdminAuthorized")
     public Page<CommunityRest> findAdminAuthorized (
         Pageable pageable, @Parameter(value = "query") String query) {
+        return findAuthorized(pageable, Constants.ADMIN, query);
+    }
+
+    @PreAuthorize("hasAuthority('AUTHENTICATED')")
+    @SearchRestMethod(name = "findEditAuthorized")
+    public Page<CommunityRest> findEditAuthorized (
+        Pageable pageable, @Parameter(value = "query") String query) {
+        return findAuthorized(pageable, Constants.WRITE, query);
+    }
+
+    @PreAuthorize("hasAuthority('AUTHENTICATED')")
+    @SearchRestMethod(name = "findAddAuthorized")
+    public Page<CommunityRest> findAddAuthorized (
+        Pageable pageable, @Parameter(value = "query") String query) {
+        return findAuthorized(pageable, Constants.ADD, query);
+    }
+
+    private Page<CommunityRest> findAuthorized(Pageable pageable, int action, String query) {
         try {
             Context context = obtainContext();
-            List<Community> communities = authorizeService.findAdminAuthorizedCommunity(context, query,
+            List<Community> communities = authorizeService.findAuthorizedCommunityByAction(context, query,
+                action,
                 Math.toIntExact(pageable.getOffset()),
                 Math.toIntExact(pageable.getPageSize()));
-            long tot = authorizeService.countAdminAuthorizedCommunity(context, query);
+            long tot = authorizeService.countAuthorizedCommunityByAction(context, query, action);
             return converter.toRestPage(communities, pageable, tot , utils.obtainProjection());
         } catch (SearchServiceException | SQLException e) {
             throw new RuntimeException(e.getMessage(), e);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ItemRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ItemRestRepository.java
@@ -47,6 +47,7 @@ import org.dspace.content.service.RelationshipService;
 import org.dspace.content.service.WorkspaceItemService;
 import org.dspace.core.Context;
 import org.dspace.core.exception.SQLRuntimeException;
+import org.dspace.discovery.SearchServiceException;
 import org.dspace.util.UUIDUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -260,6 +261,27 @@ public class ItemRestRepository extends DSpaceObjectRestRepository<Item, ItemRes
         context.commit();
 
         return bundle;
+    }
+
+    /**
+     * Method to find the items for which the current user has editing rights.
+     *
+     * @param query    Query string
+     * @param pageable Pagination information
+     * @return Page of Items (REST representation) for which the current user has editing rights
+     * @throws SearchServiceException
+     */
+    @PreAuthorize("hasAuthority('AUTHENTICATED')")
+    @SearchRestMethod(name = "findEditAuthorized")
+    public Page<ItemRest> findEditAuthorized(@Parameter(value = "query") String query,
+                                             Pageable pageable)
+        throws SearchServiceException {
+        Context context = obtainContext();
+        List<Item> items = itemService.findItemsWithEdit(context, query,
+            Math.toIntExact(pageable.getOffset()),
+            Math.toIntExact(pageable.getPageSize()));
+        int tot = itemService.countItemsWithEdit(context, query);
+        return converter.toRestPage(items, pageable, tot, utils.obtainProjection());
     }
 
     @Override

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
@@ -50,6 +50,7 @@ import org.dspace.app.rest.model.patch.ReplaceOperation;
 import org.dspace.app.rest.projection.Projection;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
 import org.dspace.app.rest.test.MetadataPatchSuite;
+import org.dspace.authorize.ResourcePolicy;
 import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.authorize.service.ResourcePolicyService;
 import org.dspace.builder.CollectionBuilder;
@@ -2753,6 +2754,486 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
                                                             subCommunity.getHandle())
                                            )))
                                .andExpect(jsonPath("$.page.totalElements", is(1)));
+    }
+
+    @Test
+    public void addParentComAdminGroupToCheckAdminPropagationTest() throws Exception {
+        addParentComAdminGroupToCheckGenericPropagationTest("findAdminAuthorized");
+    }
+
+    @Test
+    public void addParentComAdminGroupToCheckEditPropagationTest() throws Exception {
+        addParentComAdminGroupToCheckGenericPropagationTest("findEditAuthorized");
+    }
+
+    @Test
+    public void addParentComAdminGroupToCheckAddPropagationTest() throws Exception {
+        addParentComAdminGroupToCheckGenericPropagationTest("findAddAuthorized");
+    }
+
+    public void addParentComAdminGroupToCheckGenericPropagationTest(String method) throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        Community rootCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Root Community")
+            .build();
+
+        Community subCommunity = CommunityBuilder.createSubCommunity(context, rootCommunity)
+            .withName("MyTestCom")
+            .build();
+
+        context.restoreAuthSystemState();
+
+        String epersonToken = getAuthToken(eperson.getEmail(), password);
+        getClient(epersonToken).perform(get("/api/core/communities/search/" + method)
+                .param("query", "MyTestCom"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded").doesNotExist())
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
+
+        AtomicReference<UUID> idRef = new AtomicReference<>();
+        ObjectMapper mapper = new ObjectMapper();
+        GroupRest groupRest = new GroupRest();
+        String token = getAuthToken(admin.getEmail(), password);
+        getClient(token).perform(post("/api/core/communities/" + rootCommunity.getID() + "/adminGroup")
+                .content(mapper.writeValueAsBytes(groupRest))
+                .contentType(contentType))
+            .andExpect(status().isCreated())
+            .andDo(result -> idRef.set(
+                UUID.fromString(read(result.getResponse().getContentAsString(), "$.id")))
+            );
+
+        String adminToken = getAuthToken(admin.getEmail(), password);
+        getClient(adminToken).perform(post("/api/eperson/groups/" + idRef.get() + "/epersons")
+            .contentType(parseMediaType(TEXT_URI_LIST_VALUE))
+            .content(REST_SERVER_URL + "eperson/groups/" + eperson.getID()
+            ));
+
+        getClient(epersonToken).perform(get("/api/core/communities/search/" + method)
+                .param("query", "MyTestCom"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.communities", Matchers.contains(CommunityMatcher
+                .matchProperties(subCommunity.getName(),
+                    subCommunity.getID(),
+                    subCommunity.getHandle())
+            )))
+            .andExpect(jsonPath("$.page.totalElements", is(1)));
+    }
+
+    @Test
+    public void removeParentComAdminPolicyToCheckAdminPropagationTest() throws Exception {
+        removeParentComAdminPolicyToCheckGenericPropagationTest("findAdminAuthorized");
+    }
+
+    @Test
+    public void removeParentComAdminPolicyToCheckEditPropagationTest() throws Exception {
+        removeParentComAdminPolicyToCheckGenericPropagationTest("findEditAuthorized");
+    }
+
+    @Test
+    public void removeParentComAdminPolicyToCheckAddPropagationTest() throws Exception {
+        removeParentComAdminPolicyToCheckGenericPropagationTest("findAddAuthorized");
+    }
+
+    public void removeParentComAdminPolicyToCheckGenericPropagationTest(String method) throws Exception {
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Root Community")
+            .build();
+
+        ResourcePolicy policy = ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
+            .withDspaceObject(parentCommunity).withAction(Constants.ADMIN)
+            .build();
+
+        Community subCommunity = CommunityBuilder.createSubCommunity(context, parentCommunity)
+            .withName("MyTestCom")
+            .build();
+        context.restoreAuthSystemState();
+
+        String epersonToken = getAuthToken(eperson.getEmail(), password);
+        getClient(epersonToken).perform(get("/api/core/communities/search/" + method)
+                .param("query", "MyTestCom"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.communities", Matchers.contains(CommunityMatcher
+                .matchProperties(subCommunity.getName(),
+                    subCommunity.getID(),
+                    subCommunity.getHandle())
+            )))
+            .andExpect(jsonPath("$.page.totalElements", is(1)));
+
+        String token = getAuthToken(admin.getEmail(), password);
+        getClient(token).perform(delete("/api/authz/resourcepolicies/" + policy.getID()))
+            .andExpect(status().is(204));
+
+        getClient(epersonToken).perform(get("/api/core/communities/search/" + method)
+                .param("query", "MyTestCom"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded").doesNotExist())
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
+    }
+
+    @Test
+    public void findEditAuthorizedUnauthorizedTest() throws Exception {
+        getClient().perform(get("/api/core/communities/search/findEditAuthorized"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void findEditAuthorizedResourcePolicyTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Community comm1 = CommunityBuilder.createCommunity(context).withName("Community 1").build();
+
+        EPerson hasDirectEditRights = EPersonBuilder.createEPerson(context)
+            .withEmail("has@editrights.com").withPassword(password)
+            .build();
+        EPerson hasDirectAdminRights = EPersonBuilder.createEPerson(context)
+            .withEmail("has@adminrights.com").withPassword(password)
+            .build();
+        Community byResourcePolicy = CommunityBuilder.createCommunity(context)
+            .withName("direct edit rights for eperson").build();
+        Community uneditable = CommunityBuilder.createCommunity(context)
+            .withName("uneditable community")
+            .build();
+        ResourcePolicy policy = ResourcePolicyBuilder.createResourcePolicy(context, hasDirectEditRights, null)
+            .withDspaceObject(byResourcePolicy).withAction(Constants.WRITE)
+            .build();
+        policy = ResourcePolicyBuilder.createResourcePolicy(context, hasDirectAdminRights, null)
+            .withDspaceObject(byResourcePolicy).withAction(Constants.ADMIN)
+            .build();
+        context.restoreAuthSystemState();
+
+        String tokenHasDirectEditRightsToken = getAuthToken(hasDirectEditRights.getEmail(), password);
+        String tokenHasDirectAdminRightsToken = getAuthToken(hasDirectAdminRights.getEmail(), password);
+
+        getClient(tokenHasDirectEditRightsToken).perform(get("/api/core/communities/search/findEditAuthorized"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._embedded.communities",
+                Matchers.contains(CommunityMatcher.matchCommunity(byResourcePolicy))))
+            .andExpect(jsonPath("$.page.totalElements", is(1)));
+        getClient(tokenHasDirectAdminRightsToken).perform(get("/api/core/communities/search/findEditAuthorized"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._embedded.communities",
+                Matchers.contains(CommunityMatcher.matchCommunity(byResourcePolicy))))
+            .andExpect(jsonPath("$.page.totalElements", is(1)));
+    }
+
+    @Test
+    public void findEditAuthorizedAdminPropagationTest() throws Exception {
+
+        context.turnOffAuthorisationSystem();
+
+        /*
+        DSO structure:
+        root
+        └── subcomm1
+            └── subcomm1subcomm2
+         */
+        EPerson rootAdmin = EPersonBuilder.createEPerson(context)
+            .withEmail("root@admin.com").withPassword(password).build();
+        EPerson subcomm1Admin = EPersonBuilder.createEPerson(context)
+            .withEmail("subcomm1@admin.com").withPassword(password).build();
+        EPerson subcomm2Admin = EPersonBuilder.createEPerson(context)
+            .withEmail("subcomm2@admin.com").withPassword(password).build();
+
+        Community root = CommunityBuilder.createCommunity(context)
+            .withAdminGroup(rootAdmin)
+            .withName("root")
+            .build();
+        Community subcomm1 = CommunityBuilder.createSubCommunity(context, root)
+            .withAdminGroup(subcomm1Admin)
+            .withName("subcomm1")
+            .build();
+        Community subcomm1subcomm2 = CommunityBuilder.createSubCommunity(context, subcomm1)
+            .withAdminGroup(subcomm2Admin)
+            .withName("subcomm1subcomm2")
+            .build();
+        context.restoreAuthSystemState();
+
+        String siteAdminToken = getAuthToken(admin.getEmail(), password);
+        String rootAdminToken = getAuthToken(rootAdmin.getEmail(), password);
+        String subcomm1AdminToken = getAuthToken(subcomm1Admin.getEmail(), password);
+        String subcomm2AdminToken = getAuthToken(subcomm2Admin.getEmail(), password);
+
+        getClient(siteAdminToken).perform(get("/api/core/communities/search/findEditAuthorized"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._embedded.communities",
+                Matchers.containsInAnyOrder(
+                    CommunityMatcher.matchCommunity(root),
+                    CommunityMatcher.matchCommunity(subcomm1),
+                    CommunityMatcher.matchCommunity(subcomm1subcomm2)
+                )))
+            .andExpect(jsonPath("$.page.totalElements", is(3)));
+
+        getClient(rootAdminToken).perform(get("/api/core/communities/search/findEditAuthorized"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._embedded.communities",
+                Matchers.containsInAnyOrder(
+                    CommunityMatcher.matchCommunity(root),
+                    CommunityMatcher.matchCommunity(subcomm1),
+                    CommunityMatcher.matchCommunity(subcomm1subcomm2)
+                )))
+            .andExpect(jsonPath("$.page.totalElements", is(3)));
+
+        getClient(subcomm1AdminToken).perform(get("/api/core/communities/search/findEditAuthorized"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._embedded.communities",
+                Matchers.containsInAnyOrder(
+                    CommunityMatcher.matchCommunity(subcomm1),
+                    CommunityMatcher.matchCommunity(subcomm1subcomm2)
+                )))
+            .andExpect(jsonPath("$.page.totalElements", is(2)));
+
+        getClient(subcomm2AdminToken).perform(get("/api/core/communities/search/findEditAuthorized"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._embedded.communities",
+                Matchers.containsInAnyOrder(
+                    CommunityMatcher.matchCommunity(subcomm1subcomm2)
+                )))
+            .andExpect(jsonPath("$.page.totalElements", is(1)));
+
+    }
+
+    @Test
+    public void findAddAuthorizedUnauthorizedTest() throws Exception {
+        getClient().perform(get("/api/core/communities/search/findAddAuthorized"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void findAddAuthorizedResourcePolicyTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Community comm1 = CommunityBuilder.createCommunity(context).withName("Community 1").build();
+
+        EPerson hasDirectEditRights = EPersonBuilder.createEPerson(context)
+            .withEmail("has@editrights.com").withPassword(password)
+            .build();
+        EPerson hasDirectAdminRights = EPersonBuilder.createEPerson(context)
+            .withEmail("has@adminrights.com").withPassword(password)
+            .build();
+        Community byResourcePolicy = CommunityBuilder.createCommunity(context)
+            .withName("direct add rights for eperson").build();
+        Community uneditable = CommunityBuilder.createCommunity(context)
+            .withName("no add community")
+            .build();
+        ResourcePolicy policy = ResourcePolicyBuilder.createResourcePolicy(context, hasDirectEditRights, null)
+            .withDspaceObject(byResourcePolicy).withAction(Constants.ADD)
+            .build();
+        policy = ResourcePolicyBuilder.createResourcePolicy(context, hasDirectAdminRights, null)
+            .withDspaceObject(byResourcePolicy).withAction(Constants.ADMIN)
+            .build();
+        context.restoreAuthSystemState();
+
+        String tokenHasDirectAddRightsToken = getAuthToken(hasDirectEditRights.getEmail(), password);
+        String tokenHasDirectAdminRightsToken = getAuthToken(hasDirectAdminRights.getEmail(), password);
+
+        getClient(tokenHasDirectAddRightsToken).perform(get("/api/core/communities/search/findAddAuthorized"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._embedded.communities",
+                Matchers.contains(CommunityMatcher.matchCommunity(byResourcePolicy))))
+            .andExpect(jsonPath("$.page.totalElements", is(1)));
+        getClient(tokenHasDirectAdminRightsToken).perform(get("/api/core/communities/search/findAddAuthorized"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._embedded.communities",
+                Matchers.contains(CommunityMatcher.matchCommunity(byResourcePolicy))))
+            .andExpect(jsonPath("$.page.totalElements", is(1)));
+    }
+
+    @Test
+    public void findAddAuthorizedAdminPropagationTest() throws Exception {
+
+        context.turnOffAuthorisationSystem();
+
+        /*
+        DSO structure:
+        root
+        └── subcomm1
+            └── subcomm2
+         */
+        EPerson rootAdmin = EPersonBuilder.createEPerson(context)
+            .withEmail("root@admin.com").withPassword(password).build();
+        EPerson subcomm1Admin = EPersonBuilder.createEPerson(context)
+            .withEmail("subcomm1@admin.com").withPassword(password).build();
+        EPerson subcomm2Admin = EPersonBuilder.createEPerson(context)
+            .withEmail("subcomm2@admin.com").withPassword(password).build();
+
+        Community root = CommunityBuilder.createCommunity(context)
+            .withAdminGroup(rootAdmin)
+            .withName("root")
+            .build();
+        Community subcomm1 = CommunityBuilder.createSubCommunity(context, root)
+            .withAdminGroup(subcomm1Admin)
+            .withName("subcomm1")
+            .build();
+        Community subcomm2 = CommunityBuilder.createSubCommunity(context, subcomm1)
+            .withAdminGroup(subcomm2Admin)
+            .withName("subcomm2")
+            .build();
+        context.restoreAuthSystemState();
+
+        String siteAdminToken = getAuthToken(admin.getEmail(), password);
+        String rootAdminToken = getAuthToken(rootAdmin.getEmail(), password);
+        String subcomm1AdminToken = getAuthToken(subcomm1Admin.getEmail(), password);
+        String subcomm2AdminToken = getAuthToken(subcomm2Admin.getEmail(), password);
+
+        getClient(siteAdminToken).perform(get("/api/core/communities/search/findAddAuthorized"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._embedded.communities",
+                Matchers.containsInAnyOrder(
+                    CommunityMatcher.matchCommunity(root),
+                    CommunityMatcher.matchCommunity(subcomm1),
+                    CommunityMatcher.matchCommunity(subcomm2)
+                )))
+            .andExpect(jsonPath("$.page.totalElements", is(3)));
+
+        getClient(rootAdminToken).perform(get("/api/core/communities/search/findAddAuthorized"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._embedded.communities",
+                Matchers.containsInAnyOrder(
+                    CommunityMatcher.matchCommunity(root),
+                    CommunityMatcher.matchCommunity(subcomm1),
+                    CommunityMatcher.matchCommunity(subcomm2)
+                )))
+            .andExpect(jsonPath("$.page.totalElements", is(3)));
+
+        getClient(subcomm1AdminToken).perform(get("/api/core/communities/search/findAddAuthorized"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._embedded.communities",
+                Matchers.containsInAnyOrder(
+                    CommunityMatcher.matchCommunity(subcomm1),
+                    CommunityMatcher.matchCommunity(subcomm2)
+                )))
+            .andExpect(jsonPath("$.page.totalElements", is(2)));
+
+        getClient(subcomm2AdminToken).perform(get("/api/core/communities/search/findAddAuthorized"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._embedded.communities",
+                Matchers.containsInAnyOrder(
+                    CommunityMatcher.matchCommunity(subcomm2)
+                )))
+            .andExpect(jsonPath("$.page.totalElements", is(1)));
+    }
+
+    @Test
+    public void findEditAuthorizedCommunitiesWithQueryTest() throws Exception {
+        findGenericAuthorizedCommunitiesWithQueryTest("findEditAuthorized");
+    }
+
+    @Test
+    public void findAddAuthorizedCommunitiesWithQueryTest() throws Exception {
+        findGenericAuthorizedCommunitiesWithQueryTest("findAddAuthorized");
+    }
+
+    @Test
+    public void findReadAuthorizedCommunitiesWithQueryTest() throws Exception {
+        findGenericAuthorizedCommunitiesWithQueryTest("findAdminAuthorized");
+    }
+
+    public void findGenericAuthorizedCommunitiesWithQueryTest(String method) throws Exception {
+
+        context.turnOffAuthorisationSystem();
+
+        EPerson eperson2 = EPersonBuilder.createEPerson(context)
+            .withEmail("eperson2@mail.com")
+            .withPassword(password)
+            .build();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+            .withName("Sub Community")
+            .build();
+        Community child2 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+            .withName("Sub Community Two")
+            .build();
+        Community com1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+            .withName("Sample community")
+            .withAdminGroup(eperson)
+            .build();
+        Community com2 = CommunityBuilder.createSubCommunity(context, child1)
+            .withName("Test community")
+            .build();
+        Community com3 = CommunityBuilder.createSubCommunity(context, child2)
+            .withName("community of sample items")
+            .withAdminGroup(eperson)
+            .build();
+        context.restoreAuthSystemState();
+
+        // Test simple query
+        String tokenEPerson = getAuthToken(eperson.getEmail(), password);
+        getClient(tokenEPerson).perform(get("/api/core/communities/search/" + method)
+                .param("query", "community"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.communities", Matchers.containsInAnyOrder(
+                CommunityMatcher.matchProperties(com1.getName(), com1.getID(), com1.getHandle()),
+                CommunityMatcher.matchProperties(com3.getName(), com3.getID(), com3.getHandle())
+            )))
+            .andExpect(jsonPath("$.page.totalElements", is(2)));
+
+        // Test case insensitive query
+        getClient(tokenEPerson).perform(get("/api/core/communities/search/" + method)
+                .param("query", "COMMUNITY"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.communities", Matchers.containsInAnyOrder(
+                CommunityMatcher.matchProperties(com1.getName(), com1.getID(), com1.getHandle()),
+                CommunityMatcher.matchProperties(com3.getName(), com3.getID(), com3.getHandle())
+            )))
+            .andExpect(jsonPath("$.page.totalElements", is(2)));
+
+        // Test word for unauthorized community
+        getClient(tokenEPerson).perform(get("/api/core/communities/search/" + method)
+                .param("query", "test"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
+
+        // Test eperson with no authorized communities
+        String tokenEPerson2 = getAuthToken(eperson2.getEmail(), password);
+        getClient(tokenEPerson2).perform(get("/api/core/communities/search/" + method)
+                .param("query", "community"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
+
+        // Test as admin
+        String tokenAdmin = getAuthToken(admin.getEmail(), password);
+        getClient(tokenAdmin).perform(get("/api/core/communities/search/" + method)
+                .param("query", "sample"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.communities", Matchers.containsInAnyOrder(
+                CommunityMatcher.matchProperties(com1.getName(), com1.getID(), com1.getHandle()),
+                CommunityMatcher.matchProperties(com3.getName(), com3.getID(), com3.getHandle())
+            )))
+            .andExpect(jsonPath("$.page.totalElements", is(2)));
+
+        // Test more specific unsorted query words
+        getClient(tokenAdmin).perform(get("/api/core/communities/search/" + method)
+                .param("query", "items sample"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.communities", Matchers.contains(
+                CommunityMatcher.matchProperties(com3.getName(), com3.getID(), com3.getHandle())
+            )))
+            .andExpect(jsonPath("$.page.totalElements", is(1)));
+
+        // Test add retrieve the col not authorized to community admin user
+        getClient(tokenAdmin).perform(get("/api/core/communities/search/" + method)
+                .param("query", "test"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.communities", Matchers.containsInAnyOrder(
+                CommunityMatcher.matchProperties(com2.getName(), com2.getID(), com2.getHandle())
+            )))
+            .andExpect(jsonPath("$.page.totalElements", is(1)));
+
     }
 
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
@@ -29,6 +29,8 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.springframework.data.rest.webmvc.RestMediaTypes.TEXT_URI_LIST_VALUE;
+import static org.springframework.http.MediaType.parseMediaType;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -58,6 +60,7 @@ import org.dspace.app.rest.matcher.BundleMatcher;
 import org.dspace.app.rest.matcher.CollectionMatcher;
 import org.dspace.app.rest.matcher.HalMatcher;
 import org.dspace.app.rest.matcher.ItemMatcher;
+import org.dspace.app.rest.model.GroupRest;
 import org.dspace.app.rest.model.ItemRest;
 import org.dspace.app.rest.model.MetadataRest;
 import org.dspace.app.rest.model.MetadataValueRest;
@@ -66,6 +69,7 @@ import org.dspace.app.rest.model.patch.Operation;
 import org.dspace.app.rest.model.patch.ReplaceOperation;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
 import org.dspace.app.rest.test.MetadataPatchSuite;
+import org.dspace.authorize.ResourcePolicy;
 import org.dspace.builder.BitstreamBuilder;
 import org.dspace.builder.BundleBuilder;
 import org.dspace.builder.CollectionBuilder;
@@ -4902,7 +4906,6 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
                 .andExpect(status().isNoContent());
     }
 
-
     @Test
     public void testSearchItemByCustomUrl() throws Exception {
 
@@ -5171,6 +5174,410 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
                                      .param("q", "my-custom-url"))
                        .andExpect(status().isOk())
                        .andExpect(jsonPath("$.uuid", is(item.getID().toString())));
+
+    }
+
+    @Test
+    public void findEditAuthorizedUnauthorizedTest() throws Exception {
+        getClient().perform(get("/api/core/items/search/findEditAuthorized"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void findEditAuthorizedResourcePolicyTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Community comm1 = CommunityBuilder.createCommunity(context).withName("Community 1").build();
+        Collection col1 = CollectionBuilder.createCollection(context, comm1).withName("Collection 1").build();
+
+        EPerson hasDirectEditRights = EPersonBuilder.createEPerson(context)
+            .withEmail("has@editrights.com").withPassword(password)
+            .build();
+        EPerson hasDirectAdminRights = EPersonBuilder.createEPerson(context)
+            .withEmail("has@adminrights.com").withPassword(password)
+            .build();
+        Item byResourcePolicy = ItemBuilder.createItem(context, col1)
+            .withTitle("direct edit rights for eperson")
+            .build();
+        Item uneditable = ItemBuilder.createItem(context, col1)
+            .withTitle("uneditable item")
+            .build();
+        ResourcePolicy policy = ResourcePolicyBuilder.createResourcePolicy(context, hasDirectEditRights, null)
+            .withDspaceObject(byResourcePolicy).withAction(WRITE)
+            .build();
+        policy = ResourcePolicyBuilder.createResourcePolicy(context, hasDirectAdminRights, null)
+            .withDspaceObject(byResourcePolicy).withAction(Constants.ADMIN)
+            .build();
+        context.restoreAuthSystemState();
+
+        String tokenHasDirectEditRightsToken = getAuthToken(hasDirectEditRights.getEmail(), password);
+        String tokenHasDirectAdminRightsToken = getAuthToken(hasDirectAdminRights.getEmail(), password);
+
+        getClient(tokenHasDirectEditRightsToken).perform(get("/api/core/items/search/findEditAuthorized"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._embedded.items",
+                Matchers.contains(ItemMatcher.matchItemProperties(byResourcePolicy))))
+            .andExpect(jsonPath("$.page.totalElements", is(1)));
+        getClient(tokenHasDirectAdminRightsToken).perform(get("/api/core/items/search/findEditAuthorized"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._embedded.items",
+                Matchers.contains(ItemMatcher.matchItemProperties(byResourcePolicy))))
+            .andExpect(jsonPath("$.page.totalElements", is(1)));
+    }
+
+    @Test
+    public void findEditAuthorizedAdminPropagationTest() throws Exception {
+        /*
+        Cases:
+          - items in collection with admin rights
+          - items in collection in community with admin rights
+         */
+
+        context.turnOffAuthorisationSystem();
+
+        /*
+        DSO structure:
+        root
+        ├── subcomm1
+            ├── subcomm1collA
+                ├── subcomm1collAitemX
+                ├── subcomm1collAitemY
+            ├── subcomm1collB
+                └── subcomm1collBitem
+        └── subcomm2
+            └── subcomm2coll
+                └── subcomm2collitem
+         */
+        EPerson rootAdmin = EPersonBuilder.createEPerson(context)
+            .withEmail("root@admin.com").withPassword(password).build();
+        EPerson subcomm1Admin = EPersonBuilder.createEPerson(context)
+            .withEmail("subcomm1@admin.com").withPassword(password).build();
+        EPerson subcomm2Admin = EPersonBuilder.createEPerson(context)
+            .withEmail("subcomm2@admin.com").withPassword(password).build();
+        EPerson subcomm1collA_Admin = EPersonBuilder.createEPerson(context)
+            .withEmail("subcomm1collA@admin.com").withPassword(password).build();
+        EPerson subcomm1collB_Admin = EPersonBuilder.createEPerson(context)
+            .withEmail("subcomm1collB@admin.com").withPassword(password).build();
+        EPerson subcomm2collAdmin = EPersonBuilder.createEPerson(context)
+            .withEmail("subcomm2coll@admin.com").withPassword(password).build();
+
+        Community root = CommunityBuilder.createCommunity(context)
+            .withAdminGroup(rootAdmin)
+            .withName("root")
+            .build();
+        Community subcomm1 = CommunityBuilder.createSubCommunity(context, root)
+            .withAdminGroup(subcomm1Admin)
+            .withName("subcomm1")
+            .build();
+        Community subcomm2 = CommunityBuilder.createSubCommunity(context, root)
+            .withAdminGroup(subcomm2Admin)
+            .withName("subcomm2")
+            .build();
+        Collection subcomm1collA = CollectionBuilder.createCollection(context, subcomm1)
+            .withAdminGroup(subcomm1collA_Admin)
+            .withName("subcomm1collA")
+            .build();
+        Collection subcomm1collB = CollectionBuilder.createCollection(context, subcomm1)
+            .withAdminGroup(subcomm1collB_Admin)
+            .withName("subcomm1collB")
+            .build();
+        Collection subcomm2coll = CollectionBuilder.createCollection(context, subcomm2)
+            .withAdminGroup(subcomm2collAdmin)
+            .withName("subcomm2coll")
+            .build();
+        Item subcomm1collAitemX = ItemBuilder.createItem(context, subcomm1collA).withTitle("subcomm1collAitemX")
+            .build();
+        Item subcomm1collAitemY = ItemBuilder.createItem(context, subcomm1collA).withTitle("subcomm1collAitemY")
+            .build();
+        Item subcomm1collBitem = ItemBuilder.createItem(context, subcomm1collB).withTitle("subcomm1collBitem")
+            .build();
+        Item subcomm2collitem = ItemBuilder.createItem(context, subcomm2coll).withTitle("subcomm2collitem")
+            .build();
+        context.restoreAuthSystemState();
+
+        String siteAdminToken = getAuthToken(admin.getEmail(), password);
+        String rootAdminToken = getAuthToken(rootAdmin.getEmail(), password);
+        String subcomm1AdminToken = getAuthToken(subcomm1Admin.getEmail(), password);
+        String subcomm2AdminToken = getAuthToken(subcomm2Admin.getEmail(), password);
+        String subcomm1collA_AdminToken = getAuthToken(subcomm1collA_Admin.getEmail(), password);
+        String subcomm1collB_AdminToken = getAuthToken(subcomm1collB_Admin.getEmail(), password);
+        String subcomm2collAdminToken = getAuthToken(subcomm2collAdmin.getEmail(), password);
+
+        getClient(siteAdminToken).perform(get("/api/core/items/search/findEditAuthorized"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._embedded.items",
+                Matchers.containsInAnyOrder(
+                    ItemMatcher.matchItemProperties(subcomm1collAitemX),
+                    ItemMatcher.matchItemProperties(subcomm1collAitemY),
+                    ItemMatcher.matchItemProperties(subcomm1collBitem),
+                    ItemMatcher.matchItemProperties(subcomm2collitem)
+                )))
+            .andExpect(jsonPath("$.page.totalElements", is(4)));
+
+        getClient(rootAdminToken).perform(get("/api/core/items/search/findEditAuthorized"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._embedded.items",
+                Matchers.containsInAnyOrder(
+                    ItemMatcher.matchItemProperties(subcomm1collAitemX),
+                    ItemMatcher.matchItemProperties(subcomm1collAitemY),
+                    ItemMatcher.matchItemProperties(subcomm1collBitem),
+                    ItemMatcher.matchItemProperties(subcomm2collitem)
+                )))
+            .andExpect(jsonPath("$.page.totalElements", is(4)));
+
+        getClient(subcomm1AdminToken).perform(get("/api/core/items/search/findEditAuthorized"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._embedded.items",
+                Matchers.containsInAnyOrder(
+                    ItemMatcher.matchItemProperties(subcomm1collAitemX),
+                    ItemMatcher.matchItemProperties(subcomm1collAitemY),
+                    ItemMatcher.matchItemProperties(subcomm1collBitem)
+                )))
+            .andExpect(jsonPath("$.page.totalElements", is(3)));
+
+        getClient(subcomm2AdminToken).perform(get("/api/core/items/search/findEditAuthorized"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._embedded.items",
+                Matchers.containsInAnyOrder(
+                    ItemMatcher.matchItemProperties(subcomm2collitem)
+                )))
+            .andExpect(jsonPath("$.page.totalElements", is(1)));
+
+        getClient(subcomm1collA_AdminToken).perform(get("/api/core/items/search/findEditAuthorized"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._embedded.items",
+                Matchers.containsInAnyOrder(
+                    ItemMatcher.matchItemProperties(subcomm1collAitemX),
+                    ItemMatcher.matchItemProperties(subcomm1collAitemY)
+                )))
+            .andExpect(jsonPath("$.page.totalElements", is(2)));
+
+        getClient(subcomm1collB_AdminToken).perform(get("/api/core/items/search/findEditAuthorized"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._embedded.items",
+                Matchers.containsInAnyOrder(
+                    ItemMatcher.matchItemProperties(subcomm1collBitem)
+                )))
+            .andExpect(jsonPath("$.page.totalElements", is(1)));
+
+        getClient(subcomm2collAdminToken).perform(get("/api/core/items/search/findEditAuthorized"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$._embedded.items",
+                Matchers.containsInAnyOrder(
+                    ItemMatcher.matchItemProperties(subcomm2collitem)
+                )))
+            .andExpect(jsonPath("$.page.totalElements", is(1)));
+    }
+
+    @Test
+    public void addParentComAdminGroupToCheckReindexingTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .build();
+
+        Collection col1 = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("col1")
+            .build();
+
+        Item item = ItemBuilder.createItem(context, col1)
+            .withTitle("MyTest")
+            .build();
+
+        context.restoreAuthSystemState();
+
+        String epersonToken = getAuthToken(eperson.getEmail(), password);
+        getClient(epersonToken).perform(get("/api/core/items/search/findEditAuthorized")
+                .param("query", "MyTest"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded").doesNotExist())
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
+
+        AtomicReference<UUID> idRef = new AtomicReference<>();
+        ObjectMapper mapper = new ObjectMapper();
+        GroupRest groupRest = new GroupRest();
+        String token = getAuthToken(admin.getEmail(), password);
+        getClient(token).perform(post("/api/core/communities/" + parentCommunity.getID() + "/adminGroup")
+                .content(mapper.writeValueAsBytes(groupRest))
+                .contentType(contentType))
+            .andExpect(status().isCreated())
+            .andDo(result -> idRef.set(
+                UUID.fromString(read(result.getResponse().getContentAsString(), "$.id")))
+            );
+
+        String adminToken = getAuthToken(admin.getEmail(), password);
+        getClient(adminToken).perform(post("/api/eperson/groups/" + idRef.get() + "/epersons")
+            .contentType(parseMediaType(TEXT_URI_LIST_VALUE))
+            .content(REST_SERVER_URL + "eperson/groups/" + eperson.getID()
+            ));
+
+        getClient(epersonToken).perform(get("/api/core/items/search/findEditAuthorized")
+                .param("query", "MyTest"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.items", Matchers.contains(ItemMatcher
+                .matchItemProperties(item)
+            )))
+            .andExpect(jsonPath("$.page.totalElements", is(1)));
+    }
+
+    @Test
+    public void removeParentComAdminPolicyToCheckEditPropagationTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .build();
+
+        ResourcePolicy policy = ResourcePolicyBuilder.createResourcePolicy(context, eperson, null)
+            .withDspaceObject(parentCommunity).withAction(Constants.ADMIN)
+            .build();
+
+        Collection col1 = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("col1")
+            .build();
+
+        Item item = ItemBuilder.createItem(context, col1)
+            .withTitle("MyTest")
+            .build();
+
+        context.restoreAuthSystemState();
+
+        String epersonToken = getAuthToken(eperson.getEmail(), password);
+        getClient(epersonToken).perform(get("/api/core/items/search/findEditAuthorized")
+                .param("query", "MyTest"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.items", Matchers.contains(ItemMatcher
+                .matchItemProperties(item)
+            )))
+            .andExpect(jsonPath("$.page.totalElements", is(1)));
+
+        String token = getAuthToken(admin.getEmail(), password);
+        getClient(token).perform(delete("/api/authz/resourcepolicies/" + policy.getID()))
+            .andExpect(status().is(204));
+
+        getClient(epersonToken).perform(get("/api/core/items/search/findEditAuthorized")
+                .param("query", "MyTest"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded").doesNotExist())
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
+    }
+
+    @Test
+    public void findEditAuthorizedItemsWithQueryTest() throws Exception {
+        findGenericAuthorizedItemsWithQueryTest("findEditAuthorized");
+    }
+
+    public void findGenericAuthorizedItemsWithQueryTest(String method) throws Exception {
+
+        context.turnOffAuthorisationSystem();
+
+        EPerson eperson2 = EPersonBuilder.createEPerson(context)
+            .withEmail("eperson2@mail.com")
+            .withPassword(password)
+            .build();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .build();
+        Community child1 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+            .withName("Sub Community")
+            .build();
+        Community child2 = CommunityBuilder.createSubCommunity(context, parentCommunity)
+            .withName("Sub Community Two")
+            .build();
+        Collection col1 = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Sample collection")
+            .withAdminGroup(eperson)
+            .build();
+        Collection col2 = CollectionBuilder.createCollection(context, child1)
+            .withName("col2")
+            .build();
+        Collection col3 = CollectionBuilder.createCollection(context, child2)
+            .withName("col3")
+            .withAdminGroup(eperson)
+            .build();
+        Item item1 = ItemBuilder.createItem(context, col1)
+            .withTitle("Sample item")
+            .build();
+        Item item2 = ItemBuilder.createItem(context, col2)
+            .withTitle("Test item")
+            .build();
+        Item item3 = ItemBuilder.createItem(context, col3)
+            .withTitle("Item of sample bitstreams")
+            .build();
+
+        context.restoreAuthSystemState();
+
+        // Test simple query
+        String tokenEPerson = getAuthToken(eperson.getEmail(), password);
+        getClient(tokenEPerson).perform(get("/api/core/items/search/" + method)
+                .param("query", "item"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.items", Matchers.containsInAnyOrder(
+                ItemMatcher.matchItemProperties(item1),
+                ItemMatcher.matchItemProperties(item3)
+            )))
+            .andExpect(jsonPath("$.page.totalElements", is(2)));
+
+        // Test case insensitive
+        getClient(tokenEPerson).perform(get("/api/core/items/search/" + method)
+                .param("query", "ITEM"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.items", Matchers.containsInAnyOrder(
+                ItemMatcher.matchItemProperties(item1),
+                ItemMatcher.matchItemProperties(item3)
+            )))
+            .andExpect(jsonPath("$.page.totalElements", is(2)));
+
+        // Test word for unauthorized item
+        getClient(tokenEPerson).perform(get("/api/core/items/search/" + method)
+                .param("query", "test"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
+
+        // Test eperson with no authorized items
+        String tokenEPerson2 = getAuthToken(eperson2.getEmail(), password);
+        getClient(tokenEPerson2).perform(get("/api/core/items/search/" + method)
+                .param("query", "community"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", is(0)));
+
+        // Test query as admin
+        String tokenAdmin = getAuthToken(admin.getEmail(), password);
+        getClient(tokenAdmin).perform(get("/api/core/items/search/" + method)
+                .param("query", "sample"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.items", Matchers.containsInAnyOrder(
+                ItemMatcher.matchItemProperties(item1),
+                ItemMatcher.matchItemProperties(item3)
+            )))
+            .andExpect(jsonPath("$.page.totalElements", is(2)));
+
+        // Test unsorted query words
+        getClient(tokenAdmin).perform(get("/api/core/items/search/" + method)
+                .param("query", "bitstreams sample"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.items", Matchers.contains(
+                ItemMatcher.matchItemProperties(item3)
+            )))
+            .andExpect(jsonPath("$.page.totalElements", is(1)));
+
+        // Test item not authorized for eperson is returned for admin
+        getClient(tokenAdmin).perform(get("/api/core/items/search/" + method)
+                .param("query", "test"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.items", Matchers.containsInAnyOrder(
+                ItemMatcher.matchItemProperties(item2)
+            )))
+            .andExpect(jsonPath("$.page.totalElements", is(1)));
 
     }
 

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -30,8 +30,6 @@
     <bean id="solrServiceMetadataBrowseIndexingPlugin" class="org.dspace.discovery.SolrServiceMetadataBrowseIndexingPlugin" scope="prototype"/>
     <bean id="solrServicePrivateItemPlugin" class="org.dspace.discovery.SolrServicePrivateItemPlugin" scope="prototype"/>
     <bean id="SolrServiceParentObjectIndexingPlugin" class="org.dspace.discovery.SolrServiceParentObjectIndexingPlugin" scope="prototype"/>
-    <bean id="SolrServiceIndexCollectionSubmittersPlugin" class="org.dspace.discovery.SolrServiceIndexCollectionSubmittersPlugin" scope="prototype"/>
-    <bean id="SolrServiceIndexItemEditorsPlugin" class="org.dspace.discovery.SolrServiceIndexItemEditorsPlugin" scope="prototype"/>
     <bean id="solrServiceCustomUrlIndexPlugin" class="org.dspace.discovery.SolrServiceCustomUrlIndexPlugin"/>
 
     <alias name="solrServiceResourceIndexPlugin" alias="org.dspace.discovery.SolrServiceResourceRestrictionPlugin"/>


### PR DESCRIPTION
## References
* Fixes #2853
* Fixes #9652
* Fixes DSpace/dspace-angular#1331
* Related to DSpace/RestContract#319
* Requires angular DSpace/dspace-angular#4918

## Description

This PR updates Solr permission indexing and search restrictions to allow retrieval of results based on direct permissions or inherited permissions via the `location` field, which lists ancestor community and collection UUIDs.

The following changes are included:

* Permissions are now indexed only if they are directly assigned to the object.
* The filter applied for permission-based restrictions has been updated to search for either direct permissions or objects whose ancestor community/collection is one where the user has admin rights (using the same strategy as `SolrServiceResourceRestrictionPlugin` for checking READ access for the current user).
* All permission-related restrictions are now applied within `SolrServiceResourceRestrictionPlugin` to build the query more efficiently.
* The function `createLocationQueryForAdministrableItems` has been replaced by a new function that retrieves the same information via a Solr query (this should address some of the issues described in #10084 and could improve the performance).
* New endpoints `findEditAuthorized` and `findAddAuthorized` have been added to retrieve communities, collections, or items based on specific permissions.

These changes allow admin permission modifications on a community or collection to propagate without needing to reindex their child objects.

## Instructions for Reviewers

List of changes in this PR:

* The main modification is in `SolrServiceResourceRestrictionPlugin`, which is now responsible for indexing all *direct* permissions added to objects and for including the necessary filter in the search query to respect the permissions required by the ongoing search. This includes:
    * It now only indexes direct permissions added to objects for READ, WRITE, ADD, and ADMIN actions, and it does not index inherited permissions.
    * The `filterquery` it includes to filter by permissions is calculated more efficiently, querying for the specific permissions requested. For example, if ADMIN permissions are requested, it does not include clauses to search for READ permission since that is already implied by ADMIN.
    * The calculation of the groups a user belongs to is performed only once for all required permissions.
    * If inherited permissions are required, they are included in the `filterQuery` by searching based on the communities and collections where the user is an administrator via the `location` field.
    * If no specific permissions are requested, the search will always filter by READ permission.
* `SolrServiceIndexCollectionSubmittersPlugin` and `SolrServiceIndexItemEditorsPlugin` have been unconfigured because the indexing they performed is now handled by `SolrServiceResourceRestrictionPlugin`.
* New parameters have been included in `DiscoveryQuery`: one to indicate which action the current user needs on the returned objects, and a second one to specify whether inherited permissions should be used (useful for the next point).
* Changes in `AuthorizeServiceImpl` to avoid querying for inherited permissions in the `isComAdmin` and `isComColAdmin` functions. Finding a single object with administrator permission is sufficient to demonstrate admin status, and inherited permissions are not needed in this case.
* In `SearchService`, a new function `createLocationQueryForAdministrableDSOs` has been created. This replaces the more costly `createLocationQueryForAdministrableItems` by finding the communities and collections where the user and their groups have direct ADMIN permissions through a direct Solr query.
* Adaptation of the `getSubmitAuthorizedTypes` function in `EntityTypeServiceImpl` to search using inherited permissions.
* Various changes in `AuthorizeServiceImpl`, `ItemServiceImpl`, and `CollectionServiceImpl` to adapt permission-based searches to the introduced changes.
* Indexing in `CommunityIndexFactoryImpl` has been modified so that the `location` field now includes all antecedent communities; previously, only the direct parent was included.
* Finally, new endpoints have been included for item, collection, and community to search based on specific permissions:
    * Item
        * `findEditAuthorized`
    * Collection
        * `findEditAuthorized` see note (*)
        * `findAddAuthorized`
    * Community
        * `findEditAuthorized` see note (*)
        * `findAddAuthorized`
* New Integration Tests (ITs) have been included to test these and other similar permission-based endpoints, including checks to ensure that permissions correctly propagate to children when an admin permission is added or removed from a community or collection.

(*) Note that although `findEditAuthorized` exists for communities and collections, it is not used by the Angular PR because the UI currently requires admin permissions to edit a community or collection.

Other minor changes:

* The order of parameters has been changed in some functions of `CollectionServiceImpl` since the `Context` is usually the first parameter.
* In many functions, the `SQLException` is no longer thrown because the calculation of the current user's groups is done later, and this exception is now wrapped in a `SearchServiceException`.
* A small modification in `SolrServicePrivateItemPlugin` to check `isComColAdmin` instead of making two separate calls to `isCommunityAdmin` and `isCollectionAdmin`.
* In the `performCheck` method, the number of documents returned by solr has been limited to 0 (`rows=0`) since the only goal is to know if there are any results.

## How to Test the Changes

**Important:** To test this PR, a complete re-indexation is necessary once applied.

To test the changes, verify that the six selection pop-ups used for the creation or editing of items, collections, and communities return the correct objects based on the permissions associated with a local administrator. The tests should include:

* Adding admin permissions to a root community and verifying that the user can see its child objects for editing/adding.
* Removing this admin permission and verifying that the user no longer sees the child objects in the selection lists.
* Specifically check the selection pop-up for editing items (it is the only one that currently does not filter by permissions).
* Verify that objects also appear if a direct permission is added:
    *  Adding an ADD or ADMIN permission to a specific collection or community should allow the user to select that collection or community to create items or sub-collections/communities within it. For this test, it is necessary to apply this Angular PR: DSpace/dspace-angular#4937
    * Adding a WRITE or ADMIN permission to a specific item should allow the user to select that item in the edit item selector.
    * Adding an ADMIN permission (not WRITE in this case) to a specific community or collection should allow the user to select that community or collection in the edit item selector.
* There should also be performance improvements in some cases, but these might be difficult to observe in a small test repository.

## Checklist

- [x] My PR is created against the `main` branch of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR includes details on how to test it. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).