### PR TITLE
DSpace Scripts: fixes & improvements

### DIFF
--- a/dspace-api/src/main/java/org/dspace/administer/ProcessCleaner.java
+++ b/dspace-api/src/main/java/org/dspace/administer/ProcessCleaner.java
@@ -20,11 +20,11 @@ import org.dspace.content.ProcessStatus;
 import org.dspace.core.Context;
 import org.dspace.scripts.DSpaceRunnable;
 import org.dspace.scripts.Process;
+import org.dspace.scripts.configuration.ScriptConfiguration;
 import org.dspace.scripts.factory.ScriptServiceFactory;
 import org.dspace.scripts.service.ProcessService;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
-import org.dspace.utils.DSpace;
 
 /**
  * Script to cleanup the old processes in the specified state.
@@ -32,7 +32,7 @@ import org.dspace.utils.DSpace;
  * @author Luca Giamminonni (luca.giamminonni at 4science.it)
  *
  */
-public class ProcessCleaner extends DSpaceRunnable<ProcessCleanerConfiguration<ProcessCleaner>> {
+public class ProcessCleaner<T extends ScriptConfiguration<?>> extends DSpaceRunnable<T> {
 
     private ConfigurationService configurationService;
 
@@ -48,6 +48,17 @@ public class ProcessCleaner extends DSpaceRunnable<ProcessCleanerConfiguration<P
     private boolean help = false;
 
     private Integer days;
+
+    /**
+     * Constructor for ProcessCleaner script.
+     * Cleans up old processes from the database based on their status
+     * and age to maintain system performance and storage efficiency.
+     * 
+     * @param scriptConfiguration The script configuration defining cleanup criteria and retention policies
+     */
+    public ProcessCleaner(T scriptConfiguration) {
+        super(scriptConfiguration);
+    }
 
 
     @Override
@@ -128,13 +139,6 @@ public class ProcessCleaner extends DSpaceRunnable<ProcessCleanerConfiguration<P
 
     private Instant calculateCreationDate() {
         return Instant.now().minus(days, ChronoUnit.DAYS);
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public ProcessCleanerConfiguration<ProcessCleaner> getScriptConfiguration() {
-        return new DSpace().getServiceManager()
-            .getServiceByName("process-cleaner", ProcessCleanerConfiguration.class);
     }
 
 }

--- a/dspace-api/src/main/java/org/dspace/administer/ProcessCleanerCli.java
+++ b/dspace-api/src/main/java/org/dspace/administer/ProcessCleanerCli.java
@@ -7,12 +7,24 @@
  */
 package org.dspace.administer;
 
+import org.dspace.scripts.configuration.ScriptConfiguration;
+
 /**
  * The {@link ProcessCleaner} for CLI.
  *
  * @author Luca Giamminonni (luca.giamminonni at 4science.it)
  *
  */
-public class ProcessCleanerCli extends ProcessCleaner {
+public class ProcessCleanerCli<T extends ScriptConfiguration<?>> extends ProcessCleaner<T> {
 
+
+    /**
+     * Constructor for ProcessCleanerCli.
+     * Command-line interface wrapper for ProcessCleaner script.
+     * 
+     * @param scriptConfiguration The CLI script configuration with command-line options
+     */
+    public ProcessCleanerCli(T scriptConfiguration) {
+        super(scriptConfiguration);
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/administer/ProcessCleanerCliConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/administer/ProcessCleanerCliConfiguration.java
@@ -13,6 +13,6 @@ package org.dspace.administer;
  * @author Luca Giamminonni (luca.giamminonni at 4science.it)
  *
  */
-public class ProcessCleanerCliConfiguration extends ProcessCleanerConfiguration<ProcessCleanerCli> {
+public class ProcessCleanerCliConfiguration<T extends ProcessCleaner<?>> extends ProcessCleanerConfiguration<T> {
 
 }

--- a/dspace-api/src/main/java/org/dspace/administer/ProcessCleanerConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/administer/ProcessCleanerConfiguration.java
@@ -13,7 +13,7 @@ import org.dspace.scripts.configuration.ScriptConfiguration;
 /**
  * The {@link ScriptConfiguration} for the {@link ProcessCleaner} script.
  */
-public class ProcessCleanerConfiguration<T extends ProcessCleaner> extends ScriptConfiguration<T> {
+public class ProcessCleanerConfiguration<T extends ProcessCleaner<?>> extends ScriptConfiguration<T> {
 
     private Class<T> dspaceRunnableClass;
 

--- a/dspace-api/src/main/java/org/dspace/app/bulkaccesscontrol/BulkAccessControl.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkaccesscontrol/BulkAccessControl.java
@@ -65,6 +65,7 @@ import org.dspace.eperson.EPerson;
 import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.eperson.service.EPersonService;
 import org.dspace.scripts.DSpaceRunnable;
+import org.dspace.scripts.configuration.ScriptConfiguration;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.submit.model.AccessConditionOption;
@@ -76,7 +77,7 @@ import org.dspace.utils.DSpace;
  * @author Mohamed Eskander (mohamed.eskander at 4science.it)
  *
  */
-public class BulkAccessControl extends DSpaceRunnable<BulkAccessControlScriptConfiguration<BulkAccessControl>> {
+public class BulkAccessControl<T extends ScriptConfiguration<?>> extends DSpaceRunnable<T> {
 
     private DSpaceObjectUtils dSpaceObjectUtils;
 
@@ -111,6 +112,16 @@ public class BulkAccessControl extends DSpaceRunnable<BulkAccessControlScriptCon
     private boolean help = false;
 
     protected String eperson = null;
+
+    /**
+     * Constructor for BulkAccessControl script.
+     * 
+     * @param scriptConfiguration The script configuration that defines the parameters
+     *                           and settings for this bulk access control operation
+     */
+    public BulkAccessControl(T scriptConfiguration) {
+        super(scriptConfiguration);
+    }
 
     @Override
     @SuppressWarnings("unchecked")
@@ -678,13 +689,6 @@ public class BulkAccessControl extends DSpaceRunnable<BulkAccessControlScriptCon
 
     protected boolean isAuthorized(Context context) {
         return true;
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public BulkAccessControlScriptConfiguration<BulkAccessControl> getScriptConfiguration() {
-        return new DSpace().getServiceManager()
-                           .getServiceByName("bulk-access-control", BulkAccessControlScriptConfiguration.class);
     }
 
 }

--- a/dspace-api/src/main/java/org/dspace/app/bulkaccesscontrol/BulkAccessControlCli.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkaccesscontrol/BulkAccessControlCli.java
@@ -16,6 +16,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
 import org.dspace.scripts.DSpaceCommandLineParameter;
+import org.dspace.scripts.configuration.ScriptConfiguration;
 
 /**
  * Extension of {@link BulkAccessControl} for CLI.
@@ -23,7 +24,17 @@ import org.dspace.scripts.DSpaceCommandLineParameter;
  * @author Mohamed Eskander (mohamed.eskander at 4science.it)
  *
  */
-public class BulkAccessControlCli extends BulkAccessControl {
+public class BulkAccessControlCli<T extends ScriptConfiguration<?>> extends BulkAccessControl<T> {
+
+    /**
+     * Constructor for BulkAccessControlCli.
+     * Command-line interface wrapper for BulkAccessControl script.
+     * 
+     * @param scriptConfiguration The CLI script configuration with command-line options
+     */
+    public BulkAccessControlCli(T scriptConfiguration) {
+        super(scriptConfiguration);
+    }
 
     @Override
     protected void setEPerson(Context context) throws SQLException {

--- a/dspace-api/src/main/java/org/dspace/app/bulkaccesscontrol/BulkAccessControlCliScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkaccesscontrol/BulkAccessControlCliScriptConfiguration.java
@@ -17,7 +17,7 @@ import org.apache.commons.cli.Options;
  * @author Mohamed Eskander (mohamed.eskander at 4science.it)
  *
  */
-public class BulkAccessControlCliScriptConfiguration<T extends BulkAccessControlCli>
+public class BulkAccessControlCliScriptConfiguration<T extends BulkAccessControl<?>>
     extends BulkAccessControlScriptConfiguration<T> {
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/app/bulkaccesscontrol/BulkAccessControlScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkaccesscontrol/BulkAccessControlScriptConfiguration.java
@@ -30,7 +30,7 @@ import org.dspace.utils.DSpace;
  *
  * @param  <T> the {@link BulkAccessControl} type
  */
-public class BulkAccessControlScriptConfiguration<T extends BulkAccessControl> extends ScriptConfiguration<T> {
+public class BulkAccessControlScriptConfiguration<T extends BulkAccessControl<?>> extends ScriptConfiguration<T> {
 
     private Class<T> dspaceRunnableClass;
 

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataDeletion.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataDeletion.java
@@ -17,9 +17,9 @@ import org.dspace.content.service.MetadataFieldService;
 import org.dspace.content.service.MetadataValueService;
 import org.dspace.core.Context;
 import org.dspace.scripts.DSpaceRunnable;
+import org.dspace.scripts.configuration.ScriptConfiguration;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
-import org.dspace.utils.DSpace;
 
 /**
  * {@link DSpaceRunnable} implementation to delete all the values of the given
@@ -28,7 +28,7 @@ import org.dspace.utils.DSpace;
  * @author Luca Giamminonni (luca.giamminonni at 4science.it)
  *
  */
-public class MetadataDeletion extends DSpaceRunnable<MetadataDeletionScriptConfiguration<MetadataDeletion>> {
+public class MetadataDeletion<T extends ScriptConfiguration<?>> extends DSpaceRunnable<T> {
 
     private MetadataValueService metadataValueService;
 
@@ -39,6 +39,17 @@ public class MetadataDeletion extends DSpaceRunnable<MetadataDeletionScriptConfi
     private String metadataField;
 
     private boolean list;
+
+    /**
+     * Constructor for MetadataDeletion script.
+     * Deletes all values of specified metadata fields from items across the repository,
+     * with safety controls to prevent accidental data loss.
+     * 
+     * @param scriptConfiguration The script configuration defining metadata field deletion parameters
+     */
+    public MetadataDeletion(T scriptConfiguration) {
+        super(scriptConfiguration);
+    }
 
     @Override
     public void internalRun() throws Exception {
@@ -87,13 +98,6 @@ public class MetadataDeletion extends DSpaceRunnable<MetadataDeletionScriptConfi
 
     private String[] getErasableMetadata() {
         return configurationService.getArrayProperty("bulkedit.allow-bulk-deletion");
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public MetadataDeletionScriptConfiguration<MetadataDeletion> getScriptConfiguration() {
-        return new DSpace().getServiceManager()
-            .getServiceByName("metadata-deletion", MetadataDeletionScriptConfiguration.class);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataDeletionCli.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataDeletionCli.java
@@ -7,12 +7,23 @@
  */
 package org.dspace.app.bulkedit;
 
+import org.dspace.scripts.configuration.ScriptConfiguration;
+
 /**
  * The {@link MetadataDeletion} for CLI.
  *
  * @author Luca Giamminonni (luca.giamminonni at 4science.it)
  *
  */
-public class MetadataDeletionCli extends MetadataDeletion {
+public class MetadataDeletionCli<T extends ScriptConfiguration<?>> extends MetadataDeletion<T> {
 
+    /**
+     * Constructor for MetadataDeletionCli.
+     * Command-line interface wrapper for MetadataDeletion script.
+     * 
+     * @param scriptConfiguration The CLI script configuration with command-line options
+     */
+    public MetadataDeletionCli(T scriptConfiguration) {
+        super(scriptConfiguration);
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataDeletionCliScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataDeletionCliScriptConfiguration.java
@@ -13,6 +13,7 @@ package org.dspace.app.bulkedit;
  * @author Luca Giamminonni (luca.giamminonni at 4science.it)
  *
  */
-public class MetadataDeletionCliScriptConfiguration extends MetadataDeletionScriptConfiguration<MetadataDeletionCli> {
+public class MetadataDeletionCliScriptConfiguration<T extends MetadataDeletion<?>>
+    extends MetadataDeletionScriptConfiguration<T> {
 
 }

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataDeletionScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataDeletionScriptConfiguration.java
@@ -13,7 +13,7 @@ import org.dspace.scripts.configuration.ScriptConfiguration;
 /**
  * The {@link ScriptConfiguration} for the {@link MetadataDeletion} script.
  */
-public class MetadataDeletionScriptConfiguration<T extends MetadataDeletion> extends ScriptConfiguration<T> {
+public class MetadataDeletionScriptConfiguration<T extends MetadataDeletion<?>> extends ScriptConfiguration<T> {
 
     private Class<T> dspaceRunnableClass;
 

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExport.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExport.java
@@ -22,6 +22,7 @@ import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.eperson.service.EPersonService;
 import org.dspace.handle.factory.HandleServiceFactory;
 import org.dspace.scripts.DSpaceRunnable;
+import org.dspace.scripts.configuration.ScriptConfiguration;
 import org.dspace.utils.DSpace;
 
 /**
@@ -29,7 +30,7 @@ import org.dspace.utils.DSpace;
  *
  * @author Stuart Lewis
  */
-public class MetadataExport extends DSpaceRunnable<MetadataExportScriptConfiguration> {
+public class MetadataExport<T extends ScriptConfiguration<?>> extends DSpaceRunnable<T> {
 
     private boolean help = false;
     private String filename = null;
@@ -45,6 +46,17 @@ public class MetadataExport extends DSpaceRunnable<MetadataExportScriptConfigura
     private EPersonService ePersonService = EPersonServiceFactory.getInstance().getEPersonService();
 
     private DSpaceObjectUtils dSpaceObjectUtils = UtilServiceFactory.getInstance().getDSpaceObjectUtils();
+
+    /**
+     * Constructor for MetadataExport script.
+     * Exports metadata from items, collections, or communities to CSV format
+     * for batch editing and external processing.
+     * 
+     * @param scriptConfiguration The script configuration defining export scope and format options
+     */
+    public MetadataExport(T scriptConfiguration) {
+        super(scriptConfiguration);
+    }
 
     @Override
     public void internalRun() throws Exception {
@@ -72,12 +84,6 @@ public class MetadataExport extends DSpaceRunnable<MetadataExportScriptConfigura
     protected void logHelpInfo() {
         handler.logInfo("\nfull export: metadata-export");
         handler.logInfo("partial export: metadata-export -i handle/UUID");
-    }
-
-    @Override
-    public MetadataExportScriptConfiguration getScriptConfiguration() {
-        return new DSpace().getServiceManager().getServiceByName("metadata-export",
-                                                                 MetadataExportScriptConfiguration.class);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExportCli.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExportCli.java
@@ -8,8 +8,19 @@
 package org.dspace.app.bulkedit;
 
 import org.apache.commons.cli.ParseException;
+import org.dspace.scripts.configuration.ScriptConfiguration;
 
-public class MetadataExportCli extends MetadataExport {
+public class MetadataExportCli<T extends ScriptConfiguration<?>> extends MetadataExport<T> {
+
+    /**
+     * Constructor for MetadataExportCli.
+     * Command-line interface wrapper for MetadataExport script.
+     * 
+     * @param scriptConfiguration The CLI script configuration with command-line options
+     */
+    public MetadataExportCli(T scriptConfiguration) {
+        super(scriptConfiguration);
+    }
 
     @Override
     protected String getFileNameForExportFile() {

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExportCliScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExportCliScriptConfiguration.java
@@ -11,7 +11,8 @@ import java.io.OutputStream;
 
 import org.apache.commons.cli.Options;
 
-public class MetadataExportCliScriptConfiguration extends MetadataExportScriptConfiguration<MetadataExportCli> {
+public class MetadataExportCliScriptConfiguration<T extends MetadataExport<?>>
+    extends MetadataExportScriptConfiguration<T> {
 
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExportFilteredItemsReport.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExportFilteredItemsReport.java
@@ -35,6 +35,7 @@ import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.eperson.service.EPersonService;
 import org.dspace.kernel.ServiceManager;
 import org.dspace.scripts.DSpaceRunnable;
+import org.dspace.scripts.configuration.ScriptConfiguration;
 import org.dspace.services.ConfigurationService;
 import org.dspace.utils.DSpace;
 
@@ -43,8 +44,7 @@ import org.dspace.utils.DSpace;
  *
  * @author Jean-François Morin (Université Laval)
  */
-public class MetadataExportFilteredItemsReport extends DSpaceRunnable
-        <MetadataExportFilteredItemsReportScriptConfiguration<MetadataExportFilteredItemsReport>> {
+public class MetadataExportFilteredItemsReport<T extends ScriptConfiguration<?>> extends DSpaceRunnable<T> {
 
     private static final String EXPORT_CSV = "exportCSV";
     public static final String DEFAULT_FILENAME = "metadataExportFilteredItems.csv";
@@ -58,14 +58,17 @@ public class MetadataExportFilteredItemsReport extends DSpaceRunnable
     private EPersonService ePersonService;
     private MetadataDSpaceCsvExportService metadataDSpaceCsvExportService;
 
-    @SuppressWarnings("unchecked")
-    @Override
-    public MetadataExportFilteredItemsReportScriptConfiguration<MetadataExportFilteredItemsReport>
-            getScriptConfiguration() {
-        return new DSpace().getServiceManager()
-            .getServiceByName("metadata-export-filtered-items-report",
-                    MetadataExportFilteredItemsReportScriptConfiguration.class);
+    /**
+     * Constructor for MetadataExportFilteredItemsReport script.
+     * Exports metadata from items that match specified filtering criteria
+     * to CSV format for reporting and analysis purposes.
+     * 
+     * @param scriptConfiguration The script configuration defining filter criteria and export parameters
+     */
+    public MetadataExportFilteredItemsReport(T scriptConfiguration) {
+        super(scriptConfiguration);
     }
+
 
     @Override
     public void setup() throws ParseException {

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExportFilteredItemsReportCli.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExportFilteredItemsReportCli.java
@@ -11,13 +11,26 @@ package org.dspace.app.bulkedit;
 import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
+import org.dspace.scripts.configuration.ScriptConfiguration;
 
 /**
  * The CLI version of the {@link MetadataExportFilteredItemsReport} script
  *
  * @author Jean-François Morin (Université Laval)
  */
-public class MetadataExportFilteredItemsReportCli extends MetadataExportFilteredItemsReport {
+public class MetadataExportFilteredItemsReportCli<T extends ScriptConfiguration<?>>
+    extends MetadataExportFilteredItemsReport<T> {
+
+
+    /**
+     * Constructor for MetadataExportFilteredItemsReportCli.
+     * Command-line interface wrapper for MetadataExportFilteredItemsReport script.
+     * 
+     * @param scriptConfiguration The CLI script configuration with command-line options
+     */
+    public MetadataExportFilteredItemsReportCli(T scriptConfiguration) {
+        super(scriptConfiguration);
+    }
 
     @Override
     protected String getFileNameOrExportFile() {

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExportFilteredItemsReportCliScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExportFilteredItemsReportCliScriptConfiguration.java
@@ -18,8 +18,8 @@ import org.springframework.beans.factory.annotation.Autowired;
  *
  * @author Jean-François Morin (Université Laval)
  */
-public class MetadataExportFilteredItemsReportCliScriptConfiguration
-    extends MetadataExportFilteredItemsReportScriptConfiguration<MetadataExportFilteredItemsReportCli> {
+public class MetadataExportFilteredItemsReportCliScriptConfiguration<T extends MetadataExportFilteredItemsReport<?>>
+    extends MetadataExportFilteredItemsReportScriptConfiguration<T> {
 
     @Autowired
     private ConfigurationService configurationService;

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExportFilteredItemsReportScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExportFilteredItemsReportScriptConfiguration.java
@@ -16,7 +16,7 @@ import org.dspace.scripts.configuration.ScriptConfiguration;
  *
  * @author Jean-François Morin (Université Laval)
  */
-public class MetadataExportFilteredItemsReportScriptConfiguration<T extends MetadataExportFilteredItemsReport>
+public class MetadataExportFilteredItemsReportScriptConfiguration<T extends MetadataExportFilteredItemsReport<?>>
         extends ScriptConfiguration<T> {
 
     private Class<T> dspaceRunnableclass;

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExportScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExportScriptConfiguration.java
@@ -13,7 +13,7 @@ import org.dspace.scripts.configuration.ScriptConfiguration;
 /**
  * The {@link ScriptConfiguration} for the {@link MetadataExport} script
  */
-public class MetadataExportScriptConfiguration<T extends MetadataExport> extends ScriptConfiguration<T> {
+public class MetadataExportScriptConfiguration<T extends MetadataExport<?>> extends ScriptConfiguration<T> {
 
     private Class<T> dspaceRunnableClass;
 

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExportSearch.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExportSearch.java
@@ -37,6 +37,7 @@ import org.dspace.discovery.utils.parameter.QueryBuilderSearchFilter;
 import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.eperson.service.EPersonService;
 import org.dspace.scripts.DSpaceRunnable;
+import org.dspace.scripts.configuration.ScriptConfiguration;
 import org.dspace.sort.SortOption;
 import org.dspace.utils.DSpace;
 
@@ -44,7 +45,7 @@ import org.dspace.utils.DSpace;
  * Metadata exporter to allow the batch export of metadata from a discovery search into a file
  *
  */
-public class MetadataExportSearch extends DSpaceRunnable<MetadataExportSearchScriptConfiguration> {
+public class MetadataExportSearch<T extends ScriptConfiguration<?>> extends DSpaceRunnable<T> {
     private static final String EXPORT_CSV = "exportCSV";
     private boolean help = false;
     private String identifier;
@@ -61,10 +62,15 @@ public class MetadataExportSearch extends DSpaceRunnable<MetadataExportSearchScr
     private CollectionService collectionService;
     private DiscoverQueryBuilder queryBuilder;
 
-    @Override
-    public MetadataExportSearchScriptConfiguration getScriptConfiguration() {
-        return new DSpace().getServiceManager()
-            .getServiceByName("metadata-export-search", MetadataExportSearchScriptConfiguration.class);
+    /**
+     * Constructor for MetadataExportSearch script.
+     * Exports metadata from items found through discovery search queries
+     * to CSV format, enabling targeted metadata extraction and reporting.
+     * 
+     * @param scriptConfiguration The script configuration defining search parameters and export settings
+     */
+    public MetadataExportSearch(T scriptConfiguration) {
+        super(scriptConfiguration);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExportSearchCli.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExportSearchCli.java
@@ -8,10 +8,22 @@
 
 package org.dspace.app.bulkedit;
 
+import org.dspace.scripts.configuration.ScriptConfiguration;
+
 /**
  * The cli version of the {@link MetadataExportSearch} script
  */
-public class MetadataExportSearchCli extends MetadataExportSearch {
+public class MetadataExportSearchCli<T extends ScriptConfiguration<?>> extends MetadataExportSearch<T> {
+
+    /**
+     * Constructor for MetadataExportSearchCli.
+     * Command-line interface wrapper for MetadataExportSearch script.
+     * 
+     * @param scriptConfiguration The CLI script configuration with command-line options
+     */
+    public MetadataExportSearchCli(T scriptConfiguration) {
+        super(scriptConfiguration);
+    }
 
     @Override
     protected String getFileNameOrExportFile() {

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExportSearchCliScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExportSearchCliScriptConfiguration.java
@@ -14,8 +14,8 @@ import org.apache.commons.cli.Options;
  * This is the CLI version of the {@link MetadataExportSearchScriptConfiguration} class that handles the
  * configuration for the {@link MetadataExportSearchCli} script
  */
-public class MetadataExportSearchCliScriptConfiguration
-    extends MetadataExportSearchScriptConfiguration<MetadataExportSearchCli> {
+public class MetadataExportSearchCliScriptConfiguration<T extends MetadataExportSearch<?>>
+    extends MetadataExportSearchScriptConfiguration<T> {
 
     @Override
     public Options getOptions() {

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExportSearchScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataExportSearchScriptConfiguration.java
@@ -14,7 +14,7 @@ import org.dspace.scripts.configuration.ScriptConfiguration;
 /**
  * The {@link ScriptConfiguration} for the {@link MetadataExportSearch} script
  */
-public class MetadataExportSearchScriptConfiguration<T extends MetadataExportSearch> extends ScriptConfiguration<T> {
+public class MetadataExportSearchScriptConfiguration<T extends MetadataExportSearch<?>> extends ScriptConfiguration<T> {
 
     private Class<T> dspaceRunnableclass;
 

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
@@ -64,10 +64,10 @@ import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.handle.factory.HandleServiceFactory;
 import org.dspace.handle.service.HandleService;
 import org.dspace.scripts.DSpaceRunnable;
+import org.dspace.scripts.configuration.ScriptConfiguration;
 import org.dspace.scripts.handler.DSpaceRunnableHandler;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
-import org.dspace.utils.DSpace;
 import org.dspace.workflow.WorkflowException;
 import org.dspace.workflow.WorkflowItem;
 import org.dspace.workflow.WorkflowService;
@@ -78,7 +78,7 @@ import org.dspace.workflow.factory.WorkflowServiceFactory;
  *
  * @author Stuart Lewis
  */
-public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfiguration> {
+public class MetadataImport<T extends ScriptConfiguration<?>> extends DSpaceRunnable<T> {
 
     /**
      * The DSpaceCSV object we're processing
@@ -152,6 +152,7 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
      */
     protected static final Logger log = org.apache.logging.log4j.LogManager.getLogger(MetadataImport.class);
 
+
     protected ItemService itemService = ContentServiceFactory.getInstance().getItemService();
     protected InstallItemService installItemService = ContentServiceFactory.getInstance().getInstallItemService();
     protected CollectionService collectionService = ContentServiceFactory.getInstance().getCollectionService();
@@ -169,6 +170,17 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
     protected MetadataAuthorityService metadataAuthorityService = ContentAuthorityServiceFactory
         .getInstance()
         .getMetadataAuthorityService();
+
+    /**
+     * Constructor for MetadataImport script.
+     * Imports metadata from CSV files to update or create items in the repository,
+     * supporting batch operations with validation and relationship management.
+     * 
+     * @param scriptConfiguration The script configuration defining import file and processing options
+     */
+    public MetadataImport(T scriptConfiguration) {
+        super(scriptConfiguration);
+    }
 
     /**
      * Create an instance of the metadata importer. Requires a context and an array of CSV lines
@@ -293,12 +305,6 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
      */
     protected boolean determineChange(DSpaceRunnableHandler handler) throws IOException {
         return true;
-    }
-
-    @Override
-    public MetadataImportScriptConfiguration getScriptConfiguration() {
-        return new DSpace().getServiceManager().getServiceByName("metadata-import",
-                                                                 MetadataImportScriptConfiguration.class);
     }
 
 

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImportCLI.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImportCLI.java
@@ -16,13 +16,24 @@ import org.apache.commons.cli.ParseException;
 import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.factory.EPersonServiceFactory;
+import org.dspace.scripts.configuration.ScriptConfiguration;
 import org.dspace.scripts.handler.DSpaceRunnableHandler;
 
 /**
  * CLI variant for the {@link MetadataImport} class
  * This has been made so that we can specify the behaviour of the determineChanges method to be specific for the CLI
  */
-public class MetadataImportCLI extends MetadataImport {
+public class MetadataImportCLI<T extends ScriptConfiguration<?>> extends MetadataImport<T> {
+
+    /**
+     * Constructor for MetadataImportCLI.
+     * Command-line interface wrapper for MetadataImport script.
+     * 
+     * @param scriptConfiguration The CLI script configuration with command-line options
+     */
+    public MetadataImportCLI(T scriptConfiguration) {
+        super(scriptConfiguration);
+    }
 
     @Override
     protected boolean determineChange(DSpaceRunnableHandler handler) throws IOException {

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImportCliScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImportCliScriptConfiguration.java
@@ -13,7 +13,8 @@ import org.dspace.scripts.configuration.ScriptConfiguration;
 /**
  * The {@link ScriptConfiguration} for the {@link org.dspace.app.bulkedit.MetadataImportCLI} CLI script
  */
-public class MetadataImportCliScriptConfiguration extends MetadataImportScriptConfiguration<MetadataImportCLI> {
+public class MetadataImportCliScriptConfiguration<T extends MetadataImport<?>>
+    extends MetadataImportScriptConfiguration<T> {
 
     @Override
     public Options getOptions() {

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImportScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImportScriptConfiguration.java
@@ -15,7 +15,7 @@ import org.dspace.scripts.configuration.ScriptConfiguration;
 /**
  * The {@link ScriptConfiguration} for the {@link MetadataImport} script
  */
-public class MetadataImportScriptConfiguration<T extends MetadataImport> extends ScriptConfiguration<T> {
+public class MetadataImportScriptConfiguration<T extends MetadataImport<?>> extends ScriptConfiguration<T> {
 
     private Class<T> dspaceRunnableClass;
 

--- a/dspace-api/src/main/java/org/dspace/app/harvest/Harvest.java
+++ b/dspace-api/src/main/java/org/dspace/app/harvest/Harvest.java
@@ -34,14 +34,14 @@ import org.dspace.harvest.OAIHarvester;
 import org.dspace.harvest.factory.HarvestServiceFactory;
 import org.dspace.harvest.service.HarvestedCollectionService;
 import org.dspace.scripts.DSpaceRunnable;
-import org.dspace.utils.DSpace;
+import org.dspace.scripts.configuration.ScriptConfiguration;
 
 /**
  * Test class for harvested collections.
  *
  * @author Alexey Maslov
  */
-public class Harvest extends DSpaceRunnable<HarvestScriptConfiguration> {
+public class Harvest<T extends ScriptConfiguration<?>> extends DSpaceRunnable<T> {
 
     private HarvestedCollectionService harvestedCollectionService;
     protected EPersonService ePersonService;
@@ -57,11 +57,17 @@ public class Harvest extends DSpaceRunnable<HarvestScriptConfiguration> {
 
     protected Context context;
 
-
-    public HarvestScriptConfiguration getScriptConfiguration() {
-        return new DSpace().getServiceManager()
-                           .getServiceByName("harvest", HarvestScriptConfiguration.class);
+    /**
+     * Constructor for Harvest script.
+     * This script manages OAI-PMH harvesting operations for external collections.
+     * 
+     * @param scriptConfiguration The script configuration defining harvest parameters,
+     *                           collection settings, and OAI-PMH endpoint details
+     */
+    public Harvest(T scriptConfiguration) {
+        super(scriptConfiguration);
     }
+
 
     public void setup() throws ParseException {
         harvestedCollectionService =

--- a/dspace-api/src/main/java/org/dspace/app/harvest/HarvestCli.java
+++ b/dspace-api/src/main/java/org/dspace/app/harvest/HarvestCli.java
@@ -12,8 +12,19 @@ import java.sql.SQLException;
 import org.apache.commons.cli.ParseException;
 import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
+import org.dspace.scripts.configuration.ScriptConfiguration;
 
-public class HarvestCli extends Harvest {
+public class HarvestCli<T extends ScriptConfiguration<?>> extends Harvest<T> {
+
+    /**
+     * Constructor for HarvestCli.
+     * Command-line interface wrapper for Harvest script.
+     * 
+     * @param scriptConfiguration The CLI script configuration with command-line options
+     */
+    public HarvestCli(T scriptConfiguration) {
+        super(scriptConfiguration);
+    }
 
     /**
      * This is the overridden instance of the {@link Harvest#assignCurrentUserInContext()} method in the parent class

--- a/dspace-api/src/main/java/org/dspace/app/harvest/HarvestCliScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/app/harvest/HarvestCliScriptConfiguration.java
@@ -10,7 +10,7 @@ package org.dspace.app.harvest;
 import org.apache.commons.cli.Options;
 
 
-public class HarvestCliScriptConfiguration extends HarvestScriptConfiguration {
+public class HarvestCliScriptConfiguration<T extends Harvest<?>> extends HarvestScriptConfiguration<T> {
 
     public Options getOptions() {
         Options options = super.getOptions();

--- a/dspace-api/src/main/java/org/dspace/app/harvest/HarvestScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/app/harvest/HarvestScriptConfiguration.java
@@ -11,7 +11,7 @@ import org.apache.commons.cli.Options;
 import org.dspace.scripts.configuration.ScriptConfiguration;
 
 
-public class HarvestScriptConfiguration<T extends Harvest> extends ScriptConfiguration<T> {
+public class HarvestScriptConfiguration<T extends Harvest<?>> extends ScriptConfiguration<T> {
 
     private Class<T> dspaceRunnableClass;
 

--- a/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExport.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExport.java
@@ -34,7 +34,7 @@ import org.dspace.eperson.service.EPersonService;
 import org.dspace.handle.factory.HandleServiceFactory;
 import org.dspace.handle.service.HandleService;
 import org.dspace.scripts.DSpaceRunnable;
-import org.dspace.utils.DSpace;
+import org.dspace.scripts.configuration.ScriptConfiguration;
 
 /**
  * Item exporter to create simple AIPs for DSpace content. Currently exports
@@ -57,7 +57,7 @@ import org.dspace.utils.DSpace;
  * @author David Little
  * @author Jay Paz
  */
-public class ItemExport extends DSpaceRunnable<ItemExportScriptConfiguration> {
+public class ItemExport<T extends ScriptConfiguration<?>> extends DSpaceRunnable<T> {
 
     public static final String TEMP_DIR = "exportSAF";
     public static final String ZIP_NAME = "exportSAFZip";
@@ -83,10 +83,15 @@ public class ItemExport extends DSpaceRunnable<ItemExportScriptConfiguration> {
     protected static final EPersonService epersonService =
             EPersonServiceFactory.getInstance().getEPersonService();
 
-    @Override
-    public ItemExportScriptConfiguration getScriptConfiguration() {
-        return new DSpace().getServiceManager()
-                .getServiceByName("export", ItemExportScriptConfiguration.class);
+    /**
+     * Constructor for ItemExport script.
+     * This script exports DSpace items to Simple Archive Format (SAF) packages.
+     * 
+     * @param scriptConfiguration The script configuration defining export parameters,
+     *                           target items/collections, and output directory settings
+     */
+    public ItemExport(T scriptConfiguration) {
+        super(scriptConfiguration);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExportCLI.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExportCLI.java
@@ -15,6 +15,7 @@ import java.util.List;
 import org.dspace.app.itemexport.service.ItemExportService;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
+import org.dspace.scripts.configuration.ScriptConfiguration;
 
 /**
  * CLI variant for the {@link ItemExport} class.
@@ -22,7 +23,17 @@ import org.dspace.core.Context;
  *
  * @author Francesco Pio Scognamiglio (francescopio.scognamiglio at 4science.com)
  */
-public class ItemExportCLI extends ItemExport {
+public class ItemExportCLI<T extends ScriptConfiguration<?>> extends ItemExport<T> {
+
+    /**
+     * Constructor for ItemExportCLI.
+     * Command-line interface wrapper for ItemExport script.
+     * 
+     * @param scriptConfiguration The CLI script configuration with command-line options
+     */
+    public ItemExportCLI(T scriptConfiguration) {
+        super(scriptConfiguration);
+    }
 
     @Override
     protected void validate() {

--- a/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExportCLIScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExportCLIScriptConfiguration.java
@@ -16,7 +16,7 @@ import org.dspace.scripts.configuration.ScriptConfiguration;
  * 
  * @author Francesco Pio Scognamiglio (francescopio.scognamiglio at 4science.com)
  */
-public class ItemExportCLIScriptConfiguration extends ItemExportScriptConfiguration<ItemExportCLI> {
+public class ItemExportCLIScriptConfiguration<T extends ItemExport<?>> extends ItemExportScriptConfiguration<T> {
 
     @Override
     public Options getOptions() {

--- a/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExportScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExportScriptConfiguration.java
@@ -16,7 +16,7 @@ import org.dspace.scripts.configuration.ScriptConfiguration;
  * 
  * @author Francesco Pio Scognamiglio (francescopio.scognamiglio at 4science.com)
  */
-public class ItemExportScriptConfiguration<T extends ItemExport> extends ScriptConfiguration<T> {
+public class ItemExportScriptConfiguration<T extends ItemExport<?>> extends ScriptConfiguration<T> {
 
     private Class<T> dspaceRunnableClass;
 

--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
@@ -40,7 +40,7 @@ import org.dspace.eperson.service.EPersonService;
 import org.dspace.handle.factory.HandleServiceFactory;
 import org.dspace.handle.service.HandleService;
 import org.dspace.scripts.DSpaceRunnable;
-import org.dspace.utils.DSpace;
+import org.dspace.scripts.configuration.ScriptConfiguration;
 
 /**
  * Import items into DSpace. The conventional use is upload files by copying
@@ -58,7 +58,7 @@ import org.dspace.utils.DSpace;
  * Modified by David Little, UCSD Libraries 12/21/04 to
  * allow the registration of files (bitstreams) into DSpace.
  */
-public class ItemImport extends DSpaceRunnable<ItemImportScriptConfiguration> {
+public class ItemImport<T extends ScriptConfiguration> extends DSpaceRunnable<T> {
 
     public static String TEMP_DIR = "importSAF";
     public static String MAPFILE_FILENAME = "mapfile";
@@ -92,10 +92,8 @@ public class ItemImport extends DSpaceRunnable<ItemImportScriptConfiguration> {
     protected static final HandleService handleService =
             HandleServiceFactory.getInstance().getHandleService();
 
-    @Override
-    public ItemImportScriptConfiguration getScriptConfiguration() {
-        return new DSpace().getServiceManager()
-                .getServiceByName("import", ItemImportScriptConfiguration.class);
+    public ItemImport(T scriptConfiguration) {
+        super(scriptConfiguration);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
@@ -58,7 +58,7 @@ import org.dspace.scripts.configuration.ScriptConfiguration;
  * Modified by David Little, UCSD Libraries 12/21/04 to
  * allow the registration of files (bitstreams) into DSpace.
  */
-public class ItemImport<T extends ScriptConfiguration> extends DSpaceRunnable<T> {
+public class ItemImport<T extends ScriptConfiguration<?>> extends DSpaceRunnable<T> {
 
     public static String TEMP_DIR = "importSAF";
     public static String MAPFILE_FILENAME = "mapfile";
@@ -92,6 +92,13 @@ public class ItemImport<T extends ScriptConfiguration> extends DSpaceRunnable<T>
     protected static final HandleService handleService =
             HandleServiceFactory.getInstance().getHandleService();
 
+    /**
+     * Constructor for ItemImport script.
+     * Imports items from Simple Archive Format (SAF) into DSpace repositories,
+     * supporting both file copying and registration modes.
+     * 
+     * @param scriptConfiguration The script configuration defining import parameters and options
+     */
     public ItemImport(T scriptConfiguration) {
         super(scriptConfiguration);
     }

--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportCLI.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportCLI.java
@@ -31,8 +31,14 @@ import org.dspace.scripts.configuration.ScriptConfiguration;
  *
  * @author Francesco Pio Scognamiglio (francescopio.scognamiglio at 4science.com)
  */
-public class ItemImportCLI<T extends ScriptConfiguration> extends ItemImport<T> {
+public class ItemImportCLI<T extends ScriptConfiguration<?>> extends ItemImport<T> {
 
+    /**
+     * Constructor for ItemImportCLI.
+     * Command-line interface wrapper for ItemImport script.
+     * 
+     * @param scriptConfiguration The CLI script configuration with command-line options
+     */
     public ItemImportCLI(T scriptConfiguration) {
         super(scriptConfiguration);
     }

--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportCLI.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportCLI.java
@@ -23,6 +23,7 @@ import org.dspace.app.itemimport.service.ItemImportService;
 import org.dspace.content.Collection;
 import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
+import org.dspace.scripts.configuration.ScriptConfiguration;
 
 /**
  * CLI variant for the {@link ItemImport} class.
@@ -30,7 +31,11 @@ import org.dspace.eperson.EPerson;
  *
  * @author Francesco Pio Scognamiglio (francescopio.scognamiglio at 4science.com)
  */
-public class ItemImportCLI extends ItemImport {
+public class ItemImportCLI<T extends ScriptConfiguration> extends ItemImport<T> {
+
+    public ItemImportCLI(T scriptConfiguration) {
+        super(scriptConfiguration);
+    }
 
     @Override
     protected void validate(Context context) {

--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportCLIScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportCLIScriptConfiguration.java
@@ -16,7 +16,7 @@ import org.dspace.scripts.configuration.ScriptConfiguration;
  *
  * @author Francesco Pio Scognamiglio (francescopio.scognamiglio at 4science.com)
  */
-public class ItemImportCLIScriptConfiguration extends ItemImportScriptConfiguration<ItemImportCLI> {
+public class ItemImportCLIScriptConfiguration<T extends ItemImport<?>> extends ItemImportScriptConfiguration<T> {
 
     @Override
     public Options getOptions() {

--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportScriptConfiguration.java
@@ -18,7 +18,7 @@ import org.dspace.scripts.configuration.ScriptConfiguration;
  *
  * @author Francesco Pio Scognamiglio (francescopio.scognamiglio at 4science.com)
  */
-public class ItemImportScriptConfiguration<T extends ItemImport> extends ScriptConfiguration<T> {
+public class ItemImportScriptConfiguration<T extends ItemImport<?>> extends ScriptConfiguration<T> {
 
     private Class<T> dspaceRunnableClass;
 

--- a/dspace-api/src/main/java/org/dspace/app/launcher/ScriptLauncher.java
+++ b/dspace-api/src/main/java/org/dspace/app/launcher/ScriptLauncher.java
@@ -143,8 +143,8 @@ public class ScriptLauncher {
                                    EPerson currentUser) throws InstantiationException, IllegalAccessException {
         int status;
         ScriptService scriptService = ScriptServiceFactory.getInstance().getScriptService();
-        ScriptConfiguration scriptConfiguration = scriptService.getScriptConfiguration(args[0]);
-        DSpaceRunnable script = null;
+        ScriptConfiguration<DSpaceRunnable<?>> scriptConfiguration = scriptService.getScriptConfiguration(args[0]);
+        DSpaceRunnable<?> script = null;
         if (scriptConfiguration != null) {
             script = scriptService.createDSpaceRunnableForScriptConfiguration(scriptConfiguration);
         }
@@ -369,10 +369,10 @@ public class ScriptLauncher {
         }
 
         // commands from script service
-        Collection<ScriptConfiguration<T>> serviceCommands = getServiceCommands();
+        Collection<ScriptConfiguration<DSpaceRunnable<?>>> serviceCommands = getServiceCommands();
         if (!serviceCommands.isEmpty()) {
             System.out.println("\nCommands from script service");
-            for (ScriptConfiguration command : serviceCommands) {
+            for (ScriptConfiguration<?> command : serviceCommands) {
                 displayCommand(
                     command.getName(),
                     command.getDescription()
@@ -414,13 +414,13 @@ public class ScriptLauncher {
      * Get a sorted collection of the commands that are defined as beans. Used by {@link #display}.
      * @return sorted collection of commands
      */
-    private static <T extends DSpaceRunnable<?>> Collection<ScriptConfiguration<T>> getServiceCommands() {
+    private static <S extends ScriptConfiguration<T>, T extends DSpaceRunnable<?>> Collection<S> getServiceCommands() {
         ScriptService scriptService = ScriptServiceFactory.getInstance().getScriptService();
 
         Context throwAwayContext = new Context();
 
         throwAwayContext.turnOffAuthorisationSystem();
-        List<ScriptConfiguration<T>> scriptConfigurations = scriptService.getScriptConfigurations(throwAwayContext);
+        List<S> scriptConfigurations = scriptService.getScriptConfigurations(throwAwayContext);
         throwAwayContext.restoreAuthSystemState();
 
         try {

--- a/dspace-api/src/main/java/org/dspace/app/launcher/ScriptLauncher.java
+++ b/dspace-api/src/main/java/org/dspace/app/launcher/ScriptLauncher.java
@@ -352,7 +352,7 @@ public class ScriptLauncher {
      * Display the commands that are defined in launcher.xml and/or the script service.
      * @param commandConfigs configs as Document
      */
-    private static void display(Document commandConfigs) {
+    private static <T extends DSpaceRunnable<?>> void display(Document commandConfigs) {
         // usage
         System.out.println("Usage: dspace [command-name] {parameters}");
 
@@ -369,8 +369,8 @@ public class ScriptLauncher {
         }
 
         // commands from script service
-        Collection<ScriptConfiguration> serviceCommands = getServiceCommands();
-        if (serviceCommands.size() > 0) {
+        Collection<ScriptConfiguration<T>> serviceCommands = getServiceCommands();
+        if (!serviceCommands.isEmpty()) {
             System.out.println("\nCommands from script service");
             for (ScriptConfiguration command : serviceCommands) {
                 displayCommand(
@@ -414,13 +414,13 @@ public class ScriptLauncher {
      * Get a sorted collection of the commands that are defined as beans. Used by {@link #display}.
      * @return sorted collection of commands
      */
-    private static Collection<ScriptConfiguration> getServiceCommands() {
+    private static <T extends DSpaceRunnable<?>> Collection<ScriptConfiguration<T>> getServiceCommands() {
         ScriptService scriptService = ScriptServiceFactory.getInstance().getScriptService();
 
         Context throwAwayContext = new Context();
 
         throwAwayContext.turnOffAuthorisationSystem();
-        List<ScriptConfiguration> scriptConfigurations = scriptService.getScriptConfigurations(throwAwayContext);
+        List<ScriptConfiguration<T>> scriptConfigurations = scriptService.getScriptConfigurations(throwAwayContext);
         throwAwayContext.restoreAuthSystemState();
 
         try {

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScript.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScript.java
@@ -29,8 +29,8 @@ import org.dspace.core.SelfNamedPlugin;
 import org.dspace.core.factory.CoreServiceFactory;
 import org.dspace.handle.factory.HandleServiceFactory;
 import org.dspace.scripts.DSpaceRunnable;
+import org.dspace.scripts.configuration.ScriptConfiguration;
 import org.dspace.services.factory.DSpaceServicesFactory;
-import org.dspace.utils.DSpace;
 
 /**
  * MediaFilterManager is the class that invokes the media/format filters over the
@@ -42,7 +42,7 @@ import org.dspace.utils.DSpace;
  * maximum number of items; -fd [fromdate] takes only items starting from this date,
  * filtering by last_modified in the item table.
  */
-public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfiguration> {
+public class MediaFilterScript<T extends ScriptConfiguration<?>> extends DSpaceRunnable<T> {
 
     //key (in dspace.cfg) which lists all enabled filters by name
     private static final String MEDIA_FILTER_PLUGINS_KEY = "filter.plugins";
@@ -64,9 +64,15 @@ public class MediaFilterScript extends DSpaceRunnable<MediaFilterScriptConfigura
     private Map<String, List<String>> filterFormats = new HashMap<>();
     private LocalDate fromDate = null;
 
-    public MediaFilterScriptConfiguration getScriptConfiguration() {
-        return new DSpace().getServiceManager()
-                           .getServiceByName("filter-media", MediaFilterScriptConfiguration.class);
+    /**
+     * Constructor for MediaFilterScript script.
+     * Performs media filtering operations on bitstreams to generate derivatives
+     * such as thumbnails, text extracts, and format conversions.
+     * 
+     * @param scriptConfiguration The script configuration defining filter settings and processing options
+     */
+    public MediaFilterScript(T scriptConfiguration) {
+        super(scriptConfiguration);
     }
 
     public void setup() throws ParseException {

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterScriptConfiguration.java
@@ -11,7 +11,7 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.dspace.scripts.configuration.ScriptConfiguration;
 
-public class MediaFilterScriptConfiguration<T extends MediaFilterScript> extends ScriptConfiguration<T> {
+public class MediaFilterScriptConfiguration<T extends MediaFilterScript<?>> extends ScriptConfiguration<T> {
 
     private Class<T> dspaceRunnableClass;
 

--- a/dspace-api/src/main/java/org/dspace/app/solr/SolrCoreExportImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/solr/SolrCoreExportImport.java
@@ -37,9 +37,9 @@ import org.dspace.core.Context;
 import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.eperson.service.EPersonService;
 import org.dspace.scripts.DSpaceRunnable;
+import org.dspace.scripts.configuration.ScriptConfiguration;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
-import org.dspace.utils.DSpace;
 
 /**
  * Script for complete export and import of SOLR cores with multithreading support.
@@ -50,7 +50,7 @@ import org.dspace.utils.DSpace;
  *
  * @author Stefano Maffei (stefano.maffei at 4science.com)
  */
-public class SolrCoreExportImport extends DSpaceRunnable<SolrCoreExportImportScriptConfiguration> {
+public class SolrCoreExportImport<T extends ScriptConfiguration<?>> extends DSpaceRunnable<T> {
 
     private static final Logger log = LogManager.getLogger(SolrCoreExportImport.class);
 
@@ -72,6 +72,17 @@ public class SolrCoreExportImport extends DSpaceRunnable<SolrCoreExportImportScr
 
     // Cache for fields list to avoid multiple calls to SOLR
     private List<String> cachedFields = null;
+
+    /**
+     * Constructor for SolrCoreExportImport script.
+     * Exports and imports complete Solr cores with multithreading support
+     * for backup, migration, and data exchange purposes.
+     * 
+     * @param scriptConfiguration The script configuration defining export/import parameters and threading options
+     */
+    public SolrCoreExportImport(T scriptConfiguration) {
+        super(scriptConfiguration);
+    }
 
     /**
      * Determines if this script execution requires authentication.
@@ -670,12 +681,6 @@ public class SolrCoreExportImport extends DSpaceRunnable<SolrCoreExportImportScr
 
         handler.logInfo("Retrieved " + fields.size() + " fields from sample document for core '" + coreName + "'");
         return fields;
-    }
-
-    @Override
-    public SolrCoreExportImportScriptConfiguration getScriptConfiguration() {
-        return new DSpace().getServiceManager().getServiceByName("solr-core-management",
-                SolrCoreExportImportScriptConfiguration.class);
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/app/solr/SolrCoreExportImportCli.java
+++ b/dspace-api/src/main/java/org/dspace/app/solr/SolrCoreExportImportCli.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.app.solr;
 
-import org.dspace.utils.DSpace;
+import org.dspace.scripts.configuration.ScriptConfiguration;
 
 /**
  * CLI version of SOLR core export/import script.
@@ -15,12 +15,16 @@ import org.dspace.utils.DSpace;
  *
  * @author Stefano Maffei (stefano.maffei at 4science.com)
  */
-public class SolrCoreExportImportCli extends SolrCoreExportImport {
+public class SolrCoreExportImportCli<T extends ScriptConfiguration<?>> extends SolrCoreExportImport<T> {
 
-    @Override
-    public SolrCoreExportImportCliScriptConfiguration getScriptConfiguration() {
-        return new DSpace().getServiceManager().getServiceByName("solr-core-management",
-                SolrCoreExportImportCliScriptConfiguration.class);
+    /**
+     * Constructor for SolrCoreExportImportCli.
+     * Command-line interface wrapper for SolrCoreExportImport script.
+     * 
+     * @param scriptConfiguration The CLI script configuration with command-line options
+     */
+    public SolrCoreExportImportCli(T scriptConfiguration) {
+        super(scriptConfiguration);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/app/solr/SolrCoreExportImportCliScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/app/solr/SolrCoreExportImportCliScriptConfiguration.java
@@ -12,7 +12,7 @@ package org.dspace.app.solr;
  *
  * @author Stefano Maffei (stefano.maffei at 4science.com)
  */
-public class SolrCoreExportImportCliScriptConfiguration<T extends SolrCoreExportImportCli>
+public class SolrCoreExportImportCliScriptConfiguration<T extends SolrCoreExportImport<?>>
         extends SolrCoreExportImportScriptConfiguration<T> {
 
     private Class<T> dspaceRunnableClass;

--- a/dspace-api/src/main/java/org/dspace/app/solr/SolrCoreExportImportScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/app/solr/SolrCoreExportImportScriptConfiguration.java
@@ -16,7 +16,7 @@ import org.dspace.scripts.configuration.ScriptConfiguration;
  *
  * @author Stefano Maffei (stefano.maffei at 4science.com)
  */
-public class SolrCoreExportImportScriptConfiguration<T extends SolrCoreExportImport> extends ScriptConfiguration<T> {
+public class SolrCoreExportImportScriptConfiguration<T extends SolrCoreExportImport<?>> extends ScriptConfiguration<T> {
 
     private Class<T> dspaceRunnableClass;
 

--- a/dspace-api/src/main/java/org/dspace/app/solrdatabaseresync/SolrDatabaseResyncCli.java
+++ b/dspace-api/src/main/java/org/dspace/app/solrdatabaseresync/SolrDatabaseResyncCli.java
@@ -36,14 +36,13 @@ import org.dspace.scripts.DSpaceRunnable;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.util.SolrUtils;
-import org.dspace.utils.DSpace;
 
 /**
  * {@link DSpaceRunnable} implementation to update solr items with "predb" status to either:
  * - Delete them from solr if they're not present in the database
  * - Remove their status if they're present in the database
  */
-public class SolrDatabaseResyncCli extends DSpaceRunnable<SolrDatabaseResyncCliScriptConfiguration> {
+public class SolrDatabaseResyncCli<T extends SolrDatabaseResyncCliScriptConfiguration<?>> extends DSpaceRunnable<T> {
     /* Log4j logger */
     private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(SolrDatabaseResyncCli.class);
 
@@ -57,14 +56,21 @@ public class SolrDatabaseResyncCli extends DSpaceRunnable<SolrDatabaseResyncCliS
     private int timeUntilReindex = 0;
     private String maxTime;
 
-    @Override
-    public SolrDatabaseResyncCliScriptConfiguration getScriptConfiguration() {
-        return new DSpace().getServiceManager()
-                .getServiceByName("solr-database-resync", SolrDatabaseResyncCliScriptConfiguration.class);
+    /**
+     * Constructor for SolrDatabaseResyncCli script.
+     * Resyncs Solr index with database by updating items with "predb" status,
+     * ensuring consistency between search index and database state.
+     * 
+     * @param configuration The script configuration defining resync parameters and timing settings
+     */
+    public SolrDatabaseResyncCli(T configuration) {
+        super(configuration);
     }
 
-    public static void runScheduled() throws Exception {
-        SolrDatabaseResyncCli script = new SolrDatabaseResyncCli();
+    public static <T extends SolrDatabaseResyncCliScriptConfiguration<?>> void runScheduled(T configuration)
+        throws Exception {
+        SolrDatabaseResyncCli<T> script = new SolrDatabaseResyncCli<>(configuration);
+
         script.setup();
         script.internalRun();
     }

--- a/dspace-api/src/main/java/org/dspace/app/solrdatabaseresync/SolrDatabaseResyncCli.java
+++ b/dspace-api/src/main/java/org/dspace/app/solrdatabaseresync/SolrDatabaseResyncCli.java
@@ -33,6 +33,7 @@ import org.dspace.discovery.SolrSearchCore;
 import org.dspace.discovery.indexobject.IndexableItem;
 import org.dspace.discovery.indexobject.factory.IndexObjectFactoryFactory;
 import org.dspace.scripts.DSpaceRunnable;
+import org.dspace.scripts.configuration.ScriptConfiguration;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.util.SolrUtils;
@@ -42,7 +43,7 @@ import org.dspace.util.SolrUtils;
  * - Delete them from solr if they're not present in the database
  * - Remove their status if they're present in the database
  */
-public class SolrDatabaseResyncCli<T extends SolrDatabaseResyncCliScriptConfiguration<?>> extends DSpaceRunnable<T> {
+public class SolrDatabaseResyncCli<T extends ScriptConfiguration<?>> extends DSpaceRunnable<T> {
     /* Log4j logger */
     private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(SolrDatabaseResyncCli.class);
 

--- a/dspace-api/src/main/java/org/dspace/app/solrdatabaseresync/SolrDatabaseResyncCliScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/app/solrdatabaseresync/SolrDatabaseResyncCliScriptConfiguration.java
@@ -13,16 +13,17 @@ import org.dspace.scripts.configuration.ScriptConfiguration;
 /**
  * The {@link ScriptConfiguration} for the {@link SolrDatabaseResyncCli} script.
  */
-public class SolrDatabaseResyncCliScriptConfiguration extends ScriptConfiguration<SolrDatabaseResyncCli> {
-    private Class<SolrDatabaseResyncCli> dspaceRunnableClass;
+public class SolrDatabaseResyncCliScriptConfiguration<T extends SolrDatabaseResyncCli<?>>
+    extends ScriptConfiguration<T> {
+    private Class<T> dspaceRunnableClass;
 
     @Override
-    public Class<SolrDatabaseResyncCli> getDspaceRunnableClass() {
+    public Class<T> getDspaceRunnableClass() {
         return dspaceRunnableClass;
     }
 
     @Override
-    public void setDspaceRunnableClass(Class<SolrDatabaseResyncCli> dspaceRunnableClass) {
+    public void setDspaceRunnableClass(Class<T> dspaceRunnableClass) {
         this.dspaceRunnableClass = dspaceRunnableClass;
     }
 

--- a/dspace-api/src/main/java/org/dspace/app/suggestion/runnable/PublicationLoaderRunnable.java
+++ b/dspace-api/src/main/java/org/dspace/app/suggestion/runnable/PublicationLoaderRunnable.java
@@ -43,8 +43,8 @@ import org.slf4j.LoggerFactory;
  *
  * @author Alessandro Martelli (alessandro.martelli at 4science.it)
  **/
-public class PublicationLoaderRunnable
-    extends DSpaceRunnable<ScriptConfiguration<?>> {
+public class PublicationLoaderRunnable<T extends ScriptConfiguration<?>>
+    extends DSpaceRunnable<T> {
     private static final Logger LOGGER = LoggerFactory.getLogger(PublicationLoaderRunnable.class);
     protected Context context;
     protected String profile;
@@ -56,18 +56,15 @@ public class PublicationLoaderRunnable
     private Integer itemLimit;
     private List<SolrSuggestionProvider> providers;
 
-
     /**
-     * Retrieves the script configuration for this runnable.
-     * The configuration is fetched from the DSpace service manager.
-     *
-     * @return The {@link ScriptConfiguration} instance for the import-loader-suggestions script.
+     * Constructor for PublicationLoaderRunnable script.
+     * Loads publication suggestions from external sources into Solr
+     * for researcher profiles to enhance discoverability and completeness.
+     * 
+     * @param scriptConfiguration The script configuration defining loader settings and processing parameters
      */
-    @Override
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    public ScriptConfiguration<?> getScriptConfiguration() {
-        return new DSpace().getServiceManager()
-                           .getServiceByName("import-loader-suggestions", ScriptConfiguration.class);
+    public PublicationLoaderRunnable(T scriptConfiguration) {
+        super(scriptConfiguration);
     }
 
 

--- a/dspace-api/src/main/java/org/dspace/app/suggestion/runnable/PublicationLoaderRunnableCli.java
+++ b/dspace-api/src/main/java/org/dspace/app/suggestion/runnable/PublicationLoaderRunnableCli.java
@@ -10,7 +10,6 @@ package org.dspace.app.suggestion.runnable;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.ParseException;
 import org.dspace.scripts.configuration.ScriptConfiguration;
-import org.dspace.utils.DSpace;
 
 /**
  * CLI implementation of the {@link PublicationLoaderRunnable} script.
@@ -19,21 +18,17 @@ import org.dspace.utils.DSpace;
  *
  * @author Adamo Fapohunda (adamo.fapohunda at 4science.com)
  */
-public class PublicationLoaderRunnableCli extends PublicationLoaderRunnable {
+public class PublicationLoaderRunnableCli<T extends ScriptConfiguration<?>> extends PublicationLoaderRunnable<T> {
 
     /**
-     * Retrieves the script configuration associated with this CLI script.
-     * This method fetches the configuration from the DSpace service manager.
-     *
-     * @return The {@link ScriptConfiguration} instance for the import-loader-suggestions script.
+     * Constructor for PublicationLoaderRunnableCli.
+     * Command-line interface wrapper for PublicationLoaderRunnable script.
+     * 
+     * @param scriptConfiguration The CLI script configuration with command-line options
      */
-    @Override
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    public ScriptConfiguration<?> getScriptConfiguration() {
-        return new DSpace().getServiceManager()
-                           .getServiceByName("import-loader-suggestions", ScriptConfiguration.class);
+    public PublicationLoaderRunnableCli(T scriptConfiguration) {
+        super(scriptConfiguration);
     }
-
 
     /**
      * Sets up the script execution environment.

--- a/dspace-api/src/main/java/org/dspace/app/suggestion/script/PublicationLoaderCliScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/app/suggestion/script/PublicationLoaderCliScriptConfiguration.java
@@ -16,7 +16,7 @@ import org.dspace.app.suggestion.runnable.PublicationLoaderRunnable;
  *
  * @author Alessandro Martelli (alessandro.martelli at 4science.it)
  */
-public class PublicationLoaderCliScriptConfiguration<T extends PublicationLoaderRunnable>
+public class PublicationLoaderCliScriptConfiguration<T extends PublicationLoaderRunnable<?>>
     extends PublicationLoaderScriptConfiguration<T> {
 
     /**

--- a/dspace-api/src/main/java/org/dspace/app/suggestion/script/PublicationLoaderScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/app/suggestion/script/PublicationLoaderScriptConfiguration.java
@@ -26,7 +26,7 @@ import org.springframework.beans.factory.annotation.Autowired;
  * @param <T> The specific type of {@link PublicationLoaderRunnable} that this configuration supports.
  * @author Adamo Fapohunda (adamo.fapohunda at 4science.com)
  */
-public class PublicationLoaderScriptConfiguration<T extends PublicationLoaderRunnable>
+public class PublicationLoaderScriptConfiguration<T extends PublicationLoaderRunnable<?>>
     extends ScriptConfiguration<T> {
 
     @Autowired

--- a/dspace-api/src/main/java/org/dspace/curate/Curation.java
+++ b/dspace-api/src/main/java/org/dspace/curate/Curation.java
@@ -40,6 +40,7 @@ import org.dspace.eperson.service.EPersonService;
 import org.dspace.handle.factory.HandleServiceFactory;
 import org.dspace.handle.service.HandleService;
 import org.dspace.scripts.DSpaceRunnable;
+import org.dspace.scripts.configuration.ScriptConfiguration;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.storage.secure.SecureFileAccess;
 import org.dspace.utils.DSpace;
@@ -49,7 +50,7 @@ import org.dspace.utils.DSpace;
  *
  * @author richardrodgers
  */
-public class Curation extends DSpaceRunnable<CurationScriptConfiguration> {
+public class Curation<T extends ScriptConfiguration<?>> extends DSpaceRunnable<T> {
 
     protected EPersonService ePersonService = EPersonServiceFactory.getInstance().getEPersonService();
     protected DSpaceObjectUtils dspaceObjectUtils = DSpaceServicesFactory.getInstance().getServiceManager()
@@ -66,6 +67,16 @@ public class Curation extends DSpaceRunnable<CurationScriptConfiguration> {
     private String reporter;
     private Map<String, String> parameters;
     private boolean verbose;
+
+    /**
+     * Constructor for Curation script.
+     *
+     * @param scriptConfiguration The script configuration that defines curation tasks,
+     *                           target objects, and execution parameters
+     */
+    public Curation(T scriptConfiguration) {
+        super(scriptConfiguration);
+    }
 
     @Override
     public void internalRun() throws Exception {
@@ -243,11 +254,6 @@ public class Curation extends DSpaceRunnable<CurationScriptConfiguration> {
         super.handler.logInfo("\nwhole repo: CurationCli -t estimate -i all");
         super.handler.logInfo("single item: CurationCli -t generate -i itemId");
         super.handler.logInfo("task queue: CurationCli -q monthly");
-    }
-
-    @Override
-    public CurationScriptConfiguration getScriptConfiguration() {
-        return new DSpace().getServiceManager().getServiceByName("curate", CurationScriptConfiguration.class);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/curate/CurationCli.java
+++ b/dspace-api/src/main/java/org/dspace/curate/CurationCli.java
@@ -12,12 +12,23 @@ import java.sql.SQLException;
 import org.apache.commons.cli.ParseException;
 import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
+import org.dspace.scripts.configuration.ScriptConfiguration;
 
 /**
  * This is the CLI version of the {@link Curation} script.
  * This will only be called when the curate script is called from a commandline instance.
  */
-public class CurationCli extends Curation {
+public class CurationCli<T extends ScriptConfiguration<?>> extends Curation<T> {
+
+    /**
+     * Constructor for CurationCli.
+     * Command-line interface wrapper for Curation script.
+     * 
+     * @param scriptConfiguration The CLI script configuration with command-line options
+     */
+    public CurationCli(T scriptConfiguration) {
+        super(scriptConfiguration);
+    }
 
     /**
      * This is the overridden instance of the {@link Curation#assignCurrentUserInContext()} method in the parent class

--- a/dspace-api/src/main/java/org/dspace/curate/CurationCliScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/curate/CurationCliScriptConfiguration.java
@@ -13,7 +13,7 @@ import org.apache.commons.cli.Options;
  * This is the CLI version of the {@link CurationScriptConfiguration} class that handles the configuration for the
  * {@link CurationCli} script
  */
-public class CurationCliScriptConfiguration extends CurationScriptConfiguration<Curation> {
+public class CurationCliScriptConfiguration<T extends Curation<?>> extends CurationScriptConfiguration<T> {
 
     @Override
     public Options getOptions() {

--- a/dspace-api/src/main/java/org/dspace/curate/CurationScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/curate/CurationScriptConfiguration.java
@@ -23,7 +23,7 @@ import org.dspace.scripts.configuration.ScriptConfiguration;
  *
  * @author Maria Verdonck (Atmire) on 23/06/2020
  */
-public class CurationScriptConfiguration<T extends Curation> extends ScriptConfiguration<T> {
+public class CurationScriptConfiguration<T extends Curation<?>> extends ScriptConfiguration<T> {
 
     private Class<T> dspaceRunnableClass;
 

--- a/dspace-api/src/main/java/org/dspace/deletion/process/DSpaceObjectDeletionProcess.java
+++ b/dspace-api/src/main/java/org/dspace/deletion/process/DSpaceObjectDeletionProcess.java
@@ -34,6 +34,7 @@ import org.dspace.handle.factory.HandleServiceFactory;
 import org.dspace.handle.service.HandleService;
 import org.dspace.kernel.ServiceManager;
 import org.dspace.scripts.DSpaceRunnable;
+import org.dspace.scripts.configuration.ScriptConfiguration;
 import org.dspace.utils.DSpace;
 
 /**
@@ -43,10 +44,23 @@ import org.dspace.utils.DSpace;
  *
  * @author Mykhaylo Boychuk (mykhaylo.boychuk@4science.com)
  */
-public class DSpaceObjectDeletionProcess
-        extends DSpaceRunnable<DSpaceObjectDeletionProcessScriptConfiguration<DSpaceObjectDeletionProcess>> {
+public class DSpaceObjectDeletionProcess<T extends ScriptConfiguration<?>> extends DSpaceRunnable<T> {
 
     public static final String OBJECT_DELETION_SCRIPT = "object-deletion";
+
+    /**
+     * Constructor for DSpaceObjectDeletionProcess script.
+     * This process permanently deletes DSpace objects (Items, Collections, Communities)
+     * and all their child objects using delegation strategies.
+     * 
+     * @param scriptConfiguration The script configuration defining deletion parameters,
+     *                           target object identifiers, and safety options
+     */
+    public DSpaceObjectDeletionProcess(
+        T scriptConfiguration
+    ) {
+        super(scriptConfiguration);
+    }
 
     private ItemService itemService;
     private HandleService handleService;
@@ -198,12 +212,6 @@ public class DSpaceObjectDeletionProcess
         }
         DSpaceObject dso = handleService.resolveToObject(context, identifier);
         return dso != null ? Optional.of(dso) : Optional.empty();
-    }
-
-    @Override
-    public DSpaceObjectDeletionProcessScriptConfiguration<DSpaceObjectDeletionProcess> getScriptConfiguration() {
-        ServiceManager sm = new DSpace().getServiceManager();
-        return sm.getServiceByName(OBJECT_DELETION_SCRIPT, DSpaceObjectDeletionProcessScriptConfiguration.class);
     }
 
 }

--- a/dspace-api/src/main/java/org/dspace/deletion/process/DSpaceObjectDeletionProcessCli.java
+++ b/dspace-api/src/main/java/org/dspace/deletion/process/DSpaceObjectDeletionProcessCli.java
@@ -12,6 +12,7 @@ import java.sql.SQLException;
 import org.apache.commons.cli.ParseException;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.factory.EPersonServiceFactory;
+import org.dspace.scripts.configuration.ScriptConfiguration;
 
 /**
  * Extension of {@link DSpaceObjectDeletionProcess} for CLI execution.
@@ -22,6 +23,18 @@ import org.dspace.eperson.factory.EPersonServiceFactory;
  *
  */
 public class DSpaceObjectDeletionProcessCli extends DSpaceObjectDeletionProcess {
+
+    /**
+     * Constructor for DSpaceObjectDeletionProcess script.
+     * This process permanently deletes DSpace objects (Items, Collections, Communities)
+     * and all their child objects using delegation strategies.
+     *
+     * @param scriptConfiguration The script configuration defining deletion parameters,
+     *                            target object identifiers, and safety options
+     */
+    public DSpaceObjectDeletionProcessCli(ScriptConfiguration scriptConfiguration) {
+        super(scriptConfiguration);
+    }
 
     /**
      * Assigns the current user to the context based on the email parameter for CLI execution.
@@ -64,12 +77,6 @@ public class DSpaceObjectDeletionProcessCli extends DSpaceObjectDeletionProcess 
         } else {
             throw new ParseException("Required parameter -e missing!");
         }
-    }
-
-    @Override
-    public DSpaceObjectDeletionProcessScriptConfiguration<DSpaceObjectDeletionProcess> getScriptConfiguration() {
-        org.dspace.kernel.ServiceManager sm = new org.dspace.utils.DSpace().getServiceManager();
-        return sm.getServiceByName(OBJECT_DELETION_SCRIPT, DSpaceObjectDeletionProcessCliScriptConfiguration.class);
     }
 
 }

--- a/dspace-api/src/main/java/org/dspace/deletion/process/DSpaceObjectDeletionProcessCliScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/deletion/process/DSpaceObjectDeletionProcessCliScriptConfiguration.java
@@ -17,7 +17,7 @@ import org.apache.commons.cli.Options;
  *
  */
 public class DSpaceObjectDeletionProcessCliScriptConfiguration<T extends DSpaceObjectDeletionProcessCli>
-    extends DSpaceObjectDeletionProcessScriptConfiguration<T> {
+    extends DSpaceObjectDeletionProcessScriptConfiguration {
 
     @Override
     public Options getOptions() {

--- a/dspace-api/src/main/java/org/dspace/deletion/process/DSpaceObjectDeletionProcessScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/deletion/process/DSpaceObjectDeletionProcessScriptConfiguration.java
@@ -24,8 +24,8 @@ import org.dspace.scripts.configuration.ScriptConfiguration;
  *
  * @author Mykhaylo Boychuk (mykhaylo.boychuk@4science.com)
  */
-public class DSpaceObjectDeletionProcessScriptConfiguration<T extends DSpaceObjectDeletionProcess>
-    extends ScriptConfiguration<T> {
+public class DSpaceObjectDeletionProcessScriptConfiguration<T extends DSpaceObjectDeletionProcess<?>>
+        extends ScriptConfiguration<T> {
 
     private Class<T> dspaceRunnableClass;
 

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexClient.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexClient.java
@@ -37,19 +37,30 @@ import org.dspace.discovery.indexobject.factory.IndexFactory;
 import org.dspace.discovery.indexobject.factory.IndexObjectFactoryFactory;
 import org.dspace.handle.factory.HandleServiceFactory;
 import org.dspace.scripts.DSpaceRunnable;
+import org.dspace.scripts.configuration.ScriptConfiguration;
 import org.dspace.services.factory.DSpaceServicesFactory;
-import org.dspace.utils.DSpace;
 
 /**
  * Class used to reindex DSpace communities/collections/items into discovery.
  */
-public class IndexClient extends DSpaceRunnable<IndexDiscoveryScriptConfiguration> {
+public class IndexClient<T extends ScriptConfiguration<?>> extends DSpaceRunnable<T> {
 
     private Context context;
     private IndexingService indexer = DSpaceServicesFactory.getInstance().getServiceManager()
             .getServiceByName(IndexingService.class.getName(), IndexingService.class);
 
     private IndexClientOptions indexClientOptions;
+
+    /**
+     * Constructor for IndexClient script.
+     * This script rebuilds and updates the Solr Discovery search index.
+     * 
+     * @param scriptConfiguration The script configuration defining indexing parameters,
+     *                           target objects, and index rebuild options
+     */
+    public IndexClient(T scriptConfiguration) {
+        super(scriptConfiguration);
+    }
 
     @Override
     public void internalRun() throws Exception {
@@ -146,12 +157,6 @@ public class IndexClient extends DSpaceRunnable<IndexDiscoveryScriptConfiguratio
         }
 
         handler.logInfo("Done with indexing");
-    }
-
-    @Override
-    public IndexDiscoveryScriptConfiguration getScriptConfiguration() {
-        return new DSpace().getServiceManager().getServiceByName("index-discovery",
-                IndexDiscoveryScriptConfiguration.class);
     }
 
     public void setup() throws ParseException {

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexDiscoveryScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexDiscoveryScriptConfiguration.java
@@ -13,7 +13,7 @@ import org.dspace.scripts.configuration.ScriptConfiguration;
 /**
  * The {@link ScriptConfiguration} for the {@link IndexClient} script
  */
-public class IndexDiscoveryScriptConfiguration<T extends IndexClient> extends ScriptConfiguration<T> {
+public class IndexDiscoveryScriptConfiguration<T extends IndexClient<?>> extends ScriptConfiguration<T> {
 
     private Class<T> dspaceRunnableClass;
 

--- a/dspace-api/src/main/java/org/dspace/orcid/script/OrcidBulkPush.java
+++ b/dspace-api/src/main/java/org/dspace/orcid/script/OrcidBulkPush.java
@@ -35,9 +35,9 @@ import org.dspace.orcid.service.OrcidQueueService;
 import org.dspace.orcid.service.OrcidSynchronizationService;
 import org.dspace.profile.OrcidSynchronizationMode;
 import org.dspace.scripts.DSpaceRunnable;
+import org.dspace.scripts.configuration.ScriptConfiguration;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
-import org.dspace.utils.DSpace;
 
 /**
  * Script that perform the bulk synchronization with ORCID registry of all the
@@ -46,7 +46,7 @@ import org.dspace.utils.DSpace;
  * @author Luca Giamminonni (luca.giamminonni at 4science.it)
  *
  */
-public class OrcidBulkPush extends DSpaceRunnable<OrcidBulkPushScriptConfiguration<OrcidBulkPush>> {
+public class OrcidBulkPush<T extends ScriptConfiguration<?>> extends DSpaceRunnable<T> {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
@@ -66,6 +66,17 @@ public class OrcidBulkPush extends DSpaceRunnable<OrcidBulkPushScriptConfigurati
     private final Map<Item, OrcidSynchronizationMode> synchronizationModeByProfileItem = new HashMap<>();
 
     private boolean ignoreMaxAttempts = false;
+
+    /**
+     * Constructor for OrcidBulkPush script.
+     * Performs bulk synchronization of researcher profiles and publications
+     * with ORCID registry for batch-mode configured users.
+     * 
+     * @param scriptConfiguration The script configuration defining synchronization parameters and retry settings
+     */
+    public OrcidBulkPush(T scriptConfiguration) {
+        super(scriptConfiguration);
+    }
 
     @Override
     public void setup() throws ParseException {
@@ -319,13 +330,6 @@ public class OrcidBulkPush extends DSpaceRunnable<OrcidBulkPushScriptConfigurati
 
     private boolean isOrcidSynchronizationDisabled() {
         return !configurationService.getBooleanProperty("orcid.synchronization-enabled", true);
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public OrcidBulkPushScriptConfiguration<OrcidBulkPush> getScriptConfiguration() {
-        return new DSpace().getServiceManager().getServiceByName("orcid-bulk-push",
-            OrcidBulkPushScriptConfiguration.class);
     }
 
 }

--- a/dspace-api/src/main/java/org/dspace/orcid/script/OrcidBulkPushScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/orcid/script/OrcidBulkPushScriptConfiguration.java
@@ -17,7 +17,7 @@ import org.dspace.scripts.configuration.ScriptConfiguration;
  *
  * @param  <T> the OrcidBulkPush type
  */
-public class OrcidBulkPushScriptConfiguration<T extends OrcidBulkPush> extends ScriptConfiguration<T> {
+public class OrcidBulkPushScriptConfiguration<T extends OrcidBulkPush<?>> extends ScriptConfiguration<T> {
 
     private Class<T> dspaceRunnableClass;
 

--- a/dspace-api/src/main/java/org/dspace/qaevent/script/OpenaireEventsImport.java
+++ b/dspace-api/src/main/java/org/dspace/qaevent/script/OpenaireEventsImport.java
@@ -40,6 +40,7 @@ import org.dspace.handle.service.HandleService;
 import org.dspace.qaevent.service.OpenaireClientFactory;
 import org.dspace.qaevent.service.QAEventService;
 import org.dspace.scripts.DSpaceRunnable;
+import org.dspace.scripts.configuration.ScriptConfiguration;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.utils.DSpace;
@@ -73,8 +74,8 @@ import org.dspace.utils.DSpace;
  * @author Luca Giamminonni (luca.giamminonni at 4Science.it)
  *
  */
-public class OpenaireEventsImport
-    extends DSpaceRunnable<OpenaireEventsImportScriptConfiguration<OpenaireEventsImport>> {
+public class OpenaireEventsImport<T extends ScriptConfiguration<?>>
+    extends DSpaceRunnable<T> {
 
     private HandleService handleService;
 
@@ -96,12 +97,15 @@ public class OpenaireEventsImport
 
     private Context context;
 
-    @Override
-    @SuppressWarnings({ "rawtypes" })
-    public OpenaireEventsImportScriptConfiguration getScriptConfiguration() {
-        OpenaireEventsImportScriptConfiguration configuration = new DSpace().getServiceManager()
-                .getServiceByName("import-openaire-events", OpenaireEventsImportScriptConfiguration.class);
-        return configuration;
+    /**
+     * Constructor for OpenaireEventsImport script.
+     * Imports OpenAIRE quality assurance events from JSON files or directly
+     * from the OpenAIRE broker to enhance repository metadata quality.
+     * 
+     * @param scriptConfiguration The script configuration defining import source and event processing options
+     */
+    public OpenaireEventsImport(T scriptConfiguration) {
+        super(scriptConfiguration);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/qaevent/script/OpenaireEventsImportCli.java
+++ b/dspace-api/src/main/java/org/dspace/qaevent/script/OpenaireEventsImportCli.java
@@ -9,7 +9,7 @@ package org.dspace.qaevent.script;
 
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.ParseException;
-import org.dspace.utils.DSpace;
+import org.dspace.scripts.configuration.ScriptConfiguration;
 
 /**
  * Extensions of {@link OpenaireEventsImport} to run the script on console.
@@ -17,13 +17,16 @@ import org.dspace.utils.DSpace;
  * @author Alessandro Martelli (alessandro.martelli at 4science.it)
  *
  */
-public class OpenaireEventsImportCli extends OpenaireEventsImport {
+public class OpenaireEventsImportCli<T extends ScriptConfiguration<?>> extends OpenaireEventsImport<T> {
 
-    @Override
-    @SuppressWarnings({ "rawtypes" })
-    public OpenaireEventsImportCliScriptConfiguration getScriptConfiguration() {
-        return new DSpace().getServiceManager()
-            .getServiceByName("import-openaire-events", OpenaireEventsImportCliScriptConfiguration.class);
+    /**
+     * Constructor for OpenaireEventsImportCli.
+     * Command-line interface wrapper for OpenaireEventsImport script.
+     * 
+     * @param scriptConfiguration The CLI script configuration with command-line options
+     */
+    public OpenaireEventsImportCli(T scriptConfiguration) {
+        super(scriptConfiguration);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/qaevent/script/OpenaireEventsImportCliScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/qaevent/script/OpenaireEventsImportCliScriptConfiguration.java
@@ -16,7 +16,7 @@ import org.apache.commons.cli.Options;
  * @author Alessandro Martelli (alessandro.martelli at 4science.it)
  *
  */
-public class OpenaireEventsImportCliScriptConfiguration<T extends OpenaireEventsImport>
+public class OpenaireEventsImportCliScriptConfiguration<T extends OpenaireEventsImport<?>>
     extends OpenaireEventsImportScriptConfiguration<T> {
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/qaevent/script/OpenaireEventsImportScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/qaevent/script/OpenaireEventsImportScriptConfiguration.java
@@ -19,7 +19,7 @@ import org.dspace.scripts.configuration.ScriptConfiguration;
  * @author Alessandro Martelli (alessandro.martelli at 4science.it)
  *
  */
-public class OpenaireEventsImportScriptConfiguration<T extends OpenaireEventsImport> extends ScriptConfiguration<T> {
+public class OpenaireEventsImportScriptConfiguration<T extends OpenaireEventsImport<?>> extends ScriptConfiguration<T> {
 
     /*
     private AuthorizeService authorizeService;

--- a/dspace-api/src/main/java/org/dspace/scripts/DSpaceRunnable.java
+++ b/dspace-api/src/main/java/org/dspace/scripts/DSpaceRunnable.java
@@ -54,11 +54,32 @@ public abstract class DSpaceRunnable<T extends ScriptConfiguration> implements R
     protected DSpaceRunnableHandler handler;
 
     /**
+     * Tells if the current context user that is running the script is an admin
+     */
+    private Boolean isAdmin = null;
+
+    /**
+     * The ScriptConfiguration that this DSpaceRunnable uses to retrieve information about the script
+     */
+    private T scriptConfiguration;
+
+    /**
      * This method will return the Configuration that the implementing DSpaceRunnable uses
      * @return  The {@link ScriptConfiguration} that this implementing DspaceRunnable uses
      */
-    public abstract T getScriptConfiguration();
+    public T getScriptConfiguration() {
+        return this.scriptConfiguration;
+    }
 
+    public DSpaceRunnable() { }
+
+    /**
+     * Constructor for the DSpaceRunnable that takes in the ScriptConfiguration that this DSpaceRunnable will use
+     * @param scriptConfiguration   The ScriptConfiguration that this DSpaceRunnable will use
+     */
+    public DSpaceRunnable(T scriptConfiguration) {
+        this.scriptConfiguration = scriptConfiguration;
+    }
 
     private void setHandler(DSpaceRunnableHandler dSpaceRunnableHandler) {
         this.handler = dSpaceRunnableHandler;

--- a/dspace-api/src/main/java/org/dspace/scripts/DSpaceRunnable.java
+++ b/dspace-api/src/main/java/org/dspace/scripts/DSpaceRunnable.java
@@ -30,7 +30,7 @@ import org.dspace.scripts.handler.DSpaceRunnableHandler;
  * script
  * @param <T>
  */
-public abstract class DSpaceRunnable<T extends ScriptConfiguration> implements Runnable {
+public abstract class DSpaceRunnable<T extends ScriptConfiguration<?>> implements Runnable {
 
     /**
      * The CommandLine object for the script that'll hold the information

--- a/dspace-api/src/main/java/org/dspace/scripts/DSpaceRunnable.java
+++ b/dspace-api/src/main/java/org/dspace/scripts/DSpaceRunnable.java
@@ -54,11 +54,6 @@ public abstract class DSpaceRunnable<T extends ScriptConfiguration<?>> implement
     protected DSpaceRunnableHandler handler;
 
     /**
-     * Tells if the current context user that is running the script is an admin
-     */
-    private Boolean isAdmin = null;
-
-    /**
      * The ScriptConfiguration that this DSpaceRunnable uses to retrieve information about the script
      */
     private T scriptConfiguration;

--- a/dspace-api/src/main/java/org/dspace/scripts/ScriptServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/scripts/ScriptServiceImpl.java
@@ -56,7 +56,7 @@ public class ScriptServiceImpl implements ScriptService {
         throws IllegalAccessException, InstantiationException {
         try {
             Constructor<T> declaredConstructor =
-                scriptToExecute.getDspaceRunnableClass().getDeclaredConstructor(scriptToExecute.getClass());
+                scriptToExecute.getDspaceRunnableClass().getDeclaredConstructor(ScriptConfiguration.class);
             return declaredConstructor.newInstance(scriptToExecute);
         } catch (InvocationTargetException | NoSuchMethodException e) {
             log.error(e::getMessage, e);

--- a/dspace-api/src/main/java/org/dspace/scripts/ScriptServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/scripts/ScriptServiceImpl.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.scripts;
 
+import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Comparator;
 import java.util.List;
@@ -47,7 +48,9 @@ public class ScriptServiceImpl implements ScriptService {
     public DSpaceRunnable createDSpaceRunnableForScriptConfiguration(ScriptConfiguration scriptToExecute)
         throws IllegalAccessException, InstantiationException {
         try {
-            return (DSpaceRunnable) scriptToExecute.getDspaceRunnableClass().getDeclaredConstructor().newInstance();
+            Constructor<DSpaceRunnable<?>> declaredConstructor =
+                scriptToExecute.getDspaceRunnableClass().getDeclaredConstructor(ScriptConfiguration.class);
+            return declaredConstructor.newInstance(scriptToExecute);
         } catch (InvocationTargetException | NoSuchMethodException e) {
             log.error(e::getMessage, e);
             throw new RuntimeException(e);

--- a/dspace-api/src/main/java/org/dspace/scripts/ScriptServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/scripts/ScriptServiceImpl.java
@@ -33,7 +33,7 @@ public class ScriptServiceImpl implements ScriptService {
 
     @Override
     public <S extends ScriptConfiguration<? extends DSpaceRunnable<?>>> S getScriptConfiguration(String name) {
-        return (S) serviceManager.getServiceByName(name, ScriptConfiguration.class);
+        return serviceManager.getServiceByName(name, ScriptConfiguration.class);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/scripts/configuration/ScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/scripts/configuration/ScriptConfiguration.java
@@ -25,7 +25,7 @@ import org.springframework.beans.factory.annotation.Autowired;
  * By default script are available only to repository administrators script that have a broader audience
  * must override the {@link #isAllowedToExecute(Context, List)} method.
  */
-public abstract class ScriptConfiguration<T extends DSpaceRunnable> implements BeanNameAware {
+public abstract class ScriptConfiguration<T extends DSpaceRunnable<?>> implements BeanNameAware {
 
     @Autowired
     protected AuthorizeService authorizeService;

--- a/dspace-api/src/main/java/org/dspace/scripts/service/ScriptService.java
+++ b/dspace-api/src/main/java/org/dspace/scripts/service/ScriptService.java
@@ -24,7 +24,7 @@ public interface ScriptService {
      * @param name  The name that the script has to match
      * @return The matching ScriptConfiguration
      */
-    ScriptConfiguration<?> getScriptConfiguration(String name);
+    <S extends ScriptConfiguration<? extends DSpaceRunnable<?>>> S getScriptConfiguration(String name);
 
     /**
      * This method will return a list of ScriptConfiguration objects for which the given Context is authorized
@@ -32,7 +32,7 @@ public interface ScriptService {
      * @param context The relevant DSpace context
      * @return The list of accessible ScriptConfiguration scripts for this context
      */
-    <T extends DSpaceRunnable<?>> List<ScriptConfiguration<T>> getScriptConfigurations(Context context);
+    <S extends ScriptConfiguration<T>, T extends DSpaceRunnable<?>> List<S> getScriptConfigurations(Context context);
 
     /**
      * This method will create a new instance of the DSpaceRunnable that's linked with this Scriptconfiguration
@@ -43,6 +43,7 @@ public interface ScriptService {
      * @throws IllegalAccessException   If something goes wrong
      * @throws InstantiationException   If something goes wrong
      */
-    <T extends DSpaceRunnable<?>> T createDSpaceRunnableForScriptConfiguration(ScriptConfiguration<T> scriptToExecute)
-        throws IllegalAccessException, InstantiationException;
+    <S extends ScriptConfiguration<T>, T extends DSpaceRunnable<? extends ScriptConfiguration<?>>>
+        T createDSpaceRunnableForScriptConfiguration(S scriptToExecute)
+            throws IllegalAccessException, InstantiationException;
 }

--- a/dspace-api/src/main/java/org/dspace/scripts/service/ScriptService.java
+++ b/dspace-api/src/main/java/org/dspace/scripts/service/ScriptService.java
@@ -24,14 +24,15 @@ public interface ScriptService {
      * @param name  The name that the script has to match
      * @return The matching ScriptConfiguration
      */
-    ScriptConfiguration getScriptConfiguration(String name);
+    ScriptConfiguration<?> getScriptConfiguration(String name);
 
     /**
      * This method will return a list of ScriptConfiguration objects for which the given Context is authorized
-     * @param context   The relevant DSpace context
+     *
+     * @param context The relevant DSpace context
      * @return The list of accessible ScriptConfiguration scripts for this context
      */
-    List<ScriptConfiguration> getScriptConfigurations(Context context);
+    <T extends DSpaceRunnable<?>> List<ScriptConfiguration<T>> getScriptConfigurations(Context context);
 
     /**
      * This method will create a new instance of the DSpaceRunnable that's linked with this Scriptconfiguration
@@ -42,6 +43,6 @@ public interface ScriptService {
      * @throws IllegalAccessException   If something goes wrong
      * @throws InstantiationException   If something goes wrong
      */
-    DSpaceRunnable createDSpaceRunnableForScriptConfiguration(ScriptConfiguration scriptToExecute)
+    <T extends DSpaceRunnable<?>> T createDSpaceRunnableForScriptConfiguration(ScriptConfiguration<T> scriptToExecute)
         throws IllegalAccessException, InstantiationException;
 }

--- a/dspace-api/src/main/java/org/dspace/statistics/export/RetryFailedOpenUrlTracker.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/export/RetryFailedOpenUrlTracker.java
@@ -11,21 +11,32 @@ import org.apache.commons.cli.ParseException;
 import org.apache.commons.lang3.StringUtils;
 import org.dspace.core.Context;
 import org.dspace.scripts.DSpaceRunnable;
+import org.dspace.scripts.configuration.ScriptConfiguration;
 import org.dspace.statistics.export.factory.OpenURLTrackerLoggerServiceFactory;
 import org.dspace.statistics.export.service.OpenUrlService;
-import org.dspace.utils.DSpace;
 
 /**
  * Script to retry the failed url transmissions to IRUS
  * This script also has an option to add new failed urls for testing purposes
  */
-public class RetryFailedOpenUrlTracker extends DSpaceRunnable<RetryFailedOpenUrlTrackerScriptConfiguration> {
+public class RetryFailedOpenUrlTracker<T extends ScriptConfiguration<?>> extends DSpaceRunnable<T> {
 
     private String lineToAdd = null;
     private boolean help = false;
     private boolean retryFailed = false;
 
     private OpenUrlService openUrlService;
+
+    /**
+     * Constructor for RetryFailedOpenUrlTracker script.
+     * Retries failed OpenURL tracker commits to IRUS analytics system
+     * and manages the queue of failed usage statistics transmissions.
+     * 
+     * @param scriptConfiguration The script configuration defining retry parameters and queue management options
+     */
+    public RetryFailedOpenUrlTracker(T scriptConfiguration) {
+        super(scriptConfiguration);
+    }
 
     /**
      * Run the script
@@ -51,11 +62,6 @@ public class RetryFailedOpenUrlTracker extends DSpaceRunnable<RetryFailedOpenUrl
         }
         context.restoreAuthSystemState();
         context.complete();
-    }
-
-    public RetryFailedOpenUrlTrackerScriptConfiguration getScriptConfiguration() {
-        return new DSpace().getServiceManager().getServiceByName("retry-tracker",
-                                                                 RetryFailedOpenUrlTrackerScriptConfiguration.class);
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/statistics/export/RetryFailedOpenUrlTrackerScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/export/RetryFailedOpenUrlTrackerScriptConfiguration.java
@@ -13,7 +13,7 @@ import org.dspace.scripts.configuration.ScriptConfiguration;
 /**
  * The {@link ScriptConfiguration} for the {@link RetryFailedOpenUrlTracker} script
  */
-public class RetryFailedOpenUrlTrackerScriptConfiguration<T extends RetryFailedOpenUrlTracker>
+public class RetryFailedOpenUrlTrackerScriptConfiguration<T extends RetryFailedOpenUrlTracker<?>>
         extends ScriptConfiguration<T> {
 
     private Class<T> dspaceRunnableClass;

--- a/dspace-api/src/main/java/org/dspace/submit/migration/SubmissionFormsMigration.java
+++ b/dspace-api/src/main/java/org/dspace/submit/migration/SubmissionFormsMigration.java
@@ -27,8 +27,8 @@ import org.apache.commons.cli.ParseException;
 import org.apache.commons.lang3.StringUtils;
 import org.dspace.app.util.XMLUtils;
 import org.dspace.scripts.DSpaceRunnable;
+import org.dspace.scripts.configuration.ScriptConfiguration;
 import org.dspace.services.factory.DSpaceServicesFactory;
-import org.dspace.utils.DSpace;
 
 /**
  * Script (config {@link SubmissionFormsMigrationCliScriptConfiguration}) to transform the old input-forms.xml and
@@ -37,7 +37,7 @@ import org.dspace.utils.DSpace;
  *
  * @author Maria Verdonck (Atmire) on 13/11/2020
  */
-public class SubmissionFormsMigration extends DSpaceRunnable<SubmissionFormsMigrationCliScriptConfiguration> {
+public class SubmissionFormsMigration<T extends ScriptConfiguration<?>> extends DSpaceRunnable<T> {
 
     private boolean help = false;
     private String inputFormsFilePath = null;
@@ -64,6 +64,17 @@ public class SubmissionFormsMigration extends DSpaceRunnable<SubmissionFormsMigr
     private static final String CONTENT_DTD_INPUT_FORMS_DUMMY =
         "<!ELEMENT input-forms (form-map, form-definitions, form-value-pairs) >";
     private List<File> tempFiles = new ArrayList<>();
+
+    /**
+     * Constructor for SubmissionFormsMigration script.
+     * Migrates submission forms from DSpace 6 format to DSpace 7 format
+     * using XSLT transformations for compatibility upgrades.
+     * 
+     * @param scriptConfiguration The script configuration defining migration parameters and file paths
+     */
+    public SubmissionFormsMigration(T scriptConfiguration) {
+        super(scriptConfiguration);
+    }
 
     @Override
     public void internalRun() throws TransformerException {
@@ -191,11 +202,5 @@ public class SubmissionFormsMigration extends DSpaceRunnable<SubmissionFormsMigr
     private void throwParseException(String message) throws ParseException {
         handler.logError(message);
         throw new ParseException(message);
-    }
-
-    @Override
-    public SubmissionFormsMigrationCliScriptConfiguration getScriptConfiguration() {
-        return new DSpace().getServiceManager().getServiceByName("submission-forms-migrate",
-            SubmissionFormsMigrationCliScriptConfiguration.class);
     }
 }

--- a/dspace-api/src/main/java/org/dspace/submit/migration/SubmissionFormsMigrationCliScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/submit/migration/SubmissionFormsMigrationCliScriptConfiguration.java
@@ -15,7 +15,7 @@ import org.dspace.scripts.configuration.ScriptConfiguration;
  *
  * @author Maria Verdonck (Atmire) on 13/11/2020
  */
-public class SubmissionFormsMigrationCliScriptConfiguration<T extends SubmissionFormsMigration>
+public class SubmissionFormsMigrationCliScriptConfiguration<T extends SubmissionFormsMigration<?>>
     extends ScriptConfiguration<T> {
 
     private Class<T> dspaceRunnableClass;

--- a/dspace-api/src/main/java/org/dspace/submit/migration/SubmissionFormsMigrationScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/submit/migration/SubmissionFormsMigrationScriptConfiguration.java
@@ -20,7 +20,7 @@ import org.dspace.scripts.configuration.ScriptConfiguration;
  *
  * @author Maria Verdonck (Atmire) on 05/01/2021
  */
-public class SubmissionFormsMigrationScriptConfiguration<T extends SubmissionFormsMigration>
+public class SubmissionFormsMigrationScriptConfiguration<T extends SubmissionFormsMigration<?>>
     extends ScriptConfiguration<T> {
 
     private Class<T> dspaceRunnableClass;

--- a/dspace-api/src/main/java/org/dspace/subscriptions/SubscriptionEmailNotification.java
+++ b/dspace-api/src/main/java/org/dspace/subscriptions/SubscriptionEmailNotification.java
@@ -18,6 +18,7 @@ import org.dspace.eperson.EPerson;
 import org.dspace.eperson.FrequencyType;
 import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.scripts.DSpaceRunnable;
+import org.dspace.scripts.configuration.ScriptConfiguration;
 import org.dspace.utils.DSpace;
 
 /**
@@ -25,17 +26,20 @@ import org.dspace.utils.DSpace;
  *
  * @author alba aliu
  */
-public class SubscriptionEmailNotification
-        extends DSpaceRunnable<SubscriptionEmailNotificationConfiguration<SubscriptionEmailNotification>> {
+public class SubscriptionEmailNotification<T extends ScriptConfiguration<?>>  extends DSpaceRunnable<T> {
 
     private Context context;
     private SubscriptionEmailNotificationService subscriptionEmailNotificationService;
 
-    @Override
-    @SuppressWarnings("unchecked")
-    public SubscriptionEmailNotificationConfiguration<SubscriptionEmailNotification> getScriptConfiguration() {
-        return new DSpace().getServiceManager().getServiceByName("subscription-send",
-                SubscriptionEmailNotificationConfiguration.class);
+    /**
+     * Constructor for SubscriptionEmailNotification script.
+     * Sends subscription email notifications to users about new content
+     * in their subscribed collections and search queries.
+     * 
+     * @param scriptConfiguration The script configuration defining notification frequency and delivery settings
+     */
+    public SubscriptionEmailNotification(T scriptConfiguration) {
+        super(scriptConfiguration);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/subscriptions/SubscriptionEmailNotificationCli.java
+++ b/dspace-api/src/main/java/org/dspace/subscriptions/SubscriptionEmailNotificationCli.java
@@ -7,9 +7,21 @@
  */
 package org.dspace.subscriptions;
 
+import org.dspace.scripts.configuration.ScriptConfiguration;
+
 /**
  * Extension of {@link SubscriptionEmailNotification} for CLI.
  */
-public class SubscriptionEmailNotificationCli extends SubscriptionEmailNotification {
+public class SubscriptionEmailNotificationCli<T extends ScriptConfiguration<?>>
+    extends SubscriptionEmailNotification<T> {
 
+    /**
+     * Constructor for SubscriptionEmailNotificationCli.
+     * Command-line interface wrapper for SubscriptionEmailNotification script.
+     * 
+     * @param scriptConfiguration The CLI script configuration with command-line options
+     */
+    public SubscriptionEmailNotificationCli(T scriptConfiguration) {
+        super(scriptConfiguration);
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/subscriptions/SubscriptionEmailNotificationCliScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/subscriptions/SubscriptionEmailNotificationCliScriptConfiguration.java
@@ -10,7 +10,7 @@ package org.dspace.subscriptions;
 /**
  * Extension of {@link SubscriptionEmailNotificationCli} for CLI.
  */
-public class SubscriptionEmailNotificationCliScriptConfiguration<T extends SubscriptionEmailNotificationCli>
+public class SubscriptionEmailNotificationCliScriptConfiguration<T extends SubscriptionEmailNotificationCli<?>>
         extends SubscriptionEmailNotificationConfiguration<T> {
 
 }

--- a/dspace-api/src/main/java/org/dspace/subscriptions/SubscriptionEmailNotificationConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/subscriptions/SubscriptionEmailNotificationConfiguration.java
@@ -18,7 +18,7 @@ import org.dspace.scripts.configuration.ScriptConfiguration;
  * Implementation of {@link DSpaceRunnable} to find subscribed objects and send notification mails about them
  */
 public class SubscriptionEmailNotificationConfiguration<T
-        extends SubscriptionEmailNotification> extends ScriptConfiguration<T> {
+        extends SubscriptionEmailNotification<?>> extends ScriptConfiguration<T> {
 
     private Class<T> dspaceRunnableClass;
 

--- a/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataExportIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataExportIT.java
@@ -92,9 +92,9 @@ public class MetadataExportIT
         TestDSpaceRunnableHandler testDSpaceRunnableHandler = new TestDSpaceRunnableHandler();
 
         ScriptService scriptService = ScriptServiceFactory.getInstance().getScriptService();
-        ScriptConfiguration scriptConfiguration = scriptService.getScriptConfiguration(args[0]);
+        ScriptConfiguration<MetadataExport<?>> scriptConfiguration = scriptService.getScriptConfiguration(args[0]);
 
-        DSpaceRunnable script = null;
+        MetadataExport<?> script = null;
         if (scriptConfiguration != null) {
             script = scriptService.createDSpaceRunnableForScriptConfiguration(scriptConfiguration);
         }

--- a/dspace-api/src/test/java/org/dspace/scripts/MockDSpaceRunnableScriptConfiguration.java
+++ b/dspace-api/src/test/java/org/dspace/scripts/MockDSpaceRunnableScriptConfiguration.java
@@ -13,7 +13,8 @@ import org.apache.commons.cli.Options;
 import org.dspace.scripts.configuration.ScriptConfiguration;
 import org.dspace.scripts.impl.MockDSpaceRunnableScript;
 
-public class MockDSpaceRunnableScriptConfiguration<T extends MockDSpaceRunnableScript> extends ScriptConfiguration<T> {
+public class MockDSpaceRunnableScriptConfiguration<T extends MockDSpaceRunnableScript<?>>
+    extends ScriptConfiguration<T> {
 
     private Class<T> dspaceRunnableClass;
 

--- a/dspace-api/src/test/java/org/dspace/scripts/impl/MockDSpaceRunnableScript.java
+++ b/dspace-api/src/test/java/org/dspace/scripts/impl/MockDSpaceRunnableScript.java
@@ -9,18 +9,12 @@ package org.dspace.scripts.impl;
 
 import org.apache.commons.cli.ParseException;
 import org.dspace.scripts.DSpaceRunnable;
-import org.dspace.scripts.MockDSpaceRunnableScriptConfiguration;
-import org.dspace.utils.DSpace;
+import org.dspace.scripts.configuration.ScriptConfiguration;
 
-public class MockDSpaceRunnableScript extends DSpaceRunnable<MockDSpaceRunnableScriptConfiguration> {
-    @Override
-    public void internalRun() throws Exception {
-    }
+public class MockDSpaceRunnableScript<T extends ScriptConfiguration<?>> extends DSpaceRunnable<T> {
 
     @Override
-    public MockDSpaceRunnableScriptConfiguration getScriptConfiguration() {
-        return new DSpace().getServiceManager()
-                           .getServiceByName("mock-script", MockDSpaceRunnableScriptConfiguration.class);
+    public void internalRun() {
     }
 
     @Override

--- a/dspace-api/src/test/java/org/dspace/scripts/impl/MockDSpaceRunnableScript.java
+++ b/dspace-api/src/test/java/org/dspace/scripts/impl/MockDSpaceRunnableScript.java
@@ -13,6 +13,14 @@ import org.dspace.scripts.configuration.ScriptConfiguration;
 
 public class MockDSpaceRunnableScript<T extends ScriptConfiguration<?>> extends DSpaceRunnable<T> {
 
+    /**
+     * Constructor for the MockDSpaceRunnableScript
+     * @param scriptConfiguration
+     */
+    public MockDSpaceRunnableScript(T scriptConfiguration) {
+        super(scriptConfiguration);
+    }
+
     @Override
     public void internalRun() {
     }

--- a/dspace-api/src/test/java/org/dspace/statistics/export/ITRetryFailedOpenUrlTracker.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/export/ITRetryFailedOpenUrlTracker.java
@@ -143,8 +143,9 @@ public class ITRetryFailedOpenUrlTracker extends AbstractIntegrationTest {
     public void testReprocessPartOfUrls() throws Exception {
 
         TestDSpaceRunnableHandler testDSpaceRunnableHandler = new TestDSpaceRunnableHandler();
-        ScriptConfiguration retryOpenUrlTrackerConfig = scriptService.getScriptConfiguration("retry-tracker");
-        DSpaceRunnable retryOpenUrlTracker =
+        ScriptConfiguration<RetryFailedOpenUrlTracker<?>> retryOpenUrlTrackerConfig =
+            scriptService.getScriptConfiguration("retry-tracker");
+        RetryFailedOpenUrlTracker<?> retryOpenUrlTracker =
                 scriptService.createDSpaceRunnableForScriptConfiguration(retryOpenUrlTrackerConfig);
         String[] args = {"-r"};
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/WebApplication.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/WebApplication.java
@@ -24,6 +24,7 @@ import org.dspace.app.rest.utils.ApplicationConfig;
 import org.dspace.app.rest.utils.DSpaceAPIRequestLoggingFilter;
 import org.dspace.app.sitemap.GenerateSitemaps;
 import org.dspace.app.solrdatabaseresync.SolrDatabaseResyncCli;
+import org.dspace.app.solrdatabaseresync.SolrDatabaseResyncCliScriptConfiguration;
 import org.dspace.app.util.DSpaceContextListener;
 import org.dspace.google.GoogleAsyncEventListener;
 import org.dspace.utils.servlet.DSpaceWebappServletFilter;
@@ -62,13 +63,16 @@ public class WebApplication {
     @Autowired
     private GoogleAsyncEventListener googleAsyncEventListener;
 
+    @Autowired
+    private SolrDatabaseResyncCliScriptConfiguration<?> solrDatabaseResyncCliScriptConfiguration;
+
     @Scheduled(cron = "${sitemap.cron:-}")
     public void generateSitemap() throws IOException, SQLException {
         GenerateSitemaps.generateSitemapsScheduled();
     }
 
     @Scheduled(cron = "${ldn.queue.extractor.cron:-}")
-    public void ldnExtractFromQueue() throws IOException, SQLException {
+    public void ldnExtractFromQueue() throws SQLException {
         if (!configuration.getLdnEnabled()) {
             return;
         }
@@ -76,7 +80,7 @@ public class WebApplication {
     }
 
     @Scheduled(cron = "${ldn.queue.timeout.checker.cron:-}")
-    public void ldnQueueTimeoutCheck() throws IOException, SQLException {
+    public void ldnQueueTimeoutCheck() throws SQLException {
         if (!configuration.getLdnEnabled()) {
             return;
         }
@@ -85,7 +89,7 @@ public class WebApplication {
 
     @Scheduled(cron = "${solr-database-resync.cron:-}")
     public void solrDatabaseResync() throws Exception {
-        SolrDatabaseResyncCli.runScheduled();
+        SolrDatabaseResyncCli.runScheduled(this.solrDatabaseResyncCliScriptConfiguration);
     }
 
     @Scheduled(cron = "${google.analytics.cron:-}")

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ScriptRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ScriptRestRepository.java
@@ -79,7 +79,7 @@ public class ScriptRestRepository extends DSpaceRestRepository<ScriptRest, Strin
     // authorization check is performed inside the script service
     @PreAuthorize("hasAuthority('AUTHENTICATED')")
     public Page<ScriptRest> findAll(Context context, Pageable pageable) {
-        List<ScriptConfiguration> scriptConfigurations =
+        List<ScriptConfiguration<DSpaceRunnable<?>>> scriptConfigurations =
             scriptService.getScriptConfigurations(context);
         return converter.toRestPage(scriptConfigurations, pageable, utils.obtainProjection());
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ScriptRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ScriptRestRepository.java
@@ -79,8 +79,7 @@ public class ScriptRestRepository extends DSpaceRestRepository<ScriptRest, Strin
     // authorization check is performed inside the script service
     @PreAuthorize("hasAuthority('AUTHENTICATED')")
     public Page<ScriptRest> findAll(Context context, Pageable pageable) {
-        List<ScriptConfiguration<DSpaceRunnable<?>>> scriptConfigurations =
-            scriptService.getScriptConfigurations(context);
+        List<? extends ScriptConfiguration<?>> scriptConfigurations = scriptService.getScriptConfigurations(context);
         return converter.toRestPage(scriptConfigurations, pageable, utils.obtainProjection());
     }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/deletionprocess/DSpaceObjectDeletionProcessIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/deletionprocess/DSpaceObjectDeletionProcessIT.java
@@ -403,7 +403,8 @@ public class DSpaceObjectDeletionProcessIT extends AbstractEntityIntegrationTest
                          .collect(Collectors.toList());
     }
 
-    private void runDeletionProcessScript(String[] args, TestDSpaceRunnableHandler handler) throws IllegalAccessException, InstantiationException, ParseException {
+    private void runDeletionProcessScript(String[] args, TestDSpaceRunnableHandler handler)
+        throws IllegalAccessException, InstantiationException, ParseException {
         DSpaceObjectDeletionProcessScriptConfiguration<?> scriptConfig =
             scriptService.getScriptConfiguration(OBJECT_DELETION_SCRIPT);
         DSpaceObjectDeletionProcess<?> deletionProcess =

--- a/dspace-server-webapp/src/test/java/org/dspace/app/deletionprocess/DSpaceObjectDeletionProcessIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/deletionprocess/DSpaceObjectDeletionProcessIT.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
-import org.apache.commons.cli.ParseException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.dspace.app.rest.converter.DSpaceRunnableParameterConverter;
 import org.dspace.app.rest.model.ParameterValueRest;
@@ -39,13 +38,9 @@ import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.CollectionService;
 import org.dspace.content.service.CommunityService;
 import org.dspace.content.service.ItemService;
-import org.dspace.deletion.process.DSpaceObjectDeletionProcess;
 import org.dspace.discovery.IndexingService;
 import org.dspace.eperson.EPerson;
 import org.dspace.scripts.DSpaceCommandLineParameter;
-import org.dspace.scripts.configuration.ScriptConfiguration;
-import org.dspace.scripts.service.ScriptService;
-import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -63,18 +58,10 @@ public class DSpaceObjectDeletionProcessIT extends AbstractEntityIntegrationTest
     private DSpaceRunnableParameterConverter dSpaceRunnableParameterConverter;
 
     @Autowired
-    private ScriptService scriptService;
-    @Autowired
     private IndexingService indexingService;
     private ItemService itemService = ContentServiceFactory.getInstance().getItemService();
     private CollectionService collectionService = ContentServiceFactory.getInstance().getCollectionService();
     private CommunityService communityService = ContentServiceFactory.getInstance().getCommunityService();
-
-    @Autowired
-    private ItemService itemService;
-
-    private Item item1;
-    private Item item2;
 
     private Community community;
     private Collection collection;
@@ -401,16 +388,6 @@ public class DSpaceObjectDeletionProcessIT extends AbstractEntityIntegrationTest
                                   dSpaceRunnableParameterConverter.convert(dSpaceCommandLineParameter,
                                                                            Projection.DEFAULT))
                          .collect(Collectors.toList());
-    }
-
-    private void runDeletionProcessScript(String[] args, TestDSpaceRunnableHandler handler)
-        throws IllegalAccessException, InstantiationException, ParseException {
-        DSpaceObjectDeletionProcessScriptConfiguration<?> scriptConfig =
-            scriptService.getScriptConfiguration(OBJECT_DELETION_SCRIPT);
-        DSpaceObjectDeletionProcess<?> deletionProcess =
-            scriptService.createDSpaceRunnableForScriptConfiguration(scriptConfig);
-        deletionProcess.initialize(args, handler, admin);
-        deletionProcess.run();
     }
 
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/deletionprocess/DSpaceObjectDeletionProcessIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/deletionprocess/DSpaceObjectDeletionProcessIT.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
+import org.apache.commons.cli.ParseException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.dspace.app.rest.converter.DSpaceRunnableParameterConverter;
 import org.dspace.app.rest.model.ParameterValueRest;
@@ -42,6 +43,7 @@ import org.dspace.deletion.process.DSpaceObjectDeletionProcess;
 import org.dspace.discovery.IndexingService;
 import org.dspace.eperson.EPerson;
 import org.dspace.scripts.DSpaceCommandLineParameter;
+import org.dspace.scripts.configuration.ScriptConfiguration;
 import org.dspace.scripts.service.ScriptService;
 import org.hamcrest.Matchers;
 import org.junit.Before;
@@ -67,6 +69,9 @@ public class DSpaceObjectDeletionProcessIT extends AbstractEntityIntegrationTest
     private ItemService itemService = ContentServiceFactory.getInstance().getItemService();
     private CollectionService collectionService = ContentServiceFactory.getInstance().getCollectionService();
     private CommunityService communityService = ContentServiceFactory.getInstance().getCommunityService();
+
+    @Autowired
+    private ItemService itemService;
 
     private Item item1;
     private Item item2;
@@ -396,6 +401,15 @@ public class DSpaceObjectDeletionProcessIT extends AbstractEntityIntegrationTest
                                   dSpaceRunnableParameterConverter.convert(dSpaceCommandLineParameter,
                                                                            Projection.DEFAULT))
                          .collect(Collectors.toList());
+    }
+
+    private void runDeletionProcessScript(String[] args, TestDSpaceRunnableHandler handler) throws IllegalAccessException, InstantiationException, ParseException {
+        DSpaceObjectDeletionProcessScriptConfiguration<?> scriptConfig =
+            scriptService.getScriptConfiguration(OBJECT_DELETION_SCRIPT);
+        DSpaceObjectDeletionProcess<?> deletionProcess =
+            scriptService.createDSpaceRunnableForScriptConfiguration(scriptConfig);
+        deletionProcess.initialize(args, handler, admin);
+        deletionProcess.run();
     }
 
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/deletionprocess/DSpaceObjectDeletionProcessIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/deletionprocess/DSpaceObjectDeletionProcessIT.java
@@ -38,9 +38,12 @@ import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.CollectionService;
 import org.dspace.content.service.CommunityService;
 import org.dspace.content.service.ItemService;
+import org.dspace.deletion.process.DSpaceObjectDeletionProcess;
 import org.dspace.discovery.IndexingService;
 import org.dspace.eperson.EPerson;
 import org.dspace.scripts.DSpaceCommandLineParameter;
+import org.dspace.scripts.service.ScriptService;
+import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -58,11 +61,15 @@ public class DSpaceObjectDeletionProcessIT extends AbstractEntityIntegrationTest
     private DSpaceRunnableParameterConverter dSpaceRunnableParameterConverter;
 
     @Autowired
+    private ScriptService scriptService;
+    @Autowired
     private IndexingService indexingService;
-
     private ItemService itemService = ContentServiceFactory.getInstance().getItemService();
     private CollectionService collectionService = ContentServiceFactory.getInstance().getCollectionService();
     private CommunityService communityService = ContentServiceFactory.getInstance().getCommunityService();
+
+    private Item item1;
+    private Item item2;
 
     private Community community;
     private Collection collection;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/scripts/TypeConversionTestScript.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/scripts/TypeConversionTestScript.java
@@ -10,18 +10,12 @@ package org.dspace.app.scripts;
 import org.apache.commons.cli.ParseException;
 import org.dspace.app.rest.converter.ScriptConverter;
 import org.dspace.scripts.DSpaceRunnable;
-import org.dspace.utils.DSpace;
+import org.dspace.scripts.configuration.ScriptConfiguration;
 
 /**
  * Script used to test the type conversion in the {@link ScriptConverter}
  */
-public class TypeConversionTestScript extends DSpaceRunnable<TypeConversionTestScriptConfiguration> {
-
-
-    public TypeConversionTestScriptConfiguration getScriptConfiguration() {
-        return new DSpace().getServiceManager()
-                           .getServiceByName("type-conversion-test", TypeConversionTestScriptConfiguration.class);
-    }
+public class TypeConversionTestScript<T extends ScriptConfiguration<?>> extends DSpaceRunnable<T> {
 
     public void setup() throws ParseException {
         // This script is only used to test rest exposure, no setup is required.

--- a/dspace-server-webapp/src/test/java/org/dspace/app/scripts/TypeConversionTestScript.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/scripts/TypeConversionTestScript.java
@@ -17,6 +17,15 @@ import org.dspace.scripts.configuration.ScriptConfiguration;
  */
 public class TypeConversionTestScript<T extends ScriptConfiguration<?>> extends DSpaceRunnable<T> {
 
+    /**
+     * Constructor for the TypeConversionTestScript
+     *
+     * @param scriptConfiguration
+     */
+    public TypeConversionTestScript(T scriptConfiguration) {
+        super(scriptConfiguration);
+    }
+
     public void setup() throws ParseException {
         // This script is only used to test rest exposure, no setup is required.
     }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/scripts/TypeConversionTestScriptConfiguration.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/scripts/TypeConversionTestScriptConfiguration.java
@@ -16,7 +16,8 @@ import org.dspace.scripts.configuration.ScriptConfiguration;
 /**
  * Script configuration used to test the type conversion in the {@link ScriptConverter}
  */
-public class TypeConversionTestScriptConfiguration<T extends TypeConversionTestScript> extends ScriptConfiguration<T> {
+public class TypeConversionTestScriptConfiguration<T extends TypeConversionTestScript<?>>
+    extends ScriptConfiguration<T> {
 
 
     public Class<T> getDspaceRunnableClass() {

--- a/dspace-server-webapp/src/test/java/org/dspace/scripts/MockDSpaceRunnableScriptConfiguration.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/scripts/MockDSpaceRunnableScriptConfiguration.java
@@ -13,7 +13,8 @@ import org.apache.commons.cli.Options;
 import org.dspace.scripts.configuration.ScriptConfiguration;
 import org.dspace.scripts.impl.MockDSpaceRunnableScript;
 
-public class MockDSpaceRunnableScriptConfiguration<T extends MockDSpaceRunnableScript> extends ScriptConfiguration<T> {
+public class MockDSpaceRunnableScriptConfiguration<T extends MockDSpaceRunnableScript<?>>
+    extends ScriptConfiguration<T> {
 
     private Class<T> dspaceRunnableClass;
 

--- a/dspace-server-webapp/src/test/java/org/dspace/scripts/impl/MockDSpaceRunnableScript.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/scripts/impl/MockDSpaceRunnableScript.java
@@ -13,6 +13,15 @@ import org.dspace.scripts.configuration.ScriptConfiguration;
 
 public class MockDSpaceRunnableScript<T extends ScriptConfiguration<?>> extends DSpaceRunnable<T> {
 
+    /**
+     * Constructor for the MockDSpaceRunnableScript
+     *
+     * @param scriptConfiguration
+     */
+    public MockDSpaceRunnableScript(T scriptConfiguration) {
+        super(scriptConfiguration);
+    }
+
     @Override
     public void internalRun() {
         handler.logInfo("Logging INFO for Mock DSpace Script");

--- a/dspace-server-webapp/src/test/java/org/dspace/scripts/impl/MockDSpaceRunnableScript.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/scripts/impl/MockDSpaceRunnableScript.java
@@ -9,22 +9,16 @@ package org.dspace.scripts.impl;
 
 import org.apache.commons.cli.ParseException;
 import org.dspace.scripts.DSpaceRunnable;
-import org.dspace.scripts.MockDSpaceRunnableScriptConfiguration;
-import org.dspace.utils.DSpace;
+import org.dspace.scripts.configuration.ScriptConfiguration;
 
-public class MockDSpaceRunnableScript extends DSpaceRunnable<MockDSpaceRunnableScriptConfiguration> {
+public class MockDSpaceRunnableScript<T extends ScriptConfiguration<?>> extends DSpaceRunnable<T> {
+
     @Override
-    public void internalRun() throws Exception {
+    public void internalRun() {
         handler.logInfo("Logging INFO for Mock DSpace Script");
         handler.logError("Logging ERROR for Mock DSpace Script");
         handler.logWarning("Logging WARNING for Mock DSpace Script");
         handler.logDebug("Logging DEBUG for Mock DSpace Script");
-    }
-
-    @Override
-    public MockDSpaceRunnableScriptConfiguration getScriptConfiguration() {
-        return new DSpace().getServiceManager()
-                           .getServiceByName("mock-script", MockDSpaceRunnableScriptConfiguration.class);
     }
 
     @Override

--- a/dspace-services/src/main/java/org/dspace/kernel/ServiceManager.java
+++ b/dspace-services/src/main/java/org/dspace/kernel/ServiceManager.java
@@ -57,7 +57,7 @@ public interface ServiceManager {
      *             the interface class but can be concrete as well).
      * @return the service singleton OR null if none is found
      */
-    public <T> T getServiceByName(String name, Class<T> type);
+    <T> T getServiceByName(String name, Class<? super T> type);
 
     /**
      * Lookup to see if a service exists with the given name.

--- a/dspace-services/src/main/java/org/dspace/kernel/ServiceManager.java
+++ b/dspace-services/src/main/java/org/dspace/kernel/ServiceManager.java
@@ -36,7 +36,7 @@ public interface ServiceManager {
      *            as well)
      * @return the list of service singletons OR empty list if none is found
      */
-    public <T> List<T> getServicesByType(Class<T> type);
+    <T> List<T> getServicesByType(Class<? super T> type);
 
     /**
      * Allows developers to get the desired service singleton by the provided name and type.

--- a/dspace-services/src/main/java/org/dspace/servicemanager/DSpaceServiceManager.java
+++ b/dspace-services/src/main/java/org/dspace/servicemanager/DSpaceServiceManager.java
@@ -466,17 +466,17 @@ public final class DSpaceServiceManager implements ServiceManagerSystem {
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T> List<T> getServicesByType(Class<T> type) {
+    public <T> List<T> getServicesByType(Class<? super T> type) {
         checkRunning();
         if (type == null) {
             throw new IllegalArgumentException("type cannot be null");
         }
 
-        List<T> services = new ArrayList<>();
-        Map<String, T> beans;
+        List<T> services;
+        Map<String, ?> beans;
         try {
             beans = applicationContext.getBeansOfType(type, true, true);
-            services.addAll((Collection<? extends T>) beans.values());
+            services = new ArrayList<>((Collection<T>) beans.values());
         } catch (BeansException e) {
             throw new RuntimeException("Failed to get beans of type (" + type + "): " + e.getMessage(), e);
         }

--- a/dspace-services/src/main/java/org/dspace/servicemanager/DSpaceServiceManager.java
+++ b/dspace-services/src/main/java/org/dspace/servicemanager/DSpaceServiceManager.java
@@ -407,7 +407,7 @@ public final class DSpaceServiceManager implements ServiceManagerSystem {
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T> T getServiceByName(String name, Class<T> type) {
+    public <T> T getServiceByName(String name, Class<? super T> type) {
         checkRunning();
         if (type == null) {
             throw new IllegalArgumentException("Type cannot be null");
@@ -447,7 +447,7 @@ public final class DSpaceServiceManager implements ServiceManagerSystem {
             if (name == null
                 && service == null) {
                 try {
-                    Map<String, T> map = applicationContext.getBeansOfType(type);
+                    Map<String, ?> map = applicationContext.getBeansOfType(type);
                     if (map.size() == 1) {
                         // only return the bean if there is exactly one
                         service = (T) map.values().iterator().next();

--- a/dspace-services/src/test/java/org/dspace/servicemanager/MockServiceManagerSystem.java
+++ b/dspace-services/src/test/java/org/dspace/servicemanager/MockServiceManagerSystem.java
@@ -69,7 +69,7 @@ public class MockServiceManagerSystem implements ServiceManagerSystem {
     /* (non-Javadoc)
      * @see org.dspace.kernel.ServiceManager#getServicesByType(java.lang.Class)
      */
-    public <T> List<T> getServicesByType(Class<T> type) {
+    public <T> List<T> getServicesByType(Class<? super T> type) {
         return this.sms.getServicesByType(type);
     }
 

--- a/dspace-services/src/test/java/org/dspace/servicemanager/MockServiceManagerSystem.java
+++ b/dspace-services/src/test/java/org/dspace/servicemanager/MockServiceManagerSystem.java
@@ -58,7 +58,7 @@ public class MockServiceManagerSystem implements ServiceManagerSystem {
     /* (non-Javadoc)
      * @see org.dspace.kernel.ServiceManager#getServiceByName(java.lang.String, java.lang.Class)
      */
-    public <T> T getServiceByName(String name, Class<T> type) {
+    public <T> T getServiceByName(String name, Class<? super T> type) {
         return this.sms.getServiceByName(name, type);
     }
 

--- a/dspace-services/src/test/java/org/dspace/utils/servicemanager/ProviderStackTest.java
+++ b/dspace-services/src/test/java/org/dspace/utils/servicemanager/ProviderStackTest.java
@@ -71,7 +71,7 @@ public class ProviderStackTest {
     public void testProviderStackServiceManagerClassOfT() {
         // fake service manager for testing
         ServiceManager sm = new ServiceManager() {
-            public <T> T getServiceByName(String name, Class<T> type) {
+            public <T> T getServiceByName(String name, Class<? super T> type) {
                 return null;
             }
 

--- a/dspace-services/src/test/java/org/dspace/utils/servicemanager/ProviderStackTest.java
+++ b/dspace-services/src/test/java/org/dspace/utils/servicemanager/ProviderStackTest.java
@@ -79,7 +79,7 @@ public class ProviderStackTest {
                 return null;
             }
 
-            public <T> List<T> getServicesByType(Class<T> type) {
+            public <T> List<T> getServicesByType(Class<? super T> type) {
                 return new ArrayList<>();
             }
 

--- a/dspace/config/spring/api/scripts.xml
+++ b/dspace/config/spring/api/scripts.xml
@@ -82,7 +82,7 @@
         <property name="dspaceRunnableClass" value="org.dspace.app.solrdatabaseresync.SolrDatabaseResyncCli"/>
     </bean>
 
-    <bean id="import" class="org.dspace.app.itemimport.ItemImportCLIScriptConfiguration" primary="true">
+    <bean id="import-cli" class="org.dspace.app.itemimport.ItemImportCLIScriptConfiguration" primary="true">
         <property name="description" value="Batch Import from Simple Archive Format (SAF)" />
         <property name="dspaceRunnableClass" value="org.dspace.app.itemimport.ItemImportCLI"/>
     </bean>

--- a/dspace/config/spring/api/scripts.xml
+++ b/dspace/config/spring/api/scripts.xml
@@ -82,7 +82,7 @@
         <property name="dspaceRunnableClass" value="org.dspace.app.solrdatabaseresync.SolrDatabaseResyncCli"/>
     </bean>
 
-    <bean id="import-cli" class="org.dspace.app.itemimport.ItemImportCLIScriptConfiguration" primary="true">
+    <bean id="import" class="org.dspace.app.itemimport.ItemImportCLIScriptConfiguration" primary="true">
         <property name="description" value="Batch Import from Simple Archive Format (SAF)" />
         <property name="dspaceRunnableClass" value="org.dspace.app.itemimport.ItemImportCLI"/>
     </bean>


### PR DESCRIPTION
## References
* Fixes #11796 (if applicable - script constructor injection enhancement)

## Description
This PR comprehensively modernizes the entire DSpace script system by migrating all DSpaceRunnable classes to use constructor injection patterns.
This PR represents a significant architectural improvement to the DSpace script system.
Breaks cyclic dependency between `ScriptConfiguration` and `DspaceRunnable` classes and enhances the correct loading of scripts declared inside the `scripts.xml` files.

## Instructions for Reviewers

### List of changes in this PR:
* **Constructor Modernization**: Updated `DSpaceRunnable` script classes to accept `ScriptConfiguration` via constructor parameter instead of legacy `getScriptConfiguration()` methods
* **Architecture Standardization**: Implemented consistent constructor pattern: `public ClassName(T scriptConfiguration) { super(scriptConfiguration); }`
* **Spring Integration**: Fixed `ScriptService` generics compatibility and updated service instantiation patterns for proper type safety
* **Test Integration**: Updated integration tests and mock classes to use proper script instantiation via `ScriptService`
* **Configuration Classes**: Verified all `ScriptConfiguration` classes work correctly with the new patterns (they use default constructors)
* **Service Layer**: Resolved `ScriptService` interface/implementation generics issues that emerged during validation

### How to test:
Try to reproduce the issue pointed out by the following comment https://github.com/DSpace/DSpace/issues/11796#issuecomment-3806773479 :
 1. Try to declare two scripts inside spring/api/scripts.xml:

-   `import-cli`: that uses the `ItemImportCLIScriptConfiguration`
-   `import`: that uses the `ItemImportScriptConfiguration`

Then run them with the `help` command:

```shell
./bin/dspace import --help
./bin/dspace import-cli --help
```
Assure that they're using different definitions according to their configuration ( the `import-cli` should include the `-e parameter`)

 2. Try to rename the script from `import` to `import-cli`, without duplicating it, you will be able to run it:
```shell
 ❯ ./bin/dspace import-cli --help
usage: import-cli
 -a,--add                  add items to DSpace
 -c,--collection <arg>     destination collection(s) Handle or database ID
 -d,--delete               delete items listed in mapfile
 -e,--eperson <arg>        email of eperson doing importing
 -h,--help                 help
 -m,--mapfile <arg>        mapfile items in mapfile
 -n,--notify               if sending submissions through the workflow,
                           send notification emails
 -p,--template             apply template
 -q,--quiet                don't display metadata
 -r,--replace              replace items in mapfile
 -R,--resume               resume a failed import (add only)
 -s,--source <arg>         source of items (directory)
 -u,--url <arg>            url of zip file
 -v,--validate             test run - do not actually import items
 -w,--workflow             send submission through collection's workflow
 -x,--exclude-bitstreams   do not load or expect content bitstreams
 -z,--zip <arg>            name of zip file
```

### **How to review:**
1. Build Validation: Verify the project compiles successfully:
      `mvn clean compile -DskipTests`
2. Code Style: Confirm all changes pass Checkstyle validation:
      `mvn checkstyle:check`
4. Script Functionality: Test that scripts can be executed via REST API and CLI:
   - Try running any script through the admin UI or REST endpoints
   - Verify scripts are properly instantiated with configuration parameters
   - Check that error handling and logging work as expected
5. Constructor Pattern: Review that all `DSpaceRunnable` classes follow the new pattern:
   - Constructor accepts `T scriptConfiguration` parameter
   - Calls `super(scriptConfiguration) `
   - Has proper Javadoc documentation
   - Removes old `getScriptConfiguration()` overrides
6. Integration Tests: Run the updated integration test to verify functionality:
      `mvn verify -DskipIntegrationTests=false -Dit.test=DSpaceObjectDeletionProcessIT`
7. Spring Configuration: Verify that all script beans can be properly instantiated by Spring without errors during application startup.  Key files to focus review on:
    - `DSpaceRunnable.java` - Base class changes enabling constructor injection
    - `ScriptServiceImpl.java` - Service layer updates for proper script instantiation
    - `DSpaceObjectDeletionProcessIT.java` - Example of updated test pattern
    - Any specific script class (e.g., `BulkAccessControl.java`, `Curation.java)` - Representative of the new pattern

## Checklist

- [X] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [X] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [X] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [X] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
