### PR TITLE
Disable most file formats for "inline" display (in a user's browser) by default, unless overridden by configuration.

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
@@ -20,7 +20,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.ws.rs.core.Response;
 import org.apache.catalina.connector.ClientAbortException;
-import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.requestitem.RequestItem;
@@ -214,15 +213,17 @@ public class BitstreamRestController {
                 httpHeadersInitializer.withLastModified(lastModified);
             }
 
-            // Determine if we need to send the file as a download or if the browser can open it inline
-            // The file will be downloaded if its size is larger than the configured threshold,
-            // or if its mimetype/extension appears in the "webui.content_disposition_format" config
-            long dispositionThreshold = configurationService.getLongProperty("webui.content_disposition_threshold");
-            if ((dispositionThreshold >= 0 && filesize > dispositionThreshold)
-                    || checkFormatForContentDisposition(format)) {
-                httpHeadersInitializer.withDisposition(HttpHeadersInitializer.CONTENT_DISPOSITION_ATTACHMENT);
-            } else {
+            // Determine if we need to send the file as a download or if the browser can open it inline.
+            // By default, all files will be downloaded as that is more secure. File formats will only be opened inline
+            // if they are listed in the "webui.content_disposition_inline" config and size is less than the
+            // configured "webui.content_disposition_threshold" (default = 8MB)
+            long dispositionThreshold = configurationService.getLongProperty("webui.content_disposition_threshold",
+                                                                             8388608);
+            if (checkFormatForContentDispositionInline(format) &&
+                filesize <= dispositionThreshold) {
                 httpHeadersInitializer.withDisposition(HttpHeadersInitializer.CONTENT_DISPOSITION_INLINE);
+            } else {
+                httpHeadersInitializer.withDisposition(HttpHeadersInitializer.CONTENT_DISPOSITION_ATTACHMENT);
             }
 
             // Send the data
@@ -276,48 +277,48 @@ public class BitstreamRestController {
     }
 
     /**
-     * Check if a Bitstream of the specified format should always be downloaded (i.e. "content-disposition: attachment")
-     * or can be opened inline (i.e. "content-disposition: inline").
+     * Check if a Bitstream of the specified format should be opened inline (i.e. "content-disposition: inline")
+     * instead of the default behavior of always downloading (i.e. "content-disposition: attachment").
      * <P>
      * NOTE that downloading via "attachment" is more secure, as the user's browser will not attempt to process or
      * display the file. But, downloading via "inline" may be seen as more user-friendly for common formats.
      * @param format BitstreamFormat
-     * @return true if always download ("attachment"). false if can be opened inline ("inline")
+     * @return true if format is configured to be opened inline ("inline"). false if always download ("attachment")
      */
-    private boolean checkFormatForContentDisposition(BitstreamFormat format) {
+    private boolean checkFormatForContentDispositionInline(BitstreamFormat format) {
         // Undefined or Unknown formats should ALWAYS be downloaded for additional security.
         if (format == null || format.getSupportLevel() == BitstreamFormat.UNKNOWN) {
-            return true;
+            return false;
         }
 
-        // Load additional formats configured to require download
-        List<String> configuredFormats = List.of(configurationService.
-                                                     getArrayProperty("webui.content_disposition_format"));
-
-        // If configuration includes "*", then all formats will always be downloaded.
-        if (configuredFormats.contains("*")) {
-            return true;
+        // Return false for BANNED inline formats. Some formats, especially XML / HTML / Javascript based formats,
+        // when loaded inline may be susceptible to XSS attacks. Therefore, we will refuse to allow those formats to be
+        // displayed inline for security purposes.
+        // NOTE: "+xml" in this list will match any MIME Type that ends in "+xml", as those are XML-based formats.
+        List<String> bannedInlineFormats = List.of("text/html", "text/javascript", "text/xml", "application/xml",
+                                             "+xml");
+        for (String bannedInlineFormat : bannedInlineFormats) {
+            // If our format MIME Type contains one of the banned inline formats, we refuse to display it inline
+            if (format.getMIMEType().contains(bannedInlineFormat)) {
+                return false;
+            }
         }
 
-        // Define a download list of formats which DSpace forces to ALWAYS be downloaded.
-        // These formats can embed JavaScript which may be run in the user's browser if the file is opened inline.
-        // Therefore, DSpace blocks opening these formats inline as it could be used for an XSS attack.
-        List<String> downloadOnlyFormats = List.of("text/html", "text/javascript", "text/xml", "rdf");
-
-        // Combine our two lists
-        List<String> formats = ListUtils.union(downloadOnlyFormats, configuredFormats);
+        // Load formats configured to allow inline display
+        List<String> formats = List.of(configurationService.
+                                                     getArrayProperty("webui.content_disposition_inline"));
 
         // See if the passed in format's MIME type or file extension is listed.
-        boolean download = formats.contains(format.getMIMEType());
-        if (!download) {
+        boolean inline = formats.contains(format.getMIMEType());
+        if (!inline) {
             for (String ext : format.getExtensions()) {
                 if (formats.contains(ext)) {
-                    download = true;
+                    inline = true;
                     break;
                 }
             }
         }
-        return download;
+        return inline;
     }
 
     /**

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1699,21 +1699,20 @@ websvc.opensearch.max_num_of_items_per_request = 100
 
 #### Content Inline Disposition Threshold ####
 #
-# Set the max size of a bitstream that can be served inline
-# Use -1 to force all bitstream to be served inline
-webui.content_disposition_threshold = 8388608
-
-#### Content Attachment Disposition Formats ####
-#
-# Set which mimetypes or file extensions will NOT be opened inline.
-# Files with these mimetypes/extensions will always be downloaded, regardless of the threshold above.
+# Set which mimetypes or file extensions are allowed to be opened inline in a user's browser.
+# By default, all files will be downloaded, regardless of the threshold below, unless specified in this configuration.
 # NOTE: For security reasons, some file formats (e.g. HTML, XML, RDF, JS) will always be downloaded regardless
-# of the settings here. This blocks these formats from executing embedded JavaScript when opened inline.
-# For additional security, you may choose to set this to "*" to force all formats to always be downloaded
-# (i.e. disables all formats from opening inline within the user's browser).
+# of the settings here. This blocks these formats from executing embedded JavaScript when opened inline, protecting
+# the site from potential XSS attacks.
 #
-# By default, RTF is always downloaded because most browsers attempt to display it as plain text.
-webui.content_disposition_format = text/richtext
+# For example: enable PDF and common images formats to be opened in a user's browser.
+#webui.content_disposition_inline = application/pdf, image/gif, image/jpeg, image/png
+
+#
+# Set the max size (in bytes) of a bitstream that can be served inline. This setting only applies to formats
+# specified in the "webui.content_disposition_inline" configuration above.
+# Default = 8MB (8388608 bytes). Use -1 to ignore the size of file when serving it inline.
+#webui.content_disposition_threshold = 8388608
 
 #### Multi-file HTML document/site settings #####
 # TODO: UNSUPPORTED in DSpace 7.0. May be re-added in a later release

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1705,8 +1705,9 @@ websvc.opensearch.max_num_of_items_per_request = 100
 # of the settings here. This blocks these formats from executing embedded JavaScript when opened inline, protecting
 # the site from potential XSS attacks.
 #
-# For example: enable PDF and common images formats to be opened in a user's browser.
-#webui.content_disposition_inline = application/pdf, image/gif, image/jpeg, image/png
+# For example: this setting defaults to enabling PDF and common image / audio / video formats to be opened
+# (or potentially streamed) in a user's browser.
+webui.content_disposition_inline = application/pdf, image/gif, image/jpeg, image/png, audio/mpeg, video/mpeg, video/mp4
 
 #
 # Set the max size (in bytes) of a bitstream that can be served inline. This setting only applies to formats


### PR DESCRIPTION
## References
* Changes the behavior of #9638. This PR creates an "allow-list" to replace the current "block-list" approach.

## Description
This PR replace the existing `webui.content_disposition_format` configuration (a block-list approach) with a new `webui.content_disposition_inline` configuration (an allow-list approach) to determine which file formats are downloaded versus displayed inline in a user's browser.

This PR changes the default behavior to **disable** inline display of all file formats by default. The reason for this behavior change is just to enhance security for **custom formats** added to the Bitstream Format Registry:

* **Existing behavior** (added in #9638): The existing behavior is to **default to displaying all downloaded files inline** in a user's browser unless the file's format is listed in the `webui.content_disposition_format` configuration **or** the file's format is in a specific list of formats that are potentially vulnerable to XSS attacks (e.g. XML/HTML/JS).
    * This approach works well for DSpace out-of-the-box. But, there is a risk that an institution could add a new, custom file format (which hasn't been analyzed for potential vulnerability to XSS attacks) to DSpace in the Bitstream Format Registry. These new, custom formats would default to allowing "inline" display _unless sites remember to add the new format to `webui.content_disposition_format`_.  Inline display of custom formats may carry a risk of XSS attacks, especially if the format is based on XML.  _(This flaw in the current code was pointed out by @superpegaso2703 )_
* **New behavior** (in this PR): The new behavior would be to  **default to downloading all files** (i.e. inline display disabled) unless the file's format is listed in the `webui.content_disposition_inline` configuration, which would allow it to be displayed inline.  However, just like before, some specific formats are blocked automatically from inline display if they are potentially vulnerable to XSS attacks (e.g. XML/HTML/JS).
    * This approach would provide improved future security because any new, custom file formats would **default** to download only (i.e. inline display would be disabled).  So, all custom formats would be securely handled by default, but sites would have the ability to still allow inline display for any "trusted" file formats.

**Must be added to Release Notes "Breaking Changes":** Because this PR changes the default behavior to disabling inline (instead of allowing inline), this will require mention in the "Breaking Changes" section of all Release Notes.  We'd also need to mention that the old configuration has been removed & replaced by a new configuration.

## Instructions for Reviewers
- [ ] Verify the code and updated automated tests look good.
- [ ] Verify that the default behavior is to download all files as attachments.  For example, try to download an "image/gif" or "image/jpeg" file and verify it downloads by default (whereas it previously would be displayed inline in your browser)
- [ ] Verify that the `webui.content_disposition_inline` configuration works to enable formats to be displayed inline.  Set this in your `local.cfg` and verify that GIF/JPG/PNG images are now displayed inline in the browser:
    ```
    webui.content_disposition_inline = image/gif, image/jpeg, image/png
    ```
- [ ] Verify that some formats are never displayed inline (e.g. XML / HTML) regardless of the "inline" configuration.  For example, set this in your `local.cfg` and verify that XML/HTML **still will not be displayed inline**. They will still be downloaded as this configuration is **ignored** for formats that may be susceptible to XSS attacks.
    ```
    webui.content_disposition_inline = text/html, text/xml
    ```