### PR TITLE
[Port dspace-9_x] Move same-collection check to inheritDefaultPolicies move method (manual port)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -1142,11 +1142,6 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
     public void move(Context context, Item item, Collection from, Collection to)
         throws SQLException, AuthorizeException, IOException {
 
-        // If the two collections are the same, do nothing.
-        if (from.equals(to)) {
-            return;
-        }
-
         // Use the normal move method, and default to not inherit permissions
         this.move(context, item, from, to, false);
     }
@@ -1159,6 +1154,11 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
         // only do write authorization if user is not an editor
         if (!canEdit(context, item)) {
             authorizeService.authorizeAction(context, item, Constants.WRITE);
+        }
+
+        // If the two collections are the same, do nothing.
+        if (from.equals(to)) {
+            return;
         }
 
         // Move the Item from one Collection to the other

--- a/dspace-api/src/test/java/org/dspace/content/ItemTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/ItemTest.java
@@ -1607,6 +1607,27 @@ public class ItemTest extends AbstractDSpaceObjectTest {
     }
 
     /**
+     * Test of move with inherit default policies method, of class Item, where both Collections are the same.
+     */
+    @Test
+    public void testMoveSameCollectionWithInheritDefaultPolicies() throws Exception {
+        context.turnOffAuthorisationSystem();
+        while (it.getCollections().size() > 1) {
+            it.removeCollection(it.getCollections().get(0));
+        }
+
+        Collection collection = it.getCollections().get(0);
+        it.setOwningCollection(collection);
+        ItemService itemServiceSpy = spy(itemService);
+
+        itemService.move(context, it, collection, collection, true);
+        context.restoreAuthSystemState();
+        assertThat("testMoveSameCollection 0", it.getOwningCollection(), notNullValue());
+        assertThat("testMoveSameCollection 1", it.getOwningCollection(), equalTo(collection));
+        verify(itemServiceSpy, times(0)).delete(context, it);
+    }
+
+    /**
      * Test of hasUploadedFiles method, of class Item.
      */
     @Test


### PR DESCRIPTION
Manual port of #11845

It should also be applicable to `dspace-8_x` and `dspace-7_x`

Replaces: #11851