### PR TITLE
Fix OpenAIRE XSL crosswalk: empty <datacite:sizes> elements 

### DIFF
--- a/dspace/config/crosswalks/oai/metadataFormats/oai_openaire.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/oai_openaire.xsl
@@ -851,13 +851,13 @@
     <!-- datacite:sizes -->
     <!-- https://openaire-guidelines-for-literature-repository-managers.readthedocs.io/en/v4.0.0/field_size.html -->
     <xsl:template match="doc:element[@name='bundles']/doc:element[@name='bundle']" mode="datacite">
-        <datacite:sizes>
-            <xsl:if test="doc:field[@name='name' and text()='ORIGINAL']">
+        <xsl:if test="doc:field[@name='name' and text()='ORIGINAL']">
+            <datacite:sizes>
                 <xsl:for-each select="doc:element[@name='bitstreams']/doc:element[@name='bitstream']">
                     <xsl:apply-templates select="." mode="datacite"/>
                 </xsl:for-each>
-            </xsl:if>
-        </datacite:sizes>
+            </datacite:sizes>
+        </xsl:if>
     </xsl:template>
     
      <!-- datacite:size -->


### PR DESCRIPTION
## References
Fixes #12089

## Description
Swapped the position of the if-condition and `<datacite:sizes>` tag https://github.com/DSpace/DSpace/blob/dspace-7_x/dspace/config/crosswalks/oai/metadataFormats/oai_openaire.xsl#L854-L855

## Instructions for Reviewers
Steps to reproduce the behavior:

1. Make an item with bitstreams in the ORIGINAL bundle and any other bundle
2. Look at the OAI-PMH output for the openairev4 context & openaire metadata format
3. The should now be no empty <datacite:sizes> blocks when there are bitstreams in bundles other than ORIGINAL.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
