### PR TITLE
Fix NullPointerException in VersionHistoryService.getVersion() method

### DIFF
--- a/dspace-api/src/main/java/org/dspace/versioning/VersionHistoryServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/VersionHistoryServiceImpl.java
@@ -109,9 +109,6 @@ public class VersionHistoryServiceImpl implements VersionHistoryService {
         throws SQLException {
         Version v = versioningService.getVersion(context, item);
         if (v != null) {
-            ;
-        }
-        {
             if (versionHistory.equals(v.getVersionHistory())) {
                 return v;
             }

--- a/dspace-api/src/test/java/org/dspace/content/VersioningTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/VersioningTest.java
@@ -187,7 +187,7 @@ public class VersioningTest extends AbstractUnitTest {
             Version result = versionHistoryService.getVersion(context, versionHistory, itemWithoutVersion);
             assertThat("getVersion should return null for item without version", result, nullValue());
         } catch (NullPointerException npe) {
-            fail("NullPointerException should not be thrown. Method should return null gracefully: " + npe.getMessage());
+            fail("NullPointerException should not be thrown. Method should return null: " + npe.getMessage());
         }
         context.restoreAuthSystemState();
     }

--- a/dspace-api/src/test/java/org/dspace/content/VersioningTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/VersioningTest.java
@@ -188,7 +188,8 @@ public class VersioningTest extends AbstractUnitTest {
             assertThat("getVersion should return null for item without version", result, nullValue());
         } catch (NullPointerException npe) {
             fail("NullPointerException should not be thrown. Method should return null: " + npe.getMessage());
+        } finally {
+            context.restoreAuthSystemState();
         }
-        context.restoreAuthSystemState();
     }
 }

--- a/dspace-api/src/test/java/org/dspace/content/VersioningTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/VersioningTest.java
@@ -174,15 +174,12 @@ public class VersioningTest extends AbstractUnitTest {
     @Test
     public void testGetVersionWithNullPointerException() throws Exception {
         context.turnOffAuthorisationSystem();
-        
         // Create item without version
         Community community = communityService.create(null, context);
         Collection col = collectionService.create(context, community);
         WorkspaceItem is = workspaceItemService.create(context, col, false);
         Item itemWithoutVersion = installItemService.installItem(context, is);
-        
         VersionHistory versionHistory = versionHistoryService.findByItem(context, originalItem);
-        
         try {
             Version result = versionHistoryService.getVersion(context, versionHistory, itemWithoutVersion);
             assertThat("getVersion should return null for item without version", result, nullValue());

--- a/dspace-api/src/test/java/org/dspace/content/VersioningTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/VersioningTest.java
@@ -170,4 +170,25 @@ public class VersioningTest extends AbstractUnitTest {
         assertThat("Test_version_handle_delete", handleService.resolveToObject(context, handle), nullValue());
         context.restoreAuthSystemState();
     }
+
+    @Test
+    public void testGetVersionWithNullPointerException() throws Exception {
+        context.turnOffAuthorisationSystem();
+        
+        // Create item without version
+        Community community = communityService.create(null, context);
+        Collection col = collectionService.create(context, community);
+        WorkspaceItem is = workspaceItemService.create(context, col, false);
+        Item itemWithoutVersion = installItemService.installItem(context, is);
+        
+        VersionHistory versionHistory = versionHistoryService.findByItem(context, originalItem);
+        
+        try {
+            Version result = versionHistoryService.getVersion(context, versionHistory, itemWithoutVersion);
+            assertThat("getVersion should return null for item without version", result, nullValue());
+        } catch (NullPointerException npe) {
+            fail("NullPointerException should not be thrown. Method should return null gracefully: " + npe.getMessage());
+        }
+        context.restoreAuthSystemState();
+    }
 }


### PR DESCRIPTION
## Description
Fixes #11670 

Fixed a bug where getVersion() threw a NullPointerException when called for an item without a version. The method now safely checks for null before accessing version history and returns null instead of throwing an error. Added a unit test to cover this case and prevent future regressions.

## Instructions for Reviewers
Verify null check in VersionHistoryServiceImpl.getVersion() prevents NPE
Confirm method returns null gracefully for items without versions
Check new test testGetVersionWithNullPointerException() covers the bug scenario
Run new unit test (should pass)

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
