### PR TITLE
fix: replace deprecated AntPathRequestMatcher with PathPatternRequestMatcher

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/StatelessLoginFilter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/StatelessLoginFilter.java
@@ -18,11 +18,12 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.utils.ContextUtil;
 import org.dspace.core.Context;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 
 /**
  * This class will filter /api/authn/login requests to try and authenticate them. Keep in mind, this filter runs *after*
@@ -57,7 +58,7 @@ public class StatelessLoginFilter extends AbstractAuthenticationProcessingFilter
     public StatelessLoginFilter(String url, String httpMethod, AuthenticationManager authenticationManager,
                                 RestAuthenticationService restAuthenticationService) {
         // NOTE: attemptAuthentication() below will only be triggered by requests that match both this URL and method
-        super(new AntPathRequestMatcher(url, httpMethod));
+        super(PathPatternRequestMatcher.withDefaults().matcher(HttpMethod.valueOf(httpMethod),url));
         this.authenticationManager = authenticationManager;
         this.restAuthenticationService = restAuthenticationService;
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/WebSecurityConfiguration.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/WebSecurityConfiguration.java
@@ -30,7 +30,7 @@ import org.springframework.security.web.authentication.logout.HttpStatusReturnin
 import org.springframework.security.web.authentication.logout.LogoutFilter;
 import org.springframework.security.web.csrf.CsrfTokenRepository;
 import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 
 /**
  * Spring Security configuration for DSpace Server Webapp
@@ -104,7 +104,8 @@ public class WebSecurityConfiguration {
         http.securityMatcher("/api/**", "/iiif/**", actuatorBasePath + "/**", "/signposting/**")
             .authorizeHttpRequests((requests) -> requests
                 // Ensure /actuator/info endpoint is restricted to admins
-                .requestMatchers(new AntPathRequestMatcher(actuatorBasePath + "/info", HttpMethod.GET.name()))
+                .requestMatchers(PathPatternRequestMatcher.withDefaults().matcher(HttpMethod.GET,
+                                                                                  actuatorBasePath + "/info"))
                     .hasAnyAuthority(ADMIN_GRANT)
                 // All other requests should be permitted at this layer because we check permissions on each method
                 // via @PreAuthorize annotations. As this code runs first, we must permitAll() here in order to pass
@@ -141,7 +142,8 @@ public class WebSecurityConfiguration {
                 // On logout, clear the "session" salt
                 .addLogoutHandler(customLogoutHandler)
                 // Configure the logout entry point & require POST
-                .logoutRequestMatcher(new AntPathRequestMatcher("/api/authn/logout", HttpMethod.POST.name()))
+                .logoutRequestMatcher(PathPatternRequestMatcher.withDefaults().matcher(HttpMethod.POST,
+                                                                                       "/api/authn/logout"))
                 // When logout is successful, return OK (204) status
                 .logoutSuccessHandler(new HttpStatusReturningLogoutSuccessHandler(HttpStatus.NO_CONTENT))
             )

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/WebSecurityConfiguration.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/WebSecurityConfiguration.java
@@ -30,7 +30,6 @@ import org.springframework.security.web.authentication.logout.HttpStatusReturnin
 import org.springframework.security.web.authentication.logout.LogoutFilter;
 import org.springframework.security.web.csrf.CsrfTokenRepository;
 import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
-import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 
 /**
  * Spring Security configuration for DSpace Server Webapp
@@ -104,8 +103,7 @@ public class WebSecurityConfiguration {
         http.securityMatcher("/api/**", "/iiif/**", actuatorBasePath + "/**", "/signposting/**")
             .authorizeHttpRequests((requests) -> requests
                 // Ensure /actuator/info endpoint is restricted to admins
-                .requestMatchers(PathPatternRequestMatcher.withDefaults().matcher(HttpMethod.GET,
-                                                                                  actuatorBasePath + "/info"))
+                .requestMatchers(HttpMethod.GET, actuatorBasePath + "/info")
                     .hasAnyAuthority(ADMIN_GRANT)
                 // All other requests should be permitted at this layer because we check permissions on each method
                 // via @PreAuthorize annotations. As this code runs first, we must permitAll() here in order to pass
@@ -142,8 +140,8 @@ public class WebSecurityConfiguration {
                 // On logout, clear the "session" salt
                 .addLogoutHandler(customLogoutHandler)
                 // Configure the logout entry point & require POST
-                .logoutRequestMatcher(PathPatternRequestMatcher.withDefaults().matcher(HttpMethod.POST,
-                                                                                       "/api/authn/logout"))
+                // If CSRF protection is enabled (default in DSpace REST), a POST request is needed to trigger logout
+                .logoutUrl("/api/authn/logout")
                 // When logout is successful, return OK (204) status
                 .logoutSuccessHandler(new HttpStatusReturningLogoutSuccessHandler(HttpStatus.NO_CONTENT))
             )


### PR DESCRIPTION
## References
* Fixes #11634 

## Description
This pull request handles the deprecation of `AntPathRequestMatcher` by replacing all its usages with the recommended [`PathPatternRequestMatcher`](https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/web/servlet/util/matcher/PathPatternRequestMatcher.html). This migration in the Spring Security configuration ensures future compatibility without altering existing behavior.

## Instructions for Reviewers

List of changes in this PR:
* **Replaced Deprecated Class:** All usages of `AntPathRequestMatcher` have been replaced with the recommended `PathPatternRequestMatcher`.
* **Updated [`StatelessLoginFilter.java`](https://github.com/DSpace/DSpace/blob/main/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/StatelessLoginFilter.java):**
  * The filter's constructor now uses `PathPatternRequestMatcher` to define the URL and HTTP method it responds to.
* **Updated [WebSecurityConfiguration.java](https://github.com/DSpace/DSpace/blob/main/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/WebSecurityConfiguration.java):**
  * Modified the `requestMatchers()` call for the `/actuator/info` endpoint to use `PathPatternRequestMatcher`.
  * Updated the logout configuration such that `logoutRequestMatcher()` uses `PathPatternRequestMatcher` for the `/api/authn/logout` endpoint.

**No Functional Changes**: This is a pure migration. All existing automated tests pass; manual testing needed to confirm that the behavior (e.g. logout, etc) remains unchanged.

## Checklist

- [X] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [X] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
