### PR TITLE
Avoid exception during OAI update caused by uncached entities

### DIFF
--- a/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
@@ -193,9 +193,9 @@ public class XOAI {
                     .findInArchiveOrWithdrawnDiscoverableModifiedSince(context, last);
             Iterator<Item> nonDiscoverableChangedItems = itemService
                     .findInArchiveOrWithdrawnNonDiscoverableModifiedSince(context, last);
+            int total = this.index(discoverableChangedItems, true) + this.index(nonDiscoverableChangedItems, true);
             Iterator<Item> possiblyChangedItems = getItemsWithPossibleChangesBefore(last);
-            return this.index(discoverableChangedItems) + this.index(nonDiscoverableChangedItems)
-                    + this.index(possiblyChangedItems);
+            return total + this.index(possiblyChangedItems, false);
         } catch (SQLException ex) {
             throw new DSpaceSolrIndexerException(ex.getMessage(), ex);
         }
@@ -266,7 +266,7 @@ public class XOAI {
                     null);
             Iterator<Item> nonDiscoverableItems = itemService
                     .findInArchiveOrWithdrawnNonDiscoverableModifiedSince(context, null);
-            return this.index(discoverableItems) + this.index(nonDiscoverableItems);
+            return this.index(discoverableItems, true) + this.index(nonDiscoverableItems, true);
         } catch (SQLException ex) {
             throw new DSpaceSolrIndexerException(ex.getMessage(), ex);
         }
@@ -309,7 +309,7 @@ public class XOAI {
         }
     }
 
-    private int index(Iterator<Item> iterator) throws DSpaceSolrIndexerException {
+    private int index(Iterator<Item> iterator, boolean uncacheEntities) throws DSpaceSolrIndexerException {
         try {
             int i = 0;
             int batchSize = configurationService.getIntProperty("oai.import.batch.size", 1000);
@@ -338,10 +338,12 @@ public class XOAI {
                     server.add(list);
                     server.commit();
                     list.clear();
-                    try {
-                        context.uncacheEntities();
-                    } catch (SQLException ex) {
-                        log.error("Error uncaching entities", ex);
+                    if (uncacheEntities) {
+                        try {
+                            context.uncacheEntities();
+                        } catch (SQLException ex) {
+                            log.error("Error uncaching entities", ex);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## References
* Fixes #12112

## Description
This PR prevents a `LazyInitializationException` that may occur during OAI updates when the configured batch size is exceeded and `uncacheEntities()` is triggered while indexing items that were already loaded in memory.

## Instructions for Reviewers

List of changes in this PR:
* Move the call to `getItemsWithPossibleChangesBefore` so it is executed after indexing the discoverable and non-discoverable item iterators.
* Add a parameter to the `index()` method to control whether `context.uncacheEntities()` should be executed.
* Call `index()` with this parameter enabled or disabled depending on whether the iterator loads items lazily (`UUIDIterator`, used by the standard item queries) or returns items already loaded in memory (`getItemsWithPossibleChangesBefore`).

**How to test**
* Reproduce the problem as described in the related issue.
* Confirm that the exception occurs before applying this patch.
* Apply the patch and run the OAI update again.
* Verify that the indexing completes successfully and that the `LazyInitializationException` is no longer thrown.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
