### PR TITLE
Fix failing `S3BitStoreServiceIT` by upgrading testcontainers to version 2.0.3. 

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -860,10 +860,25 @@
         </dependency>
 
         <dependency>
-          <groupId>com.adobe.testing</groupId>
-          <artifactId>s3mock-testcontainers</artifactId>
-          <version>4.11.0</version>
-          <scope>test</scope>
+            <groupId>com.adobe.testing</groupId>
+            <artifactId>s3mock-testcontainers</artifactId>
+            <version>4.11.0</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.testcontainers</groupId>
+                    <artifactId>testcontainers</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- Override version of testcontainers that is used by s3mock-testcontainers dependency above.
+             TODO: This works around a bug with testcontainers 2.0.2. It may be possible to remove this testcontainers
+             dependency (and the exclusion above) after the next upgrade of s3mock-testcontainers. -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>2.0.3</version>
+            <scope>test</scope>
         </dependency>
 
         <!-- JClouds Assetstorage Support -->


### PR DESCRIPTION
## Description
The `S3BitStoreServiceIT` has begun to consistently fail on `main`, `dspace-9_x` and `dspace-8_x` branches as of today with the following error:
```
[ERROR] org.dspace.storage.bitstore.S3BitStoreServiceIT -- Time elapsed: 49.01 s <<< ERROR!
java.lang.IllegalStateException: Could not find a valid Docker environment. Please see logs and check configuration
        at org.testcontainers.dockerclient.DockerClientProviderStrategy.lambda$getFirstValidStrategy$7(DockerClientProviderStrategy.java:274)
        at java.base/java.util.Optional.orElseThrow(Optional.java:403)
        at org.testcontainers.dockerclient.DockerClientProviderStrategy.getFirstValidStrategy(DockerClientProviderStrategy.java:265)
        at org.testcontainers.DockerClientFactory.getOrInitializeStrategy(DockerClientFactory.java:154)
        at org.testcontainers.DockerClientFactory.client(DockerClientFactory.java:196)
        at org.testcontainers.DockerClientFactory$1.getDockerClient(DockerClientFactory.java:108)
        at com.github.dockerjava.api.DockerClientDelegate.authConfig(DockerClientDelegate.java:109)
        at org.testcontainers.containers.GenericContainer.start(GenericContainer.java:321)
        at org.dspace.storage.bitstore.S3BitStoreServiceIT.setupS3(S3BitStoreServiceIT.java:86)
```
For example: https://github.com/DSpace/DSpace/actions/runs/21926008028/job/63456300501

After digging around, I found references to this error in `testcontainers`, which is used by the `s3mock-testcontainers` dependency that we use in this `S3BitStoreServiceIT`:

https://github.com/testcontainers/testcontainers-java/issues/11212 and https://github.com/testcontainers/testcontainers-java/issues/11232

This issue was fixed in `testcontainers` version 2.0.3, but the latest version of `s3mock-testcontainers` still uses version 2.0.2 of that library.

So, this PR updates our POM to **override** `s3mock-testcontainers` to use `testcontainers` version 2.0.3.

## Instructions for Reviewers
* This PR only updates test dependences. 
* The `S3BitStoreServiceIT` test is failing on `main`, `dspace-9_x` and `dspace-8_x`. As long as that IT now passes, I plan to merge this immediately
    * (NOTE: This does NOT impact `dspace-7_x` because that uses `testcontainers` directly, and it was already upgraded to 2.0.3 in #11729)