### PR TITLE
Fix race condition in LegacyPluginServiceImpl named plugin cache

### DIFF
--- a/dspace-api/src/main/java/org/dspace/core/LegacyPluginServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/core/LegacyPluginServiceImpl.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -219,10 +220,10 @@ public class LegacyPluginServiceImpl implements PluginService {
 
     // Map of named plugin classes, [intfc,name] -> class
     // Also contains intfc -> "marker" to mark when interface has been loaded.
-    private final Map<String, String> namedPluginClasses = new HashMap<>();
+    private final Map<String, String> namedPluginClasses = new ConcurrentHashMap<>();
 
     // load and cache configuration data for the given interface.
-    private void configureNamedPlugin(String iname)
+    private synchronized void configureNamedPlugin(String iname)
         throws ClassNotFoundException {
         int found = 0;
 
@@ -307,11 +308,10 @@ public class LegacyPluginServiceImpl implements PluginService {
         int found = 0;
         for (int i = 0; i < names.length; ++i) {
             String key = iname + SEP + names[i];
-            if (namedPluginClasses.containsKey(key)) {
+            String existing = namedPluginClasses.putIfAbsent(key, classname);
+            if (existing != null) {
                 log.error("Name collision in named plugin, implementation class=\"" + classname +
                               "\", name=\"" + names[i] + "\"");
-            } else {
-                namedPluginClasses.put(key, classname);
             }
             log.debug("Got Named Plugin, intfc=" + iname + ", name=" + names[i] + ", class=" + classname);
             ++found;


### PR DESCRIPTION
## Summary
- Replace unsynchronized `HashMap` with `ConcurrentHashMap` for the `namedPluginClasses` cache to prevent corruption and `ConcurrentModificationException` on concurrent reads
- Add `synchronized` to `configureNamedPlugin()` to eliminate the check-then-act double-initialization race (called once per interface, so contention is negligible)
- Use `putIfAbsent()` in `installNamedConfigs()` instead of separate `containsKey()`/`put()` calls to eliminate spurious "Name collision in named plugin" errors

Fixes https://github.com/DSpace/DSpace/issues/12117

## Test plan
- [ ] `mvn compile -pl dspace-api` — compiles successfully
- [ ] `mvn checkstyle:check -pl dspace-api` — zero violations
- [ ] Review diff to confirm only `namedPluginClasses` type, `configureNamedPlugin` synchronization, and `installNamedConfigs` atomicity changed
- [ ] Verify no functional change to plugin resolution logic (only thread-safety improvement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)