### PR TITLE
Allow other groups to view hidden metadata fields

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/MetadataExposureServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/MetadataExposureServiceImpl.java
@@ -14,10 +14,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.commons.lang3.StringUtils;
+
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.util.service.MetadataExposureService;
 import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.core.Context;
+import org.dspace.eperson.service.GroupService;
 import org.dspace.services.ConfigurationService;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -71,6 +74,9 @@ public class MetadataExposureServiceImpl implements MetadataExposureService {
     @Autowired(required = true)
     protected ConfigurationService configurationService;
 
+    @Autowired(required = true)
+    protected GroupService groupService;
+
     protected MetadataExposureServiceImpl() {
 
     }
@@ -98,8 +104,23 @@ public class MetadataExposureServiceImpl implements MetadataExposureService {
         }
 
         if (hidden && context != null) {
-            // the administrator's override
+            // administrator's override: admins can always see hidden fields
             hidden = !authorizeService.isAdmin(context);
+        }
+
+        if (hidden && context != null) {
+            // group-based override: members of any group listed in metadata.hide.groups
+            // are also allowed to see hidden metadata fields
+            String groupsConfig = configurationService.getProperty("metadata.hide.groups");
+            if (StringUtils.isNotBlank(groupsConfig)) {
+                for (String groupName : groupsConfig.split(",")) {
+                    String trimmedGroupName = groupName.trim();
+                    if (StringUtils.isNotBlank(trimmedGroupName) && groupService.isMember(context, trimmedGroupName)) {
+                        hidden = false;
+                        break;
+                    }
+                }
+            }
         }
 
         return hidden;
@@ -130,6 +151,10 @@ public class MetadataExposureServiceImpl implements MetadataExposureService {
             List<String> propertyKeys = configurationService.getPropertyKeys();
             for (String key : propertyKeys) {
                 if (key.startsWith(CONFIG_PREFIX)) {
+                    // Skip control keys that share the prefix but are not field-hiding directives
+                    if (key.equals("metadata.hide.groups")) {
+                        continue;
+                    }
                     if (configurationService.getBooleanProperty(key, true)) {
                         String mdField = key.substring(CONFIG_PREFIX.length());
                         String segment[] = mdField.split("\\.", 3);

--- a/dspace-api/src/main/java/org/dspace/app/util/MetadataExposureServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/MetadataExposureServiceImpl.java
@@ -109,13 +109,21 @@ public class MetadataExposureServiceImpl implements MetadataExposureService {
         }
 
         if (hidden && context != null) {
-            // group-based override: members of any group listed in metadata.hide.groups
-            // are also allowed to see hidden metadata fields
-            String groupsConfig = configurationService.getProperty("metadata.hide.groups");
+            // Group-based override: resolve which groups list to use.
+            // Per-field key (metadata.hide.schema.element[.qualifier].groups) takes
+            // precedence over the global key (metadata.hide.groups).
+            // If neither is set the field remains hidden for non-admins.
+            String perFieldKey = CONFIG_PREFIX + schema + "." + element
+                    + (qualifier != null ? "." + qualifier : "") + ".groups";
+            String groupsConfig = configurationService.getProperty(perFieldKey);
+            if (StringUtils.isBlank(groupsConfig)) {
+                groupsConfig = configurationService.getProperty("metadata.hide.groups");
+            }
             if (StringUtils.isNotBlank(groupsConfig)) {
                 for (String groupName : groupsConfig.split(",")) {
                     String trimmedGroupName = groupName.trim();
-                    if (StringUtils.isNotBlank(trimmedGroupName) && groupService.isMember(context, trimmedGroupName)) {
+                    if (StringUtils.isNotBlank(trimmedGroupName)
+                            && groupService.isMember(context, trimmedGroupName)) {
                         hidden = false;
                         break;
                     }
@@ -151,8 +159,10 @@ public class MetadataExposureServiceImpl implements MetadataExposureService {
             List<String> propertyKeys = configurationService.getPropertyKeys();
             for (String key : propertyKeys) {
                 if (key.startsWith(CONFIG_PREFIX)) {
-                    // Skip control keys that share the prefix but are not field-hiding directives
-                    if (key.equals("metadata.hide.groups")) {
+                    // Skip group-access control keys (global and per-field) that share
+                    // the prefix but are not field-hiding directives.
+                    // e.g. metadata.hide.groups  or  metadata.hide.dc.title.groups
+                    if (key.endsWith(".groups")) {
                         continue;
                     }
                     if (configurationService.getBooleanProperty(key, true)) {

--- a/dspace-api/src/main/java/org/dspace/ctask/general/CleanMetadata.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/CleanMetadata.java
@@ -1,0 +1,344 @@
+/*
+ * CleanMetadata.java
+ *
+ * DSpace 9 Curation Task
+ * ----------------------
+ * Standardizes metadata field values on every Item it processes by:
+ *
+ *   1. QUOTES     — converts curly/smart quote variants to plain straight quotes
+ *                   (applies to ALL metadata fields)
+ *
+ *   2. DASHES     — converts double hyphens (--) to em dashes (—)
+ *                   (applies only to fields listed in cleanmetadata.cfg)
+ *                   Sequences of three or more hyphens (---) are preserved
+ *                   because they are often legal-document placeholders.
+ *
+ *   3. WHITESPACE — strips leading/trailing spaces and collapses internal
+ *                   runs of two or more spaces to a single space
+ *                   (applies to ALL metadata fields)
+ *
+ * Configuration file: [dspace]/config/modules/cleanmetadata.cfg
+ *
+ * Registration (curate.cfg):
+ *   plugin.named.org.dspace.curate.CurationTask = \
+ *       org.dspace.ctask.general.CleanMetadata = cleanmetadata
+ *
+ * CLI usage:
+ *   [dspace]/bin/dspace curate -t cleanmetadata -i all
+ *   [dspace]/bin/dspace curate -t cleanmetadata -i hdl:123456789/1
+ *
+ * Return codes:
+ *   Curator.CURATE_SUCCESS  — item processed; changes may or may not have been made
+ *   Curator.CURATE_SKIP     — DSO is not an Item (Community / Collection); skipped
+ *   Curator.CURATE_ERROR    — an unexpected exception occurred
+ *
+ * Author  : Generated for DSpace 9 metadata preparation
+ * Licence : MIT — free to use and modify
+ */
+package org.dspace.ctask.general;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import org.dspace.content.DSpaceObject;
+import org.dspace.content.Item;
+import org.dspace.content.MetadataValue;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.ItemService;
+import org.dspace.handle.factory.HandleServiceFactory;
+import org.dspace.handle.service.HandleService;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+import org.dspace.curate.AbstractCurationTask;
+import org.dspace.curate.Curator;
+import org.dspace.curate.Distributive;
+
+/**
+ * Curation task that standardizes quotation marks, dashes, and whitespace
+ * in DSpace Item metadata fields to prepare for or maintain Solr-consistent
+ * indexing in DSpace Discovery.
+ *
+ * Annotated with @Distributive so that when applied to a Collection or
+ * Community the curation system automatically applies it to every Item
+ * within that container.
+ */
+@Distributive
+public class CleanMetadata extends AbstractCurationTask {
+
+    private static final Logger log = LogManager.getLogger(CleanMetadata.class);
+
+    // ── Services ─────────────────────────────────────────────────────────────
+
+    private final ItemService itemService =
+            ContentServiceFactory.getInstance().getItemService();
+
+    private final HandleService handleService =
+            HandleServiceFactory.getInstance().getHandleService();
+
+    // ── Regex patterns ────────────────────────────────────────────────────────
+
+    /**
+     * All curly/smart quote Unicode characters that should become straight quotes.
+     * U+201C "  U+201D "  U+201E „  U+2033 ″   → U+0022 "
+     * U+2018 '  U+2019 '  U+201A ‚  U+2032 ′   → U+0027 '
+     */
+    private static final Pattern CURLY_DOUBLE_PATTERN =
+            Pattern.compile("[\u201C\u201D\u201E\u2033]");
+
+    private static final Pattern CURLY_SINGLE_PATTERN =
+            Pattern.compile("[\u2018\u2019\u201A\u2032]");
+
+    /**
+     * Exactly two hyphens NOT preceded or followed by another hyphen.
+     * Matches:  word--word   text -- text
+     * Skips:    ------   ---   (legal placeholders)
+     */
+    private static final Pattern DOUBLE_HYPHEN_PATTERN =
+            Pattern.compile("(?<!-)-{2}(?!-)");
+
+    /** Two or more consecutive space characters (U+0020). */
+    private static final Pattern MULTI_SPACE_PATTERN =
+            Pattern.compile(" {2,}");
+
+    // ── Configuration keys (resolved from cleanmetadata.cfg) ─────────────────
+
+    /** Comma-separated list of fields to apply dash normalization to. */
+    private static final String PROP_DASH_FIELDS    = "dash.fields";
+
+    /** Set to "false" to disable quote normalization. Default: true. */
+    private static final String PROP_FIX_QUOTES     = "fix.quotes";
+
+    /** Set to "false" to disable dash normalization. Default: true. */
+    private static final String PROP_FIX_DASHES     = "fix.dashes";
+
+    /** Set to "false" to disable whitespace normalization. Default: true. */
+    private static final String PROP_FIX_WHITESPACE = "fix.whitespace";
+
+    // ── Runtime configuration (loaded in init()) ──────────────────────────────
+
+    private Set<String> dashFields    = new HashSet<>();
+    private boolean     fixQuotes     = true;
+    private boolean     fixDashes     = true;
+    private boolean     fixWhitespace = true;
+
+    // ── Default dash target fields ────────────────────────────────────────────
+
+    private static final List<String> DEFAULT_DASH_FIELDS = Arrays.asList(
+            "dc.description.abstract",
+            "dc.description.lawtext",
+            "dc.description.summary",
+            "dc.title"
+    );
+
+    // ── Lifecycle ─────────────────────────────────────────────────────────────
+
+    /**
+     * Called once before the task begins processing objects.
+     * Reads configuration from cleanmetadata.cfg via taskProperty().
+     */
+    @Override
+    public void init(Curator curator, String taskId) throws IOException {
+        super.init(curator, taskId);
+
+        // Read boolean flags
+        fixQuotes     = taskBooleanProperty(PROP_FIX_QUOTES,     true);
+        fixDashes     = taskBooleanProperty(PROP_FIX_DASHES,     true);
+        fixWhitespace = taskBooleanProperty(PROP_FIX_WHITESPACE, true);
+
+        // Read dash target fields; fall back to defaults if not configured
+        String dashFieldsCfg = taskProperty(PROP_DASH_FIELDS);
+        if (dashFieldsCfg != null && !dashFieldsCfg.isBlank()) {
+            for (String f : dashFieldsCfg.split(",")) {
+                dashFields.add(f.trim());
+            }
+        } else {
+            dashFields.addAll(DEFAULT_DASH_FIELDS);
+        }
+
+        log.info("CleanMetadata init — fix.quotes={}, fix.dashes={}, " +
+                "fix.whitespace={}, dash.fields={}",
+                fixQuotes, fixDashes, fixWhitespace, dashFields);
+    }
+
+    // ── Main entry point ──────────────────────────────────────────────────────
+
+    /**
+     * Processes a single DSpaceObject.
+     * Non-Item objects (Communities, Collections) are skipped; the
+     * @Distributive annotation ensures child Items are still visited.
+     *
+     * @param dso the object to process
+     * @return a Curator status code
+     */
+    @Override
+    public int perform(DSpaceObject dso) throws IOException {
+
+        Context context = Curator.curationContext();
+
+        // Skip anything that is not an Item
+        if (dso.getType() != Constants.ITEM) {
+            setResult("Skipped — not an Item: " + getHandle(context, dso));
+            return Curator.CURATE_SKIP;
+        }
+
+        Item item = (Item) dso;
+        String handle = getHandle(context, item);
+
+        List<String> changeLog  = new ArrayList<>();
+        int          totalFixed = 0;
+
+        try {
+            // Iterate over a snapshot of the item's metadata values
+            List<MetadataValue> values =
+                    itemService.getMetadata(item, Item.ANY, Item.ANY, Item.ANY, Item.ANY);
+
+            for (MetadataValue mv : values) {
+
+                String original = mv.getValue();
+                if (original == null || original.isEmpty()) {
+                    continue;
+                }
+
+                // Build the fully qualified field name for logging and config lookup
+                String fieldName = buildFieldName(mv);
+
+                String cleaned = original;
+
+                // Step 1 — Quotes (all fields)
+                if (fixQuotes) {
+                    cleaned = normalizeQuotes(cleaned);
+                }
+
+                // Step 2 — Dashes (configured fields only)
+                if (fixDashes && dashFields.contains(fieldName)) {
+                    cleaned = normalizeDashes(cleaned);
+                }
+
+                // Step 3 — Whitespace (all fields)
+                if (fixWhitespace) {
+                    cleaned = normalizeWhitespace(cleaned);
+                }
+
+                // Persist the change if the value actually changed
+                if (!cleaned.equals(original)) {
+                    mv.setValue(cleaned);
+                    totalFixed++;
+                    changeLog.add(String.format(
+                            "  [%s] row=%d  \"%s\"  →  \"%s\"",
+                            fieldName,
+                            mv.getPlace(),
+                            truncate(original, 60),
+                            truncate(cleaned, 60)
+                    ));
+                }
+            }
+
+            // Persist all changes on the item in one database write
+            if (totalFixed > 0) {
+                itemService.update(context, item);
+                context.commit();
+                log.info("Item {} updated with {} cleaned value(s).", handle, totalFixed);
+            }
+
+        } catch (SQLException e) {
+            log.error("SQL error processing item {}: {}", handle, e.getMessage(), e);
+            setResult("Error: " + e.getMessage());
+            return Curator.CURATE_ERROR;
+        }
+
+        // Build and store the result string for reporting
+        String result;
+        if (totalFixed == 0) {
+            result = "Item " + handle + " — no changes needed.";
+        } else {
+            StringBuilder sb = new StringBuilder();
+            sb.append("Item ").append(handle)
+              .append(" — ").append(totalFixed).append(" value(s) cleaned:\n");
+            changeLog.forEach(sb::append);
+            result = sb.toString();
+        }
+
+        log.info(result);
+        setResult(result);
+        report(result);
+        return Curator.CURATE_SUCCESS;
+    }
+
+    // ── Normalization helpers ─────────────────────────────────────────────────
+
+    /**
+     * Converts all curly/smart quote variants to plain straight equivalents.
+     * Double curly variants → U+0022 (")
+     * Single curly variants → U+0027 (')
+     */
+    private String normalizeQuotes(String value) {
+        String result = CURLY_DOUBLE_PATTERN.matcher(value).replaceAll("\"");
+        result        = CURLY_SINGLE_PATTERN.matcher(result).replaceAll("'");
+        return result;
+    }
+
+    /**
+     * Converts exactly two consecutive hyphens (--) to an em dash (—).
+     * Sequences of three or more hyphens are left untouched.
+     */
+    private String normalizeDashes(String value) {
+        return DOUBLE_HYPHEN_PATTERN.matcher(value).replaceAll("\u2014");
+    }
+
+    /**
+     * Strips leading and trailing spaces and collapses internal runs of
+     * two or more spaces to a single space.
+     */
+    private String normalizeWhitespace(String value) {
+        return MULTI_SPACE_PATTERN.matcher(value.strip()).replaceAll(" ");
+    }
+
+    // ── Utility helpers ───────────────────────────────────────────────────────
+
+    /**
+     * Builds the dot-separated Dublin Core field name from a MetadataValue,
+     * e.g. "dc.description.abstract" or "dc.title".
+     */
+    private String getHandle(Context context, DSpaceObject dso) {
+        if (context == null || dso == null) {
+            return null;
+        }
+        try {
+            return handleService.findHandle(context, dso);
+        } catch (SQLException e) {
+            log.warn("Unable to resolve handle for {}: {}", dso.getID(), e.getMessage());
+            return null;
+        }
+    }
+
+    private String buildFieldName(MetadataValue mv) {
+        String schema    = mv.getMetadataField().getMetadataSchema().getName();
+        String element   = mv.getMetadataField().getElement();
+        String qualifier = mv.getMetadataField().getQualifier();
+
+        if (qualifier == null || qualifier.isBlank()) {
+            return schema + "." + element;
+        }
+        return schema + "." + element + "." + qualifier;
+    }
+
+    /**
+     * Truncates a string to the given length, appending "..." if truncated.
+     */
+    private String truncate(String s, int max) {
+        if (s == null) {
+            return "";
+        }
+        return s.length() <= max ? s : s.substring(0, max) + "...";
+    }
+}

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1013,7 +1013,7 @@ metadata.hide.person.email = true
 # Per-field group override: allows a specific comma-separated list of groups to
 # view a single hidden field. When set, this takes precedence over the global
 # metadata.hide.groups setting above for that specific field only.
-# Format: metadata.hide.SCHEMA.ELEMENT[.QUALIFIER].groups = Group1, Group2
+# Format: metadata.hide.[SCHEMA].[ELEMENT].[QUALIFIER].groups = Group1, Group2
 # Examples:
 #   metadata.hide.dc.description.provenance.groups = Librarians
 #   metadata.hide.person.email.groups = LibraryStaff, HRTeam

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -17,7 +17,7 @@
 
 # DSpace installation directory
 # Windows note: Please remember to use forward slashes for all paths (e.g. C:/dspace)
-dspace.dir = /opt/dspace-9
+dspace.dir = /dspace
 
 # Public URL of DSpace backend ('server' webapp). May require a port number if not using standard ports (80 or 443)
 # DO NOT end it with '/'.

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -17,7 +17,7 @@
 
 # DSpace installation directory
 # Windows note: Please remember to use forward slashes for all paths (e.g. C:/dspace)
-dspace.dir = /dspace
+dspace.dir = /opt/dspace-9
 
 # Public URL of DSpace backend ('server' webapp). May require a port number if not using standard ports (80 or 443)
 # DO NOT end it with '/'.
@@ -1002,6 +1002,13 @@ webui.licence_bundle.show = false
 # private and is mainly of interest to administrators:
 metadata.hide.dc.description.provenance = true
 metadata.hide.person.email = true
+
+# Comma-separated list of DSpace group names whose members are permitted to
+# view metadata fields that are otherwise hidden by metadata.hide.* settings.
+# Administrators always have access regardless of this setting.
+# Example:
+#   metadata.hide.groups = Reviewers, Librarians
+#metadata.hide.groups =
 
 # Behavior to generate provenance message, if set true,
 # personal data (e.g. email) of submitter will be hidden in dc.description.provenance

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1004,11 +1004,21 @@ metadata.hide.dc.description.provenance = true
 metadata.hide.person.email = true
 
 # Comma-separated list of DSpace group names whose members are permitted to
-# view metadata fields that are otherwise hidden by metadata.hide.* settings.
+# view ALL metadata fields that are otherwise hidden by metadata.hide.* settings.
 # Administrators always have access regardless of this setting.
 # Example:
 #   metadata.hide.groups = Reviewers, Librarians
 #metadata.hide.groups =
+
+# Per-field group override: allows a specific comma-separated list of groups to
+# view a single hidden field. When set, this takes precedence over the global
+# metadata.hide.groups setting above for that specific field only.
+# Format: metadata.hide.SCHEMA.ELEMENT[.QUALIFIER].groups = Group1, Group2
+# Examples:
+#   metadata.hide.dc.description.provenance.groups = Librarians
+#   metadata.hide.person.email.groups = LibraryStaff, HRTeam
+#metadata.hide.dc.description.provenance.groups =
+#metadata.hide.person.email.groups =
 
 # Behavior to generate provenance message, if set true,
 # personal data (e.g. email) of submitter will be hidden in dc.description.provenance

--- a/dspace/config/modules/cleanmetadata.cfg
+++ b/dspace/config/modules/cleanmetadata.cfg
@@ -1,0 +1,45 @@
+# cleanmetadata.cfg
+# ──────────────────────────────────────────────────────────────────────────────
+# Configuration for the CleanMetadata DSpace 9 curation task.
+# Location: [dspace]/config/modules/cleanmetadata.cfg
+#
+# Property names are resolved relative to the task's registered short name.
+# If the task is registered as "cleanmetadata" in curate.cfg, then the
+# curation system looks up "cleanmetadata.<property>" when taskProperty()
+# is called from within the task class.
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+# ── Feature toggles ───────────────────────────────────────────────────────────
+
+# Set to "false" to disable curly/smart quote normalization.
+# When enabled, all curly quote variants are converted to straight ASCII quotes.
+# Default: true
+cleanmetadata.fix.quotes = true
+
+# Set to "false" to disable double-hyphen to em dash conversion.
+# When enabled, "--" in the configured dash.fields is replaced with "—".
+# Note: sequences of 3 or more hyphens (e.g. "------") are always preserved.
+# Default: true
+cleanmetadata.fix.dashes = true
+
+# Set to "false" to disable whitespace normalization.
+# When enabled, leading/trailing spaces are stripped and internal double spaces
+# are collapsed to a single space in all metadata fields.
+# Default: true
+cleanmetadata.fix.whitespace = true
+
+
+# ── Dash normalization target fields ──────────────────────────────────────────
+
+# Comma-separated list of Dublin Core fields to apply dash normalization to.
+# Only fields in this list will have "--" converted to em dashes.
+# URL fields and structured fields (provenance, relation.*) are intentionally
+# excluded to avoid breaking links and DSpace-generated text.
+#
+# To override, list your fields here. If this property is left blank or absent,
+# the task falls back to these same defaults.
+cleanmetadata.dash.fields = dc.description.abstract, \
+                            dc.description.lawtext, \
+                            dc.description.summary, \
+                            dc.title


### PR DESCRIPTION
## Description
DSpace currently supports hiding a field from all users with the exception of users in the Administrator group using the setting `metadata.hide.[schema].[element].[qualifier]`. In this current setup, only Administrators can view the hidden metadata fields. Some dspace users may want to have additional groups, other than administrators, to view restricted metadata.

### Short summary of changes (1-2 sentences).
This PR contains a patch that allows members of other groups, other than those in Administrator group, to view the hidden metadata based on a new optional setting `metadata.hide.groups` which accepts a comma separated list of groups whose members can view restricted metadata.

## Instructions for Reviewers
- Add `metadata.hide.groups` or remove comments in dspace.cfg/local.cfg with a comma separated list of groups and ensure those group/s have members
- Ensure you have restricted metadata fields in metadata.hide.* fields. The UI should be already configured to display these fields
- Restart dspace backend

List of changes in this PR:
- Added metadata.hide.groups config key to dspace.cfg to accept a comma-separated list of DSpace group names whose members can view fields hidden by metadata.hide.* settings
- Updated MetadataExposureServiceImpl to autowire GroupService and  check group membership in isHidden() after the admin override
- Guard init() against treating metadata.hide.groups as a  field-hiding directive

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes.

- Login as a member of the allowed groups. Restricted metadata should be visible. Counter-check /api/core/items/{uuid} API
- Login as a non-member of the restricted groups or anonymous, metadata should be hidden. Counter-check /api/core/items/{uuid} API 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
