### PR TITLE
Change shardSolrIndex to copy by month

### DIFF
--- a/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java
@@ -32,7 +32,6 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;


### PR DESCRIPTION
## Description
During Solr sharding in production, we observed that execution time did not scale linearly with the number of documents per year. This PR changes the sharding logic to process data month by month instead of handling an entire year at once.

A dataset with ~58M documents previously required over 48 hours (aborted before finishing) to process. With this change, the same workload completed in ~14 hours.

## Instructions for Reviewers

List of changes in this PR:
* Previous behavior:
  * Create new core statistics-<year>.
  * For all documents of the year in core `statistics`:
    * Generate temporary CSV files in batches of 10,000 documents.
    * After all files are created, iterate and commit them to `statistics-<year>`.
  * Delete all documents of the year from `statistics`.
  * Delete all temporary files.
* New behavior (this PR):
  * Create new core statistics-<year>.
  * For each month of the year in `statistics`:
    * Generate a temporary CSV file in batches of 10,000 documents.
    * Immediately commit to `statistics-<year>` and delete the temp file.
    * Delete all documents of that month (for the given year) from `statistics`.
  * Adjusted log messages for clarity.

I've only 'tested' it by executing it in development and production DSpace.

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
