### PR TITLE
[Docker] Install Apache Ant via `apt-get` instead of manual download.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,16 +41,11 @@ ARG TARGET_DIR=dspace-installer
 # COPY the /install directory from 'build' container to /dspace-src in this container
 COPY --from=build /install /dspace-src
 WORKDIR /dspace-src
-# Create the initial install deployment using ANT
-ENV ANT_VERSION=1.10.13
-ENV ANT_HOME=/tmp/ant-$ANT_VERSION
-ENV PATH=$ANT_HOME/bin:$PATH
-# Download and install 'ant'
-RUN mkdir $ANT_HOME && \
-    curl --silent --show-error --location --fail --retry 5 --output /tmp/apache-ant.tar.gz \
-      https://archive.apache.org/dist/ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.gz && \
-    tar -zx --strip-components=1 -f /tmp/apache-ant.tar.gz -C $ANT_HOME && \
-    rm /tmp/apache-ant.tar.gz
+# Install Apache Ant
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ant \
+    && apt-get purge -y --auto-remove \
+    && rm -rf /var/lib/apt/lists/*
 # Run necessary 'ant' deploy scripts
 RUN ant init_installation update_configs update_code update_webapps
 

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -35,16 +35,11 @@ ARG TARGET_DIR=dspace-installer
 # COPY the /install directory from 'build' container to /dspace-src in this container
 COPY --from=build /install /dspace-src
 WORKDIR /dspace-src
-# Create the initial install deployment using ANT
-ENV ANT_VERSION=1.10.13
-ENV ANT_HOME=/tmp/ant-$ANT_VERSION
-ENV PATH=$ANT_HOME/bin:$PATH
-# Download and install 'ant'
-RUN mkdir $ANT_HOME && \
-    curl --silent --show-error --location --fail --retry 5 --output /tmp/apache-ant.tar.gz \
-      https://archive.apache.org/dist/ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.gz && \
-    tar -zx --strip-components=1 -f /tmp/apache-ant.tar.gz -C $ANT_HOME && \
-    rm /tmp/apache-ant.tar.gz
+# Install Apache Ant
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ant \
+    && apt-get purge -y --auto-remove \
+    && rm -rf /var/lib/apt/lists/*
 # Run necessary 'ant' deploy scripts
 RUN ant init_installation update_configs update_code
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -40,16 +40,11 @@ ARG TARGET_DIR=dspace-installer
 # COPY the /install directory from 'build' container to /dspace-src in this container
 COPY --from=build /install /dspace-src
 WORKDIR /dspace-src
-# Create the initial install deployment using ANT
-ENV ANT_VERSION=1.10.12
-ENV ANT_HOME=/tmp/ant-$ANT_VERSION
-ENV PATH=$ANT_HOME/bin:$PATH
-# Download and install 'ant'
-RUN mkdir $ANT_HOME && \
-    curl --silent --show-error --location --fail --retry 5 --output /tmp/apache-ant.tar.gz \
-      https://archive.apache.org/dist/ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.gz && \
-    tar -zx --strip-components=1 -f /tmp/apache-ant.tar.gz -C $ANT_HOME && \
-    rm /tmp/apache-ant.tar.gz
+# Install Apache Ant
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ant \
+    && apt-get purge -y --auto-remove \
+    && rm -rf /var/lib/apt/lists/*
 # Run necessary 'ant' deploy scripts
 RUN ant init_installation update_configs update_code update_webapps
 


### PR DESCRIPTION
## References
* Fixes random Docker build issues where Apache Ant cannot be downloaded, resulting in Docker build errors.

## Description
This PR updates all our Dockerfiles to install Apache Ant via `apt-get` instead of using `curl` to download it from http://archive.apache.org/.

This change is necessary because we are seeing relatively frequent (at least once per day) failures of automated Docker builds in our GitHub Actions which report errors like this:
```
 > [ant_build 4/5] RUN mkdir /tmp/ant-1.10.13 &&     curl --silent --show-error --location --fail --retry 5 --output /tmp/apache-ant.tar.gz       https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.13-bin.tar.gz &&     tar -zx --strip-components=1 -f /tmp/apache-ant.tar.gz -C /tmp/ant-1.10.13 &&     rm /tmp/apache-ant.tar.gz:
133.5 curl: (28) Failed to connect to archive.apache.org port 443 after 133448 ms: Couldn't connect to server
268.7 curl: (28) Failed to connect to archive.apache.org port 443 after 134162 ms: Couldn't connect to server
403.9 curl: (28) Failed to connect to archive.apache.org port 443 after 133161 ms: Couldn't connect to server
543.1 curl: (28) Failed to connect to archive.apache.org port 443 after 135256 ms: Couldn't connect to server
686.5 curl: (28) Failed to connect to archive.apache.org port 443 after 135346 ms: Couldn't connect to server
838.1 curl: (28) Failed to connect to archive.apache.org port 443 after 135531 ms: Couldn't connect to server
```

It appears that the https://archive.apache.org site is either rate limiting our builds, or occasionally unstable.

Since we've switched all Dockerfiles to use `docker.io/eclipse-temurin` images for this Apache Ant step, we can use `apt-get install ant` instead.  I've already verified this installs a compatible version of Apache Ant.

This should be ported to all active branches as these random failures are occurring on all branches.

## Instructions for Reviewers
* All PRs trigger an automatic build & test deploy via Docker. So, if this PR passes all tests, that will prove there's no change in the build/deployment behavior.
* I've also tested this manually by building via Apache Ant obtained from `apt-get` and found no change in behavior.

**Therefore, assuming this passes all tests, I plan to merge this quickly.**  The random failures in GitHub Actions have become increasingly annoying as they sometimes result in Docker images not being fully updated in DockerHub (which can snowball into other e2e test side effects or similar).