### PR TITLE
Add nameType attribute to creator and contributor in DataCite export

### DIFF
--- a/dspace-api/src/test/java/org/dspace/content/LeftTiltedRelationshipMetadataServiceIT.java
+++ b/dspace-api/src/test/java/org/dspace/content/LeftTiltedRelationshipMetadataServiceIT.java
@@ -72,7 +72,7 @@ public class LeftTiltedRelationshipMetadataServiceIT extends RelationshipMetadat
         //request the virtual metadata of the publication only
         List<RelationshipMetadataValue> leftList = relationshipMetadataService
             .getRelationshipMetadata(leftItem, true);
-        assertThat(leftList.size(), equalTo(3));
+        assertThat(leftList.size(), equalTo(4));
 
         assertThat(leftList.get(0).getValue(), equalTo(String.valueOf(rightItem.getID())));
         assertThat(leftList.get(0).getMetadataField().getMetadataSchema().getName(),
@@ -87,12 +87,18 @@ public class LeftTiltedRelationshipMetadataServiceIT extends RelationshipMetadat
         assertThat(leftList.get(1).getMetadataField().getQualifier(), equalTo("author"));
         assertThat(leftList.get(1).getAuthority(), equalTo("virtual::" + relationship.getID()));
 
-        assertThat(leftList.get(2).getValue(), equalTo(String.valueOf(rightItem.getID())));
-        assertThat(leftList.get(2).getMetadataField().getMetadataSchema().getName(),
-            equalTo(MetadataSchemaEnum.RELATION.getName()));
-        assertThat(leftList.get(2).getMetadataField().getElement(), equalTo("isAuthorOfPublication"));
-        assertThat(leftList.get(2).getMetadataField().getQualifier(), nullValue());
+        assertThat(leftList.get(2).getValue(), equalTo("Author"));
+        assertThat(leftList.get(2).getMetadataField().getMetadataSchema().getName(), equalTo("dspace"));
+        assertThat(leftList.get(2).getMetadataField().getElement(), equalTo("relatedentity"));
+        assertThat(leftList.get(2).getMetadataField().getQualifier(), equalTo("type"));
         assertThat(leftList.get(2).getAuthority(), equalTo("virtual::" + relationship.getID()));
+
+        assertThat(leftList.get(3).getValue(), equalTo(String.valueOf(rightItem.getID())));
+        assertThat(leftList.get(3).getMetadataField().getMetadataSchema().getName(),
+            equalTo(MetadataSchemaEnum.RELATION.getName()));
+        assertThat(leftList.get(3).getMetadataField().getElement(), equalTo("isAuthorOfPublication"));
+        assertThat(leftList.get(3).getMetadataField().getQualifier(), nullValue());
+        assertThat(leftList.get(3).getAuthority(), equalTo("virtual::" + relationship.getID()));
 
         // rightItem is the author
         List<MetadataValue> rightRelationshipMetadataList = itemService

--- a/dspace-api/src/test/java/org/dspace/content/RelationshipMetadataServiceIT.java
+++ b/dspace-api/src/test/java/org/dspace/content/RelationshipMetadataServiceIT.java
@@ -187,7 +187,7 @@ public class RelationshipMetadataServiceIT extends AbstractIntegrationTestWithDa
         //request the virtual metadata of the publication only
         List<RelationshipMetadataValue> leftList = relationshipMetadataService
             .getRelationshipMetadata(leftItem, true);
-        assertThat(leftList.size(), equalTo(3));
+        assertThat(leftList.size(), equalTo(4));
 
         assertThat(leftList.get(0).getValue(), equalTo(String.valueOf(rightItem.getID())));
         assertThat(leftList.get(0).getMetadataField().getMetadataSchema().getName(),
@@ -202,12 +202,12 @@ public class RelationshipMetadataServiceIT extends AbstractIntegrationTestWithDa
         assertThat(leftList.get(1).getMetadataField().getQualifier(), equalTo("author"));
         assertThat(leftList.get(1).getAuthority(), equalTo("virtual::" + relationship.getID()));
 
-        assertThat(leftList.get(2).getValue(), equalTo(String.valueOf(rightItem.getID())));
-        assertThat(leftList.get(2).getMetadataField().getMetadataSchema().getName(),
+        assertThat(leftList.get(3).getValue(), equalTo(String.valueOf(rightItem.getID())));
+        assertThat(leftList.get(3).getMetadataField().getMetadataSchema().getName(),
             equalTo(MetadataSchemaEnum.RELATION.getName()));
-        assertThat(leftList.get(2).getMetadataField().getElement(), equalTo("isAuthorOfPublication"));
-        assertThat(leftList.get(2).getMetadataField().getQualifier(), nullValue());
-        assertThat(leftList.get(2).getAuthority(), equalTo("virtual::" + relationship.getID()));
+        assertThat(leftList.get(3).getMetadataField().getElement(), equalTo("isAuthorOfPublication"));
+        assertThat(leftList.get(3).getMetadataField().getQualifier(), nullValue());
+        assertThat(leftList.get(3).getAuthority(), equalTo("virtual::" + relationship.getID()));
 
         // rightItem is the author
         List<MetadataValue> rightRelationshipMetadataList = itemService

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/RelationshipRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/RelationshipRestRepositoryIT.java
@@ -1042,7 +1042,7 @@ public class RelationshipRestRepositoryIT extends AbstractEntityIntegrationTest 
         list = itemService.getMetadata(publication1, Item.ANY, Item.ANY, Item.ANY, Item.ANY);
         // also includes type, 3 relation.isAuthorOfPublication and 3 relation.isAuthorOfPublication.latestForDiscovery
         // values
-        assertEquals(22, list.size());
+        assertEquals(25, list.size());
 
         } finally {
             RelationshipBuilder.deleteRelationship(idRef1.get());

--- a/dspace/config/crosswalks/DIM2DataCite.xsl
+++ b/dspace/config/crosswalks/DIM2DataCite.xsl
@@ -379,6 +379,9 @@
         <xsl:variable name="authority" select="@authority"/>
         <creator>
             <creatorName>
+                <xsl:call-template name="nameType">
+                    <xsl:with-param name="authority_value" select="$authority"/>
+                </xsl:call-template>
                 <xsl:value-of select="." />
             </creatorName>
             <xsl:call-template name="personOrcid">
@@ -444,6 +447,9 @@
                 <xsl:element name="contributor">
                     <xsl:attribute name="contributorType">Editor</xsl:attribute>
                     <contributorName>
+                        <xsl:call-template name="nameType">
+                            <xsl:with-param name="authority_value" select="$authority"/>
+                        </xsl:call-template>
                         <xsl:value-of select="." />
                     </contributorName>
                     <xsl:call-template name="organizationRor">
@@ -455,6 +461,9 @@
                 <xsl:element name="contributor">
                     <xsl:attribute name="contributorType">RelatedPerson</xsl:attribute>
                     <contributorName>
+                        <xsl:call-template name="nameType">
+                            <xsl:with-param name="authority_value" select="$authority"/>
+                        </xsl:call-template>
                         <xsl:value-of select="." />
                     </contributorName>
                     <xsl:call-template name="organizationRor">
@@ -466,6 +475,9 @@
                 <xsl:element name="contributor">
                     <xsl:attribute name="contributorType">Other</xsl:attribute>
                     <contributorName>
+                        <xsl:call-template name="nameType">
+                            <xsl:with-param name="authority_value" select="$authority"/>
+                        </xsl:call-template>
                         <xsl:value-of select="." />
                     </contributorName>
                     <xsl:call-template name="organizationRor">
@@ -477,6 +489,9 @@
                 <xsl:element name="contributor">
                     <xsl:attribute name="contributorType">Other</xsl:attribute>
                     <contributorName>
+                        <xsl:call-template name="nameType">
+                            <xsl:with-param name="authority_value" select="$authority"/>
+                        </xsl:call-template>
                         <xsl:value-of select="." />
                     </contributorName>
                     <xsl:call-template name="organizationRor">
@@ -488,6 +503,9 @@
                 <xsl:element name="contributor">
                     <xsl:attribute name="contributorType">Other</xsl:attribute>
                     <contributorName>
+                        <xsl:call-template name="nameType">
+                            <xsl:with-param name="authority_value" select="$authority"/>
+                        </xsl:call-template>
                         <xsl:value-of select="." />
                     </contributorName>
                     <xsl:call-template name="organizationRor">
@@ -711,4 +729,25 @@
         </xsl:if>
     </xsl:template>
 
+    <!--
+        This template is used to add a nameType attribute to a
+        contributorName element when a dspace.entity.type virtual
+        metadata is available to be able to tell whether the
+        contributor is a Person or an OrgUnit, or when it comes in
+        through the isOrgUnitOfPublication relationship.
+    -->
+    <xsl:template name="nameType">
+      <xsl:param name="authority_value"/>
+      <xsl:variable name="entity_type" select= "//dspace:field[@mdschema='dspace' and @element='relatedentity' and @qualifier='type' and @authority=$authority_value]" />
+      <xsl:if test="starts-with($authority_value, 'virtual::')">
+        <xsl:choose>
+          <xsl:when test="$entity_type = 'OrgUnit' or //dspace:field[@mdschema='relation' and @element='isOrgUnitOfPublication' and @authority=$authority_value]">
+            <xsl:attribute name="nameType">Organizational</xsl:attribute>
+          </xsl:when>
+          <xsl:when test="$entity_type = 'Person'">
+            <xsl:attribute name="nameType">Personal</xsl:attribute>
+          </xsl:when>
+        </xsl:choose>
+      </xsl:if>
+    </xsl:template>
 </xsl:stylesheet>

--- a/dspace/config/registries/dspace-types.xml
+++ b/dspace/config/registries/dspace-types.xml
@@ -39,6 +39,13 @@
 
     <dc-type>
         <schema>dspace</schema>
+        <element>relatedentity</element>
+        <qualifier>type</qualifier>
+        <scope_note>Stores the type of Entity that a specific Item represents when it is linked to another item</scope_note>
+    </dc-type>
+
+    <dc-type>
+        <schema>dspace</schema>
         <element>iiif</element>
         <qualifier>enabled</qualifier>
         <scope_note>Stores a boolean text value (true or false) to indicate if the iiif feature is enabled or not for the dspace object. If absent the value is derived from the parent dspace object</scope_note>

--- a/dspace/config/spring/api/virtual-metadata.xml
+++ b/dspace/config/spring/api/virtual-metadata.xml
@@ -47,6 +47,7 @@
         <entry key="dc.contributor.author" value-ref="publicationAuthor_author"/>
         <entry key="person.identifier.orcid" value-ref="publicationAuthor_identifierOrcid"/>
         <entry key="organization.identifier.ror" value-ref="publicationAuthor_identifierRor"/>
+        <entry key="dspace.relatedentity.type" value-ref="publicationAuthor_entityType"/>
     </util:map>
     <!--
          If the related item has:
@@ -79,6 +80,14 @@
         <property name="fields">
             <util:list>
                 <value>organization.identifier.ror</value>
+            </util:list>
+        </property>
+    </bean>
+
+    <bean class="org.dspace.content.virtual.Collected" id="publicationAuthor_entityType">
+        <property name="fields">
+            <util:list>
+                <value>dspace.entity.type</value>
             </util:list>
         </property>
     </bean>


### PR DESCRIPTION
## References

(Trivial) merge conflict with #11811. I will rebase one or the other when one of them is merged.

## Description

This is another PR to improve the quality of metadata exported to DataCite. Namely, it adds the `nameType` attribute to creator and contributor names according to whether the linked entity is a Person or an OrgUnit.

In order to achieve this it creates new `dspace.relatedentity.type` virtual metadata which contains the name of the type of a related entity. The `dspace.entity.type` metadata could not be used because it caused conflicts when trying to create new relationships.

Developed by The Library Code with the support of Technische Universität Dortmund and Deutsche Forschungsgemeinschaft DFG.

## Instructions for Reviewers

Link an OrgUnit and a Person as dc.contributor.author, and an OrgUnit as a dc.contributor.other, to a Publication, and export the corresponding Publication with DataCite e.g. using the `org.dspace.content.crosswalk.XSLTDisseminationCrosswalk` tool.

In order for the new virtual metadata type (and thus the feature in the DataCite XML) to work, you must re-register the metadata types in `dspace-types.xml` with `dspace registry-loader -metadata <path to the dspace-types.xml file from this branch>`

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] ~~My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).~~
- [ ] ~~My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.~~
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] ~~If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.~~
- [ ] ~~If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.~~
- [ ] ~~If my PR includes new configurations, I've provided basic technical documentation in the PR itself.~~
- [ ] ~~If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).~~
