### PR TITLE
[Docker] Fix `docker-deploy` issues with running Handle Server by excluding `spring-jcl` from classpath

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -386,13 +386,6 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-orm</artifactId>
-            <exclusions>
-                <!-- Spring JCL is unnecessary and conflicts with commons-logging when both are on classpath -->
-                <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-jcl</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/dspace-iiif/pom.xml
+++ b/dspace-iiif/pom.xml
@@ -44,11 +44,6 @@
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-starter-logging</artifactId>
                 </exclusion>
-                <!-- Spring JCL is unnecessary and conflicts with commons-logging when both are on classpath -->
-                <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-jcl</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
 

--- a/dspace-oai/pom.xml
+++ b/dspace-oai/pom.xml
@@ -78,11 +78,6 @@
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-starter-logging</artifactId>
                 </exclusion>
-                <!-- Spring JCL is unnecessary and conflicts with commons-logging when both are on classpath -->
-                <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-jcl</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
 

--- a/dspace-rdf/pom.xml
+++ b/dspace-rdf/pom.xml
@@ -67,11 +67,6 @@
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-starter-logging</artifactId>
                 </exclusion>
-                <!-- Spring JCL is unnecessary and conflicts with commons-logging when both are on classpath -->
-                <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-jcl</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
 

--- a/dspace-server-webapp/pom.xml
+++ b/dspace-server-webapp/pom.xml
@@ -460,11 +460,6 @@
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-starter-logging</artifactId>
                 </exclusion>
-                <!-- Spring JCL is unnecessary and conflicts with commons-logging when both are on classpath -->
-                <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-jcl</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
 

--- a/dspace-services/pom.xml
+++ b/dspace-services/pom.xml
@@ -90,13 +90,6 @@
             <artifactId>spring-context-support</artifactId>
             <version>${spring.version}</version>
             <scope>compile</scope>
-            <exclusions>
-                <!-- Spring JCL is unnecessary and conflicts with commons-logging when both are on classpath -->
-                <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-jcl</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/dspace-sword/pom.xml
+++ b/dspace-sword/pom.xml
@@ -46,11 +46,6 @@
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-starter-logging</artifactId>
                 </exclusion>
-                <!-- Spring JCL is unnecessary and conflicts with commons-logging when both are on classpath -->
-                <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-jcl</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
 

--- a/dspace-swordv2/pom.xml
+++ b/dspace-swordv2/pom.xml
@@ -83,11 +83,6 @@
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-starter-logging</artifactId>
                 </exclusion>
-                <!-- Spring JCL is unnecessary and conflicts with commons-logging when both are on classpath -->
-                <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-jcl</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1204,13 +1204,6 @@
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-orm</artifactId>
                 <version>${spring.version}</version>
-                <exclusions>
-                    <!-- Spring JCL is unnecessary and conflicts with commons-logging when both are on classpath -->
-                    <exclusion>
-                        <groupId>org.springframework</groupId>
-                        <artifactId>spring-jcl</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
 
             <!-- Explicitly Specify Latest Version of Spring -->
@@ -1218,6 +1211,14 @@
                 <artifactId>spring-core</artifactId>
                 <groupId>org.springframework</groupId>
                 <version>${spring.version}</version>
+                <exclusions>
+                    <!-- Spring JCL is unnecessary and conflicts with commons-logging when both are on classpath.
+                         NOTE: When Spring JCL is on the classpath, this results in Handle Server issues. -->
+                    <exclusion>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-jcl</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>


### PR DESCRIPTION

## References
* Fixes issues with `docker-deploy` caused by merging #11973 (including backports).  This PR was merged too early as it had `docker-deploy` failures which have now propagated to all branches.
* This MUST also be ported to `dspace-9_x` and `dspace-8_x`, as those same changes were merged to those branches in #11976 and #11971, respectively.

## Description
This small PR fixes Handle Server startup issues (occurring in `docker-deploy`) by excluding `spring-jcl` from `spring-core`.  These errors look like this in the output of the `Verify Handle Server is working properly` step of `docker-deploy`:
```
Run docker exec -i dspace /dspace/bin/make-handle-config
Writing simple Handle server configuration
/dspace/bin/make-handle-config: 63: cannot open Standard Commons Logging discovery in action with spring-jcl: please remove commons-logging.jar from classpath in order to avoid potential conflicts
/dspace/handle-server/config.dct: No such file
rm: cannot remove 'Standard': Is a directory
/dspace/bin/make-handle-config: 73: cannot open /tmp/handleconfig108: No such file
Starting Handle Server...
rm: cannot remove 'Standard': Is a directory
/dspace/bin/start-handle-server: 37: cannot create Standard Commons Logging discovery in action with spring-jcl: please remove commons-logging.jar from classpath in order to avoid potential conflicts
/dspace/log/handle-server.log: Directory nonexistent
Checking for errors in error.log
cat: '/dspace/handle-server/logs/error.log*': No such file or directory

Checking for errors in handle-server.log...
cat: /dspace/log/handle-server.log: No such file or directory
Error: Process completed with exit code 1.
```

Simply put, when `spring-jcl` is on the classpath, it results in conflicts with `commons-logging` (which Handle Server relies uses).

This PR also removes a lot of older `spring-jcl` exclusions as they all inherit via `spring-core`.  So, we can exclude this dependency just in one location and it will propagate to other Spring dependencies.


## Instructions for Reviewers
* Verify that `docker-deploy` now succeeds.  If it succeeds, then this has fixed the bug accidentally caused by merging #11973