### PR TITLE
Import of Person from external ORCID source is broken

### DIFF
--- a/dspace-api/src/main/java/org/dspace/external/OrcidConnectionException.java
+++ b/dspace-api/src/main/java/org/dspace/external/OrcidConnectionException.java
@@ -1,0 +1,33 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.external;
+
+/**
+ * Exception thrown when there are issues with ORCID service connections.
+ *
+ * @author Boychuk Mykhaylo (mykhaylo.boychuk@4science.com)
+ */
+public class OrcidConnectionException extends Exception {
+
+    private final int statusCode;
+
+    public OrcidConnectionException(String message, int statusCode) {
+        super(message);
+        this.statusCode = statusCode;
+    }
+
+    public OrcidConnectionException(String message, int statusCode, Throwable cause) {
+        super(message, cause);
+        this.statusCode = statusCode;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+}

--- a/dspace-api/src/main/java/org/dspace/external/provider/impl/OrcidV3AuthorDataProvider.java
+++ b/dspace-api/src/main/java/org/dspace/external/provider/impl/OrcidV3AuthorDataProvider.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.content.dto.MetadataValueDTO;
+import org.dspace.external.OrcidConnectionException;
 import org.dspace.external.OrcidRestConnector;
 import org.dspace.external.model.ExternalDataObject;
 import org.dspace.external.provider.AbstractExternalDataProvider;
@@ -172,8 +173,14 @@ public class OrcidV3AuthorDataProvider extends AbstractExternalDataProvider {
             return null;
         }
         initializeAccessToken();
-        InputStream bioDocument = orcidRestConnector.get(id + ((id.endsWith("/person")) ? "" : "/person"), accessToken);
-        return converter.convertSinglePerson(bioDocument);
+        try {
+            InputStream bioDocument = orcidRestConnector.get(id + ((id.endsWith("/person")) ? "" : "/person"),
+                                                             accessToken);
+            return converter.convertSinglePerson(bioDocument);
+        } catch (OrcidConnectionException e) {
+            log.error("Error retrieving ORCID bio for ID=" + id, e);
+            return null;
+        }
     }
 
     /**
@@ -204,21 +211,26 @@ public class OrcidV3AuthorDataProvider extends AbstractExternalDataProvider {
                 + "&start=" + start
                 + "&rows=" + limit;
         log.debug("queryBio searchPath=" + searchPath + " accessToken=" + accessToken);
-        InputStream bioDocument = orcidRestConnector.get(searchPath, accessToken);
-        List<Result> results = converter.convert(bioDocument);
-        List<Person> bios = new LinkedList<>();
-        for (Result result : results) {
-            OrcidIdentifier orcidIdentifier = result.getOrcidIdentifier();
-            if (orcidIdentifier != null) {
-                log.debug("Found OrcidId=" + orcidIdentifier.getPath());
-                String orcid = orcidIdentifier.getPath();
-                Person bio = getBio(orcid);
-                if (bio != null) {
-                    bios.add(bio);
+        try {
+            InputStream bioDocument = orcidRestConnector.get(searchPath, accessToken);
+            List<Result> results = converter.convert(bioDocument);
+            List<Person> bios = new LinkedList<>();
+            for (Result result : results) {
+                OrcidIdentifier orcidIdentifier = result.getOrcidIdentifier();
+                if (orcidIdentifier != null) {
+                    log.debug("Found OrcidId=" + orcidIdentifier.getPath());
+                    String orcid = orcidIdentifier.getPath();
+                    Person bio = getBio(orcid);
+                    if (bio != null) {
+                        bios.add(bio);
+                    }
                 }
             }
+            return bios.stream().map(bio -> convertToExternalDataObject(bio)).collect(Collectors.toList());
+        } catch (OrcidConnectionException e) {
+            log.error("Error searching ORCID for query=" + query, e);
+            return Collections.emptyList();
         }
-        return bios.stream().map(bio -> convertToExternalDataObject(bio)).collect(Collectors.toList());
     }
 
     @Override
@@ -237,8 +249,13 @@ public class OrcidV3AuthorDataProvider extends AbstractExternalDataProvider {
                 + "&start=" + 0
                 + "&rows=" + 0;
         log.debug("queryBio searchPath=" + searchPath + " accessToken=" + accessToken);
-        InputStream bioDocument = orcidRestConnector.get(searchPath, accessToken);
-        return Math.min(converter.getNumberOfResultsFromXml(bioDocument), MAX_INDEX);
+        try {
+            InputStream bioDocument = orcidRestConnector.get(searchPath, accessToken);
+            return Math.min(converter.getNumberOfResultsFromXml(bioDocument), MAX_INDEX);
+        } catch (OrcidConnectionException e) {
+            log.error("Error getting number of results from ORCID for query=" + query, e);
+            return 0;
+        }
     }
 
 

--- a/dspace-api/src/main/java/org/dspace/external/provider/impl/OrcidV3AuthorDataProvider.java
+++ b/dspace-api/src/main/java/org/dspace/external/provider/impl/OrcidV3AuthorDataProvider.java
@@ -90,6 +90,9 @@ public class OrcidV3AuthorDataProvider extends AbstractExternalDataProvider {
     public void initializeAccessToken() {
         // If we have reaches max retries or the access token is already set, return immediately
         if (maxClientRetries <= 0 || StringUtils.isNotBlank(accessToken)) {
+            if (maxClientRetries <= 0) {
+                log.warn("Maximum retry attempts reached for ORCID token retrieval");
+            }
             return;
         }
         try {

--- a/dspace-api/src/test/java/org/dspace/authority/orcid/MockOrcid.java
+++ b/dspace-api/src/test/java/org/dspace/authority/orcid/MockOrcid.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.InputStream;
 
+import org.dspace.external.OrcidConnectionException;
 import org.dspace.external.OrcidRestConnector;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
@@ -38,7 +39,7 @@ public class MockOrcid extends Orcidv3SolrAuthorityImpl {
      * Call this to set up mocking for any test classes that need it. We don't set it in init()
      * or other AbstractIntegrationTest implementations will complain of unnecessary Mockito stubbing
      */
-    public void setupNoResultsSearch() {
+    public void setupNoResultsSearch() throws OrcidConnectionException {
         when(orcidRestConnector.get(ArgumentMatchers.startsWith("search?"), ArgumentMatchers.any()))
                 .thenAnswer(new Answer<InputStream>() {
                     @Override
@@ -51,7 +52,7 @@ public class MockOrcid extends Orcidv3SolrAuthorityImpl {
      * Call this to set up mocking for any test classes that need it. We don't set it in init()
      * or other AbstractIntegrationTest implementations will complain of unnecessary Mockito stubbing
      */
-    public void setupSingleSearch() {
+    public void setupSingleSearch() throws OrcidConnectionException {
         when(orcidRestConnector.get(ArgumentMatchers.startsWith("search?q=Bollini"), ArgumentMatchers.any()))
                 .thenAnswer(new Answer<InputStream>() {
                     @Override
@@ -64,7 +65,7 @@ public class MockOrcid extends Orcidv3SolrAuthorityImpl {
      * Call this to set up mocking for any test classes that need it. We don't set it in init()
      * or other AbstractIntegrationTest implementations will complain of unnecessary Mockito stubbing
      */
-    public void setupSearchWithResults() {
+    public void setupSearchWithResults() throws OrcidConnectionException {
         when(orcidRestConnector.get(ArgumentMatchers.endsWith("/person"), ArgumentMatchers.any()))
                 .thenAnswer(new Answer<InputStream>() {
                     @Override


### PR DESCRIPTION
## References
* Fixes #11674

## Description
The CloseableHttpClient is closed in the try-with-resources block (lines 100-102), but the response entity is accessed after that (line 105: response.getEntity().getContent()).
Once the client closes, the HTTP connection closes and the response entity may no longer be accessible or may already be consumed.


## Instructions for Reviewers
List of changes in this PR:
**OrcidFactoryUtils.retrieveAccessToken method**
* Included the response entity inside the try-with-resources block, before the client closes.
* Improved response checking status code
* Encoded auth parameters (security issue)
* Improve parsing of JSON 

**Improved also OrcidRestConnector.get method**
* Improved response checking status code
* Added custom Exception to isolate better errors

**Include guidance for how to test or review your PR.** 
- Steps how to reproduce or test are described into the issue: https://github.com/DSpace/DSpace/issues/11674


## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
