### PR TITLE
Replace deprecated internal Base64 with JRE implementation.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/importer/external/epo/service/EpoImportMetadataSourceServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/epo/service/EpoImportMetadataSourceServiceImpl.java
@@ -14,6 +14,7 @@ import java.io.StringReader;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -30,7 +31,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.http.HttpException;
 import org.apache.http.client.utils.URIBuilder;
-import org.apache.jena.ext.xerces.impl.dv.util.Base64;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.util.XMLUtils;
@@ -164,7 +164,7 @@ public class EpoImportMetadataSourceServiceImpl extends AbstractImportMetadataSo
     private Map<String, String> getLoginHeaderParams() {
         Map<String, String> params = new HashMap<String, String>();
         String authString = consumerKey + ":" + consumerSecret;
-        params.put("Authorization", "Basic " + Base64.encode(authString.getBytes()));
+        params.put("Authorization", "Basic " + Base64.getEncoder().encodeToString(authString.getBytes()));
         params.put("Content-type", "application/x-www-form-urlencoded");
         return params;
     }


### PR DESCRIPTION
## Description
The European Patent Office metadata import service uses a deprecated internal Base64 encoder which seems to have disappeared in recent updates of the supplying dependency.  This patch replaces it with the JRE implementation.

## Instructions for Reviewers
List of changes in this PR:
* Replaced the Base64 class import, with small changes needed by the different method name.

To test:  try to import metadata from EPO into a submission.

I have applied for an EPO account, to get an API key for testing.  I have not used this feature before.  If someone who is already using EPO import would care to test this, that would be appreciated.

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).