### PR TITLE
[Docker] Fix bug in `dspace-postgres-loadsql` image which impacts frontend e2e tests

### DIFF
--- a/dspace/src/main/docker/dspace-postgres-loadsql/Dockerfile
+++ b/dspace/src/main/docker/dspace-postgres-loadsql/Dockerfile
@@ -21,9 +21,9 @@ ENV POSTGRES_DB=${POSTGRES_DB}
 ENV POSTGRES_USER=${POSTGRES_USER}
 ENV POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
 
-# Install curl which is necessary to load SQL file
+# Install curl and ca-certificates which are necessary to load SQL file
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl \
+    && apt-get install -y --no-install-recommends curl ca-certificates \
     && apt-get purge -y --auto-remove \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## References
* Bug was accidentally introduced in #11789

## Description

In #11789, we fixed several Docker lint warnings.  One of those lint fixes was to use the `--no-install-recommends` flag in the `dspace-postgres-loadsql`  Dockerfile.  While this fix was correct, it meant other useful packages were not installed alongside  `curl` when running this command:
```
apt-get install -y --no-install-recommends curl
```

The result is that the `dspace-postgres-loadsql`  **fails to startup** if you pass it any SQL file to download via HTTPS because `ca-certificates` is no longer installed.  **This is what is currently breaking e2e tests in `dspace-angular` because it attempts to load SQL from an HTTPS URL.**

The fix is to ensure `ca-certificates` is installed alongside `curl`, which is what this PR does.

## Instructions for Reviewers
* Prior to PR:
    * Running `docker compose -p fresh_install -f docker-compose.yml -f dspace/src/main/docker-compose/db.entities.yml up -d` **WILL FAIL** to start the `dspacedb` image as it attempts to download entity SQL data via an HTTPS URL.
* After this PR:
    * Running `docker compose -p fresh_install -f docker-compose.yml -f dspace/src/main/docker-compose/db.entities.yml up -d`  will succeed.