### PR TITLE
OAI: Correct outdated configuration references and prefixes #6962

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/harvest/HarvestScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/app/harvest/HarvestScriptConfiguration.java
@@ -47,7 +47,7 @@ public class HarvestScriptConfiguration<T extends Harvest> extends ScriptConfigu
                           "id of the PMH set representing the harvested collection");
         options.addOption("m", "metadata_format", true,
                           "the name of the desired metadata format for harvesting, resolved to namespace and " +
-                                  "crosswalk in dspace.cfg");
+                                  "crosswalk in oai.cfg");
 
         options.addOption("h", "help", false, "help");
 

--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/OREDisseminationCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/OREDisseminationCrosswalk.java
@@ -103,7 +103,7 @@ public class OREDisseminationCrosswalk
 
         if (oaiUrl == null) {
             throw new CrosswalkInternalException(
-                "Base uri for the ore generator has not been set. Check the ore.authoritative.source setting.");
+                "Base uri for the ore generator has not been set. Check the oai.ore.authoritative.source setting.");
         }
 
         String uriA = oaiUrl + "/metadata/handle/" + item.getHandle() + "/ore.xml";

--- a/dspace-api/src/main/java/org/dspace/harvest/OAIHarvester.java
+++ b/dspace-api/src/main/java/org/dspace/harvest/OAIHarvester.java
@@ -119,12 +119,12 @@ public class OAIHarvester {
     Context ourContext;
 
     // Namespace used by the ORE serialization format
-    // Set in dspace.cfg as oai.harvester.oreSerializationFormat.{ORESerialKey} = {ORESerialNS}
+    // Set in oai.cfg as oai.harvester.oreSerializationFormat.{ORESerialKey} = {ORESerialNS}
     private Namespace ORESerialNS;
     private String ORESerialKey;
 
     // Namespace of the descriptive metadata that should be harvested in addition to the ORE
-    // Set in dspace.cfg as oai.harvester.metadataformats.{MetadataKey} = {MetadataNS},{Display Name}
+    // Set in oai.cfg as oai.harvester.metadataformats.{MetadataKey} = {MetadataNS},{Display Name}
     private Namespace metadataNS;
     private String metadataKey;
 
@@ -664,11 +664,9 @@ public class OAIHarvester {
 
 
     /**
-     * Scan an item's metadata, looking for the value "identifier.*". If it meets the parameters that identify it as
-     * valid handle
-     * as set in dspace.cfg (harvester.acceptedHandleServer and harvester.rejectedHandlePrefix), use that handle
-     * instead of
-     * minting a new one.
+     * Scan an item's metadata, looking for the value "dc.identifier.*". If it meets the parameters that identify it as
+     * valid handle as set in oai.cfg (oai.harvester.acceptedHandleServer and oai.harvester.rejectedHandlePrefix),
+     * use that handle instead of minting a new one.
      *
      * @param item a newly created, but not yet installed, DSpace Item
      * @return null or the handle to be used.

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/BasicConfiguration.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/BasicConfiguration.java
@@ -75,7 +75,7 @@ public class BasicConfiguration {
 
     @Bean
     public XOAICacheService xoaiCacheService() {
-        if (configurationService().getBooleanProperty("oai", "cache.enabled", true)) {
+        if (configurationService().getBooleanProperty("oai.cache.enabled", true)) {
             try {
                 return new DSpaceXOAICacheService(xoaiManagerResolver().getManager());
             } catch (XOAIManagerResolverException e) {

--- a/dspace-oai/src/main/java/org/dspace/xoai/services/impl/cache/DSpaceXOAICacheService.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/impl/cache/DSpaceXOAICacheService.java
@@ -81,7 +81,7 @@ public class DSpaceXOAICacheService implements XOAICacheService {
 
     @Override
     public boolean isActive() {
-        return configurationService.getBooleanProperty("oai.cache", true);
+        return configurationService.getBooleanProperty("oai.cache.enabled", true);
     }
 
     @Override

--- a/dspace-oai/src/main/java/org/dspace/xoai/services/impl/cache/DSpaceXOAIItemCacheService.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/impl/cache/DSpaceXOAIItemCacheService.java
@@ -14,6 +14,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import javax.xml.stream.XMLStreamException;
 
 import com.lyncode.xoai.dataprovider.exceptions.WritingXmlException;
@@ -26,7 +27,6 @@ import org.dspace.xoai.services.api.cache.XOAIItemCacheService;
 import org.dspace.xoai.services.api.config.ConfigurationService;
 import org.springframework.beans.factory.annotation.Autowired;
 
-
 public class DSpaceXOAIItemCacheService implements XOAIItemCacheService {
     private static final String ITEMDIR = File.separator + "items";
 
@@ -37,7 +37,7 @@ public class DSpaceXOAIItemCacheService implements XOAIItemCacheService {
 
     private String getBaseDir() {
         if (baseDir == null) {
-            baseDir = configurationService.getProperty("oai", "cache.dir") + ITEMDIR;
+            baseDir = configurationService.getProperty("oai.cache.dir") + ITEMDIR;
         }
         return baseDir;
     }
@@ -62,7 +62,7 @@ public class DSpaceXOAIItemCacheService implements XOAIItemCacheService {
 
     @Override
     public Metadata get(Item item) throws IOException {
-        System.out.println(FileUtils.readFileToString(getMetadataCache(item)));
+        System.out.println(FileUtils.readFileToString(getMetadataCache(item), StandardCharsets.UTF_8));
         Metadata metadata;
         FileInputStream input = new FileInputStream(getMetadataCache(item));
         try {
@@ -86,9 +86,7 @@ public class DSpaceXOAIItemCacheService implements XOAIItemCacheService {
             context.getWriter().close();
 
             output.close();
-        } catch (XMLStreamException e) {
-            throw new IOException(e);
-        } catch (WritingXmlException e) {
+        } catch (XMLStreamException | WritingXmlException e) {
             throw new IOException(e);
         }
     }

--- a/dspace/config/modules/oai.cfg
+++ b/dspace/config/modules/oai.cfg
@@ -17,14 +17,15 @@ oai.enabled = true
 oai.path = oai
 
 # Storage: solr | database (solr is recommended)
-oai.storage=solr
+oai.storage = solr
 
 # The base URL of the OAI webapp (do not include the context e.g. /request, /openaire, etc).
 # Note: Comment out if you want to fallback to the request's URL.
 oai.url = ${dspace.server.url}/${oai.path}
 
 # Base solr index
-oai.solr.url=${solr.server}/${solr.multicorePrefix}oai
+# (used only if ${oai.storage} = solr)
+oai.solr.url = ${solr.server}/${solr.multicorePrefix}oai
 
 # OAI persistent identifier prefix
 # This field is used for two purposes:
@@ -44,10 +45,14 @@ oai.config.dir = ${dspace.dir}/config/crosswalks/oai
 # Description
 oai.description.file = ${dspace.dir}/config/crosswalks/oai/description.xml
 
-# Cache enabled?
+# Enables the XOAI response cache.
+# When true (default), generated OAI XML responses are cached under ${oai.cache.dir}
+# for faster repeated harvests.
+# When false, responses are always generated fresh, which may increase I/O load.
 oai.cache.enabled = true
 
-# Base Cache Directory
+# Base directory for XOAI cached responses.
+# Only used if oai.cache.enabled = true. Must be writable by the DSpace process.
 oai.cache.dir = ${dspace.dir}/var/oai
 
 #---------------------------------------------------------------#
@@ -79,7 +84,8 @@ oai.harvester.metadataformats.dim = http://www.dspace.org/xmlns/dspace/dim\, DSp
 # Determines whether the harvester scheduling process should be started
 # automatically when the DSpace webapp is deployed.
 # default: false
-oai.harvester.autoStart=false
+# TODO this property is unused since DSpace 7.0, see issue DSpace/DSpace#12051
+oai.harvester.autoStart = false
 
 # Amount of time subtracted from the "from" argument of the OAI-PMH request to account
 # for the time taken to negotiate a connection. Measured in seconds. Default value is 120.


### PR DESCRIPTION
## References
* Caused by DSpace/DSpace#6962
* Introduced another issue DSpace/DSpace#12051

## Description
This PR:
* replaces dspace.cfg with oai.cfg in OAI-related classes
* fixes missing `oai.` prefixes in comments/outputs
* replaces `oai.cache` (never documented) to `oai.cache.enabled` (already documented)
* replaces deprecated `FileUtils#readFileToString(File)` to `FileUtils#readFileToString(File, Charset)`

## Instructions for Reviewers
Changes are limited to comments, one `--help` output string, one exception message

No database changes, REST changes, or complex configuration structure changes are introduced

## Checklist
- [X] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [X] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [X] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [X] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
