### PR TITLE
Add Advisor entity relationship

### DIFF
--- a/dspace/config/entities/relationship-types.xml
+++ b/dspace/config/entities/relationship-types.xml
@@ -20,6 +20,19 @@
     </type>
     <type>
         <leftType>Publication</leftType>
+        <rightType>Person</rightType>
+        <leftwardType>isAdvisorOfPublication</leftwardType>
+        <rightwardType>isPublicationOfAdvisor</rightwardType>
+        <leftCardinality>
+            <min>0</min>
+        </leftCardinality>
+        <rightCardinality>
+            <min>0</min>
+        </rightCardinality>
+        <copyToLeft>true</copyToLeft>
+    </type>
+    <type>
+        <leftType>Publication</leftType>
         <rightType>Project</rightType>
         <leftwardType>isProjectOfPublication</leftwardType>
         <rightwardType>isPublicationOfProject</rightwardType>

--- a/dspace/config/registries/relationship-formats.xml
+++ b/dspace/config/registries/relationship-formats.xml
@@ -35,6 +35,30 @@
 
     <dc-type>
         <schema>relation</schema>
+        <element>isAdvisorOfPublication</element>
+        <scope_note>Contains all uuids of the "latest" ADVISORS that the current PUBLICATION links to via a relationship. In other words, this stores all relationships pointing from the current PUBLICATION to any ADVISOR where the ADVISOR is marked as "latest". Internally used by DSpace. Do not manually add, remove or edit values.</scope_note>
+    </dc-type>
+    <dc-type>
+        <schema>relation</schema>
+        <element>isAdvisorOfPublication</element>
+        <qualifier>latestForDiscovery</qualifier>
+        <scope_note>Contains all uuids of ADVISORS which link to the current PUBLICATION via a "latest" relationship. In other words, this stores all relationships pointing to the current PUBLICATION from an ADVISOR, implying that the PUBLICATION is marked as "latest". Internally used by DSpace to support versioning. Do not manually add, remove or edit values.</scope_note>
+    </dc-type>
+
+    <dc-type>
+        <schema>relation</schema>
+        <element>isPublicationOfAdvisor</element>
+        <scope_note>Contains all uuids of the "latest" PUBLICATIONS that the current ADVISOR links to via a relationship. In other words, this stores all relationships pointing from the current ADVISOR to any PUBLICATION where the PUBLICATION is marked as "latest". Internally used by DSpace. Do not manually add, remove or edit values.</scope_note>
+    </dc-type>
+    <dc-type>
+        <schema>relation</schema>
+        <element>isPublicationOfAdvisor</element>
+        <qualifier>latestForDiscovery</qualifier>
+        <scope_note>Contains all uuids of PUBLICATIONS which link to the current ADVISOR via a "latest" relationship. In other words, this stores all relationships pointing to the current ADVISOR from any PUBLICATION, implying that the ADVISOR is marked as "latest". Internally used by DSpace to support versioning. Do not manually add, remove or edit values.</scope_note>
+    </dc-type>
+
+    <dc-type>
+        <schema>relation</schema>
         <element>isProjectOfPublication</element>
         <scope_note>Contains all uuids of the "latest" PROJECTS that the current PUBLICATION links to via a relationship. In other words, this stores all relationships pointing from the current PUBLICATION to any PROJECT where the PROJECT is marked as "latest". Internally used by DSpace. Do not manually add, remove or edit values.</scope_note>
     </dc-type>

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -217,6 +217,7 @@
                 <ref bean="searchFilterEntityType"/>
                 <ref bean="searchFilterAccessStatus" />
                 <ref bean="searchFilterIsAuthorOfPublicationRelation"/>
+                <ref bean="searchFilterIsAdvisorOfPublicationRelation"/>
                 <ref bean="searchFilterIsProjectOfPublicationRelation"/>
                 <ref bean="searchFilterIsOrgUnitOfPublicationRelation"/>
                 <ref bean="searchFilterIsPublicationOfJournalIssueRelation"/>
@@ -400,6 +401,7 @@
                 <ref bean="searchFilterFileDescriptionInOriginalBundle" />
                 <ref bean="searchFilterEntityType"/>
                 <ref bean="searchFilterIsAuthorOfPublicationRelation"/>
+                <ref bean="searchFilterIsAdvisorOfPublicationRelation"/>
                 <ref bean="searchFilterIsProjectOfPublicationRelation"/>
                 <ref bean="searchFilterIsOrgUnitOfPublicationRelation"/>
                 <ref bean="searchFilterIsPublicationOfJournalIssueRelation"/>
@@ -539,6 +541,7 @@
                 <ref bean="searchFilterFileDescriptionInOriginalBundle" />
                 <ref bean="searchFilterEntityType"/>
                 <ref bean="searchFilterIsAuthorOfPublicationRelation"/>
+                <ref bean="searchFilterIsAdvisorOfPublicationRelation"/>
                 <ref bean="searchFilterIsProjectOfPublicationRelation"/>
                 <ref bean="searchFilterIsOrgUnitOfPublicationRelation"/>
                 <ref bean="searchFilterIsPublicationOfJournalIssueRelation"/>
@@ -685,6 +688,7 @@
                 <ref bean="searchFilterFileDescriptionInOriginalBundle" />
                 <ref bean="searchFilterEntityType"/>
                 <ref bean="searchFilterIsAuthorOfPublicationRelation"/>
+                <ref bean="searchFilterIsAdvisorOfPublicationRelation"/>
                 <ref bean="searchFilterIsProjectOfPublicationRelation"/>
                 <ref bean="searchFilterIsOrgUnitOfPublicationRelation"/>
                 <ref bean="searchFilterIsPublicationOfJournalIssueRelation"/>
@@ -1202,6 +1206,7 @@
                 <ref bean="searchFilterFileDescriptionInOriginalBundle" />
                 <ref bean="searchFilterEntityType"/>
                 <ref bean="searchFilterIsAuthorOfPublicationRelation"/>
+                <ref bean="searchFilterIsAdvisorOfPublicationRelation"/>
                 <ref bean="searchFilterIsProjectOfPublicationRelation"/>
                 <ref bean="searchFilterIsOrgUnitOfPublicationRelation"/>
                 <ref bean="searchFilterIsPublicationOfJournalIssueRelation"/>
@@ -1272,6 +1277,7 @@
                 <ref bean="searchFilterFileDescriptionInOriginalBundle" />
                 <ref bean="searchFilterEntityType"/>
                 <ref bean="searchFilterIsAuthorOfPublicationRelation"/>
+                <ref bean="searchFilterIsAdvisorOfPublicationRelation"/>
                 <ref bean="searchFilterIsProjectOfPublicationRelation"/>
                 <ref bean="searchFilterIsOrgUnitOfPublicationRelation"/>
                 <ref bean="searchFilterIsPublicationOfJournalIssueRelation"/>
@@ -2567,6 +2573,17 @@
         <property name="metadataFields">
             <list>
                 <value>relation.isAuthorOfPublication.latestForDiscovery</value>
+            </list>
+        </property>
+        <property name="isOpenByDefault" value="false"/>
+        <property name="pageSize" value="10"/>
+    </bean>
+
+    <bean id="searchFilterIsAdvisorOfPublicationRelation" class="org.dspace.discovery.configuration.DiscoverySearchFilter">
+        <property name="indexFieldName" value="isAdvisorOfPublication"/>
+        <property name="metadataFields">
+            <list>
+                <value>relation.isAdvisorOfPublication.latestForDiscovery</value>
             </list>
         </property>
         <property name="isOpenByDefault" value="false"/>

--- a/dspace/config/spring/api/virtual-metadata.xml
+++ b/dspace/config/spring/api/virtual-metadata.xml
@@ -12,6 +12,7 @@
                  are to be added to the item that has a relationship with this relationship type-->
             <map>
                 <entry key="isAuthorOfPublication" value-ref="isAuthorOfPublicationMap"/>
+                <entry key="isAdvisorOfPublication" value-ref="isAdvisorOfPublicationMap"/>
                 <entry key="isOrgUnitOfPublication" value-ref="isOrgUnitOfPublicationMap"/>
                 <entry key="isPersonOfProject" value-ref="isPersonOfProjectMap"/>
                 <entry key="isOrgUnitOfProject" value-ref="isOrgUnitOfProjectMap"/>
@@ -68,6 +69,26 @@
                 <value>person.identifier.orcid</value>
             </util:list>
         </property>
+    </bean>
+
+    <!-- Config like this will tell our VirtualMetadataPopulator to include the virtual metadata field
+         'dc.contributor.advisor' on the appropriate item with the values defined in the value-ref.
+          This value-ref should be a bean of type VirtualMetadataConfiguration -->
+    <util:map id="isAdvisorOfPublicationMap">
+        <entry key="dc.contributor.advisor" value-ref="publicationAdvisor_advisor"/>
+    </util:map>
+    <bean class="org.dspace.content.virtual.Concatenate" id="publicationAdvisor_advisor">
+        <property name="fields">
+            <util:list>
+                <value>person.familyName</value>
+                <value>person.givenName</value>
+            </util:list>
+        </property>
+        <property name="separator">
+            <value>, </value>
+        </property>
+        <property name="useForPlace" value="true"/>
+        <property name="populateWithNameVariant" value="true"/>
     </bean>
 
     <!-- Config like this will tell our VirtualMetadataPopulator to include the virtual metadata field

--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -266,6 +266,23 @@
                 </relation-field>
             </row>
             <row>
+                <relation-field>
+                    <relationship-type>isAdvisorOfPublication</relationship-type>
+                    <search-configuration>person</search-configuration>
+                    <repeatable>true</repeatable>
+                    <label>Advisor</label>
+                    <hint>Enter the advisor's name (Family name, Given names).</hint>
+                    <linked-metadata-field>
+                        <dc-schema>dc</dc-schema>
+                        <dc-element>contributor</dc-element>
+                        <dc-qualifier>advisor</dc-qualifier>
+                        <input-type>onebox</input-type>
+                    </linked-metadata-field>
+                    <externalsources>orcid</externalsources>
+                    <required></required>
+                </relation-field>
+            </row>
+            <row>
                 <field>
                     <dc-schema>dc</dc-schema>
                     <dc-element>title</dc-element>


### PR DESCRIPTION
## Overview
Implements support for linking publications to their advisors through a new entity relationship type.

## Changes
Adds configuration for the Advisor entity relationship between Publications and Persons:

- **Relationship types**: Defines bidirectional relationship `isAdvisorOfPublication` / `isPublicationOfAdvisor` with flexible cardinality (0 or more on both sides)
- **Metadata formats**: Registers `relation.isAdvisorOfPublication` and `relation.isAdvisorOfPublication.latestForDiscovery` for indexing and versioning support
- **Discovery**: Configures faceting and discovery indexing for advisor relationships
- **Virtual metadata**: Sets up virtual metadata resolution for advisor relationships
- **Submission forms**: Adds UI support for selecting advisors during publication submission

## Why
This enables proper tracking of academic advisory relationships in the repository, allowing users to associate publications with their advisors and maintain institutional knowledge about advising activities.

## Testing
Configuration updates allow publications and advisor persons to be linked through the relationship system with appropriate discovery and display support.

Fixes #11982