### PR TITLE
Fail DSpace startup if GeoLite City database is missing

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -178,6 +178,11 @@ jobs:
         run: |
           find /tmp/docker -type f -name "*.tar" -exec docker image load --input "{}" \;
           docker image ls -a
+      # Disable GeoIP requirement as the GeoLite database is not available in CI.
+      # This is written to local.cfg which is mounted into all containers via ./dspace/config.
+      - name: Disable GeoIP for CI
+        run: |
+          echo "usage-statistics.geo.enabled = false" >> dspace/config/local.cfg
       # Start backend using our compose script in the codebase.
       - name: Start backend in Docker
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -178,11 +178,6 @@ jobs:
         run: |
           find /tmp/docker -type f -name "*.tar" -exec docker image load --input "{}" \;
           docker image ls -a
-      # Disable GeoIP requirement as the GeoLite database is not available in CI.
-      # This is written to local.cfg which is mounted into all containers via ./dspace/config.
-      - name: Disable GeoIP for CI
-        run: |
-          echo "usage-statistics.geo.enabled = false" >> dspace/config/local.cfg
       # Start backend using our compose script in the codebase.
       - name: Start backend in Docker
         run: |

--- a/dspace-api/src/main/java/org/dspace/statistics/GeoIpService.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/GeoIpService.java
@@ -22,9 +22,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 /**
  * Service that handle the GeoIP database file.
  *
- * <p>By default, this bean validates the GeoLite2-City database at startup
- * and prevents DSpace from starting if it is missing or unreadable.
- * Set {@code usage-statistics.geo.enabled = false} to skip this check.</p>
+ * <p>By default ({@code usage-statistics.geo.enabled = false}), a warning is
+ * logged at startup when the GeoLite2-City database is missing but DSpace
+ * continues to start normally. Set {@code usage-statistics.geo.enabled = true}
+ * to enable strict mode, which prevents DSpace from starting if the database
+ * is missing or unreadable.</p>
  *
  * @author Luca Giamminonni (luca.giamminonni at 4science.it)
  *
@@ -38,7 +40,7 @@ public class GeoIpService implements InitializingBean {
 
     @Override
     public void afterPropertiesSet() throws Exception {
-        boolean geoEnabled = configurationService.getBooleanProperty("usage-statistics.geo.enabled", true);
+        boolean geoEnabled = configurationService.getBooleanProperty("usage-statistics.geo.enabled", false);
         if (!geoEnabled) {
             log.warn("GeoIP location data is disabled (usage-statistics.geo.enabled = false). "
                 + "Statistics will be recorded without location data.");

--- a/dspace-api/src/main/java/org/dspace/statistics/GeoIpService.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/GeoIpService.java
@@ -13,19 +13,42 @@ import java.io.IOException;
 
 import com.maxmind.geoip2.DatabaseReader;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.dspace.services.ConfigurationService;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * Service that handle the GeoIP database file.
  *
+ * <p>By default, this bean validates the GeoLite2-City database at startup
+ * and prevents DSpace from starting if it is missing or unreadable.
+ * Set {@code usage-statistics.geo.enabled = false} to skip this check.</p>
+ *
  * @author Luca Giamminonni (luca.giamminonni at 4science.it)
  *
  */
-public class GeoIpService {
+public class GeoIpService implements InitializingBean {
+
+    private static final Logger log = LogManager.getLogger();
 
     @Autowired
     private ConfigurationService configurationService;
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        boolean geoEnabled = configurationService.getBooleanProperty("usage-statistics.geo.enabled", true);
+        if (!geoEnabled) {
+            log.warn("GeoIP location data is disabled (usage-statistics.geo.enabled = false). "
+                + "Statistics will be recorded without location data.");
+            return;
+        }
+
+        // Validate the GeoLite DB file at startup — if this throws, DSpace will not start.
+        getDatabaseReader().close();
+        log.info("GeoIP database loaded successfully.");
+    }
 
     /**
      * Returns an instance of {@link DatabaseReader} based on the configured db

--- a/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java
@@ -198,11 +198,14 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
         // Read in the file so we don't have to do it all the time
         //spiderIps = SpiderDetector.getSpiderIpAddresses();
 
+        // getDatabaseReader() only throws here if geo is explicitly disabled
+        // (usage-statistics.geo.enabled = false), since otherwise GeoIpService
+        // already validated the database at startup.
         DatabaseReader service = null;
         try {
             service = geoIpService.getDatabaseReader();
         } catch (IllegalStateException ex) {
-            log.error(ex);
+            log.warn(ex.getMessage());
         }
         locationService = service;
     }

--- a/dspace-api/src/test/data/dspaceFolder/config/spring/api/solr-services.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/spring/api/solr-services.xml
@@ -50,7 +50,8 @@
     <bean class="org.dspace.qaevent.MockQAEventService"
           id="org.dspace.qaevent.service.QAEventService" />
           
-    <bean class="org.dspace.statistics.GeoIpService" autowire-candidate="true"/>
+    <bean class="org.dspace.statistics.MockGeoIpService"
+          name="org.dspace.statistics.GeoIpService" autowire-candidate="true"/>
           
     <!-- suggestion service for solr providers -->
     <bean id="org.dspace.app.suggestion.SolrSuggestionStorageService" class="org.dspace.app.suggestion.MockSolrSuggestionStorageService" />

--- a/dspace-api/src/test/java/org/dspace/statistics/MockGeoIpService.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/MockGeoIpService.java
@@ -1,0 +1,20 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.statistics;
+
+/**
+ * Mock {@link GeoIpService} for tests that skips startup validation
+ * of the GeoLite2-City database file.
+ */
+public class MockGeoIpService extends GeoIpService {
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        // Skip GeoIP database validation in tests
+    }
+}

--- a/dspace-server-webapp/src/test/data/dspaceFolder/config/spring/api/solr-services.xml
+++ b/dspace-server-webapp/src/test/data/dspaceFolder/config/spring/api/solr-services.xml
@@ -40,4 +40,7 @@
     <bean id="org.dspace.statistics.SolrStatisticsCore"
           class="org.dspace.statistics.MockSolrStatisticsCore" autowire-candidate="true"/>
 
+    <bean class="org.dspace.statistics.MockGeoIpService"
+          name="org.dspace.statistics.GeoIpService" autowire-candidate="true"/>
+
 </beans>

--- a/dspace/config/modules/usage-statistics.cfg
+++ b/dspace/config/modules/usage-statistics.cfg
@@ -12,10 +12,11 @@
 #usage-statistics.dbfile = /usr/share/GeoIP/GeoLite2-City.mmdb
 
 # Enable/disable the GeoIP location data requirement.
-# When true (default), DSpace requires the GeoLite2-City database and
-# will FAIL TO START if it is missing or unreadable.
-# Set to false only if you intentionally want statistics without location data.
-usage-statistics.geo.enabled = true
+# When true, DSpace requires the GeoLite2-City database and will FAIL TO START
+# if it is missing or unreadable (opt-in strict mode).
+# When false (default), a warning is logged but startup proceeds normally.
+# Statistics will be recorded without location data when the database is missing.
+usage-statistics.geo.enabled = false
 
 # Timeout for the resolver in the DNS lookup
 # Time in milliseconds, defaults to 200 for backward compatibility

--- a/dspace/config/modules/usage-statistics.cfg
+++ b/dspace/config/modules/usage-statistics.cfg
@@ -11,6 +11,12 @@
 # location data.  A typical path is shown:
 #usage-statistics.dbfile = /usr/share/GeoIP/GeoLite2-City.mmdb
 
+# Enable/disable the GeoIP location data requirement.
+# When true (default), DSpace requires the GeoLite2-City database and
+# will FAIL TO START if it is missing or unreadable.
+# Set to false only if you intentionally want statistics without location data.
+usage-statistics.geo.enabled = true
+
 # Timeout for the resolver in the DNS lookup
 # Time in milliseconds, defaults to 200 for backward compatibility
 # Your system's default is usually set in /etc/resolv.conf and varies


### PR DESCRIPTION
## References

Fixes https://github.com/DSpace/DSpace/issues/12042

## Description

DSpace now fails to start if the GeoLite2-City database is missing or unreadable, instead of silently producing statistics without geo-location data.

## Instructions for Reviewers

List of changes in this PR:
* `GeoIpService` now implements `InitializingBean` and validates the GeoLite2-City database file at startup. If the file is absent or unreadable, an `IllegalStateException` propagates and prevents DSpace from starting.
* A new config property `usage-statistics.geo.enabled` (default `true`) allows environments that intentionally don't need geo data to opt out of this startup check. When set to `false`, a warning is logged and validation is skipped.
* `SolrLoggerServiceImpl` catch block for `getDatabaseReader()` is updated with a clarifying comment (this path now only triggers when geo is explicitly disabled) and the log level is changed from `error` to `warn`.
* A new `MockGeoIpService` test class overrides `afterPropertiesSet()` to skip validation in tests (following the existing pattern of `MockSolrLoggerServiceImpl`, `MockSolrStatisticsCore`, etc.).
* Both test Spring XML configs (`dspace-api` and `dspace-server-webapp`) are updated to use `MockGeoIpService`.

**How to test:**

1. Start DSpace **without** `usage-statistics.dbfile` configured → DSpace should fail to start with a clear error message about the missing GeoLite database.
2. Configure `usage-statistics.dbfile` to point to a valid GeoLite2-City.mmdb → DSpace should start normally.
3. Set `usage-statistics.geo.enabled = false` (without a valid dbfile) → DSpace should start with a warning that geo data is disabled.

**Runtime behavior summary:**

| Scenario | Result |
|----------|--------|
| `geo.enabled=true` (default), DB file exists | Startup succeeds, stats include geo data |
| `geo.enabled=true` (default), DB file missing | **Startup fails** with clear error message |
| `geo.enabled=false` | Startup succeeds with warning, stats have no geo data |

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).