### PR TITLE
feat(ror): Adds client-id in ROR requests if provided by config

### DIFF
--- a/dspace/config/modules/external-providers.cfg
+++ b/dspace/config/modules/external-providers.cfg
@@ -103,6 +103,9 @@ datacite.projectimport.entityfilterquery = AND ((types.resourceTypeGeneral:Proje
 #---------------------------------------------------------------#
 
 ror.orgunit-import.api-url = https://api.ror.org/v2/organizations
+# This client-id must be set inside local.cfg you can find details on how to generate it here:
+# https://ror.readme.io/docs/client-id#how-to-register-a-client-id
+# ror.client-id =
 #################################################################
 #------------------------- OpenAlex ----------------------------#
 #---------------------------------------------------------------#


### PR DESCRIPTION
## Description
This PR adds support for sending a `Client-Id` header in requests to the ROR (Research Organization Registry) API. This is useful for tracking usage or meeting API requirements. The client ID is configurable via the `ror.client-id` property in `external-providers.cfg`.

## Instructions for Reviewers

List of changes in this PR:
* Added `ror.client-id` configuration property to `external-providers.cfg`.
* Updated `RorImportMetadataSourceServiceImpl` to include the `Client-Id` header in requests if the configuration is present.

**Include guidance for how to test or review your PR.**
1. Configure `ror.client-id` in `local.cfg` or `external-providers.cfg` (e.g., `ror.client-id = my-client-id`).
2. Perform a ROR import or lookup (e.g., via the submission form or command line).
3. Verify that the request to ROR includes the `Client-Id` header (this may require logging or a proxy to verify explicitly).

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).