### PR TITLE
Remove ErrorProne pin and bump to latest version for JDK 21

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -135,10 +135,6 @@ updates:
       # Don't try to auto-update any DSpace dependencies
       - dependency-name: "org.dspace:*"
       - dependency-name: "org.dspace.*:*"
-      # Last version of errorprone to support JDK 17 is 2.42.0
-      # TODO: Remove this after this ticket is resolved https://github.com/DSpace/DSpace/issues/11621
-      - dependency-name: "com.google.errorprone:*"
-        versions: [ ">=2.43.0" ]
       # Don't automatically update BouncyCastle because maven-gpg-plugin REQUIRES a very specific version or release
       # errors will occur. See https://github.com/DSpace/DSpace/pull/11696
       - dependency-name: "org.bouncycastle:*"
@@ -277,9 +273,6 @@ updates:
       # Don't try to auto-update any DSpace dependencies
       - dependency-name: "org.dspace:*"
       - dependency-name: "org.dspace.*:*"
-      # Last version of errorprone to support JDK 17 is 2.42.0
-      - dependency-name: "com.google.errorprone:*"
-        versions: [ ">=2.43.0" ]
       # Don't automatically update BouncyCastle because maven-gpg-plugin REQUIRES a very specific version or release
       # errors will occur. See https://github.com/DSpace/DSpace/pull/11696
       - dependency-name: "org.bouncycastle:*"
@@ -418,9 +411,6 @@ updates:
       # Don't try to auto-update any DSpace dependencies
       - dependency-name: "org.dspace:*"
       - dependency-name: "org.dspace.*:*"
-      # Last version of errorprone to support JDK 17 is 2.42.0
-      - dependency-name: "com.google.errorprone:*"
-        versions: [ ">=2.43.0" ]
       # Don't automatically update BouncyCastle because maven-gpg-plugin REQUIRES a very specific version or release
       # errors will occur. See https://github.com/DSpace/DSpace/pull/11696
       - dependency-name: "org.bouncycastle:*"

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <solr.client.version>8.11.4</solr.client.version>
 
         <ehcache.version>3.11.1</ehcache.version>
-        <errorprone.version>2.42.0</errorprone.version>
+        <errorprone.version>2.47.0</errorprone.version>
         <!-- NOTE: when updating jackson.version, also sync jackson-annotations.version below -->
         <jackson.version>2.20.1</jackson.version>
         <jackson-annotations.version>2.20</jackson-annotations.version>
@@ -154,6 +154,8 @@
                             <arg>-XDcompilePolicy=simple</arg>
                             <arg>--should-stop=ifError=FLOW</arg>
                             <arg>-Xplugin:ErrorProne</arg>
+                            <!-- Required by Error Prone on JDK 21+: enables javac fix for JDK-8225377 -->
+                            <arg>-XDaddTypeAnnotationsToSymbol=true</arg>
                             <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
                             <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
                             <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>


### PR DESCRIPTION
## References
* Fixes #11913
* Completes #11621 
* Relates to #11739 (introduce JDK 21)
* Reverts #11622 (ErrorProne pin)

## Description
This PR:
- removes the ErrorProne version pin now that JDK 21 is supported
- bumps ErrorProne to the latest stable version
- adds a new required compiler flag for JDK 21+ compatibility: `<arg>-XDaddTypeAnnotationsToSymbol=true</arg>`

**Without the flag**, error prone gives the following error:

```java
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.14.1:compile (default-compile) on project dspace-services: Compilation failure
[ERROR]         at jdk.compiler/com.sun.tools.javac.api.BasicJavacTask.initPlugins(BasicJavacTask.java:232)
[ERROR]         at jdk.compiler/com.sun.tools.javac.main.Main.compile(Main.java:294)
[ERROR]         at jdk.compiler/com.sun.tools.javac.main.Main.compile(Main.java:178)
[ERROR]         at jdk.compiler/com.sun.tools.javac.Main.compile(Main.java:64)
[ERROR]         at jdk.compiler/com.sun.tools.javac.Main.main(Main.java:50)
[ERROR] Caused by: com.google.errorprone.InvalidCommandLineOptionException: -XDaddTypeAnnotationsToSymbol=true is required by Error Prone on JDK 21
[ERROR]         at com.google.errorprone.BaseErrorProneJavaCompiler.checkAddTypeAnnotationsToSymbol(BaseErrorProneJavaCompiler.java:243)
[ERROR]         at com.google.errorprone.BaseErrorProneJavaCompiler.addTaskListener(BaseErrorProneJavaCompiler.java:91)
[ERROR]         at com.google.errorprone.ErrorProneJavacPlugin.init(ErrorProneJavacPlugin.java:34)
[ERROR]         at jdk.compiler/com.sun.tools.javac.api.BasicJavacTask.initPlugin(BasicJavacTask.java:256)
[ERROR]         at jdk.compiler/com.sun.tools.javac.api.BasicJavacTask.initPlugins(BasicJavacTask.java:230)
[ERROR]         ... 4 more
```

## Instructions for Reviewers
* google/error-prone diff v2.42.0 (current) -> v2.47.0 (new in this PR): https://github.com/google/error-prone/compare/v2.42.0...v2.47.0

No runtime behaviour changes are expected, **only compile-time analysis** is affected.

To test, run `mvn clean verify` and observe that project compiles without errors.

## Checklist
- [X] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [X] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [X] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [X] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
