### PR TITLE
chore: resolve Dockerfile lint warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,12 +17,13 @@ FROM ${DOCKER_REGISTRY}/dspace/dspace-dependencies:${DSPACE_VERSION} AS build
 ARG TARGET_DIR=dspace-installer
 WORKDIR /app
 # The dspace-installer directory will be written to /install
+USER root
 RUN mkdir /install \
     && chown -Rv dspace: /install \
     && chown -Rv dspace: /app
 USER dspace
 # Copy the DSpace source code (from local machine) into the workdir (excluding .dockerignore contents)
-ADD --chown=dspace . /app/
+COPY --chown=dspace . /app/
 # Build DSpace
 # Copy the dspace-installer directory to /install.  Clean up the build to keep the docker image small
 # Maven flags here ensure that we skip building test environment and skip all code verification checks.

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -17,12 +17,13 @@ FROM ${DOCKER_REGISTRY}/dspace/dspace-dependencies:${DSPACE_VERSION} AS build
 ARG TARGET_DIR=dspace-installer
 WORKDIR /app
 # The dspace-installer directory will be written to /install
+USER root
 RUN mkdir /install \
     && chown -Rv dspace: /install \
     && chown -Rv dspace: /app
 USER dspace
 # Copy the DSpace source code (from local machine) into the workdir (excluding .dockerignore contents)
-ADD --chown=dspace . /app/
+COPY --chown=dspace . /app/
 # Build DSpace.  Copy the dspace-installer directory to /install.  Clean up the build to keep the docker image small
 RUN mvn --no-transfer-progress package && \
   mv /app/dspace/target/${TARGET_DIR}/* /install && \

--- a/Dockerfile.dependencies
+++ b/Dockerfile.dependencies
@@ -24,51 +24,51 @@ USER dspace
 # performing any code compilation steps.
 
 # Parent POM
-ADD --chown=dspace pom.xml /app/
+COPY --chown=dspace pom.xml /app/
 RUN mkdir -p /app/dspace
 
 # 'dspace' module POM. Includes 'additions' ONLY, as it's the only submodule that is required to exist.
-ADD --chown=dspace dspace/pom.xml /app/dspace/
+COPY --chown=dspace dspace/pom.xml /app/dspace/
 RUN mkdir -p /app/dspace/modules/
-ADD --chown=dspace dspace/modules/pom.xml /app/dspace/modules/
+COPY --chown=dspace dspace/modules/pom.xml /app/dspace/modules/
 RUN mkdir -p /app/dspace/modules/additions
-ADD --chown=dspace dspace/modules/additions/pom.xml /app/dspace/modules/additions/
+COPY --chown=dspace dspace/modules/additions/pom.xml /app/dspace/modules/additions/
 
 # 'dspace-api' module POM
 RUN mkdir -p /app/dspace-api
-ADD --chown=dspace dspace-api/pom.xml /app/dspace-api/
+COPY --chown=dspace dspace-api/pom.xml /app/dspace-api/
 
 # 'dspace-iiif' module POM
 RUN mkdir -p /app/dspace-iiif
-ADD --chown=dspace dspace-iiif/pom.xml /app/dspace-iiif/
+COPY --chown=dspace dspace-iiif/pom.xml /app/dspace-iiif/
 
 # 'dspace-oai' module POM
 RUN mkdir -p /app/dspace-oai
-ADD --chown=dspace dspace-oai/pom.xml /app/dspace-oai/
+COPY --chown=dspace dspace-oai/pom.xml /app/dspace-oai/
 
 # 'dspace-rdf' module POM
 RUN mkdir -p /app/dspace-rdf
-ADD --chown=dspace dspace-rdf/pom.xml /app/dspace-rdf/
+COPY --chown=dspace dspace-rdf/pom.xml /app/dspace-rdf/
 
 # 'dspace-saml2' module POM
 RUN mkdir -p /app/dspace-saml2
-ADD --chown=dspace dspace-saml2/pom.xml /app/dspace-saml2/
+COPY --chown=dspace dspace-saml2/pom.xml /app/dspace-saml2/
 
 # 'dspace-server-webapp' module POM
 RUN mkdir -p /app/dspace-server-webapp
-ADD --chown=dspace dspace-server-webapp/pom.xml /app/dspace-server-webapp/
+COPY --chown=dspace dspace-server-webapp/pom.xml /app/dspace-server-webapp/
 
 # 'dspace-services' module POM
 RUN mkdir -p /app/dspace-services
-ADD --chown=dspace dspace-services/pom.xml /app/dspace-services/
+COPY --chown=dspace dspace-services/pom.xml /app/dspace-services/
 
 # 'dspace-sword' module POM
 RUN mkdir -p /app/dspace-sword
-ADD --chown=dspace dspace-sword/pom.xml /app/dspace-sword/
+COPY --chown=dspace dspace-sword/pom.xml /app/dspace-sword/
 
 # 'dspace-swordv2' module POM
 RUN mkdir -p /app/dspace-swordv2
-ADD --chown=dspace dspace-swordv2/pom.xml /app/dspace-swordv2/
+COPY --chown=dspace dspace-swordv2/pom.xml /app/dspace-swordv2/
 
 # Trigger the installation of all maven dependencies (hide download progress messages)
 # Maven flags here ensure that we skip final assembly, skip building test environment and skip all code verification checks.
@@ -80,3 +80,6 @@ RUN mvn --no-transfer-progress verify ${MAVEN_FLAGS}
 # This ensures when dspace:dspace is built, it will use the Maven local cache (~/.m2) for dependencies
 USER root
 RUN rm -rf /app/*
+
+# Switch to initial user to drop root privileges (DL3002)
+USER dspace

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -19,12 +19,13 @@ FROM ${DOCKER_REGISTRY}/dspace/dspace-dependencies:${DSPACE_VERSION} AS build
 ARG TARGET_DIR=dspace-installer
 WORKDIR /app
 # The dspace-installer directory will be written to /install
+USER root
 RUN mkdir /install \
     && chown -Rv dspace: /install \
     && chown -Rv dspace: /app
 USER dspace
 # Copy the DSpace source code (from local machine) into the workdir (excluding .dockerignore contents)
-ADD --chown=dspace . /app/
+COPY --chown=dspace . /app/
 # Build DSpace
 # Copy the dspace-installer directory to /install.  Clean up the build to keep the docker image small
 RUN mvn --no-transfer-progress package && \
@@ -71,6 +72,6 @@ EXPOSE 8080 8000
 # Give java extra memory (2GB)
 ENV JAVA_OPTS=-Xmx2000m
 # enable JVM debugging via JDWP
-ENV JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8000
+ENV JAVA_TOOL_OPTIONS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8000"
 # On startup, run DSpace Runnable JAR (uses the "dspace.dir" setting defined in "dspace__P__dir" env variable)
 ENTRYPOINT ["java", "-jar", "webapps/server-boot.jar"]

--- a/dspace/src/main/docker/dspace-postgres-loadsql/Dockerfile
+++ b/dspace/src/main/docker/dspace-postgres-loadsql/Dockerfile
@@ -22,7 +22,10 @@ ENV POSTGRES_USER=${POSTGRES_USER}
 ENV POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
 
 # Install curl which is necessary to load SQL file
-RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && apt-get purge -y --auto-remove \
+    && rm -rf /var/lib/apt/lists/*
 
 # Load a SQL dump.  Set LOADSQL to a URL for the sql dump file.
 COPY loadsql.sh /docker-entrypoint-initdb.d/

--- a/dspace/src/main/docker/dspace-shibboleth/Dockerfile
+++ b/dspace/src/main/docker/dspace-shibboleth/Dockerfile
@@ -39,10 +39,10 @@ RUN a2enmod ssl proxy proxy_ajp proxy_http shib && \
     a2ensite dspace-vhost.conf
 
 # Setup Shibboleth configs
-COPY shibboleth2.xml /etc/shibboleth/
-COPY attribute-map.xml /etc/shibboleth/
-RUN cd /etc/shibboleth/ \
-    && shib-keygen
+WORKDIR /etc/shibboleth
+COPY shibboleth2.xml .
+COPY attribute-map.xml .
+RUN shib-keygen
 
 # Copy over our startup script
 COPY httpd-shibd-foreground.sh /usr/local/bin/

--- a/dspace/src/main/docker/dspace-solr/Dockerfile
+++ b/dspace/src/main/docker/dspace-solr/Dockerfile
@@ -12,6 +12,11 @@
 
 ARG SOLR_VERSION=9.8
 
+# NOTE: "solrconfigs" is a placeholder stage. It MUST be populated at runtime.
+# usage: docker build --build-context solrconfigs=[path-to-dspace/solr]
+#    or: via "additional_contexts" in docker-compose
+FROM scratch AS solrconfigs
+
 # NOTE: Cannot use the "-slim" image because it doesn't include the extra modules needed for DSpace (e.g. icu4j)
 FROM docker.io/solr:${SOLR_VERSION}
 
@@ -36,8 +41,7 @@ RUN mkdir -p $AUTHORITY_CONFIGSET_PATH && \
     mkdir -p $SUGGESTION_CONFIGSET_PATH && \
     mkdir -p $AUDIT_CONFIGSET_PATH
 
-# NOTE: "solrconfigs" MUST be passed in by docker-compose via "additional_contexts"
-# OR via "docker build --build-context solrconfigs=[path-to-dspace/solr]"
+# Copy configurations from the external 'solrconfigs' build context
 COPY --from=solrconfigs authority/conf/* $AUTHORITY_CONFIGSET_PATH/
 COPY --from=solrconfigs oai/conf/* $OAI_CONFIGSET_PATH/
 COPY --from=solrconfigs search/conf/* $SEARCH_CONFIGSET_PATH/


### PR DESCRIPTION
## References
* Related to DSpace/DSpace#11788

## Description
This PR applies fixes to all Dockerfiles in the repository based on Hadolint analysis.

Rules addressed:

- DL3002 warning: Last USER should not be root
- DL3003 warning: Use WORKDIR to switch to a directory
- DL3015 info: Avoid additional packages by specifying `--no-install-recommends`
- DL3008 warning: Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
  - Intentionally ignored.
- DL3020 error: Use COPY instead of ADD for files and folders
- DL3022 warning: `COPY --from` should reference a previously defined `FROM` alias
  - Provided as **a separate commit**, please check `dspace/src/main/docker/dspace-solr/Dockerfile` to see if you agree with this change

Below is the Hadolint output **before this PR**.

### Dockerfile.dependencies

```
$ docker run --rm -i hadolint/hadolint < ./Dockerfile.dependencies
-:27 DL3020 error: Use COPY instead of ADD for files and folders
-:31 DL3020 error: Use COPY instead of ADD for files and folders
-:33 DL3020 error: Use COPY instead of ADD for files and folders
-:35 DL3020 error: Use COPY instead of ADD for files and folders
-:39 DL3020 error: Use COPY instead of ADD for files and folders
-:43 DL3020 error: Use COPY instead of ADD for files and folders
-:47 DL3020 error: Use COPY instead of ADD for files and folders
-:51 DL3020 error: Use COPY instead of ADD for files and folders
-:55 DL3020 error: Use COPY instead of ADD for files and folders
-:59 DL3020 error: Use COPY instead of ADD for files and folders
-:63 DL3020 error: Use COPY instead of ADD for files and folders
-:67 DL3020 error: Use COPY instead of ADD for files and folders
-:71 DL3020 error: Use COPY instead of ADD for files and folders
-:81 DL3002 warning: Last USER should not be root
```

### Dockerfile.test

```
$ docker run --rm -i hadolint/hadolint < Dockerfile.test
-:27 DL3020 error: Use COPY instead of ADD for files and folders
-:67 DL3008 warning: Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
```

### Dockerfile

```
$ docker run --rm -i hadolint/hadolint < Dockerfile
-:25 DL3020 error: Use COPY instead of ADD for files and folders
-:68 DL3008 warning: Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
```

### Dockerfile.cli

```
$ docker run --rm -i hadolint/hadolint < Dockerfile.cli
-:25 DL3020 error: Use COPY instead of ADD for files and folders
-:62 DL3008 warning: Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
```

### Dockerflie (loadsql)

```
$ docker run --rm -i hadolint/hadolint < ./dspace/src/main/docker/dspace-postgres-loadsql/Dockerfile
-:25 DL3008 warning: Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
-:25 DL3015 info: Avoid additional packages by specifying `--no-install-recommends`
```

### Dockerfile (Shibboleth)

```
$ docker run --rm -i hadolint/hadolint < ./dspace/src/main/docker/dspace-shibboleth/Dockerfile
-:25 DL3008 warning: Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
-:44 DL3003 warning: Use WORKDIR to switch to a directory
```

### Dockerfile (Solr)

```
$ docker run --rm -i hadolint/hadolint < ./dspace/src/main/docker/dspace-solr/Dockerfile
-:41 DL3022 warning: `COPY --from` should reference a previously defined `FROM` alias
-:42 DL3022 warning: `COPY --from` should reference a previously defined `FROM` alias
-:43 DL3022 warning: `COPY --from` should reference a previously defined `FROM` alias
-:44 DL3022 warning: `COPY --from` should reference a previously defined `FROM` alias
-:45 DL3022 warning: `COPY --from` should reference a previously defined `FROM` alias
-:46 DL3022 warning: `COPY --from` should reference a previously defined `FROM` alias
-:47 DL3022 warning: `COPY --from` should reference a previously defined `FROM` alias
```

## Instructions for Reviewers
1. Remove existing DSpace Docker images (either use Docker Desktop, or use CLI commands: `docker images`, find image ID, do `docker rmi <IMAGE_ID>`
2. Refer to DSpace documentation on how to build each Docker image locally. Or, make use of Docker Compose:
`$ docker build -t docker.io/dspace/dspace-dependencies -f Dockerfile.dependencies .`
`$ docker compose -p d10 -f docker-compose.yml -f docker-compose-cli.yml -f dspace/src/main/docker-compose/docker-compose-angular.yml build --no-cache`
`$ docker compose -p d10 -f docker-compose.yml -f docker-compose-cli.yml -f dspace/src/main/docker-compose/docker-compose-angular.yml up`
3. For Solr, test external config injection (`solrconfigs`) via `docker build --build-context solrconfigs=[path-to-dspace/solr]` or via docker-compose additional contexts

## Checklist
- [X] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [X] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [X] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [X] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
