### PR TITLE
[Port dspace-9_x] Include orcid in dim2datacite crosswalks - fixes #9883

### DIFF
--- a/dspace/config/crosswalks/DIM2DataCite.xsl
+++ b/dspace/config/crosswalks/DIM2DataCite.xsl
@@ -359,10 +359,14 @@
 
     <!-- DataCite (2) :: Creator -->
     <xsl:template match="//dspace:field[@mdschema='dc' and @element='contributor' and @qualifier='author']">
+        <xsl:variable name="authority" select="@authority"/>
         <creator>
             <creatorName>
                 <xsl:value-of select="." />
             </creatorName>
+            <xsl:call-template name="personOrcid">
+                <xsl:with-param name="authority_value" select="$authority"/>
+            </xsl:call-template>
         </creator>
     </xsl:template>
 
@@ -643,6 +647,21 @@
             </xsl:attribute>
             <xsl:value-of select="." />
         </xsl:element>
+    </xsl:template>
+
+    <!--
+        This template will return ORCiD nameIdentifier information based on a given authority value, if a person entity
+        is related with the publication and contains a value for the metadata field dc.identifier.orcid.
+    -->
+    <xsl:template name="personOrcid">
+        <xsl:param name="authority_value"/>
+        <xsl:if test="starts-with($authority_value, 'virtual::') and //dspace:field[@mdschema='person' and @element='identifier' and @qualifier='orcid' and @authority=$authority_value]">
+            <xsl:element name="nameIdentifier">
+                <xsl:attribute name="schemeURI">https://orcid.org/</xsl:attribute>
+                <xsl:attribute name="nameIdentifierScheme">ORCID</xsl:attribute>
+                <xsl:value-of select="//dspace:field[@mdschema='person' and @element='identifier' and @qualifier='orcid' and @authority=$authority_value]/text()"/>
+            </xsl:element>
+        </xsl:if>
     </xsl:template>
 
 </xsl:stylesheet>

--- a/dspace/config/spring/api/virtual-metadata.xml
+++ b/dspace/config/spring/api/virtual-metadata.xml
@@ -40,6 +40,7 @@
           This value-ref should be a bean of type VirtualMetadataConfiguration -->
     <util:map id="isAuthorOfPublicationMap">
         <entry key="dc.contributor.author" value-ref="publicationAuthor_author"/>
+        <entry key="person.identifier.orcid" value-ref="publicationAuthor_identifierOrcid"/>
     </util:map>
     <!--
          If the related item has:
@@ -60,6 +61,13 @@
         </property>
         <property name="useForPlace" value="true"/>
         <property name="populateWithNameVariant" value="true"/>
+    </bean>
+    <bean class="org.dspace.content.virtual.Collected" id="publicationAuthor_identifierOrcid">
+        <property name="fields">
+            <util:list>
+                <value>person.identifier.orcid</value>
+            </util:list>
+        </property>
     </bean>
 
     <!-- Config like this will tell our VirtualMetadataPopulator to include the virtual metadata field


### PR DESCRIPTION
## References

_Add references/links to any related issues or PRs. These may include:_
* Fixes #9883
* Original PR #11322

## Description

This PR is a backport for the original PR to the dspace_9.x branch. 

## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:

* Added a new mapping the virtual-metadata.xml to pass orcid metadata from Person-entities to Publication-entities.
* Created a new xsl:template in the Dim2DataCite.xsl crosswalk to create a nameIdentifier tag for a person based on a given authority value
* Used the template in the DataCite (2) :: Creator-Template

Include guidance for how to test or review your PR. This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes.

1. Activate the standard entity-relationship model
2. Create a new person entity including an ORCiD
3. Create a new publication entity with the person entity connected as an author of the publication.
    3.1 Check if the person.identifier.orcid information is visible in the publication metadata
4. Run [dspace]/bin/dspace dsrun org.dspace.content.crosswalk.XSLTDisseminationCrosswalk DataCite <handle> on the commandline, using the handle of the newly created publication. Make sure, the creator information in the output not only includes the creatorName tag, but also the nameIdentifier tag. It should look similar to this:
```xml
<creators>
  <creator>
    <creatorName>Smith, Doe</creatorName>
    <nameIdentifier schemeURI="https://orcid.org/" nameIdentifierScheme="ORCID">1234-4568-7891-123</nameIdentifier>
  </creator>
</creators>
```
The complete documentation for the creator field in the DataCite schema can be found [here](https://datacite-metadata-schema.readthedocs.io/en/4.6/properties/creator/).

Optional: If possible, register a new doi via the DataCite Test API and check via [DataCite Fabrica](https://doi.test.datacite.org/), if the ORCiD information has been transferred correctly.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x ] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
