### PR TITLE
Pin jboss-logging version and ignore updates in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -141,6 +141,9 @@ updates:
       # Ignore major/minor updates for Hibernate. Only patch updates can be automated.
       - dependency-name: "org.hibernate.*:*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      # Ignore updates for jboss-logging because it is a "convergence only" dependency
+      # that we do not use directly (see comments in pom.xml).
+      - dependency-name: "org.jboss.logging:*"
       # Ignore all major version updates for all dependencies. We'll only automate minor/patch updates.
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
@@ -279,6 +282,9 @@ updates:
       # Ignore major/minor updates for Hibernate. Only patch updates can be automated.
       - dependency-name: "org.hibernate.*:*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      # Ignore updates for jboss-logging because it is a "convergence only" dependency
+      # that we do not use directly (see comments in pom.xml).
+      - dependency-name: "org.jboss.logging:*"
       # Ignore all major version updates for all dependencies. We'll only automate minor/patch updates.
       - dependency-name: "*"
         update-types: [ "version-update:semver-major" ]
@@ -417,6 +423,9 @@ updates:
       # Ignore major/minor updates for Hibernate. Only patch updates can be automated.
       - dependency-name: "org.hibernate.*:*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      # Ignore updates for jboss-logging because it is a "convergence only" dependency
+      # that we do not use directly (see comments in pom.xml).
+      - dependency-name: "org.jboss.logging:*"
       # Ignore all major version updates for all dependencies. We'll only automate minor/patch updates.
       - dependency-name: "*"
         update-types: [ "version-update:semver-major" ]
@@ -574,6 +583,9 @@ updates:
       # Ignore major/minor updates for Hibernate. Only patch updates can be automated.
       - dependency-name: "org.hibernate.*:*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      # Ignore updates for jboss-logging because it is a "convergence only" dependency
+      # that we do not use directly (see comments in pom.xml).
+      - dependency-name: "org.jboss.logging:*"
       # Ignore all major version updates for all dependencies. We'll only automate minor/patch updates.
       - dependency-name: "*"
         update-types: [ "version-update:semver-major" ]

--- a/pom.xml
+++ b/pom.xml
@@ -1151,11 +1151,21 @@
                 <version>${hibernate-validator.version}</version>
             </dependency>
 
-            <!-- Hibernate introduces multiple versions of jboss-logging. So, specify version we want -->
+            <!-- Different Hibernate components introduce different (conflicting)
+                 versions of jboss-logging. We specify it here to avoid dependency
+                 convergence issues, and the version here is pinned to the version
+                 used by the hibernate-orm parent.
+
+                 See: https://github.com/hibernate/hibernate-orm/blob/6.4/settings.gradle#L74
+
+                 Dependabot is configured to ignore updates for jboss-logging.
+
+                 See: .github/dependabot.yml
+            -->
             <dependency>
                 <groupId>org.jboss.logging</groupId>
                 <artifactId>jboss-logging</artifactId>
-                <version>3.6.1.Final</version>
+                <version>3.5.0.Final</version>
             </dependency>
 
             <!-- Hibernate & Solr disagree on the version of antlr. So, specify the latest version -->


### PR DESCRIPTION
# References
* Related to https://github.com/DSpace/DSpace/pull/11939

# Description
`jboss-logging` is a transitive dependency and it causes dependency convergence errors because various hibernate components pull in different versions. We should be pinning this to the same version used by the hibernate parent and disabling dependabot updates for it.

See: https://github.com/hibernate/hibernate-orm/blob/6.4/settings.gradle#L74

# Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* First, pin jboss-logging to version 3.5.0 because that is what the hibernate parent uses
* Second, disable updates for jboss-logging in dependabot

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

# Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).