### PR TITLE
[DSpace-CRIS] Inverse Relations via Authority Framework (Backend)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/FacetYearRange.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/FacetYearRange.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang3.StringUtils;
 import org.dspace.core.Context;
 import org.dspace.discovery.configuration.DiscoverySearchFilterFacet;
 
@@ -104,7 +105,15 @@ public class FacetYearRange {
         yearRangeQuery.setSortField(dateFacet + "_sort", DiscoverQuery.SORT_ORDER.asc);
         yearRangeQuery.addFilterQueries(filterQueries.toArray(new String[filterQueries.size()]));
         yearRangeQuery.addSearchField(dateFacet);
-        DiscoverResult lastYearResult = searchService.search(context, scope, yearRangeQuery);
+        boolean isRelatedEntity =
+            StringUtils.isNotBlank(parentQuery.getDiscoveryConfigurationName()) &&
+            parentQuery.getDiscoveryConfigurationName().toUpperCase().startsWith("RELATION");
+        DiscoverResult lastYearResult;
+        if (isRelatedEntity) {
+            lastYearResult = searchService.search(context, yearRangeQuery);
+        } else {
+            lastYearResult = searchService.search(context, scope, yearRangeQuery);
+        }
 
         if (0 < lastYearResult.getIndexableObjects().size()) {
             List<DiscoverResult.SearchDocument> searchDocuments = lastYearResult
@@ -115,7 +124,12 @@ public class FacetYearRange {
         }
         //Now get the first year
         yearRangeQuery.setSortField(dateFacet + "_sort", DiscoverQuery.SORT_ORDER.desc);
-        DiscoverResult firstYearResult = searchService.search(context, scope, yearRangeQuery);
+        DiscoverResult firstYearResult;
+        if (isRelatedEntity) {
+            firstYearResult = searchService.search(context, yearRangeQuery);
+        } else {
+            firstYearResult = searchService.search(context, scope, yearRangeQuery);
+        }
         if (0 < firstYearResult.getIndexableObjects().size()) {
             List<DiscoverResult.SearchDocument> searchDocuments = firstYearResult
                 .getSearchDocument(firstYearResult.getIndexableObjects().get(0));

--- a/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoveryConfigurationService.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoveryConfigurationService.java
@@ -53,6 +53,16 @@ public class DiscoveryConfigurationService {
 
     public void setMap(Map<String, DiscoveryConfiguration> map) {
         this.map = map;
+        if (map != null) {
+            // improve the configuration assigning the map key as id to any configuration
+            // that doesn't have one
+            for (Map.Entry<String, DiscoveryConfiguration> entry : map.entrySet()) {
+                DiscoveryConfiguration conf = entry.getValue();
+                if (StringUtils.isBlank(conf.getId())) {
+                    conf.setId(entry.getKey());
+                }
+            }
+        }
     }
 
     public Map<Integer, List<String>> getToIgnoreMetadataFields() {

--- a/dspace-api/src/main/java/org/dspace/discovery/utils/DiscoverQueryBuilder.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/utils/DiscoverQueryBuilder.java
@@ -12,6 +12,7 @@ import static java.util.Collections.singletonList;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 
 import java.sql.SQLException;
+import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -33,10 +34,12 @@ import org.dspace.discovery.SearchServiceException;
 import org.dspace.discovery.configuration.DiscoveryConfiguration;
 import org.dspace.discovery.configuration.DiscoveryConfigurationParameters;
 import org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration;
+import org.dspace.discovery.configuration.DiscoveryRelatedItemConfiguration;
 import org.dspace.discovery.configuration.DiscoverySearchFilter;
 import org.dspace.discovery.configuration.DiscoverySearchFilterFacet;
 import org.dspace.discovery.configuration.DiscoverySortConfiguration;
 import org.dspace.discovery.configuration.DiscoverySortFieldConfiguration;
+import org.dspace.discovery.configuration.DiscoverySortFunctionConfiguration;
 import org.dspace.discovery.configuration.MultiLanguageDiscoverSearchFilterFacet;
 import org.dspace.discovery.indexobject.factory.IndexFactory;
 import org.dspace.discovery.utils.parameter.QueryBuilderSearchFilter;
@@ -112,15 +115,21 @@ public class DiscoverQueryBuilder implements InitializingBean {
                                     String sortDirection)
             throws IllegalArgumentException, SearchServiceException {
 
-        DiscoverQuery queryArgs = buildCommonDiscoverQuery(context, discoveryConfiguration, query, searchFilters,
-                                                           dsoTypes);
+        DiscoverQuery queryArgs =
+            buildCommonDiscoverQuery(
+                context, discoveryConfiguration, query, searchFilters,
+                dsoTypes, scope
+            );
 
         //When all search criteria are set, configure facet results
         addFaceting(context, scope, queryArgs, discoveryConfiguration);
 
         //Configure pagination and sorting
         configurePagination(pageSize, offset, queryArgs);
-        configureSorting(sortProperty, sortDirection, queryArgs, discoveryConfiguration.getSearchSortConfiguration());
+        configureSorting(
+            sortProperty, sortDirection, queryArgs, discoveryConfiguration.getSearchSortConfiguration(),
+            scope
+        );
 
         addDiscoveryHitHighlightFields(discoveryConfiguration, queryArgs);
         return queryArgs;
@@ -187,7 +196,7 @@ public class DiscoverQueryBuilder implements InitializingBean {
             throws IllegalArgumentException {
 
         DiscoverQuery queryArgs = buildCommonDiscoverQuery(context, discoveryConfiguration, query, searchFilters,
-                                                           dsoTypes);
+                                                           dsoTypes, scope);
 
         //When all search criteria are set, configure facet results
         addFacetingForFacets(context, scope, prefix, queryArgs, discoveryConfiguration, facetName, pageSize);
@@ -202,8 +211,8 @@ public class DiscoverQueryBuilder implements InitializingBean {
     }
 
     private void configurePaginationForFacets(Long offset, DiscoverQuery queryArgs) {
-        if (offset != null) {
-            queryArgs.setFacetOffset(Math.toIntExact(offset));
+        if (offset != null && queryArgs.getFacetFields().size() == 1) {
+            queryArgs.getFacetFields().get(0).setOffset(offset.intValue());
         }
     }
 
@@ -261,9 +270,11 @@ public class DiscoverQueryBuilder implements InitializingBean {
 
     private DiscoverQuery buildCommonDiscoverQuery(Context context, DiscoveryConfiguration discoveryConfiguration,
                                                    String query,
-                                                   List<QueryBuilderSearchFilter> searchFilters, List<String> dsoTypes)
+                                                   List<QueryBuilderSearchFilter> searchFilters,
+                                                   List<String> dsoTypes,
+                                                   IndexableObject scope)
             throws IllegalArgumentException {
-        DiscoverQuery queryArgs = buildBaseQueryForConfiguration(discoveryConfiguration);
+        DiscoverQuery queryArgs = buildBaseQueryForConfiguration(discoveryConfiguration, scope);
 
         queryArgs.addFilterQueries(convertFiltersToString(context, discoveryConfiguration, searchFilters));
 
@@ -282,19 +293,27 @@ public class DiscoverQueryBuilder implements InitializingBean {
         return queryArgs;
     }
 
-    private DiscoverQuery buildBaseQueryForConfiguration(DiscoveryConfiguration discoveryConfiguration) {
+    private DiscoverQuery buildBaseQueryForConfiguration(DiscoveryConfiguration discoveryConfiguration,
+        IndexableObject scope) {
+
         DiscoverQuery queryArgs = new DiscoverQuery();
         queryArgs.setDiscoveryConfigurationName(discoveryConfiguration.getId());
-        queryArgs.addFilterQueries(discoveryConfiguration.getDefaultFilterQueries()
-                                                         .toArray(
-                                                                 new String[discoveryConfiguration
-                                                                         .getDefaultFilterQueries()
-                                                                         .size()]));
+
+        String[] queryArray = discoveryConfiguration.getDefaultFilterQueries()
+            .toArray(new String[discoveryConfiguration.getDefaultFilterQueries().size()]);
+
+        if (scope != null && discoveryConfiguration instanceof DiscoveryRelatedItemConfiguration) {
+            for (int i = 0; i < queryArray.length; i++) {
+                queryArray[i] = MessageFormat.format(queryArray[i], scope.getID());
+            }
+        }
+
+        queryArgs.addFilterQueries(queryArray);
         return queryArgs;
     }
 
     private void configureSorting(String sortProperty, String sortDirection, DiscoverQuery queryArgs,
-                                  DiscoverySortConfiguration searchSortConfiguration)
+        DiscoverySortConfiguration searchSortConfiguration, IndexableObject scope)
             throws IllegalArgumentException, SearchServiceException {
         String sortBy = sortProperty;
         String sortOrder = sortDirection;
@@ -318,8 +337,18 @@ public class DiscoverQueryBuilder implements InitializingBean {
                 .getSortFieldConfiguration(sortBy);
 
         if (sortFieldConfiguration != null) {
-            String sortField = searchService
-                    .toSortFieldIndex(sortFieldConfiguration.getMetadataField(), sortFieldConfiguration.getType());
+
+            String sortField;
+
+            if (DiscoverySortFunctionConfiguration.SORT_FUNCTION.equals(sortFieldConfiguration.getType())) {
+                sortField = MessageFormat.format(
+                    ((DiscoverySortFunctionConfiguration) sortFieldConfiguration).getFunction(scope.getID()),
+                    scope.getID());
+            } else {
+                sortField = searchService
+                    .toSortFieldIndex(
+                        sortFieldConfiguration.getMetadataField(), sortFieldConfiguration.getType());
+            }
 
             if ("asc".equalsIgnoreCase(sortOrder)) {
                 queryArgs.setSortField(sortField, DiscoverQuery.SORT_ORDER.asc);

--- a/dspace-api/src/test/java/org/dspace/builder/ItemBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/ItemBuilder.java
@@ -248,8 +248,16 @@ public class ItemBuilder extends AbstractDSpaceObjectBuilder<Item> {
         return addMetadataValue(item, MetadataSchemaEnum.DC.getName(), "description", "abstract", description);
     }
 
+    public ItemBuilder withRelationProject(String project, String authority) {
+        return addMetadataValue(item, DC.getName(), "relation", "project", null, project, authority, 600);
+    }
+
     public ItemBuilder withRelationJournal(String journal, String authority) {
         return addMetadataValue(item, DC.getName(), "relation", "journal", null, journal, authority, 600);
+    }
+
+    public ItemBuilder withProjectInvestigator(String investigator, String authority) {
+        return addMetadataValue(item, "crispj", "investigator", null, null, investigator, authority, 600);
     }
 
     public ItemBuilder withType(String type) {

--- a/dspace-api/src/test/java/org/dspace/discovery/utils/DiscoverQueryBuilderTest.java
+++ b/dspace-api/src/test/java/org/dspace/discovery/utils/DiscoverQueryBuilderTest.java
@@ -322,10 +322,9 @@ public class DiscoverQueryBuilderTest {
         assertThat(discoverQuery.getMaxResults(), is(0));
         assertThat(discoverQuery.getStart(), is(0));
         assertThat(discoverQuery.getFacetMinCount(), is(1));
-        assertThat(discoverQuery.getFacetOffset(), is(10));
         assertThat(discoverQuery.getFacetFields(), hasSize(1));
         assertThat(discoverQuery.getFacetFields(), contains(
-                discoverFacetFieldMatcher(new DiscoverFacetField("subject", TYPE_TEXT, 11, COUNT, "prefix"))
+                discoverFacetFieldMatcher(new DiscoverFacetField("subject", TYPE_TEXT, 11, COUNT, "prefix", 10))
         ));
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/DiscoverFacetResultsConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/DiscoverFacetResultsConverter.java
@@ -82,7 +82,9 @@ public class DiscoverFacetResultsConverter {
         facetResultsRest.setPrefix(prefix);
         facetResultsRest.setScope(dsoScope);
         facetResultsRest.setDsoTypes(dsoTypes);
-
+        if (configuration != null) {
+            facetResultsRest.setConfiguration(configuration.getId());
+        }
         facetResultsRest.setFacetEntry(convertFacetEntry(facetName, searchResult, configuration, page, projection));
 
         facetResultsRest.setSort(SearchResultsRest.Sorting.fromPage(page));

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/ScopeResolver.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/ScopeResolver.java
@@ -8,16 +8,24 @@
 package org.dspace.app.rest.utils;
 
 import java.sql.SQLException;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.DSpaceObject;
+import org.dspace.content.Item;
 import org.dspace.content.service.CollectionService;
 import org.dspace.content.service.CommunityService;
+import org.dspace.content.service.DSpaceObjectService;
+import org.dspace.content.service.ItemService;
 import org.dspace.core.Context;
 import org.dspace.discovery.IndexableObject;
 import org.dspace.discovery.indexobject.IndexableCollection;
 import org.dspace.discovery.indexobject.IndexableCommunity;
+import org.dspace.discovery.indexobject.IndexableItem;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -35,47 +43,112 @@ public class ScopeResolver {
     @Autowired
     CommunityService communityService;
 
+    @Autowired
+    ItemService itemService;
+
     /**
-     * Returns an IndexableObject corresponding to the community or collection
+     * Returns an IndexableObject corresponding to the community, collection, or item
      * of the given scope, or null if the scope is not a valid UUID, or is a
-     * valid UUID that does not correspond to a community of collection.
+     * valid UUID that does not correspond to a community, collection, or item.
      *
      * @param context the DSpace context
-     * @param scope a String containing the UUID of the community or collection
-     * to return.
-     * @return an IndexableObject corresponding to the community or collection
+     * @param scope a String containing the UUID of the DSpace object to return
+     * @return an IndexableObject corresponding to the community, collection, or item
      * of the given scope, or null if the scope is not a valid UUID, or is a
-     * valid UUID that does not correspond to a community of collection.
+     * valid UUID that does not correspond to a community, collection, or item.
      */
     public IndexableObject resolveScope(Context context, String scope) {
-        IndexableObject scopeObj = null;
-        if (StringUtils.isNotBlank(scope)) {
-            try {
-                UUID uuid = UUID.fromString(scope);
-                scopeObj = new IndexableCommunity(communityService.find(context, uuid));
-                if (scopeObj.getIndexedObject() == null) {
-                    scopeObj = new IndexableCollection(collectionService.find(context, uuid));
-                    if (scopeObj.getIndexedObject() == null) {
-                        // Can't find the UUID as a community or collection
-                        // so log and return null
-                        log.warn(
-                            "The given scope string " +
-                            StringUtils.trimToEmpty(scope) +
-                            " is not a collection or community UUID."
-                        );
-                        scopeObj = null;
-                    }
-                }
-            } catch (IllegalArgumentException ex) {
-                log.warn("The given scope string " + StringUtils.trimToEmpty(scope) + " is not a UUID", ex);
-            } catch (SQLException ex) {
-                log.warn(
-                    "Unable to retrieve DSpace Object with ID " + StringUtils.trimToEmpty(scope) + " from the database",
-                    ex);
+        Optional<UUID> uuidOptional = Optional.ofNullable(scope)
+                                              .filter(StringUtils::isNotBlank)
+                                              .map(this::asUUID);
+
+        // First try to resolve as a Community
+        return uuidOptional
+            .flatMap(uuid -> resolveWithIndexedObject(context, uuid, communityService))
+            // If not a Community, try as a Collection
+            .or(() -> uuidOptional.flatMap(uuid -> resolveWithIndexedObject(context, uuid, collectionService)))
+            // If not a Community or Collection, try as an Item
+            .or(() -> uuidOptional.flatMap(uuid -> resolveWithIndexedObject(context, uuid, itemService)))
+            .orElseGet(() -> {
+                log.warn("Cannot find any valid scope object related to this scope {}", scope);
+                return null;
+            });
+    }
+
+    /**
+     * Attempts to convert a string to a UUID
+     *
+     * @param scope the string to convert
+     * @return the UUID or null if conversion fails
+     */
+    private UUID asUUID(String scope) {
+        try {
+            return UUID.fromString(scope);
+        } catch (IllegalArgumentException ex) {
+            log.warn("The given scope string {} is not a valid UUID", StringUtils.trimToEmpty(scope));
+            return null;
+        }
+    }
+
+    /**
+     * Resolves a UUID to an IndexableObject using the provided service
+     *
+     * @param context the DSpace context
+     * @param uuid    the UUID to resolve
+     * @param service the service to use for resolution
+     * @param <T>     the type of DSpaceObject
+     * @return an Optional containing the IndexableObject if found, empty otherwise
+     */
+    private <T extends DSpaceObject> Optional<IndexableObject> resolveWithIndexedObject(
+        Context context, UUID uuid, DSpaceObjectService<T> service
+    ) {
+        return Optional.ofNullable(resolve(context, uuid, service));
+    }
+
+    /**
+     * Resolves a UUID to a DSpaceObject and wraps it in the appropriate IndexableObject
+     *
+     * @param context the DSpace context
+     * @param uuid the UUID to resolve
+     * @param service the service to use for resolution
+     * @param <T> the type of DSpaceObject
+     * @return the IndexableObject or null if not found
+     */
+    public <T extends DSpaceObject> IndexableObject resolve(
+        Context context, UUID uuid, DSpaceObjectService<T> service
+    ) {
+        if (uuid == null) {
+            return null;
+        }
+
+        T dspaceObject = null;
+        try {
+            dspaceObject = service.find(context, uuid);
+        } catch (IllegalArgumentException ex) {
+            if (log.isDebugEnabled()) {
+                log.debug("Invalid UUID format: {}", StringUtils.trimToEmpty(uuid.toString()), ex);
+            }
+        } catch (SQLException ex) {
+            if (log.isDebugEnabled()) {
+                log.debug("Error retrieving object with ID {}", StringUtils.trimToEmpty(uuid.toString()), ex);
             }
         }
 
-        return scopeObj;
-    }
+        if (dspaceObject == null) {
+            return null;
+        }
 
+        // Create the appropriate IndexableObject based on the type of DSpaceObject
+        if (dspaceObject instanceof Community) {
+            return new IndexableCommunity((Community) dspaceObject);
+        } else if (dspaceObject instanceof Collection) {
+            return new IndexableCollection((Collection) dspaceObject);
+        } else if (dspaceObject instanceof Item) {
+            return new IndexableItem((Item) dspaceObject);
+        }
+
+        // This should not happen if all DSpaceObject types are handled above.
+        log.warn("Unhandled DSpaceObject type: {}", dspaceObject.getClass().getName());
+        return null;
+    }
 }

--- a/dspace-server-webapp/src/test/data/dspaceFolder/config/spring/api/test-discovery.xml
+++ b/dspace-server-webapp/src/test/data/dspaceFolder/config/spring/api/test-discovery.xml
@@ -110,6 +110,50 @@
                 <entry key="eperson_claims" value-ref="eperson_claims"/>
                 <!-- multilanguage types facet configuration -->
                 <entry key="123456789/language-test-1" value-ref="multilanguage-types"/>
+                <!-- ========================================================== -->
+                <!-- DSpace-CRIS Authority-based RELATION Discovery Configurations -->
+                <!-- These configurations map entity relationships to discovery    -->
+                <!-- searches using authority-based metadata fields.               -->
+                <!-- ========================================================== -->
+
+                <!-- Person Related Items -->
+                <!-- Maps to: Person.isProjectOfPerson (from Project → Person relationship) -->
+                <!-- Shows Projects where this Person is an investigator -->
+                <entry key="RELATION.Person.projects" value-ref="relationInvestigatorProjectsConfiguration"/>
+                <!-- Maps to: Person.isPublicationOfAuthor (from Publication → Person relationship) -->
+                <!-- Shows Publications where this Person is an author -->
+                <entry key="RELATION.Person.researchoutputs" value-ref="relationAuthorResearchOutputsConfiguration"/>
+
+                <!-- OrgUnit Related Items -->
+                <!-- Maps to: OrgUnit.isProjectOfOrgUnit (from Project → OrgUnit relationship) -->
+                <!-- Shows RP Projects via investigators affiliated with this OrgUnit -->
+                <entry key="RELATION.OrgUnit.rpprojects" value-ref="relationOrgunitRPProjectConfiguration"/>
+                <!-- Maps to: OrgUnit.isPublicationOfOrgUnit (from Publication → OrgUnit relationship) -->
+                <!-- Shows Publications sponsored by this OrgUnit -->
+                <entry key="RELATION.OrgUnit.publications" value-ref="relationOrgunitPublicationsConfiguration"/>
+                <!-- Maps to: OrgUnit.isPublicationOfOrgUnit via Person affiliation -->
+                <!-- Shows Publications authored by people affiliated with this OrgUnit -->
+                <entry key="RELATION.OrgUnit.rppublications" value-ref="relationOrgunitRPPublicationsConfiguration"/>
+                <!-- Maps to: OrgUnit.isPersonOfOrgUnit (from Person → OrgUnit relationship) -->
+                <!-- Shows People affiliated with this OrgUnit -->
+                <entry key="RELATION.OrgUnit.people" value-ref="relationOrgunitPersonsConfiguration"/>
+                <!-- Maps to: OrgUnit.isProjectOfOrgUnit (from Project → OrgUnit relationship) -->
+                <!-- Shows Projects participated by this OrgUnit -->
+                <entry key="RELATION.OrgUnit.projects" value-ref="relationOrgunitProjectsConfiguration"/>
+                <!-- Maps to: OrgUnit.isOrgUnitOfOrgUnit (hierarchical OrgUnit relationship) -->
+                <!-- Shows sub-organizations of this OrgUnit -->
+                <entry key="RELATION.OrgUnit.organizations" value-ref="relationOrgunitOrgunitsConfiguration"/>
+
+                <!-- Project Related Items -->
+                <!-- Maps to: Project.isProjectOfProject (related projects) -->
+                <!-- Shows Projects related to this Project -->
+                <entry key="RELATION.Project.projects" value-ref="relationProjectProjectsConfiguration"/>
+                <!-- Maps to: Project.isFundingOfProject (from Funding → Project relationship) -->
+                <!-- Shows Fundings related to this Project -->
+                <entry key="RELATION.Project.fundings" value-ref="relationProjectFundingsConfiguration"/>
+                <!-- Maps to: Project.isPublicationOfProject (from Publication → Project relationship) -->
+                <!-- Shows Publications related to this Project -->
+                <entry key="RELATION.Project.researchoutputs" value-ref="relationProjectPublicationConfiguration"/>
                 <!-- COAR NOTIFY LDN MESSAGES configuration -->
                 <entry key="NOTIFY.incoming" value-ref="NOTIFY.incoming"/>
                 <entry key="NOTIFY.outgoing" value-ref="NOTIFY.outgoing"/>
@@ -1054,6 +1098,363 @@
         <!-- When true a "did you mean" example will be displayed, value can be true or false -->
         <property name="spellCheckEnabled" value="true"/>
     </bean>
+    <!-- Inverse Relations -->
+    <!-- project of an researcher -->
+    <bean id="relationInvestigatorProjectsConfiguration" class="org.dspace.discovery.configuration.DiscoveryRelatedItemConfiguration">
+        <!--Which sidebar facets are to be displayed-->
+        <property name="sidebarFacets">
+            <list>
+                <ref bean="searchFilterEntityType" />
+            </list>
+        </property>
+        <!--The search filters which can be used on the discovery search page-->
+        <property name="searchFilters">
+            <list>
+                <ref bean="searchFilterEntityType" />
+                <ref bean="searchFilterProjectInvestigator"/>
+            </list>
+        </property>
+        <!--The sort filters for the discovery search-->
+        <property name="searchSortConfiguration">
+            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
+                <!--DefaultSortOrder can either be desc or asc (desc is default)-->
+                <property name="sortFields">
+                    <list>
+                        <ref bean="sortByProjectsSelection" />
+                        <ref bean="sortTitleAsc" />
+                    </list>
+                </property>
+            </bean>
+        </property>
+        <!--Any default filter queries, these filter queries will be used for all
+                queries done by discovery for this configuration -->
+        <property name="defaultFilterQueries">
+            <list>
+                <!--Only find related items. The placeholder {0} will be replaced with scope (UUID of item)-->
+                <value>projectinvestigators_authority:{0} AND search.resourcetype:Item</value>
+                <value>-withdrawn:true AND -discoverable:false</value>
+            </list>
+        </property>
+        <!--Default result per page  -->
+        <property name="defaultRpp" value="10" />
+        <property name="hitHighlightingConfiguration">
+            <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightingConfiguration">
+                <property name="metadataFields">
+                    <list>
+                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
+                            <property name="field" value="dspace.entity.type"/>
+                            <property name="snippets" value="5"/>
+                        </bean>
+                    </list>
+                </property>
+            </bean>
+        </property>
+    </bean>
+
+    <!-- publications of an author -->
+    <bean id="relationAuthorResearchOutputsConfiguration" class="org.dspace.discovery.configuration.DiscoveryRelatedItemConfiguration">
+        <!--Which sidebar facets are to be displayed-->
+        <property name="sidebarFacets">
+            <list>
+                <ref bean="searchFilterIssued" />
+                <ref bean="searchFilterAuthor" />
+                <ref bean="searchFilterEditor" />
+                <ref bean="searchFilterOrgUnit" />
+                <ref bean="searchFilterSubject" />
+                <ref bean="searchFilterFunding" />
+                <ref bean="searchFilterContentInOriginalBundle"/>
+                <ref bean="searchFilterType" />
+            </list>
+        </property>
+        <!-- Set TagCloud configuration per discovery configuration -->
+        <property name="tagCloudFacetConfiguration" ref="defaultTagCloudFacetConfiguration"/>
+        <!--The search filters which can be used on the discovery search page-->
+        <property name="searchFilters">
+            <list>
+                <ref bean="searchFilterTitle" />
+                <ref bean="searchFilterIssued" />
+                <ref bean="searchFilterAuthor" />
+                <ref bean="searchFilterEditor" />
+                <ref bean="searchFilterOrgUnit" />
+                <ref bean="searchFilterSubject" />
+                <ref bean="searchFilterFunding" />
+                <ref bean="searchFilterContentInOriginalBundle"/>
+                <ref bean="searchFilterType" />
+            </list>
+        </property>
+        <!--The sort filters for the discovery search-->
+        <property name="searchSortConfiguration">
+            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
+                <!--<property name="defaultSort" ref="sortDateIssued"/>-->
+                <!--DefaultSortOrder can either be desc or asc (desc is default)-->
+                <property name="sortFields">
+                    <list>
+                        <ref bean="sortByResearchOutputsSelection" />
+                        <ref bean="sortTitleAsc" />
+                    </list>
+                </property>
+            </bean>
+        </property>
+        <!--Any default filter queries, these filter queries will be used for all
+                queries done by discovery for this configuration -->
+        <property name="defaultFilterQueries">
+            <list>
+                <!--Only find related items. The placeholder {0} will be replaced with scope (UUID of item)-->
+                <value>author_authority:{0} AND search.resourcetype:Item</value>
+                <value>-withdrawn:true AND -discoverable:false</value>
+            </list>
+        </property>
+        <!--Default result per page  -->
+        <property name="defaultRpp" value="10" />
+        <property name="hitHighlightingConfiguration">
+            <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightingConfiguration">
+                <property name="metadataFields">
+                    <list>
+                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
+                            <property name="field" value="dspace.entity.type"/>
+                            <property name="snippets" value="5"/>
+                        </bean>
+                    </list>
+                </property>
+            </bean>
+        </property>
+    </bean>
+
+    <!-- project investigated by people affiliated to an orgunit -->
+    <bean id="relationOrgunitRPProjectConfiguration" class="org.dspace.discovery.configuration.DiscoveryRelatedItemConfiguration">
+        <!--The sort filters for the discovery search-->
+        <property name="searchSortConfiguration">
+            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
+                <!--<property name="defaultSort" ref="sortDateIssued"/>-->
+                <!--DefaultSortOrder can either be desc or asc (desc is default)-->
+                <property name="sortFields">
+                    <list>
+                        <ref bean="sortByRPProjectsSelection" />
+                        <ref bean="sortTitleAsc" />
+                    </list>
+                </property>
+            </bean>
+        </property>
+        <!--Any default filter queries, these filter queries will be used for all
+                queries done by discovery for this configuration -->
+        <property name="defaultFilterQueries">
+            <list>
+                <!--Only find related items. The placeholder {0} will be replaced with scope (UUID of item)-->
+                <value>'{'!join from=search.resourceid to=projectinvestigators_authority fromIndex=${solr.multicorePrefix}search'}'person.affiliation.name_authority:{0}</value>
+                <value>-withdrawn:true AND -discoverable:false</value>
+            </list>
+        </property>
+    </bean>
+
+    <!-- publication sponsored by an orgunit -->
+    <bean id="relationOrgunitPublicationsConfiguration" class="org.dspace.discovery.configuration.DiscoveryRelatedItemConfiguration">
+        <!--The sort filters for the discovery search-->
+        <property name="searchSortConfiguration">
+            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
+                <!--<property name="defaultSort" ref="sortDateIssued"/>-->
+                <!--DefaultSortOrder can either be desc or asc (desc is default)-->
+                <property name="sortFields">
+                    <list>
+                        <ref bean="sortByPublicationsSelection" />
+                        <ref bean="sortTitleAsc" />
+                    </list>
+                </property>
+            </bean>
+        </property>
+        <!--Any default filter queries, these filter queries will be used for all
+                queries done by discovery for this configuration -->
+        <property name="defaultFilterQueries">
+            <list>
+                <!--Only find related items. The placeholder {0} will be replaced with scope (UUID of item)-->
+                <value>dc.description.sponsorship_authority:{0}</value>
+                <value>-withdrawn:true AND -discoverable:false</value>
+            </list>
+        </property>
+    </bean>
+
+    <!-- publication authored by people affiliated to an orgunit -->
+    <bean id="relationOrgunitRPPublicationsConfiguration" class="org.dspace.discovery.configuration.DiscoveryRelatedItemConfiguration">
+        <!--The sort filters for the discovery search-->
+        <property name="searchSortConfiguration">
+            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
+                <!--<property name="defaultSort" ref="sortDateIssued"/>-->
+                <!--DefaultSortOrder can either be desc or asc (desc is default)-->
+                <property name="sortFields">
+                    <list>
+                        <ref bean="sortByRPPublicationsSelection" />
+                        <ref bean="sortTitleAsc" />
+                    </list>
+                </property>
+            </bean>
+        </property>
+        <!--Any default filter queries, these filter queries will be used for all
+                queries done by discovery for this configuration -->
+        <property name="defaultFilterQueries">
+            <list>
+                <!--Only find related items. The placeholder {0} will be replaced with scope (UUID of item)-->
+                <value>'{'!join from=search.resourceid to=author_authority fromIndex=${solr.multicorePrefix}search'}'person.affiliation.name_authority:{0}</value>
+                <value>-withdrawn:true AND -discoverable:false</value>
+            </list>
+        </property>
+    </bean>
+
+    <!-- people affiliated to an orgunit -->
+    <bean id="relationOrgunitPersonsConfiguration" class="org.dspace.discovery.configuration.DiscoveryRelatedItemConfiguration">
+        <!--The sort filters for the discovery search-->
+        <property name="searchSortConfiguration">
+            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
+                <!--<property name="defaultSort" ref="sortDateIssued"/>-->
+                <!--DefaultSortOrder can either be desc or asc (desc is default)-->
+                <property name="sortFields">
+                    <list>
+                        <ref bean="sortByPeopleSelection" />
+                        <ref bean="sortTitleAsc" />
+                    </list>
+                </property>
+            </bean>
+        </property>
+        <!--Any default filter queries, these filter queries will be used for all
+                queries done by discovery for this configuration -->
+        <property name="defaultFilterQueries">
+            <list>
+                <!--Only find related items. The placeholder {0} will be replaced with scope (UUID of item)-->
+                <value>person.affiliation.name_authority:{0}</value>
+                <value>-withdrawn:true AND -discoverable:false</value>
+            </list>
+        </property>
+    </bean>
+
+    <!-- project participated by an orgunit -->
+    <bean id="relationOrgunitProjectsConfiguration" class="org.dspace.discovery.configuration.DiscoveryRelatedItemConfiguration">
+        <!--The sort filters for the discovery search-->
+        <property name="searchSortConfiguration">
+            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
+                <!--<property name="defaultSort" ref="sortDateIssued"/>-->
+                <!--DefaultSortOrder can either be desc or asc (desc is default)-->
+                <property name="sortFields">
+                    <list>
+                        <ref bean="sortByProjectsSelection" />
+                        <ref bean="sortTitleAsc" />
+                    </list>
+                </property>
+            </bean>
+        </property>
+        <!--Any default filter queries, these filter queries will be used for all
+                queries done by discovery for this configuration -->
+        <property name="defaultFilterQueries">
+            <list>
+                <!--Only find related items. The placeholder {0} will be replaced with scope (UUID of item)-->
+                <value>involvedorganisation_authority:{0}</value>
+                <value>-withdrawn:true AND -discoverable:false</value>
+            </list>
+        </property>
+    </bean>
+
+    <!-- suborganisation unit of an orgunit -->
+    <bean id="relationOrgunitOrgunitsConfiguration" class="org.dspace.discovery.configuration.DiscoveryRelatedItemConfiguration">
+        <!--The sort filters for the discovery search-->
+        <property name="searchSortConfiguration">
+            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
+                <!--<property name="defaultSort" ref="sortDateIssued"/>-->
+                <!--DefaultSortOrder can either be desc or asc (desc is default)-->
+                <property name="sortFields">
+                    <list>
+                        <ref bean="sortByOrganizationsSelection" />
+                        <ref bean="sortTitleAsc" />
+                    </list>
+                </property>
+            </bean>
+        </property>
+        <!--Any default filter queries, these filter queries will be used for all
+                queries done by discovery for this configuration -->
+        <property name="defaultFilterQueries">
+            <list>
+                <!--Only find related items. The placeholder {0} will be replaced with scope (UUID of item)-->
+                <value>organization.parentOrganization_authority:{0}</value>
+                <value>-withdrawn:true AND -discoverable:false</value>
+            </list>
+        </property>
+    </bean>
+
+    <!-- project related to a project -->
+    <bean id="relationProjectProjectsConfiguration" class="org.dspace.discovery.configuration.DiscoveryRelatedItemConfiguration">
+        <!--The sort filters for the discovery search-->
+        <property name="searchSortConfiguration">
+            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
+                <!--<property name="defaultSort" ref="sortDateIssued"/>-->
+                <!--DefaultSortOrder can either be desc or asc (desc is default)-->
+                <property name="sortFields">
+                    <list>
+                        <ref bean="sortByProjectsSelection" />
+                        <ref bean="sortTitleAsc" />
+                    </list>
+                </property>
+            </bean>
+        </property>
+        <!--Any default filter queries, these filter queries will be used for all
+                queries done by discovery for this configuration -->
+        <property name="defaultFilterQueries">
+            <list>
+                <!--Only find related items. The placeholder {0} will be replaced with scope (UUID of item)-->
+                <value>dc.relation.project_authority:{0} AND entityType_keyword:Project</value>
+                <value>-withdrawn:true AND -discoverable:false</value>
+            </list>
+        </property>
+    </bean>
+
+    <!-- fundings related to a project -->
+    <bean id="relationProjectFundingsConfiguration" class="org.dspace.discovery.configuration.DiscoveryRelatedItemConfiguration">
+        <!--The sort filters for the discovery search-->
+        <property name="searchSortConfiguration">
+            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
+                <!--<property name="defaultSort" ref="sortDateIssued"/>-->
+                <!--DefaultSortOrder can either be desc or asc (desc is default)-->
+                <property name="sortFields">
+                    <list>
+                        <ref bean="sortByFundingsSelection" />
+                        <ref bean="sortTitleAsc" />
+                    </list>
+                </property>
+            </bean>
+        </property>
+        <!--Any default filter queries, these filter queries will be used for all
+                queries done by discovery for this configuration -->
+        <property name="defaultFilterQueries">
+            <list>
+                <!--Only find related items. The placeholder {0} will be replaced with scope (UUID of item)-->
+                <value>dc.relation.project_authority:{0} AND entityType_keyword:Funding</value>
+                <value>-withdrawn:true AND -discoverable:false</value>
+            </list>
+        </property>
+    </bean>
+
+    <!-- publications related to a project -->
+    <bean id="relationProjectPublicationConfiguration" class="org.dspace.discovery.configuration.DiscoveryRelatedItemConfiguration">
+        <!--The sort filters for the discovery search-->
+        <property name="searchSortConfiguration">
+            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
+                <!--<property name="defaultSort" ref="sortDateIssued"/>-->
+                <!--DefaultSortOrder can either be desc or asc (desc is default)-->
+                <property name="sortFields">
+                    <list>
+                        <ref bean="sortByResearchOutputsSelection" />
+                        <ref bean="sortTitleAsc" />
+                    </list>
+                </property>
+            </bean>
+        </property>
+        <!--Any default filter queries, these filter queries will be used for all
+                queries done by discovery for this configuration -->
+        <property name="defaultFilterQueries">
+            <list>
+                <!--Only find related items. The placeholder {0} will be replaced with scope (UUID of item)-->
+                <value>dc.relation.project_authority:{0} AND entityType_keyword:Publication</value>
+                <value>-withdrawn:true AND -discoverable:false</value>
+            </list>
+        </property>
+    </bean>
+
+
     <bean id="discovery-collection-2-2-1" class="org.dspace.discovery.configuration.DiscoveryConfiguration" scope="prototype">
         <property name="id" value="discovery-collection-2-2-1"/>
         <!--Which sidebar facets are to be displayed-->
@@ -1177,6 +1578,17 @@
         <property name="spellCheckEnabled" value="true"/>
     </bean>
 
+    <bean id="searchFilterTitle" class="org.dspace.discovery.configuration.DiscoverySearchFilter">
+        <property name="indexFieldName" value="title"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.title</value>
+            </list>
+        </property>
+        <property name="isOpenByDefault" value="true"/>
+        <property name="pageSize" value="10"/>
+    </bean>
+
     <bean id="scopeBasedTagCloudFacetConfiguration" class="org.dspace.discovery.configuration.TagCloudFacetConfiguration">
         <!-- Actual configuration of the tagcloud (colors, sorting, etc.) -->
         <property name="tagCloudConfiguration" ref="tagCloudConfiguration"/>
@@ -1186,6 +1598,22 @@
                 <ref bean="searchFilterAuthor" />
             </list>
         </property>
+    </bean>
+
+    <bean id="searchFilterAuthor" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
+        <property name="indexFieldName" value="author"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.contributor.author</value>
+                <value>dc.creator</value>
+            </list>
+        </property>
+        <property name="facetLimit" value="5"/>
+        <property name="sortOrderSidebar" value="COUNT"/>
+        <property name="sortOrderFilterPage" value="COUNT"/>
+        <property name="isOpenByDefault" value="true"/>
+        <property name="pageSize" value="10"/>
+        <property name="exposeMinAndMaxValue" value="true"/>
     </bean>
 
     <bean id="searchFilterParentCommunity1Field" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
@@ -1201,6 +1629,90 @@
         <property name="isOpenByDefault" value="true"/>
         <property name="pageSize" value="10"/>
         <property name="exposeMinAndMaxValue" value="true"/>
+    </bean>
+
+    <bean id="searchFilterSubject" class="org.dspace.discovery.configuration.HierarchicalSidebarFacetConfiguration">
+        <property name="indexFieldName" value="subject"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.subject.*</value>
+            </list>
+        </property>
+        <property name="facetLimit" value="5"/>
+        <property name="sortOrderSidebar" value="COUNT"/>
+        <property name="sortOrderFilterPage" value="COUNT"/>
+        <property name="splitter" value="::"/>
+
+    </bean>
+
+    <bean id="searchFilterContentInOriginalBundle" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
+        <property name="indexFieldName" value="has_content_in_original_bundle"/>
+        <property name="metadataFields">
+            <list/>
+        </property>
+        <property name="facetLimit" value="2"/>
+        <property name="type" value="standard"/>
+        <property name="sortOrderSidebar" value="COUNT"/>
+        <property name="sortOrderFilterPage" value="COUNT"/>
+        <property name="isOpenByDefault" value="false"/>
+        <property name="pageSize" value="10"/>
+
+    </bean>
+
+    <bean id="searchFilterFileNameInOriginalBundle" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
+        <property name="indexFieldName" value="original_bundle_filenames"/>
+        <property name="metadataFields">
+            <list/>
+        </property>
+    </bean>
+
+    <bean id="searchFilterFileDescriptionInOriginalBundle" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
+        <property name="indexFieldName" value="original_bundle_descriptions"/>
+        <property name="metadataFields">
+            <list/>
+        </property>
+    </bean>
+
+    <bean id="searchFilterType" class="org.dspace.discovery.configuration.HierarchicalSidebarFacetConfiguration">
+        <property name="indexFieldName" value="itemtype" />
+        <property name="splitter" value="::" />
+        <property name="metadataFields">
+            <list>
+                <value>dc.type</value>
+            </list>
+        </property>
+    </bean>
+
+
+    <bean id="searchFilterEntityType" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
+        <property name="indexFieldName" value="entityType"/>
+        <property name="metadataFields">
+            <list>
+                <value>dspace.entity.type</value>
+            </list>
+        </property>
+        <property name="facetLimit" value="5"/>
+        <property name="sortOrderSidebar" value="COUNT"/>
+        <property name="sortOrderFilterPage" value="COUNT"/>
+
+
+    </bean>
+
+    <bean id="searchFilterIssued" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
+        <property name="indexFieldName" value="dateIssued"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.date.issued</value>
+            </list>
+        </property>
+        <property name="type" value="date"/>
+        <property name="facetLimit" value="5"/>
+        <property name="sortOrderSidebar" value="COUNT"/>
+        <property name="sortOrderFilterPage" value="COUNT"/>
+        <property name="isOpenByDefault" value="false"/>
+        <property name="pageSize" value="10"/>
+        <property name="exposeMinAndMaxValue" value="true"/>
+
     </bean>
 
     <bean id="searchFilterSubCommunity11Field" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
@@ -1261,6 +1773,167 @@
         <property name="isOpenByDefault" value="true"/>
         <property name="pageSize" value="10"/>
         <property name="exposeMinAndMaxValue" value="true"/>
+    </bean>
+
+    <bean id="searchFilterProjectInvestigator"
+        class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
+        <property name="indexFieldName" value="projectinvestigators" />
+        <property name="metadataFields">
+            <list>
+                <value>crispj.investigator</value>
+                <value>crispj.coinvestigators</value>
+            </list>
+        </property>
+        <property name="facetLimit" value="5"/>
+        <property name="sortOrderSidebar" value="COUNT"/>
+        <property name="sortOrderFilterPage" value="COUNT"/>
+        <property name="isOpenByDefault" value="false"/>
+        <property name="pageSize" value="10"/>
+        <property name="exposeMinAndMaxValue" value="false"/>
+    </bean>
+
+    <bean id="searchFilterEditor" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
+        <property name="indexFieldName" value="editor"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.contributor.editor</value>
+                <value>dc.creator</value>
+            </list>
+        </property>
+        <property name="facetLimit" value="5"/>
+        <property name="sortOrderSidebar" value="COUNT"/>
+        <property name="sortOrderFilterPage" value="COUNT"/>
+        <property name="isOpenByDefault" value="true"/>
+        <property name="pageSize" value="10"/>
+        <property name="exposeMinAndMaxValue" value="true"/>
+    </bean>
+
+    <bean id="searchFilterOrgUnit" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
+        <property name="indexFieldName" value="organization"/>
+        <property name="metadataFields">
+            <list>
+                <value>oairecerif.author.affiliation</value>
+                <value>oairecerif.editor.affiliation</value>
+            </list>
+        </property>
+        <property name="facetLimit" value="5"/>
+        <property name="sortOrderSidebar" value="COUNT"/>
+        <property name="sortOrderFilterPage" value="COUNT"/>
+        <property name="isOpenByDefault" value="true"/>
+        <property name="pageSize" value="10"/>
+        <property name="exposeMinAndMaxValue" value="true"/>
+    </bean>
+
+    <bean id="searchFilterFunding" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
+        <property name="indexFieldName" value="funding"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.relation.funding</value>
+            </list>
+        </property>
+        <property name="facetLimit" value="5"/>
+        <property name="sortOrderSidebar" value="COUNT"/>
+        <property name="sortOrderFilterPage" value="COUNT"/>
+        <property name="isOpenByDefault" value="true"/>
+        <property name="pageSize" value="10"/>
+        <property name="exposeMinAndMaxValue" value="true"/>
+    </bean>
+
+    <bean id="sortTitleAsc" class="org.dspace.discovery.configuration.DiscoverySortFieldConfiguration">
+        <property name="metadataField" value="dc.title"/>
+        <property name="defaultSortOrder" value="asc"/>
+    </bean>
+
+    <!-- functional sorting -->
+    <bean name="sortByProjectsSelection" class="org.dspace.discovery.configuration.DiscoverySortFunctionConfiguration">
+        <property name="defaultSortOrder" value="desc"/>
+        <!--sort by frequency of relation.isProjectsSelectedFor. The placeholder {0} will be replaced with scope (UUID of researcher)-->
+        <property name="function" value="termfreq"/>
+        <property name="id" value="ownerselection"/>
+        <property name="arguments">
+            <list>
+                <value>relation.isProjectsSelectedFor</value>
+                <value>{0}</value>
+            </list>
+        </property>
+    </bean>
+
+    <bean name="sortByRPProjectsSelection" class="org.dspace.discovery.configuration.DiscoverySortFunctionConfiguration">
+        <property name="defaultSortOrder" value="desc"/>
+        <!--sort by frequency of relation.isProjectsSelectedFor. The placeholder {0} will be replaced with scope (UUID of researcher)-->
+        <property name="function" value="termfreq"/>
+        <property name="id" value="ownerselection"/>
+        <property name="arguments">
+            <list>
+                <value>relation.isRpprojectsSelectedFor</value>
+                <value>{0}</value>
+            </list>
+        </property>
+    </bean>
+
+    <bean name="sortByPublicationsSelection" class="org.dspace.discovery.configuration.DiscoverySortFunctionConfiguration">
+        <property name="defaultSortOrder" value="desc"/>
+        <!--sort by frequency of relation.isProjectsSelectedFor. The placeholder {0} will be replaced with scope (UUID of researcher)-->
+        <property name="function" value="termfreq"/>
+        <property name="id" value="ownerselection"/>
+        <property name="arguments">
+            <list>
+                <value>relation.isPublicationsSelectedFor</value>
+                <value>{0}</value>
+            </list>
+        </property>
+    </bean>
+
+    <bean name="sortByRPPublicationsSelection" class="org.dspace.discovery.configuration.DiscoverySortFunctionConfiguration">
+        <property name="defaultSortOrder" value="desc"/>
+        <!--sort by frequency of relation.isProjectsSelectedFor. The placeholder {0} will be replaced with scope (UUID of researcher)-->
+        <property name="function" value="termfreq"/>
+        <property name="id" value="ownerselection"/>
+        <property name="arguments">
+            <list>
+                <value>relation.isRppublicationsSelectedFor</value>
+                <value>{0}</value>
+            </list>
+        </property>
+    </bean>
+
+    <bean name="sortByPeopleSelection" class="org.dspace.discovery.configuration.DiscoverySortFunctionConfiguration">
+        <property name="defaultSortOrder" value="desc"/>
+        <!--sort by frequency of relation.isProjectsSelectedFor. The placeholder {0} will be replaced with scope (UUID of researcher)-->
+        <property name="function" value="termfreq"/>
+        <property name="id" value="ownerselection"/>
+        <property name="arguments">
+            <list>
+                <value>relation.isPeopleSelectedFor</value>
+                <value>{0}</value>
+            </list>
+        </property>
+    </bean>
+
+    <bean name="sortByOrganizationsSelection" class="org.dspace.discovery.configuration.DiscoverySortFunctionConfiguration">
+        <property name="defaultSortOrder" value="desc"/>
+        <!--sort by frequency of relation.isProjectsSelectedFor. The placeholder {0} will be replaced with scope (UUID of researcher)-->
+        <property name="function" value="termfreq"/>
+        <property name="id" value="ownerselection"/>
+        <property name="arguments">
+            <list>
+                <value>relation.isOrganizationsSelectedFor</value>
+                <value>{0}</value>
+            </list>
+        </property>
+    </bean>
+
+    <bean name="sortByFundingsSelection" class="org.dspace.discovery.configuration.DiscoverySortFunctionConfiguration">
+        <property name="defaultSortOrder" value="desc"/>
+        <!--sort by frequency of relation.isProjectsSelectedFor. The placeholder {0} will be replaced with scope (UUID of researcher)-->
+        <property name="function" value="termfreq"/>
+        <property name="id" value="ownerselection"/>
+        <property name="arguments">
+            <list>
+                <value>relation.isGrantsSelectedFor</value>
+                <value>{0}</value>
+            </list>
+        </property>
     </bean>
     <bean id="searchFilterCollection211Field" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
         <property name="indexFieldName" value="collection211field"/>

--- a/dspace-server-webapp/src/test/data/dspaceFolder/config/spring/api/test-discovery.xml
+++ b/dspace-server-webapp/src/test/data/dspaceFolder/config/spring/api/test-discovery.xml
@@ -110,6 +110,7 @@
                 <entry key="eperson_claims" value-ref="eperson_claims"/>
                 <!-- multilanguage types facet configuration -->
                 <entry key="123456789/language-test-1" value-ref="multilanguage-types"/>
+
                 <!-- ========================================================== -->
                 <!-- DSpace-CRIS Authority-based RELATION Discovery Configurations -->
                 <!-- These configurations map entity relationships to discovery    -->
@@ -128,9 +129,6 @@
                 <!-- Maps to: OrgUnit.isProjectOfOrgUnit (from Project → OrgUnit relationship) -->
                 <!-- Shows RP Projects via investigators affiliated with this OrgUnit -->
                 <entry key="RELATION.OrgUnit.rpprojects" value-ref="relationOrgunitRPProjectConfiguration"/>
-                <!-- Maps to: OrgUnit.isPublicationOfOrgUnit (from Publication → OrgUnit relationship) -->
-                <!-- Shows Publications sponsored by this OrgUnit -->
-                <entry key="RELATION.OrgUnit.publications" value-ref="relationOrgunitPublicationsConfiguration"/>
                 <!-- Maps to: OrgUnit.isPublicationOfOrgUnit via Person affiliation -->
                 <!-- Shows Publications authored by people affiliated with this OrgUnit -->
                 <entry key="RELATION.OrgUnit.rppublications" value-ref="relationOrgunitRPPublicationsConfiguration"/>
@@ -140,20 +138,7 @@
                 <!-- Maps to: OrgUnit.isProjectOfOrgUnit (from Project → OrgUnit relationship) -->
                 <!-- Shows Projects participated by this OrgUnit -->
                 <entry key="RELATION.OrgUnit.projects" value-ref="relationOrgunitProjectsConfiguration"/>
-                <!-- Maps to: OrgUnit.isOrgUnitOfOrgUnit (hierarchical OrgUnit relationship) -->
-                <!-- Shows sub-organizations of this OrgUnit -->
-                <entry key="RELATION.OrgUnit.organizations" value-ref="relationOrgunitOrgunitsConfiguration"/>
 
-                <!-- Project Related Items -->
-                <!-- Maps to: Project.isProjectOfProject (related projects) -->
-                <!-- Shows Projects related to this Project -->
-                <entry key="RELATION.Project.projects" value-ref="relationProjectProjectsConfiguration"/>
-                <!-- Maps to: Project.isFundingOfProject (from Funding → Project relationship) -->
-                <!-- Shows Fundings related to this Project -->
-                <entry key="RELATION.Project.fundings" value-ref="relationProjectFundingsConfiguration"/>
-                <!-- Maps to: Project.isPublicationOfProject (from Publication → Project relationship) -->
-                <!-- Shows Publications related to this Project -->
-                <entry key="RELATION.Project.researchoutputs" value-ref="relationProjectPublicationConfiguration"/>
                 <!-- COAR NOTIFY LDN MESSAGES configuration -->
                 <entry key="NOTIFY.incoming" value-ref="NOTIFY.incoming"/>
                 <entry key="NOTIFY.outgoing" value-ref="NOTIFY.outgoing"/>
@@ -1131,7 +1116,7 @@
         <property name="defaultFilterQueries">
             <list>
                 <!--Only find related items. The placeholder {0} will be replaced with scope (UUID of item)-->
-                <value>projectinvestigators_authority:{0} AND search.resourcetype:Item</value>
+                <value>project.investigator_authority:{0} AND search.resourcetype:Item</value>
                 <value>-withdrawn:true AND -discoverable:false</value>
             </list>
         </property>
@@ -1156,6 +1141,8 @@
         <!--Which sidebar facets are to be displayed-->
         <property name="sidebarFacets">
             <list>
+                <!--                <ref bean="graphPublicationByType" />-->
+                <!--                <ref bean="graphPublicationByDate" />-->
                 <ref bean="searchFilterIssued" />
                 <ref bean="searchFilterAuthor" />
                 <ref bean="searchFilterEditor" />
@@ -1172,6 +1159,8 @@
         <property name="searchFilters">
             <list>
                 <ref bean="searchFilterTitle" />
+                <!--                <ref bean="graphPublicationByType" />-->
+                <!--                <ref bean="graphPublicationByDate" />-->
                 <ref bean="searchFilterIssued" />
                 <ref bean="searchFilterAuthor" />
                 <ref bean="searchFilterEditor" />
@@ -1220,240 +1209,86 @@
         </property>
     </bean>
 
-    <!-- project investigated by people affiliated to an orgunit -->
+    <!-- OrgUnit → RP Projects (via join from person affiliation) -->
+    <!-- Maps to: OrgUnit.isProjectOfOrgUnit via Person investigators -->
     <bean id="relationOrgunitRPProjectConfiguration" class="org.dspace.discovery.configuration.DiscoveryRelatedItemConfiguration">
-        <!--The sort filters for the discovery search-->
         <property name="searchSortConfiguration">
             <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
-                <!--<property name="defaultSort" ref="sortDateIssued"/>-->
-                <!--DefaultSortOrder can either be desc or asc (desc is default)-->
                 <property name="sortFields">
                     <list>
-                        <ref bean="sortByRPProjectsSelection" />
                         <ref bean="sortTitleAsc" />
                     </list>
                 </property>
             </bean>
         </property>
-        <!--Any default filter queries, these filter queries will be used for all
-                queries done by discovery for this configuration -->
         <property name="defaultFilterQueries">
             <list>
-                <!--Only find related items. The placeholder {0} will be replaced with scope (UUID of item)-->
-                <value>'{'!join from=search.resourceid to=projectinvestigators_authority fromIndex=${solr.multicorePrefix}search'}'person.affiliation.name_authority:{0}</value>
+                <value>'{'!join from=search.resourceid to=project.investigator_authority fromIndex=${solr.multicorePrefix}search'}'person.affiliation.name_authority:{0}</value>
                 <value>-withdrawn:true AND -discoverable:false</value>
             </list>
         </property>
     </bean>
 
-    <!-- publication sponsored by an orgunit -->
-    <bean id="relationOrgunitPublicationsConfiguration" class="org.dspace.discovery.configuration.DiscoveryRelatedItemConfiguration">
-        <!--The sort filters for the discovery search-->
-        <property name="searchSortConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
-                <!--<property name="defaultSort" ref="sortDateIssued"/>-->
-                <!--DefaultSortOrder can either be desc or asc (desc is default)-->
-                <property name="sortFields">
-                    <list>
-                        <ref bean="sortByPublicationsSelection" />
-                        <ref bean="sortTitleAsc" />
-                    </list>
-                </property>
-            </bean>
-        </property>
-        <!--Any default filter queries, these filter queries will be used for all
-                queries done by discovery for this configuration -->
-        <property name="defaultFilterQueries">
-            <list>
-                <!--Only find related items. The placeholder {0} will be replaced with scope (UUID of item)-->
-                <value>dc.description.sponsorship_authority:{0}</value>
-                <value>-withdrawn:true AND -discoverable:false</value>
-            </list>
-        </property>
-    </bean>
-
-    <!-- publication authored by people affiliated to an orgunit -->
+    <!-- OrgUnit → RP Publications (via join from author affiliation) -->
+    <!-- Maps to: OrgUnit.isPublicationOfOrgUnit via Person authors -->
     <bean id="relationOrgunitRPPublicationsConfiguration" class="org.dspace.discovery.configuration.DiscoveryRelatedItemConfiguration">
-        <!--The sort filters for the discovery search-->
         <property name="searchSortConfiguration">
             <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
-                <!--<property name="defaultSort" ref="sortDateIssued"/>-->
-                <!--DefaultSortOrder can either be desc or asc (desc is default)-->
                 <property name="sortFields">
                     <list>
-                        <ref bean="sortByRPPublicationsSelection" />
+                        <ref bean="sortDateIssuedDesc" />
                         <ref bean="sortTitleAsc" />
                     </list>
                 </property>
             </bean>
         </property>
-        <!--Any default filter queries, these filter queries will be used for all
-                queries done by discovery for this configuration -->
         <property name="defaultFilterQueries">
             <list>
-                <!--Only find related items. The placeholder {0} will be replaced with scope (UUID of item)-->
                 <value>'{'!join from=search.resourceid to=author_authority fromIndex=${solr.multicorePrefix}search'}'person.affiliation.name_authority:{0}</value>
                 <value>-withdrawn:true AND -discoverable:false</value>
             </list>
         </property>
     </bean>
 
-    <!-- people affiliated to an orgunit -->
+    <!-- OrgUnit → People (via person.affiliation.name_authority) -->
+    <!-- Maps to: OrgUnit.isPersonOfOrgUnit (affiliated people) -->
     <bean id="relationOrgunitPersonsConfiguration" class="org.dspace.discovery.configuration.DiscoveryRelatedItemConfiguration">
-        <!--The sort filters for the discovery search-->
         <property name="searchSortConfiguration">
             <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
-                <!--<property name="defaultSort" ref="sortDateIssued"/>-->
-                <!--DefaultSortOrder can either be desc or asc (desc is default)-->
                 <property name="sortFields">
                     <list>
-                        <ref bean="sortByPeopleSelection" />
                         <ref bean="sortTitleAsc" />
                     </list>
                 </property>
             </bean>
         </property>
-        <!--Any default filter queries, these filter queries will be used for all
-                queries done by discovery for this configuration -->
         <property name="defaultFilterQueries">
             <list>
-                <!--Only find related items. The placeholder {0} will be replaced with scope (UUID of item)-->
                 <value>person.affiliation.name_authority:{0}</value>
                 <value>-withdrawn:true AND -discoverable:false</value>
             </list>
         </property>
     </bean>
 
-    <!-- project participated by an orgunit -->
+    <!-- OrgUnit → Projects (via dc.contributor.other_authority) -->
+    <!-- Maps to: OrgUnit.isProjectOfOrgUnit (participated projects) -->
     <bean id="relationOrgunitProjectsConfiguration" class="org.dspace.discovery.configuration.DiscoveryRelatedItemConfiguration">
-        <!--The sort filters for the discovery search-->
         <property name="searchSortConfiguration">
             <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
-                <!--<property name="defaultSort" ref="sortDateIssued"/>-->
-                <!--DefaultSortOrder can either be desc or asc (desc is default)-->
                 <property name="sortFields">
                     <list>
-                        <ref bean="sortByProjectsSelection" />
                         <ref bean="sortTitleAsc" />
                     </list>
                 </property>
             </bean>
         </property>
-        <!--Any default filter queries, these filter queries will be used for all
-                queries done by discovery for this configuration -->
         <property name="defaultFilterQueries">
             <list>
-                <!--Only find related items. The placeholder {0} will be replaced with scope (UUID of item)-->
-                <value>involvedorganisation_authority:{0}</value>
+                <value>dc.contributor.other_authority:{0}</value>
                 <value>-withdrawn:true AND -discoverable:false</value>
             </list>
         </property>
     </bean>
-
-    <!-- suborganisation unit of an orgunit -->
-    <bean id="relationOrgunitOrgunitsConfiguration" class="org.dspace.discovery.configuration.DiscoveryRelatedItemConfiguration">
-        <!--The sort filters for the discovery search-->
-        <property name="searchSortConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
-                <!--<property name="defaultSort" ref="sortDateIssued"/>-->
-                <!--DefaultSortOrder can either be desc or asc (desc is default)-->
-                <property name="sortFields">
-                    <list>
-                        <ref bean="sortByOrganizationsSelection" />
-                        <ref bean="sortTitleAsc" />
-                    </list>
-                </property>
-            </bean>
-        </property>
-        <!--Any default filter queries, these filter queries will be used for all
-                queries done by discovery for this configuration -->
-        <property name="defaultFilterQueries">
-            <list>
-                <!--Only find related items. The placeholder {0} will be replaced with scope (UUID of item)-->
-                <value>organization.parentOrganization_authority:{0}</value>
-                <value>-withdrawn:true AND -discoverable:false</value>
-            </list>
-        </property>
-    </bean>
-
-    <!-- project related to a project -->
-    <bean id="relationProjectProjectsConfiguration" class="org.dspace.discovery.configuration.DiscoveryRelatedItemConfiguration">
-        <!--The sort filters for the discovery search-->
-        <property name="searchSortConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
-                <!--<property name="defaultSort" ref="sortDateIssued"/>-->
-                <!--DefaultSortOrder can either be desc or asc (desc is default)-->
-                <property name="sortFields">
-                    <list>
-                        <ref bean="sortByProjectsSelection" />
-                        <ref bean="sortTitleAsc" />
-                    </list>
-                </property>
-            </bean>
-        </property>
-        <!--Any default filter queries, these filter queries will be used for all
-                queries done by discovery for this configuration -->
-        <property name="defaultFilterQueries">
-            <list>
-                <!--Only find related items. The placeholder {0} will be replaced with scope (UUID of item)-->
-                <value>dc.relation.project_authority:{0} AND entityType_keyword:Project</value>
-                <value>-withdrawn:true AND -discoverable:false</value>
-            </list>
-        </property>
-    </bean>
-
-    <!-- fundings related to a project -->
-    <bean id="relationProjectFundingsConfiguration" class="org.dspace.discovery.configuration.DiscoveryRelatedItemConfiguration">
-        <!--The sort filters for the discovery search-->
-        <property name="searchSortConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
-                <!--<property name="defaultSort" ref="sortDateIssued"/>-->
-                <!--DefaultSortOrder can either be desc or asc (desc is default)-->
-                <property name="sortFields">
-                    <list>
-                        <ref bean="sortByFundingsSelection" />
-                        <ref bean="sortTitleAsc" />
-                    </list>
-                </property>
-            </bean>
-        </property>
-        <!--Any default filter queries, these filter queries will be used for all
-                queries done by discovery for this configuration -->
-        <property name="defaultFilterQueries">
-            <list>
-                <!--Only find related items. The placeholder {0} will be replaced with scope (UUID of item)-->
-                <value>dc.relation.project_authority:{0} AND entityType_keyword:Funding</value>
-                <value>-withdrawn:true AND -discoverable:false</value>
-            </list>
-        </property>
-    </bean>
-
-    <!-- publications related to a project -->
-    <bean id="relationProjectPublicationConfiguration" class="org.dspace.discovery.configuration.DiscoveryRelatedItemConfiguration">
-        <!--The sort filters for the discovery search-->
-        <property name="searchSortConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
-                <!--<property name="defaultSort" ref="sortDateIssued"/>-->
-                <!--DefaultSortOrder can either be desc or asc (desc is default)-->
-                <property name="sortFields">
-                    <list>
-                        <ref bean="sortByResearchOutputsSelection" />
-                        <ref bean="sortTitleAsc" />
-                    </list>
-                </property>
-            </bean>
-        </property>
-        <!--Any default filter queries, these filter queries will be used for all
-                queries done by discovery for this configuration -->
-        <property name="defaultFilterQueries">
-            <list>
-                <!--Only find related items. The placeholder {0} will be replaced with scope (UUID of item)-->
-                <value>dc.relation.project_authority:{0} AND entityType_keyword:Publication</value>
-                <value>-withdrawn:true AND -discoverable:false</value>
-            </list>
-        </property>
-    </bean>
-
 
     <bean id="discovery-collection-2-2-1" class="org.dspace.discovery.configuration.DiscoveryConfiguration" scope="prototype">
         <property name="id" value="discovery-collection-2-2-1"/>

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -28,6 +28,7 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -36,6 +37,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.time.Period;
+import java.util.Optional;
 import java.util.UUID;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -59,28 +61,37 @@ import org.dspace.builder.ClaimedTaskBuilder;
 import org.dspace.builder.CollectionBuilder;
 import org.dspace.builder.CommunityBuilder;
 import org.dspace.builder.EPersonBuilder;
+import org.dspace.builder.EntityTypeBuilder;
 import org.dspace.builder.GroupBuilder;
 import org.dspace.builder.ItemBuilder;
 import org.dspace.builder.LDNMessageBuilder;
 import org.dspace.builder.NotifyServiceBuilder;
 import org.dspace.builder.PoolTaskBuilder;
+import org.dspace.builder.RelationshipBuilder;
+import org.dspace.builder.RelationshipTypeBuilder;
 import org.dspace.builder.SupervisionOrderBuilder;
 import org.dspace.builder.WorkflowItemBuilder;
 import org.dspace.builder.WorkspaceItemBuilder;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
+import org.dspace.content.EntityType;
 import org.dspace.content.Item;
+import org.dspace.content.Relationship;
+import org.dspace.content.RelationshipType;
 import org.dspace.content.WorkspaceItem;
 import org.dspace.content.authority.Choices;
 import org.dspace.content.authority.service.ChoiceAuthorityService;
 import org.dspace.content.authority.service.MetadataAuthorityService;
+import org.dspace.content.service.EntityTypeService;
+import org.dspace.discovery.configuration.DiscoveryConfigurationService;
 import org.dspace.discovery.configuration.DiscoverySortFieldConfiguration;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.supervision.SupervisionOrder;
+import org.dspace.util.UUIDUtils;
 import org.dspace.xmlworkflow.storedcomponents.ClaimedTask;
 import org.dspace.xmlworkflow.storedcomponents.XmlWorkflowItem;
 import org.hamcrest.Matchers;
@@ -95,6 +106,12 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
 
     @Autowired
     MetadataAuthorityService metadataAuthorityService;
+
+    @Autowired
+    private DiscoveryConfigurationService discoveryConfigurationService;
+
+    @Autowired
+    private EntityTypeService entityTypeService;
 
     @Autowired
     ChoiceAuthorityService choiceAuthorityService;
@@ -6708,6 +6725,701 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
             .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(notifyOutgoingFacetMatchers)))
             //There always needs to be a self link
             .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")));
+    }
+
+    /**
+     * This test verifies a known bug fund with the DSC-940,
+     * the number of date facets returned by issuing a search with scope should be
+     * the same of a search issued using a filter for that entity scope.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void discoverFacetsTestSameResultWithOrWithoutScope() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        parentCommunity =
+            CommunityBuilder.createCommunity(context)
+                            .withName("SharedParentCommunity!!!")
+                            .build();
+
+        Collection authors =
+            CollectionBuilder.createCollection(context, parentCommunity)
+                             .withEntityType("Person")
+                             .withName("Authors")
+                             .build();
+
+        Item author =
+            ItemBuilder.createItem(context, authors)
+                       .withTitle("Author 1")
+                       .withDspaceObjectOwner(admin)
+                       .build();
+
+        Collection col1 =
+            CollectionBuilder.createCollection(context, parentCommunity)
+                             .withName("Collection 1")
+                             .build();
+
+        Collection col2 =
+            CollectionBuilder.createCollection(context, parentCommunity)
+                             .withName("Collection 2")
+                             .build();
+
+        Item publicItem1 =
+            ItemBuilder.createItem(context, col1)
+                       .withTitle("Public item 1")
+                       .withIssueDate("2017-10-17")
+                       .withAuthor(author.getName(), author.getID().toString())
+                       .withAuthor("Smith, Donald")
+                       .withSubject("ExtraEntry")
+                       .build();
+
+        Item publicItem2 =
+            ItemBuilder.createItem(context, col2)
+                       .withTitle("Public item 2")
+                       .withIssueDate("2020-02-13")
+                       .withAuthor(author.getName(), author.getID().toString())
+                       .withAuthor("Doe, Jane")
+                       .withSubject("ExtraEntry")
+                       .build();
+
+        Item publicItem3 =
+            ItemBuilder.createItem(context, col2)
+                       .withTitle("Public item 2")
+                       .withIssueDate("2020-02-13")
+                       .withAuthor(author.getName(), author.getID().toString())
+                       .withAuthor("Anton, Senek")
+                       .withSubject("TestingForMore")
+                       .withSubject("ExtraEntry")
+                       .build();
+
+        context.restoreAuthSystemState();
+
+        // finds the facets using the relation configuration using
+        // the author as scope
+        getClient()
+            .perform(
+                get("/api/discover/facets/dateIssued")
+                    .param("configuration", "RELATION.Person.researchoutputs")
+                    .param("scope", author.getID().toString())
+            )
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.type", is("discover")))
+            .andExpect(jsonPath("$.name", is("dateIssued")))
+            .andExpect(jsonPath("$.facetType", is("date")))
+            .andExpect(jsonPath("$.scope", is(author.getID().toString())))
+            .andExpect(jsonPath("$._links.self.href",
+                                containsString(
+                                    "api/discover/facets/dateIssued?scope=" +
+                                        author.getID().toString() +
+                                        "&configuration=RELATION.Person.researchoutputs"
+                                )
+            ))
+            .andExpect(jsonPath("$._embedded.values[0].label", is("2017 - 2020")))
+            .andExpect(jsonPath("$._embedded.values[0].count", is(3)))
+            .andExpect(jsonPath("$._embedded.values[0]._links.search.href",
+                                containsString(
+                                    "api/discover/search/objects?scope=" +
+                                        author.getID().toString() +
+                                        "&configuration=RELATION.Person.researchoutputs" +
+                                        "&f.dateIssued=%5B2017%20TO%202020%5D,equals"
+                                )
+            ))
+            .andExpect(jsonPath("$._embedded.values").value(Matchers.hasSize(1)));
+
+        // finds the facets using the default configuration and
+        // a filter that is the same used for the previous scope
+        getClient()
+            .perform(
+                get("/api/discover/facets/dateIssued")
+                    .param("configuration", "defaultConfiguration")
+                    .param("f.author", author.getID().toString() + ",authority")
+            )
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.type", is("discover")))
+            .andExpect(jsonPath("$.name", is("dateIssued")))
+            .andExpect(jsonPath("$.facetType", is("date")))
+            .andExpect(jsonPath("$.scope", is(emptyOrNullString())))
+            .andExpect(jsonPath("$._links.self.href",
+                                containsString(
+                                    "api/discover/facets/dateIssued?configuration=defaultConfiguration" +
+                                        "&f.author=" + author.getID().toString() + ",authority"
+                                )
+            ))
+            .andExpect(jsonPath("$._embedded.values[0].label", is("2017 - 2020")))
+            .andExpect(jsonPath("$._embedded.values[0].count", is(3)))
+            .andExpect(jsonPath("$._embedded.values[0]._links.search.href",
+                                containsString(
+                                    "api/discover/search/objects?configuration=defaultConfiguration" +
+                                        "&f.author=" + author.getID().toString() + ",authority" +
+                                        "&f.dateIssued=%5B2017%20TO%202020%5D,equals"
+                                )
+            ))
+            .andExpect(jsonPath("$._embedded.values").value(Matchers.hasSize(1)));
+
+    }
+
+    @Test
+    public void relevanceByRelationPlacesTest() throws Exception {
+
+        configurationService.setProperty("relationship.places.onlyright",
+                                         "null::Person::isResearchoutputsSelectedFor::hasSelectedResearchoutputs");
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+
+        final Collection publications = CollectionBuilder.createCollection(context, parentCommunity)
+                                                         .withEntityType("Publication")
+                                                         .build();
+        final Collection patents = CollectionBuilder.createCollection(context, parentCommunity)
+                                                    .withEntityType("Patent")
+                                                    .build();
+        final Collection people = CollectionBuilder.createCollection(context, parentCommunity)
+                                                   .withEntityType("Person")
+                                                   .build();
+
+        Item author1 = ItemBuilder.createItem(context, people)
+                                  .withTitle("Doe, John").build();
+        Item author2 = ItemBuilder.createItem(context, people)
+                                  .withTitle("Smith, John").build();
+
+        Item publication1 = ItemBuilder.createItem(context, publications).withTitle("Publication 1")
+                                       .withAuthor(author1.getName(), author1.getID().toString()).build();
+        Item publication2 = ItemBuilder.createItem(context, publications).withTitle("Publication 2")
+                                       .withAuthor(author1.getName(), author1.getID().toString())
+                                       .withAuthor(author2.getName(), author2.getID().toString())
+                                       .build();
+        Item publication3 = ItemBuilder.createItem(context, publications).withTitle("Publication 3")
+                                       .withAuthor(author2.getName(), author2.getID().toString())
+                                       .build();
+        Item patent1 = ItemBuilder.createItem(context, patents).withTitle("Patent 1")
+                                  .withAuthor(author1.getName(), author1.getID().toString())
+                                  .build();
+
+        final EntityType personEntity = Optional
+            .ofNullable(entityTypeService.findByEntityType(context, "Person"))
+            .orElseGet(() -> EntityTypeBuilder.createEntityTypeBuilder(context, "Person").build());
+        final RelationshipType selectedResearchOutput = RelationshipTypeBuilder
+            .createRelationshipTypeBuilder(
+                context,
+                null,
+                personEntity,
+                "isResearchoutputsSelectedFor",
+                "hasSelectedResearchoutputs",
+                0, null,
+                0, null).build();
+
+        final Relationship publication2ToAuthor1 =
+            RelationshipBuilder.createRelationshipBuilder(context, publication2, author1, selectedResearchOutput,
+                                                          -1, -1).build();
+
+        final Relationship publication1ToAuthor1 =
+            RelationshipBuilder.createRelationshipBuilder(context, publication1,
+                                                          author1, selectedResearchOutput, -1, -1)
+                               .build();
+        final Relationship publication3ToAuthor2 =
+            RelationshipBuilder.createRelationshipBuilder(context, publication3, author2, selectedResearchOutput,
+                                                          -1, -1)
+                               .build();
+
+        final Relationship publication2ToAuthor2 =
+            RelationshipBuilder.createRelationshipBuilder(context, publication2, author2, selectedResearchOutput,
+                                                          -1, -1)
+                               .build();
+
+        final Relationship patent1ToAuthor1 =
+            RelationshipBuilder.createRelationshipBuilder(context, patent1, author1, selectedResearchOutput,
+                                                          -1, -1)
+                               .build();
+
+        context.restoreAuthSystemState();
+
+        getClient().perform(get("/api/discover/search/objects")
+                                .param("configuration", "RELATION.Person.researchoutputs")
+                                .param("scope", author1.getID().toString()))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.configuration", is("RELATION.Person.researchoutputs")))
+                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.contains(
+                       SearchResultMatcher.matchOnItemName("item", "items", "Publication 2"),
+                       SearchResultMatcher.matchOnItemName("item", "items", "Publication 1"),
+                       SearchResultMatcher.matchOnItemName("item", "items", "Patent 1"))))
+                   .andExpect(jsonPath("$._embedded.searchResult.page.totalElements", is(3)));
+
+        getClient().perform(get("/api/discover/search/objects")
+                                .param("configuration", "RELATION.Person.researchoutputs")
+                                .param("scope", author2.getID().toString()))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.configuration", is("RELATION.Person.researchoutputs")))
+                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.contains(
+                       SearchResultMatcher.matchOnItemName("item", "items", "Publication 3"),
+                       SearchResultMatcher.matchOnItemName("item", "items", "Publication 2"))))
+                   .andExpect(jsonPath("$._embedded.searchResult.page.totalElements", is(2)));
+
+        configurationService.setProperty("relationship.places.onlyright", "");
+
+
+    }
+
+    @Test
+    public void hiddenItemsTest() throws Exception {
+
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+
+        final Collection publications = CollectionBuilder.createCollection(context, parentCommunity)
+                                                         .withEntityType("Publication")
+                                                         .build();
+        final Collection projects = CollectionBuilder.createCollection(context, parentCommunity)
+                                                     .withEntityType("Project")
+                                                     .build();
+        final Collection people = CollectionBuilder.createCollection(context, parentCommunity)
+                                                   .withEntityType("Person")
+                                                   .build();
+        EPerson owner = EPersonBuilder.createEPerson(context)
+                                      .withEmail("test@test.com")
+                                      .withPassword("password")
+                                      .withCanLogin(true)
+                                      .withNameInMetadata("John", "Doe").build();
+
+        Item author = ItemBuilder.createItem(context, people)
+                                 .withDspaceObjectOwner(owner.getFullName(), UUIDUtils.toString(owner.getID()))
+                                 .withTitle("Doe, John").build();
+
+        Item publication1 = ItemBuilder.createItem(context, publications).withTitle("Publication 1")
+                                       .withAuthor(author.getName(), author.getID().toString()).build();
+        Item publication2 = ItemBuilder.createItem(context, publications).withTitle("Publication 2")
+                                       .withAuthor(author.getName(), author.getID().toString())
+                                       .build();
+
+
+        Item project2 = ItemBuilder.createItem(context, projects).withTitle("Project 2")
+                                   .withProjectInvestigator(author.getName(), author.getID().toString())
+                                   .build();
+
+        final EntityType personEntity = Optional.ofNullable(entityTypeService.findByEntityType(context, "Person"))
+                                                .orElseGet(() -> EntityTypeBuilder
+                                                    .createEntityTypeBuilder(
+                                                        context, "Person").build());
+        final RelationshipType hiddenResearchOutput = RelationshipTypeBuilder
+            .createRelationshipTypeBuilder(
+                context,
+                null,
+                personEntity,
+                "isResearchoutputsHiddenFor",
+                "notDisplayingResearchoutputs",
+                0, null,
+                0, null).build();
+
+        final RelationshipType hiddenProject = RelationshipTypeBuilder
+            .createRelationshipTypeBuilder(
+                context,
+                null,
+                personEntity,
+                "isProjectsHiddenFor",
+                "notDisplayingProjects",
+                0, null,
+                0, null).build();
+
+        RelationshipBuilder.createRelationshipBuilder(context, publication1, author, hiddenResearchOutput)
+                           .build();
+        RelationshipBuilder.createRelationshipBuilder(context, project2, author, hiddenProject)
+                           .build();
+
+        context.restoreAuthSystemState();
+
+        getClient().perform(get("/api/discover/search/objects")
+                                .param("configuration", "RELATION.Person.researchoutputs")
+                                .param("scope", author.getID().toString()))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.configuration", is("RELATION.Person.researchoutputs")))
+                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
+                       SearchResultMatcher.matchOnItemName("item", "items", "Publication 2"))))
+                   .andExpect(jsonPath("$._embedded.searchResult.page.totalElements", is(1)));
+
+
+        final String ownerToken = getAuthToken(owner.getEmail(), "password");
+
+        getClient(ownerToken).perform(get("/api/discover/search/objects")
+                              .param("configuration", "RELATION.Person.researchoutputs")
+                              .param("scope", author.getID().toString()))
+                 .andExpect(status().isOk())
+                 .andExpect(jsonPath("$.configuration", is("RELATION.Person.researchoutputs")))
+                 .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
+                     SearchResultMatcher.matchOnItemName("item", "items", "Publication 2"),
+                     SearchResultMatcher.matchOnItemName("item", "items", "Publication 1"))))
+                 .andExpect(jsonPath("$._embedded.searchResult.page.totalElements", is(2)));
+
+
+        final String adminToken = getAuthToken(admin.getEmail(), password);
+        getClient(adminToken).perform(get("/api/discover/search/objects")
+                                          .param("configuration", "RELATION.Person.researchoutputs")
+                                          .param("scope", author.getID().toString()))
+                             .andExpect(status().isOk())
+                             .andExpect(jsonPath("$.configuration", is("RELATION.Person.researchoutputs")))
+                             .andExpect(
+                                 jsonPath("$._embedded.searchResult._embedded.objects",
+                                          Matchers.containsInAnyOrder(
+                                              SearchResultMatcher
+                                                  .matchOnItemName("item", "items", "Publication 2"),
+                                              SearchResultMatcher
+                                                  .matchOnItemName("item", "items", "Publication 1"))))
+                             .andExpect(jsonPath("$._embedded.searchResult.page.totalElements", is(2)));
+
+
+    }
+
+    /**
+     * This test checks the scenario when an item is related to many owners and it is hidden by only one, many or all of
+     * them.
+     * @throws Exception
+     */
+    @Test
+    public void sameItemHiddenByDifferentOwners() throws Exception {
+
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+
+
+
+        final Collection publications = CollectionBuilder.createCollection(context, parentCommunity)
+                                                         .withEntityType("Publication")
+                                                         .build();
+        final Collection projects = CollectionBuilder.createCollection(context, parentCommunity)
+                                                     .withEntityType("Project")
+                                                     .build();
+        final Collection people = CollectionBuilder.createCollection(context, parentCommunity)
+                                                   .withEntityType("Person")
+                                                   .build();
+
+
+        Item firstPerson = ItemBuilder.createItem(context, people)
+                                      .withTitle("Doe, John").build();
+        Item secondPerson = ItemBuilder.createItem(context, people)
+                                       .withTitle("Smith, Bryan").build();
+
+        Item project = ItemBuilder.createItem(context, projects).withTitle("Project 2")
+                                  .withProjectInvestigator(firstPerson.getName(), firstPerson.getID().toString())
+                                  .build();
+
+        Item publication1 = ItemBuilder.createItem(context, publications).withTitle("Publication 1")
+                                       .withAuthor(firstPerson.getName(), firstPerson.getID().toString())
+                                       .withAuthor(secondPerson.getName(), secondPerson.getID().toString())
+                                       .withRelationProject(project.getName(), project.getID().toString())
+                                       .build();
+
+        Item publication2 = ItemBuilder.createItem(context, publications).withTitle("Publication 2")
+                                       .withAuthor(firstPerson.getName(), firstPerson.getID().toString())
+                                       .withAuthor(secondPerson.getName(), secondPerson.getID().toString())
+                                       .withRelationProject(project.getName(), project.getID().toString())
+                                       .build();
+
+
+
+
+        final EntityType personEntity = Optional.ofNullable(entityTypeService.findByEntityType(context, "Person"))
+                                                .orElseGet(() -> EntityTypeBuilder
+                                                    .createEntityTypeBuilder(
+                                                        context, "Person").build());
+
+        final EntityType publicationEntity = Optional.ofNullable(
+                                                         entityTypeService.findByEntityType(context, "Publication"))
+                                                     .orElseGet(() -> EntityTypeBuilder
+                                                         .createEntityTypeBuilder(
+                                                             context, "Publication").build());
+
+        final EntityType projectEntity = Optional.ofNullable(entityTypeService.findByEntityType(context, "Project"))
+                                                 .orElseGet(() -> EntityTypeBuilder
+                                                     .createEntityTypeBuilder(
+                                                         context, "Project").build());
+        final RelationshipType researchOutputHiddenByPerson = RelationshipTypeBuilder
+            .createRelationshipTypeBuilder(
+                context,
+                null,
+                personEntity,
+                "isResearchoutputsHiddenFor",
+                "notDisplayingResearchoutputs",
+                0, null,
+                0, null).build();
+
+        final RelationshipType researchOutputHiddenByProject = RelationshipTypeBuilder
+            .createRelationshipTypeBuilder(
+                context,
+                null,
+                projectEntity,
+                "isResearchoutputsHiddenFor",
+                "notDisplayingResearchoutputs",
+                0, null,
+                0, null).build();
+
+
+        // first scenario: publication 1 hidden by first person
+        final Relationship publicationOneHiddenByFirstPerson =
+            RelationshipBuilder.createRelationshipBuilder(
+                context, publication1, firstPerson, researchOutputHiddenByPerson)
+                               .build();
+
+        context.restoreAuthSystemState();
+
+        getClient().perform(get("/api/discover/search/objects")
+                                .param("configuration", "RELATION.Person.researchoutputs")
+                                .param("scope", firstPerson.getID().toString()))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.configuration", is("RELATION.Person.researchoutputs")))
+                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
+                       SearchResultMatcher.matchOnItemName("item", "items", "Publication 2"))))
+                   .andExpect(jsonPath("$._embedded.searchResult.page.totalElements", is(1)));
+
+        getClient().perform(get("/api/discover/search/objects")
+                                .param("configuration", "RELATION.Person.researchoutputs")
+                                .param("scope", secondPerson.getID().toString()))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.configuration", is("RELATION.Person.researchoutputs")))
+                   .andExpect(
+                       jsonPath("$._embedded.searchResult._embedded.objects",
+                                Matchers.containsInAnyOrder(
+                                    SearchResultMatcher
+                                        .matchOnItemName("item", "items", "Publication 2"),
+                                    SearchResultMatcher
+                                        .matchOnItemName("item", "items", "Publication 1"))))
+                   .andExpect(jsonPath("$._embedded.searchResult.page.totalElements", is(2)));
+
+        getClient().perform(get("/api/discover/search/objects")
+                                .param("configuration", "RELATION.Project.researchoutputs")
+                                .param("scope", project.getID().toString()))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.configuration", is("RELATION.Project.researchoutputs")))
+                   .andExpect(
+                       jsonPath("$._embedded.searchResult._embedded.objects",
+                                Matchers.containsInAnyOrder(
+                                    SearchResultMatcher
+                                        .matchOnItemName("item", "items", "Publication 2"),
+                                    SearchResultMatcher
+                                        .matchOnItemName("item", "items", "Publication 1"))))
+                   .andExpect(jsonPath("$._embedded.searchResult.page.totalElements", is(2)));
+
+        // second scenario: publication 2 hidden by second person
+        final String adminToken = getAuthToken(admin.getEmail(), password);
+        getClient(adminToken).perform(delete("/api/core/relationships/" + publicationOneHiddenByFirstPerson.getID()));
+        context.turnOffAuthorisationSystem();
+        final Relationship publicationTwoHiddenBySecondPerson =
+            RelationshipBuilder.createRelationshipBuilder(
+                context, publication2, secondPerson, researchOutputHiddenByPerson)
+                               .build();
+
+        context.restoreAuthSystemState();
+
+        getClient().perform(get("/api/discover/search/objects")
+                                .param("configuration", "RELATION.Person.researchoutputs")
+                                .param("scope", secondPerson.getID().toString()))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.configuration", is("RELATION.Person.researchoutputs")))
+                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
+                       SearchResultMatcher.matchOnItemName("item", "items", "Publication 1"))))
+                   .andExpect(jsonPath("$._embedded.searchResult.page.totalElements", is(1)));
+
+        getClient().perform(get("/api/discover/search/objects")
+                                .param("configuration", "RELATION.Person.researchoutputs")
+                                .param("scope", firstPerson.getID().toString()))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.configuration", is("RELATION.Person.researchoutputs")))
+                   .andExpect(
+                       jsonPath("$._embedded.searchResult._embedded.objects",
+                                Matchers.containsInAnyOrder(
+                                    SearchResultMatcher
+                                        .matchOnItemName("item", "items", "Publication 2"),
+                                    SearchResultMatcher
+                                        .matchOnItemName("item", "items", "Publication 1"))))
+                   .andExpect(jsonPath("$._embedded.searchResult.page.totalElements", is(2)));
+
+        getClient().perform(get("/api/discover/search/objects")
+                                .param("configuration", "RELATION.Project.researchoutputs")
+                                .param("scope", project.getID().toString()))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.configuration", is("RELATION.Project.researchoutputs")))
+                   .andExpect(
+                       jsonPath("$._embedded.searchResult._embedded.objects",
+                                Matchers.containsInAnyOrder(
+                                    SearchResultMatcher
+                                        .matchOnItemName("item", "items", "Publication 2"),
+                                    SearchResultMatcher
+                                        .matchOnItemName("item", "items", "Publication 1"))))
+                   .andExpect(jsonPath("$._embedded.searchResult.page.totalElements", is(2)));
+
+        // third scenario: publication 1 hidden by project owner
+        getClient(adminToken).perform(delete("/api/core/relationships/" + publicationTwoHiddenBySecondPerson.getID()));
+        context.turnOffAuthorisationSystem();
+        final Relationship publicationOneHiddenByProjectOwner =
+            RelationshipBuilder.createRelationshipBuilder(context, publication1, project, researchOutputHiddenByProject)
+                               .build();
+
+        context.restoreAuthSystemState();
+
+        getClient().perform(get("/api/discover/search/objects")
+                                .param("configuration", "RELATION.Person.researchoutputs")
+                                .param("scope", firstPerson.getID().toString()))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.configuration", is("RELATION.Person.researchoutputs")))
+                   .andExpect(
+                       jsonPath("$._embedded.searchResult._embedded.objects",
+                                Matchers.containsInAnyOrder(
+                                    SearchResultMatcher
+                                        .matchOnItemName("item", "items", "Publication 2"),
+                                    SearchResultMatcher
+                                        .matchOnItemName("item", "items", "Publication 1"))))
+                   .andExpect(jsonPath("$._embedded.searchResult.page.totalElements", is(2)));
+
+        getClient().perform(get("/api/discover/search/objects")
+                                .param("configuration", "RELATION.Person.researchoutputs")
+                                .param("scope", secondPerson.getID().toString()))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.configuration", is("RELATION.Person.researchoutputs")))
+                   .andExpect(
+                       jsonPath("$._embedded.searchResult._embedded.objects",
+                                Matchers.containsInAnyOrder(
+                                    SearchResultMatcher
+                                        .matchOnItemName("item", "items", "Publication 2"),
+                                    SearchResultMatcher
+                                        .matchOnItemName("item", "items", "Publication 1"))))
+                   .andExpect(jsonPath("$._embedded.searchResult.page.totalElements", is(2)));
+
+        getClient().perform(get("/api/discover/search/objects")
+                                .param("configuration", "RELATION.Project.researchoutputs")
+                                .param("scope", project.getID().toString()))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.configuration", is("RELATION.Project.researchoutputs")))
+                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
+                       SearchResultMatcher.matchOnItemName("item", "items", "Publication 2"))))
+                   .andExpect(jsonPath("$._embedded.searchResult.page.totalElements", is(1)));
+
+        // fifth scenario: publication 1 hidden by both authors and project owner
+        getClient(adminToken).perform(delete("/api/core/relationships/" + publicationOneHiddenByProjectOwner.getID()));
+        context.turnOffAuthorisationSystem();
+
+        RelationshipBuilder.createRelationshipBuilder(context, publication1, firstPerson, researchOutputHiddenByPerson)
+                           .build();
+        RelationshipBuilder.createRelationshipBuilder(context, publication1, secondPerson, researchOutputHiddenByPerson)
+                           .build();
+
+        context.restoreAuthSystemState();
+
+        getClient().perform(get("/api/discover/search/objects")
+                                .param("configuration", "RELATION.Person.researchoutputs")
+                                .param("scope", firstPerson.getID().toString()))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.configuration", is("RELATION.Person.researchoutputs")))
+                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
+                       SearchResultMatcher.matchOnItemName("item", "items", "Publication 2"))))
+                   .andExpect(jsonPath("$._embedded.searchResult.page.totalElements", is(1)));
+
+        getClient().perform(get("/api/discover/search/objects")
+                                .param("configuration", "RELATION.Person.researchoutputs")
+                                .param("scope", secondPerson.getID().toString()))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.configuration", is("RELATION.Person.researchoutputs")))
+                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
+                       SearchResultMatcher.matchOnItemName("item", "items", "Publication 2"))))
+                   .andExpect(jsonPath("$._embedded.searchResult.page.totalElements", is(1)));
+
+        getClient().perform(get("/api/discover/search/objects")
+                                .param("configuration", "RELATION.Project.researchoutputs")
+                                .param("scope", project.getID().toString()))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.configuration", is("RELATION.Project.researchoutputs")))
+                   .andExpect(
+                       jsonPath("$._embedded.searchResult._embedded.objects",
+                                Matchers.containsInAnyOrder(
+                                    SearchResultMatcher
+                                        .matchOnItemName("item", "items", "Publication 2"),
+                                    SearchResultMatcher
+                                        .matchOnItemName("item", "items", "Publication 1"))))
+                   .andExpect(jsonPath("$._embedded.searchResult.page.totalElements", is(2)));
+
+        // fifth scenario: publication 1 hidden by both authors and project owner
+        getClient(adminToken).perform(delete("/api/core/relationships/" + publicationOneHiddenByProjectOwner.getID()));
+        context.turnOffAuthorisationSystem();
+
+        RelationshipBuilder.createRelationshipBuilder(context, publication1, project, researchOutputHiddenByProject)
+                           .build();
+
+        context.restoreAuthSystemState();
+
+        getClient().perform(get("/api/discover/search/objects")
+                                .param("configuration", "RELATION.Person.researchoutputs")
+                                .param("scope", firstPerson.getID().toString()))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.configuration", is("RELATION.Person.researchoutputs")))
+                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
+                       SearchResultMatcher.matchOnItemName("item", "items", "Publication 2"))))
+                   .andExpect(jsonPath("$._embedded.searchResult.page.totalElements", is(1)));
+
+        getClient().perform(get("/api/discover/search/objects")
+                                .param("configuration", "RELATION.Person.researchoutputs")
+                                .param("scope", secondPerson.getID().toString()))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.configuration", is("RELATION.Person.researchoutputs")))
+                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
+                       SearchResultMatcher.matchOnItemName("item", "items", "Publication 2"))))
+                   .andExpect(jsonPath("$._embedded.searchResult.page.totalElements", is(1)));
+
+        getClient().perform(get("/api/discover/search/objects")
+                                .param("configuration", "RELATION.Project.researchoutputs")
+                                .param("scope", project.getID().toString()))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.configuration", is("RELATION.Project.researchoutputs")))
+                   .andExpect(jsonPath("$._embedded.searchResult._embedded.objects", Matchers.containsInAnyOrder(
+                       SearchResultMatcher.matchOnItemName("item", "items", "Publication 2"))))
+                   .andExpect(jsonPath("$._embedded.searchResult.page.totalElements", is(1)));
+
+
+        // admin user is able to see hidden items
+
+        getClient(adminToken).perform(get("/api/discover/search/objects")
+                                          .param("configuration", "RELATION.Person.researchoutputs")
+                                          .param("scope", firstPerson.getID().toString()))
+                             .andExpect(status().isOk())
+                             .andExpect(jsonPath("$.configuration", is("RELATION.Person.researchoutputs")))
+                             .andExpect(
+                                 jsonPath("$._embedded.searchResult._embedded.objects",
+                                          Matchers.containsInAnyOrder(
+                                              SearchResultMatcher
+                                                  .matchOnItemName("item", "items", "Publication 2"),
+                                              SearchResultMatcher
+                                                  .matchOnItemName("item", "items", "Publication 1"))))
+                             .andExpect(jsonPath("$._embedded.searchResult.page.totalElements", is(2)));
+
+        getClient(adminToken).perform(get("/api/discover/search/objects")
+                                          .param("configuration", "RELATION.Person.researchoutputs")
+                                          .param("scope", secondPerson.getID().toString()))
+                             .andExpect(status().isOk())
+                             .andExpect(jsonPath("$.configuration", is("RELATION.Person.researchoutputs")))
+                             .andExpect(
+                                 jsonPath("$._embedded.searchResult._embedded.objects",
+                                          Matchers.containsInAnyOrder(
+                                              SearchResultMatcher
+                                                  .matchOnItemName("item", "items", "Publication 2"),
+                                              SearchResultMatcher
+                                                  .matchOnItemName("item", "items", "Publication 1"))))
+                             .andExpect(jsonPath("$._embedded.searchResult.page.totalElements", is(2)));
+
+        getClient(adminToken).perform(get("/api/discover/search/objects")
+                                          .param("configuration", "RELATION.Project.researchoutputs")
+                                          .param("scope", project.getID().toString()))
+                             .andExpect(status().isOk())
+                             .andExpect(jsonPath("$.configuration", is("RELATION.Project.researchoutputs")))
+                             .andExpect(
+                                 jsonPath("$._embedded.searchResult._embedded.objects",
+                                          Matchers.containsInAnyOrder(
+                                              SearchResultMatcher
+                                                  .matchOnItemName("item", "items", "Publication 2"),
+                                              SearchResultMatcher
+                                                  .matchOnItemName("item", "items", "Publication 1"))))
+                             .andExpect(jsonPath("$._embedded.searchResult.page.totalElements", is(2)));
+
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -5885,9 +5885,11 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                    .andExpect(jsonPath("$._embedded.values[0].label", is("2017 - 2020")))
                    .andExpect(jsonPath("$._embedded.values[0].count", is(3)))
                    .andExpect(jsonPath("$._embedded.values[0]._links.search.href",
-                                       containsString(
-                                           "api/discover/search/objects?dsoType=Item&configuration=default"
-                                               + "&f.dateIssued=%5B2017%20TO%202020%5D,equals")))
+                        containsString("api/discover/search/objects?dsoType=Item" +
+                                           "&configuration=default" +
+                                           "&f.dateIssued=" +
+                                urlPathSegmentEscaper().escape("[2017 TO 2020],equals")
+                        )))
                    .andExpect(jsonPath("$._embedded.values").value(Matchers.hasSize(1)));
 
     }
@@ -6820,9 +6822,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                                     "api/discover/search/objects?scope=" +
                                         author.getID().toString() +
                                         "&configuration=RELATION.Person.researchoutputs" +
-                                        "&f.dateIssued=%5B2017%20TO%202020%5D,equals"
-                                )
-            ))
+                                        "&f.dateIssued=" +
+                                    urlPathSegmentEscaper().escape("[2017 TO 2020],equals")
+                                )))
             .andExpect(jsonPath("$._embedded.values").value(Matchers.hasSize(1)));
 
         // finds the facets using the default configuration and
@@ -6850,9 +6852,9 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                                 containsString(
                                     "api/discover/search/objects?configuration=default" +
                                         "&f.author=" + author.getID().toString() + ",authority" +
-                                        "&f.dateIssued=%5B2017%20TO%202020%5D,equals"
-                                )
-            ))
+                                        "&f.dateIssued=" +
+                                        urlPathSegmentEscaper().escape("[2017 TO 2020],equals")
+                                )))
             .andExpect(jsonPath("$._embedded.values").value(Matchers.hasSize(1)));
 
     }

--- a/dspace/config/modules/authority.cfg
+++ b/dspace/config/modules/authority.cfg
@@ -394,6 +394,16 @@ org.dspace.content.authority.EPersonAuthority = EPersonAuthority
 # choices.presentation.crispj.coinvestigators = suggest
 # authority.controlled.crispj.coinvestigators = true
 #
+# project.investigator: Investigator (links to Person)
+# choices.plugin.project.investigator = AuthorAuthority
+# choices.presentation.project.investigator = suggest
+# authority.controlled.project.investigator = true
+#
+# dc.contributor.other: Organization's name (links to OrgUnit)
+# choices.plugin.dc.contributor.other = OrgUnitAuthority
+# choices.presentation.dc.contributor.other = suggest
+# authority.controlled.dc.contributor.other = true
+#
 #---------------------------------------------------------------#
 # PERSON METADATA AUTHORITIES
 #---------------------------------------------------------------#

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -179,9 +179,6 @@
                 <!-- Maps to: OrgUnit.isProjectOfOrgUnit (from Project → OrgUnit relationship) -->
                 <!-- Shows RP Projects via investigators affiliated with this OrgUnit -->
                 <entry key="RELATION.OrgUnit.rpprojects" value-ref="relationOrgunitRPProjectConfiguration"/>
-                <!-- Maps to: OrgUnit.isPublicationOfOrgUnit (from Publication → OrgUnit relationship) -->
-                <!-- Shows Publications sponsored by this OrgUnit -->
-                <entry key="RELATION.OrgUnit.publications" value-ref="relationOrgunitPublicationsConfiguration"/>
                 <!-- Maps to: OrgUnit.isPublicationOfOrgUnit via Person affiliation -->
                 <!-- Shows Publications authored by people affiliated with this OrgUnit -->
                 <entry key="RELATION.OrgUnit.rppublications" value-ref="relationOrgunitRPPublicationsConfiguration"/>
@@ -191,20 +188,7 @@
                 <!-- Maps to: OrgUnit.isProjectOfOrgUnit (from Project → OrgUnit relationship) -->
                 <!-- Shows Projects participated by this OrgUnit -->
                 <entry key="RELATION.OrgUnit.projects" value-ref="relationOrgunitProjectsConfiguration"/>
-                <!-- Maps to: OrgUnit.isOrgUnitOfOrgUnit (hierarchical OrgUnit relationship) -->
-                <!-- Shows sub-organizations of this OrgUnit -->
-                <entry key="RELATION.OrgUnit.organizations" value-ref="relationOrgunitOrgunitsConfiguration"/>
 
-                <!-- Project Related Items -->
-                <!-- Maps to: Project.isProjectOfProject (related projects) -->
-                <!-- Shows Projects related to this Project -->
-                <entry key="RELATION.Project.projects" value-ref="relationProjectProjectsConfiguration"/>
-                <!-- Maps to: Project.isFundingOfProject (from Funding → Project relationship) -->
-                <!-- Shows Fundings related to this Project -->
-                <entry key="RELATION.Project.fundings" value-ref="relationProjectFundingsConfiguration"/>
-                <!-- Maps to: Project.isPublicationOfProject (from Publication → Project relationship) -->
-                <!-- Shows Publications related to this Project -->
-                <entry key="RELATION.Project.researchoutputs" value-ref="relationProjectPublicationConfiguration"/>
                 <!-- COAR NOTIFY LDN MESSAGES configuration -->
                 <entry key="NOTIFY.incoming" value-ref="NOTIFY.incoming"/>
                 <entry key="NOTIFY.outgoing" value-ref="NOTIFY.outgoing"/>
@@ -1285,7 +1269,7 @@
         <property name="defaultFilterQueries">
             <list>
                 <!--Only find related items. The placeholder {0} will be replaced with scope (UUID of item)-->
-                <value>projectinvestigators_authority:{0} AND search.resourcetype:Item</value>
+                <value>project.investigator_authority:{0} AND search.resourcetype:Item</value>
                 <value>-withdrawn:true AND -discoverable:false</value>
             </list>
         </property>
@@ -1393,28 +1377,7 @@
         </property>
         <property name="defaultFilterQueries">
             <list>
-                <value>'{'!join from=search.resourceid to=projectinvestigators_authority fromIndex=${solr.multicorePrefix}search'}'person.affiliation.name_authority:{0}</value>
-                <value>-withdrawn:true AND -discoverable:false</value>
-            </list>
-        </property>
-    </bean>
-
-    <!-- OrgUnit → Publications (via dc.description.sponsorship_authority) -->
-    <!-- Maps to: OrgUnit.isPublicationOfOrgUnit (sponsored publications) -->
-    <bean id="relationOrgunitPublicationsConfiguration" class="org.dspace.discovery.configuration.DiscoveryRelatedItemConfiguration">
-        <property name="searchSortConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
-                <property name="sortFields">
-                    <list>
-                        <ref bean="sortDateIssuedDesc" />
-                        <ref bean="sortTitleAsc" />
-                    </list>
-                </property>
-            </bean>
-        </property>
-        <property name="defaultFilterQueries">
-            <list>
-                <value>dc.description.sponsorship_authority:{0}</value>
+                <value>'{'!join from=search.resourceid to=project.investigator_authority fromIndex=${solr.multicorePrefix}search'}'person.affiliation.name_authority:{0}</value>
                 <value>-withdrawn:true AND -discoverable:false</value>
             </list>
         </property>
@@ -1481,83 +1444,6 @@
         </property>
     </bean>
 
-    <!-- OrgUnit → Sub-organizations (via organization.parentOrganization_authority) -->
-    <!-- Maps to: OrgUnit.isOrgUnitOfOrgUnit (hierarchical) -->
-    <bean id="relationOrgunitOrgunitsConfiguration" class="org.dspace.discovery.configuration.DiscoveryRelatedItemConfiguration">
-        <property name="searchSortConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
-                <property name="sortFields">
-                    <list>
-                        <ref bean="sortTitleAsc" />
-                    </list>
-                </property>
-            </bean>
-        </property>
-        <property name="defaultFilterQueries">
-            <list>
-                <value>organization.parentOrganization_authority:{0}</value>
-                <value>-withdrawn:true AND -discoverable:false</value>
-            </list>
-        </property>
-    </bean>
-
-    <!-- Project → Related Projects (via dc.relation.project_authority) -->
-    <bean id="relationProjectProjectsConfiguration" class="org.dspace.discovery.configuration.DiscoveryRelatedItemConfiguration">
-        <property name="searchSortConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
-                <property name="sortFields">
-                    <list>
-                        <ref bean="sortTitleAsc" />
-                    </list>
-                </property>
-            </bean>
-        </property>
-        <property name="defaultFilterQueries">
-            <list>
-                <value>dc.relation.project_authority:{0} AND entityType_keyword:Project</value>
-                <value>-withdrawn:true AND -discoverable:false</value>
-            </list>
-        </property>
-    </bean>
-
-    <!-- Project → Fundings (via dc.relation.project_authority) -->
-    <bean id="relationProjectFundingsConfiguration" class="org.dspace.discovery.configuration.DiscoveryRelatedItemConfiguration">
-        <property name="searchSortConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
-                <property name="sortFields">
-                    <list>
-                        <ref bean="sortTitleAsc" />
-                    </list>
-                </property>
-            </bean>
-        </property>
-        <property name="defaultFilterQueries">
-            <list>
-                <value>dc.relation.project_authority:{0} AND entityType_keyword:Funding</value>
-                <value>-withdrawn:true AND -discoverable:false</value>
-            </list>
-        </property>
-    </bean>
-
-    <!-- Project → Research Outputs/Publications (via dc.relation.project_authority) -->
-    <bean id="relationProjectPublicationConfiguration" class="org.dspace.discovery.configuration.DiscoveryRelatedItemConfiguration">
-        <property name="searchSortConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
-                <property name="sortFields">
-                    <list>
-                        <ref bean="sortDateIssuedDesc" />
-                        <ref bean="sortTitleAsc" />
-                    </list>
-                </property>
-            </bean>
-        </property>
-        <property name="defaultFilterQueries">
-            <list>
-                <value>dc.relation.project_authority:{0} AND entityType_keyword:Publication</value>
-                <value>-withdrawn:true AND -discoverable:false</value>
-            </list>
-        </property>
-    </bean>
 
     <bean id="publication" class="org.dspace.discovery.configuration.DiscoveryConfiguration" scope="prototype">
         <property name="id" value="publication"/>

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -40,6 +40,7 @@
                 <value>person.name.translated</value>
                 <value>person.givenName</value>
                 <value>person.familyName</value>
+                <value>organization.legalName</value>
             </list>
         </property>
     </bean>
@@ -50,6 +51,7 @@
                 <value>crisrp.name</value>
                 <value>person.name.variant</value>
                 <value>person.name.translated</value>
+                <value>organization.legalName</value>
             </list>
         </property>
     </bean>
@@ -1459,7 +1461,7 @@
         </property>
     </bean>
 
-    <!-- OrgUnit → Projects (via involvedorganisation_authority) -->
+    <!-- OrgUnit → Projects (via dc.contributor.other_authority) -->
     <!-- Maps to: OrgUnit.isProjectOfOrgUnit (participated projects) -->
     <bean id="relationOrgunitProjectsConfiguration" class="org.dspace.discovery.configuration.DiscoveryRelatedItemConfiguration">
         <property name="searchSortConfiguration">
@@ -1473,7 +1475,7 @@
         </property>
         <property name="defaultFilterQueries">
             <list>
-                <value>involvedorganisation_authority:{0}</value>
+                <value>dc.contributor.other_authority:{0}</value>
                 <value>-withdrawn:true AND -discoverable:false</value>
             </list>
         </property>

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -158,6 +158,51 @@
                 <!-- Openaire4 guidelines - search for an OrgUnit that have a specific dc.type=FundingOrganization -->
                 <entry key="openaireFundingAgency" value-ref="openaireFundingAgency"/>
                 <entry key="eperson_claims" value-ref="eperson_claims"/>
+
+                <!-- ========================================================== -->
+                <!-- DSpace-CRIS Authority-based RELATION Discovery Configurations -->
+                <!-- These configurations map entity relationships to discovery    -->
+                <!-- searches using authority-based metadata fields.               -->
+                <!-- ========================================================== -->
+
+                <!-- Person Related Items -->
+                <!-- Maps to: Person.isProjectOfPerson (from Project → Person relationship) -->
+                <!-- Shows Projects where this Person is an investigator -->
+                <entry key="RELATION.Person.projects" value-ref="relationInvestigatorProjectsConfiguration"/>
+                <!-- Maps to: Person.isPublicationOfAuthor (from Publication → Person relationship) -->
+                <!-- Shows Publications where this Person is an author -->
+                <entry key="RELATION.Person.researchoutputs" value-ref="relationAuthorResearchOutputsConfiguration"/>
+
+                <!-- OrgUnit Related Items -->
+                <!-- Maps to: OrgUnit.isProjectOfOrgUnit (from Project → OrgUnit relationship) -->
+                <!-- Shows RP Projects via investigators affiliated with this OrgUnit -->
+                <entry key="RELATION.OrgUnit.rpprojects" value-ref="relationOrgunitRPProjectConfiguration"/>
+                <!-- Maps to: OrgUnit.isPublicationOfOrgUnit (from Publication → OrgUnit relationship) -->
+                <!-- Shows Publications sponsored by this OrgUnit -->
+                <entry key="RELATION.OrgUnit.publications" value-ref="relationOrgunitPublicationsConfiguration"/>
+                <!-- Maps to: OrgUnit.isPublicationOfOrgUnit via Person affiliation -->
+                <!-- Shows Publications authored by people affiliated with this OrgUnit -->
+                <entry key="RELATION.OrgUnit.rppublications" value-ref="relationOrgunitRPPublicationsConfiguration"/>
+                <!-- Maps to: OrgUnit.isPersonOfOrgUnit (from Person → OrgUnit relationship) -->
+                <!-- Shows People affiliated with this OrgUnit -->
+                <entry key="RELATION.OrgUnit.people" value-ref="relationOrgunitPersonsConfiguration"/>
+                <!-- Maps to: OrgUnit.isProjectOfOrgUnit (from Project → OrgUnit relationship) -->
+                <!-- Shows Projects participated by this OrgUnit -->
+                <entry key="RELATION.OrgUnit.projects" value-ref="relationOrgunitProjectsConfiguration"/>
+                <!-- Maps to: OrgUnit.isOrgUnitOfOrgUnit (hierarchical OrgUnit relationship) -->
+                <!-- Shows sub-organizations of this OrgUnit -->
+                <entry key="RELATION.OrgUnit.organizations" value-ref="relationOrgunitOrgunitsConfiguration"/>
+
+                <!-- Project Related Items -->
+                <!-- Maps to: Project.isProjectOfProject (related projects) -->
+                <!-- Shows Projects related to this Project -->
+                <entry key="RELATION.Project.projects" value-ref="relationProjectProjectsConfiguration"/>
+                <!-- Maps to: Project.isFundingOfProject (from Funding → Project relationship) -->
+                <!-- Shows Fundings related to this Project -->
+                <entry key="RELATION.Project.fundings" value-ref="relationProjectFundingsConfiguration"/>
+                <!-- Maps to: Project.isPublicationOfProject (from Publication → Project relationship) -->
+                <!-- Shows Publications related to this Project -->
+                <entry key="RELATION.Project.researchoutputs" value-ref="relationProjectPublicationConfiguration"/>
                 <!-- COAR NOTIFY LDN MESSAGES configuration -->
                 <entry key="NOTIFY.incoming" value-ref="NOTIFY.incoming"/>
                 <entry key="NOTIFY.outgoing" value-ref="NOTIFY.outgoing"/>
@@ -1203,6 +1248,313 @@
         </property>
         <!-- When true a "did you mean" example will be displayed, value can be true or false -->
         <property name="spellCheckEnabled" value="true"/>
+    </bean>
+
+    <!-- Inverse Relations -->
+        <!-- project of an researcher -->
+    <bean id="relationInvestigatorProjectsConfiguration" class="org.dspace.discovery.configuration.DiscoveryRelatedItemConfiguration">
+        <!--Which sidebar facets are to be displayed-->
+        <property name="sidebarFacets">
+            <list>
+                <ref bean="searchFilterEntityType" />
+            </list>
+        </property>
+        <!--The search filters which can be used on the discovery search page-->
+        <property name="searchFilters">
+            <list>
+                <ref bean="searchFilterEntityType" />
+                <ref bean="searchFilterProjectInvestigator"/>
+            </list>
+        </property>
+        <!--The sort filters for the discovery search-->
+        <property name="searchSortConfiguration">
+            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
+                <!--DefaultSortOrder can either be desc or asc (desc is default)-->
+                <property name="sortFields">
+                    <list>
+                        <ref bean="sortByProjectsSelection" />
+                        <ref bean="sortTitleAsc" />
+                    </list>
+                </property>
+            </bean>
+        </property>
+        <!--Any default filter queries, these filter queries will be used for all
+                queries done by discovery for this configuration -->
+        <property name="defaultFilterQueries">
+            <list>
+                <!--Only find related items. The placeholder {0} will be replaced with scope (UUID of item)-->
+                <value>projectinvestigators_authority:{0} AND search.resourcetype:Item</value>
+                <value>-withdrawn:true AND -discoverable:false</value>
+            </list>
+        </property>
+        <!--Default result per page  -->
+        <property name="defaultRpp" value="10" />
+        <property name="hitHighlightingConfiguration">
+            <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightingConfiguration">
+                <property name="metadataFields">
+                    <list>
+                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
+                            <property name="field" value="dspace.entity.type"/>
+                            <property name="snippets" value="5"/>
+                        </bean>
+                    </list>
+                </property>
+            </bean>
+        </property>
+    </bean>
+
+
+    <!-- publications of an author -->
+    <bean id="relationAuthorResearchOutputsConfiguration" class="org.dspace.discovery.configuration.DiscoveryRelatedItemConfiguration">
+        <!--Which sidebar facets are to be displayed-->
+        <property name="sidebarFacets">
+            <list>
+<!--                <ref bean="graphPublicationByType" />-->
+<!--                <ref bean="graphPublicationByDate" />-->
+                <ref bean="searchFilterIssued" />
+                <ref bean="searchFilterAuthor" />
+	            <ref bean="searchFilterEditor" />
+	            <ref bean="searchFilterOrgUnit" />
+	            <ref bean="searchFilterSubject" />
+	            <ref bean="searchFilterFunding" />
+	            <ref bean="searchFilterContentInOriginalBundle"/>
+	            <ref bean="searchFilterType" />
+            </list>
+        </property>
+        <!-- Set TagCloud configuration per discovery configuration -->
+        <property name="tagCloudFacetConfiguration" ref="defaultTagCloudFacetConfiguration"/>
+        <!--The search filters which can be used on the discovery search page-->
+        <property name="searchFilters">
+            <list>
+                <ref bean="searchFilterTitle" />
+<!--                <ref bean="graphPublicationByType" />-->
+<!--                <ref bean="graphPublicationByDate" />-->
+                <ref bean="searchFilterIssued" />
+                <ref bean="searchFilterAuthor" />
+                <ref bean="searchFilterEditor" />
+                <ref bean="searchFilterOrgUnit" />
+                <ref bean="searchFilterSubject" />
+                <ref bean="searchFilterFunding" />
+                <ref bean="searchFilterContentInOriginalBundle"/>
+                <ref bean="searchFilterType" />
+            </list>
+        </property>
+        <!--The sort filters for the discovery search-->
+        <property name="searchSortConfiguration">
+            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
+                <!--<property name="defaultSort" ref="sortDateIssued"/>-->
+                <!--DefaultSortOrder can either be desc or asc (desc is default)-->
+                <property name="sortFields">
+                    <list>
+                        <ref bean="sortByResearchOutputsSelection" />
+                        <ref bean="sortTitleAsc" />
+                    </list>
+                </property>
+            </bean>
+        </property>
+        <!--Any default filter queries, these filter queries will be used for all
+                queries done by discovery for this configuration -->
+        <property name="defaultFilterQueries">
+            <list>
+                <!--Only find related items. The placeholder {0} will be replaced with scope (UUID of item)-->
+                <value>author_authority:{0} AND search.resourcetype:Item</value>
+                <value>-withdrawn:true AND -discoverable:false</value>
+            </list>
+        </property>
+        <!--Default result per page  -->
+        <property name="defaultRpp" value="10" />
+        <property name="hitHighlightingConfiguration">
+            <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightingConfiguration">
+                <property name="metadataFields">
+                    <list>
+                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
+                            <property name="field" value="dspace.entity.type"/>
+                            <property name="snippets" value="5"/>
+                        </bean>
+                    </list>
+                </property>
+            </bean>
+        </property>
+    </bean>
+
+    <!-- OrgUnit → RP Projects (via join from person affiliation) -->
+    <!-- Maps to: OrgUnit.isProjectOfOrgUnit via Person investigators -->
+    <bean id="relationOrgunitRPProjectConfiguration" class="org.dspace.discovery.configuration.DiscoveryRelatedItemConfiguration">
+        <property name="searchSortConfiguration">
+            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
+                <property name="sortFields">
+                    <list>
+                        <ref bean="sortTitleAsc" />
+                    </list>
+                </property>
+            </bean>
+        </property>
+        <property name="defaultFilterQueries">
+            <list>
+                <value>'{'!join from=search.resourceid to=projectinvestigators_authority fromIndex=${solr.multicorePrefix}search'}'person.affiliation.name_authority:{0}</value>
+                <value>-withdrawn:true AND -discoverable:false</value>
+            </list>
+        </property>
+    </bean>
+
+    <!-- OrgUnit → Publications (via dc.description.sponsorship_authority) -->
+    <!-- Maps to: OrgUnit.isPublicationOfOrgUnit (sponsored publications) -->
+    <bean id="relationOrgunitPublicationsConfiguration" class="org.dspace.discovery.configuration.DiscoveryRelatedItemConfiguration">
+        <property name="searchSortConfiguration">
+            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
+                <property name="sortFields">
+                    <list>
+                        <ref bean="sortDateIssuedDesc" />
+                        <ref bean="sortTitleAsc" />
+                    </list>
+                </property>
+            </bean>
+        </property>
+        <property name="defaultFilterQueries">
+            <list>
+                <value>dc.description.sponsorship_authority:{0}</value>
+                <value>-withdrawn:true AND -discoverable:false</value>
+            </list>
+        </property>
+    </bean>
+
+    <!-- OrgUnit → RP Publications (via join from author affiliation) -->
+    <!-- Maps to: OrgUnit.isPublicationOfOrgUnit via Person authors -->
+    <bean id="relationOrgunitRPPublicationsConfiguration" class="org.dspace.discovery.configuration.DiscoveryRelatedItemConfiguration">
+        <property name="searchSortConfiguration">
+            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
+                <property name="sortFields">
+                    <list>
+                        <ref bean="sortDateIssuedDesc" />
+                        <ref bean="sortTitleAsc" />
+                    </list>
+                </property>
+            </bean>
+        </property>
+        <property name="defaultFilterQueries">
+            <list>
+                <value>'{'!join from=search.resourceid to=author_authority fromIndex=${solr.multicorePrefix}search'}'person.affiliation.name_authority:{0}</value>
+                <value>-withdrawn:true AND -discoverable:false</value>
+            </list>
+        </property>
+    </bean>
+
+    <!-- OrgUnit → People (via person.affiliation.name_authority) -->
+    <!-- Maps to: OrgUnit.isPersonOfOrgUnit (affiliated people) -->
+    <bean id="relationOrgunitPersonsConfiguration" class="org.dspace.discovery.configuration.DiscoveryRelatedItemConfiguration">
+        <property name="searchSortConfiguration">
+            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
+                <property name="sortFields">
+                    <list>
+                        <ref bean="sortTitleAsc" />
+                    </list>
+                </property>
+            </bean>
+        </property>
+        <property name="defaultFilterQueries">
+            <list>
+                <value>person.affiliation.name_authority:{0}</value>
+                <value>-withdrawn:true AND -discoverable:false</value>
+            </list>
+        </property>
+    </bean>
+
+    <!-- OrgUnit → Projects (via involvedorganisation_authority) -->
+    <!-- Maps to: OrgUnit.isProjectOfOrgUnit (participated projects) -->
+    <bean id="relationOrgunitProjectsConfiguration" class="org.dspace.discovery.configuration.DiscoveryRelatedItemConfiguration">
+        <property name="searchSortConfiguration">
+            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
+                <property name="sortFields">
+                    <list>
+                        <ref bean="sortTitleAsc" />
+                    </list>
+                </property>
+            </bean>
+        </property>
+        <property name="defaultFilterQueries">
+            <list>
+                <value>involvedorganisation_authority:{0}</value>
+                <value>-withdrawn:true AND -discoverable:false</value>
+            </list>
+        </property>
+    </bean>
+
+    <!-- OrgUnit → Sub-organizations (via organization.parentOrganization_authority) -->
+    <!-- Maps to: OrgUnit.isOrgUnitOfOrgUnit (hierarchical) -->
+    <bean id="relationOrgunitOrgunitsConfiguration" class="org.dspace.discovery.configuration.DiscoveryRelatedItemConfiguration">
+        <property name="searchSortConfiguration">
+            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
+                <property name="sortFields">
+                    <list>
+                        <ref bean="sortTitleAsc" />
+                    </list>
+                </property>
+            </bean>
+        </property>
+        <property name="defaultFilterQueries">
+            <list>
+                <value>organization.parentOrganization_authority:{0}</value>
+                <value>-withdrawn:true AND -discoverable:false</value>
+            </list>
+        </property>
+    </bean>
+
+    <!-- Project → Related Projects (via dc.relation.project_authority) -->
+    <bean id="relationProjectProjectsConfiguration" class="org.dspace.discovery.configuration.DiscoveryRelatedItemConfiguration">
+        <property name="searchSortConfiguration">
+            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
+                <property name="sortFields">
+                    <list>
+                        <ref bean="sortTitleAsc" />
+                    </list>
+                </property>
+            </bean>
+        </property>
+        <property name="defaultFilterQueries">
+            <list>
+                <value>dc.relation.project_authority:{0} AND entityType_keyword:Project</value>
+                <value>-withdrawn:true AND -discoverable:false</value>
+            </list>
+        </property>
+    </bean>
+
+    <!-- Project → Fundings (via dc.relation.project_authority) -->
+    <bean id="relationProjectFundingsConfiguration" class="org.dspace.discovery.configuration.DiscoveryRelatedItemConfiguration">
+        <property name="searchSortConfiguration">
+            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
+                <property name="sortFields">
+                    <list>
+                        <ref bean="sortTitleAsc" />
+                    </list>
+                </property>
+            </bean>
+        </property>
+        <property name="defaultFilterQueries">
+            <list>
+                <value>dc.relation.project_authority:{0} AND entityType_keyword:Funding</value>
+                <value>-withdrawn:true AND -discoverable:false</value>
+            </list>
+        </property>
+    </bean>
+
+    <!-- Project → Research Outputs/Publications (via dc.relation.project_authority) -->
+    <bean id="relationProjectPublicationConfiguration" class="org.dspace.discovery.configuration.DiscoveryRelatedItemConfiguration">
+        <property name="searchSortConfiguration">
+            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
+                <property name="sortFields">
+                    <list>
+                        <ref bean="sortDateIssuedDesc" />
+                        <ref bean="sortTitleAsc" />
+                    </list>
+                </property>
+            </bean>
+        </property>
+        <property name="defaultFilterQueries">
+            <list>
+                <value>dc.relation.project_authority:{0} AND entityType_keyword:Publication</value>
+                <value>-withdrawn:true AND -discoverable:false</value>
+            </list>
+        </property>
     </bean>
 
     <bean id="publication" class="org.dspace.discovery.configuration.DiscoveryConfiguration" scope="prototype">
@@ -2425,7 +2777,6 @@
         <property name="spellCheckEnabled" value="false"/>
     </bean>
 
-
     <bean id="ldnMessageEntityBaseConfig"
         class="org.dspace.discovery.configuration.DiscoveryConfiguration"
         scope="prototype">
@@ -2811,6 +3162,53 @@
         <property name="exposeMinAndMaxValue" value="true"/>
     </bean>
 
+    <bean id="searchFilterEditor" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
+        <property name="indexFieldName" value="editor"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.contributor.editor</value>
+                <value>dc.creator</value>
+            </list>
+        </property>
+        <property name="facetLimit" value="5"/>
+        <property name="sortOrderSidebar" value="COUNT"/>
+        <property name="sortOrderFilterPage" value="COUNT"/>
+        <property name="isOpenByDefault" value="true"/>
+        <property name="pageSize" value="10"/>
+        <property name="exposeMinAndMaxValue" value="true"/>
+    </bean>
+
+    <bean id="searchFilterOrgUnit" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
+        <property name="indexFieldName" value="organization"/>
+        <property name="metadataFields">
+            <list>
+                <value>oairecerif.author.affiliation</value>
+                <value>oairecerif.editor.affiliation</value>
+            </list>
+        </property>
+        <property name="facetLimit" value="5"/>
+        <property name="sortOrderSidebar" value="COUNT"/>
+        <property name="sortOrderFilterPage" value="COUNT"/>
+        <property name="isOpenByDefault" value="true"/>
+        <property name="pageSize" value="10"/>
+        <property name="exposeMinAndMaxValue" value="true"/>
+    </bean>
+
+    <bean id="searchFilterFunding" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
+        <property name="indexFieldName" value="funding"/>
+        <property name="metadataFields">
+            <list>
+                <value>dc.relation.funding</value>
+            </list>
+        </property>
+        <property name="facetLimit" value="5"/>
+        <property name="sortOrderSidebar" value="COUNT"/>
+        <property name="sortOrderFilterPage" value="COUNT"/>
+        <property name="isOpenByDefault" value="true"/>
+        <property name="pageSize" value="10"/>
+        <property name="exposeMinAndMaxValue" value="true"/>
+    </bean>
+
     <bean id="searchFilterEntityType" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
         <property name="indexFieldName" value="entityType"/>
         <property name="metadataFields">
@@ -2883,6 +3281,23 @@
         <property name="isOpenByDefault" value="false"/>
         <property name="pageSize" value="10"/>
 
+    </bean>
+
+    <bean id="searchFilterProjectInvestigator"
+        class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
+        <property name="indexFieldName" value="projectinvestigators" />
+        <property name="metadataFields">
+            <list>
+                <value>crispj.investigator</value>
+                <value>crispj.coinvestigators</value>
+            </list>
+        </property>
+        <property name="facetLimit" value="5"/>
+        <property name="sortOrderSidebar" value="COUNT"/>
+        <property name="sortOrderFilterPage" value="COUNT"/>
+        <property name="isOpenByDefault" value="false"/>
+        <property name="pageSize" value="10"/>
+        <property name="exposeMinAndMaxValue" value="false"/>
     </bean>
 
     <bean id="searchFilterFileNameInOriginalBundle" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
@@ -3719,6 +4134,33 @@
     <bean id="sortEntityType" class="org.dspace.discovery.configuration.DiscoverySortFieldConfiguration">
         <property name="metadataField" value="dspace.entity.type"/>
         <property name="defaultSortOrder" value="desc"/>
+    </bean>
+
+    <!-- functional sorting -->
+    <bean name="sortByProjectsSelection" class="org.dspace.discovery.configuration.DiscoverySortFunctionConfiguration">
+        <property name="defaultSortOrder" value="desc"/>
+        <!--sort by frequency of relation.isProjectsSelectedFor. The placeholder {0} will be replaced with scope (UUID of researcher)-->
+        <property name="function" value="termfreq"/>
+        <property name="id" value="ownerselection"/>
+        <property name="arguments">
+            <list>
+                <value>relation.isProjectsSelectedFor</value>
+                <value>{0}</value>
+            </list>
+        </property>
+    </bean>
+
+    <bean name="sortByResearchOutputsSelection" class="org.dspace.discovery.configuration.DiscoverySortFunctionConfiguration">
+        <property name="defaultSortOrder" value="desc"/>
+        <!--sort by frequency of relation.isProjectsSelectedFor. The placeholder {0} will be replaced with scope (UUID of researcher)-->
+        <property name="function" value="termfreq"/>
+        <property name="id" value="ownerselection"/>
+        <property name="arguments">
+            <list>
+                <value>relation.isResearchoutputsSelectedFor</value>
+                <value>{0}</value>
+            </list>
+        </property>
     </bean>
 
     <bean id="sortLastModified" class="org.dspace.discovery.configuration.DiscoverySortFieldConfiguration">


### PR DESCRIPTION
## References

* Fixes #12164
* Requires frontend PR: https://github.com/DSpace/dspace-angular/pull/5134
* Related to DSpace/RestContract#pr-number  (if a corresponding REST Contract PR exists)
* Related to #11718, #11945

## Description
This PR ports the inverse relations feature from DSpace-CRIS to DSpace core, enabling entity profile pages to display related items through relation box components with faceting support. It covers [feature differences #3](https://wiki.lyrasis.org/display/DSPACE/DSpace-CRIS+and+DSpace+Differences).


## Instructions for Reviewers
### List of changes in this PR:
- **First**, added `DiscoveryRelatedItemConfiguration` class that extends `DiscoveryConfiguration` to support entity-to-entity searches. These configurations are identified by names starting with `RELATION.` and allow Items to be used as search scope objects.
- **Second**, extended `ScopeResolver` to support Items as search scope objects (previously only Communities and Collections were supported). The resolver now uses functional Optional chaining to resolve any type of DSpaceObject including Items.
- **Third**, modified `DiscoveryRestRepository` search logic to handle `RELATION.*` configurations differently - for related item configurations, the search is performed without a traditional scope object since the item UUID is injected into filter queries instead.
- **Fourth**, enhanced `DiscoverQueryBuilder` with several improvements:
  - Dynamic filter query injection that substitutes `{0}` placeholders with the scope item's UUID for relation searches
  - Support for `DiscoverySortFunctionConfiguration` allowing dynamic sort functions using the item scope
  - Fixed facet offset handling to set offset on individual facet fields rather than globally
- **Fifth**, updated `FacetYearRange` to detect RELATION configurations and adapt search calls accordingly.
- **Sixth**, modified `DiscoverFacetResultsConverter` to include the configuration ID in responses for proper link generation.
- **Seventh**, updated `DiscoveryConfigurationService` to automatically assign configuration IDs from map keys if not explicitly set.
- **Eighth**, enhanced `DiscoverQuery` to store the scope object internally, allowing downstream components like `FacetYearRange` to access it when needed.
- **Ninth**, added comprehensive test configurations and integration tests for all relation search scenarios.
### Testing/Review Guidance:
1. Configure entity relationships in `discovery.xml` (see Required Configuration below)
2. Create entities (Person, OrgUnit, Project) with relationships to other items
3. Test the following API endpoints:
   - Person's publications: `/api/discover/search/objects?configuration=RELATION.Person.researchoutputs&scope={person-uuid}`
   - OrgUnit's people: `/api/discover/search/objects?configuration=RELATION.OrgUnit.people&scope={orgunit-uuid}`
   - Project's publications: `/api/discover/search/objects?configuration=RELATION.Project.researchoutputs&scope={project-uuid}`
4. Verify that facets work correctly on relation searches
5. Verify that sorting works correctly including dynamic sort functions
6. Ensure backward compatibility - regular discovery searches should continue to work as before
---
## Required Configuration
To enable relation box discovery, add the following to your `dspace/config/spring/api/discovery.xml`:
### 1. Add RELATION Configuration Entries
Add entries to the `map` property of `DiscoveryConfigurationService`:
```xml
<entry key="RELATION.Person.researchoutputs" value-ref="relationAuthorResearchOutputsConfiguration"/>
<entry key="RELATION.Person.projects" value-ref="relationInvestigatorProjectsConfiguration"/>
<entry key="RELATION.OrgUnit.people" value-ref="relationOrgunitPersonsConfiguration"/>
<entry key="RELATION.OrgUnit.publications" value-ref="relationOrgunitPublicationsConfiguration"/>
<entry key="RELATION.Project.researchoutputs" value-ref="relationProjectPublicationConfiguration"/>
```
### 2. Define DiscoveryRelatedItemConfiguration Beans
Example configuration for showing publications of an author:
```xml
<bean id="relationAuthorResearchOutputsConfiguration" class="org.dspace.discovery.configuration.DiscoveryRelatedItemConfiguration">
    <property name="sidebarFacets">
        <list>
            <ref bean="searchFilterIssued" />
            <ref bean="searchFilterAuthor" />
            <ref bean="searchFilterSubject" />
            <ref bean="searchFilterContentInOriginalBundle"/>
        </list>
    </property>
    <property name="searchFilters">
        <list>
            <ref bean="searchFilterIssued" />
            <ref bean="searchFilterAuthor" />
            <ref bean="searchFilterSubject" />
            <ref bean="searchFilterContentInOriginalBundle"/>
        </list>
    </property>
    <property name="searchSortConfiguration">
        <ref bean="relationPublicationSortConfiguration" />
    </property>
    <property name="filterQueries">
        <list>
            <value>{relationship.type:Publication AND relationship.left:{0}}</value>
        </list>
    </property>
    <property name="defaultFilterQueries">
        <list>
            <value>search.resourcetype:Item</value>
        </list>
    </property>
</bean>
```
### 3. Define Sort Configuration (Optional)
For dynamic sorting based on relationship properties:
```xml
<bean id="relationPublicationSortConfiguration" class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
    <property name="sortFields">
        <list>
            <ref bean="sortDateIssued" />
            <ref bean="sortTitle" />
        </list>
    </property>
</bean>
```
### Key Configuration Properties:
- **filterQueries**: Use `{0}` placeholder which will be replaced with the scope item's UUID at query time
- **sidebarFacets**: Facets to display in the relation box
- **searchFilters**: Filters available for the relation search
- **defaultFilterQueries**: Static filters applied to all searches (e.g., limiting to Items only)
### Example Filter Query Patterns:
- Publications by author: `{relationship.type:Publication AND relationship.left:{0}}`
- People of OrgUnit: `{relationship.type:Person AND organization.id:{0}}`
- Projects of OrgUnit: `{relationship.type:Project AND organization.id:{0}}`
---
## API Usage Examples
Once configured, the following endpoints become available:
**Get all publications for a Person:**
```
GET /api/discover/search/objects?configuration=RELATION.Person.researchoutputs&scope=123e4567-e89b-12d3-a456-426614174000
```
**Get people affiliated with an OrgUnit:**
```
GET /api/discover/search/objects?configuration=RELATION.OrgUnit.people&scope=123e4567-e89b-12d3-a456-426614174001
```
**Get publications for a Project:**
```
GET /api/discover/search/objects?configuration=RELATION.Project.researchoutputs&scope=123e4567-e89b-12d3-a456-426614174002
```


## Checklist

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
