### PR TITLE
[Docker] Minor cleanup to Docker Compose scripts to align with frontend changes and run UI in production mode

### DIFF
--- a/docker-compose-cli.yml
+++ b/docker-compose-cli.yml
@@ -26,8 +26,6 @@ services:
     # Mount local [src]/dspace/config/ to container. This syncs your local configs with container
     # NOTE: Environment variables specified above will OVERRIDE any configs in local.cfg or dspace.cfg
     - ./dspace/config:/dspace/config
-    tty: true
-    stdin_open: true
 
 volumes:
   assetstore:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ networks:
         # Define a custom subnet for our DSpace network, so that we can easily trust requests from host to container.
         # If you customize this value, be sure to customize the 'proxies.trusted.ipranges' env variable below.
         - subnet: 172.23.0.0/16
+    # Explicitly set external=false because this script creates the network.
+    external: false
 services:
   # DSpace (backend) webapp container
   dspace:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,8 +42,6 @@ services:
       target: 8080
     - published: 8000
       target: 8000
-    stdin_open: true
-    tty: true
     volumes:
     # Keep DSpace assetstore directory between reboots
     - assetstore:/dspace/assetstore
@@ -76,8 +74,6 @@ services:
     ports:
     - published: 5432
       target: 5432
-    stdin_open: true
-    tty: true
     volumes:
     # Keep Postgres data directory between reboots
     - pgdata:/pgdata
@@ -97,8 +93,6 @@ services:
     ports:
     - published: 8983
       target: 8983
-    stdin_open: true
-    tty: true
     working_dir: /var/solr/data
     volumes:
     # Keep Solr data directory between reboots

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,9 @@ services:
       # dspace__P__dir: /dspace
       # dspace__P__server__P__url: http://localhost:8080/server
       # dspace__P__ui__P__url: http://localhost:4000
+      # Set SSR URL to the Docker container name so that UI can contact container directly in Production mode.
+      # (This is necessary for docker-compose-angular.yml as it uses production mode by default)
+      dspace__P__server__P__ssr__P__url: http://dspace:8080/server
       dspace__P__name: 'DSpace Started with Docker Compose'
       # db.url: Ensure we are using the 'dspacedb' image for our database
       db__P__url: 'jdbc:postgresql://dspacedb:5432/dspace'

--- a/dspace/src/main/docker-compose/README.md
+++ b/dspace/src/main/docker-compose/README.md
@@ -74,13 +74,13 @@ Default is Java 11, but other LTS releases (e.g. 17) are also supported.
 
 ## Run DSpace 9 REST from your current branch
 ```
-docker compose -p d9 up -d
+docker compose -p d10 up -d
 ```
 
 ## Run DSpace 9 REST and Angular from your branch
 
 ```
-docker compose -p d9 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-angular.yml up -d
+docker compose -p d10 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-angular.yml up -d
 ```
 NOTE: This starts the UI in development mode. It will take a few minutes to see the UI as the Angular code needs to be compiled.
 
@@ -98,7 +98,7 @@ That container provides a [Cantaloupe image server](https://cantaloupe-project.g
 which can be used when IIIF support is enabled in DSpace (`iiif.enabled=true`).
 
 ```
-docker compose -p d9 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-iiif.yml up -d
+docker compose -p d10 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-iiif.yml up -d
 ```
 
 ## Run DSpace 9 REST and Shibboleth SP (in Apache) from your branch
@@ -136,17 +136,17 @@ The remainder of these instructions assume you are using ngrok (though other pro
 3. Build the Shibboleth container (if you haven't built or pulled it before):
    ```
    cd [dspace-src]
-   docker compose -p d9 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-shibboleth.yml build
+   docker compose -p d10 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-shibboleth.yml build
    ```
 
 4. Start all containers, passing your public hostname as the `DSPACE_HOSTNAME` environment variable:
    ```
-   DSPACE_HOSTNAME=[subdomain].ngrok.io docker compose -p d9 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-shibboleth.yml up -d
+   DSPACE_HOSTNAME=[subdomain].ngrok.io docker compose -p d10 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-shibboleth.yml up -d
    ```
    NOTE: For Windows you MUST either set the environment variable separately, or use the 'env' command provided with Git/Cygwin
    (you may already have this command if you are running Git for Windows). See https://superuser.com/a/1079563
    ```
-   env DSPACE_HOSTNAME=[subdomain].ngrok.io docker compose -p d9 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-shibboleth.yml up -d
+   env DSPACE_HOSTNAME=[subdomain].ngrok.io docker compose -p d10 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-shibboleth.yml up -d
    ```
 
 5. Finally, for https://samltest.id/, you need to upload your Shibboleth Metadata for the site to "trust" you.
@@ -174,7 +174,7 @@ The remainder of these instructions assume you are using ngrok (though other pro
         ```
       * Spin up the `dspace-angular` container alongside the others, e.g.
         ```
-        DSPACE_HOSTNAME=[subdomain].ngrok.io docker compose -p d9 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-angular.yml -f dspace/src/main/docker-compose/docker-compose-shibboleth.yml up -d
+        DSPACE_HOSTNAME=[subdomain].ngrok.io docker compose -p d10 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-angular.yml -f dspace/src/main/docker-compose/docker-compose-shibboleth.yml up -d
         ```
 ## Run DSpace 9 REST and Matomo from your branch
 
@@ -184,7 +184,7 @@ This Matomo container uses the port 8081 to expose its API and User Interface.
 
 You can start both DSpace and Matomo with the following commnad:
 ```shell
-docker compose -p d9 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-matomo.yml up -d
+docker compose -p d10 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-matomo.yml up -d
 ```
 
 Once started you can complete the Matomo configuration directly from the [Matomo Home Page](http://localhost:8081/matomo.php).
@@ -219,12 +219,12 @@ Prerequisites
 
 Create an admin account.  By default, the dspace-cli container runs the dspace command.
 ```
-docker compose -p d9 -f docker-compose-cli.yml run --rm dspace-cli create-administrator -e test@test.edu -f admin -l user -p admin -c en
+docker compose -p d10 -f docker-compose-cli.yml run --rm dspace-cli create-administrator -e test@test.edu -f admin -l user -p admin -c en
 ```
 
 Download a Zip file of AIP content and ingest test data
 ```
-docker compose -p d9 -f docker-compose-cli.yml -f dspace/src/main/docker-compose/cli.ingest.yml run --rm dspace-cli
+docker compose -p d10 -f docker-compose-cli.yml -f dspace/src/main/docker-compose/cli.ingest.yml run --rm dspace-cli
 ```
 
 ### Ingest Entities Test Data
@@ -238,12 +238,12 @@ Prerequisites
 
 Start DSpace REST with a postgres database dump downloaded from the internet.
 ```
-docker compose -p d9 -f docker-compose.yml -f dspace/src/main/docker-compose/db.entities.yml up -d
+docker compose -p d10 -f docker-compose.yml -f dspace/src/main/docker-compose/db.entities.yml up -d
 ```
 
 Download an assetstore from a tar file on the internet.
 ```
-docker compose -p d9 -f docker-compose-cli.yml -f dspace/src/main/docker-compose/cli.assetstore.yml run dspace-cli
+docker compose -p d10 -f docker-compose-cli.yml -f dspace/src/main/docker-compose/cli.assetstore.yml run dspace-cli
 ```
 
 ## Modify DSpace Configuration in Docker
@@ -257,20 +257,20 @@ Many DSpace configuration settings will reload automatically (after a few second
 While the Docker containers are running, you can use the DSpace CLI image to run any DSpace commandline script (i.e. any command that normally can be run by `[dspace]/bin/dspace`).  The general format is:
 
 ```
-docker compose -p d9 -f docker-compose-cli.yml run --rm dspace-cli [command] [parameters]
+docker compose -p d10 -f docker-compose-cli.yml run --rm dspace-cli [command] [parameters]
 ```
 
 So, for example, to reindex all content in Discovery, normally you'd run `./dspace index-discovery -b` from commandline.  Using our DSpace CLI image, that command becomes:
 
 ```
-docker compose -p d9 -f docker-compose-cli.yml run --rm dspace-cli index-discovery -b
+docker compose -p d10 -f docker-compose-cli.yml run --rm dspace-cli index-discovery -b
 ```
 
 Similarly, you can see the value of any DSpace configuration (in local.cfg or dspace.cfg) by running:
 
 ```
 # Output the value of `dspace.ui.url` from running Docker instance
-docker compose -p d9 -f docker-compose-cli.yml run --rm dspace-cli dsprop -p dspace.ui.url
+docker compose -p d10 -f docker-compose-cli.yml run --rm dspace-cli dsprop -p dspace.ui.url
 ```
 
 NOTE: It is also possible to run CLI scripts directly on the "dspace" container (where the backend runs)
@@ -279,7 +279,7 @@ This can be useful if you want to pass environment variables which override DSpa
 # Run the "./dspace database clean" command from the "dspace" container
 # Before doing so, it sets "db.cleanDisabled=false".
 # WARNING: This will delete all your data. It's just an example of how to do so.
-docker compose -p d9 exec -e "db__P__cleanDisabled=false" dspace /dspace/bin/dspace database clean
+docker compose -p d10 exec -e "db__P__cleanDisabled=false" dspace /dspace/bin/dspace database clean
 ```
 
 ## Upgrading PostgreSQL in Docker
@@ -297,7 +297,7 @@ Here's how to fix those issues by migrating your old Postgres data to the new ve
 1. First, you must start up the older PostgreSQL image (to dump your existing data to a `*.sql` file)
     ```
     # This command assumes you are using the process described above to start all your containers
-    POSTGRES_VERSION=11 docker compose -p d9 up -d
+    POSTGRES_VERSION=11 docker compose -p d10 up -d
     ```
 2. Dump your entire "dspace" database out of the old "dspacedb" container to a local file named `pgdump.sql`
     ```
@@ -320,12 +320,12 @@ Here's how to fix those issues by migrating your old Postgres data to the new ve
 3. Now, stop all existing containers. This shuts down the old version of PostgreSQL
     ```
     # This command assumes you are using the process described above to start/stop all your containers
-    docker compose -p d9 down
+    docker compose -p d10 down
     ```
 4. Delete the `pgdata` volume. WARNING: This deletes all your old PostgreSQL data. Make sure you have that `pgdump.sql` file FIRST!
     ```
-    # Assumes you are using `-p d9` which prefixes all volumes with `d9_`
-    docker volume rm d9_pgdata
+    # Assumes you are using `-p d10` which prefixes all volumes with `d10_`
+    docker volume rm d10_pgdata
     ```
 5. Just for safety, pull down the latest versions of all images
     ```
@@ -336,12 +336,12 @@ using the local `./pgdump.sql` file. IMPORTANT: If you renamed that "pgdump.sql"
 then you MUST change the name/directory in the `db.restore.yml` script.
     ```
     # Restore database from "./pgdump.sql" (this path is hardcoded in db.restore.yml)
-    docker compose -p d9 -f docker-compose.yml -f dspace/src/main/docker-compose/db.restore.yml up -d
+    docker compose -p d10 -f docker-compose.yml -f dspace/src/main/docker-compose/db.restore.yml up -d
     ```
 7. Finally, reindex all database contents into Solr (just to be sure Solr indexes are current).
     ```
     # Run "./dspace index-discovery -b" using our CLI image
-    docker compose -p d9 -f docker-compose-cli.yml run --rm dspace-cli index-discovery -b
+    docker compose -p d10 -f docker-compose-cli.yml run --rm dspace-cli index-discovery -b
     ```
 At this point in time, all your old database data should be migrated to the new Postgres
 and running at http://localhost:8080/server/

--- a/dspace/src/main/docker-compose/db.entities.yml
+++ b/dspace/src/main/docker-compose/db.entities.yml
@@ -8,7 +8,7 @@
 
 services:
   dspacedb:
-    image: dspace/dspace-postgres-loadsql:${DSPACE_VER:-latest}
+    image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-postgres-loadsql:${DSPACE_VER:-latest}"
     environment:
       # This SQL is available from https://github.com/DSpace-Labs/AIP-Files/releases/tag/demo-entities-data
       - LOADSQL=https://github.com/DSpace-Labs/AIP-Files/releases/download/demo-entities-data/dspace7-entities-data.sql

--- a/dspace/src/main/docker-compose/db.restore.yml
+++ b/dspace/src/main/docker-compose/db.restore.yml
@@ -12,7 +12,7 @@
 # This can be used to restore a "dspacedb" container from a pg_dump, or during upgrade to a new version of PostgreSQL.
 services:
   dspacedb:
-    image: dspace/dspace-postgres-loadsql:${DSPACE_VER:-latest}
+    image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-postgres-loadsql:${DSPACE_VER:-latest}"
     environment:
       # Location where the dump SQL file will be available on the running container
       - LOCALSQL=/tmp/pgdump.sql

--- a/dspace/src/main/docker-compose/docker-compose-angular.yml
+++ b/dspace/src/main/docker-compose/docker-compose-angular.yml
@@ -26,7 +26,9 @@ services:
       DSPACE_REST_HOST: localhost
       DSPACE_REST_PORT: 8080
       DSPACE_REST_NAMESPACE: /server
-    image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-angular:${DSPACE_VER:-latest}"
+      # Ensure SSR can use the 'dspace' Docker image directly (see docker-compose-rest.yml)
+      DSPACE_REST_SSRBASEURL: http://dspace:8080/server
+    image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-angular:${DSPACE_VER:-latest-dist}"
     ports:
     - published: 4000
       target: 4000

--- a/dspace/src/main/docker-compose/docker-compose-angular.yml
+++ b/dspace/src/main/docker-compose/docker-compose-angular.yml
@@ -32,5 +32,3 @@ services:
       target: 4000
     - published: 9876
       target: 9876
-    stdin_open: true
-    tty: true

--- a/dspace/src/main/docker-compose/docker-compose-angular.yml
+++ b/dspace/src/main/docker-compose/docker-compose-angular.yml
@@ -26,9 +26,7 @@ services:
       DSPACE_REST_HOST: localhost
       DSPACE_REST_PORT: 8080
       DSPACE_REST_NAMESPACE: /server
-    image: dspace/dspace-angular:${DSPACE_VER:-latest}
+    image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-angular:${DSPACE_VER:-latest}"
     ports:
     - published: 4000
       target: 4000
-    - published: 9876
-      target: 9876

--- a/dspace/src/main/docker-compose/docker-compose-shibboleth.yml
+++ b/dspace/src/main/docker-compose/docker-compose-shibboleth.yml
@@ -21,7 +21,7 @@ services:
     container_name: dspace-shibboleth
     depends_on:
       - dspace
-    image: dspace/dspace-shibboleth
+    image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-shibboleth"
     build:
       # Must be relative to root, so that it can be built alongside [src]/docker-compose.yml
       context: ./dspace/src/main/docker/dspace-shibboleth

--- a/dspace/src/main/docker-compose/docker-compose-shibboleth.yml
+++ b/dspace/src/main/docker-compose/docker-compose-shibboleth.yml
@@ -30,8 +30,6 @@ services:
         target: 80
       - published: 443
         target: 443
-    stdin_open: true
-    tty: true
     environment:
       # Default to using "localhost" for Apache & Shibboleth
       # However, you can override this via the "DSPACE_HOSTNAME" environment variable.


### PR DESCRIPTION
## References
* Related to https://github.com/DSpace/dspace-angular/pull/4987

## Description
This PR makes minor updates to the Docker Compose scripts to align the backend with https://github.com/DSpace/dspace-angular/pull/4987

These changes include:
  * Minor updates to several scripts to use the $DOCKER_REGISTRY and $DOCKER_OWNER variables that all other scripts use.
  * Removed unnecessary tty and stdin_open configurations from scripts, similar to https://github.com/DSpace/dspace-angular/pull/4987
  * Fix minor networking issues in several compose scripts similar to https://github.com/DSpace/dspace-angular/pull/4987
  * Update `docker-dspace-angular.yml` script to use production mode for the Angular UI (now that it's working in https://github.com/DSpace/dspace-angular/pull/4987).  This change was made because developer mode only makes sense if you have the `dspace-angular` source code locally.

## Instructions for Reviewers

Verify starting the backend and frontend (now running in production mode) still works from these scripts.

1. Install this PR
2. Start the backend and frontend in Docker Compose via:
    ```
    docker compose -p d10 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-angular.yml up -d
    ```
3. Optionally watch the logs as everything starts up:
    ```
    docker compose -p d10 -f docker-compose.yml -f dspace/src/main/docker-compose/docker-compose-angular.yml logs -f
    ```
4. The UI should start immediately. The backend will take about 30 seconds or so to boot up (check the logs).  Once the backend is started, the UI will be available at http:/localhost:4000/ and the backend at http://localhost:8080/server/