### PR TITLE
test(#9611): Fix AccessConditionOptionMatcher validation logic

### DIFF
--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/AccessConditionOptionMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/AccessConditionOptionMatcher.java
@@ -11,11 +11,17 @@ import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasNoJsonPath;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.Objects;
 
 import org.apache.commons.lang3.StringUtils;
+import org.dspace.util.DateMathParser;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 
 /**
@@ -36,11 +42,54 @@ public class AccessConditionOptionMatcher {
                                               : hasNoJsonPath("$.hasStartDate"),
                 Objects.nonNull(hasEndDate) ? hasJsonPath("$.hasEndDate", is(hasEndDate))
                                             : hasNoJsonPath("$.hasEndDate"),
-                StringUtils.isNotBlank(maxStartDate) ? hasJsonPath("$.maxStartDate", notNullValue())
+                StringUtils.isNotBlank(maxStartDate) ? hasJsonPath("$.maxStartDate", new DateMathMatcher(maxStartDate))
                                                      : hasNoJsonPath("$.maxStartDate"),
-                StringUtils.isNotBlank(maxEndDate) ? hasJsonPath("$.maxEndDate", notNullValue())
+                StringUtils.isNotBlank(maxEndDate) ? hasJsonPath("$.maxEndDate", new DateMathMatcher(maxEndDate))
                                                      : hasNoJsonPath("$.maxEndDate")
                 );
     }
 
+    /**
+     * Internal matcher to compare an ISO date from JSON with a DateMath expression.
+     */
+    private static class DateMathMatcher extends BaseMatcher<String> {
+        private final String mathExpression;
+        private final LocalDate expectedDate;
+
+        public DateMathMatcher(String mathExpression) {
+            this.mathExpression = mathExpression;
+            try {
+                DateMathParser dmp = new DateMathParser();
+                LocalDateTime calculated = dmp.parseMath(mathExpression);
+                this.expectedDate = calculated.toLocalDate();
+            } catch (Exception e) {
+                throw new RuntimeException("Error calculating DateMath in Matcher: " + mathExpression, e);
+            }
+        }
+
+        @Override
+        public boolean matches(Object item) {
+            if (!(item instanceof String)) {
+                return false;
+            }
+            String dateStr = (String) item;
+            try {
+                LocalDate actualDate;
+
+                if (dateStr.length() > 10) {
+                    actualDate = LocalDate.parse(dateStr, DateTimeFormatter.ISO_DATE_TIME);
+                } else {
+                    actualDate = LocalDate.parse(dateStr);
+                }
+                return expectedDate.equals(actualDate);
+            } catch (DateTimeParseException e) {
+                return false;
+            }
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendText("A date matching expression'" + mathExpression + "' (" + expectedDate + ")");
+        }
+    }
 }


### PR DESCRIPTION
## References
* Fixes #9611 

## Description
Updates AccessConditionOptionMatcher to correctly validate date limits using DateMathParser instead of ignoring the arguments. Refactors BulkAccessConditionRestRepositoryIT to use dynamic configuration values instead of hardcoded strings.

## Instructions for Reviewers
### List of changes in this PR:

* Refactored `AccessConditionOptionMatcher` to use `DateMathParser` and `LocalDate`. It now parses the math expression (e.g., +36MONTHS) and validates strictly against the JSON response date.
* Updated `BulkAccessConditionRestRepositoryIT` to inject `BulkAccessConditionConfigurationService`.
* The test now fetches the actual configured limits (`embargoLimit`, `leaseLimit`) dynamically instead of using hardcoded strings like "+36MONTHS".

### Guidance for testing:
1. Run the integration test: `mvn -pl dspace-server-webapp -Dtest=org.dspace.app.rest.BulkAccessConditionRestRepositoryIT -DskipUnitTests=false -DtrimStackTrace=false -e test`
2. To verify robustness, you can temporarily change the embargo limit in access-conditions.xml (e.g., to +1YEAR) and verify that the test still passes without modification.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
