### PR TITLE
Fix CurationScriptIT failing when the Publications community is removed on demo.dspace.org

### DIFF
--- a/dspace-server-webapp/src/test/java/org/dspace/curate/CurationScriptIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/curate/CurationScriptIT.java
@@ -670,7 +670,7 @@ public class CurationScriptIT extends AbstractControllerIntegrationTest {
                 // MetadataValueLinkChecker uri field with regular link
                 .withMetadata("dc", "description", null, "https://google.com")
                 // MetadataValueLinkChecker uri field with redirect link
-                .withMetadata("dc", "description", "uri", "https://demo7.dspace.org/handle/123456789/1")
+                .withMetadata("dc", "description", "uri", "http://google.com")
                 // MetadataValueLinkChecker uri field with non resolving link
                 .withMetadata("dc", "description", "uri", "https://www.atmire.com/broken-link")
                 .withSubject("ExtraEntry")
@@ -693,9 +693,9 @@ public class CurationScriptIT extends AbstractControllerIntegrationTest {
 
         // field that should be ignored
         assertFalse(checkIfInfoTextLoggedByHandler(handler, "demo.dspace.org/home"));
-        // redirect links in field that should not be ignored (https) => expect OK
-        assertTrue(checkIfInfoTextLoggedByHandler(handler, "https://demo7.dspace.org/handle/123456789/1 = 200 - OK"));
-        // regular link in field that should not be ignored (http) => expect OK
+        // redirect links in field that should not be ignored => expect OK (even though curl responds with 301)
+        assertTrue(checkIfInfoTextLoggedByHandler(handler, "http://google.com = 200 - OK"));
+        // regular link in field that should not be ignored => expect OK
         assertTrue(checkIfInfoTextLoggedByHandler(handler, "https://google.com = 200 - OK"));
         // nonexistent link in field that should not be ignored => expect 404
         assertTrue(checkIfInfoTextLoggedByHandler(handler, "https://www.atmire.com/broken-link = 404 - FAILED"));


### PR DESCRIPTION
## Description
Fixed the `CurationScriptIT` failing when someone deletes the [Publications](https://demo.dspace.org/handle/123456789/1) community on [demo.dspace.org](https://demo.dspace.org).

## Instructions for Reviewers
List of changes in this PR:
* Updated the demo.dspace.org link with HTTP call to google.com (this way we still test the response of a URL that returns a 301 status code)

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
