### PR TITLE
Pin antlr4-runtime to Hibernate-compatible version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,8 @@
         <spring-security.version>6.5.7</spring-security.version> <!-- sync with version used by spring-boot-->
         <hibernate.version>6.4.10.Final</hibernate.version>
         <hibernate-validator.version>8.0.3.Final</hibernate-validator.version>
+        <!-- Pin antlr4-runtime to the version required by Hibernate (compiled with ANTLR tool 4.13.0) -->
+        <antlr4.version>4.13.0</antlr4.version>
         <postgresql.driver.version>42.7.10</postgresql.driver.version>
         <flyway.version>10.22.0</flyway.version>
         <solr.client.version>8.11.4</solr.client.version>
@@ -1166,6 +1168,19 @@
                 <groupId>org.jboss.logging</groupId>
                 <artifactId>jboss-logging</artifactId>
                 <version>3.5.0.Final</version>
+            </dependency>
+            <!--
+                Pin antlr4-runtime to the version required by Hibernate ORM 6.4.x.
+                Hibernate is compiled with ANTLR tool 4.13.0 (ATN serialized format v4),
+                but transitive dependencies (e.g. solr-core) pull in antlr4-runtime 4.5.1
+                which only understands ATN format v3, causing an InvalidClassException at
+                startup.  Declaring the version here ensures the Hibernate-compatible
+                runtime wins across all modules.
+            -->
+            <dependency>
+                <groupId>org.antlr</groupId>
+                <artifactId>antlr4-runtime</artifactId>
+                <version>${antlr4.version}</version>
             </dependency>
 
             <!-- Rome is used for RSS / ATOM syndication feeds -->


### PR DESCRIPTION
Fixes #11988
Reverts #11980

The application fails to start on the current main due to an ANTLR runtime version conflict. Hibernate ORM 6.4.x is compiled with ANTLR 4.13.0 (which uses ATN serialized format v4), but transitive dependencies like solr-core pull in antlr4-runtime 4.5.1. This older version only understands ATN format v3, causing an InvalidClassException during startup.

This change explicitly pins antlr4-runtime to version 4.13.0 in the dependency management section, ensuring the Hibernate-compatible version is used across all modules instead of the older transitive dependency.