### PR TITLE
[Port dspace-9_x] Revert bouncycastle to version that is compatible with maven-gpg-plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,9 @@
         <slf4j.version>2.0.17</slf4j.version>
         <tika.version>3.2.3</tika.version>
         <!-- Sync BouncyCastle & ASM with whatever version Tika uses -->
-        <bouncycastle.version>1.82</bouncycastle.version>
+        <!-- WARNING: BouncyCastle is also required by the maven-gpg-plugin to sign code during release. Do not update
+             unless the new BouncyCastle version is compatible both with tika-parsers and maven-gpg-plugin. -->
+        <bouncycastle.version>1.81</bouncycastle.version>
         <asm.version>8.0.1</asm.version>
         <!-- Jersey is used to integrate with external sources/services -->
         <jersey.version>3.1.11</jersey.version>


### PR DESCRIPTION
Manual port of #11696 to `dspace-9_x`. See that PR for details.
