### PR TITLE
[Port dspace-8_x] Fix OAI-PMH: OpenAIRE XSL crosswalk: bogus resourcetype exposed if the repository uses dc.type.* fields with a qualifier

### DIFF
--- a/dspace/config/crosswalks/oai/metadataFormats/oai_openaire.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/oai_openaire.xsl
@@ -796,7 +796,7 @@
 
     <!-- oaire:resourceType -->
     <!-- https://openaire-guidelines-for-literature-repository-managers.readthedocs.io/en/v4.0.0/field_publicationtype.html -->
-    <xsl:template match="doc:element[@name='dc']/doc:element[@name='type']/doc:element" mode="oaire">
+    <xsl:template match="doc:element[@name='dc']/doc:element[@name='type']/doc:element[doc:field[@name='value']]" mode="oaire">
         <xsl:variable name="resourceTypeGeneral">
             <xsl:call-template name="resolveResourceTypeGeneral">
                 <xsl:with-param name="field" select="./doc:field[@name='value']/text()"/>


### PR DESCRIPTION
Port of #11947 by @AbhinavS96 