### PR TITLE
Thumbnail with a given page number

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickThumbnailFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickThumbnailFilter.java
@@ -46,6 +46,8 @@ public abstract class ImageMagickThumbnailFilter extends MediaFilter {
 
     protected static final String PRE = ImageMagickThumbnailFilter.class.getName();
 
+    private Item item;
+
     static {
         String s = configurationService.getProperty(PRE + ".ProcessStarter");
         ProcessStarter.setGlobalSearchPath(s);
@@ -143,6 +145,23 @@ public abstract class ImageMagickThumbnailFilter extends MediaFilter {
             op.density(Integer.valueOf(density));
         }
 
+        // Get custom page number from metadata if available
+        int pageNumber = 0;
+        String pageNumberStr = itemService.getMetadataFirstValue(this.item, "dspace", "thumbnail", "page", Item.ANY);
+        try {
+            if (pageNumberStr != null) {
+                pageNumber = Integer.parseInt(pageNumberStr);
+                pageNumber -= 1; // Convert to zero-based index
+                if (pageNumber < 0) {
+                    pageNumber = 0;
+                }
+            }
+        } catch (NumberFormatException e) {
+            System.err.format("dspace.thumbnail.page metadata contains an invalid page number: %s%n",
+                    pageNumberStr);
+            pageNumber = 0;
+        }
+
         // Check the PDF's MediaBox and CropBox to see if they are the same.
         // If not, then tell ImageMagick to use the CropBox when generating
         // the thumbnail because the CropBox is generally used to define the
@@ -152,9 +171,9 @@ public abstract class ImageMagickThumbnailFilter extends MediaFilter {
         // CropBox. Note: we don't need to do anything special to detect if
         // the CropBox is missing or empty because pdfbox will set it to the
         // same size as the MediaBox if it doesn't exist. Also note that we
-        // only need to check the first page, since that's what we use for
-        // generating the thumbnail (PDPage uses a zero-based index).
-        PDPage pdfPage = Loader.loadPDF(f).getPage(0);
+        // check the page specified by the metadata, or the first page if not set
+        // (PDPage uses a zero-based index).
+        PDPage pdfPage = Loader.loadPDF(f).getPage(pageNumber);
         PDRectangle pdfPageMediaBox = pdfPage.getMediaBox();
         PDRectangle pdfPageCropBox = pdfPage.getCropBox();
 
@@ -163,7 +182,7 @@ public abstract class ImageMagickThumbnailFilter extends MediaFilter {
             op.define("pdf:use-cropbox=true");
         }
 
-        String s = "[0]";
+        String s = "[" + pageNumber + "]";
         op.addImage(f.getAbsolutePath() + s);
         if (configurationService.getBooleanProperty(PRE + ".flatten", true)) {
             op.flatten();
@@ -191,6 +210,7 @@ public abstract class ImageMagickThumbnailFilter extends MediaFilter {
 
     @Override
     public boolean preProcessBitstream(Context c, Item item, Bitstream source, boolean verbose) throws Exception {
+        this.item = item;
         String nsrc = source.getName();
         for (Bundle b : itemService.getBundles(item, "THUMBNAIL")) {
             for (Bitstream bit : b.getBitstreams()) {

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/PDFBoxThumbnail.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/PDFBoxThumbnail.java
@@ -72,12 +72,34 @@ public class PDFBoxThumbnail extends MediaFilter {
         throws Exception {
         BufferedImage buf;
 
+        String pageNumberStr = currentItem.getItemService()
+            .getMetadataFirstValue(currentItem, "dspace", "thumbnail", "page", Item.ANY);
+
+        int pageNumber = 0;
+
+        try {
+            if (pageNumberStr != null) {
+                pageNumber = Integer.parseInt(pageNumberStr);
+                // Convert to zero-based index
+                pageNumber -= 1;
+                if (pageNumber < 0) {
+                    pageNumber = 0;
+                }
+            }
+        } catch (NumberFormatException e) {
+            log.error("dspace.thumbnail.page metadata contains an invalid page number: {}",
+                    pageNumberStr);
+        }
+
         // Render the page image.
         try ( PDDocument doc = Loader.loadPDF(new RandomAccessReadBuffer(source)); ) {
             PDFRenderer renderer = new PDFRenderer(doc);
-            buf = renderer.renderImage(0);
+            buf = renderer.renderImage(pageNumber);
         } catch (InvalidPasswordException ex) {
             log.error("PDF is encrypted. Cannot create thumbnail (item: {})", currentItem::getHandle);
+            return null;
+        } catch (IndexOutOfBoundsException ex) {
+            log.error("Cannot create thumbnail with the given page number: {}", pageNumber + 1);
             return null;
         }
 


### PR DESCRIPTION
## References
* Related to #9829 

## Description
I had some issues with my local and forked branch. This PR is the same as #9829:
- Add dspace.thumbnail.page metadata support in both PDFBoxThumbnail and ImageMagickThumbnailFilter
- Updated for PDFBox 3.0
- Handles IndexOutOfBoundsException when page number exceeds PDF page count

And it is based on the current main branch. 

## Instructions for Reviewers
Please see #9829 

List of changes in this PR:
Please see #9829 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).