### PR TITLE
[GitHub Actions] Enable updating GitHub action dependencies via dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -147,6 +147,17 @@ updates:
       # Ignore all major version updates for all dependencies. We'll only automate minor/patch updates.
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+  # Also automatically update all our GitHub actions on the main branch
+  - package-ecosystem: "github-actions"
+    directories: "/"
+    # Monthly dependency updates
+    schedule:
+      interval: "monthly"
+      time: "02:00"
+    # Allow updates to be delayed for a configurable number of days to mitigate
+    # some classes of supply chain attacks
+    cooldown:
+      default-days: 7
   ######################
   ## dspace-9_x branch
   ######################
@@ -288,6 +299,18 @@ updates:
       # Ignore all major version updates for all dependencies. We'll only automate minor/patch updates.
       - dependency-name: "*"
         update-types: [ "version-update:semver-major" ]
+  # Also automatically update all our GitHub actions on the dspace-9_x branch
+  - package-ecosystem: "github-actions"
+    directories: "/"
+    target-branch: dspace-9_x
+    # Monthly dependency updates
+    schedule:
+      interval: "monthly"
+      time: "02:00"
+    # Allow updates to be delayed for a configurable number of days to mitigate
+    # some classes of supply chain attacks
+    cooldown:
+      default-days: 7
   ######################
   ## dspace-8_x branch
   ######################
@@ -429,6 +452,18 @@ updates:
       # Ignore all major version updates for all dependencies. We'll only automate minor/patch updates.
       - dependency-name: "*"
         update-types: [ "version-update:semver-major" ]
+  # Also automatically update all our GitHub actions on the dspace-8_x branch
+  - package-ecosystem: "github-actions"
+    directories: "/"
+    target-branch: dspace-8_x
+    # Monthly dependency updates
+    schedule:
+      interval: "monthly"
+      time: "02:00"
+    # Allow updates to be delayed for a configurable number of days to mitigate
+    # some classes of supply chain attacks
+    cooldown:
+      default-days: 7
   ######################
   ## dspace-7_x branch
   ######################
@@ -589,3 +624,15 @@ updates:
       # Ignore all major version updates for all dependencies. We'll only automate minor/patch updates.
       - dependency-name: "*"
         update-types: [ "version-update:semver-major" ]
+  # Also automatically update all our GitHub actions on the dspace-7_x branch
+  - package-ecosystem: "github-actions"
+    directories: "/"
+    target-branch: dspace-7_x
+    # Monthly dependency updates
+    schedule:
+      interval: "monthly"
+      time: "02:00"
+    # Allow updates to be delayed for a configurable number of days to mitigate
+    # some classes of supply chain attacks
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## References
* Inspired by #11998  (But does not fix this ticket)

## Description
This PR enables `dependabot` updates to our GitHub action files on all active branches.  This way we can better keep them up-to-date in order to avoid deprecation warnings, like in #11998.

Once this is merged, I expect we'll have an autogenerated PR which fixes #11998.  We also may have additional auto-generated PRs to update other out-of-date actions.

NOTE: A similar PR should also be applied to `DSpace/dspace-angular`.  I'll create one after this one is verified to be working properly.

## Instructions for Reviewers
* This can only be tested via merger as `@dependabot` will only run once it's merged.