### PR TITLE
[Port dspace-8_x] Fix test failures in `WorkflowCurationIT` when executed after `CreateMissingIdentifiersIT`.

### DIFF
--- a/dspace-api/src/test/java/org/dspace/ctask/general/CreateMissingIdentifiersIT.java
+++ b/dspace-api/src/test/java/org/dspace/ctask/general/CreateMissingIdentifiersIT.java
@@ -45,6 +45,7 @@ public class CreateMissingIdentifiersIT
         // Must remove any cached named plugins before creating a new one
         CoreServiceFactory.getInstance().getPluginService().clearNamedPluginClasses();
         // Define a new task dynamically
+        String[] prevTaskDef = configurationService.getArrayProperty(P_TASK_DEF);
         configurationService.setProperty(P_TASK_DEF,
                 CreateMissingIdentifiers.class.getCanonicalName() + " = " + TASK_NAME);
 
@@ -82,5 +83,6 @@ public class CreateMissingIdentifiersIT
         curator.curate(context, item);
         int status = curator.getStatus(TASK_NAME);
         assertEquals("Curation should succeed", Curator.CURATE_SUCCESS, status);
+        configurationService.setProperty(P_TASK_DEF, prevTaskDef);
     }
 }

--- a/dspace-api/src/test/java/org/dspace/workflow/WorkflowCurationIT.java
+++ b/dspace-api/src/test/java/org/dspace/workflow/WorkflowCurationIT.java
@@ -22,6 +22,7 @@ import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.MetadataValue;
 import org.dspace.content.service.ItemService;
+import org.dspace.core.LegacyPluginServiceImpl;
 import org.dspace.ctask.testing.MarkerTask;
 import org.dspace.eperson.EPerson;
 import org.dspace.util.DSpaceConfigurationInitializer;
@@ -29,6 +30,7 @@ import org.dspace.util.DSpaceKernelInitializer;
 import org.dspace.xmlworkflow.storedcomponents.XmlWorkflowItem;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -46,6 +48,8 @@ public class WorkflowCurationIT
         extends AbstractIntegrationTestWithDatabase {
     @Inject
     private ItemService itemService;
+    @Autowired
+    private LegacyPluginServiceImpl legacyPluginService;
 
     /**
      * Basic smoke test of a curation task attached to a workflow step.
@@ -56,6 +60,7 @@ public class WorkflowCurationIT
     public void curationTest()
             throws Exception {
         context.turnOffAuthorisationSystem();
+        legacyPluginService.clearNamedPluginClasses();
 
         //** GIVEN **
 


### PR DESCRIPTION


## References
This PR is backporting minor IT changes which were already made on `main` and `dspace-9_x` as subcommits of these PRs:
* #10684 - See commit a9eda335f442e81aed09508178fc2bad747d2817 and bde999160119842559da4f3ea18294d997829a65
* #11453 - See commit a9eda335f442e81aed09508178fc2bad747d2817 and bde999160119842559da4f3ea18294d997829a65

## Description
Fix broken `WorkflowCurationIT` due to random order execution.  When `CreateMissingIdentifiersIT` is run before `WorkflowCurationIT`, it was causing the latter to fail.

This failure is currently occurring on `dspace-8_x` builds, e.g. https://github.com/DSpace/DSpace/actions/runs/21967489274/job/63526556880

This PR also needs to be backported to `dspace-7_x` as the changes have not been applied to that branch either.

## Instructions for Reviewers
* Only includes minor fixes to ITs.  If these ITs succeed now, then the fix worked.