### PR TITLE
Migrate remaining Apache Commons Lang 2 imports to 3

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -76,6 +76,12 @@ For more information on CheckStyle configurations below, see: http://checkstyle.
             <property name="separateLineBetweenGroups" value="true"/>
             <property name="customImportOrderRules" value="STATIC###STANDARD_JAVA_PACKAGE###THIRD_PARTY_PACKAGE"/>
         </module>
+        <!-- Forbid obsolete Apache Commons Lang 2 imports -->
+        <module name="IllegalImport">
+            <property name="illegalPkgs" value="org.apache.commons.lang"/> <!-- use org.apache.commons.lang3 instead -->
+            <message key="import.illegal"
+                     value="Do not use obsolete Apache Commons Lang 2; use Lang 3 or (preferably) JDK alternatives"/>
+        </module>
 
         <!-- ##### Javadocs requirements ##### -->
         <!-- Requirements for Javadocs for classes/interfaces -->

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/TikaTextExtractionFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/TikaTextExtractionFilter.java
@@ -15,7 +15,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.poi.util.IOUtils;

--- a/dspace-api/src/main/java/org/dspace/app/util/OpenSearchServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/OpenSearchServiceImpl.java
@@ -19,7 +19,7 @@ import com.rometools.modules.opensearch.OpenSearchModule;
 import com.rometools.modules.opensearch.entity.OSQuery;
 import com.rometools.modules.opensearch.impl.OpenSearchModuleImpl;
 import com.rometools.rome.io.FeedException;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.util.service.OpenSearchService;
 import org.dspace.content.DSpaceObject;

--- a/dspace-api/src/main/java/org/dspace/authenticate/OidcAuthenticationBean.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/OidcAuthenticationBean.java
@@ -10,7 +10,7 @@ package org.dspace.authenticate;
 
 import static java.lang.String.format;
 import static java.net.URLEncoder.encode;
-import static org.apache.commons.lang.BooleanUtils.toBoolean;
+import static org.apache.commons.lang3.BooleanUtils.toBoolean;
 import static org.apache.commons.lang3.StringUtils.isAnyBlank;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 

--- a/dspace-api/src/main/java/org/dspace/authenticate/OrcidAuthenticationBean.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/OrcidAuthenticationBean.java
@@ -9,7 +9,7 @@ package org.dspace.authenticate;
 
 import static java.lang.String.format;
 import static java.net.URLEncoder.encode;
-import static org.apache.commons.lang.BooleanUtils.toBoolean;
+import static org.apache.commons.lang3.BooleanUtils.toBoolean;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.dspace.content.Item.ANY;
 

--- a/dspace-api/src/main/java/org/dspace/authority/orcid/Orcidv3AuthorityValue.java
+++ b/dspace-api/src/main/java/org/dspace/authority/orcid/Orcidv3AuthorityValue.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import org.apache.commons.lang.ObjectUtils;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.solr.common.SolrDocument;

--- a/dspace-api/src/main/java/org/dspace/authority/orcid/Orcidv3SolrAuthorityImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authority/orcid/Orcidv3SolrAuthorityImpl.java
@@ -16,7 +16,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.authority.AuthorityValue;

--- a/dspace-api/src/main/java/org/dspace/authorize/RegexPasswordValidator.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/RegexPasswordValidator.java
@@ -7,7 +7,7 @@
  */
 package org.dspace.authorize;
 
-import static org.apache.commons.lang.StringUtils.isNotBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.util.regex.Pattern;
 

--- a/dspace-api/src/main/java/org/dspace/content/DSpaceObjectServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/DSpaceObjectServiceImpl.java
@@ -20,8 +20,8 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang.NotImplementedException;
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.Logger;

--- a/dspace-api/src/main/java/org/dspace/content/FeedbackServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/FeedbackServiceImpl.java
@@ -12,7 +12,7 @@ import java.util.Objects;
 
 import jakarta.mail.MessagingException;
 import jakarta.servlet.http.HttpServletRequest;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.dspace.content.service.FeedbackService;
 import org.dspace.core.Context;
 import org.dspace.core.Email;

--- a/dspace-api/src/main/java/org/dspace/eperson/AccountServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/AccountServiceImpl.java
@@ -19,7 +19,7 @@ import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import jakarta.mail.MessagingException;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.authenticate.service.AuthenticationService;

--- a/dspace-api/src/main/java/org/dspace/google/GoogleAsyncEventListener.java
+++ b/dspace-api/src/main/java/org/dspace/google/GoogleAsyncEventListener.java
@@ -21,7 +21,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.apache.commons.collections.Buffer;
 import org.apache.commons.collections.BufferUtils;
 import org.apache.commons.collections.buffer.CircularFifoBuffer;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.content.Bitstream;

--- a/dspace-api/src/main/java/org/dspace/google/client/GoogleAnalytics4ClientRequestBuilder.java
+++ b/dspace-api/src/main/java/org/dspace/google/client/GoogleAnalytics4ClientRequestBuilder.java
@@ -8,7 +8,6 @@
 package org.dspace.google.client;
 
 import static java.util.stream.Collectors.groupingBy;
-import static org.apache.commons.lang.StringUtils.startsWith;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -20,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.dspace.google.GoogleAnalyticsEvent;
 import org.dspace.services.ConfigurationService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,7 +47,7 @@ public class GoogleAnalytics4ClientRequestBuilder implements GoogleAnalyticsClie
     @Override
     public String getEndpointUrl(String analyticsKey) {
 
-        if (!startsWith(analyticsKey, "G-")) {
+        if (!Strings.CS.startsWith(analyticsKey, "G-")) {
             throw new IllegalArgumentException("Only keys with G- prefix are supported");
         }
 

--- a/dspace-api/src/main/java/org/dspace/google/client/UniversalAnalyticsClientRequestBuilder.java
+++ b/dspace-api/src/main/java/org/dspace/google/client/UniversalAnalyticsClientRequestBuilder.java
@@ -7,7 +7,6 @@
  */
 package org.dspace.google.client;
 
-import static org.apache.commons.lang.StringUtils.startsWith;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 import java.net.URLEncoder;
@@ -16,6 +15,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.Strings;
 import org.dspace.google.GoogleAnalyticsEvent;
 
 /**
@@ -41,7 +41,7 @@ public class UniversalAnalyticsClientRequestBuilder implements GoogleAnalyticsCl
     @Override
     public List<String> composeRequestsBody(String analyticsKey, List<GoogleAnalyticsEvent> events) {
 
-        if (!startsWith(analyticsKey, "UA-")) {
+        if (!Strings.CS.startsWith(analyticsKey, "UA-")) {
             throw new IllegalArgumentException("Only keys with UA- prefix are supported");
         }
 

--- a/dspace-api/src/main/java/org/dspace/identifier/doi/DataCiteConnector.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/doi/DataCiteConnector.java
@@ -19,7 +19,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;

--- a/dspace-api/src/main/java/org/dspace/importer/external/cinii/CiniiImportMetadataSourceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/cinii/CiniiImportMetadataSourceServiceImpl.java
@@ -21,7 +21,7 @@ import java.util.Objects;
 import java.util.concurrent.Callable;
 
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpException;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.logging.log4j.LogManager;

--- a/dspace-api/src/main/java/org/dspace/importer/external/metadatamapping/contributor/AuthorMetadataContributor.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/metadatamapping/contributor/AuthorMetadataContributor.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.dspace.importer.external.metadatamapping.MetadataFieldConfig;
 import org.dspace.importer.external.metadatamapping.MetadatumDTO;
 import org.jaxen.JaxenException;

--- a/dspace-api/src/main/java/org/dspace/matomo/factory/MatomoRequestDetailsEnricherFactory.java
+++ b/dspace-api/src/main/java/org/dspace/matomo/factory/MatomoRequestDetailsEnricherFactory.java
@@ -10,7 +10,7 @@ package org.dspace.matomo.factory;
 import java.sql.SQLException;
 import java.util.Optional;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.content.DSpaceObject;

--- a/dspace-api/src/main/java/org/dspace/profile/ResearcherProfileServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/profile/ResearcherProfileServiceImpl.java
@@ -26,7 +26,7 @@ import java.util.UUID;
 
 import jakarta.annotation.PostConstruct;
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.exception.ResourceAlreadyExistsException;

--- a/dspace-api/src/main/java/org/dspace/statistics/export/service/OpenUrlServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/export/service/OpenUrlServiceImpl.java
@@ -14,7 +14,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;

--- a/dspace-api/src/main/java/org/dspace/subscriptions/ContentGenerator.java
+++ b/dspace-api/src/main/java/org/dspace/subscriptions/ContentGenerator.java
@@ -8,7 +8,7 @@
 package org.dspace.subscriptions;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.commons.lang.StringUtils.EMPTY;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
 
 import java.io.ByteArrayOutputStream;
 import java.util.HashMap;

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/XmlWorkflowServiceImpl.java
@@ -22,7 +22,7 @@ import java.util.UUID;
 import jakarta.mail.MessagingException;
 import jakarta.servlet.http.HttpServletRequest;
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.ResourcePolicy;

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/processingaction/SelectReviewerAction.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/state/actions/processingaction/SelectReviewerAction.java
@@ -15,7 +15,7 @@ import java.util.UUID;
 
 import jakarta.annotation.Nullable;
 import jakarta.servlet.http.HttpServletRequest;
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/dspace-api/src/test/java/org/dspace/builder/VersionBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/VersionBuilder.java
@@ -10,7 +10,7 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.util.Objects;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;

--- a/dspace-api/src/test/java/org/dspace/eperson/SubscribeServiceIT.java
+++ b/dspace-api/src/test/java/org/dspace/eperson/SubscribeServiceIT.java
@@ -24,7 +24,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.dspace.AbstractIntegrationTestWithDatabase;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.builder.CollectionBuilder;

--- a/dspace-api/src/test/java/org/dspace/google/client/UniversalAnalyticsClientRequestBuilderTest.java
+++ b/dspace-api/src/test/java/org/dspace/google/client/UniversalAnalyticsClientRequestBuilderTest.java
@@ -8,7 +8,7 @@
 package org.dspace.google.client;
 
 import static java.util.List.of;
-import static org.apache.commons.lang.StringUtils.countMatches;
+import static org.apache.commons.lang3.StringUtils.countMatches;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;

--- a/dspace-api/src/test/java/org/dspace/iiif/canvasdimension/CanvasDimensionsIT.java
+++ b/dspace-api/src/test/java/org/dspace/iiif/canvasdimension/CanvasDimensionsIT.java
@@ -15,7 +15,7 @@ import java.io.InputStream;
 import java.io.PrintStream;
 import java.util.regex.Pattern;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.dspace.AbstractIntegrationTestWithDatabase;
 import org.dspace.builder.BitstreamBuilder;
 import org.dspace.builder.CollectionBuilder;

--- a/dspace-api/src/test/java/org/dspace/orcid/service/OrcidEntityFactoryServiceIT.java
+++ b/dspace-api/src/test/java/org/dspace/orcid/service/OrcidEntityFactoryServiceIT.java
@@ -7,7 +7,6 @@
  */
 package org.dspace.orcid.service;
 
-import static org.apache.commons.lang.StringUtils.endsWith;
 import static org.dspace.app.matcher.LambdaMatcher.has;
 import static org.dspace.app.matcher.LambdaMatcher.matches;
 import static org.dspace.builder.RelationshipTypeBuilder.createRelationshipTypeBuilder;
@@ -27,6 +26,7 @@ import static org.orcid.jaxb.model.common.SequenceType.FIRST;
 import java.util.List;
 import java.util.function.Predicate;
 
+import org.apache.commons.lang3.Strings;
 import org.dspace.AbstractIntegrationTestWithDatabase;
 import org.dspace.builder.CollectionBuilder;
 import org.dspace.builder.CommunityBuilder;
@@ -386,6 +386,6 @@ public class OrcidEntityFactoryServiceIT extends AbstractIntegrationTestWithData
     }
 
     private Predicate<Url> urlEndsWith(String handle) {
-        return url -> url != null && url.getValue() != null && endsWith(url.getValue(), handle);
+        return url -> url != null && url.getValue() != null && Strings.CI.endsWith(url.getValue(), handle);
     }
 }

--- a/dspace-api/src/test/java/org/dspace/storage/bitstore/S3BitStoreServiceIT.java
+++ b/dspace-api/src/test/java/org/dspace/storage/bitstore/S3BitStoreServiceIT.java
@@ -36,7 +36,7 @@ import java.util.Map;
 
 import com.adobe.testing.s3mock.testcontainers.S3MockContainer;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.BooleanUtils;
+import org.apache.commons.lang3.BooleanUtils;
 import org.dspace.AbstractIntegrationTestWithDatabase;
 import org.dspace.app.matcher.LambdaMatcher;
 import org.dspace.authorize.AuthorizeException;

--- a/dspace-api/src/test/java/org/dspace/util/DoiCheckTest.java
+++ b/dspace-api/src/test/java/org/dspace/util/DoiCheckTest.java
@@ -14,7 +14,7 @@ import java.text.ParseException;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.dspace.importer.external.service.DoiCheck;
 import org.junit.Test;
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/CanManageMappingsFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/CanManageMappingsFeature.java
@@ -10,7 +10,7 @@ import java.sql.SQLException;
 import java.util.Optional;
 import java.util.UUID;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.dspace.app.rest.authorization.AuthorizationFeature;
 import org.dspace.app.rest.authorization.AuthorizationFeatureDocumentation;
 import org.dspace.app.rest.model.BaseObjectRest;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/CanSendFeedbackFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/CanSendFeedbackFeature.java
@@ -8,7 +8,7 @@
 package org.dspace.app.rest.authorization.impl;
 import java.sql.SQLException;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.dspace.app.rest.authorization.AuthorizationFeature;
 import org.dspace.app.rest.authorization.AuthorizationFeatureDocumentation;
 import org.dspace.app.rest.model.BaseObjectRest;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/DiscoverConfigurationConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/DiscoverConfigurationConverter.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.dspace.app.rest.model.SearchConfigurationRest;
 import org.dspace.app.rest.projection.Projection;
 import org.dspace.discovery.configuration.DiscoveryConfiguration;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/hdlresolver/HdlResolverRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/hdlresolver/HdlResolverRestController.java
@@ -14,7 +14,7 @@ import java.util.Optional;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.utils.ContextUtil;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/EntityTypeRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/EntityTypeRestRepository.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.dspace.app.rest.SearchRestMethod;
 import org.dspace.app.rest.model.EntityTypeRest;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/QAEventRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/QAEventRestRepository.java
@@ -16,7 +16,7 @@ import java.util.UUID;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.http.HttpServletRequest;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.dspace.app.rest.Parameter;
 import org.dspace.app.rest.SearchRestMethod;
 import org.dspace.app.rest.exception.RepositoryMethodNotImplementedException;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/VersionRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/VersionRestRepository.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.Objects;
 
 import jakarta.servlet.http.HttpServletRequest;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.converter.ConverterService;
 import org.dspace.app.rest.exception.DSpaceBadRequestException;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/ExtractorOfAInprogressSubmissionInformations.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/ExtractorOfAInprogressSubmissionInformations.java
@@ -12,7 +12,7 @@ import java.util.UUID;
 
 import jakarta.annotation.Nullable;
 import jakarta.servlet.http.HttpServletRequest;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.dspace.app.rest.model.WorkflowItemRest;
 import org.dspace.app.rest.model.WorkspaceItemRest;
 import org.dspace.app.rest.utils.ContextUtil;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/ResourcePolicyAdminPermissionEvalutatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/ResourcePolicyAdminPermissionEvalutatorPlugin.java
@@ -11,8 +11,8 @@ import java.io.Serializable;
 import java.sql.SQLException;
 import java.util.UUID;
 
-import org.apache.commons.lang.math.NumberUtils;
 import org.apache.commons.lang3.Strings;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.model.ResourcePolicyRest;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/signposting/converter/LinksetRestMessageConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/signposting/converter/LinksetRestMessageConverter.java
@@ -9,7 +9,7 @@ package org.dspace.app.rest.signposting.converter;
 
 import static java.lang.String.format;
 import static java.util.Objects.nonNull;
-import static org.apache.commons.lang.StringUtils.isNotBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.util.List;
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/signposting/processor/item/ItemAuthorProcessor.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/signposting/processor/item/ItemAuthorProcessor.java
@@ -8,8 +8,8 @@
 package org.dspace.app.rest.signposting.processor.item;
 
 import static java.util.Objects.nonNull;
-import static org.apache.commons.lang.StringUtils.isNotBlank;
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.dspace.content.Item.ANY;
 
 import java.text.MessageFormat;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/AccessConditionReplacePatchOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/AccessConditionReplacePatchOperation.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.Objects;
 
 import jakarta.servlet.http.HttpServletRequest;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.exception.UnprocessableEntityException;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/AccessConditionStep.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/AccessConditionStep.java
@@ -11,7 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import jakarta.servlet.http.HttpServletRequest;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.dspace.app.rest.exception.UnprocessableEntityException;
 import org.dspace.app.rest.model.AccessConditionDTO;
 import org.dspace.app.rest.model.patch.Operation;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/ShowIdentifiersStep.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/ShowIdentifiersStep.java
@@ -12,7 +12,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import jakarta.servlet.http.HttpServletRequest;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.model.patch.Operation;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/AccessConditionOptionMatcher.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/matcher/AccessConditionOptionMatcher.java
@@ -6,6 +6,7 @@
  * http://www.dspace.org/license/
  */
 package org.dspace.app.rest.matcher;
+
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasNoJsonPath;
 import static org.hamcrest.Matchers.allOf;
@@ -14,7 +15,7 @@ import static org.hamcrest.Matchers.notNullValue;
 
 import java.util.Objects;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.Matcher;
 
 /**


### PR DESCRIPTION
## References
* Fixes #11911 

## Description
This PR completes the migration of Apache Commons Lang 2.x usages to Lang 3.x in DSpace. 

It also adds a Checkstyle rule to discourage future usage of Lang 2 classes.

## Instructions for Reviewers
Changes included in this PR:
* Replaced all imports of `org.apache.commons.lang.*` with `org.apache.commons.lang3.*`:
  * 1 × `ArrayUtils`
  * 1 × `BooleanUtils`
  * 1 × `NotImplementedException`
  * 1 × `ObjectUtils`
  * 1 × `StringUtils.EMPTY`
  * 1 × `StringUtils.countMatches`
  * 1 × `NumberUtils`
  * 2 × `BooleanUtils.toBoolean`
  * 3 × `Strings` (see below)
  * 3 × `StringUtils.isNotBlank`
  * 29 × `StringUtils`
* Updated deprecated `StringUtils#startsWith` and `StringUtils#endsWith` to use `Strings.CS` (case-sensitive), `String.CI` (case-insensitive):
  * `GoogleAnalytics4ClientRequestBuilder` & `UniversalAnalyticsClientRequestBuilder` – Google UA-/G-code checks (**they are case-sensitive**, [source](https://www.drupal.org/project/google_analytics/issues/1336252))
  * `OrcidEntityFactoryServiceIT` – `urlEndsWith` usage (this is **case-insensitive**, [source](https://github.com/DSpace/DSpace/pull/11912#discussion_r2813458240))
* Added a Checkstyle `IllegalImport` module to warn against usage of Apache Commons Lang 2 in future code.

**Testing Guidance:**
1. Build DSpace. Ensure compilation passes. Verify unit and integration tests.
2. Confirm new checkstyle warning (`mvn checkstyle:check`) if any `org.apache.commons.lang` import is introduced in new code.

The new check should look like this:

```
[INFO] --- checkstyle:3.6.0:check (default-cli) @ dspace-api ---
[INFO] There is 1 error reported by Checkstyle 10.26.1 with /[dspace-source]/dspace-api/../checkstyle.xml ruleset.
[ERROR] src/test/java/org/dspace/builder/VersionBuilder.java:[13,1] (imports) IllegalImport: Do not use obsolete Apache Commons Lang 2; use Lang 3 or (preferably) JDK alternatives
```

## Checklist
- [X] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [X] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [X] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [X] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
