### PR TITLE
Return 404 Instead of 401 for Deleted Bitstreams

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
@@ -128,7 +128,7 @@ public class BitstreamRestController {
         Context context = ContextUtil.obtainContext(request);
         // Find bitstream
         Bitstream bit = bitstreamService.find(context, uuid);
-        if (bit == null) {
+        if (bit == null || bit.isDeleted()) {
             response.sendError(HttpServletResponse.SC_NOT_FOUND);
             return null;
         }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/AuthorizeServicePermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/AuthorizeServicePermissionEvaluatorPlugin.java
@@ -15,6 +15,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.utils.ContextUtil;
 import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.content.Bitstream;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.content.factory.ContentServiceFactory;
@@ -84,6 +85,10 @@ public class AuthorizeServicePermissionEvaluatorPlugin extends RestObjectPermiss
                     //If the dso is null then we give permission so we can throw another status code instead
                     if (dSpaceObject == null) {
                         return true;
+                    }
+
+                    if (dSpaceObject instanceof Bitstream && ((Bitstream) dSpaceObject).isDeleted()) {
+                        return true; // Let downstream REST layer handle with 404
                     }
 
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/BitstreamMetadataReadPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/BitstreamMetadataReadPermissionEvaluatorPlugin.java
@@ -73,6 +73,9 @@ public class BitstreamMetadataReadPermissionEvaluatorPlugin extends RestObjectPe
     }
 
     public boolean metadataReadPermissionOnBitstream(Context context, Bitstream bitstream) throws SQLException {
+        if (bitstream.isDeleted()) {
+            return true; // Let downstream REST layer handle with 404
+        }
         if (authorizeService.isAdmin(context, bitstream)) {
             // Is Admin on bitstream
             return true;


### PR DESCRIPTION
## References
* Fixes #11629
* Fixes #11611

## Description
Fixes an issue where deleted bitstreams returned HTTP 401 instead of 404.

## Instructions for Reviewers
This PR updates the Bitstream data access and authorization logic to ensure that deleted bitstreams are treated as non-existent resources rather than unauthorized ones.

**How to Test**
1. Add an item that includes a bitstream.
2. Copy the bitstream’s link.
3. Delete the bitstream.
4. Try to access the bitstream link — the API should now return 404 (Not Found).
5. Try to access the bitstream content URL — the API should also return 404 (Not Found).

**List of changes in this PR:**
Overrode the findByID method in BitstreamDAOImpl to return only bitstreams where deleted <> true:

```
@Override
public Bitstream findByID(Context context, Class clazz, UUID id) throws SQLException {
    Query query = createQuery(context, "SELECT b FROM Bitstream b WHERE b.id = :id AND b.deleted <> true");
    query.setParameter("id", id);
    try {
        return uniqueResult(query);
    } catch (NoResultException e) {
        return null;
    }
}
```


Updated the hasDSpacePermission method in AuthorizeServicePermissionEvaluatorPlugin to grant permission when the DSO is null, allowing the API to return a 404 instead of a 401 for deleted bitstreams:

```
if (dSpaceObject == null) {
    return true;
}
```


This ensures that deleted bitstreams are correctly reported as missing (404) instead of triggering an unauthorized (401) response.


## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
