### PR TITLE
feat(docker): Run create-administrator in docker-compose.yml + add .env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,8 @@ rebel.xml
 
 ## Ignore jenv configuration
 .java-version
+
+## Ignore local environment configuration (dotenv)
+## TODO: Use '!' or comment out if .env files should be commited.
+.env
+.env*.local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,12 @@ services:
       # from the host machine. This IP range MUST correspond to the 'dspacenet' subnet defined above.
       proxies__P__trusted__P__ipranges: '172.23.0'
       LOGGING_CONFIG: /dspace/config/log4j2-container.xml
+      # [DEV ONLY] Initial DSpace Admin Configuration.
+      # If these are set, the entrypoint will attempt to create this user on startup.
+      # SECURITY WARNING: Storing cleartext passwords in docker-compose.yml is insecure.
+      # For production, either move these values to a non-commited .env file or remove them entirely.
+      INIT_ADMIN_EMAIL: dspace@dspace.org
+      INIT_ADMIN_PASSWORD: dspace
     image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace:${DSPACE_VER:-latest-test}"
     build:
       context: .
@@ -63,6 +69,15 @@ services:
     - |
       while (!</dev/tcp/dspacedb/5432) > /dev/null 2>&1; do sleep 1; done;
       /dspace/bin/dspace database migrate
+      if [ -n "$$INIT_ADMIN_EMAIL" ] && [ -n "$$INIT_ADMIN_PASSWORD" ]; then
+        /dspace/bin/dspace create-administrator \
+          -e "$$INIT_ADMIN_EMAIL" \
+          -f "$${INIT_ADMIN_FIRSTNAME:-DSpace}" \
+          -l "$${INIT_ADMIN_LASTNAME:-Admin}" \
+          -p "$$INIT_ADMIN_PASSWORD"
+      else
+        echo "Skipped initializing admin account: INIT_ADMIN_EMAIL and/or INIT_ADMIN_PASSWORD missing."
+      fi
       java -jar /dspace/webapps/server-boot.jar
   # DSpace PostgreSQL database container
   dspacedb:


### PR DESCRIPTION
## References
...

## Description
This PR updates the `docker-compose.yml` to allow the automatic creation of an initial DSpace administrator account on container startup using two new environment variables: `INIT_ADMIN_EMAIL` and `INIT_ADMIN_PASSWORD`. DSpace already supports the same approach with `dspacedb` service (`POSTGRES_USER`, `POSTGRES_PASSWORD` are pre-filled).

While it may raise eyebrows at first, this approach aligns with standard Docker images (such as PostgreSQL or MongoDB), which allow initial admin provisioning via configuration, in an infrastructure as code manner.

There's also a second commit that adds `.env` and `.env*.local` files to the `.gitignore`.

## Instructions for Reviewers
I have modified the `dspace` service definition in `docker-compose.yml` to support an optional auto-configuration step in the entrypoint script.

List of changes in this PR:
* Added `INIT_ADMIN_EMAIL`, `INIT_ADMIN_PASSWORD` to the `environment` section.
* Updated the `entrypoint` script logic to check if these variables are defined in a POSIX-compliant way (so no double `[[ ]]` brackets).
* Added a call to `/dspace/bin/dspace create-administrator` during the startup sequence (after database migration, before Tomcat boot).

## How to Test

1. In `docker-compose.yml`, verify values for `INIT_ADMIN_EMAIL` and `INIT_ADMIN_PASSWORD` (use defaults or either comment or change them).
2. Run `docker compose up`.
    * **Expected**: You should see `Administrator account created` (output of `create-administrator` script) or `Skipped initializing admin account: ...` (if either `INIT_ADMIN_EMAIL` or `INIT_ADMIN_PASSWORD` are not set)
3. Verify you can log in to DSpace (either via localhost:8080/server/login.html, or localhost:4000/login, if using UI).

## Checklist

- [X] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [X] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [X] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [X] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
