### PR TITLE
Revert `bouncycastle` to version that is compatible with `maven-gpg-plugin`.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,9 @@
         <slf4j.version>2.0.17</slf4j.version>
         <tika.version>3.2.3</tika.version>
         <!-- Sync BouncyCastle & ASM with whatever version Tika uses -->
-        <bouncycastle.version>1.82</bouncycastle.version>
+        <!-- WARNING: BouncyCastle is also required by the maven-gpg-plugin to sign code during release. Do not update
+             unless the new BouncyCastle version is compatible both with tika-parsers and maven-gpg-plugin. -->
+        <bouncycastle.version>1.81</bouncycastle.version>
         <asm.version>8.0.1</asm.version>
         <!-- Jersey is used to integrate with external sources/services -->
         <jersey.version>3.1.11</jersey.version>


### PR DESCRIPTION
## Description

This issue was discovered during the release of DSpace 8.3.

The `bouncycastle` dependency is used by the `maven-gpg-plugin` during the signing of a new release.  If that `bouncycastle` dependency is not compatible with the `maven-gpg-plugin` requirements, then you'll see errors like this during release:
```
[INFO] [ERROR] Failed to execute goal org.apache.maven.plugins:maven-gpg-plugin:3.2.8:sign (sign-artifacts) on project dspace-parent: Execution sign-artifacts of goal org.apache.maven.plugins:maven-gpg-plugin:3.2.8:sign failed: Plugin org.apache.maven.plugins:maven-gpg-plugin:3.2.8 or one of its dependencies could not be resolved: Failed to collect dependencies at org.apache.maven.plugins:maven-gpg-plugin:jar:3.2.8 -> org.bouncycastle:bcpg-jdk18on:jar:1.81 -> org.bouncycastle:bcprov-jdk18on:jar:[1.81,1.82): No versions available for org.bouncycastle:bcprov-jdk18on:jar:[1.81,1.82) within specified range
```

The reason for this error is that there's a **specific range** of versions for `bouncycastle` specified in the requirements.  

This PR fixes that issue by reverting bouncycastle to `1.81` which is the version that `mvn-gpg-plugin` is expecting.

## Instructions for Reviewers
* Once tests all pass, I'm going to merge this immediately.  I've verified this version of bouncycastle is also the one used by Tika by default.  So, it should be safe.