### PR TITLE
fix(#9395): Remove unused authentication-ldap.enable property

### DIFF
--- a/dspace/config/modules/authentication-ldap.cfg
+++ b/dspace/config/modules/authentication-ldap.cfg
@@ -23,13 +23,6 @@
 # LDAP server administrators as LDAP configuration will vary from server
 # to server.
 
-# This setting will enable or disable LDAP authentication in DSpace.
-# With the setting off, users will be required to register and login with
-# their email address.  With this setting on, users will be able to login
-# and register with their LDAP user ids and passwords.
-authentication-ldap.enable = false
-
-
 ##### LDAP AutoRegister Settings #####
 
 # This will turn LDAP autoregistration on or off.  With this


### PR DESCRIPTION
Removes the `authentication-ldap.enable` property and its associated comments from `authentication-ldap.cfg`.

## References
* Fixes #9395

## Description
Removes the unused `authentication-ldap.enable` property from `authentication-ldap.cfg`. This property is a legacy leftover from DSpace 6 (JSPUI) and is no longer referenced anywhere in the DSpace 7+ backend.

## Instructions for Reviewers
Authentication methods, including LDAP, are now entirely managed via the plugin sequence stack (`plugin.sequence.org.dspace.authenticate.AuthenticationMethod`) in `authentication.cfg`.
https://github.com/DSpace/DSpace/blob/188f6ffa232fc450cc51cbcbcdf5abdd1cdd3013/dspace-api/src/main/java/org/dspace/authenticate/AuthenticationServiceImpl.java#L68-L70
https://github.com/DSpace/DSpace/blob/188f6ffa232fc450cc51cbcbcdf5abdd1cdd3013/dspace-api/src/main/java/org/dspace/authenticate/service/AuthenticationService.java#L20-L46

**List of changes in this PR:**
* Removed the `authentication-ldap.enable = false` property and its descriptive comments from `dspace/config/modules/authentication-ldap.cfg`.

**Context & Verification:**
* A thorough search of the codebase confirms that `authentication-ldap.enable` is completely unreferenced in the Java backend.
* Enabling or disabling LDAP is safely and exclusively handled by uncommenting or commenting the `org.dspace.authenticate.LDAPAuthentication` plugin in the `authentication.cfg` stack. Keeping this unused property in the LDAP config could cause confusion for system administrators.

**How to test:**
1. Pull this branch.
2. Build and start the DSpace backend.
3. Verify that the system starts normally and no configuration parsing errors are thrown.
4. (Optional) If an LDAP server is configured, verify that LDAP authentication still functions exactly as expected when enabled in `authentication.cfg`.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
