### PR TITLE
New endpoint for embargo information (start_date & end_date)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authorize/ResourcePolicyServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/ResourcePolicyServiceImpl.java
@@ -71,16 +71,6 @@ public class ResourcePolicyServiceImpl implements ResourcePolicyService {
         return resourcePolicyDAO.findByID(context, ResourcePolicy.class, id);
     }
 
-    @Override
-    public List<ResourcePolicy> findAll(Context context, int offset, int limit) throws SQLException {
-        return resourcePolicyDAO.findAll(context, offset, limit);
-    }
-
-    @Override
-    public int countAll(Context context) throws SQLException {
-        return resourcePolicyDAO.countAll(context);
-    }
-
     /**
      * Create a new ResourcePolicy
      *

--- a/dspace-api/src/main/java/org/dspace/authorize/ResourcePolicyServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/ResourcePolicyServiceImpl.java
@@ -71,6 +71,16 @@ public class ResourcePolicyServiceImpl implements ResourcePolicyService {
         return resourcePolicyDAO.findByID(context, ResourcePolicy.class, id);
     }
 
+    @Override
+    public List<ResourcePolicy> findAll(Context context, int offset, int limit) throws SQLException {
+        return resourcePolicyDAO.findAll(context, offset, limit);
+    }
+
+    @Override
+    public int countAll(Context context) throws SQLException {
+        return resourcePolicyDAO.countAll(context);
+    }
+
     /**
      * Create a new ResourcePolicy
      *
@@ -412,6 +422,17 @@ public class ResourcePolicyServiceImpl implements ResourcePolicyService {
     @Override
     public int countByGroupAndResourceUuid(Context context, Group group, UUID resourceUuid) throws SQLException {
         return resourcePolicyDAO.countByGroupAndResourceUuid(context, group, resourceUuid);
+    }
+
+    @Override
+    public List<ResourcePolicy> findByDate(Context context, Boolean hasStartDate, Boolean hasEndDate,
+                                                   int offset, int limit) throws SQLException {
+        return resourcePolicyDAO.findByDate(context, hasStartDate, hasEndDate, offset, limit);
+    }
+
+    @Override
+    public int countByDate(Context context, Boolean hasStartDate, Boolean hasEndDate) throws SQLException {
+        return resourcePolicyDAO.countByDate(context, hasStartDate, hasEndDate);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/authorize/dao/ResourcePolicyDAO.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/dao/ResourcePolicyDAO.java
@@ -243,26 +243,6 @@ public interface ResourcePolicyDAO extends GenericDAO<ResourcePolicy> {
     public ResourcePolicy findOneById(Context context, Integer id) throws SQLException;
 
     /**
-     * Return a paginated list of all resource policies
-     *
-     * @param context        DSpace context object
-     * @param offset         the position of the first result to return
-     * @param limit          paging limit
-     * @return               list of resource policies
-     * @throws SQLException  if database error
-     */
-    public List<ResourcePolicy> findAll(Context context, int offset, int limit) throws SQLException;
-
-    /**
-     * Count all the resource policies
-     *
-     * @param context        DSpace context object
-     * @return               total resource policies
-     * @throws SQLException  if database error
-     */
-    public int countAll(Context context) throws SQLException;
-
-    /**
      * Return a paginated list of policies based on embargo date presence criteria
      * 
      * @param context        DSpace context object

--- a/dspace-api/src/main/java/org/dspace/authorize/dao/ResourcePolicyDAO.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/dao/ResourcePolicyDAO.java
@@ -242,5 +242,48 @@ public interface ResourcePolicyDAO extends GenericDAO<ResourcePolicy> {
 
     public ResourcePolicy findOneById(Context context, Integer id) throws SQLException;
 
+    /**
+     * Return a paginated list of all resource policies
+     *
+     * @param context        DSpace context object
+     * @param offset         the position of the first result to return
+     * @param limit          paging limit
+     * @return               list of resource policies
+     * @throws SQLException  if database error
+     */
+    public List<ResourcePolicy> findAll(Context context, int offset, int limit) throws SQLException;
 
+    /**
+     * Count all the resource policies
+     *
+     * @param context        DSpace context object
+     * @return               total resource policies
+     * @throws SQLException  if database error
+     */
+    public int countAll(Context context) throws SQLException;
+
+    /**
+     * Return a paginated list of policies based on embargo date presence criteria
+     * 
+     * @param context        DSpace context object
+     * @param hasStartDate   filter for start date presence, null=any, true=required, false=must be absent
+     * @param hasEndDate     filter for end date presence, null=any, true=required, false=must be absent
+     * @param offset         the position of the first result to return
+     * @param limit          paging limit
+     * @return               list of resource policies
+     * @throws SQLException  if database error
+     */
+    public List<ResourcePolicy> findByDate(Context context, Boolean hasStartDate, Boolean hasEndDate,
+                                                   int offset, int limit) throws SQLException;
+
+    /**
+     * Count all the resource policies based on embargo date presence criteria
+     * 
+     * @param context        DSpace context object
+     * @param hasStartDate   filter for start date presence, null=any, true=required, false=must be absent
+     * @param hasEndDate     filter for end date presence, null=any, true=required, false=must be absent
+     * @return               total policies
+     * @throws SQLException  if database error
+     */
+    public int countByDate(Context context, Boolean hasStartDate, Boolean hasEndDate) throws SQLException;
 }

--- a/dspace-api/src/main/java/org/dspace/authorize/dao/impl/ResourcePolicyDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/dao/impl/ResourcePolicyDAOImpl.java
@@ -421,20 +421,6 @@ public class ResourcePolicyDAOImpl extends AbstractHibernateDAO<ResourcePolicy> 
         return singleResult(context, criteriaQuery);
     }
 
-    @Override
-    public List<ResourcePolicy> findAll(Context context, int offset, int limit) throws SQLException {
-        Query query = createQuery(context, "SELECT rp FROM ResourcePolicy rp ORDER BY rp.id");
-        query.setFirstResult(offset);
-        query.setMaxResults(limit);
-        return list(query);
-    }
-
-    @Override
-    public int countAll(Context context) throws SQLException {
-        Query query = createQuery(context, "SELECT count(rp.id) FROM ResourcePolicy rp");
-        return count(query);
-    }
-
     /**
      * Helper to build the WHERE clause for date presence queries.
      */
@@ -453,6 +439,10 @@ public class ResourcePolicyDAOImpl extends AbstractHibernateDAO<ResourcePolicy> 
             return " WHERE rp.startDate IS NULL AND rp.endDate IS NOT NULL";
         } else if (Boolean.FALSE.equals(hasStartDate) && Boolean.FALSE.equals(hasEndDate)) {
             return " WHERE rp.startDate IS NULL AND rp.endDate IS NULL";
+        } else if (Boolean.FALSE.equals(hasStartDate) && hasEndDate == null) {
+            return " WHERE rp.startDate IS NULL";
+        } else if (hasStartDate == null && Boolean.FALSE.equals(hasEndDate)) {
+            return " WHERE rp.endDate IS NULL";
         }
         return "";
     }

--- a/dspace-api/src/main/java/org/dspace/authorize/dao/impl/ResourcePolicyDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/dao/impl/ResourcePolicyDAOImpl.java
@@ -420,4 +420,62 @@ public class ResourcePolicyDAOImpl extends AbstractHibernateDAO<ResourcePolicy> 
         criteriaQuery.where(criteriaBuilder.equal(resourcePolicyRoot.get(ResourcePolicy_.id), id));
         return singleResult(context, criteriaQuery);
     }
+
+    @Override
+    public List<ResourcePolicy> findAll(Context context, int offset, int limit) throws SQLException {
+        Query query = createQuery(context, "SELECT rp FROM ResourcePolicy rp ORDER BY rp.id");
+        query.setFirstResult(offset);
+        query.setMaxResults(limit);
+        return list(query);
+    }
+
+    @Override
+    public int countAll(Context context) throws SQLException {
+        Query query = createQuery(context, "SELECT count(rp.id) FROM ResourcePolicy rp");
+        return count(query);
+    }
+
+    /**
+     * Helper to build the WHERE clause for date presence queries.
+     */
+    private String buildDatePresenceWhere(Boolean hasStartDate, Boolean hasEndDate) {
+        if (hasStartDate == null && hasEndDate == null) {
+            return " WHERE rp.startDate IS NOT NULL OR rp.endDate IS NOT NULL";
+        } else if (Boolean.TRUE.equals(hasStartDate) && Boolean.TRUE.equals(hasEndDate)) {
+            return " WHERE rp.startDate IS NOT NULL AND rp.endDate IS NOT NULL";
+        } else if (Boolean.TRUE.equals(hasStartDate) && hasEndDate == null) {
+            return " WHERE rp.startDate IS NOT NULL";
+        } else if (hasStartDate == null && Boolean.TRUE.equals(hasEndDate)) {
+            return " WHERE rp.endDate IS NOT NULL";
+        } else if (Boolean.TRUE.equals(hasStartDate) && Boolean.FALSE.equals(hasEndDate)) {
+            return " WHERE rp.startDate IS NOT NULL AND rp.endDate IS NULL";
+        } else if (Boolean.FALSE.equals(hasStartDate) && Boolean.TRUE.equals(hasEndDate)) {
+            return " WHERE rp.startDate IS NULL AND rp.endDate IS NOT NULL";
+        } else if (Boolean.FALSE.equals(hasStartDate) && Boolean.FALSE.equals(hasEndDate)) {
+            return " WHERE rp.startDate IS NULL AND rp.endDate IS NULL";
+        }
+        return "";
+    }
+
+    @Override
+    public List<ResourcePolicy> findByDate(Context context, Boolean hasStartDate, Boolean hasEndDate,
+                                                   int offset, int limit) throws SQLException {
+        StringBuilder queryBuilder = new StringBuilder("SELECT rp FROM ResourcePolicy rp");
+        queryBuilder.append(buildDatePresenceWhere(hasStartDate, hasEndDate));
+        queryBuilder.append(" ORDER BY rp.id");
+
+        Query query = createQuery(context, queryBuilder.toString());
+        query.setFirstResult(offset);
+        query.setMaxResults(limit);
+
+        return list(query);
+    }
+
+    @Override
+    public int countByDate(Context context, Boolean hasStartDate, Boolean hasEndDate) throws SQLException {
+        StringBuilder queryBuilder = new StringBuilder("SELECT count(rp.id) FROM ResourcePolicy rp");
+        queryBuilder.append(buildDatePresenceWhere(hasStartDate, hasEndDate));
+        Query query = createQuery(context, queryBuilder.toString());
+        return count(query);
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/authorize/service/ResourcePolicyService.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/service/ResourcePolicyService.java
@@ -32,6 +32,26 @@ public interface ResourcePolicyService {
     public ResourcePolicy find(Context context, int id) throws SQLException;
 
     /**
+     * Finds all ResourcePolicies in the database with pagination.
+     *
+     * @param context The relevant DSpace Context.
+     * @param offset  The number of records to skip.
+     * @param limit   The number of records to retrieve.
+     * @return A list of ResourcePolicy objects.
+     * @throws SQLException If a database error occurs.
+     */
+    public List<ResourcePolicy> findAll(Context context, int offset, int limit) throws SQLException;
+
+    /**
+     * Counts the total number of ResourcePolicies in the database.
+     *
+     * @param context The relevant DSpace Context.
+     * @return The total number of policies.
+     * @throws SQLException If a database error occurs.
+     */
+    public int countAll(Context context) throws SQLException;
+
+    /**
      * Persist a model object.
      *
      * @param context
@@ -299,6 +319,31 @@ public interface ResourcePolicyService {
      * @throws SQLException  if database error
      */
     public int countByGroupAndResourceUuid(Context context, Group group, UUID resourceUuid) throws SQLException;
+
+    /**
+     * Return a paginated list of policies based on embargo date presence criteria
+     * 
+     * @param context      DSpace context object
+     * @param hasStartDate filter for start date presence, null=any, true=required, false=must be absent
+     * @param hasEndDate   filter for end date presence, null=any, true=required, false=must be absent
+     * @param offset       the position of the first result to return
+     * @param limit        paging limit
+     * @return             list of resource policies
+     * @throws SQLException if database error
+     */
+    public List<ResourcePolicy> findByDate(Context context, Boolean hasStartDate, Boolean hasEndDate,
+                                                   int offset, int limit) throws SQLException;
+
+    /**
+     * Count all the resource policies based on embargo date presence criteria
+     * 
+     * @param context      DSpace context object
+     * @param hasStartDate filter for start date presence, null=any, true=required, false=must be absent
+     * @param hasEndDate   filter for end date presence, null=any, true=required, false=must be absent
+     * @return             total policies
+     * @throws SQLException if database error
+     */
+    public int countByDate(Context context, Boolean hasStartDate, Boolean hasEndDate) throws SQLException;
 
     /**
      * Check if the resource policy identified with (id) belong to ePerson

--- a/dspace-api/src/main/java/org/dspace/authorize/service/ResourcePolicyService.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/service/ResourcePolicyService.java
@@ -32,26 +32,6 @@ public interface ResourcePolicyService {
     public ResourcePolicy find(Context context, int id) throws SQLException;
 
     /**
-     * Finds all ResourcePolicies in the database with pagination.
-     *
-     * @param context The relevant DSpace Context.
-     * @param offset  The number of records to skip.
-     * @param limit   The number of records to retrieve.
-     * @return A list of ResourcePolicy objects.
-     * @throws SQLException If a database error occurs.
-     */
-    public List<ResourcePolicy> findAll(Context context, int offset, int limit) throws SQLException;
-
-    /**
-     * Counts the total number of ResourcePolicies in the database.
-     *
-     * @param context The relevant DSpace Context.
-     * @return The total number of policies.
-     * @throws SQLException If a database error occurs.
-     */
-    public int countAll(Context context) throws SQLException;
-
-    /**
      * Persist a model object.
      *
      * @param context

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ResourcePolicyRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ResourcePolicyRestRepository.java
@@ -230,6 +230,37 @@ public class ResourcePolicyRestRepository extends DSpaceRestRepository<ResourceP
         return converter.toRestPage(resourcePolisies, pageable, total, utils.obtainProjection());
     }
 
+    /**
+     * Find the resource policies matching embargo date presence criteria
+     *
+     * @param hasStartDate optional, filter for start date presence
+     * @param hasEndDate   optional, filter for end date presence
+     * @param pageable     contains the pagination information
+     * @return a Page of ResourcePolicyRest instances matching the embargo criteria
+     */
+    @PreAuthorize("hasAuthority('ADMIN')")
+    @SearchRestMethod(name = "embargo")
+    public Page<ResourcePolicyRest> findByDate(
+            @Parameter(value = "hasStartDate", required = false) Boolean hasStartDate,
+            @Parameter(value = "hasEndDate", required = false) Boolean hasEndDate,
+            Pageable pageable) {
+
+        try {
+            Context context = obtainContext();
+
+            List<ResourcePolicy> policies;
+            int total;
+
+            policies = resourcePolicyService.findByDate(context, hasStartDate, hasEndDate,
+                        Math.toIntExact(pageable.getOffset()),
+                        Math.toIntExact(pageable.getPageSize()));
+            total = resourcePolicyService.countByDate(context, hasStartDate, hasEndDate);
+            return converter.toRestPage(policies, pageable, total, utils.obtainProjection());
+        } catch (SQLException e) {
+            throw new RuntimeException("Database error while searching embargo policies: " + e.getMessage(), e);
+        }
+    }
+
     @Override
     @PreAuthorize("isAuthenticated()")
     protected ResourcePolicyRest createAndReturn(Context context) throws AuthorizeException, SQLException {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
@@ -27,6 +27,8 @@ import java.io.InputStream;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
@@ -25,6 +25,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.io.InputStream;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -4199,30 +4200,34 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
             calendar2.set(Calendar.DATE, 31);
             Date embargoEndDate = calendar2.getTime();
 
+            // Convert Date objects to LocalDate for ResourcePolicyBuilder
+            LocalDate embargoStartLocalDate = embargoStartDate.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+            LocalDate embargoEndLocalDate = embargoEndDate.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+
             // Create ResourcePolicies with different date combinations
             ResourcePolicy rpWithStartDate = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
                     .withAction(Constants.READ)
                     .withDspaceObject(item)
-                    .withStartDate(embargoStartDate)
+                    .withStartDate(embargoStartLocalDate)
                     .build();
 
             ResourcePolicy rpWithEndDate = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
                     .withAction(Constants.READ)
                     .withDspaceObject(item)
-                    .withEndDate(embargoEndDate)
+                    .withEndDate(embargoEndLocalDate)
                     .build();
 
             ResourcePolicy rpWithEndDate2 = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
                     .withAction(Constants.READ)
                     .withDspaceObject(item)
-                    .withEndDate(embargoEndDate)
+                    .withEndDate(embargoEndLocalDate)
                     .build();
 
             ResourcePolicy rpWithBothDates = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
                     .withAction(Constants.READ)
                     .withDspaceObject(item)
-                    .withStartDate(embargoStartDate)
-                    .withEndDate(embargoEndDate)
+                    .withStartDate(embargoStartLocalDate)
+                    .withEndDate(embargoEndLocalDate)
                     .build();
 
             ResourcePolicy rpWithoutDates = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
@@ -9,6 +9,7 @@ package org.dspace.app.rest;
 
 import static com.jayway.jsonpath.JsonPath.read;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.springframework.data.rest.webmvc.RestMediaTypes.TEXT_URI_LIST_VALUE;
@@ -4163,4 +4164,146 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
                              .andExpect(status().isUnprocessableEntity());
     }
 
+    /**
+     * Setups test data for embargo policy tests including:
+     * - Community, Collection, and Item
+     * - ResourcePolicies with different date combinations
+     * - Predefined start and end dates for consistency
+     *
+     * @throws Exception if test data creation fails
+     */
+    private void setupEmbargoTestData() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        try {
+            // Create test hierarchy
+            Community community = CommunityBuilder.createCommunity(context)
+                    .withName("Test Community").build();
+            Collection collection = CollectionBuilder.createCollection(context, community)
+                    .withName("Test Collection").build();
+            Item item = ItemBuilder.createItem(context, collection)
+                    .withTitle("Item with Embargo").build();
+
+            // Create consistent embargo dates
+            Calendar calendar1 = Calendar.getInstance();
+            calendar1.set(Calendar.YEAR, 2019);
+            calendar1.set(Calendar.MONTH, 9);
+            calendar1.set(Calendar.DATE, 31);
+            Date embargoStartDate = calendar1.getTime();
+
+            Calendar calendar2 = Calendar.getInstance();
+            calendar2.set(Calendar.YEAR, 2200);
+            calendar2.set(Calendar.MONTH, 9);
+            calendar2.set(Calendar.DATE, 31);
+            Date embargoEndDate = calendar2.getTime();
+
+            // Create ResourcePolicies with different date combinations
+            ResourcePolicy rpWithStartDate = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
+                    .withAction(Constants.READ)
+                    .withDspaceObject(item)
+                    .withStartDate(embargoStartDate)
+                    .build();
+
+            ResourcePolicy rpWithEndDate = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
+                    .withAction(Constants.READ)
+                    .withDspaceObject(item)
+                    .withEndDate(embargoEndDate)
+                    .build();
+
+            ResourcePolicy rpWithEndDate2 = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
+                    .withAction(Constants.READ)
+                    .withDspaceObject(item)
+                    .withEndDate(embargoEndDate)
+                    .build();
+
+            ResourcePolicy rpWithBothDates = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
+                    .withAction(Constants.READ)
+                    .withDspaceObject(item)
+                    .withStartDate(embargoStartDate)
+                    .withEndDate(embargoEndDate)
+                    .build();
+
+            ResourcePolicy rpWithoutDates = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
+                    .withAction(Constants.READ)
+                    .withDspaceObject(item)
+                    .build();
+        } finally {
+            context.restoreAuthSystemState();
+        }
+    }
+
+    @Test
+    public void findEmbargoWithStartDate() throws Exception {
+        // Baseline count
+        int baselineCount = this.resourcePolicyService.countByDate(context, true, null);
+
+        setupEmbargoTestData();
+
+        String authToken = getAuthToken(admin.getEmail(), password);
+
+        getClient(authToken)
+                .perform(get("/api/authz/resourcepolicies/search/embargo?hasStartDate=true"))
+                .andExpect(jsonPath("$.page.totalElements", is(baselineCount + 2)));
+                // rpWithStartDate + rpWithBothDates
+    }
+
+    @Test
+    public void findEmbargoWithEndDate() throws Exception {
+        // Baseline count
+        int baselineCount = this.resourcePolicyService.countByDate(context, null, true);
+
+        setupEmbargoTestData();
+
+        String authToken = getAuthToken(admin.getEmail(), password);
+
+        getClient(authToken)
+                .perform(get("/api/authz/resourcepolicies/search/embargo?hasEndDate=true"))
+                .andExpect(jsonPath("$.page.totalElements", is(baselineCount + 3)));
+                // rpWithEndDate + rpWithEndDate2 + rpWithBothDates
+    }
+
+    @Test
+    public void findEmbargoWithoutDates() throws Exception {
+        // Baseline count
+        int baselineCount = this.resourcePolicyService.countByDate(context, false, false);
+
+        setupEmbargoTestData();
+
+        String authToken = getAuthToken(admin.getEmail(), password);
+
+        getClient(authToken)
+                .perform(get("/api/authz/resourcepolicies/search/embargo?hasStartDate=false&hasEndDate=false"))
+                .andExpect(jsonPath("$.page.totalElements", greaterThanOrEqualTo(baselineCount + 1)));
+                // rpWithoutDates
+    }
+
+    @Test
+    public void findEmbargoWithAnyDate() throws Exception {
+        // Baseline count
+        int baselineCount = this.resourcePolicyService.countByDate(context, null, null);
+
+        setupEmbargoTestData();
+
+        String authToken = getAuthToken(admin.getEmail(), password);
+
+        getClient(authToken)
+                .perform(get("/api/authz/resourcepolicies/search/embargo"))
+                .andExpect(jsonPath("$.page.totalElements", is(baselineCount + 4)));
+                // All our rps except rpWithoutDates
+    }
+
+    @Test
+    public void findEmbargoWithBothDates() throws Exception {
+        // Baseline count
+        int baselineCount = this.resourcePolicyService.countByDate(context, true, true);
+
+        setupEmbargoTestData();
+
+        String authToken = getAuthToken(admin.getEmail(), password);
+
+        getClient(authToken)
+                .perform(get("/api/authz/resourcepolicies/search/embargo?hasStartDate=true&hasEndDate=true"))
+                .andExpect(jsonPath("$.page.totalElements", is(baselineCount + 1)));
+                // rpWithBothDates
+    }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResourcePolicyRestRepositoryIT.java
@@ -25,11 +25,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.io.InputStream;
 import java.time.LocalDate;
-import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
@@ -4188,21 +4185,8 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
                     .withTitle("Item with Embargo").build();
 
             // Create consistent embargo dates
-            Calendar calendar1 = Calendar.getInstance();
-            calendar1.set(Calendar.YEAR, 2019);
-            calendar1.set(Calendar.MONTH, 9);
-            calendar1.set(Calendar.DATE, 31);
-            Date embargoStartDate = calendar1.getTime();
-
-            Calendar calendar2 = Calendar.getInstance();
-            calendar2.set(Calendar.YEAR, 2200);
-            calendar2.set(Calendar.MONTH, 9);
-            calendar2.set(Calendar.DATE, 31);
-            Date embargoEndDate = calendar2.getTime();
-
-            // Convert Date objects to LocalDate for ResourcePolicyBuilder
-            LocalDate embargoStartLocalDate = embargoStartDate.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
-            LocalDate embargoEndLocalDate = embargoEndDate.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+            LocalDate embargoStartLocalDate = LocalDate.of(2019, 10, 31);
+            LocalDate embargoEndLocalDate = LocalDate.of(2200, 10, 31);
 
             // Create ResourcePolicies with different date combinations
             ResourcePolicy rpWithStartDate = ResourcePolicyBuilder.createResourcePolicy(context, admin, null)
@@ -4237,6 +4221,21 @@ public class ResourcePolicyRestRepositoryIT extends AbstractControllerIntegratio
         } finally {
             context.restoreAuthSystemState();
         }
+    }
+
+    @Test
+    public void findEmbargoForbiddenForNonAdminTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        EPerson eperson = EPersonBuilder.createEPerson(context)
+            .withEmail("nonAdmin@mail.com")
+            .withPassword(password)
+            .build();
+        context.restoreAuthSystemState();
+
+        String authToken = getAuthToken(eperson.getEmail(), password);
+        getClient(authToken)
+            .perform(get("/api/authz/resourcepolicies/search/embargo"))
+            .andExpect(status().isForbidden());
     }
 
     @Test


### PR DESCRIPTION
## Description
Resolves https://github.com/DSpace/DSpace/issues/12151
This PR introduces a new endpoint for retrieving embargo-related information from resource policies.

## What it does
The endpoint allows retrieving all resource policies that represent embargos, including their:
- start_date
- end_date

Endpoint:
```
/server/api/authz/resourcepolicies/search/embargo
```
By default, it returns all policies with embargo.

It can be filtered using:
```
hasStartDate=[true, false]
hasEndDate=[true, false]
```

Example:
```
/server/api/authz/resourcepolicies/search/embargo?hasStartDate=false&hasEndDate=false
```

## Why is it helpful?
This endpoint allows administrators to quickly identify how many resource policies (items and bitstreams) have an embargo and verify whether their start_date and end_date are correctly set, as well as detect incorrectly configured embargo periods.

## Instructions for Reviewers
- Test the new endpoint:
```
/server/api/authz/resourcepolicies/search/embargo
```
- Verify correct filtering with:
    - ?hasStartDate=false
    - ?hasEndDate=false
- Confirm that start_date and end_date are returned correctly.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
