### PR TITLE
Move same-collection check to inheritDefaultPolicies move method

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -1149,11 +1149,6 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
     public void move(Context context, Item item, Collection from, Collection to)
         throws SQLException, AuthorizeException, IOException {
 
-        // If the two collections are the same, do nothing.
-        if (from.equals(to)) {
-            return;
-        }
-
         // Use the normal move method, and default to not inherit permissions
         this.move(context, item, from, to, false);
     }
@@ -1166,6 +1161,11 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
         // only do write authorization if user is not an editor
         if (!canEdit(context, item)) {
             authorizeService.authorizeAction(context, item, Constants.WRITE);
+        }
+
+        // If the two collections are the same, do nothing.
+        if (from.equals(to)) {
+            return;
         }
 
         // Move the Item from one Collection to the other

--- a/dspace-api/src/test/java/org/dspace/content/ItemTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/ItemTest.java
@@ -1623,6 +1623,35 @@ public class ItemTest extends AbstractDSpaceObjectTest {
     }
 
     /**
+     * Test of move with inherit default policies method, of class Item, where both Collections are the same.
+     */
+    @Test
+    public void testMoveSameCollectionWithInheritDefaultPolicies() throws Exception {
+        context.turnOffAuthorisationSystem();
+        while (it.getCollections().size() > 1) {
+            it.removeCollection(it.getCollections().get(0));
+        }
+
+        Collection collection = it.getCollections().get(0);
+        it.setOwningCollection(collection);
+        // Use mock with custom default answer for Mockito 5.x compatibility with Spring proxies
+        final ItemService realItemService = itemService;
+        ItemService itemServiceSpy = mock(ItemService.class, withSettings().defaultAnswer(invocation -> {
+            try {
+                return invocation.getMethod().invoke(realItemService, invocation.getArguments());
+            } catch (java.lang.reflect.InvocationTargetException e) {
+                throw e.getCause();
+            }
+        }));
+
+        itemService.move(context, it, collection, collection, true);
+        context.restoreAuthSystemState();
+        assertThat("testMoveSameCollection 0", it.getOwningCollection(), notNullValue());
+        assertThat("testMoveSameCollection 1", it.getOwningCollection(), equalTo(collection));
+        verify(itemServiceSpy, times(0)).delete(context, it);
+    }
+
+    /**
      * Test of hasUploadedFiles method, of class Item.
      */
     @Test


### PR DESCRIPTION
## References
* Related to #8171

## Description
Ensures that moving an Item to the same Collection is safely ignored when using the `move` method with the `inheritDefaultPolicies` parameter.

## Instructions for Reviewers
This PR aligns the behavior of both `move` method variants by ensuring that no action is taken when the source and destination Collections are the same, regardless of whether `inheritDefaultPolicies` is used.

Previously, this validation existed only in the `move` method without the `inheritDefaultPolicies` parameter (added in PR #8171). This change moves the check to the core implementation so it applies consistently to both method signatures.

List of changes in this PR:
* Moved the "same Collection" check from the wrapper move method to the core move implementation that accepts the `inheritDefaultPolicies` parameter.
* Added a unit test to verify that calling move with the same source and destination Collection and `inheritDefaultPolicies = true` results in no changes to the Item.

How to test/review:
* Run the test suite and verify that the new `testMoveSameCollectionWithInheritDefaultPolicies` test passes.
* Review `ItemServiceImpl.move(...)` to confirm the early return is now applied consistently for both move variants.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
