### PR TITLE
[Port dspace-9_x][Docker] Minor cleanup to Docker Compose scripts to align with frontend changes and run UI in production mode

### DIFF
--- a/docker-compose-cli.yml
+++ b/docker-compose-cli.yml
@@ -26,8 +26,6 @@ services:
     # Mount local [src]/dspace/config/ to container. This syncs your local configs with container
     # NOTE: Environment variables specified above will OVERRIDE any configs in local.cfg or dspace.cfg
     - ./dspace/config:/dspace/config
-    tty: true
-    stdin_open: true
 
 volumes:
   assetstore:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ networks:
         # Define a custom subnet for our DSpace network, so that we can easily trust requests from host to container.
         # If you customize this value, be sure to customize the 'proxies.trusted.ipranges' env variable below.
         - subnet: 172.23.0.0/16
+    # Explicitly set external=false because this script creates the network.
+    external: false
 services:
   # DSpace (backend) webapp container
   dspace:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,8 +42,6 @@ services:
       target: 8080
     - published: 8000
       target: 8000
-    stdin_open: true
-    tty: true
     volumes:
     # Keep DSpace assetstore directory between reboots
     - assetstore:/dspace/assetstore
@@ -76,8 +74,6 @@ services:
     ports:
     - published: 5432
       target: 5432
-    stdin_open: true
-    tty: true
     volumes:
     # Keep Postgres data directory between reboots
     - pgdata:/pgdata
@@ -97,8 +93,6 @@ services:
     ports:
     - published: 8983
       target: 8983
-    stdin_open: true
-    tty: true
     working_dir: /var/solr/data
     volumes:
     # Keep Solr data directory between reboots

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,9 @@ services:
       # dspace__P__dir: /dspace
       # dspace__P__server__P__url: http://localhost:8080/server
       # dspace__P__ui__P__url: http://localhost:4000
+      # Set SSR URL to the Docker container name so that UI can contact container directly in Production mode.
+      # (This is necessary for docker-compose-angular.yml as it uses production mode by default)
+      dspace__P__server__P__ssr__P__url: http://dspace:8080/server
       dspace__P__name: 'DSpace Started with Docker Compose'
       # db.url: Ensure we are using the 'dspacedb' image for our database
       db__P__url: 'jdbc:postgresql://dspacedb:5432/dspace'

--- a/dspace/src/main/docker-compose/db.entities.yml
+++ b/dspace/src/main/docker-compose/db.entities.yml
@@ -8,7 +8,7 @@
 
 services:
   dspacedb:
-    image: dspace/dspace-postgres-loadsql:${DSPACE_VER:-dspace-9_x}
+    image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-postgres-loadsql:${DSPACE_VER:-dspace-9_x}"
     environment:
       # This SQL is available from https://github.com/DSpace-Labs/AIP-Files/releases/tag/demo-entities-data
       - LOADSQL=https://github.com/DSpace-Labs/AIP-Files/releases/download/demo-entities-data/dspace7-entities-data.sql

--- a/dspace/src/main/docker-compose/db.restore.yml
+++ b/dspace/src/main/docker-compose/db.restore.yml
@@ -12,7 +12,7 @@
 # This can be used to restore a "dspacedb" container from a pg_dump, or during upgrade to a new version of PostgreSQL.
 services:
   dspacedb:
-    image: dspace/dspace-postgres-loadsql:${DSPACE_VER:-dspace-9_x}
+    image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-postgres-loadsql:${DSPACE_VER:-dspace-9_x}"
     environment:
       # Location where the dump SQL file will be available on the running container
       - LOCALSQL=/tmp/pgdump.sql

--- a/dspace/src/main/docker-compose/docker-compose-angular.yml
+++ b/dspace/src/main/docker-compose/docker-compose-angular.yml
@@ -32,5 +32,3 @@ services:
       target: 4000
     - published: 9876
       target: 9876
-    stdin_open: true
-    tty: true

--- a/dspace/src/main/docker-compose/docker-compose-angular.yml
+++ b/dspace/src/main/docker-compose/docker-compose-angular.yml
@@ -26,7 +26,9 @@ services:
       DSPACE_REST_HOST: localhost
       DSPACE_REST_PORT: 8080
       DSPACE_REST_NAMESPACE: /server
-    image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-angular:${DSPACE_VER:-dspace-9_x}"
+      # Ensure SSR can use the 'dspace' Docker image directly (see docker-compose-rest.yml)
+      DSPACE_REST_SSRBASEURL: http://dspace:8080/server
+    image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-angular:${DSPACE_VER:-dspace-9_x-dist}"
     ports:
     - published: 4000
       target: 4000

--- a/dspace/src/main/docker-compose/docker-compose-angular.yml
+++ b/dspace/src/main/docker-compose/docker-compose-angular.yml
@@ -26,9 +26,7 @@ services:
       DSPACE_REST_HOST: localhost
       DSPACE_REST_PORT: 8080
       DSPACE_REST_NAMESPACE: /server
-    image: dspace/dspace-angular:${DSPACE_VER:-dspace-9_x}
+    image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-angular:${DSPACE_VER:-dspace-9_x}"
     ports:
     - published: 4000
       target: 4000
-    - published: 9876
-      target: 9876

--- a/dspace/src/main/docker-compose/docker-compose-shibboleth.yml
+++ b/dspace/src/main/docker-compose/docker-compose-shibboleth.yml
@@ -21,7 +21,7 @@ services:
     container_name: dspace-shibboleth
     depends_on:
       - dspace
-    image: dspace/dspace-shibboleth
+    image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-shibboleth"
     build:
       # Must be relative to root, so that it can be built alongside [src]/docker-compose.yml
       context: ./dspace/src/main/docker/dspace-shibboleth

--- a/dspace/src/main/docker-compose/docker-compose-shibboleth.yml
+++ b/dspace/src/main/docker-compose/docker-compose-shibboleth.yml
@@ -30,8 +30,6 @@ services:
         target: 80
       - published: 443
         target: 443
-    stdin_open: true
-    tty: true
     environment:
       # Default to using "localhost" for Apache & Shibboleth
       # However, you can override this via the "DSPACE_HOSTNAME" environment variable.


### PR DESCRIPTION
Manual port of #11742 to `dspace-9_x`

I've manually tested this backport and ensured that both the backend and frontend run in Docker, and the frontend starts in production mode now.