### PR TITLE
Curator does not support items without handles

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/service/DSpaceObjectUtils.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/service/DSpaceObjectUtils.java
@@ -30,4 +30,17 @@ public interface DSpaceObjectUtils {
      * @throws SQLException
      */
     public DSpaceObject findDSpaceObject(Context context, UUID uuid) throws SQLException;
+
+    /**
+     * Retrieve a DSpaceObject from its uuid or handle. As this method need to iterate over all the different services
+     * that support concrete class of DSpaceObject it has poor performance. Please consider the use of the direct
+     * service (ItemService, CommunityService, etc.) if you know in advance the type of DSpaceObject that you are
+     * looking for
+     *
+     * @param context DSpace context
+     * @param id the uuid or handle to lookup
+     * @return the DSpaceObject if any with the supplied uuid or handle
+     * @throws SQLException
+     */
+    public DSpaceObject findDSpaceObject(Context context, String id) throws SQLException;
 }

--- a/dspace-api/src/main/java/org/dspace/curate/AbstractCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/curate/AbstractCurationTask.java
@@ -11,7 +11,6 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.util.Iterator;
 import java.util.List;
-import java.util.UUID;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -161,41 +160,13 @@ public abstract class AbstractCurationTask implements CurationTask {
 
     @Override
     public int perform(Context ctx, String id) throws IOException {
-        DSpaceObject dso = dereference(ctx, id);
-        return (dso != null) ? perform(dso) : Curator.CURATE_FAIL;
-    }
-
-    /**
-     * Returns a DSpaceObject for passed identifier, if it exists
-     *
-     * @param ctx DSpace context
-     * @param id  canonical id of object
-     * @return dso
-     * DSpace object, or null if no object with id exists
-     * @throws IOException if IO error
-     */
-    protected DSpaceObject dereference(Context ctx, String id) throws IOException {
-        // the identifier can be a handle or uuid. Try handle first
+        DSpaceObject dso = null;
         try {
-            DSpaceObject dso = handleService.resolveToObject(ctx, id);
-            // if the id did not resolve to a handle, check if it is a uuid
-            if (dso == null) {
-                UUID uuid = null;
-                try {
-                    uuid = UUID.fromString(id);
-                } catch (IllegalArgumentException iae) {
-                    // no uuid, nothing to do here.
-                    log.debug("ID {} is not a valid UUID", id);
-                }
-                if (uuid != null) {
-                    dso = dspaceObjectUtils.findDSpaceObject(ctx, uuid);
-                }
-            }
-            // dso is either null or a DSpaceObject
-            return dso;
+            dso = dspaceObjectUtils.findDSpaceObject(ctx, id);
         } catch (SQLException sqlE) {
             throw new IOException(sqlE.getMessage(), sqlE);
         }
+        return (dso != null) ? perform(dso) : Curator.CURATE_FAIL;
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/curate/Curator.java
+++ b/dspace-api/src/main/java/org/dspace/curate/Curator.java
@@ -16,7 +16,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -254,20 +253,7 @@ public class Curator {
             //Save the context on current execution thread
             curationCtx.set(c);
 
-            DSpaceObject dso = handleService.resolveToObject(c, id);
-            // check if the DSpace Object does not have a handle and must be resolved by its uuid
-            if (dso == null) {
-                UUID uuid = null;
-                try {
-                    uuid = UUID.fromString(id);
-                } catch (IllegalArgumentException iae) {
-                    // no uuid, nothing to do here.
-                    log.debug("ID {} is not a valid UUID", id);
-                }
-                if (uuid != null) {
-                    dso = dspaceObjectUtils.findDSpaceObject(c, uuid);
-                }
-            }
+            DSpaceObject dso = dspaceObjectUtils.findDSpaceObject(c,id);
             if (dso != null) {
                 curate(dso);
             } else {

--- a/dspace-api/src/test/java/org/dspace/ctask/general/CreateMissingIdentifiersIT.java
+++ b/dspace-api/src/test/java/org/dspace/ctask/general/CreateMissingIdentifiersIT.java
@@ -8,8 +8,12 @@
 package org.dspace.ctask.general;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import org.dspace.builder.CollectionBuilder;
 import org.dspace.builder.CommunityBuilder;
@@ -19,6 +23,7 @@ import org.dspace.content.Item;
 import org.dspace.core.factory.CoreServiceFactory;
 import org.dspace.curate.Curator;
 import org.dspace.identifier.AbstractIdentifierProviderIT;
+import org.dspace.identifier.IdentifierProvider;
 import org.dspace.identifier.VersionedHandleIdentifierProvider;
 import org.dspace.identifier.VersionedHandleIdentifierProviderWithCanonicalHandles;
 import org.dspace.services.ConfigurationService;
@@ -84,5 +89,60 @@ public class CreateMissingIdentifiersIT
         int status = curator.getStatus(TASK_NAME);
         assertEquals("Curation should succeed", Curator.CURATE_SUCCESS, status);
         configurationService.setProperty(P_TASK_DEF, prevTaskDef);
+    }
+
+    @Test
+    public void testCreationOfMissingHandles() throws IOException {
+        // Must remove any cached named plugins before creating a new one
+        CoreServiceFactory.getInstance().getPluginService().clearNamedPluginClasses();
+        // Define a new task dynamically
+        configurationService.setProperty(P_TASK_DEF,
+                CreateMissingIdentifiers.class.getCanonicalName() + " = " + TASK_NAME);
+
+        // deactivate all identifier provider
+        List<IdentifierProvider> identifierProviders = identifierService.getProviders();
+        List<Class> identifierProviderClasses =
+                identifierProviders.stream().map(Object::getClass).distinct().collect(Collectors.toList());
+        for (Class identifierProviderClass : identifierProviderClasses) {
+            unregisterProvider(identifierProviderClass);
+        }
+
+        try {
+            context.setCurrentUser(admin);
+            parentCommunity = CommunityBuilder.createCommunity(context)
+                    .build();
+            Collection collection = CollectionBuilder.createCollection(context, parentCommunity)
+                    .build();
+            // create item and assert it did not got any handle
+            Item item = ItemBuilder.createItem(context, collection)
+                    .build();
+            assertNull("Internal error in createMissingIdentifiersIT: item should not have a handle",
+                    item.getHandle());
+
+            // setup the curator
+            Curator curator = new Curator();
+            curator.addTask(TASK_NAME);
+
+            // register the default Handle Provider
+            registerProvider(VersionedHandleIdentifierProvider.class);
+
+            /*
+             * Now, verify curate with default Handle Provider works
+             * (and that our re-registration of the default provider above was successful)
+             * Use the uuid as reference to the item as the curation system takes handles and uuid as cli arguments.
+             * Do not use the item reference, to be sure the curator and the curation task are able to work without
+             * handle.
+             */
+            curator.curate(context, item.getID().toString());
+            int status = curator.getStatus(TASK_NAME);
+            assertEquals("Curation should succeed", Curator.CURATE_SUCCESS, status);
+            // assure we got a handle
+            assertNotNull("Curation task CreateMissingIdentifiers, did not assign a handle.", item.getHandle());
+        } finally {
+            // restore the identifierProviders for following tests
+            for (Class identifierProviderClass : identifierProviderClasses) {
+                registerProvider(identifierProviderClass);
+            }
+        }
     }
 }

--- a/dspace-api/src/test/java/org/dspace/ctask/general/CreateMissingIdentifiersIT.java
+++ b/dspace-api/src/test/java/org/dspace/ctask/general/CreateMissingIdentifiersIT.java
@@ -96,6 +96,7 @@ public class CreateMissingIdentifiersIT
         // Must remove any cached named plugins before creating a new one
         CoreServiceFactory.getInstance().getPluginService().clearNamedPluginClasses();
         // Define a new task dynamically
+        String[] prevTaskDef = configurationService.getArrayProperty(P_TASK_DEF);
         configurationService.setProperty(P_TASK_DEF,
                 CreateMissingIdentifiers.class.getCanonicalName() + " = " + TASK_NAME);
 
@@ -143,6 +144,8 @@ public class CreateMissingIdentifiersIT
             for (Class identifierProviderClass : identifierProviderClasses) {
                 registerProvider(identifierProviderClass);
             }
+            // restore curation task configuration
+            configurationService.setProperty(P_TASK_DEF, prevTaskDef);
         }
     }
 }


### PR DESCRIPTION
## Description

The curation task CreateMissingIdentifiers should create all identifiers an item misses. Unfortunately it will not be started, if the item does not have a handle, as the curator falls back internally to handles, even if a uuid is given as identifier.

## Instructions for Reviewers

1. Comment out any Handle Provider in `dspace/config/spring/api/identifier-service.xml`
2. Create and archive an item
3. Check via UI or in the database that no handle was assigned
4. Uncomment a Handle Provider in `dspace/config/spring/api/identifier-service.xml` except for the one with Canonical Handles
5. Add the CreateMissingIdentifiers curation task to `dspace/config/modules/curate.cfg`
6. Start the CreateMissingIdentifiers curation task, using the uuid of the item as identifier
7. Verify that the item did not got a handle
8. Apply this patch
9. Run the curation task again, using the uuid of the item again
10. Verify the Item got a handle

List of changes in this PR:
* Changes the Curator to check if an identifier is a uuid if no handle was found.
* Adds a test to the CreateMissingIdentifiersIT. It would probably be better to add a test to the Curator, but the CreateMissingIdentifier task seems to be the most likely target for such a scenario and was easy to test.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
