### PR TITLE
Add Advisor entity relationship

### DIFF
--- a/dspace/config/entities/relationship-types.xml
+++ b/dspace/config/entities/relationship-types.xml
@@ -33,6 +33,19 @@
     </type>
     <type>
         <leftType>Publication</leftType>
+        <rightType>Person</rightType>
+        <leftwardType>isAdvisorOfPublication</leftwardType>
+        <rightwardType>isPublicationOfAdvisor</rightwardType>
+        <leftCardinality>
+            <min>0</min>
+        </leftCardinality>
+        <rightCardinality>
+            <min>0</min>
+        </rightCardinality>
+        <copyToLeft>true</copyToLeft>
+    </type>
+    <type>
+        <leftType>Publication</leftType>
         <rightType>Project</rightType>
         <leftwardType>isProjectOfPublication</leftwardType>
         <rightwardType>isPublicationOfProject</rightwardType>

--- a/dspace/config/registries/relationship-formats.xml
+++ b/dspace/config/registries/relationship-formats.xml
@@ -261,6 +261,30 @@
         <scope_note>Contains all uuids of PUBLICATIONS which link to the current ISSUE via a "latest" relationship. In other words, this stores all relationships pointing to the current ISSUE from any PUBLICATION, implying that the ISSUE is marked as "latest". Internally used by DSpace to support versioning. Do not manually add, remove or edit values.</scope_note>
     </dc-type>
 
+    <dc-type>
+        <schema>relation</schema>
+        <element>isAdvisorOfPublication</element>
+        <scope_note>Contains all uuids of the "latest" ADVISORS that the current PUBLICATION links to via a relationship. In other words, this stores all relationships pointing from the current PUBLICATION to any ADVISOR where the ADVISOR is marked as "latest". Internally used by DSpace. Do not manually add, remove or edit values.</scope_note>
+    </dc-type>
+    <dc-type>
+        <schema>relation</schema>
+        <element>isAdvisorOfPublication</element>
+        <qualifier>latestForDiscovery</qualifier>
+        <scope_note>Contains all uuids of ADVISORS which link to the current PUBLICATION via a "latest" relationship. In other words, this stores all relationships pointing to the current PUBLICATION from an ADVISOR, implying that the PUBLICATION is marked as "latest". Internally used by DSpace to support versioning. Do not manually add, remove or edit values.</scope_note>
+    </dc-type>
+
+    <dc-type>
+        <schema>relation</schema>
+        <element>isPublicationOfAdvisor</element>
+        <scope_note>Contains all uuids of the "latest" PUBLICATIONS that the current ADVISOR links to via a relationship. In other words, this stores all relationships pointing from the current ADVISOR to any PUBLICATION where the PUBLICATION is marked as "latest". Internally used by DSpace. Do not manually add, remove or edit values.</scope_note>
+    </dc-type>
+    <dc-type>
+        <schema>relation</schema>
+        <element>isPublicationOfAdvisor</element>
+        <qualifier>latestForDiscovery</qualifier>
+        <scope_note>Contains all uuids of PUBLICATIONS which link to the current ADVISOR via a "latest" relationship. In other words, this stores all relationships pointing to the current ADVISOR from any PUBLICATION, implying that the ADVISOR is marked as "latest". Internally used by DSpace to support versioning. Do not manually add, remove or edit values.</scope_note>
+    </dc-type>
+
     <!-- Openaire4 Guidelines - required relationships -->
 
     <dc-type>

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -283,6 +283,9 @@
                 <ref bean="searchFilterIsOrgUnitOfPublicationRelation"/>
                 <ref bean="searchFilterIsPublicationOfJournalIssueRelation"/>
                 <ref bean="searchFilterIsJournalOfPublicationRelation"/>
+                <!-- Uncomment to enable Advisor relationship filter for discovery searches
+                <ref bean="searchFilterIsAdvisorOfPublicationRelation"/>
+                -->
                 <ref bean="searchFilterGeospatialPoint"/>
             </list>
         </property>
@@ -466,6 +469,9 @@
                 <ref bean="searchFilterIsOrgUnitOfPublicationRelation"/>
                 <ref bean="searchFilterIsPublicationOfJournalIssueRelation"/>
                 <ref bean="searchFilterIsJournalOfPublicationRelation"/>
+                <!-- Uncomment to enable Advisor relationship filter for discovery searches
+                <ref bean="searchFilterIsAdvisorOfPublicationRelation"/>
+                -->
             </list>
         </property>
         <!--The sort filters for the discovery search-->
@@ -605,6 +611,9 @@
                 <ref bean="searchFilterIsOrgUnitOfPublicationRelation"/>
                 <ref bean="searchFilterIsPublicationOfJournalIssueRelation"/>
                 <ref bean="searchFilterIsJournalOfPublicationRelation"/>
+                <!-- Uncomment to enable Advisor relationship filter for discovery searches
+                <ref bean="searchFilterIsAdvisorOfPublicationRelation"/>
+                -->
             </list>
         </property>
         <!--The sort filters for the discovery search-->
@@ -751,6 +760,9 @@
                 <ref bean="searchFilterIsOrgUnitOfPublicationRelation"/>
                 <ref bean="searchFilterIsPublicationOfJournalIssueRelation"/>
                 <ref bean="searchFilterIsJournalOfPublicationRelation"/>
+                <!-- Uncomment to enable Advisor relationship filter for discovery searches
+                <ref bean="searchFilterIsAdvisorOfPublicationRelation"/>
+                -->
                 <ref bean="searchFilterNotifyRelation" />
                 <ref bean="searchFilterNotifyEndorsement" />
                 <ref bean="searchFilterNotifyReview" />
@@ -1555,6 +1567,9 @@
                 <ref bean="searchFilterIsOrgUnitOfPublicationRelation"/>
                 <ref bean="searchFilterIsPublicationOfJournalIssueRelation"/>
                 <ref bean="searchFilterIsJournalOfPublicationRelation"/>
+                <!-- Uncomment to enable Advisor relationship filter for discovery searches
+                <ref bean="searchFilterIsAdvisorOfPublicationRelation"/>
+                -->
                 <ref bean="searchFilterIsDatasetOfPublicationRelation"/>
             </list>
         </property>
@@ -1626,6 +1641,9 @@
                 <ref bean="searchFilterIsOrgUnitOfPublicationRelation"/>
                 <ref bean="searchFilterIsPublicationOfJournalIssueRelation"/>
                 <ref bean="searchFilterIsJournalOfPublicationRelation"/>
+                <!-- Uncomment to enable Advisor relationship filter for discovery searches
+                <ref bean="searchFilterIsAdvisorOfPublicationRelation"/>
+                -->
                 <ref bean="searchFilterIsDatasetOfPublicationRelation"/>
             </list>
         </property>

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -3714,6 +3714,28 @@
         <property name="pageSize" value="10"/>
     </bean>
 
+    <bean id="searchFilterIsAdvisorOfPublicationRelation" class="org.dspace.discovery.configuration.DiscoverySearchFilter">
+        <property name="indexFieldName" value="isAdvisorOfPublication"/>
+        <property name="metadataFields">
+            <list>
+                <value>relation.isAdvisorOfPublication.latestForDiscovery</value>
+            </list>
+        </property>
+        <property name="isOpenByDefault" value="false"/>
+        <property name="pageSize" value="10"/>
+    </bean>
+
+    <bean id="searchFilterIsPublicationOfAdvisorRelation" class="org.dspace.discovery.configuration.DiscoverySearchFilter">
+        <property name="indexFieldName" value="isPublicationOfAdvisor"/>
+        <property name="metadataFields">
+            <list>
+                <value>relation.isPublicationOfAdvisor.latestForDiscovery</value>
+            </list>
+        </property>
+        <property name="isOpenByDefault" value="false"/>
+        <property name="pageSize" value="10"/>
+    </bean>
+
     <bean id="searchFilterIsContributorOfPublicationRelation" class="org.dspace.discovery.configuration.DiscoverySearchFilter">
         <property name="indexFieldName" value="isContributorOfPublication"/>
         <property name="metadataFields">

--- a/dspace/config/spring/api/virtual-metadata.xml
+++ b/dspace/config/spring/api/virtual-metadata.xml
@@ -1,3 +1,4 @@
+```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:util="http://www.springframework.org/schema/util"
@@ -13,6 +14,7 @@
             <map>
                 <entry key="isAuthorOfPublication" value-ref="isAuthorOfPublicationMap"/>
                 <entry key="isEditorOfPublication" value-ref="isEditorOfPublicationMap"/>
+                <entry key="isAdvisorOfPublication" value-ref="isAdvisorOfPublicationMap"/>
                 <entry key="isOrgUnitOfPublication" value-ref="isOrgUnitOfPublicationMap"/>
                 <entry key="isPersonOfProject" value-ref="isPersonOfProjectMap"/>
                 <entry key="isOrgUnitOfProject" value-ref="isOrgUnitOfProjectMap"/>
@@ -136,38 +138,16 @@
         </property>
     </bean>
 
-    <!-- Config like this will tell our VirtualMetadataPopulator to include the virtual metadata field
-     'dc.contributor.other' on the appropriate item with the values defined in the value-ref.
-      This value-ref should be a bean of type VirtualMetadataConfiguration -->
-    <util:map id="isOrgUnitOfPublicationMap">
-        <entry key="dc.contributor.other" value-ref="publicationOrgUnit_name"/>
-        <entry key="organization.identifier.ror" value-ref="publicationOrgUnit_ror"/>
-    </util:map>
-    <bean class="org.dspace.content.virtual.Collected" id="publicationOrgUnit_name">
-        <property name="fields">
-            <util:list>
-                <value>organization.legalName</value>
-            </util:list>
-        </property>
-    </bean>
-    <bean class="org.dspace.content.virtual.Collected" id="publicationOrgUnit_ror">
-        <property name="fields">
-            <util:list>
-                <value>organization.identifier.ror</value>
-            </util:list>
-        </property>
-    </bean>
-
-    <util:map id="isPersonOfProjectMap">
-        <entry key="project.investigator" value-ref="projectPerson_author"/>
+    <util:map id="isAdvisorOfPublicationMap">
+        <entry key="dc.contributor.advisor" value-ref="publicationAdvisor_advisor"/>
     </util:map>
     <!--
-     If the related item has:
-        person.familyName = Smith
-        person.givenName = John
-     Then the original item will have, in this case:
-        dc.contributor.author = Smith, John -->
-    <bean class="org.dspace.content.virtual.Concatenate" id="projectPerson_author">
+         If the related item has:
+            person.familyName = Smith
+            person.givenName = John
+         Then the original item will have, in this case:
+            dc.contributor.advisor = Smith, John -->
+    <bean class="org.dspace.content.virtual.Concatenate" id="publicationAdvisor_advisor">
         <property name="fields">
             <util:list>
                 <value>person.familyName</value>
@@ -177,184 +157,7 @@
         <property name="separator">
             <value>, </value>
         </property>
+        <property name="useForPlace" value="true"/>
     </bean>
-
-    <util:map id="isOrgUnitOfProjectMap">
-        <entry key="dc.contributor.other" value-ref="projectOrgUnit_other"/>
-    </util:map>
-    <!-- This Collected bean wil create a list of project.contributor.other virtual metadata fields that hold
-         the value of organization.legalName, each of them in a separate metadatavalue
-         If the related item has:
-            organization.legalName = Generic name
-            organization.legalName = Even more generic name
-         Then the original item will have, in this case:
-            project.contributor.other = Generic name
-            project.contributor.other = Even more generic name -->
-    <bean class="org.dspace.content.virtual.Collected" id="projectOrgUnit_other">
-        <property name="fields">
-            <util:list>
-                <value>organization.legalName</value>
-            </util:list>
-        </property>
-    </bean>
-
-    <util:map id="isOrgUnitOfPersonMap">
-        <entry key="person.contributor.other" value-ref="personProject_other"/>
-    </util:map>
-    <bean class="org.dspace.content.virtual.Collected" id="personProject_other">
-        <property name="fields">
-            <util:list>
-                <value>organization.legalName</value>
-            </util:list>
-        </property>
-    </bean>
-
-    <util:map id="isJournalVolumeOfIssueMap">
-        <entry key="publicationvolume.volumeNumber" value-ref="issueVolume_volume"/>
-        <entry key="creativeworkseries.issn" value-ref="volumeJournal_issn_related"/>
-        <entry key="journal.title" value-ref="volumeJournal_title_related"/>
-    </util:map>
-    <!-- This Collected bean will create a list of publicationVolume.volumeNumber virtual metadata fields that hold
-     the value of publicationVolume.volumeNumber, each of them in a separate metadatavalue
-     If the related item has:
-        publicationVolume.volumeNumber = Generic volume
-        publicationVolume.volumeNumber = Even more generic volume
-     Then the original item will have, in this case:
-        publicationVolume.volumeNumber = Generic volume
-        publicationVolume.volumeNumber = Even more generic volume
-     Note that these metadata fields have the same signature of schema, element and qualifier, but that poses no problem
-     -->
-    <bean class="org.dspace.content.virtual.Collected" id="issueVolume_volume">
-        <property name="fields">
-            <util:list>
-                <value>publicationvolume.volumeNumber</value>
-            </util:list>
-        </property>
-    </bean>
-    <!--    This Related bean defines a relationship type that will be used on a journal issue.
-            The journal issue will receive 2 metadata fields if we look at the map 'isJournalVolumeOfIssueMap' it'll
-            receive the publicationVolume.volumeNumber metadata field and the creativeworkseries.issn metadata field.
-         Since the creativeworkseries.issn metadata field can't be filled in through the metadata of the journalvolume
-         alone, we need to pass this call higher up the chain to the journalvolume's relationships to find the journal.
-         Therefore we've created this Related bean which will look at the journalvolume's relationships with type
-         'isJournalOfVolume' to find the journal that this journalvolume is related to and it'll then call the next
-         VirtualMetadataConfiguration with that journal to retrieve the value. This will leave the retrieving
-         of the values to the next bean in the chain -->
-    <bean class="org.dspace.content.virtual.Related" id="volumeJournal_issn_related">
-        <property name="relationshipTypeString" value="isJournalOfVolume"/>
-        <property name="virtualMetadataConfiguration" ref="volumeJournal_issn"/>
-    </bean>
-
-    <bean class="org.dspace.content.virtual.Related" id="volumeJournal_title_related">
-        <property name="relationshipTypeString" value="isJournalOfVolume"/>
-        <property name="virtualMetadataConfiguration" ref="volumeJournal_title"/>
-    </bean>
-
-    <util:map id="isJournalOfVolumeMap">
-        <entry key="creativeworkseries.issn" value-ref="volumeJournal_issn"/>
-        <entry key="journal.title" value-ref="volumeJournal_title"/>
-    </util:map>
-    <bean class="org.dspace.content.virtual.Collected" id="volumeJournal_issn">
-        <property name="fields">
-            <util:list>
-                <value>creativeworkseries.issn</value>
-            </util:list>
-        </property>
-    </bean>
-    <bean class="org.dspace.content.virtual.Collected" id="volumeJournal_title">
-        <property name="fields">
-            <util:list>
-                <value>dc.title</value>
-            </util:list>
-        </property>
-    </bean>
-
-    <util:map id="isVolumeOfJournalMap">
-    </util:map>
-
-    <util:map id="isIssueOfJournalVolumeMap">
-        <entry key="publicationissue.issueNumber" value-ref="journalIssue_number"/>
-    </util:map>
-    <bean class="org.dspace.content.virtual.Collected" id="journalIssue_number">
-        <property name="fields">
-            <util:list>
-                <value>publicationissue.issueNumber</value>
-            </util:list>
-        </property>
-    </bean>
-
-    <util:map id="isJournalIssueOfPublicationMap">
-        <entry key="creativeworkseries.issn"  value-ref="issueVolumeJournal_issn_related"/>
-        <entry key="journal.title"  value-ref="issueVolumeJournal_title_related"/>
-        <entry key="journalvolume.identifier.name" value-ref="issueVolume_title_related"/>
-        <entry key="relation.isJournalOfPublication" value-ref="issueVolumeJournal_uuid_related"/>
-    </util:map>
-    <bean class="org.dspace.content.virtual.Concatenate" id="issueVolume_title">
-        <property name="fields">
-            <util:list>
-                <value>dc.title</value>
-            </util:list>
-        </property>
-        <property name="separator">
-            <value>, </value>
-        </property>
-    </bean>
-
-    <util:map id="isDatasetOfPublicationMap">
-        <entry key="dc.relation.isbasedon" value-ref="relatedEntityIdentifier_uri"/>
-    </util:map>
-    <util:map id="isPublicationOfDatasetMap">
-        <entry key="dc.relation.isreferencedby" value-ref="relatedEntityIdentifier_uri"/>
-    </util:map>
-    <!-- This Collected bean will create a list of dc.identifier.uri virtual metadata fields that hold the value of
-    Create new scratch file from selection, each of them in a separate metadata value.
-    If the related item has:
-        dc.relation.isbasedon/isreferencedby = https://demo.dspace.org/handle/123456789/123
-    Then the original item will have, in this case:
-        dc.identifier.uri = https://demo.dspace.org/handle/123456789/123
-    -->
-    <bean class="org.dspace.content.virtual.Collected" id="relatedEntityIdentifier_uri">
-        <property name="fields">
-            <util:list>
-                <value>dc.identifier.uri</value>
-            </util:list>
-        </property>
-    </bean>
-
-    <!-- This Related bean defines a relationship type that will be used on a publication.
-        The publication will receive 1 virtual metadata value namely the creativeworkseries.issn to which it belongs
-     Since the creativeworkseries.issn metadata field can't be filled in through the metadata of the journalIssue
-     alone, we need to pass this call higher up the chain to the journalissue's relationships to find the journal.
-     Therefore we've created this Related bean which will look at the journalissue's relationships with type
-     'isJournalVolumeOfIssue' to find the journalvolume that this journalissue is related to and it'll then call the next
-     VirtualMetadataConfiguration with that journalvolume to retrieve the value. This will leave the retrieving
-     of the values to the next bean in the chain.
-     In this specific case, it'll call another Related bean to retrieve the journal for the journalvolume and it'll
-     then retrieve the volume. This example has 2 Related beans chained to eachother to finally chain to a Collected
-     bean to retrieve the final value -->
-    <bean class="org.dspace.content.virtual.Related" id="issueVolumeJournal_issn_related">
-        <property name="relationshipTypeString" value="isJournalVolumeOfIssue"/>
-        <property name="virtualMetadataConfiguration" ref="volumeJournal_issn_related"/>
-    </bean>
-
-    <bean class="org.dspace.content.virtual.Related" id="issueVolumeJournal_title_related">
-        <property name="relationshipTypeString" value="isJournalVolumeOfIssue"/>
-        <property name="virtualMetadataConfiguration" ref="volumeJournal_title_related"/>
-    </bean>
-
-    <bean class="org.dspace.content.virtual.Related" id="issueVolume_title_related">
-        <property name="relationshipTypeString" value="isJournalVolumeOfIssue"/>
-        <property name="virtualMetadataConfiguration" ref="issueVolume_title"/>
-    </bean>
-
-    <bean class="org.dspace.content.virtual.Related" id="issueVolumeJournal_uuid_related">
-        <property name="relationshipTypeString" value="isJournalVolumeOfIssue"/>
-        <property name="virtualMetadataConfiguration" ref="volumeJournal_uuid_related"/>
-    </bean>
-
-    <bean class="org.dspace.content.virtual.Related" id="volumeJournal_uuid_related">
-        <property name="relationshipTypeString" value="isJournalOfVolume"/>
-        <property name="virtualMetadataConfiguration" ref="volumeJournal_uuid"/>
-    </bean>
-    <bean class="org.dspace.content.virtual.UUIDValue" id="volumeJournal_uuid"/>
 </beans>
+```

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -289,6 +289,22 @@
               </row>
               -->
             <row>
+                <relation-field>
+                    <relationship-type>isAdvisorOfPublication</relationship-type>
+                    <search-configuration>person</search-configuration>
+                    <repeatable>true</repeatable>
+                    <label>Advisor</label>
+                    <hint>Enter the advisor's name (Family name, Given names).</hint>
+                    <linked-metadata-field>
+                        <dc-schema>dc</dc-schema>
+                        <dc-element>contributor</dc-element>
+                        <dc-qualifier>advisor</dc-qualifier>
+                        <input-type>onebox</input-type>
+                    </linked-metadata-field>
+                    <required></required>
+                </relation-field>
+            </row>
+            <row>
                 <field>
                     <dc-schema>dc</dc-schema>
                     <dc-element>title</dc-element>

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -288,6 +288,8 @@
                 </relation-field>
               </row>
               -->
+            <!-- Uncomment this block to enable the Advisor field on your submission form.
+                 This adds a relationship lookup for advisor entities linked to publications.
             <row>
                 <relation-field>
                     <relationship-type>isAdvisorOfPublication</relationship-type>
@@ -304,6 +306,7 @@
                     <required></required>
                 </relation-field>
             </row>
+            -->
             <row>
                 <field>
                     <dc-schema>dc</dc-schema>


### PR DESCRIPTION
## Summary

Adds support for linking advisors to publications through a new entity relationship type. This enables DSpace to track and manage publication-advisor relationships alongside other entity types.

## Changes

- **relationship-types.xml**: Define new relationship type between Publication and Person entities with `isAdvisorOfPublication` and `isPublicationOfAdvisor` relationship labels
- **relationship-formats.xml**: Register metadata formats for the advisor relationship in the relation schema
- **discovery.xml**: Configure discovery indexing for advisor relationships
- **virtual-metadata.xml**: Add virtual metadata mappings for advisor relationship traversal
- **submission-forms.xml**: Enable advisor relationship selection in submission forms

The implementation follows the existing DSpace relationship patterns and cardinality constraints.

Fixes #11982