### PR TITLE
Add Solr search core socket timeout config

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/SolrSearchCore.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrSearchCore.java
@@ -83,6 +83,9 @@ public class SolrSearchCore {
                     log.debug("Solr URL: {}", solrService);
                     HttpSolrClient solrServer = new HttpSolrClient.Builder(solrService)
                             .withHttpClient(httpConnectionPoolService.getClient())
+                            .withSocketTimeout(
+                                configurationService.getIntProperty("discovery.solr.socketTimeout", 120000)
+                            )
                             .build();
 
                     solrServer.setBaseURL(solrService);

--- a/dspace/config/modules/discovery.cfg
+++ b/dspace/config/modules/discovery.cfg
@@ -11,6 +11,10 @@ discovery.search.server = ${solr.server}/${solr.multicorePrefix}search
 #Defaults to true: validation is enabled
 #discovery.solr.url.validation.enabled = true
 
+#Overrides the Solr socket timeout (in milliseconds) for the search core.
+#Defaults to 120000 (2 minutes), the same default value as in SolrClientBuilder.
+#discovery.solr.socketTimeout = 120000
+
 #Char used to ensure that the sidebar facets are case insensitive
 #discovery.solr.facets.split.char=\n|||\n
 


### PR DESCRIPTION
## Description
Introduce an optional configuration property `discovery.solr.socketTimeout` to customize the Solr socket timeout (in milliseconds) for the search core. 

If not specified, the default remains 120000 ms (2 minutes), consistent with previous behavior.

## Instructions for Reviewers

Context:

After upgrading from DSpace 9.1 → 9.2, two instances (~30k items and ~270k items) experienced failures in the `index-discovery -s` cronjob (spellcheck build) due to timeouts.

No other apparent reason was found for the timeouts.

Manual calls to the Solr API for spellcheck exceeded the default 2‑minute limit. No alternative configuration options (via Spring or Solr) were found to override this value.

When calling the Solr API to build the spellcheck manually, the total time exceeded slightly the default value of 2 minutes. I have not found any other way (Spring configs, or Solr configs) that this value could be overridden. 

List of changes in this PR:

- `SolrSearchCore` now reads the optional `discovery.solr.socketTimeout` property when being built.
- If present (`local.cfg` for example), the value overrides the default.
- If omitted, the default of 120000 ms is used.

Verified via debugging that the Solr client correctly applies the configured timeout.

Confirmed that production environments no longer encounter spellcheck build timeouts when using a higher value.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
