### PR TITLE
Freeze versions of all Maven plugins, and enforce freezing in future

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,17 @@
                                 </rules>
                             </configuration>
                         </execution>
+                        <execution>
+                            <id>enforce-plugin-versions</id>
+                            <goals>
+                                <goal>enforce</goal>
+                            </goals>
+                            <configuration>
+                                <rules>
+                                    <requirePluginVersions />
+                                </rules>
+                            </configuration>
+                        </execution>
                     </executions>
                 </plugin>
                 <!-- Used to compile all Java classes -->
@@ -414,6 +425,22 @@
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
                     <version>0.8.14</version>
+                </plugin>
+                <!-- Freeze versions of the remaining compiler plugins for reproducible builds -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>3.1.2</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>3.12.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>3.1.2</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
## References

## Description

At The Library Code we are investigating deploying DSpace with [Nix](https://nixos.org/) as part of our future infrastructure. Nix [enforces a reproducible set of dependencies](https://ryantm.github.io/nixpkgs/languages-frameworks/maven/#stable-maven-plugins) including for Maven’s core plugins. This means their versions have to be frozen and stable in the POM file.

Almost all of DSpace’s Maven plugins already have frozen versions. This PR adds a specified version for the remaining three plugins which are currently still only used implicitly, and configures Maven to require that future plugins also have their version specified and fixed in the POM file.

Besides its potential utility for making DSpace available in package managers like Nix which enforce reproducible dependency chains, [reproducible builds](https://en.wikipedia.org/wiki/Reproducible_builds) also have more general security and reliability benefits and are recommended for open source projects by e.g. the Software Freedom Conservancy. (This configuration does not yet provide absolutely 100% reproducible builds, but it should be a big step on the way. Maven 4.0 [promises to have reproducible builds by default,](https://maven.apache.org/guides/mini/guide-reproducible-builds.html#:~:text=Notice%3A%20starting%20with%20Maven%204%2E0%2E0%2Dbeta%2D5%2C%20Reproducible%20Builds%20mode%20will%20be%20active%20by%20default) so at some point this change is likely to come around anyway.)

## Instructions for Reviewers

No real testing required, beyond that ensuring DSpace builds and runs correctly with this Maven configuration

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] ~~My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.~~
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] ~~My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.~~
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] ~~If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.~~
- [ ] ~~If my PR includes new configurations, I've provided basic technical documentation in the PR itself.~~
- [ ] ~~If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).~~
