### PR TITLE
[DSpace-CRIS] Nested / Basic Hierarchical Metadata (Backend)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
           #  - surefire.rerunFailingTestsCount => try again for flakey tests, and keep track of/report on number of retries
           - type: "Unit Tests"
             java: 21
-            mvnflags: "-Dtest.argLine=-Xmx2048m -DskipUnitTests=false -Dsurefire.rerunFailingTestsCount=2"
+            mvnflags: "-DskipUnitTests=false -Dsurefire.rerunFailingTestsCount=2"
             resultsdir: "**/target/surefire-reports/**"
           # NOTE: ITs skip all code validation checks, as they are already done by Unit Test job.
           #  - enforcer.skip     => Skip maven-enforcer-plugin rules

--- a/dspace-api/src/main/java/org/dspace/app/util/DCInputSet.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/DCInputSet.java
@@ -119,6 +119,42 @@ public class DCInputSet {
         return getField(fieldName).isPresent();
     }
 
+    /**
+     * Recursively searches for a field by its fully qualified name within this input set.
+     *
+     * <p>The search process handles several field types differently:</p>
+     *
+     * <ul>
+     *   <li><strong>qualdrop_value fields:</strong> Checks both the base field name and all possible
+     *       qualifier combinations from the dropdown pairs</li>
+     *   <li><strong>group fields:</strong> Recursively searches in child forms following the naming
+     *       convention {@code {parentFormName}-{schema}-{element}-{qualifier}}. Child forms are loaded
+     *       and searched for nested fields. This allows relation-fields with grouped metadata
+     *       (e.g., author with affiliation) to be properly resolved.</li>
+     *   <li><strong>inline-group fields:</strong> Similar to group fields, recursively searches in child
+     *       forms for nested fields within inline groups. The difference from group is that inline-group
+     *       is used for simple field grouping without relation-field associations.</li>
+     *   <li><strong>relationship fields:</strong> Matches fields using the pattern
+     *       {@code relation.{relationshipType}}</li>
+     *   <li><strong>standard fields:</strong> Direct field name matching</li>
+     * </ul>
+     *
+     * <p><strong>Behavior difference between group and inline-group:</strong></p>
+     * <ul>
+     *   <li><strong>group:</strong> Used within {@code <relation-field>} elements to define nested metadata
+     *       that should be grouped with relationship entities. For example, when creating an author relationship,
+     *       the author's affiliation can be captured as grouped metadata. The parent field stores a placeholder
+     *       value or relationship reference.</li>
+     *   <li><strong>inline-group:</strong> Used for simple grouping of related metadata fields without
+     *       relationship associations. Fields are grouped purely for UI presentation and data organization.
+     *       Both parent and child fields store actual metadata values directly on the item.</li>
+     * </ul>
+     *
+     * @param fieldName the fully qualified field name to search for, in the format
+     *                  {@code schema.element.qualifier} (e.g., "dc.contributor.author")
+     * @return an Optional containing the DCInput if found, or Optional.empty() if not found
+     *         or if an error occurs during recursive resolution
+     */
     public Optional<DCInput> getField(String fieldName) {
         for (int i = 0; i < inputs.length; i++) {
             for (int j = 0; j < inputs[i].length; j++) {
@@ -134,6 +170,8 @@ public class DCInputSet {
                         }
                     }
                 } else if (Strings.CS.equalsAny(field.getInputType(), "group", "inline-group")) {
+                    // For group and inline-group types, recursively search in child form
+                    // Child form naming convention: {parentFormName}-{schema}-{element}-{qualifier}
                     String formName = getFormName() + "-" + Utils.standardize(field.getSchema(),
                         field.getElement(), field.getQualifier(), "-");
                     try {

--- a/dspace-api/src/main/java/org/dspace/app/util/DCInputsReader.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/DCInputsReader.java
@@ -220,8 +220,7 @@ public class DCInputsReader {
         if (pages == null) {
             throw new DCInputsReaderException("Missing the " + formName + " form");
         }
-        lastInputSet = new DCInputSet(formName,
-                                      pages, valuePairs);
+        lastInputSet = new DCInputSet(this, formName, pages, valuePairs);
         return lastInputSet;
     }
 

--- a/dspace-api/src/test/data/dspaceFolder/config/item-submission.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/item-submission.xml
@@ -20,6 +20,8 @@
         <name-map collection-handle="default" submission-name="traditional"/>
         <name-map collection-handle="123456789/traditional-with-custom-url"
                   submission-name="traditional-with-custom-url"/>
+        <name-map collection-handle="123456789/nested-metadata-test"
+                  submission-name="nestedMetadataTest"/>
         <name-map collection-handle="123456789/language-test-1" submission-name="languagetestprocess"/>
         <name-map collection-handle="123456789/extraction-test" submission-name="extractiontestprocess"/>
         <name-map collection-handle="123456789/qualdrop-test" submission-name="qualdroptest"/>
@@ -223,6 +225,12 @@
             <type>submission-form</type>
         </step-definition>
 
+        <step-definition id="publicationStepGroup" mandatory="true">
+            <heading>submit.progressbar.describe.stepone</heading>
+            <processing-class>org.dspace.app.rest.submit.step.DescribeStep</processing-class>
+            <type>submission-form</type>
+        </step-definition>
+
         <step-definition id="custom-url">
             <heading>submit.progressbar.CustomUrlStep</heading>
             <processing-class>org.dspace.app.rest.submit.step.CustomUrlStep</processing-class>
@@ -351,6 +359,11 @@
             <step id="traditionalpageone" />
             <step id="upload-no-required-metadata" />
             <step id="license" />
+        </submission-process>
+
+        <submission-process name="nestedMetadataTest">
+            <step id="collection" />
+            <step id="publicationStepGroup" />
         </submission-process>
 
         <submission-process name="person-submission">

--- a/dspace-api/src/test/data/dspaceFolder/config/submission-forms.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/submission-forms.xml
@@ -325,8 +325,6 @@ it, please enter the types and the actual numbers or codes.</hint>
          <required>You must enter at least the author.</required>
          <hint>The editors of this publication.</hint>
        </field>
-     </row>
-     <row>
        <field>
          <dc-schema>oairecerif</dc-schema>
          <dc-element>editor</dc-element>

--- a/dspace-api/src/test/data/dspaceFolder/config/submission-forms.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/submission-forms.xml
@@ -287,6 +287,59 @@ it, please enter the types and the actual numbers or codes.</hint>
      </row>
    </form>
 
+   <form name="publicationStepGroup-dc-contributor-author">
+     <row>
+       <field>
+         <dc-schema>dc</dc-schema>
+         <dc-element>contributor</dc-element>
+         <dc-qualifier>author</dc-qualifier>
+         <label>Author</label>
+         <input-type>onebox</input-type>
+         <repeatable>false</repeatable>
+         <required>You must enter at least the author.</required>
+         <hint>Enter the names of the authors of this item in the form Lastname, Firstname [i.e. Smith, Josh or Smith, J].</hint>
+       </field>
+     </row>
+     <row>
+       <field>
+         <dc-schema>oairecerif</dc-schema>
+         <dc-element>author</dc-element>
+         <dc-qualifier>affiliation</dc-qualifier>
+         <label>Affiliation</label>
+         <input-type>onebox</input-type>
+         <repeatable>false</repeatable>
+         <required />
+         <hint>Enter the affiliation of the author as stated on the publication.</hint>
+       </field>
+     </row>
+   </form>
+   <form name="publicationStepGroup-dc-contributor-editor">
+     <row>
+       <field>
+         <dc-schema>dc</dc-schema>
+         <dc-element>contributor</dc-element>
+         <dc-qualifier>editor</dc-qualifier>
+         <label>Editor</label>
+         <input-type>onebox</input-type>
+         <repeatable>false</repeatable>
+         <required>You must enter at least the author.</required>
+         <hint>The editors of this publication.</hint>
+       </field>
+     </row>
+     <row>
+       <field>
+         <dc-schema>oairecerif</dc-schema>
+         <dc-element>editor</dc-element>
+         <dc-qualifier>affiliation</dc-qualifier>
+         <label>Affiliation</label>
+         <input-type>onebox</input-type>
+         <repeatable>false</repeatable>
+         <required />
+         <hint>Enter the affiliation of the editor as stated on the publication.</hint>
+       </field>
+     </row>
+   </form>
+
    <form name="qualdroptest">
      <row>
        <field>
@@ -480,6 +533,38 @@ it, please enter the types and the actual numbers or codes.</hint>
               However, this is disabled by default to support organizations as authors, etc. -->
          <!--<regex>\w+(,)+\w+</regex>-->
        </relation-field>
+     </row>
+   </form>
+
+   <form name="publicationStepGroup">
+     <row>
+       <relation-field>
+         <relationship-type>isAuthorOfPublication</relationship-type>
+         <search-configuration>person</search-configuration>
+         <repeatable>true</repeatable>
+         <label>Author</label>
+         <hint>Enter the author's name (Family name, Given names).</hint>
+         <linked-metadata-field>
+           <dc-schema>dc</dc-schema>
+           <dc-element>contributor</dc-element>
+           <dc-qualifier>author</dc-qualifier>
+           <input-type>group</input-type>
+         </linked-metadata-field>
+         <externalsources>orcid</externalsources>
+         <required></required>
+       </relation-field>
+     </row>
+     <row>
+       <field>
+         <dc-schema>dc</dc-schema>
+         <dc-element>contributor</dc-element>
+         <dc-qualifier>editor</dc-qualifier>
+         <repeatable>false</repeatable>
+         <label>Editor</label>
+         <input-type>inline-group</input-type>
+         <hint>The editors of this publication.</hint>
+         <required>You must enter at least the author.</required>
+       </field>
      </row>
    </form>
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionFormConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionFormConverter.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
-import jakarta.servlet.http.HttpServletRequest;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
@@ -33,7 +32,6 @@ import org.dspace.app.util.DCInputSet;
 import org.dspace.core.Context;
 import org.dspace.core.Utils;
 import org.dspace.services.RequestService;
-import org.dspace.services.model.Request;
 import org.dspace.submit.model.LanguageFormField;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -141,14 +139,7 @@ public class SubmissionFormConverter implements DSpaceConverter<DCInputSet, Subm
                     inputRest.setType(inputType);
                 }
 
-                Context context = null;
-                Request currentRequest = requestService.getCurrentRequest();
-                if (currentRequest != null) {
-                    HttpServletRequest request = currentRequest.getHttpServletRequest();
-                    context = ContextUtil.obtainContext(request);
-                } else {
-                    context = new Context();
-                }
+                Context context = ContextUtil.obtainCurrentRequestContext();
 
                 if (Strings.CI.equals(dcinput.getInputType(), "group") ||
                     Strings.CI.equals(dcinput.getInputType(), "inline-group")) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/SubmissionFormFieldRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/SubmissionFormFieldRest.java
@@ -11,8 +11,10 @@ package org.dspace.app.rest.model;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import org.dspace.app.rest.model.submit.SelectableMetadata;
 import org.dspace.app.rest.model.submit.SelectableRelationship;
 import org.dspace.submit.model.LanguageFormField;
@@ -39,6 +41,14 @@ public class SubmissionFormFieldRest {
      * The visibility restriction for the field
      */
     private SubmissionVisibilityRest visibility;
+
+    @JsonInclude(Include.NON_NULL)
+    @JsonIgnoreProperties( { "name", "type", "id" })
+    @JsonUnwrapped
+    /**
+     * The list of rows for "group"/"inline-group" field
+     */
+    private SubmissionFormRest rows;
 
     /**
      * The label of the field
@@ -269,6 +279,23 @@ public class SubmissionFormFieldRest {
         if (visibility != null && (visibility.getMain() != null || visibility.getOther() != null)) {
             this.visibility = visibility;
         }
+    }
+
+    /**
+     * Getter for {@link #rows}
+     *
+     * @return {@link #rows}
+     */
+    public SubmissionFormRest getRows() {
+        return rows;
+    }
+
+    /**
+     * Setter for {@link #rows}
+     *
+     */
+    public void setRows(SubmissionFormRest rows) {
+        this.rows = rows;
     }
 
     public List<String> getTypeBind() {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/DescribeStep.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/DescribeStep.java
@@ -93,6 +93,13 @@ public class DescribeStep extends AbstractProcessingStep {
                     for (Object qualifier : input.getPairs()) {
                         fieldsName.add(input.getFieldName() + "." + (String) qualifier);
                     }
+                } else if (Strings.CI.equals(input.getInputType(), "group") ||
+                    Strings.CI.equals(input.getInputType(), "inline-group")) {
+                    log.debug("Called child form:" + config.getId() + "-" +
+                             Utils.standardize(input.getSchema(), input.getElement(), input.getQualifier(), "-"));
+                    DCInputSet inputConfigChild = inputReader.getInputsByFormName(config.getId() + "-" + Utils
+                        .standardize(input.getSchema(), input.getElement(), input.getQualifier(), "-"));
+                    readField(obj, config, data, inputConfigChild);
                 } else {
                     String fieldName = input.getFieldName();
                     if (fieldName != null) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/DescribeStep.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/DescribeStep.java
@@ -9,6 +9,7 @@ package org.dspace.app.rest.submit.step;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import jakarta.servlet.http.HttpServletRequest;
 import org.apache.commons.lang3.Strings;
@@ -175,7 +176,9 @@ public class DescribeStep extends AbstractProcessingStep {
             PatchOperation<MetadataValueRest> patchOperation = new PatchOperationFactory()
                         .instanceOf(DESCRIBE_STEP_METADATA_OPERATION_ENTRY, op.getOp());
             String[] split = patchOperation.getAbsolutePath(op.getPath()).split("/");
-            if (inputConfig.isFieldPresent(split[0])) {
+            String fieldName = split[0];
+            Optional<DCInput> field = inputConfig.getField(fieldName);
+            if (field.isPresent()) {
                 patchOperation.perform(context, currentRequest, source, op);
             } else {
                 throw new UnprocessableEntityException("The field " + split[0] + " is not present in section "

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataAuthorityCheckIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/MetadataAuthorityCheckIT.java
@@ -1,0 +1,138 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+
+package org.dspace.app.rest;
+
+import static org.dspace.core.CrisConstants.PLACEHOLDER_PARENT_METADATA_VALUE;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThrows;
+
+import java.util.List;
+
+import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.ItemBuilder;
+import org.dspace.content.Collection;
+import org.dspace.content.Item;
+import org.dspace.content.authority.service.MetadataAuthorityService;
+import org.dspace.content.service.ItemService;
+import org.dspace.services.ConfigurationService;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/*
+ * @author Jurgen Mamani
+ */
+public class MetadataAuthorityCheckIT extends AbstractControllerIntegrationTest {
+
+    @Autowired
+    private ItemService itemService;
+
+    @Autowired
+    private ConfigurationService configurationService;
+
+    @Autowired
+    private MetadataAuthorityService metadataAuthorityService;
+
+    private Item item;
+
+    @Before
+    public void setup() {
+        context.turnOffAuthorisationSystem();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+
+        Collection col1 = CollectionBuilder.createCollection(context, parentCommunity)
+                .withEntityType("Publication")
+                .withName("Collection 1")
+                .build();
+
+        item = ItemBuilder.createItem(context, col1)
+                .withIssueDate("2022-02-01")
+                .build();
+
+        context.restoreAuthSystemState();
+    }
+
+    @Test
+    public void addAuthorityControlledMetadataWithAuthorities() throws Exception {
+        itemService.addMetadata(context, item, "dc", "contributor", "author", null, "Smith, Maria");
+        String metadataValue = itemService.getMetadataFirstValue(item, "dc", "contributor", "author", null);
+        MatcherAssert.assertThat(metadataValue, Matchers.is("Smith, Maria"));
+    }
+
+    @Test
+    public void addAuthorityControlledMetadataWithoutAuthorities() throws Exception {
+        itemService.addMetadata(context, item, "dc", "contributor","author", null,
+                List.of("Smith, Maria"), null, null);
+        String metadataValue = itemService.getMetadataFirstValue(item, "dc", "contributor", "author", null);
+        MatcherAssert.assertThat(metadataValue, Matchers.is("Smith, Maria"));
+    }
+
+    @Test
+    public void addNonAuthorityControlledMetadataWithAuthorities() {
+        Throwable throwable = Assert.assertThrows(IllegalArgumentException.class,
+                () -> itemService.addMetadata(context, item, "dc", "title",null, null,
+                        List.of("Public Item A"), List.of("test_authority"), null));
+
+        MatcherAssert.assertThat(throwable.getMessage(),
+                Matchers.is("The metadata field \"dc_title\" is not authority controlled " +
+                       "but authorities were provided. Values:\"[test_authority]\""));
+    }
+
+    @Test
+    public void addNonAuthorityControlledMetadataWithoutAuthorities() throws Exception {
+        itemService.addMetadata(context, item, "dc", "title", null, null, "Public Item A");
+        String metadataValue = itemService.getMetadataFirstValue(item, "dc", "title", null, null);
+        MatcherAssert.assertThat(metadataValue, Matchers.is("Public Item A"));
+    }
+
+    @Test
+    public void addRequiredAuthorityControlledMetadataWithoutAuthorities() throws Exception {
+        configurationService.setProperty("authority.controlled.dc.contributor.author", "true");
+        metadataAuthorityService.clearCache();
+        try {
+            configurationService.setProperty("authority.required.dc.contributor.author", true);
+            IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> itemService.addMetadata(context, item,
+                    "dc", "contributor", "author",null, "Smith, Maria", null, -1)
+            );
+
+            assertThat(exception.getMessage(), containsString("The metadata field \"dc_contributor_author\"" +
+                " requires an authority key but none was provided."));
+        } finally {
+            configurationService.setProperty("authority.required.dc.contributor.author", false);
+            metadataAuthorityService.clearCache();
+        }
+    }
+
+    @Test
+    public void addRequiredAuthorityControlledMetadataWithPlaceholderValue() throws Exception {
+        metadataAuthorityService.clearCache();
+        try {
+            configurationService.setProperty("authority.required.dc.contributor.author", true);
+            itemService.addMetadata(context, item,
+                "dc", "contributor", "author",null, PLACEHOLDER_PARENT_METADATA_VALUE, null, -1);
+
+            String metadataValue = itemService.getMetadataFirstValue(item, "dc", "contributor", "author", null);
+            MatcherAssert.assertThat(metadataValue, Matchers.is(PLACEHOLDER_PARENT_METADATA_VALUE));
+        } finally {
+            configurationService.setProperty("authority.required.dc.contributor.author", false);
+            metadataAuthorityService.clearCache();
+        }
+    }
+
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionFormsControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionFormsControllerIT.java
@@ -13,13 +13,18 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
 
+import com.jayway.jsonpath.JsonPath;
 import org.dspace.app.rest.matcher.SubmissionFormFieldMatcher;
 import org.dspace.app.rest.repository.SubmissionFormRestRepository;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
@@ -68,14 +73,14 @@ public class SubmissionFormsControllerIT extends AbstractControllerIntegrationTe
                         .andExpect(content().contentType(contentType))
                         //The configuration file for the test env includes 6 forms
                         .andExpect(jsonPath("$.page.size", is(20)))
-                        .andExpect(jsonPath("$.page.totalElements", equalTo(12)))
+                        .andExpect(jsonPath("$.page.totalElements", equalTo(15)))
                         .andExpect(jsonPath("$.page.totalPages", equalTo(1)))
                         .andExpect(jsonPath("$.page.number", is(0)))
                         .andExpect(
                             jsonPath("$._links.self.href",
                                      Matchers.startsWith(REST_SERVER_URL + "config/submissionforms")))
                         //The array of submissionforms should have a size of 12
-                        .andExpect(jsonPath("$._embedded.submissionforms", hasSize(equalTo(12))))
+                        .andExpect(jsonPath("$._embedded.submissionforms", hasSize(equalTo(15))))
         ;
     }
 
@@ -86,12 +91,12 @@ public class SubmissionFormsControllerIT extends AbstractControllerIntegrationTe
                         .andExpect(status().isOk())
                         .andExpect(content().contentType(contentType))
                         .andExpect(jsonPath("$.page.size", is(20)))
-                        .andExpect(jsonPath("$.page.totalElements", equalTo(12)))
+                        .andExpect(jsonPath("$.page.totalElements", equalTo(15)))
                         .andExpect(jsonPath("$.page.totalPages", equalTo(1)))
                         .andExpect(jsonPath("$.page.number", is(0)))
                         .andExpect(jsonPath("$._links.self.href", Matchers.startsWith(REST_SERVER_URL
                                                                                           + "config/submissionforms")))
-                        .andExpect(jsonPath("$._embedded.submissionforms", hasSize(equalTo(12))));
+                        .andExpect(jsonPath("$._embedded.submissionforms", hasSize(equalTo(15))));
     }
 
     @Test
@@ -506,7 +511,7 @@ public class SubmissionFormsControllerIT extends AbstractControllerIntegrationTe
     @Test
     public void userChoiceAnotherLanguageTest() throws Exception {
         context.turnOffAuthorisationSystem();
-
+        cas.getChoiceAuthoritiesNames();
         String[] supportedLanguage = {"it","uk"};
         configurationService.setProperty("default.locale","it");
         configurationService.setProperty("webui.supported.locales",supportedLanguage);
@@ -680,154 +685,46 @@ public class SubmissionFormsControllerIT extends AbstractControllerIntegrationTe
     @Test
     public void findAllPaginationTest() throws Exception {
         String tokenAdmin = getAuthToken(admin.getEmail(), password);
-        getClient(tokenAdmin).perform(get("/api/config/submissionforms")
-                                          .param("size", "2")
-                                          .param("page", "0"))
-                             .andExpect(status().isOk())
-                             .andExpect(content().contentType(contentType))
-                             .andExpect(jsonPath("$._embedded.submissionforms[0].id", is("personstep")))
-                             .andExpect(jsonPath("$._embedded.submissionforms[1].id", is("bitstream-metadata")))
-                             .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=0"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=0"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$._links.next.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=1"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=5"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$.page.size", is(2)))
-                             .andExpect(jsonPath("$.page.totalElements", equalTo(12)))
-                             .andExpect(jsonPath("$.page.totalPages", equalTo(6)))
-                             .andExpect(jsonPath("$.page.number", is(0)));
+        int pageSize = 2;
+        int totalElements = 15;
+        int totalPages = 8;
 
-        getClient(tokenAdmin).perform(get("/api/config/submissionforms")
-                                          .param("size", "2")
-                                          .param("page", "1"))
-                             .andExpect(status().isOk())
-                             .andExpect(content().contentType(contentType))
-                             .andExpect(jsonPath("$._embedded.submissionforms[0].id", is("journalVolumeStep")))
-                             .andExpect(jsonPath("$._embedded.submissionforms[1].id",
-                                                 is("test-outside-workflow-hidden")))
-                             .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=0"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$._links.prev.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=0"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=1"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$._links.next.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=2"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=5"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$.page.size", is(2)))
-                             .andExpect(jsonPath("$.page.totalElements", equalTo(12)))
-                             .andExpect(jsonPath("$.page.totalPages", equalTo(6)))
-                             .andExpect(jsonPath("$.page.number", is(1)));
+        List<String> expectedIds = Arrays.asList(
+            "personstep",
+            "publicationStepGroup-dc-contributor-author",
+            "journalVolumeStep",
+            "publicationStepGroup",
+            "publicationStepGroup-dc-contributor-editor",
+            "typebindtest",
+            "bitstream-metadata",
+            "test-outside-workflow-hidden",
+            "languagetest",
+            "publicationStep",
+            "test-outside-submission-hidden",
+            "qualdroptest",
+            "traditionalpagetwo",
+            "sampleauthority",
+            "traditionalpageone"
+        );
 
-        getClient(tokenAdmin).perform(get("/api/config/submissionforms")
-                                          .param("size", "2")
-                                          .param("page", "2"))
-                             .andExpect(status().isOk())
-                             .andExpect(content().contentType(contentType))
-                             .andExpect(jsonPath("$._embedded.submissionforms[0].id", is("languagetest")))
-                             .andExpect(jsonPath("$._embedded.submissionforms[1].id", is("publicationStep")))
-                             .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=0"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$._links.prev.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=1"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=2"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=5"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$.page.size", is(2)))
-                             .andExpect(jsonPath("$.page.totalElements", equalTo(12)))
-                             .andExpect(jsonPath("$.page.totalPages", equalTo(6)))
-                             .andExpect(jsonPath("$.page.number", is(2)));
+        List<String> allIds = new ArrayList<>();
+        for (int page = 0; page < totalPages; page++) {
+            getClient(tokenAdmin)
+                .perform(get("/api/config/submissionforms")
+                             .param("size", String.valueOf(pageSize))
+                             .param("page", String.valueOf(page)))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(contentType))
+                .andExpect(jsonPath("$._embedded.submissionforms", hasSize(Matchers.lessThanOrEqualTo(pageSize))))
+                .andDo(result -> {
+                    List<String> ids = JsonPath.read(result.getResponse().getContentAsString(),
+                                                     "$._embedded.submissionforms[*].id");
+                    allIds.addAll(ids);
+                });
+        }
 
-        getClient(tokenAdmin).perform(get("/api/config/submissionforms")
-                                          .param("size", "2")
-                                          .param("page", "3"))
-                             .andExpect(status().isOk())
-                             .andExpect(content().contentType(contentType))
-                             .andExpect(jsonPath("$._embedded.submissionforms[0].id",
-                                                 is("test-outside-submission-hidden")))
-                             .andExpect(jsonPath("$._embedded.submissionforms[1].id", is("qualdroptest")))
-                             .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=0"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$._links.prev.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=2"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=3"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=5"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$.page.size", is(2)))
-                             .andExpect(jsonPath("$.page.totalElements", equalTo(12)))
-                             .andExpect(jsonPath("$.page.totalPages", equalTo(6)))
-                             .andExpect(jsonPath("$.page.number", is(3)));
-
-        getClient(tokenAdmin).perform(get("/api/config/submissionforms")
-                                          .param("size", "2")
-                                          .param("page", "4"))
-                             .andExpect(status().isOk())
-                             .andExpect(content().contentType(contentType))
-                             .andExpect(jsonPath("$._embedded.submissionforms[0].id", is("traditionalpagetwo")))
-                             .andExpect(jsonPath("$._embedded.submissionforms[1].id", is("sampleauthority")))
-                             .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=0"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$._links.prev.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=3"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=4"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=5"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$.page.size", is(2)))
-                             .andExpect(jsonPath("$.page.totalElements", equalTo(12)))
-                             .andExpect(jsonPath("$.page.totalPages", equalTo(6)))
-                             .andExpect(jsonPath("$.page.number", is(4)));
-
-        getClient(tokenAdmin).perform(get("/api/config/submissionforms")
-                                          .param("size", "2")
-                                          .param("page", "5"))
-                             .andExpect(status().isOk())
-                             .andExpect(content().contentType(contentType))
-                             .andExpect(jsonPath("$._embedded.submissionforms[0].id", is("traditionalpageone")))
-                             .andExpect(jsonPath("$._embedded.submissionforms[1].id", is("typebindtest")))
-                             .andExpect(jsonPath("$._links.first.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=0"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$._links.prev.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=4"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$._links.self.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=5"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$._links.last.href", Matchers.allOf(
-                                 Matchers.containsString("/api/config/submissionforms?"),
-                                 Matchers.containsString("page=5"), Matchers.containsString("size=2"))))
-                             .andExpect(jsonPath("$.page.size", is(2)))
-                             .andExpect(jsonPath("$.page.totalElements", equalTo(12)))
-                             .andExpect(jsonPath("$.page.totalPages", equalTo(6)))
-                             .andExpect(jsonPath("$.page.number", is(5)));
+        assertEquals("Total unique IDs collected should match metadata", totalElements, allIds.size());
+        assertEquals("Collected IDs should exactly match the expected configuration set", expectedIds, allIds);
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionFormsControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionFormsControllerIT.java
@@ -829,4 +829,21 @@ public class SubmissionFormsControllerIT extends AbstractControllerIntegrationTe
                              .andExpect(jsonPath("$.page.totalPages", equalTo(6)))
                              .andExpect(jsonPath("$.page.number", is(5)));
     }
+
+    @Test
+    public void findPublicationStepGroupAndInlineGroupFields() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+        getClient(token).perform(get("/api/config/submissionforms/publicationStepGroup"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$.id", is("publicationStepGroup")))
+            // Check for the group (Author) --- row[0] relation-field with group child
+            .andExpect(jsonPath("$.rows[0].fields[0].input.type", is("group")))
+            .andExpect(jsonPath("$.rows[0].fields[0].rows").exists())
+            .andExpect(jsonPath("$.rows[0].fields[0].rows").isArray())
+            // Check for inline-group (Editor) --- row[1] field
+            .andExpect(jsonPath("$.rows[1].fields[0].input.type", is("inline-group")))
+            .andExpect(jsonPath("$.rows[1].fields[0].rows").exists())
+            .andExpect(jsonPath("$.rows[1].fields[0].rows").isArray());
+    }
 }


### PR DESCRIPTION
## References

* Fixes #12159 
* Requires DSpace/dspace-angular#5097
* Related to #11718

## Description

This PR ports nested metadata support from DSpace-CRIS to the DSpace core, enabling hierarchical metadata entry in submission forms through new `group` and `inline-group` input types. This allows fields like authors with affiliations to be grouped together during submission.

## Instructions for Reviewers

### List of changes in this PR:

- **First**, added support for two new input types: `group` and `inline-group`. These allow submission forms to display nested/hierarchical metadata fields (e.g., an author field with an associated affiliation field).
- **Second**, enhanced `DCInputSet` with recursive field lookup to properly resolve nested metadata fields within groups. Added a new `getField()` method returning `Optional<DCInput>` for robust field resolution.
- **Third**, updated `SubmissionFormConverter` to handle nested `SubmissionFormFieldRest` objects with embedded rows for child fields within groups.
- **Fourth**, updated `DescribeStep` to process group and inline-group field types during form handling and validation.
- **Fifth**, integrated support for placeholder metadata values in authority-controlled fields. This allows parent metadata fields in nested groups to store placeholder values without triggering authority validation errors.
- **Sixth**, added new test cases in `WorkspaceItemRestRepositoryIT` to verify that groups and inline-groups are correctly retrieved and processed during submission.

### Testing/Review Guidance:

1. Create a submission form configuration with grouped fields (see Required Configuration below)
2. Start a new submission using the configured form
3. Verify that nested fields (e.g., author + affiliation) appear grouped together
4. Test saving and retrieving nested metadata values via REST API
5. Verify backward compatibility - non-grouped forms should continue to work as before

---

## Required Configuration

To use nested metadata groups, update your `submission-forms.xml` and `item-submission.xml`:

### 1. Define a Step in item-submission.xml

```xml
<step-definition id="publicationStepGroup" mandatory="true">
    <heading>submit.progressbar.describe.stepone</heading>
    <processing-class>org.dspace.app.rest.submit.step.DescribeStep</processing-class>
    <type>submission-form</type>
</step-definition>
```

Then reference it in a submission process:

```xml
<submission-process name="publication-submission">
    <step id="collection"/>
    <step id="publicationStepGroup"/>
</submission-process>
```

### 2. Define Grouped Forms in submission-forms.xml

For `group` input type (used with relation-field), create a main form and child forms following the naming convention `formName-dc-element-qualifier`:

**Main form (`publicationStepGroup`):**
```xml
<form name="publicationStepGroup">
    <row>
        <relation-field>
            <relationship-type>isAuthorOfPublication</relationship-type>
            <search-configuration>person</search-configuration>
            <repeatable>true</repeatable>
            <label>Author</label>
            <hint>Enter the author's name.</hint>
            <linked-metadata-field>
                <dc-schema>dc</dc-schema>
                <dc-element>contributor</dc-element>
                <dc-qualifier>author</dc-qualifier>
                <input-type>group</input-type>
            </linked-metadata-field>
            <externalsources>orcid</externalsources>
        </relation-field>
    </row>
</form>
```

**Child form (`publicationStepGroup-dc-contributor-author`):**
```xml
<form name="publicationStepGroup-dc-contributor-author">
    <row>
        <field>
            <dc-schema>dc</dc-schema>
            <dc-element>contributor</dc-element>
            <dc-qualifier>author</dc-qualifier>
            <label>Author</label>
            <input-type>onebox</input-type>
            <repeatable>false</repeatable>
            <required>You must enter at least the author.</required>
            <hint>Enter the names of the authors.</hint>
        </field>
    </row>
    <row>
        <field>
            <dc-schema>oairecerif</dc-schema>
            <dc-element>author</dc-element>
            <dc-qualifier>affiliation</dc-qualifier>
            <label>Affiliation</label>
            <input-type>onebox</input-type>
            <repeatable>false</repeatable>
            <required />
            <hint>Enter the affiliation of the author.</hint>
        </field>
    </row>
</form>
```

For `inline-group` input type (simple field grouping):
```xml
<form name="publicationStepGroup">
    <row>
        <field>
            <dc-schema>dc</dc-schema>
            <dc-element>contributor</dc-element>
            <dc-qualifier>editor</dc-qualifier>
            <repeatable>false</repeatable>
            <label>Editor</label>
            <input-type>inline-group</input-type>
            <hint>The editors of this publication.</hint>
            <required>You must enter at least the author.</required>
        </field>
    </row>
</form>
```

**Note:** Child forms must be named using the pattern: `{parentFormName}-{dc-element}-{dc-qualifier}` for the group input type to resolve correctly.
**Note 2:** This PR is based on #11718 and will be rebased onto main once that PR is merged.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
