### PR TITLE
[Port main] Revert bouncycastle to version that is compatible with maven-gpg-plugin.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -139,6 +139,9 @@ updates:
       # TODO: Remove this after this ticket is resolved https://github.com/DSpace/DSpace/issues/11621
       - dependency-name: "com.google.errorprone:*"
         versions: [ ">=2.43.0" ]
+      # Don't automatically update BouncyCastle because maven-gpg-plugin REQUIRES a very specific version or release
+      # errors will occur. See https://github.com/DSpace/DSpace/pull/11696
+      - dependency-name: "org.bouncycastle:*"
       # Ignore major/minor updates for Hibernate. Only patch updates can be automated.
       - dependency-name: "org.hibernate.*:*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
@@ -277,6 +280,9 @@ updates:
       # Last version of errorprone to support JDK 17 is 2.42.0
       - dependency-name: "com.google.errorprone:*"
         versions: [ ">=2.43.0" ]
+      # Don't automatically update BouncyCastle because maven-gpg-plugin REQUIRES a very specific version or release
+      # errors will occur. See https://github.com/DSpace/DSpace/pull/11696
+      - dependency-name: "org.bouncycastle:*"
       # Ignore major/minor updates for Hibernate. Only patch updates can be automated.
       - dependency-name: "org.hibernate.*:*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
@@ -415,6 +421,9 @@ updates:
       # Last version of errorprone to support JDK 17 is 2.42.0
       - dependency-name: "com.google.errorprone:*"
         versions: [ ">=2.43.0" ]
+      # Don't automatically update BouncyCastle because maven-gpg-plugin REQUIRES a very specific version or release
+      # errors will occur. See https://github.com/DSpace/DSpace/pull/11696
+      - dependency-name: "org.bouncycastle:*"
       # Ignore major/minor updates for Hibernate. Only patch updates can be automated.
       - dependency-name: "org.hibernate.*:*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
@@ -565,6 +574,9 @@ updates:
       # Last version of errorprone to support JDK 11 is 2.31.0
       - dependency-name: "com.google.errorprone:*"
         versions: [">=2.32.0"]
+      # Don't automatically update BouncyCastle because maven-gpg-plugin REQUIRES a very specific version or release
+      # errors will occur. See https://github.com/DSpace/DSpace/pull/11696
+      - dependency-name: "org.bouncycastle:*"
       # Spring Security 5.8 changes the behavior of CSRF Tokens in a way which is incompatible with DSpace 7
       # See https://github.com/DSpace/DSpace/pull/9888#issuecomment-2408165545
       - dependency-name: "org.springframework.security:*"

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,9 @@
         <slf4j.version>2.0.17</slf4j.version>
         <tika.version>3.2.3</tika.version>
         <!-- Sync BouncyCastle & ASM with whatever version Tika uses -->
-        <bouncycastle.version>1.82</bouncycastle.version>
+        <!-- WARNING: BouncyCastle is also required by the maven-gpg-plugin to sign code during release. Do not update
+             unless the new BouncyCastle version is compatible both with tika-parsers and maven-gpg-plugin. -->
+        <bouncycastle.version>1.81</bouncycastle.version>
         <asm.version>9.9</asm.version>
         <!-- Jersey is used to integrate with external sources/services -->
         <jersey.version>3.1.11</jersey.version>


### PR DESCRIPTION
Manual port of #11696 to `main`. See that PR for details.

This PR also includes updated rules for `dependabot` to tell it to no longer update bouncycastle