### PR TITLE
Support registration of DOIs with Crossref

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -519,6 +519,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>

--- a/dspace-api/src/main/java/org/dspace/app/client/DSpaceHttpClientFactory.java
+++ b/dspace-api/src/main/java/org/dspace/app/client/DSpaceHttpClientFactory.java
@@ -10,6 +10,7 @@ package org.dspace.app.client;
 import static org.apache.commons.collections4.ListUtils.emptyIfNull;
 
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.HttpResponseInterceptor;
@@ -56,6 +57,20 @@ public class DSpaceHttpClientFactory {
      */
     public CloseableHttpClient build() {
         return build(HttpClientBuilder.create(), true);
+    }
+
+    /**
+     * Build an instance of {@link HttpClient} setting the proxy if
+     * configured, customized by a Consumer of an HttpClientBuilder.
+     *
+     * @param customize The Consumer which will be called to customize
+     *                  the client
+     * @return the client
+     */
+    public CloseableHttpClient build(Consumer<HttpClientBuilder> customize) {
+        var builder = HttpClientBuilder.create();
+        customize.accept(builder);
+        return build(builder, true);
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/identifier/doi/crossref/BaseHttpClient.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/doi/crossref/BaseHttpClient.java
@@ -1,0 +1,104 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.identifier.doi.crossref;
+
+import java.io.IOException;
+import javax.annotation.Nullable;
+
+import org.apache.http.HttpHeaders;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
+import org.dspace.app.client.DSpaceHttpClientFactory;
+import org.dspace.identifier.doi.DOIIdentifierException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Low-level HTTP operations for CrossRef/DOI registries.
+ */
+@Component
+class BaseHttpClient {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BaseHttpClient.class);
+
+    private final DSpaceHttpClientFactory httpClientFactory;
+
+    BaseHttpClient(DSpaceHttpClientFactory httpClientFactory) {
+        this.httpClientFactory = httpClientFactory;
+    }
+
+    interface ErrorHandler {
+        void handleError(int statusCode, String content) throws DOIIdentifierException;
+    }
+
+    /**
+     * Sends a request to a DOI registry.
+     *
+     * @param req The request to be sent.
+     * @return A {@link HttpResponse} object containing information about the registry response.
+     * @throws DOIIdentifierException if an error occurs during request submission.
+     */
+    HttpResponse sendHttpRequest(HttpUriRequest req,
+                                 boolean disableRedirects,
+                                 ErrorHandler handleError) throws DOIIdentifierException {
+
+        /*
+            for request logging try increasing loglevels:
+
+            org.apache.http=DEBUG
+            org.apache.http.wire=DEBUG
+         */
+
+        try (var client = newClient(disableRedirects)) {
+            try (var response = client.execute(req)) {
+                var status = response.getStatusLine();
+                var statusCode = status.getStatusCode();
+                var content = extractContent(response);
+
+                handleError.handleError(statusCode, content);
+
+                var url = extractRedirectUrlFromResponse(response);
+
+                return new HttpResponse(statusCode, content, url);
+            }
+        } catch (IOException e) {
+            LOG.warn("Caught an IOException: ", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    private CloseableHttpClient newClient(boolean disableRedirects) {
+        if (disableRedirects) {
+            return httpClientFactory.build(HttpClientBuilder::disableRedirectHandling);
+        } else {
+            return httpClientFactory.build();
+        }
+    }
+
+    @Nullable
+    private String extractContent(CloseableHttpResponse response) throws IOException {
+        var entity = response.getEntity();
+        if (entity != null) {
+            return EntityUtils.toString(entity, "UTF-8");
+        }
+        return null;
+    }
+
+    @Nullable
+    private String extractRedirectUrlFromResponse(org.apache.http.HttpResponse response) {
+        if (response.containsHeader(HttpHeaders.LOCATION)) {
+            return response.getFirstHeader(HttpHeaders.LOCATION).getValue();
+        }
+
+        return null;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/identifier/doi/crossref/CrossRefClient.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/doi/crossref/CrossRefClient.java
@@ -1,0 +1,239 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+
+package org.dspace.identifier.doi.crossref;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.mime.MultipartEntityBuilder;
+import org.dspace.identifier.doi.DOIIdentifierException;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.JDOMException;
+import org.jdom2.filter.Filters;
+import org.jdom2.input.SAXBuilder;
+import org.jdom2.output.Format;
+import org.jdom2.output.XMLOutputter;
+import org.jdom2.xpath.XPathExpression;
+import org.jdom2.xpath.XPathFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CrossRefClient {
+
+    /**
+     * Timeout for API responses. Defaults to 2 minutes (120,000
+     * milliseconds) as processing can be very, very slow. We don’t
+     * get any answer at all from this CrossRef API until its own
+     * internal queue has reached the task we give it, so the amount
+     * of time it takes to respond depends strongly on the number of
+     * other people who are trying to register DOIs at the same time.
+     * In the future it might be nice to re-engineer the CrossRef DOI
+     * connector to enqueue asynchronously and wait for a response or
+     * poll for success separately.
+     */
+    protected int TIMEOUT = 120000;
+
+    private static final Logger LOG = LoggerFactory.getLogger(CrossRefClient.class);
+
+    private final BaseHttpClient client;
+    private final String scheme;
+    private final String host;
+    private final Integer port;
+    private final String path;
+
+    private final String userName;
+    private final String password;
+
+    private static final String FORM_DATA_FILE = "mdFile";
+
+    public CrossRefClient(
+            @Value("${identifier.doi.crossref.schema:https}")
+            String scheme,
+
+            @Value("${identifier.doi.crossref.host:test.crossref.org}")
+            String host,
+
+            @Value("${identifier.doi.crossref.port:#{null}}")
+            Integer port,
+
+            @Value("${identifier.doi.crossref.path:/v2/deposits}")
+            String path,
+
+            @Value("${identifier.doi.user}")
+            String userName,
+
+            @Value("${identifier.doi.password}")
+            String password,
+
+            BaseHttpClient client) {
+        this.scheme = scheme;
+        this.host = host;
+        this.port = port;
+        this.path = path;
+        this.userName = userName;
+        this.password = password;
+        this.client = client;
+    }
+
+    protected HttpResponse sendDepositRequest(Element metadataRoot) throws DOIIdentifierException {
+        Format format = Format.getCompactFormat();
+        format.setEncoding("UTF-8");
+        XMLOutputter xout = new XMLOutputter(format);
+        String xoutString = xout.outputString(new Document(metadataRoot));
+        return sendDepositRequest(xoutString);
+    }
+
+    protected HttpResponse sendDepositRequest(String metadata) throws DOIIdentifierException {
+
+        var httppost = buildRequest();
+
+        LOG.info("Sending the following xml: \n{}", metadata);
+
+        var payload = MultipartEntityBuilder.create()
+                .addTextBody("operation", "doMDUpload")
+                .addTextBody("usr", userName)
+                .addTextBody("pwd", password)
+                .addBinaryBody(FORM_DATA_FILE,
+                        metadata.getBytes(),
+                        ContentType.create("text/xml", StandardCharsets.UTF_8),
+                        "requestData.xml")
+                .build();
+        httppost.setEntity(payload);
+
+        return client.sendHttpRequest(httppost, false, this::handleErrorCodes);
+    }
+
+    private HttpPost buildRequest() {
+        // check https://crossref.gitlab.io/knowledge_base/docs/services/xml-deposit-synchronous-2/  for API documentation
+
+        var uri = new URIBuilder();
+        uri.setScheme(scheme).setHost(host).setPath(path);
+
+        if (port != null) {
+            uri.setPort(port);
+        }
+
+        try {
+            var post = new HttpPost(uri.build());
+            var requestConfig = RequestConfig.custom()
+                    .setConnectionRequestTimeout(TIMEOUT).setSocketTimeout(TIMEOUT).build();
+            post.setConfig(requestConfig);
+
+            return post;
+        } catch (URISyntaxException e) {
+            LOG.error("The URL we constructed to deposit a new DOI"
+                      + "produced a URISyntaxException. Please check the configuration parameters!");
+            LOG.error("The URL was {}.", scheme + "://" + host + path);
+            throw new RuntimeException("The URL we constructed to deposit a new DOI "
+                                       + "produced a URISyntaxException. " +
+                                       "Please check the configuration parameters!", e);
+        }
+    }
+
+    private void handleErrorCodes(int statusCode, String content) throws DOIIdentifierException {
+        switch (statusCode) {
+            case (200): {
+                try {
+                    SAXBuilder builder = new SAXBuilder();
+                    Document doc = builder.build(new StringReader(content));
+                    XPathExpression<Object> xpath = XPathFactory.instance().compile(
+                            "/doi_batch_diagnostic/record_diagnostic[@status = 'Failure']", Filters.fpassthrough(),
+                            null);
+                    List<Object> res = xpath.evaluate(doc);
+                    if (res.size() > 0) {
+                        LOG.info("Crossref failed to process the input paylod.");
+                        LOG.info("The response was: {}", content);
+                        throw new DOIIdentifierException("Crossref returned 200 but with a failure status",
+                                                                 DOIIdentifierException.BAD_REQUEST);
+                    }
+
+                    return;
+                } catch (JDOMException e) {
+                    LOG.warn("Crossref returned 200 but with invalid XML: the DOI might have been registered or not");
+                    LOG.warn("The response was: {}", content);
+                    throw new DOIIdentifierException("The response from Crossref was not valid parseable XML",
+                                                             DOIIdentifierException.BAD_ANSWER);
+                } catch (IOException e) {
+                    LOG.warn("Crossref returned 200 but we failed to parse the response");
+                    LOG.warn("The response was: {}", content);
+                    throw new DOIIdentifierException("An internal error occurred parsing the response from Crossref",
+                                                             DOIIdentifierException.INTERNAL_ERROR);
+                }
+            }
+
+            case (400): {
+                LOG.info("Crossref did not accept the sent request.");
+                LOG.info("The response was: {}", content);
+                throw new DOIIdentifierException("Crossref did not accept the sent request.",
+                        DOIIdentifierException.BAD_REQUEST);
+            }
+
+            // we get a 401 if we forgot to send credentials or if the username
+            // and password did not match.
+            case (401): {
+                LOG.info("We were unable to authenticate against the Crossref server!");
+                LOG.info("The response was: {}", content);
+                throw new DOIIdentifierException("Cannot authenticate at the "
+                                                 + "Crossref server. Please check if username "
+                                                 + "and password are set correctly.",
+                        DOIIdentifierException.AUTHENTICATION_ERROR);
+            }
+
+            case (403): {
+                var msg = "There was some error during the processing of the submission. " +
+                          "The message body will contain the doi_batch_diagnostic message.";
+                LOG.info(msg);
+                LOG.info("The response was: {}", content);
+
+                throw new DOIIdentifierException(msg,
+                        DOIIdentifierException.BAD_REQUEST);
+            }
+
+            // 500 is documented and signals an internal server error
+            case (500): {
+                LOG.warn("Caught an http status code 500 while managing DOI " + "{}. Message was: ", content);
+                throw new DOIIdentifierException("Crossref API has an internal error. "
+                                                 + "It is temporarily impossible to manage DOIs. "
+                                                 + "Further information can be found in DSpace log file.",
+                        DOIIdentifierException.INTERNAL_ERROR);
+            }
+
+            // 504 is gateway timeout and means we should increase our client-side timeout
+            case (504): {
+                LOG.warn("Caught an http status code 504 (gateway timeout) while managing DOI. Message was: {}",
+                        content);
+                throw new DOIIdentifierException("Crossref API took too long responding to our request. "
+                                                 + "Increase the CROSSREF_TIMEOUT in the " +
+                                                 "identifier services spring configuration. "
+                                                 + "Further information can be found in DSpace log file.",
+                        DOIIdentifierException.INTERNAL_ERROR);
+            }
+
+            // Catch all other http status code in case we forgot one.
+            default: {
+                LOG.warn("While registering we got a http status code {} and the message \"{}\".",
+                        statusCode, content);
+                throw new DOIIdentifierException("Unable to parse an answer from Crossref API. " +
+                                                 "Please have a look into the DSpace logs.",
+                        DOIIdentifierException.BAD_ANSWER);
+            }
+        }
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/identifier/doi/crossref/CrossRefConnector.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/doi/crossref/CrossRefConnector.java
@@ -1,0 +1,401 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.identifier.doi.crossref;
+
+import static org.dspace.identifier.DOIIdentifierProvider.CFG_DOI_METADATA;
+
+import java.sql.SQLException;
+import java.util.Date;
+import java.util.List;
+
+import org.dspace.content.DSpaceObject;
+import org.dspace.content.Item;
+import org.dspace.content.MetadataFieldName;
+import org.dspace.content.MetadataValue;
+import org.dspace.content.service.ItemService;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+import org.dspace.handle.service.HandleService;
+import org.dspace.identifier.doi.DOIConnector;
+import org.dspace.identifier.doi.DOIIdentifierException;
+import org.dspace.identifier.service.DOIService;
+import org.dspace.services.ConfigurationService;
+import org.jdom2.Element;
+import org.jdom2.Namespace;
+import org.jdom2.filter.Filters;
+import org.jdom2.output.Format;
+import org.jdom2.output.XMLOutputter;
+import org.jdom2.xpath.XPathExpression;
+import org.jdom2.xpath.XPathFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CrossRefConnector implements DOIConnector {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CrossRefConnector.class);
+
+    private final ItemService itemService;
+    private final DOIService doiService;
+    private final DOIResolverClient doiResolverClient;
+    private final CrossRefClient crossRefClient;
+    private final CrossRefPayloadService crossRefPayloadService;
+    private final HandleService handleService;
+    private final ConfigurationService configurationService;
+    private final boolean crossRefOverride;
+    private static final String CROSSREF_SCHEMA = "http://www.crossref.org/schema/4.4.2";
+
+    // dc.identifier.issn
+    private String parentIssnField;
+
+    private String registrant;
+    private String depositor;
+    private String depositorEmail;
+    private String SCHEME = "https";
+
+    @Autowired
+    public CrossRefConnector(ItemService itemService,
+            DOIService doiService,
+            DOIResolverClient doiResolverClient,
+            CrossRefClient crossRefClient,
+            CrossRefPayloadService crossRefPayloadService,
+            HandleService handleService,
+            ConfigurationService configurationService,
+            @Value("${identifier.doi.crossref.override:false}") boolean crossRefOverride,
+            @Value("${identifier.doi.crossref.parentIssnField:dc.identifier.issn}") String parentIssnField,
+            @Value("${identifier.doi.crossref.registrant:REGISTRANT}") String registrant,
+            @Value("${identifier.doi.crossref.depositor:DEPOSITOR}") String depositor,
+            @Value("${identifier.doi.crossref.depositorEmail:DEPOSITOREMAIL}") String depositorEmail) {
+        this.handleService = handleService;
+        this.configurationService = configurationService;
+        this.itemService = itemService;
+        this.doiService = doiService;
+        this.doiResolverClient = doiResolverClient;
+        this.crossRefClient = crossRefClient;
+        this.crossRefPayloadService = crossRefPayloadService;
+        this.crossRefOverride = crossRefOverride;
+        this.parentIssnField = parentIssnField;
+        this.registrant = registrant;
+        this.depositor = depositor;
+        this.depositorEmail = depositorEmail;
+
+    }
+
+    @Override
+    public boolean isDOIReserved(Context context, String doi) {
+        // Crossref does not require reservation of DOIs, we just return true
+        return true;
+    }
+
+    @Override
+    public boolean isDOIRegistered(Context context, String doi) throws DOIIdentifierException {
+        return isDOIRegistered(context, null, doi);
+    }
+
+    private boolean isDOIRegistered(Context context, DSpaceObject dso, String doi) throws DOIIdentifierException {
+        var response = doiResolverClient.sendDOIGetRequest(doi);
+
+        if (response.statusCode() == getDoiGetSuccessStatusCode()) {
+
+            if (dso == null) {
+                return true;
+            }
+
+            var doiUrl = response.url();
+
+            if (doiUrl == null) {
+                LOG.error("Received a status code 302 without a response content. DOI: {}.", doi);
+                throw new DOIIdentifierException("Received a http status code 302 without a response content.",
+                        DOIIdentifierException.BAD_ANSWER);
+            }
+
+            var dsoUrl = getDsoUrl(context, dso);
+
+            if (dsoUrl == null) {
+                // the handle of the dso was not found in our db?!
+                LOG.error("The HandleManager was unable to find the handle of a DSpaceObject in the database! "
+                          + "Type: {} ID: {}", getTypeText(dso), dso.getID());
+                throw new RuntimeException(
+                        "The HandleManager was unable to find the handle of a DSpaceObject in the database!");
+            }
+
+            return (dsoUrl.equals(doiUrl));
+        }
+
+        // 404 "Not Found" means DOI is neither reserved nor registered.
+        if (response.statusCode() == 404) {
+            return false;
+        }
+
+        // Catch all other http status code in case we forgot one.
+        LOG.warn(
+                "While checking if the DOI {} is registered, we got a "
+                + "http status code {} and the message \"{}\".", doi, response.statusCode(), response.content());
+        throw new DOIIdentifierException(
+                "Unable to parse an answer from " + "DataCite API. Please have a look into DSpace logs.",
+                DOIIdentifierException.BAD_ANSWER);
+    }
+
+    /**
+     * This method returns the URL the doi should resolve to.
+     */
+    private String getDsoUrl(Context context, DSpaceObject dso) throws DOIIdentifierException {
+        try {
+            return handleService.resolveToURL(context, dso.getHandle());
+        } catch (SQLException e) {
+            throw new DOIIdentifierException("could not lookup url", e);
+        }
+    }
+
+    static String getTypeText(DSpaceObject dso) {
+        var type = dso.getType();
+
+        return Constants.typeText[type];
+    }
+
+    private int getDoiGetSuccessStatusCode() {
+        // We are resolving the DOI and if that is successful, we'll get a 302 Found
+        // back
+        return 302;
+    }
+
+    @Override
+    public void deleteDOI(Context context, String doi) {
+        LOG.warn("Skipping deletion of DOI as Crossref does not allow deactivation of DOIs.");
+    }
+
+    @Override
+    public void reserveDOI(Context context, DSpaceObject dso, String doi) {
+        LOG.warn("Skipping reserving DOI as Crossref does not require this step.");
+    }
+
+    @Override
+    public void registerDOI(Context context, DSpaceObject dso, String doi) throws DOIIdentifierException {
+
+        if (!(dso instanceof Item item)) {
+            throw new IllegalArgumentException("cannot register DOIs for non-Item objects!");
+        }
+
+        // check if the DOI is already registered online
+        if (isDOIRegistered(context, doi)) {
+            // if it is registered for another object we should notify an admin
+            if (!crossRefOverride && !isDOIRegistered(context, dso, doi)) {
+                LOG.warn("DOI {} is registered for another object already.", doi);
+                throw new DOIIdentifierException(DOIIdentifierException.DOI_ALREADY_EXISTS);
+            }
+        }
+
+        List<MetadataValue> typeMetaData = itemService.getMetadata(item, "dc", "type", Item.ANY, Item.ANY);
+
+        if (typeMetaData == null || typeMetaData.isEmpty()) {
+            throw new DOIIdentifierException("Type of record is missing.");
+        }
+
+        String type = typeMetaData.get(0).getValue();
+
+        validateItemMetadata(item, type);
+
+        var metadataDOI = extractDOI(item);
+        if (metadataDOI != null) {
+            var existingDoi = stripDoiUrl(metadataDOI);
+            // Are we trying to update the wrong object?
+            if (!existingDoi.equals(doi)) {
+                LOG.info("DSO with type {} and id {} already has DOI {} which doesn't match {}. Won't register object.",
+                        getTypeText(dso), dso.getID(), metadataDOI, doi);
+                return;
+            }
+        }
+
+        Element payload = crossRefPayloadService.disseminate(context, dso, type, doi);
+
+        // Add additional XML elements not derived from metadata
+        addHeadInfo(payload, dso);
+        try {
+            addDoi(context, payload, doi, dso);
+        } catch (SQLException ex) {
+            LOG.debug("Error while ingesting doi into crossref xml", ex);
+            throw new RuntimeException(ex);
+        }
+
+        HttpResponse resp = crossRefClient.sendDepositRequest(payload);
+        LOG.debug("Deposit DOI response: {}", resp);
+    }
+
+    private String stripDoiUrl(String doiUrl) {
+        return doiUrl.replaceFirst("https?://(dx\\.)?doi\\.org(:\\d+)?/", "doi:");
+    }
+
+    private void validateItemMetadata(Item item, String type) throws DOIIdentifierException {
+        if ("article".equals(type)) {
+            // Journal articles must have a journal ISSN to provide as journal metadata
+            String[] issnFieldParts = parentIssnField.split("\\.");
+            if (issnFieldParts.length < 2) {
+                LOG.error("Invalid ISSN field configured in spring. Should be eg. dc.identifier.issn");
+                throw new DOIIdentifierException(DOIIdentifierException.CONVERSION_ERROR);
+            }
+            // Get ISSNs
+            var issns = itemService.getMetadata(item, issnFieldParts[0], issnFieldParts[1],
+                    (issnFieldParts.length == 3 ? issnFieldParts[2] : null), Item.ANY);
+            if (issns.isEmpty()) {
+                LOG.error("article type must supply at least one ISSN or DOI to identify the parent publication.");
+                throw new DOIIdentifierException(DOIIdentifierException.CONVERSION_ERROR);
+            }
+        }
+    }
+
+    @Override
+    public void updateMetadata(Context context, DSpaceObject dso, String doi) throws DOIIdentifierException {
+        if (!crossRefOverride && isDOIRegistered(context, dso, doi)) {
+            LOG.warn("Trying to update metadata for DOI {}, that is reserved for another dso.", doi);
+            throw new DOIIdentifierException("Trying to update metadata for a DOI that is reserved for another object.",
+                    DOIIdentifierException.DOI_ALREADY_EXISTS);
+        }
+
+        // We can simply make another deposit request to Crossref for updating metadata
+        this.registerDOI(context, dso, doi);
+    }
+
+    /**
+     * This method gets the doi from the passed object if it already has one.
+     *
+     * @param dso the object to extract the doi from
+     * @return the doi of the object or null
+     */
+    private String extractDOI(Item dso) {
+        MetadataFieldName doiMetadataFieldName = new MetadataFieldName(
+                this.configurationService.getProperty(CFG_DOI_METADATA, "dc.identifier.doi"));
+        List<MetadataValue> metadataValues = itemService.getMetadata(dso,
+                doiMetadataFieldName.schema,
+                doiMetadataFieldName.element,
+                doiMetadataFieldName.qualifier,
+                Item.ANY);
+
+        if (metadataValues.size() == 0) {
+            return null;
+        } else {
+            if (metadataValues.size() > 1) {
+                LOG.warn("Found multiple DOI metadata fields for item {}, using the first one", dso.getID());
+            }
+            return metadataValues.get(0).getValue();
+        }
+    }
+
+    /**
+     * Crossref requires any request to have an integer version of date and time
+     * upon which it decides if a record needs to be updated if it already exits.
+     *
+     * @param root
+     * @return
+     */
+    protected Element addTimestamp(Element root) {
+        Element identifier = new Element("timestamp", CROSSREF_SCHEMA);
+        identifier.addContent(new Date().getTime() + "");
+        return root.getChild("head", Namespace.getNamespace(CROSSREF_SCHEMA)).addContent(identifier);
+    }
+
+    /**
+     * Crossref requires a batch id. This method adds a batch id created out of the handle
+     * of a DSpaceObject to the head element.
+     *
+     * @param root The root of the XML.
+     * @return The parent of the new created element (<code>head</code>)
+     */
+    protected Element addBatchId(Element root, DSpaceObject dso) {
+        Element batchId = new Element("doi_batch_id", CROSSREF_SCHEMA);
+        batchId.addContent(dso.getHandle().replaceAll("/", "_"));
+        LOG.info("Set id: " + dso.getHandle().replaceAll("/", "_"));
+        return root.getChild("head", Namespace.getNamespace(CROSSREF_SCHEMA)).addContent(0, batchId);
+    }
+
+    /**
+     * Adds the <code>head</code> information to the XML document to be submitted
+     * to Crossref. Specifically, this method adds timestamp, batch id, depositor,
+     * and registrant information. Depositor and registrant values should be configured
+     * in dspace.cfg.
+     *
+     * @param root The root of the XML.
+     * @param dso The DSpaceObject for which the XML is being created.
+     * @return The parent of the new created element (<code>head</code>)
+     */
+    protected Element addHeadInfo(Element root, DSpaceObject dso) {
+        // add batch id
+        addBatchId(root, dso);
+
+        // add timestamp
+        addTimestamp(root);
+
+        // add depositor element
+        Element depositor = new Element("depositor", CROSSREF_SCHEMA);
+        Element depositorName = new Element("depositor_name", CROSSREF_SCHEMA);
+        depositorName.addContent(this.depositor);
+        Element depositorEmail = new Element("email_address", CROSSREF_SCHEMA);
+        depositorEmail.addContent(this.depositorEmail);
+
+        depositor.addContent(depositorName);
+        depositor.addContent(depositorEmail);
+
+        root.getChild("head", Namespace.getNamespace(CROSSREF_SCHEMA)).addContent(depositor);
+
+        // add registrant
+        Element registrant = new Element("registrant", CROSSREF_SCHEMA);
+        registrant.addContent(this.registrant);
+
+        return root.getChild("head", Namespace.getNamespace(CROSSREF_SCHEMA)).addContent(registrant);
+    }
+
+    /**
+     * Add the doi to the xml that will be send to CrossRef. We expect the XML to contain exactly one node doi_data
+     * into which we will ingest the doi information.
+     * @param c org.dspace.core.Context
+     * @param root The XML into which the doi information shall be ingested.
+     * @param doi The doi to ingest.
+     * @param dso The DSpaceObject for which the DOI is registered, to create the URL to which the DOI shall point to.
+     * @return The XML with the ingested DOI information.
+     * @throws SQLException
+     */
+    protected Element addDoi(Context c, Element root, String doi, DSpaceObject dso) throws SQLException {
+        // create the information to ingest (doi and url)
+        Element doiInformation = new Element("doi", CROSSREF_SCHEMA);
+        doiInformation.addContent(doi.substring(SCHEME.length() - 1));
+        Element resource = new Element("resource", CROSSREF_SCHEMA);
+        resource.addContent(handleService.resolveToURL(c, dso.getHandle()));
+
+        // find the node into which the information shall be ingested
+        List<Element> nodes = null;
+        try {
+            XPathFactory xPathFactory = XPathFactory.instance();
+            Namespace xns = Namespace.getNamespace("x", root.getNamespaceURI());
+            XPathExpression<Element> expr = xPathFactory.compile(".//x:doi_data", Filters.element(), null, xns);
+            nodes = expr.evaluate(root);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        if (nodes.size() != 1 ) {
+            LOG.error("Trying to create invalid XML for Crossref. There should be exactly one node 'doi_data'.");
+            throw new IllegalStateException("Trying to create invalid XML for Crossref. " +
+                                            "There should be one node 'doi_data' only.");
+        }
+
+        Element doiData = nodes.get(0);
+        doiData.addContent(doiInformation);
+        doiData.addContent(resource);
+
+        if (LOG.isDebugEnabled()) {
+            Format format = Format.getCompactFormat();
+            format.setEncoding("UTF-8");
+            XMLOutputter xout = new XMLOutputter(format);
+            LOG.debug("Ingested " + doi + ":");
+            LOG.debug(xout.outputString(root));
+        }
+        return root;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/identifier/doi/crossref/CrossRefPayloadService.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/doi/crossref/CrossRefPayloadService.java
@@ -1,0 +1,110 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+
+package org.dspace.identifier.doi.crossref;
+
+import static org.dspace.identifier.doi.crossref.CrossRefConnector.getTypeText;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.content.DSpaceObject;
+import org.dspace.content.crosswalk.CrosswalkException;
+import org.dspace.content.crosswalk.DisseminationCrosswalk;
+import org.dspace.content.crosswalk.ParameterizedDisseminationCrosswalk;
+import org.dspace.core.Context;
+import org.dspace.core.service.PluginService;
+import org.dspace.identifier.doi.DOIIdentifierException;
+import org.dspace.services.ConfigurationService;
+import org.jdom2.Element;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * responsibility of this class is to build a payload suitable for uploading to the CrossRef
+ * <a href="https://www.crossref.org/documentation/register-maintain-records/direct-deposit-xml/https-post/">API</a>
+ */
+@Component
+public class CrossRefPayloadService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CrossRefPayloadService.class);
+
+    private final ConfigurationService configurationService;
+    private final PluginService pluginService;
+    private final String crosswalkName;
+    private final String institution;
+
+    @Autowired
+    CrossRefPayloadService(PluginService pluginService,
+                           ConfigurationService configurationService,
+                           @Value("${identifier.doi.crossref.crosswalkname:Crossref}") String crosswalkName) {
+        this.pluginService = pluginService;
+        this.crosswalkName = crosswalkName;
+        this.configurationService = configurationService;
+
+        if (configurationService.hasProperty("identifier.doi.crossref.institution")) {
+            this.institution = configurationService.getProperty("identifier.doi.crossref.institution");
+        } else {
+            this.institution = null;
+        }
+    }
+
+    Element disseminate(Context context, DSpaceObject dso, String type, String doi) throws DOIIdentifierException {
+
+        var xwalk = lookupXwalk(type);
+
+        Map<String, String> parameters = new HashMap<>();
+        if (this.institution != null) {
+            parameters.put("institution", this.institution);
+        }
+
+        if (!xwalk.canDisseminate(dso)) {
+            LOG.error("Crosswalk {} cannot disseminate DSO with type {} and ID {}. Giving up reserving the DOI {}.",
+                    this.crosswalkName,
+                    dso.getType(),
+                    dso.getID(),
+                    doi);
+
+            throw new DOIIdentifierException("Cannot disseminate " + getTypeText(dso) + "/" + dso.getID()
+                                             + " using crosswalk " + this.crosswalkName + ".",
+                    DOIIdentifierException.CONVERSION_ERROR);
+        }
+
+        try {
+            return xwalk.disseminateElement(context, dso, parameters);
+        } catch (CrosswalkException | IOException | SQLException | AuthorizeException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private ParameterizedDisseminationCrosswalk lookupXwalk(String type) {
+        var xwalk = (ParameterizedDisseminationCrosswalk) pluginService
+                .getNamedPlugin(DisseminationCrosswalk.class,
+                        this.crosswalkName + "_" + type.replace(" ", "_").toLowerCase());
+
+        // default crosswalk
+        if (xwalk == null) {
+            xwalk = (ParameterizedDisseminationCrosswalk) pluginService
+                    .getNamedPlugin(DisseminationCrosswalk.class, this.crosswalkName + "_other");
+        }
+
+        if (xwalk == null) {
+            throw new RuntimeException("Can't find crosswalk '" + crosswalkName
+                                       + "_" + type.replace(" ", "_").toLowerCase()
+                                       + "' or " + crosswalkName  + "_other!");
+        }
+
+        return xwalk;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/identifier/doi/crossref/DOIResolverClient.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/doi/crossref/DOIResolverClient.java
@@ -1,0 +1,133 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.identifier.doi.crossref;
+
+import java.net.URISyntaxException;
+
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.utils.URIBuilder;
+import org.dspace.identifier.DOI;
+import org.dspace.identifier.doi.DOIIdentifierException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DOIResolverClient {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DOIResolverClient.class);
+
+    private final BaseHttpClient client;
+    private final String scheme;
+    private final String host;
+    private final Integer port;
+
+    DOIResolverClient(@Value("${doi.resolver.scheme:https}") String scheme,
+                      @Value("${doi.resolver.host:dx.doi.org}") String host,
+                      @Value("${doi.resolver.port:#{null}}") Integer port,
+                      BaseHttpClient client
+    ) {
+        this.scheme = scheme;
+        this.host = host;
+        this.port = port;
+        this.client = client;
+    }
+
+    /**
+     * Timeout for API responses. Defaults to 5 seconds as processing can be slow.
+     */
+    protected int TIMEOUT = 5000;
+
+    /**
+     * This method checks if a DOI is already registered.
+     *
+     * See https://www.crossref.org/documentation/register-maintain-records/verify-your-registration/ for
+     * details.
+     */
+    HttpResponse sendDOIGetRequest(String doi) throws DOIIdentifierException {
+
+        validateDoiFormat(doi);
+
+        var request = buildRequest(doi);
+
+        return doRequest(doi, request);
+    }
+
+    private void validateDoiFormat(String doi) {
+        if (!doi.startsWith(DOI.SCHEME)) {
+            throw new IllegalArgumentException("The DOI " + doi + " does not start with " + DOI.SCHEME);
+        }
+    }
+
+    private HttpResponse doRequest(String doi, HttpGet httpget) throws DOIIdentifierException {
+        return client.sendHttpRequest(httpget, true, buildErrorHandler(doi));
+    }
+
+    private HttpGet buildRequest(String doi) {
+
+        var uribuilder = new URIBuilder();
+
+        uribuilder.setScheme(scheme).setHost(host)
+                .setPath("/" + doi.substring(DOI.SCHEME.length()));
+
+        if (port != null) {
+            uribuilder.setPort(port);
+        }
+
+        try {
+            // we don't want to follow the redirect, or we don't know if just the handle
+            // doesn't resolve or the DOI
+            var requestConfig = RequestConfig.custom()
+                    .setSocketTimeout(TIMEOUT)
+                    .setConnectionRequestTimeout(TIMEOUT)
+                    .setRedirectsEnabled(false)
+                    .build();
+
+            var httpGet = new HttpGet(uribuilder.build());
+            httpGet.setConfig(requestConfig);
+
+            return httpGet;
+
+        } catch (URISyntaxException e) {
+            LOG.error("The URL we constructed to check a DOI "
+                      + "produced a URISyntaxException. Please check the configuration parameters!");
+            LOG.error("The URL was {}.",
+                    scheme + "://" + host + (port != null ? (":" + port) : "") + "/"
+                    + doi.substring(DOI.SCHEME.length()));
+            throw new RuntimeException("The URL we constructed to check a DOI "
+                                       + "produced a URISyntaxException. " +
+                                       "Please check the configuration parameters!", e);
+        }
+    }
+
+    private BaseHttpClient.ErrorHandler buildErrorHandler(String doi) {
+        return (statusCode, content) -> handleErrorCodes(doi, statusCode, content);
+    }
+
+    private void handleErrorCodes(String doi, int statusCode, String content) throws DOIIdentifierException {
+
+        switch (statusCode) {
+            case (404): // fallthrough
+            case (302): {
+                // No error, return (this check is necessary since we include a 'default' case
+                return;
+            }
+
+            // Catch all other http status code in case we forgot one.
+            default: {
+                LOG.warn("While checking the DOI {}, we got an unexpected http status code {} and the message \"{}\".",
+                        doi, statusCode, content);
+                throw new DOIIdentifierException("Unable to parse an answer from Crossref API. " +
+                                                 "Please have a look into the DSpace logs.",
+                        DOIIdentifierException.BAD_ANSWER);
+            }
+        }
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/identifier/doi/crossref/HttpResponse.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/doi/crossref/HttpResponse.java
@@ -1,0 +1,11 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.identifier.doi.crossref;
+
+public record HttpResponse(int statusCode, String content, String url) {
+}

--- a/dspace-api/src/test/java/org/dspace/identifier/doi/crossref/CrossRefClientTest.java
+++ b/dspace-api/src/test/java/org/dspace/identifier/doi/crossref/CrossRefClientTest.java
@@ -1,0 +1,116 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+
+package org.dspace.identifier.doi.crossref;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import java.io.IOException;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.dspace.identifier.doi.DOIIdentifierException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class CrossRefClientTest {
+
+    private MockWebServer server;
+    private CrossRefClient client;
+
+    @Before
+    public void setUp() throws IOException {
+        server = new MockWebServer();
+        server.start();
+
+        var baseClient = TestClient.baseHttpClientForTest();
+
+        client = new CrossRefClient(
+                "http",
+                server.getHostName(),
+                server.getPort(),
+                "/deposit",
+                "user",
+                "pass",
+                baseClient);
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        server.shutdown();
+    }
+
+    @Test
+    public void sendDepositRequest_success_returnsDoiResponseAndSendsMultipart() throws Exception {
+        var metadata = "metaData";
+
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setBody("<?xml version=\"1.0\" encoding=\"UTF-8\"?><doi_batch_diagnostic />"));
+
+        var response = client.sendDepositRequest(metadata);
+
+        assertThat(response).isNotNull();
+        assertThat(response.statusCode()).isEqualTo(200);
+
+        var recorded = server.takeRequest();
+
+        // check https://www.crossref.org/documentation/register-maintain-records/direct-deposit-xml/https-post/ on details of the crossref API
+
+        assertThat(recorded.getMethod()).isEqualTo("POST");
+        assertThat(recorded.getPath()).isEqualTo("/deposit");
+
+        var body = recorded.getBody().readUtf8();
+        assertThat(body).contains("Content-Disposition: form-data; name=\"mdFile\"; filename=\"requestData.xml\"");
+        assertThat(body).contains(metadata);
+
+        var contentType = recorded.getHeader("Content-Type");
+        assertThat(contentType).contains("multipart/form-data");
+    }
+
+    @Test
+    public void sendDepositRequest_unauthorized_throwsDOIIdentifierExceptionWithAuthCode() throws Exception {
+        server.enqueue(new MockResponse()
+                .setResponseCode(401)
+                .setBody("<?xml version=\"1.0\" encoding=\"UTF-8\"?><doi_batch_diagnostic />"));
+
+        assertThatExceptionOfType(DOIIdentifierException.class)
+                .isThrownBy(() -> client.sendDepositRequest("metadata"))
+                .matches(ex -> ex.getCode() == DOIIdentifierException.AUTHENTICATION_ERROR);
+
+    }
+
+    @Test
+    public void sendDepositRequest_200withFailureMessage_throwsDOIIdentifierExceptionWithBadRequest() throws Exception {
+        server.enqueue(new MockResponse()
+                       .setResponseCode(200)
+                       .setBody("""
+                                <?xml version="1.0" encoding="UTF-8"?>
+                                <doi_batch_diagnostic status="completed" sp="cskAir.local">
+                                    <submission_id>1407395745</submission_id>
+                                    <batch_id>test201707181318</batch_id>
+                                    <record_diagnostic status="Failure" msg_id="4">
+                                       <doi>10.5555/doitestwithcomponent_2</doi>
+                                       <msg>Record not processed (etc.)</msg>
+                                    </record_diagnostic>
+                                    <batch_data>
+                                       <record_count>1</record_count>
+                                       <success_count>0</success_count>
+                                       <warning_count>0</warning_count>
+                                       <failure_count>1</failure_count>
+                                    </batch_data>
+                                 </doi_batch_diagnostic>
+                                """));
+
+        assertThatExceptionOfType(DOIIdentifierException.class)
+                .isThrownBy(() -> client.sendDepositRequest("metadata"))
+                .matches(ex -> ex.getCode() == DOIIdentifierException.BAD_REQUEST);
+    }
+}

--- a/dspace-api/src/test/java/org/dspace/identifier/doi/crossref/CrossRefConnectorTest.java
+++ b/dspace-api/src/test/java/org/dspace/identifier/doi/crossref/CrossRefConnectorTest.java
@@ -1,0 +1,115 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.identifier.doi.crossref;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.dspace.AbstractDSpaceTest;
+import org.dspace.content.Item;
+import org.dspace.content.MetadataValue;
+import org.dspace.content.service.ItemService;
+import org.dspace.core.Context;
+import org.dspace.handle.service.HandleService;
+import org.dspace.identifier.service.DOIService;
+import org.dspace.services.ConfigurationService;
+import org.dspace.utils.DSpace;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class CrossRefConnectorTest extends AbstractDSpaceTest {
+
+    ItemService itemService = Mockito.mock(ItemService.class);
+
+    DOIResolverClient doiResolverClient = Mockito.mock(DOIResolverClient.class);
+    CrossRefClient crossRefClient = Mockito.mock(CrossRefClient.class);
+    DOIService doiService = Mockito.mock(DOIService.class);
+    HandleService handleService = Mockito.mock(HandleService.class);
+
+    protected ConfigurationService configurationService = new DSpace().getConfigurationService();
+
+    CrossRefConnector sut = new CrossRefConnector(itemService,
+            doiService,
+            doiResolverClient,
+            crossRefClient,
+            Mockito.mock(CrossRefPayloadService.class),
+            handleService,
+            configurationService,
+            true,
+            "dc.identifier.issn",
+            "registrant",
+            "depositor",
+            "depositorEmail"
+            );
+
+    @Test
+    public void canCheckDOIReservation() throws Exception {
+        assertThat(sut.isDOIReserved(aContext(), aDoi())).isTrue();
+    }
+
+    @Test
+    public void canReserveDOI() throws Exception {
+        sut.reserveDOI(aContext(), null, aDoi());
+    }
+
+    @Test
+    public void canCheckDOIRegistration404() throws Exception {
+
+        Mockito.doReturn(new HttpResponse(404, null, null))
+                .when(doiResolverClient).sendDOIGetRequest(Mockito.anyString());
+
+        assertThat(sut.isDOIRegistered(aContext(), aDoi())).isFalse();
+    }
+
+    @Test
+    public void canCheckDOIRegistration302() throws Exception {
+
+        Mockito.doReturn(new HttpResponse(302, null, "https://www.example.com/"))
+                .when(doiResolverClient).sendDOIGetRequest(Mockito.anyString());
+
+        assertThat(sut.isDOIRegistered(aContext(), aDoi())).isTrue();
+    }
+
+    @Test
+    public void canRegisterDOI() throws Exception {
+
+        givenDoiNotRegistered();
+
+        var dso = Mockito.mock(Item.class);
+
+        Mockito.doReturn(List.of(aMetadataValue("article")))
+                .when(itemService)
+                .getMetadata(Mockito.any(),
+                        Mockito.anyString(),
+                        Mockito.anyString(),
+                        Mockito.anyString(),
+                        Mockito.any());
+
+        sut.registerDOI(aContext(), dso, aDoi());
+    }
+
+    private void givenDoiNotRegistered() throws Exception {
+        Mockito.doReturn(new HttpResponse(404, null, null))
+                .when(doiResolverClient).sendDOIGetRequest(Mockito.anyString());
+    }
+
+    private Context aContext() {
+        return Mockito.mock(Context.class);
+    }
+
+    private String aDoi() {
+        return "doi";
+    }
+
+    private MetadataValue aMetadataValue(String withValue) {
+        var md = Mockito.mock(MetadataValue.class);
+        Mockito.doReturn(withValue).when(md).getValue();
+        return md;
+    }
+}

--- a/dspace-api/src/test/java/org/dspace/identifier/doi/crossref/DOIResolverClientTest.java
+++ b/dspace-api/src/test/java/org/dspace/identifier/doi/crossref/DOIResolverClientTest.java
@@ -1,0 +1,77 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.identifier.doi.crossref;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class DOIResolverClientTest {
+
+    private MockWebServer server;
+    private DOIResolverClient client;
+
+    @Before
+    public void setUp() throws Exception {
+        server = new MockWebServer();
+        server.start();
+
+        var baseClient = TestClient.baseHttpClientForTest();
+
+        client = new DOIResolverClient("http", server.getHostName(), server.getPort(), baseClient);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.shutdown();
+    }
+
+    @Test
+    public void sendDOIGetRequest_followsConfigAndReturnsRedirectInfo() throws Exception {
+        // Arrange: enqueue a 302 with a Location header as dx.doi would do for a registered DOI
+        var redirectUrl = "https://example.org/handle/123456789";
+        server.enqueue(new MockResponse()
+                .setResponseCode(302)
+                .setHeader("Location", redirectUrl)
+                .setBody("Found"));
+
+        var doi = "doi:10.1234/abcd";
+
+        var response = client.sendDOIGetRequest(doi);
+
+        assertThat(response.statusCode()).isEqualTo(302);
+        assertThat(response.url()).isEqualTo(redirectUrl);
+
+        var recorded = server.takeRequest();
+        assertThat(recorded.getMethod()).isEqualTo("GET");
+        assertThat(recorded.getPath()).isEqualTo("/10.1234/abcd");
+    }
+
+    @Test
+    public void sendDOIGetRequest_handles404WithoutException() throws Exception {
+        // Arrange: enqueue a 404 Not Found to simulate unknown DOI
+        server.enqueue(new MockResponse()
+                .setResponseCode(404)
+                .setBody("Not Found"));
+
+        var doi = "doi:10.9999/missing";
+
+        var response = client.sendDOIGetRequest(doi);
+
+        assertThat(response.statusCode()).isEqualTo(404);
+        assertThat(response.url()).isNull();
+
+        var recorded = server.takeRequest();
+        assertThat(recorded.getMethod()).isEqualTo("GET");
+        assertThat(recorded.getPath()).isEqualTo("/10.9999/missing");
+    }
+}

--- a/dspace-api/src/test/java/org/dspace/identifier/doi/crossref/TestClient.java
+++ b/dspace-api/src/test/java/org/dspace/identifier/doi/crossref/TestClient.java
@@ -1,0 +1,35 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+
+package org.dspace.identifier.doi.crossref;
+
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.dspace.app.client.DSpaceHttpClientFactory;
+import org.mockito.Mockito;
+
+class TestClient {
+
+    private TestClient() { }
+
+    /**
+     * provides a BaseHttpClient without the need of fully initializing DSpaceHttpClientFactory.
+     */
+    @SuppressWarnings("Regexp")
+    static BaseHttpClient baseHttpClientForTest() {
+        var factory = Mockito.mock(DSpaceHttpClientFactory.class);
+
+        // here we mock the 2 configurations that are used by BaseHttpClient
+        // in case BaseHttpClient changes this mocking must be updated too!
+        Mockito.doReturn(HttpClientBuilder.create()
+                .disableRedirectHandling().build()).when(factory).build(Mockito.any());
+
+        Mockito.doReturn(HttpClientBuilder.create().build()).when(factory).build();
+
+        return new BaseHttpClient(factory);
+    }
+}

--- a/dspace/config/crosswalks/crossref/DIM2CrossrefDIM.xsl
+++ b/dspace/config/crosswalks/crossref/DIM2CrossrefDIM.xsl
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Document   : DIM2CrossrefDIM.xsl
+    Created on : October 4, 2020, 1:26 PM
+    Author     : jdamerow
+    Description: This XSLT simply returns the input XML (the DIM XML). It is useful during
+              the development of new XSLTs.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:dspace="http://www.dspace.org/xmlns/dspace/dim"
+                xmlns="http://datacite.org/schema/kernel-2.2"
+                version="1.0">
+
+    <xsl:output method="xml" indent="yes" encoding="utf-8" />
+
+    <!-- Don't copy everything by default! -->
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/dspace/config/crosswalks/crossref/DIM2Crossref_article.xsl
+++ b/dspace/config/crosswalks/crossref/DIM2Crossref_article.xsl
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Document   : DIM2CRossref_article.xsl
+    Created on : October 4, 2020, 1:26 PM
+    Author     : jdamerow
+    Description: Converts metadata from DSpace Intermediat Format (DIM) into
+                 metadata following the Crossref Schema for Article, version 4.4.2
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:dspace="http://www.dspace.org/xmlns/dspace/dim"
+                xmlns="http://www.crossref.org/schema/4.4.2"
+                version="1.0">
+    <xsl:variable name="bookType" select="//dspace:field[@mdschema='dc' and @element='type']/text()" ></xsl:variable>
+
+    <xsl:output method="xml" indent="yes" encoding="utf-8" />
+
+    <!-- Don't copy everything by default! -->
+    <xsl:template match="@* | text()" />
+
+    <xsl:template match="/dspace:dim[@dspaceType='ITEM']">
+      <doi_batch version="4.4.2" xmlns="http://www.crossref.org/schema/4.4.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://www.crossref.org/schema/4.4.2 http://www.crossref.org/schema/deposit/crossref4.4.2.xsd">
+
+          <head>
+              <!-- This section will be filled programmatically. Do not remove! -->
+          </head>
+
+          <body>
+            <journal>
+              <journal_metadata>
+
+                <!--
+                  CrossRef
+                  Add title information
+                -->
+                <full_title>
+                    <xsl:choose>
+                      <xsl:when test="//dspace:field[@mdschema='dc' and @element='relation' and @qualifier='ispartof']">
+                        <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='relation' and @qualifier='ispartof']"/>
+                      </xsl:when>
+                      <xsl:otherwise>
+                        (:unas) unassigned
+                      </xsl:otherwise>
+                    </xsl:choose>
+                </full_title>
+                <abbrev_title>
+                    <xsl:choose>
+                      <xsl:when test="//dspace:field[@mdschema='dc' and @element='relation' and @qualifier='ispartof']">
+                        <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='relation' and @qualifier='ispartof']"/>
+                      </xsl:when>
+                      <xsl:otherwise>
+                        (:unas) unassigned
+                      </xsl:otherwise>
+                    </xsl:choose>
+                </abbrev_title>
+
+                <xsl:if test="//dspace:field[@mdschema='dc' and @element='identifier' and @qualifier='issn']">
+                  <xsl:apply-templates select="dspace:field[@mdschema='dc' and @element='identifier' and @qualifier='issn']" />
+                </xsl:if>
+              </journal_metadata>
+
+              <!-- Add journal article info -->
+              <journal_article>
+
+                <!--
+                  CrossRef
+                  Add title information
+                -->
+                <titles>
+                    <xsl:variable name="title-field" select="(//dspace:field[@mdschema='dc' and @element='title' and not(@qualifier)])[1]" />
+                    <xsl:choose>
+                      <xsl:when test="$title-field">
+                        <xsl:apply-templates select="$title-field"/>
+                        <original_language_title>
+                          (:unas) unassigned
+                        </original_language_title>
+                      </xsl:when>
+                      <xsl:otherwise>
+                        <title>
+                          (:unas) unassigned
+                        </title>
+                        <original_language_title>
+                          (:unas) unassigned
+                        </original_language_title>
+                      </xsl:otherwise>
+                    </xsl:choose>
+                </titles>
+
+                <!--
+                  CrossRef
+                  Add author information
+                -->
+                <contributors>
+                  <xsl:choose>
+                      <xsl:when test="//dspace:field[@mdschema='dc' and @element='contributor' and @qualifier='author']">
+                        <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='contributor' and @qualifier='author']" />
+                      </xsl:when>
+                      <xsl:otherwise>
+                        <anonymous contributor_role="author" sequence="first" />
+                      </xsl:otherwise>
+                  </xsl:choose>
+                </contributors>
+
+                <!--
+                  CrossRef
+                  Add publication year information
+                -->
+                <publication_date>
+                  <year>
+                    <xsl:choose>
+                        <xsl:when test="//dspace:field[@mdschema='dc' and @element='date' and @qualifier='issued']">
+                            <xsl:value-of select="substring(//dspace:field[@mdschema='dc' and @element='date' and @qualifier='issued'], 1, 4)" />
+                        </xsl:when>
+                        <xsl:when test="//dspace:field[@mdschema='dc' and @element='date' and @qualifier='available']">
+                            <xsl:value-of select="substring(//dspace:field[@mdschema='dc' and @element='date' and @qualifier='issued'], 1, 4)" />
+                        </xsl:when>
+                        <xsl:when test="//dspace:field[@mdschema='dc' and @element='date']">
+                            <xsl:value-of select="substring(//dspace:field[@mdschema='dc' and @element='date'], 1, 4)" />
+                        </xsl:when>
+                        <xsl:otherwise>0000</xsl:otherwise>
+                    </xsl:choose>
+                  </year>
+                </publication_date>
+
+                <!--
+                  CrossRef
+                  Add DOI information
+                -->
+                <doi_data>
+                    <!-- This section will be filled programmitcally. Do not remove! -->
+                </doi_data>
+              </journal_article>
+            </journal>
+          </body>
+      </doi_batch>
+    </xsl:template>
+
+    <!-- template to create first author -->
+    <xsl:template match="//dspace:field[@mdschema='dc' and @element='contributor' and @qualifier='author'][1]">
+      <person_name sequence="first" contributor_role="author" >
+      <given_name>
+        <xsl:value-of select="substring-before(./text(), ',')"/>
+      </given_name>
+      <surname>
+        <xsl:value-of select="substring-after(./text(), ',')"/>
+      </surname>
+    </person_name>
+    </xsl:template>
+
+    <!-- template to create additional authors -->
+    <xsl:template match="//dspace:field[@mdschema='dc' and @element='contributor' and @qualifier='author'][position() > 1]">
+      <person_name sequence="additional" contributor_role="author" >
+      <given_name>
+        <xsl:value-of select="substring-before(./text(), ',')"/>
+      </given_name>
+      <surname>
+        <xsl:value-of select="substring-after(./text(), ',')"/>
+      </surname>
+    </person_name>
+    </xsl:template>
+
+    <!-- template to create titles -->
+    <xsl:template match="dspace:field[@mdschema='dc' and @element='title' and not(@qualifier)]">
+      <title>
+        <xsl:value-of select="." />
+      </title>
+    </xsl:template>
+
+    <!-- template to create journal title -->
+    <xsl:template match="dspace:field[@mdschema='dc' and @element='relation' and @qualifier='ispartof']">
+      <xsl:value-of select="." />
+    </xsl:template>
+
+    <!-- template to create journal issn -->
+    <xsl:template match="dspace:field[@mdschema='dc' and @element='identifier' and @qualifier='issn']">
+      <issn>
+        <xsl:value-of select="." />
+      </issn>
+    </xsl:template>
+</xsl:stylesheet>

--- a/dspace/config/crosswalks/crossref/DIM2Crossref_book.xsl
+++ b/dspace/config/crosswalks/crossref/DIM2Crossref_book.xsl
@@ -1,0 +1,192 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Document   : DIM2Crossref_book.xsl
+    Created on : October 4, 2020, 1:26 PM
+    Author     : jdamerow
+    Description: Converts metadata from DSpace Intermediat Format (DIM) into
+                 metadata following the Crossref Schema for Books, version 4.4.2
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:dspace="http://www.dspace.org/xmlns/dspace/dim"
+                xmlns="http://www.crossref.org/schema/4.4.2"
+                version="1.0">
+
+    <xsl:output method="xml" indent="yes" encoding="utf-8" />
+
+    <!-- Don't copy everything by default! -->
+    <xsl:template match="@* | text()" />
+
+    <xsl:variable name="bookType" select="//dspace:field[@mdschema='dc' and @element='type']/text()" ></xsl:variable>
+
+    <xsl:template match="/dspace:dim[@dspaceType='ITEM']">
+      <doi_batch version="4.4.2" xmlns="http://www.crossref.org/schema/4.4.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://www.crossref.org/schema/4.4.2 http://www.crossref.org/schema/deposit/crossref4.4.2.xsd">
+
+          <head>
+            <!-- This section will be filled programmatically. Do not remove! -->
+        	</head>
+
+          <body>
+            <book>
+              <xsl:attribute name="book_type">
+                  <xsl:choose>
+                      <xsl:when test="$bookType='Book'">monograph</xsl:when>
+                      <xsl:otherwise>other</xsl:otherwise>
+                  </xsl:choose>
+              </xsl:attribute>
+
+              <book_metadata>
+                <!--
+                  CrossRef
+                  Add author information
+                -->
+                <contributors>
+                  <xsl:choose>
+                      <xsl:when test="//dspace:field[@mdschema='dc' and @element='contributor' and (@qualifier='author' or @qualifier='editor')]">
+                        <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='contributor'  and (@qualifier='author' or @qualifier='editor')]" />
+                      </xsl:when>
+                      <xsl:otherwise>
+                        <anonymous contributor_role="author" sequence="first" />
+                      </xsl:otherwise>
+                  </xsl:choose>
+
+                </contributors>
+
+                <!--
+                  CrossRef
+                  Add title information
+                  Crossref requires this field
+                -->
+                <titles>
+                    <xsl:variable name="title-field" select="(//dspace:field[@mdschema='dc' and @element='title' and not(@qualifier)])[1]" />
+                    <xsl:choose>
+                      <xsl:when test="$title-field">
+                        <xsl:apply-templates select="$title-field"/>
+                        <original_language_title>
+                          (:unas) unassigned
+                        </original_language_title>
+                      </xsl:when>
+                      <xsl:otherwise>
+                        <title>
+                          (:unas) unassigned
+                        </title>
+                        <original_language_title>
+                          (:unas) unassigned
+                        </original_language_title>
+                      </xsl:otherwise>
+                    </xsl:choose>
+                </titles>
+  
+                <!--
+                  CrossRef
+                  Add publication year information
+                  Crossref requires this field
+                -->
+                <publication_date>
+                  <year>
+                    <xsl:choose>
+                        <xsl:when test="//dspace:field[@mdschema='dc' and @element='date' and @qualifier='issued']">
+                            <xsl:value-of select="substring(//dspace:field[@mdschema='dc' and @element='date' and @qualifier='issued'], 1, 4)" />
+                        </xsl:when>
+                        <xsl:when test="//dspace:field[@mdschema='dc' and @element='date' and @qualifier='available']">
+                            <xsl:value-of select="substring(//dspace:field[@mdschema='dc' and @element='date' and @qualifier='issued'], 1, 4)" />
+                        </xsl:when>
+                        <xsl:when test="//dspace:field[@mdschema='dc' and @element='date']">
+                            <xsl:value-of select="substring(//dspace:field[@mdschema='dc' and @element='date'], 1, 4)" />
+                        </xsl:when>
+                        <xsl:otherwise>0000</xsl:otherwise>
+                    </xsl:choose>
+                  </year>
+                </publication_date>
+
+                <!--
+                  CrossRef
+                  Add ISBN information
+                  Crossref requires this field
+                -->
+                <xsl:choose>
+                  <xsl:when test="//dspace:field[@mdschema='dc' and @element='identifier' and @qualifier='isbn']">
+                    <isbn>
+                      <xsl:value-of select="//dspace:field[@mdschema='dc' and @element='identifier' and @qualifier='isbn']/text()" />
+                    </isbn>
+                  </xsl:when>
+                  <xsl:otherwise>
+                    <noisbn reason="monograph" />
+                  </xsl:otherwise>
+                </xsl:choose>
+
+                <publisher>
+                  <publisher_name>
+                    <xsl:value-of select="//dspace:field[@mdschema='dc' and @element='publisher']/text()" />
+                  </publisher_name>
+                </publisher>
+
+                  <doi_data>
+                      <!-- This section will be filled programmitcally. Do not remove! -->
+                  </doi_data>
+              </book_metadata>
+            </book>
+          </body>
+      </doi_batch>
+    </xsl:template>
+
+    <!-- template to create titles -->
+    <xsl:template match="dspace:field[@mdschema='dc' and @element='title']">
+        <xsl:choose>
+            <xsl:when test="@qualifier='alternative'">
+                <subtitle>
+                  <xsl:value-of select="." />
+                </subtitle>
+            </xsl:when>
+            <xsl:otherwise>
+              <title>
+                <xsl:value-of select="." />
+              </title>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <!-- template to create first author -->
+    <xsl:template match="//dspace:field[@mdschema='dc' and @element='contributor' and @qualifier='author'][1]">
+      <person_name sequence="first" contributor_role="author" >
+      <given_name>
+        <xsl:value-of select="substring-before(./text(), ',')"/>
+      </given_name>
+      <surname>
+        <xsl:value-of select="substring-after(./text(), ',')"/>
+      </surname>
+    </person_name>
+    </xsl:template>
+
+    <!-- template to create additional authors -->
+    <xsl:template match="//dspace:field[@mdschema='dc' and @element='contributor' and @qualifier='author'][position() > 1]">
+      <person_name sequence="additional" contributor_role="author" >
+      <given_name>
+        <xsl:value-of select="substring-before(./text(), ',')"/>
+      </given_name>
+      <surname>
+        <xsl:value-of select="substring-after(./text(), ',')"/>
+      </surname>
+    </person_name>
+    </xsl:template>
+
+    <!-- template to create editors -->
+    <xsl:template match="//dspace:field[@mdschema='dc' and @element='contributor' and @qualifier!='author']">
+      <person_name sequence="additional">
+        <xsl:attribute name="contributor_role">
+          <xsl:choose>
+              <xsl:when test="self::node()[@qualifier='editor']">editor</xsl:when>
+          </xsl:choose>
+        </xsl:attribute>
+        <given_name>
+          <xsl:value-of select="substring-before(./text(), ',')"/>
+        </given_name>
+        <surname>
+          <xsl:value-of select="substring-after(./text(), ',')"/>
+        </surname>
+      </person_name>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/dspace/config/crosswalks/crossref/DIM2Crossref_book_chapter.xsl
+++ b/dspace/config/crosswalks/crossref/DIM2Crossref_book_chapter.xsl
@@ -1,0 +1,230 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Document   : DIM2Crossref_book_chapter.xsl
+    Created on : October 4, 2020, 1:26 PM
+    Author     : jdamerow
+    Description: Converts metadata from DSpace Intermediat Format (DIM) into
+                 metadata following the Crossref Schema for Book Chapters, version 4.4.2
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:dspace="http://www.dspace.org/xmlns/dspace/dim"
+                xmlns="http://www.crossref.org/schema/4.4.2"
+                version="1.0">
+    <xsl:variable name="bookType" select="//dspace:field[@mdschema='dc' and @element='type']/text()" ></xsl:variable>
+
+    <xsl:output method="xml" indent="yes" encoding="utf-8" />
+
+    <!-- Don't copy everything by default! -->
+    <xsl:template match="@* | text()" />
+
+    <xsl:template match="/dspace:dim[@dspaceType='ITEM']">
+      <doi_batch version="4.4.2" xmlns="http://www.crossref.org/schema/4.4.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://www.crossref.org/schema/4.4.2 http://www.crossref.org/schema/deposit/crossref4.4.2.xsd">
+
+          <head>
+              <!-- This section will be filled programmatically. Do not remove! -->
+          </head>
+
+          <body>
+            <book>
+              <xsl:attribute name="book_type">
+                  <xsl:choose>
+                      <xsl:when test="$bookType='Book chapter'">monograph</xsl:when>
+                      <xsl:otherwise>other</xsl:otherwise>
+                  </xsl:choose>
+              </xsl:attribute>
+              <book_metadata>
+
+                <!--
+                  CrossRef
+                  Add title information
+                -->
+                <titles>
+                    <xsl:choose>
+                      <xsl:when test="//dspace:field[@mdschema='dc' and @element='relation' and @qualifier='ispartof']">
+                          <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='relation' and @qualifier='ispartof']"/>
+                      </xsl:when>
+                      <xsl:otherwise>
+                        <title>
+                          (:unas) unassigned
+                        </title>
+                      </xsl:otherwise>
+                    </xsl:choose>
+                </titles>
+
+                <!--
+                  CrossRef
+                  Add publication year information
+                  This is required by crossref
+                -->
+                <publication_date>
+                  <year>
+                    <xsl:choose>
+                        <xsl:when test="//dspace:field[@mdschema='dc' and @element='date' and @qualifier='issued']">
+                            <xsl:value-of select="substring(//dspace:field[@mdschema='dc' and @element='date' and @qualifier='issued'], 1, 4)" />
+                        </xsl:when>
+                        <xsl:when test="//dspace:field[@mdschema='dc' and @element='date' and @qualifier='available']">
+                            <xsl:value-of select="substring(//dspace:field[@mdschema='dc' and @element='date' and @qualifier='issued'], 1, 4)" />
+                        </xsl:when>
+                        <xsl:when test="//dspace:field[@mdschema='dc' and @element='date']">
+                            <xsl:value-of select="substring(//dspace:field[@mdschema='dc' and @element='date'], 1, 4)" />
+                        </xsl:when>
+                        <xsl:otherwise>0000</xsl:otherwise>
+                    </xsl:choose>
+                  </year>
+                </publication_date>
+
+
+                <!--
+                  CrossRef
+                  Add ISBN information
+                  Crossref requires this field
+                -->
+                <xsl:choose>
+                  <xsl:when test="//dspace:field[@mdschema='dc' and @element='identifier' and @qualifier='isbn']">
+                    <isbn>
+                      <xsl:value-of select="//dspace:field[@mdschema='dc' and @element='identifier' and @qualifier='isbn']/text()" />
+                    </isbn>
+                  </xsl:when>
+                  <xsl:otherwise>
+                    <noisbn reason="monograph" />
+                  </xsl:otherwise>
+                </xsl:choose>
+
+                <!--
+                  CrossRef
+                  Add publisher information
+                  This is required by crossref
+                -->
+                <publisher>
+                  <publisher_name>
+                    <xsl:value-of select="//dspace:field[@mdschema='dc' and @element='publisher']/text()" />
+                  </publisher_name>
+                </publisher>
+              </book_metadata>
+
+              <!-- Add chapter info -->
+              <content_item component_type="chapter">
+                <!--
+                  CrossRef
+                  Add author information
+                -->
+                <contributors>
+                  <xsl:choose>
+                      <xsl:when test="//dspace:field[@mdschema='dc' and @element='contributor' and @qualifier='author']">
+                        <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='contributor' and @qualifier='author']" />
+                      </xsl:when>
+                      <xsl:otherwise>
+                        <anonymous contributor_role="author" sequence="first" />
+                      </xsl:otherwise>
+                  </xsl:choose>
+                </contributors>
+
+                <!--
+                  CrossRef
+                  Add title information
+                -->
+                <titles>
+                    <xsl:variable name="title-field" select="(//dspace:field[@mdschema='dc' and @element='title' and not(@qualifier)])[1]" />
+                    <xsl:choose>
+                      <xsl:when test="$title-field">
+                        <xsl:apply-templates select="$title-field"/>
+                        <original_language_title>
+                          (:unas) unassigned
+                        </original_language_title>
+                      </xsl:when>
+                      <xsl:otherwise>
+                        <title>
+                          (:unas) unassigned
+                        </title>
+                        <original_language_title>
+                          (:unas) unassigned
+                        </original_language_title>
+                      </xsl:otherwise>
+                    </xsl:choose>
+                </titles>
+
+                <!--
+                  CrossRef
+                  Add publication year information
+                -->
+                <publication_date>
+                  <year>
+                    <xsl:choose>
+                        <xsl:when test="//dspace:field[@mdschema='dc' and @element='date' and @qualifier='issued']">
+                            <xsl:value-of select="substring(//dspace:field[@mdschema='dc' and @element='date' and @qualifier='issued'], 1, 4)" />
+                        </xsl:when>
+                        <xsl:when test="//dspace:field[@mdschema='dc' and @element='date' and @qualifier='available']">
+                            <xsl:value-of select="substring(//dspace:field[@mdschema='dc' and @element='date' and @qualifier='issued'], 1, 4)" />
+                        </xsl:when>
+                        <xsl:when test="//dspace:field[@mdschema='dc' and @element='date']">
+                            <xsl:value-of select="substring(//dspace:field[@mdschema='dc' and @element='date'], 1, 4)" />
+                        </xsl:when>
+                        <xsl:otherwise>0000</xsl:otherwise>
+                    </xsl:choose>
+                  </year>
+                </publication_date>
+
+                <!--
+                  CrossRef
+                  Add DOI information
+                -->
+                <doi_data>
+                    <!-- This section will be filled programmitcally. Do not remove! -->
+                </doi_data>
+              </content_item>
+            </book>
+          </body>
+      </doi_batch>
+    </xsl:template>
+
+    <!-- template to create first author -->
+    <xsl:template match="//dspace:field[@mdschema='dc' and @element='contributor' and @qualifier='author'][1]">
+      <person_name sequence="first" contributor_role="author" >
+      <given_name>
+        <xsl:value-of select="substring-before(./text(), ',')"/>
+      </given_name>
+      <surname>
+        <xsl:value-of select="substring-after(./text(), ',')"/>
+      </surname>
+    </person_name>
+    </xsl:template>
+
+    <!-- template to create additional authors -->
+    <xsl:template match="//dspace:field[@mdschema='dc' and @element='contributor' and @qualifier='author'][position() > 1]">
+      <person_name sequence="additional" contributor_role="author" >
+      <given_name>
+        <xsl:value-of select="substring-before(./text(), ',')"/>
+      </given_name>
+      <surname>
+        <xsl:value-of select="substring-after(./text(), ',')"/>
+      </surname>
+    </person_name>
+    </xsl:template>
+
+    <!-- template to create titles -->
+    <xsl:template match="dspace:field[@mdschema='dc' and @element='title']">
+        <xsl:choose>
+            <xsl:when test="@qualifier='alternative'">
+                <subtitle>
+                  <xsl:value-of select="." />
+                </subtitle>
+            </xsl:when>
+            <xsl:otherwise>
+              <title>
+                <xsl:value-of select="." />
+              </title>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <!-- template to create book title -->
+    <xsl:template match="dspace:field[@mdschema='dc' and @element='relation' and @qualifier='ispartof']">
+        <title>
+          <xsl:value-of select="." />
+        </title>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/dspace/config/crosswalks/crossref/DIM2Crossref_other.xsl
+++ b/dspace/config/crosswalks/crossref/DIM2Crossref_other.xsl
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Document   : DIM2Crossref_other.xsl
+    Created on : October 4, 2020, 1:26 PM
+    Author     : jdamerow
+    Description: Converts metadata from DSpace Intermediat Format (DIM) into
+                 metadata following the Crossref Schema, version 4.4.2 for posted
+                 content (other), which is the default format used for any type
+                 that can't be mapped.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:dspace="http://www.dspace.org/xmlns/dspace/dim"
+                xmlns="http://www.crossref.org/schema/4.4.2"
+                version="1.0">
+
+    <xsl:output method="xml" indent="yes" encoding="utf-8" />
+
+    <!-- Don't copy everything by default! -->
+    <xsl:template match="@* | text()" />
+
+    <xsl:template match="/dspace:dim[@dspaceType='ITEM']">
+      <doi_batch version="4.4.2" xmlns="http://www.crossref.org/schema/4.4.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://www.crossref.org/schema/4.4.2 http://www.crossref.org/schema/deposit/crossref4.4.2.xsd">
+
+          <head>
+            <!-- This section will be filled programmatically. Do not remove! -->
+        	</head>
+
+          <body>
+            <posted_content type="other">
+              <!--
+                CrossRef
+                Add author information
+              -->
+              <contributors>
+                <xsl:choose>
+                    <xsl:when test="//dspace:field[@mdschema='dc' and @element='contributor' and (@qualifier='author' or @qualifier='editor')]">
+                      <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='contributor'  and (@qualifier='author' or @qualifier='editor')]" />
+                    </xsl:when>
+                    <xsl:otherwise>
+                      <anonymous contributor_role="author" sequence="first" />
+                    </xsl:otherwise>
+                </xsl:choose>
+
+              </contributors>
+
+              <!--
+                CrossRef
+                Add title information
+                Crossref requires this field
+              -->
+              <titles>
+                  <xsl:variable name="title-field" select="(//dspace:field[@mdschema='dc' and @element='title' and not(@qualifier)])[1]" />
+                  <xsl:choose>
+                    <xsl:when test="$title-field">
+                      <xsl:apply-templates select="$title-field"/>
+                      <original_language_title>
+                        (:unas) unassigned
+                      </original_language_title>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      <title>
+                        (:unas) unassigned
+                      </title>
+                      <original_language_title>
+                        (:unas) unassigned
+                      </original_language_title>
+                    </xsl:otherwise>
+                  </xsl:choose>
+              </titles>
+
+              <!--
+                CrossRef
+                Add publication year information
+                Crossref requires this field
+              -->
+              <posted_date media_type="print">
+                <year>
+                  <xsl:choose>
+                      <xsl:when test="//dspace:field[@mdschema='dc' and @element='date' and @qualifier='issued']">
+                          <xsl:value-of select="substring(//dspace:field[@mdschema='dc' and @element='date' and @qualifier='issued'], 1, 4)" />
+                      </xsl:when>
+                      <xsl:when test="//dspace:field[@mdschema='dc' and @element='date' and @qualifier='available']">
+                          <xsl:value-of select="substring(//dspace:field[@mdschema='dc' and @element='date' and @qualifier='issued'], 1, 4)" />
+                      </xsl:when>
+                      <xsl:when test="//dspace:field[@mdschema='dc' and @element='date']">
+                          <xsl:value-of select="substring(//dspace:field[@mdschema='dc' and @element='date'], 1, 4)" />
+                      </xsl:when>
+                      <xsl:otherwise>0000</xsl:otherwise>
+                  </xsl:choose>
+                </year>
+              </posted_date>
+
+              <doi_data>
+                  <!-- This section will be filled programmitcally. Do not remove! -->
+              </doi_data>
+          </posted_content>
+        </body>
+      </doi_batch>
+    </xsl:template>
+
+    <!-- template to create titles -->
+    <xsl:template match="dspace:field[@mdschema='dc' and @element='title']">
+        <xsl:choose>
+            <xsl:when test="@qualifier='alternative'">
+                <subtitle>
+                  <xsl:value-of select="." />
+                </subtitle>
+            </xsl:when>
+            <xsl:otherwise>
+              <title>
+                <xsl:value-of select="." />
+              </title>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <!-- template to create first author -->
+    <xsl:template match="//dspace:field[@mdschema='dc' and @element='contributor' and @qualifier='author'][1]">
+      <person_name sequence="first" contributor_role="author" >
+      <given_name>
+        <xsl:value-of select="substring-before(./text(), ',')"/>
+      </given_name>
+      <surname>
+        <xsl:value-of select="substring-after(./text(), ',')"/>
+      </surname>
+    </person_name>
+    </xsl:template>
+
+    <!-- template to create additional authors -->
+    <xsl:template match="//dspace:field[@mdschema='dc' and @element='contributor' and @qualifier='author'][position() > 1]">
+      <person_name sequence="additional" contributor_role="author" >
+      <given_name>
+        <xsl:value-of select="substring-before(./text(), ',')"/>
+      </given_name>
+      <surname>
+        <xsl:value-of select="substring-after(./text(), ',')"/>
+      </surname>
+    </person_name>
+    </xsl:template>
+
+    <!-- template to create editors -->
+    <xsl:template match="//dspace:field[@mdschema='dc' and @element='contributor' and @qualifier!='author']">
+      <person_name sequence="additional">
+        <xsl:attribute name="contributor_role">
+          <xsl:choose>
+              <xsl:when test="self::node()[@qualifier='editor']">editor</xsl:when>
+          </xsl:choose>
+        </xsl:attribute>
+        <given_name>
+          <xsl:value-of select="substring-before(./text(), ',')"/>
+        </given_name>
+        <surname>
+          <xsl:value-of select="substring-after(./text(), ',')"/>
+        </surname>
+      </person_name>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/dspace/config/crosswalks/crossref/DIM2Crossref_preprint.xsl
+++ b/dspace/config/crosswalks/crossref/DIM2Crossref_preprint.xsl
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Document   : DIM2Crossref_preprint.xsl
+    Created on : October 4, 2020, 1:26 PM
+    Author     : jdamerow
+    Description: Converts metadata from DSpace Intermediat Format (DIM) into
+                 metadata following the Crossref Schema for Preprints, version 4.4.2
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:dspace="http://www.dspace.org/xmlns/dspace/dim"
+                xmlns="http://www.crossref.org/schema/4.4.2"
+                version="1.0">
+
+    <xsl:output method="xml" indent="yes" encoding="utf-8" />
+
+    <!-- Don't copy everything by default! -->
+    <xsl:template match="@* | text()" />
+
+    <xsl:template match="/dspace:dim[@dspaceType='ITEM']">
+      <doi_batch version="4.4.2" xmlns="http://www.crossref.org/schema/4.4.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://www.crossref.org/schema/4.4.2 http://www.crossref.org/schema/deposit/crossref4.4.2.xsd">
+
+          <head>
+            <!-- This section will be filled programmatically. Do not remove! -->
+        	</head>
+
+          <body>
+            <posted_content type="preprint">
+              <!--
+                CrossRef
+                Add author information
+              -->
+              <contributors>
+                <xsl:choose>
+                    <xsl:when test="//dspace:field[@mdschema='dc' and @element='contributor' and (@qualifier='author' or @qualifier='editor')]">
+                      <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='contributor'  and (@qualifier='author' or @qualifier='editor')]" />
+                    </xsl:when>
+                    <xsl:otherwise>
+                      <anonymous contributor_role="author" sequence="first" />
+                    </xsl:otherwise>
+                </xsl:choose>
+
+              </contributors>
+
+              <!--
+                CrossRef
+                Add title information
+                Crossref requires this field
+              -->
+              <titles>
+                  <xsl:variable name="title-field" select="(//dspace:field[@mdschema='dc' and @element='title' and not(@qualifier)])[1]" />
+                  <xsl:choose>
+                    <xsl:when test="$title-field">
+                      <xsl:apply-templates select="$title-field"/>
+                      <original_language_title>
+                        (:unas) unassigned
+                      </original_language_title>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      <title>
+                        (:unas) unassigned
+                      </title>
+                      <original_language_title>
+                        (:unas) unassigned
+                      </original_language_title>
+                    </xsl:otherwise>
+                  </xsl:choose>
+              </titles>
+
+              <!--
+                CrossRef
+                Add publication year information
+                Crossref requires this field
+              -->
+              <posted_date media_type="print">
+                <year>
+                  <xsl:choose>
+                      <xsl:when test="//dspace:field[@mdschema='dc' and @element='date' and @qualifier='issued']">
+                          <xsl:value-of select="substring(//dspace:field[@mdschema='dc' and @element='date' and @qualifier='issued'], 1, 4)" />
+                      </xsl:when>
+                      <xsl:when test="//dspace:field[@mdschema='dc' and @element='date' and @qualifier='available']">
+                          <xsl:value-of select="substring(//dspace:field[@mdschema='dc' and @element='date' and @qualifier='issued'], 1, 4)" />
+                      </xsl:when>
+                      <xsl:when test="//dspace:field[@mdschema='dc' and @element='date']">
+                          <xsl:value-of select="substring(//dspace:field[@mdschema='dc' and @element='date'], 1, 4)" />
+                      </xsl:when>
+                      <xsl:otherwise>0000</xsl:otherwise>
+                  </xsl:choose>
+                </year>
+              </posted_date>
+
+              <doi_data>
+                  <!-- This section will be filled programmitcally. Do not remove! -->
+              </doi_data>
+          </posted_content>
+        </body>
+      </doi_batch>
+    </xsl:template>
+
+    <!-- template to create titles -->
+    <xsl:template match="dspace:field[@mdschema='dc' and @element='title']">
+        <xsl:choose>
+            <xsl:when test="@qualifier='alternative'">
+                <subtitle>
+                  <xsl:value-of select="." />
+                </subtitle>
+            </xsl:when>
+            <xsl:otherwise>
+              <title>
+                <xsl:value-of select="." />
+              </title>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <!-- template to create first author -->
+    <xsl:template match="//dspace:field[@mdschema='dc' and @element='contributor' and @qualifier='author'][1]">
+      <person_name sequence="first" contributor_role="author" >
+      <given_name>
+        <xsl:value-of select="substring-before(./text(), ',')"/>
+      </given_name>
+      <surname>
+        <xsl:value-of select="substring-after(./text(), ',')"/>
+      </surname>
+    </person_name>
+    </xsl:template>
+
+    <!-- template to create additional authors -->
+    <xsl:template match="//dspace:field[@mdschema='dc' and @element='contributor' and @qualifier='author'][position() > 1]">
+      <person_name sequence="additional" contributor_role="author" >
+      <given_name>
+        <xsl:value-of select="substring-before(./text(), ',')"/>
+      </given_name>
+      <surname>
+        <xsl:value-of select="substring-after(./text(), ',')"/>
+      </surname>
+    </person_name>
+    </xsl:template>
+
+    <!-- template to create editors -->
+    <xsl:template match="//dspace:field[@mdschema='dc' and @element='contributor' and @qualifier!='author']">
+      <person_name sequence="additional">
+        <xsl:attribute name="contributor_role">
+          <xsl:choose>
+              <xsl:when test="self::node()[@qualifier='editor']">editor</xsl:when>
+          </xsl:choose>
+        </xsl:attribute>
+        <given_name>
+          <xsl:value-of select="substring-before(./text(), ',')"/>
+        </given_name>
+        <surname>
+          <xsl:value-of select="substring-after(./text(), ',')"/>
+        </surname>
+      </person_name>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/dspace/config/crosswalks/crossref/DIM2Crossref_technical_report.xsl
+++ b/dspace/config/crosswalks/crossref/DIM2Crossref_technical_report.xsl
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Document   : DIM2Crossref_technical_report.xsl
+    Created on : October 4, 2020, 1:26 PM
+    Author     : jdamerow
+    Description: Converts metadata from DSpace Intermediat Format (DIM) into
+                 metadata following the Crossref Schema for Technical Reports, version 4.4.2
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:dspace="http://www.dspace.org/xmlns/dspace/dim"
+                xmlns="http://www.crossref.org/schema/4.4.2"
+                version="1.0">
+
+    <xsl:output method="xml" indent="yes" encoding="utf-8" />
+
+    <!-- Don't copy everything by default! -->
+    <xsl:template match="@* | text()" />
+
+    <xsl:template match="/dspace:dim[@dspaceType='ITEM']">
+      <doi_batch version="4.4.2" xmlns="http://www.crossref.org/schema/4.4.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://www.crossref.org/schema/4.4.2 http://www.crossref.org/schema/deposit/crossref4.4.2.xsd">
+
+          <head>
+            <!-- This section will be filled programmatically. Do not remove! -->
+        	</head>
+
+          <body>
+            <report-paper>
+              <report-paper_metadata>
+              <!--
+                CrossRef
+                Add author information
+              -->
+              <contributors>
+                <xsl:choose>
+                    <xsl:when test="//dspace:field[@mdschema='dc' and @element='contributor' and (@qualifier='author' or @qualifier='editor')]">
+                      <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='contributor'  and (@qualifier='author' or @qualifier='editor')]" />
+                    </xsl:when>
+                    <xsl:otherwise>
+                      <anonymous contributor_role="author" sequence="first" />
+                    </xsl:otherwise>
+                </xsl:choose>
+
+              </contributors>
+
+              <!--
+                CrossRef
+                Add title information
+                Crossref requires this field
+              -->
+              <titles>
+                  <xsl:variable name="title-field" select="(//dspace:field[@mdschema='dc' and @element='title' and not(@qualifier)])[1]" />
+                  <xsl:choose>
+                    <xsl:when test="$title-field">
+                      <xsl:apply-templates select="$title-field"/>
+                      <original_language_title>
+                        (:unas) unassigned
+                      </original_language_title>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      <title>
+                        (:unas) unassigned
+                      </title>
+                      <original_language_title>
+                        (:unas) unassigned
+                      </original_language_title>
+                    </xsl:otherwise>
+                  </xsl:choose>
+              </titles>
+
+              <!--
+                CrossRef
+                Add publication year information
+                Crossref requires this field
+              -->
+              <publication_date>
+                <year>
+                  <xsl:choose>
+                      <xsl:when test="//dspace:field[@mdschema='dc' and @element='date' and @qualifier='issued']">
+                          <xsl:value-of select="substring(//dspace:field[@mdschema='dc' and @element='date' and @qualifier='issued'], 1, 4)" />
+                      </xsl:when>
+                      <xsl:when test="//dspace:field[@mdschema='dc' and @element='date' and @qualifier='available']">
+                          <xsl:value-of select="substring(//dspace:field[@mdschema='dc' and @element='date' and @qualifier='issued'], 1, 4)" />
+                      </xsl:when>
+                      <xsl:when test="//dspace:field[@mdschema='dc' and @element='date']">
+                          <xsl:value-of select="substring(//dspace:field[@mdschema='dc' and @element='date'], 1, 4)" />
+                      </xsl:when>
+                      <xsl:otherwise>0000</xsl:otherwise>
+                  </xsl:choose>
+                </year>
+              </publication_date>
+
+              <xsl:if test="//dspace:field[@mdschema='dc' and @element='publisher']">
+                <publisher>
+                  <publisher_name>
+                    <xsl:value-of select="//dspace:field[@mdschema='dc' and @element='publisher']/text()" />
+                  </publisher_name>
+                </publisher>
+              </xsl:if>
+
+              <doi_data>
+                  <!-- This section will be filled programmitcally. Do not remove! -->
+              </doi_data>
+            </report-paper_metadata>
+          </report-paper>
+        </body>
+      </doi_batch>
+    </xsl:template>
+
+    <!-- template to create titles -->
+    <xsl:template match="dspace:field[@mdschema='dc' and @element='title']">
+        <xsl:choose>
+            <xsl:when test="@qualifier='alternative'">
+                <subtitle>
+                  <xsl:value-of select="." />
+                </subtitle>
+            </xsl:when>
+            <xsl:otherwise>
+              <title>
+                <xsl:value-of select="." />
+              </title>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <!-- template to create first author -->
+    <xsl:template match="//dspace:field[@mdschema='dc' and @element='contributor' and @qualifier='author'][1]">
+      <person_name sequence="first" contributor_role="author" >
+      <given_name>
+        <xsl:value-of select="substring-before(./text(), ',')"/>
+      </given_name>
+      <surname>
+        <xsl:value-of select="substring-after(./text(), ',')"/>
+      </surname>
+    </person_name>
+    </xsl:template>
+
+    <!-- template to create additional authors -->
+    <xsl:template match="//dspace:field[@mdschema='dc' and @element='contributor' and @qualifier='author'][position() > 1]">
+      <person_name sequence="additional" contributor_role="author" >
+      <given_name>
+        <xsl:value-of select="substring-before(./text(), ',')"/>
+      </given_name>
+      <surname>
+        <xsl:value-of select="substring-after(./text(), ',')"/>
+      </surname>
+    </person_name>
+    </xsl:template>
+
+    <!-- template to create editors -->
+    <xsl:template match="//dspace:field[@mdschema='dc' and @element='contributor' and @qualifier!='author']">
+      <person_name sequence="additional">
+        <xsl:attribute name="contributor_role">
+          <xsl:choose>
+              <xsl:when test="self::node()[@qualifier='editor']">editor</xsl:when>
+          </xsl:choose>
+        </xsl:attribute>
+        <given_name>
+          <xsl:value-of select="substring-before(./text(), ',')"/>
+        </given_name>
+        <surname>
+          <xsl:value-of select="substring-after(./text(), ',')"/>
+        </surname>
+      </person_name>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/dspace/config/crosswalks/crossref/DIM2Crossref_thesis.xsl
+++ b/dspace/config/crosswalks/crossref/DIM2Crossref_thesis.xsl
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Document   : DIM2Crossref_thesis.xsl
+    Created on : October 4, 2020, 1:26 PM
+    Author     : jdamerow
+    Description: Converts metadata from DSpace Intermediat Format (DIM) into
+                 metadata following the Crossref Schema for Dissertations, version 4.4.2
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:dspace="http://www.dspace.org/xmlns/dspace/dim"
+                xmlns="http://www.crossref.org/schema/4.4.2"
+                version="1.0">
+
+    <xsl:output method="xml" indent="yes" encoding="utf-8" />
+
+    <!--
+        Theses must have an institution. By default, this is
+        configured globally for all items with the
+        identifier.doi.crossref.institution property. If there is a
+        dc.publisher, this will be used instead. If your institution
+        hosts theses from multiple institutions, you may have a more
+        appropriate local metadata field, in which case this crosswalk
+        should be configured to respect that instead.
+    -->
+    <xsl:param name="institution" />
+
+    <!-- Don't copy everything by default! -->
+    <xsl:template match="@* | text()" />
+
+    <xsl:template match="/dspace:dim[@dspaceType='ITEM']">
+      <doi_batch version="4.4.2" xmlns="http://www.crossref.org/schema/4.4.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://www.crossref.org/schema/4.4.2 http://www.crossref.org/schema/deposit/crossref4.4.2.xsd">
+
+          <head>
+            <!-- This section will be filled programmatically. Do not remove! -->
+          </head>
+
+          <body>
+            <dissertation>
+              <!--
+                CrossRef
+                Add author information
+              -->
+              <contributors>
+                <xsl:choose>
+                    <xsl:when test="//dspace:field[@mdschema='dc' and @element='contributor' and (@qualifier='author' or @qualifier='editor')]">
+                      <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='contributor'  and (@qualifier='author' or @qualifier='editor')]" />
+                    </xsl:when>
+                    <xsl:otherwise>
+                      <anonymous contributor_role="author" sequence="first" />
+                    </xsl:otherwise>
+                </xsl:choose>
+
+              </contributors>
+
+              <!--
+                CrossRef
+                Add title information
+                Crossref requires this field
+              -->
+              <titles>
+                  <xsl:variable name="title-field" select="(//dspace:field[@mdschema='dc' and @element='title' and not(@qualifier)])[1]" />
+                  <xsl:choose>
+                    <xsl:when test="$title-field">
+                      <xsl:apply-templates select="$title-field"/>
+                      <original_language_title>
+                        (:unas) unassigned
+                      </original_language_title>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      <title>
+                        (:unas) unassigned
+                      </title>
+                      <original_language_title>
+                        (:unas) unassigned
+                      </original_language_title>
+                    </xsl:otherwise>
+                  </xsl:choose>
+              </titles>
+
+              <!--
+                CrossRef
+                Add publication year information
+                Crossref requires this field
+              -->
+              <approval_date media_type="print">
+                <year>
+                  <xsl:choose>
+                      <xsl:when test="//dspace:field[@mdschema='dc' and @element='date' and @qualifier='issued']">
+                          <xsl:value-of select="substring(//dspace:field[@mdschema='dc' and @element='date' and @qualifier='issued'], 1, 4)" />
+                      </xsl:when>
+                      <xsl:when test="//dspace:field[@mdschema='dc' and @element='date' and @qualifier='available']">
+                          <xsl:value-of select="substring(//dspace:field[@mdschema='dc' and @element='date' and @qualifier='issued'], 1, 4)" />
+                      </xsl:when>
+                      <xsl:when test="//dspace:field[@mdschema='dc' and @element='date']">
+                          <xsl:value-of select="substring(//dspace:field[@mdschema='dc' and @element='date'], 1, 4)" />
+                      </xsl:when>
+                      <xsl:otherwise>0000</xsl:otherwise>
+                  </xsl:choose>
+                </year>
+              </approval_date>
+
+              <institution xmlns="http://www.crossref.org/schema/4.4.2">
+                <institution_name>
+                  <xsl:choose>
+                    <xsl:when test="//dspace:field[@mdschema='dc' and @element='publisher']">
+                      <xsl:value-of select="//dspace:field[@mdschema='dc' and @element='publisher']" />
+                    </xsl:when>
+                    <xsl:otherwise>
+                      <xsl:value-of select="$institution" />
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </institution_name>
+              </institution>
+
+              <doi_data>
+                  <!-- This section will be filled programmitcally. Do not remove! -->
+              </doi_data>
+          </dissertation>
+        </body>
+      </doi_batch>
+    </xsl:template>
+
+    <!-- template to create titles -->
+    <xsl:template match="dspace:field[@mdschema='dc' and @element='title']">
+        <xsl:choose>
+            <xsl:when test="@qualifier='alternative'">
+                <subtitle>
+                  <xsl:value-of select="." />
+                </subtitle>
+            </xsl:when>
+            <xsl:otherwise>
+              <title>
+                <xsl:value-of select="." />
+              </title>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <!-- template to create first author -->
+    <xsl:template match="//dspace:field[@mdschema='dc' and @element='contributor' and @qualifier='author'][1]">
+      <person_name sequence="first" contributor_role="author" >
+      <given_name>
+        <xsl:value-of select="substring-before(./text(), ',')"/>
+      </given_name>
+      <surname>
+        <xsl:value-of select="substring-after(./text(), ',')"/>
+      </surname>
+    </person_name>
+    </xsl:template>
+
+    <!-- template to create additional authors -->
+    <xsl:template match="//dspace:field[@mdschema='dc' and @element='contributor' and @qualifier='author'][position() > 1]">
+      <person_name sequence="additional" contributor_role="author" >
+      <given_name>
+        <xsl:value-of select="substring-before(./text(), ',')"/>
+      </given_name>
+      <surname>
+        <xsl:value-of select="substring-after(./text(), ',')"/>
+      </surname>
+    </person_name>
+    </xsl:template>
+
+    <!-- template to create editors -->
+    <xsl:template match="//dspace:field[@mdschema='dc' and @element='contributor' and @qualifier!='author']">
+      <person_name sequence="additional">
+        <xsl:attribute name="contributor_role">
+          <xsl:choose>
+              <xsl:when test="self::node()[@qualifier='editor']">editor</xsl:when>
+          </xsl:choose>
+        </xsl:attribute>
+        <given_name>
+          <xsl:value-of select="substring-before(./text(), ',')"/>
+        </given_name>
+        <surname>
+          <xsl:value-of select="substring-after(./text(), ',')"/>
+        </surname>
+      </person_name>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/dspace/config/crosswalks/crossref/DIM2Crossref_working_paper.xsl
+++ b/dspace/config/crosswalks/crossref/DIM2Crossref_working_paper.xsl
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Document   : DIM2Crossref_working_paper.xsl
+    Created on : October 4, 2020, 1:26 PM
+    Author     : jdamerow
+    Description: Converts metadata from DSpace Intermediat Format (DIM) into
+                 metadata following the Crossref Schema for Working Papers, version 4.4.2
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:dspace="http://www.dspace.org/xmlns/dspace/dim"
+                xmlns="http://www.crossref.org/schema/4.4.2"
+                version="1.0">
+
+    <xsl:output method="xml" indent="yes" encoding="utf-8" />
+
+    <!-- Don't copy everything by default! -->
+    <xsl:template match="@* | text()" />
+
+    <xsl:template match="/dspace:dim[@dspaceType='ITEM']">
+      <doi_batch version="4.4.2" xmlns="http://www.crossref.org/schema/4.4.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://www.crossref.org/schema/4.4.2 http://www.crossref.org/schema/deposit/crossref4.4.2.xsd">
+
+          <head>
+            <!-- This section will be filled programmatically. Do not remove! -->
+        	</head>
+
+          <body>
+            <posted_content type="working_paper">
+              <!--
+                CrossRef
+                Add author information
+              -->
+              <contributors>
+                <xsl:choose>
+                    <xsl:when test="//dspace:field[@mdschema='dc' and @element='contributor' and (@qualifier='author' or @qualifier='editor')]">
+                      <xsl:apply-templates select="//dspace:field[@mdschema='dc' and @element='contributor'  and (@qualifier='author' or @qualifier='editor')]" />
+                    </xsl:when>
+                    <xsl:otherwise>
+                      <anonymous contributor_role="author" sequence="first" />
+                    </xsl:otherwise>
+                </xsl:choose>
+
+              </contributors>
+
+              <!--
+                CrossRef
+                Add title information
+                Crossref requires this field
+              -->
+              <titles>
+                  <xsl:variable name="title-field" select="(//dspace:field[@mdschema='dc' and @element='title' and not(@qualifier)])[1]" />
+                  <xsl:choose>
+                    <xsl:when test="$title-field">
+                      <xsl:apply-templates select="$title-field"/>
+                      <original_language_title>
+                        (:unas) unassigned
+                      </original_language_title>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      <title>
+                        (:unas) unassigned
+                      </title>
+                      <original_language_title>
+                        (:unas) unassigned
+                      </original_language_title>
+                    </xsl:otherwise>
+                  </xsl:choose>
+              </titles>
+
+              <!--
+                CrossRef
+                Add publication year information
+                Crossref requires this field
+              -->
+              <posted_date media_type="print">
+                <year>
+                  <xsl:choose>
+                      <xsl:when test="//dspace:field[@mdschema='dc' and @element='date' and @qualifier='issued']">
+                          <xsl:value-of select="substring(//dspace:field[@mdschema='dc' and @element='date' and @qualifier='issued'], 1, 4)" />
+                      </xsl:when>
+                      <xsl:when test="//dspace:field[@mdschema='dc' and @element='date' and @qualifier='available']">
+                          <xsl:value-of select="substring(//dspace:field[@mdschema='dc' and @element='date' and @qualifier='issued'], 1, 4)" />
+                      </xsl:when>
+                      <xsl:when test="//dspace:field[@mdschema='dc' and @element='date']">
+                          <xsl:value-of select="substring(//dspace:field[@mdschema='dc' and @element='date'], 1, 4)" />
+                      </xsl:when>
+                      <xsl:otherwise>0000</xsl:otherwise>
+                  </xsl:choose>
+                </year>
+              </posted_date>
+
+              <doi_data>
+                  <!-- This section will be filled programmitcally. Do not remove! -->
+              </doi_data>
+          </posted_content>
+        </body>
+      </doi_batch>
+    </xsl:template>
+
+    <!-- template to create titles -->
+    <xsl:template match="dspace:field[@mdschema='dc' and @element='title']">
+        <xsl:choose>
+            <xsl:when test="@qualifier='alternative'">
+                <subtitle>
+                  <xsl:value-of select="." />
+                </subtitle>
+            </xsl:when>
+            <xsl:otherwise>
+              <title>
+                <xsl:value-of select="." />
+              </title>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <!-- template to create first author -->
+    <xsl:template match="//dspace:field[@mdschema='dc' and @element='contributor' and @qualifier='author'][1]">
+      <person_name sequence="first" contributor_role="author" >
+      <given_name>
+        <xsl:value-of select="substring-before(./text(), ',')"/>
+      </given_name>
+      <surname>
+        <xsl:value-of select="substring-after(./text(), ',')"/>
+      </surname>
+    </person_name>
+    </xsl:template>
+
+    <!-- template to create additional authors -->
+    <xsl:template match="//dspace:field[@mdschema='dc' and @element='contributor' and @qualifier='author'][position() > 1]">
+      <person_name sequence="additional" contributor_role="author" >
+      <given_name>
+        <xsl:value-of select="substring-before(./text(), ',')"/>
+      </given_name>
+      <surname>
+        <xsl:value-of select="substring-after(./text(), ',')"/>
+      </surname>
+    </person_name>
+    </xsl:template>
+
+    <!-- template to create editors -->
+    <xsl:template match="//dspace:field[@mdschema='dc' and @element='contributor' and @qualifier!='author']">
+      <person_name sequence="additional">
+        <xsl:attribute name="contributor_role">
+          <xsl:choose>
+              <xsl:when test="self::node()[@qualifier='editor']">editor</xsl:when>
+          </xsl:choose>
+        </xsl:attribute>
+        <given_name>
+          <xsl:value-of select="substring-before(./text(), ',')"/>
+        </given_name>
+        <surname>
+          <xsl:value-of select="substring-after(./text(), ',')"/>
+        </surname>
+      </person_name>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -630,6 +630,19 @@ crosswalk.dissemination.DataCite.publisher = My University
 #crosswalk.dissemination.DataCite.hostingInstitution = # defaults to publisher
 crosswalk.dissemination.DataCite.namespace = http://datacite.org/schema/kernel-4
 
+##
+## Configure XSLT-driven submission crosswalk for Crossref
+##
+crosswalk.dissemination.Crossref_article.stylesheet = crosswalks/crossref/DIM2Crossref_article.xsl
+crosswalk.dissemination.Crossref_book.stylesheet = crosswalks/crossref/DIM2Crossref_book.xsl
+crosswalk.dissemination.Crossref_book_chapter.stylesheet = crosswalks/crossref/DIM2Crossref_book_chapter.xsl
+crosswalk.dissemination.Crossref_technical_report.stylesheet = crosswalks/crossref/DIM2Crossref_technical_report.xsl
+crosswalk.dissemination.Crossref_preprint.stylesheet = crosswalks/crossref/DIM2Crossref_preprint.xsl
+crosswalk.dissemination.Crossref_working_paper.stylesheet = crosswalks/crossref/DIM2Crossref_working_paper.xsl
+crosswalk.dissemination.Crossref_thesis.stylesheet = crosswalks/crossref/DIM2Crossref_thesis.xsl
+crosswalk.dissemination.Crossref_other.stylesheet = crosswalks/crossref/DIM2Crossref_other.xsl
+crosswalk.dissemination.CrossrefDIM.stylesheet = crosswalks/crossref/DIM2CrossrefDIM.xsl
+
 # Crosswalk Plugin Configuration:
 #   The purpose of Crosswalks is to translate an external metadata format to/from
 #   the DSpace Internal Metadata format (DIM) or the DSpace Database.

--- a/dspace/config/spring/api/core-services.xml
+++ b/dspace/config/spring/api/core-services.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd"
        default-lazy-init="true">
 
     <!-- ******************** -->
@@ -182,5 +183,6 @@
     <bean id="org.dspace.app.customurl.consumer.CustomUrlConsumerConfig"
           class="org.dspace.app.customurl.consumer.CustomUrlConsumerConfig"/>
 
+    <context:component-scan base-package="org.dspace.identifier.doi.crossref" />
 </beans>
 

--- a/dspace/config/spring/api/identifier-service.xml
+++ b/dspace/config/spring/api/identifier-service.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-           http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
+           http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+           http://www.springframework.org/schema/context
+           http://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
     <!-- Identifier Service Application Interface. Will be autowired with
          any Identifier Providers present in Spring context.
@@ -17,6 +20,10 @@
     <bean id="org.dspace.identifier.HandleIdentifierProvider" class="org.dspace.identifier.HandleIdentifierProvider" scope="singleton">
         <property name="configurationService" ref="org.dspace.services.ConfigurationService"/>
     </bean>
+    -->
+
+    <!--
+        <context:component-scan base-package="org.dspace.identifier.doi.crossref" />
     -->
 
     <!-- If you enabled versioning, you should use one of the versioned
@@ -76,7 +83,6 @@
     on the filters defined in item-filters.xml, eg.
     Of course, you can use a filter on the VersionedDOIIdentifierProvider as well.
     -->
-    <!--
     <bean id="org.dspace.identifier.DOIIdentifierProvider"
         class="org.dspace.identifier.DOIIdentifierProvider"
         scope="singleton">
@@ -86,8 +92,9 @@
             ref="org.dspace.identifier.doi.DOIConnector" />
         <property name="filter" ref="doi-filter" />
     </bean>
-    -->
 
+    <bean id="org.dspace.identifier.doi.DOIConnector"
+	    class="org.dspace.identifier.doi.crossref.CrossRefConnector"/>
 
     <!-- The DOIConnector will handle the API calls to your DOI registration
          agency for the DOIIdentifierProvider. If your registration agency

--- a/pom.xml
+++ b/pom.xml
@@ -1805,6 +1805,12 @@
                 <version>5.21.0</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>3.26.3</version>
+                <scope>test</scope>
+            </dependency>
             <!-- H2 is an in-memory database used for Unit/Integration tests -->
             <dependency>
                 <groupId>com.h2database</groupId>


### PR DESCRIPTION
## References

Fixes #9061
Depends on and includes #11545

## Description

Add a DOIConnector for registering DOIs with [Crossref](https://www.crossref.org/)

This PR was developed by The Library Code with the support of Crossref.

## Instructions for Reviewers

Set up a test account on `test.crossref.org`

Set `identifier.doi.user` to the email address of the registered user, plus a `/` character, plus the name of the configured role for that user on `test.crossref.org`. Set `identifier.doi.password` to the password of this user.

Set `identifier.doi.prefix` to a prefix your test account is authorized to mint DOIs under. Set `identifier.doi.namespaceseparator` if desired.

You *must* configure `identifier.doi.crossref.depositorEmail` to a valid email address, or Crossref will simply not accept your submitted DOIs. In production, you *should* set `identifier.doi.crossref.registrant` to the registering institution’s name and `identifier.doi.crossref.depositor` to the name of the person responsible for depositing DOIs.

In production, `identifier.doi.crossref.host` *must* be set to `api.crossref.org`.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).