### PR TITLE
Replace IndexBasedSpellChecker with DirectSolrSpellChecker

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -473,19 +473,11 @@ public class SolrServiceImpl implements SearchService, IndexingService {
     @Override
     public void buildSpellCheck()
             throws SearchServiceException, IOException {
-        try {
-            if (solrSearchCore.getSolr() == null) {
-                return;
-            }
-            SolrQuery solrQuery = new SolrQuery();
-            solrQuery.set("spellcheck", true);
-            solrQuery.set(SpellingParams.SPELLCHECK_BUILD, true);
-            solrSearchCore.getSolr().query(solrQuery, solrSearchCore.REQUEST_METHOD);
-        } catch (SolrServerException e) {
-            //Make sure to also log the exception since this command is usually run from a crontab.
-            log.error(e, e);
-            throw new SearchServiceException(e);
-        }
+        // DirectSolrSpellChecker reads directly from the main Solr index at query time,
+        // so no separate build step is needed. This eliminates timeout issues on large
+        // repositories where the previous IndexBasedSpellChecker could take minutes to
+        // rebuild its parallel index.
+        log.info("Spellcheck uses DirectSolrSpellChecker — no build step required.");
     }
 
     @Override

--- a/dspace/solr/search/conf/solrconfig.xml
+++ b/dspace/solr/search/conf/solrconfig.xml
@@ -135,17 +135,23 @@
          </lst>
     </requestHandler>
 
-    <!-- IndexBasedSpellChecker uses Solr index as basis for a parallel index used for spell checking -->
+    <!-- DirectSolrSpellChecker reads directly from the main Solr index at query time.
+         No separate build step is needed, eliminating timeout issues on large repositories.
+         See: https://solr.apache.org/guide/solr/latest/query-guide/spell-checking.html -->
     <searchComponent name="spellcheck" class="solr.SpellCheckComponent">
         <str name="queryAnalyzerFieldType">textSpell</str>
 
         <lst name="spellchecker">
-          <str name="classname">solr.IndexBasedSpellChecker</str>
+          <str name="classname">solr.DirectSolrSpellChecker</str>
           <str name="name">default</str>
           <str name="field">a_spell</str>
-          <str name="spellcheckIndexDir">./spellchecker</str>
-          <str name="buildOnOptimize">true</str>
-          <str name="spellcheck.onlyMorePopular">false</str>
+          <str name="distanceMeasure">internal</str>
+          <float name="accuracy">0.5</float>
+          <int name="maxEdits">2</int>
+          <int name="minPrefix">1</int>
+          <int name="maxInspections">5</int>
+          <float name="thresholdTokenFrequency">.0001</float>
+          <int name="minQueryLength">4</int>
         </lst>
     </searchComponent>
 


### PR DESCRIPTION
## Summary

- Switch from `IndexBasedSpellChecker` to `DirectSolrSpellChecker` in the search core's `solrconfig.xml`
- Make `SolrServiceImpl.buildSpellCheck()` a no-op since `DirectSolrSpellChecker` reads directly from the main index at query time — no separate build step needed

This eliminates the spellcheck rebuild timeout reported in #11769 for repositories with ~30k–270k items. Root cause analysis in #11873.

### Why this is the right fix

| Aspect | `IndexBasedSpellChecker` (current) | `DirectSolrSpellChecker` (this PR) |
|--------|--------------------------------------|--------------------------|
| Build step | Requires explicit `spellcheck.build=true` — can time out | **No build step needed** |
| Timeout risk | Blocks for minutes on large indexes | **Zero timeout risk** |
| Maintenance | Separate index can go stale, needs rebuild cron | **Always up to date** |
| Solr support | Legacy approach | **Recommended since Solr 4.x** |

### Upgrade notes

Existing `./spellchecker/` directories inside the search core data dir become unused and can be deleted after upgrading. The `index-discovery -s` flag still works but is now a no-op for spellcheck (it logs an info message).

## :warning: Hold for Solr 10 merge

**This PR should be reviewed again / held off until the Solr 10 migration lands on `main`.** The `solrconfig.xml` in this PR targets the current Solr 8.11 config. Since the Solr 10 work may restructure or replace this config, it would be better to coordinate this change with that effort to avoid merge conflicts or redundant work. The `DirectSolrSpellChecker` approach is valid for both Solr 8 and Solr 10, but the exact config file contents may differ.

## Test plan

- [ ] Verify spellcheck still works: search with a misspelled term and confirm suggestions appear
- [ ] Verify `index-discovery -s` completes instantly (no-op, logs info message)
- [ ] Full reindex (`index-discovery -b`) and confirm search works normally
- [ ] Run `DiscoveryRestControllerIT` integration tests

## Related

- Fixes #11873
- Addresses root cause of #11769

🤖 Generated with [Claude Code](https://claude.com/claude-code)