### PR TITLE
Fix test that can easily fail because of config changes by introducing test config

### DIFF
--- a/dspace-api/src/test/data/dspaceFolder/config/local.cfg
+++ b/dspace-api/src/test/data/dspaceFolder/config/local.cfg
@@ -203,3 +203,7 @@ assetstore.jcloud.subfolder = assetstore
 assetstore.jcloud.provider = filesystem
 assetstore.jcloud.container = assetstore-jclouds-container
 assetstore.jcloud.basedir = target/testing/dspace
+
+webui.submit.upload.required = true
+rest.cors.allowed-origins = http://localhost:4000
+dspace.name = DSpace at My University

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadatafieldRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadatafieldRestRepositoryIT.java
@@ -81,24 +81,29 @@ public class MetadatafieldRestRepositoryIT extends AbstractControllerIntegration
     public void findAll() throws Exception {
 
         context.turnOffAuthorisationSystem();
-        MetadataField metadataField = MetadataFieldBuilder
-            .createMetadataField(context, "AnElement", "AQualifier", "AScopeNote").build();
-        context.restoreAuthSystemState();
 
         getClient().perform(get("/api/core/metadatafields")
-            .param("size", String.valueOf(100)))
+            .param("size", String.valueOf(9999)))
                    .andExpect(status().isOk())
                    .andExpect(content().contentType(contentType))
                    .andExpect(jsonPath("$._embedded.metadatafields", Matchers.hasItems(
                        MetadataFieldMatcher.matchMetadataFieldByKeys("dc", "title", null),
                        MetadataFieldMatcher.matchMetadataFieldByKeys("dc", "date", "issued"))
-                                      ))
+                                      ));
+    }
+
+    @Test
+    public void findAllPaginated() throws Exception {
+        getClient().perform(get("/api/core/metadatafields")
+                           .param("size", String.valueOf(2)))
+                   .andExpect(status().isOk())
+                   .andExpect(content().contentType(contentType))
+                   .andExpect(jsonPath("$._embedded.metadatafields", Matchers.notNullValue()))
                    .andExpect(jsonPath("$._links.first.href", Matchers.containsString("/api/core/metadatafields")))
                    .andExpect(jsonPath("$._links.self.href", Matchers.containsString("/api/core/metadatafields")))
                    .andExpect(jsonPath("$._links.next.href", Matchers.containsString("/api/core/metadatafields")))
                    .andExpect(jsonPath("$._links.last.href", Matchers.containsString("/api/core/metadatafields")))
-
-                   .andExpect(jsonPath("$.page.size", is(100)));
+                   .andExpect(jsonPath("$.page.size", is(2)));
     }
 
     @Test


### PR DESCRIPTION
## Description
Quick QOL fix which makes sure tests don't start failing because a configuration property was changed (that is very subject to change). I also split the `findAll` test `MetadatafieldRestRepositoryIT` in a paginated one that tests pagination and a regular one with a huge page size param that checks for the metadata fields to be present. This is needed because if you had more than the given 100 metadata fields, they will not be included (depending on the sort)

For this example:
- `InfoEndpointIT` fails when altering `dspace.name` or `rest.cors.allowed-origins`
- `WorkspaceItemRestRepositoryIT` fails when altering `webui.submit.upload.required`
- `MetadatafieldRestRepositoryIT` (can) fail when you have more than 100 metadata fields

Tests should not fail because of simple configuration properties like those being changed, I'm sure more cases still exist somewhere but these are ones I personally run in to a lot.

## Instructions for Reviewers

- Verify the listed tests fail when setting those properties in e.g `dspace.cfg` **before** my PR
- Verify this no longer occurs **after** my PR

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
