### PR TITLE
Harden DocumentBuilderFactory against entity processing in PdfGenerator

### DIFF
--- a/dspace-api/src/main/java/org/dspace/disseminate/PdfGenerator.java
+++ b/dspace-api/src/main/java/org/dspace/disseminate/PdfGenerator.java
@@ -7,21 +7,29 @@
  */
 package org.dspace.disseminate;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.stream.Collectors;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.ParserConfigurationException;
 
+import com.lowagie.text.DocumentException;
 import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.pdmodel.PDDocument;
+import org.dspace.app.util.XMLUtils;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
 import org.thymeleaf.templatemode.TemplateMode;
 import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver;
+import org.w3c.dom.Document;
 import org.xhtmlrenderer.pdf.ITextRenderer;
+import org.xml.sax.SAXException;
 
 /**
  * Generates a PDF coverpage.
@@ -36,7 +44,7 @@ public class PdfGenerator {
      * Render a HTML coverpage.
      *
      * @param templateName the name of the thymeleaf template
-     * @param variables dynamic content for the template
+     * @param variables    dynamic content for the template
      * @return a rendered HTML coverpage
      */
     public String parseTemplate(String templateName, Map<String, String> variables) {
@@ -65,7 +73,7 @@ public class PdfGenerator {
     /**
      * render a HTML coverpage to a file
      *
-     * @param html the coverpage HTML
+     * @param html   the coverpage HTML
      * @param toFile file to write to
      */
     public void generateToFile(String html, File toFile) {
@@ -81,6 +89,9 @@ public class PdfGenerator {
      *
      * @param html the coverpage HTML
      * @return resulting pdfbox PDDocument
+     * @throws IOException                  if IO error
+     * @throws ParserConfigurationException if config error
+     * @throws SAXException                 if XML error
      */
     public PDDocument generate(String html) {
         try (var out = new ByteArrayOutputStream()) {
@@ -92,10 +103,15 @@ public class PdfGenerator {
     }
 
     private void generate(String html, OutputStream out) {
-        var renderer = new ITextRenderer();
-
-        renderer.setDocumentFromString(html);
-        renderer.layout();
-        renderer.createPDF(out);
+        try {
+            var renderer = new ITextRenderer();
+            DocumentBuilder builder = XMLUtils.getDocumentBuilder();
+            Document doc = builder.parse(new ByteArrayInputStream(html.getBytes(StandardCharsets.UTF_8)));
+            renderer.setDocument(doc, null);
+            renderer.layout();
+            renderer.createPDF(out);
+        } catch (ParserConfigurationException | SAXException | IOException | DocumentException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/dspace-api/src/main/java/org/dspace/disseminate/PdfGenerator.java
+++ b/dspace-api/src/main/java/org/dspace/disseminate/PdfGenerator.java
@@ -19,7 +19,6 @@ import java.util.stream.Collectors;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.ParserConfigurationException;
 
-import com.lowagie.text.DocumentException;
 import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.dspace.app.util.XMLUtils;
@@ -110,7 +109,7 @@ public class PdfGenerator {
             renderer.setDocument(doc, null);
             renderer.layout();
             renderer.createPDF(out);
-        } catch (ParserConfigurationException | SAXException | IOException | DocumentException e) {
+        } catch (ParserConfigurationException | SAXException | IOException e) {
             throw new RuntimeException(e);
         }
     }


### PR DESCRIPTION
## References
No related issue.

## Description
While this seems to be a bug, I have changed  setDocumentFromString() to setDocument() with a XMLUtils DocumentBuilderFactory which is protected against XXE, I have doubts if this is exploitable as it will be displayed as th:text which I think such html tags will be encoded and therefore not be feasible to inject DTDs . The doctype could not be injected at the top of the HTML template, as it seems a HTML template is used and data inserted there. However I recommend this PR for future use of PdfGenerator.java

## Instructions for Reviewers
If something it's not fine with this code I'll allow to modify it.
I have tested new code to see how it did generate PDF, however its recommended testing for those DSpace servers which have custom templates.
<img width="1165" height="597" alt="image" src="https://github.com/user-attachments/assets/39e26f48-45f0-4c90-bd6a-2679b700479d" />


List of changes in this PR:

Used a Secure DocumentBuilderFactory.
If PdfGenerator is used in more classes with th:utext, an XXE could became possible.

## Checklist

- [*] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [*] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [*] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
