### PR TITLE
Add DataCite sandbox url to crosswalk

### DIFF
--- a/dspace/config/crosswalks/DIM2DataCite.xsl
+++ b/dspace/config/crosswalks/DIM2DataCite.xsl
@@ -350,6 +350,9 @@
                 <xsl:if test="starts-with(string(text()), 'http://dx.doi.org/')">
                     <xsl:value-of select="substring(., 19)"/>
                 </xsl:if>
+                <xsl:if test="starts-with(string(text()), 'https://api.test.datacite.org/')">
+                    <xsl:value-of select="substring(., 31)"/>
+                </xsl:if>
             </identifier>
         </xsl:if>
     </xsl:template>


### PR DESCRIPTION
## References
Fixes #11246

## Description
Adds DataCite sandbox uri to crosswalk. (See https://support.datacite.org/docs/testing-guide)

## Instructions for Reviewers
Configure DSpace to use the DataCite sandbox. Mint a DOI, see it successfully complete the update cycle without throwing an error.

List of changes in this PR:
* Adds DataCite sandbox uri (https://api.test.datacite.org/) to crosswalk - [DIM2DataCite.xsl](https://github.com/DSpace/DSpace/blob/main/dspace/config/crosswalks/DIM2DataCite.xsl).

**Include guidance for how to test or review your PR.** 
Test DOIs minted using the DataCite sandbox take the form https://api.test.datacite.org/{TEST PREFIX}/test-1. Since this does not match one of the URI strings expected by the crosswalk, they fail when the update cycle happens, throwing an error and clogging the DOI data in your DSpace. Adding the sandbox URI as a possible match allows the crosswalk to successfully extract and update the status of the DOI.