### PR TITLE
Fix handling of special characters in FindAuthorized search queries

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authorize/AuthorizeServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authorize/AuthorizeServiceImpl.java
@@ -827,6 +827,7 @@ public class AuthorizeServiceImpl implements AuthorizeService {
                                                            int limit)
         throws SearchServiceException {
         List<Community> communities = new ArrayList<>();
+        query = searchService.formatAutoCompleteQuery(query, "dc.title_sort");
         query = formatCustomQuery(query);
         DiscoverResult discoverResult = getDiscoverResult(context, query + RESOURCE_TYPE_FIELD + ":" +
                 IndexableCommunity.TYPE, action, true,
@@ -864,6 +865,7 @@ public class AuthorizeServiceImpl implements AuthorizeService {
     @Override
     public long countAuthorizedCommunityByAction(Context context, String query, int action)
         throws SearchServiceException {
+        query = searchService.formatAutoCompleteQuery(query, "dc.title_sort");
         query = formatCustomQuery(query);
         DiscoverResult discoverResult = getDiscoverResult(context, query + RESOURCE_TYPE_FIELD + ":" +
                 IndexableCommunity.TYPE, action, true,
@@ -907,6 +909,7 @@ public class AuthorizeServiceImpl implements AuthorizeService {
             return collections;
         }
 
+        query = searchService.formatAutoCompleteQuery(query, "dc.title_sort");
         query = formatCustomQuery(query);
         DiscoverResult discoverResult = getDiscoverResult(context, query + RESOURCE_TYPE_FIELD + ":" +
                 IndexableCollection.TYPE, action, true,
@@ -944,6 +947,7 @@ public class AuthorizeServiceImpl implements AuthorizeService {
     @Override
     public long countAuthorizedCollectionByAction(Context context, String query, int action)
         throws SearchServiceException {
+        query = searchService.formatAutoCompleteQuery(query, "dc.title_sort");
         query = formatCustomQuery(query);
         DiscoverResult discoverResult = getDiscoverResult(context, query + RESOURCE_TYPE_FIELD + ":" +
                 IndexableCollection.TYPE, action,

--- a/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
@@ -29,7 +29,6 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.Logger;
-import org.apache.solr.client.solrj.util.ClientUtils;
 import org.dspace.app.util.AuthorizeUtil;
 import org.dspace.authorize.AuthorizeConfiguration;
 import org.dspace.authorize.AuthorizeException;
@@ -1092,11 +1091,8 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
             discoverQuery.addFilterQueries("search.entitytype:" + entityType);
         }
         if (StringUtils.isNotBlank(q)) {
-            StringBuilder buildQuery = new StringBuilder();
-            String escapedQuery = ClientUtils.escapeQueryChars(q);
-            buildQuery.append("(").append(escapedQuery).append(" OR dc.title_sort:*")
-                .append(escapedQuery).append("*").append(")");
-            discoverQuery.setQuery(buildQuery.toString());
+            q = searchService.formatAutoCompleteQuery(q, "dc.title_sort");
+            discoverQuery.setQuery(q);
         }
         discoverQuery.addRequiredAuthorization(Constants.ADD);
         DiscoverResult resp = searchService.search(context, discoverQuery);

--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -1274,6 +1274,9 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
     private DiscoverResult retrieveItemsWithEdit(Context context, DiscoverQuery discoverQuery, String q)
         throws SearchServiceException {
         if (StringUtils.isNotBlank(q)) {
+            // Although not all items will have a metadata dc.title, we use it for autocomplete because it is the
+            // most common. Ideally, we should use a field that all indexed items have
+            q = searchService.formatAutoCompleteQuery(q, "dc.title_sort");
             discoverQuery.setQuery(q);
         }
         discoverQuery.addRequiredAuthorization(Constants.WRITE);

--- a/dspace-api/src/main/java/org/dspace/discovery/SearchService.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SearchService.java
@@ -126,6 +126,15 @@ public interface SearchService {
      */
     String escapeQueryChars(String query);
 
+    /**
+     * Utility method to format an autocomplete query over a specific field.
+     *
+     * @param query to search for
+     * @param autocompleteField the field to use to autocomplete search, if null or empty no field is used
+     * @return the constructed solr query
+     */
+    String formatAutoCompleteQuery(String query, String autocompleteField);
+
     FacetYearRange getFacetYearRange(Context context, IndexableObject scope, DiscoverySearchFilterFacet facet,
             List<String> filterQueries, DiscoverQuery parentQuery)
                     throws SearchServiceException;

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -1608,6 +1608,27 @@ public class SolrServiceImpl implements SearchService, IndexingService {
         return ClientUtils.escapeQueryChars(query);
     }
 
+    /**
+     * Utility method to format an autocomplete query over a specific field. Combines the escaped query with a
+     * wildcard search over the specified {@code autocompleteField}. This field is typically non-tokenized and
+     * allows recovering searches containing spaces as a single value.
+     *
+     * @param query the user input to search for
+     * @param autocompleteField non-tokenized field used for wildcard autocomplete
+     * @return the constructed Solr query, or the original query if blank
+     */
+    @Override
+    public String formatAutoCompleteQuery(String query, String autocompleteField) {
+        if (StringUtils.isNotBlank(query)) {
+            StringBuilder buildQuery = new StringBuilder();
+            String escapedQuery = escapeQueryChars(query);
+            buildQuery.append("(").append(escapedQuery).append(" OR ").append(autocompleteField).append(":*")
+                .append(escapedQuery).append("*").append(")");
+            return buildQuery.toString();
+        }
+        return query;
+    }
+
     @Override
     public FacetYearRange getFacetYearRange(Context context, IndexableObject scope,
                                             DiscoverySearchFilterFacet facet, List<String> filterQueries,

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CollectionRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CollectionRestRepositoryIT.java
@@ -3942,6 +3942,13 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
             .withName("Collection of sample items")
             .withAdminGroup(eperson)
             .build();
+        Collection col4 = CollectionBuilder.createCollection(context, child2)
+            .withName("Testing autocomplete in collection")
+            .withAdminGroup(eperson2)
+            .build();
+        Collection col5 = CollectionBuilder.createCollection(context, child2)
+            .withName("Title: subtitle (special characters)")
+            .build();
         context.restoreAuthSystemState();
 
         String tokenEPerson = getAuthToken(eperson.getEmail(), password);
@@ -3972,11 +3979,29 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
             .andExpect(jsonPath("$.page.totalElements", is(0)));
 
         // Test eperson with no authorized collections
-        String tokenEPerson2 = getAuthToken(eperson2.getEmail(), password);
-        getClient(tokenEPerson2).perform(get("/api/core/collections/search/" + method)
-                .param("query", "collection"))
+        getClient(tokenEPerson).perform(get("/api/core/collections/search/" + method)
+                .param("query", "auto"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.page.totalElements", is(0)));
+
+        String tokenEPerson2 = getAuthToken(eperson2.getEmail(), password);
+        // Test eperson2 gets only their authorized collection
+        getClient(tokenEPerson2).perform(get("/api/core/collections/search/" + method)
+                .param("query", "auto"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.collections", Matchers.contains(
+                CollectionMatcher.matchProperties(col4.getName(), col4.getID(), col4.getHandle())
+            )))
+            .andExpect(jsonPath("$.page.totalElements", is(1)));
+
+        // Test query with multiple words
+        getClient(tokenEPerson2).perform(get("/api/core/collections/search/" + method)
+                .param("query", "testing auto"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.collections", Matchers.containsInAnyOrder(
+                CollectionMatcher.matchProperties(col4.getName(), col4.getID(), col4.getHandle())
+            )))
+            .andExpect(jsonPath("$.page.totalElements", is(1)));
 
         // Test admin gets all authorized collections
         String tokenAdmin = getAuthToken(admin.getEmail(), password);
@@ -4003,10 +4028,19 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
                 .param("query", "test"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$._embedded.collections", Matchers.containsInAnyOrder(
-                CollectionMatcher.matchProperties(col2.getName(), col2.getID(), col2.getHandle())
+                CollectionMatcher.matchProperties(col2.getName(), col2.getID(), col2.getHandle()),
+                CollectionMatcher.matchProperties(col4.getName(), col4.getID(), col4.getHandle())
+            )))
+            .andExpect(jsonPath("$.page.totalElements", is(2)));
+
+        // Test query with special characters
+        getClient(tokenAdmin).perform(get("/api/core/collections/search/" + method)
+                .param("query", "title: subtitle (special"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.collections", Matchers.contains(
+                CollectionMatcher.matchProperties(col5.getName(), col5.getID(), col5.getHandle())
             )))
             .andExpect(jsonPath("$.page.totalElements", is(1)));
-
     }
 
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CommunityRestRepositoryIT.java
@@ -3169,6 +3169,13 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
             .withName("community of sample items")
             .withAdminGroup(eperson)
             .build();
+        Community com4 = CommunityBuilder.createSubCommunity(context, child2)
+            .withName("Testing autocomplete in community")
+            .withAdminGroup(eperson2)
+            .build();
+        Community com5 = CommunityBuilder.createSubCommunity(context, child2)
+            .withName("Title: subtitle (special characters)")
+            .build();
         context.restoreAuthSystemState();
 
         // Test simple query
@@ -3199,11 +3206,29 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
             .andExpect(jsonPath("$.page.totalElements", is(0)));
 
         // Test eperson with no authorized communities
-        String tokenEPerson2 = getAuthToken(eperson2.getEmail(), password);
-        getClient(tokenEPerson2).perform(get("/api/core/communities/search/" + method)
-                .param("query", "community"))
+        getClient(tokenEPerson).perform(get("/api/core/communities/search/" + method)
+                .param("query", "auto"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.page.totalElements", is(0)));
+
+        String tokenEPerson2 = getAuthToken(eperson2.getEmail(), password);
+        // Test eperson2 gets only their authorized community
+        getClient(tokenEPerson2).perform(get("/api/core/communities/search/" + method)
+                .param("query", "auto"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.communities", Matchers.contains(
+                CommunityMatcher.matchProperties(com4.getName(), com4.getID(), com4.getHandle())
+            )))
+            .andExpect(jsonPath("$.page.totalElements", is(1)));
+
+        // Test query with multiple words
+        getClient(tokenEPerson2).perform(get("/api/core/communities/search/" + method)
+                .param("query", "testing auto"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.communities", Matchers.containsInAnyOrder(
+                CommunityMatcher.matchProperties(com4.getName(), com4.getID(), com4.getHandle())
+            )))
+            .andExpect(jsonPath("$.page.totalElements", is(1)));
 
         // Test as admin
         String tokenAdmin = getAuthToken(admin.getEmail(), password);
@@ -3230,7 +3255,17 @@ public class CommunityRestRepositoryIT extends AbstractControllerIntegrationTest
                 .param("query", "test"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$._embedded.communities", Matchers.containsInAnyOrder(
-                CommunityMatcher.matchProperties(com2.getName(), com2.getID(), com2.getHandle())
+                CommunityMatcher.matchProperties(com2.getName(), com2.getID(), com2.getHandle()),
+                CommunityMatcher.matchProperties(com4.getName(), com4.getID(), com4.getHandle())
+            )))
+            .andExpect(jsonPath("$.page.totalElements", is(2)));
+
+        // Test query with special characters
+        getClient(tokenAdmin).perform(get("/api/core/communities/search/" + method)
+                .param("query", "title: subtitle"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.communities", Matchers.contains(
+                CommunityMatcher.matchProperties(com5.getName(), com5.getID(), com5.getHandle())
             )))
             .andExpect(jsonPath("$.page.totalElements", is(1)));
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
@@ -5504,6 +5504,10 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
             .withName("col3")
             .withAdminGroup(eperson)
             .build();
+        Collection col4 = CollectionBuilder.createCollection(context, child2)
+            .withName("col4")
+            .withAdminGroup(eperson2)
+            .build();
         Item item1 = ItemBuilder.createItem(context, col1)
             .withTitle("Sample item")
             .build();
@@ -5512,6 +5516,12 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
             .build();
         Item item3 = ItemBuilder.createItem(context, col3)
             .withTitle("Item of sample bitstreams")
+            .build();
+        Item item4 = ItemBuilder.createItem(context, col4)
+            .withTitle("Testing autocomplete in items")
+            .build();
+        Item item5 = ItemBuilder.createItem(context, col4)
+            .withTitle("Title: subtitle (special characters)")
             .build();
 
         context.restoreAuthSystemState();
@@ -5544,11 +5554,29 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
             .andExpect(jsonPath("$.page.totalElements", is(0)));
 
         // Test eperson with no authorized items
-        String tokenEPerson2 = getAuthToken(eperson2.getEmail(), password);
-        getClient(tokenEPerson2).perform(get("/api/core/items/search/" + method)
-                .param("query", "community"))
+        getClient(tokenEPerson).perform(get("/api/core/items/search/" + method)
+                .param("query", "auto"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.page.totalElements", is(0)));
+
+        String tokenEPerson2 = getAuthToken(eperson2.getEmail(), password);
+        // Test eperson2 with one authorized item
+        getClient(tokenEPerson2).perform(get("/api/core/items/search/" + method)
+                .param("query", "auto"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.items", Matchers.contains(
+                ItemMatcher.matchItemProperties(item4)
+            )))
+            .andExpect(jsonPath("$.page.totalElements", is(1)));
+
+        // Test query with multiple words
+        getClient(tokenEPerson2).perform(get("/api/core/items/search/" + method)
+                .param("query", "testing auto"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.items", Matchers.containsInAnyOrder(
+                ItemMatcher.matchItemProperties(item4)
+            )))
+            .andExpect(jsonPath("$.page.totalElements", is(1)));
 
         // Test query as admin
         String tokenAdmin = getAuthToken(admin.getEmail(), password);
@@ -5575,7 +5603,17 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
                 .param("query", "test"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$._embedded.items", Matchers.containsInAnyOrder(
-                ItemMatcher.matchItemProperties(item2)
+                ItemMatcher.matchItemProperties(item2),
+                ItemMatcher.matchItemProperties(item4)
+            )))
+            .andExpect(jsonPath("$.page.totalElements", is(2)));
+
+        // Test special characters in query
+        getClient(tokenAdmin).perform(get("/api/core/items/search/" + method)
+                .param("query", "title: subtitle (special"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.items", Matchers.contains(
+                ItemMatcher.matchItemProperties(item5)
             )))
             .andExpect(jsonPath("$.page.totalElements", is(1)));
 


### PR DESCRIPTION
## References
* Follow-up to #11646
* Related to #10109

## Description
This PR adapts the `Find*Authorized` endpoints introduced or modified in #11648 to escape Solr special characters and ensure that searches containing spaces continue to work correctly, applying the same approach implemented in #10109.

## Instructions for Reviewers
Currently, when searching for text containing special characters in the popup selectors used in the administrative interface (e.g. when selecting Communities, Collections, or Items in the administration menus for creating or editing objects), the request may return an error or generate an invalid Solr query.

<img width="744" height="428" alt="imagen" src="https://github.com/user-attachments/assets/c6b8137a-d3d7-4904-b8be-94be70baf06c" />


This PR updates the query used by these selectors to escape Solr special characters and adds an `OR` condition using the `dc.title_sort` field, allowing searches containing spaces to work correctly. The implementation follows the same approach previously introduced in #10109 for the `findSubmitAuthorized` method.

**Notes**
* For item searches in the administration menus used for editing items, using `dc.title_sort` is not ideal for all entity types, as some entities may use a different field as their primary name. However, it is the most commonly used field.

List of changes in this PR:
* Updated authorized Solr searches used by `Find*Authorized` endpoints to escape special characters and support queries containing spaces.
* Introduced a reusable utility method `formatAutoCompleteQuery` in `SearchService` to build safe autocomplete queries.
* Replaced custom query-building logic with the new utility method in Community, Collection and Item authorized searches.
* Added integration tests to verify behavior with queries containing spaces and special characters.

**How to review / test this PR:**

1. Open the popup selectors in the administration menus for creating or editing Communities, Collections, or Items.
2. Perform searches using text containing **spaces** or **special Solr characters** such as `:`, `(`, `)`.
3. Verify that queries return results correctly without errors and that authorized results are filtered properly.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).