### PR TITLE
Add DAO-level pagination to DOIOrganiser bulk operations

### DIFF
--- a/dspace-api/src/main/java/org/dspace/identifier/DOIServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/DOIServiceImpl.java
@@ -175,6 +175,12 @@ public class DOIServiceImpl implements DOIService {
     }
 
     @Override
+    public List<DOI> getDOIsByStatus(Context context, List<Integer> statuses, int limit, int offset)
+        throws SQLException {
+        return doiDAO.findByStatus(context, statuses, limit, offset);
+    }
+
+    @Override
     public List<DOI> getSimilarDOIsNotInState(Context context, String doiPattern, List<Integer> statuses,
                                               boolean dsoIsNotNull)
         throws SQLException {

--- a/dspace-api/src/main/java/org/dspace/identifier/dao/DOIDAO.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/dao/DOIDAO.java
@@ -33,5 +33,18 @@ public interface DOIDAO extends GenericDAO<DOI> {
 
     public List<DOI> findByStatus(Context context, List<Integer> statuses) throws SQLException;
 
+    /**
+     * Find all DOIs with any of the given statuses, with pagination support.
+     *
+     * @param context  current DSpace session.
+     * @param statuses desired statuses.
+     * @param limit    maximum number of results to return (-1 for unlimited).
+     * @param offset   number of results to skip (-1 for none).
+     * @return matching DOIs ordered by ID.
+     * @throws SQLException passed through.
+     */
+    public List<DOI> findByStatus(Context context, List<Integer> statuses, int limit, int offset)
+        throws SQLException;
+
     public DOI findDOIByDSpaceObject(Context context, DSpaceObject dso) throws SQLException;
 }

--- a/dspace-api/src/main/java/org/dspace/identifier/dao/impl/DOIDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/dao/impl/DOIDAOImpl.java
@@ -71,6 +71,12 @@ public class DOIDAOImpl extends AbstractHibernateDAO<DOI> implements DOIDAO {
 
     @Override
     public List<DOI> findByStatus(Context context, List<Integer> statuses) throws SQLException {
+        return findByStatus(context, statuses, -1, -1);
+    }
+
+    @Override
+    public List<DOI> findByStatus(Context context, List<Integer> statuses, int limit, int offset)
+        throws SQLException {
         CriteriaBuilder criteriaBuilder = getCriteriaBuilder(context);
         CriteriaQuery criteriaQuery = getCriteriaQuery(criteriaBuilder, DOI.class);
         Root<DOI> doiRoot = criteriaQuery.from(DOI.class);
@@ -80,7 +86,8 @@ public class DOIDAOImpl extends AbstractHibernateDAO<DOI> implements DOIDAO {
             orPredicates.add(criteriaBuilder.equal(doiRoot.get(DOI_.status), status));
         }
         criteriaQuery.where(criteriaBuilder.or(orPredicates.toArray(new Predicate[] {})));
-        return list(context, criteriaQuery, false, DOI.class, -1, -1);
+        criteriaQuery.orderBy(criteriaBuilder.asc(doiRoot.get(DOI_.id)));
+        return list(context, criteriaQuery, false, DOI.class, limit, offset);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/identifier/service/DOIService.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/service/DOIService.java
@@ -142,6 +142,19 @@ public interface DOIService {
     public List<DOI> getDOIsByStatus(Context context, List<Integer> statuses) throws SQLException;
 
     /**
+     * Find DOIs that have one of a given set of statuses, with pagination support.
+     *
+     * @param context  current DSpace session.
+     * @param statuses desired statuses.
+     * @param limit    maximum number of results to return (-1 for unlimited).
+     * @param offset   number of results to skip (-1 for none).
+     * @return matching DOIs ordered by ID.
+     * @throws SQLException passed through.
+     */
+    public List<DOI> getDOIsByStatus(Context context, List<Integer> statuses, int limit, int offset)
+        throws SQLException;
+
+    /**
      * Find all DOIs that are similar to the specified pattern and not in the
      * specified states.
      *


### PR DESCRIPTION
## Summary

- Adds paginated `findByStatus(context, statuses, limit, offset)` at the DAO and service layers
- Refactors all 4 bulk operations in `DOIOrganiser` (`-s`, `-r`, `-u`, `-d`) to automatically fetch DOIs in batches of 100 instead of loading all matching DOIs into memory at once
- Includes infinite-loop protection: stops when an entire batch fails (all DOIs have persistent errors)
- Fixes existing bug where update-all (`-u`) lacked per-DOI error handling

Resolves #9622

## Motivation

With 10K+ DOIs queued, `DOIOrganiser` would OOM because `findByStatus(..., -1, -1)` loaded everything into a single list. PR #9835 added per-DOI commits (reducing per-transaction memory), but the initial unbounded query remained.

This PR adds automatic batched processing: each batch queries offset 0 with limit 100. Successfully processed DOIs change status and drop out of subsequent queries, so the loop naturally terminates. Unlike the 4Science DSpace-CRIS approach (manual `--offset`/`--limit` CLI flags), this is fully transparent to the user.

## Changes

| File | Change |
|------|--------|
| `DOIDAO.java` | Add paginated `findByStatus` overload |
| `DOIDAOImpl.java` | Implement paginated query with `ORDER BY id` for deterministic results; delegate unpaginated version |
| `DOIService.java` | Add paginated `getDOIsByStatus` overload |
| `DOIServiceImpl.java` | Delegate to DAO |
| `DOIOrganiser.java` | Add `BATCH_SIZE`, `DOIOperation` interface, `processBatched()` helper; replace 4 bulk blocks |

## What is NOT changed

- Non-paginated `findByStatus`/`getDOIsByStatus` (kept for backward compat, now delegates)
- `list` command (read-only, needs all results)
- Single-DOI operations (`--reserve-doi`, `--register-doi`, etc.)
- No new configuration properties or Spring XML changes

## Test plan

- [ ] `mvn compile -pl dspace-api` — compiles cleanly
- [ ] `mvn checkstyle:check -pl dspace-api` — 0 violations
- [ ] Existing unit tests unaffected (pre-existing Spring context failures are unrelated)
- [ ] CI integration tests should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)