### PR TITLE
[Docker] Update all Docker Compose scripts to allow for environment variable overrides (Backend port)

### DIFF
--- a/docker-compose-cli.yml
+++ b/docker-compose-cli.yml
@@ -17,9 +17,9 @@ services:
       # __P__ => "." (e.g. dspace__P__dir => dspace.dir)
       # __D__ => "-" (e.g. google__D__metadata => google-metadata)
       # db.url: Ensure we are using the 'dspacedb' image for our database
-      db__P__url: 'jdbc:postgresql://dspacedb:5432/dspace'
+      db__P__url: ${db__P__url:-jdbc:postgresql://dspacedb:5432/dspace}
       # solr.server: Ensure we are using the 'dspacesolr' image for Solr
-      solr__P__server: http://dspacesolr:8983/solr
+      solr__P__server: ${solr__P__server:-http://dspacesolr:8983/solr}
     volumes:
     # Keep DSpace assetstore directory between reboots
     - assetstore:/dspace/assetstore

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,18 +22,18 @@ services:
       # dspace__P__ui__P__url: http://localhost:4000
       # Set SSR URL to the Docker container name so that UI can contact container directly in Production mode.
       # (This is necessary for docker-compose-angular.yml as it uses production mode by default)
-      dspace__P__server__P__ssr__P__url: http://dspace:8080/server
-      dspace__P__name: 'DSpace Started with Docker Compose'
+      dspace__P__server__P__ssr__P__url: ${dspace__P__server__P__ssr__P__url:-http://dspace:8080/server}
+      dspace__P__name: ${dspace__P__name:-DSpace Started with Docker Compose}
       # db.url: Ensure we are using the 'dspacedb' image for our database
-      db__P__url: 'jdbc:postgresql://dspacedb:5432/dspace'
+      db__P__url: ${db__P__url:-jdbc:postgresql://dspacedb:5432/dspace}
       # solr.server: Ensure we are using the 'dspacesolr' image for Solr
-      solr__P__server: http://dspacesolr:8983/solr
+      solr__P__server: ${solr__P__server:-http://dspacesolr:8983/solr}
       # matomo.tracker.url: Ensure we are using the 'matomo' image for Matomo
-      matomo__P__tracker__P__url: http://matomo
+      matomo__P__tracker__P__url: ${matomo__P__tracker__P__url:-http://matomo}
       # proxies.trusted.ipranges: This setting is required for a REST API running in Docker to trust requests
       # from the host machine. This IP range MUST correspond to the 'dspacenet' subnet defined above.
-      proxies__P__trusted__P__ipranges: '172.23.0'
-      LOGGING_CONFIG: /dspace/config/log4j2-container.xml
+      proxies__P__trusted__P__ipranges: ${proxies__P__trusted__P__ipranges:-172.23.0}
+      LOGGING_CONFIG: ${LOGGING_CONFIG:-/dspace/config/log4j2-container.xml}
     image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace:${DSPACE_VER:-latest-test}"
     build:
       context: .

--- a/dspace/src/main/docker-compose/cli.assetstore.yml
+++ b/dspace/src/main/docker-compose/cli.assetstore.yml
@@ -10,7 +10,7 @@ services:
   dspace-cli:
     environment:
       # This assetstore zip is available from https://github.com/DSpace-Labs/AIP-Files/releases/tag/demo-entities-data
-      - LOADASSETS=https://github.com/DSpace-Labs/AIP-Files/releases/download/demo-entities-data/assetstore.tar.gz
+      - LOADASSETS=${LOADASSETS:-https://github.com/DSpace-Labs/AIP-Files/releases/download/demo-entities-data/assetstore.tar.gz}
     entrypoint:
       - /bin/bash
       - '-c'

--- a/dspace/src/main/docker-compose/cli.ingest.yml
+++ b/dspace/src/main/docker-compose/cli.ingest.yml
@@ -9,9 +9,9 @@
 services:
   dspace-cli:
     environment:
-    - AIPZIP=https://github.com/DSpace-Labs/AIP-Files/raw/main/dogAndReport.zip
-    - ADMIN_EMAIL=test@test.edu
-    - AIPDIR=/tmp/aip-dir
+    - AIPZIP=${AIPZIP:-https://github.com/DSpace-Labs/AIP-Files/raw/main/dogAndReport.zip}
+    - ADMIN_EMAIL=${ADMIN_EMAIL:-test@test.edu}
+    - AIPDIR=${AIPDIR:-/tmp/aip-dir}
     entrypoint:
       - /bin/bash
       - '-c'

--- a/dspace/src/main/docker-compose/db.entities.yml
+++ b/dspace/src/main/docker-compose/db.entities.yml
@@ -11,7 +11,7 @@ services:
     image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-postgres-loadsql:${DSPACE_VER:-latest}"
     environment:
       # This SQL is available from https://github.com/DSpace-Labs/AIP-Files/releases/tag/demo-entities-data
-      - LOADSQL=https://github.com/DSpace-Labs/AIP-Files/releases/download/demo-entities-data/dspace7-entities-data.sql
+      - LOADSQL=${LOADSQL:-https://github.com/DSpace-Labs/AIP-Files/releases/download/demo-entities-data/dspace7-entities-data.sql}
   dspace:
     ### OVERRIDE default 'entrypoint' in 'docker-compose.yml ####
     # Ensure that the database is ready BEFORE starting tomcat

--- a/dspace/src/main/docker-compose/db.restore.yml
+++ b/dspace/src/main/docker-compose/db.restore.yml
@@ -15,7 +15,7 @@ services:
     image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-postgres-loadsql:${DSPACE_VER:-latest}"
     environment:
       # Location where the dump SQL file will be available on the running container
-      - LOCALSQL=/tmp/pgdump.sql
+      - LOCALSQL=${LOCALSQL:-/tmp/pgdump.sql}
     volumes:
       # Volume which shares a local SQL file at "./pgdump.sql" to the running container
       # IF YOUR LOCAL FILE HAS A DIFFERENT NAME (or is in a different location), then change the "./pgdump.sql"

--- a/dspace/src/main/docker-compose/docker-compose-angular.yml
+++ b/dspace/src/main/docker-compose/docker-compose-angular.yml
@@ -18,16 +18,17 @@ services:
     depends_on:
     - dspace
     environment:
-      DSPACE_UI_SSL: 'false'
-      DSPACE_UI_HOST: dspace-angular
-      DSPACE_UI_PORT: '4000'
-      DSPACE_UI_NAMESPACE: /
-      DSPACE_REST_SSL: 'false'
-      DSPACE_REST_HOST: localhost
-      DSPACE_REST_PORT: 8080
-      DSPACE_REST_NAMESPACE: /server
+      DSPACE_UI_SSL: ${DSPACE_UI_SSL:-false}
+      DSPACE_UI_HOST: ${DSPACE_UI_HOST:-dspace-angular}
+      DSPACE_UI_PORT: ${DSPACE_UI_PORT:-4000}
+      DSPACE_UI_NAMESPACE: ${DSPACE_UI_NAMESPACE:-/}
+      DSPACE_UI_BASEURL: ${DSPACE_UI_BASEURL:-http://localhost:4000}
+      DSPACE_REST_SSL: ${DSPACE_REST_SSL:-false}
+      DSPACE_REST_HOST: ${DSPACE_REST_HOST:-localhost}
+      DSPACE_REST_PORT: ${DSPACE_REST_PORT:-8080}
+      DSPACE_REST_NAMESPACE: ${DSPACE_REST_NAMESPACE:-/server}
       # Ensure SSR can use the 'dspace' Docker image directly (see docker-compose-rest.yml)
-      DSPACE_REST_SSRBASEURL: http://dspace:8080/server
+      DSPACE_REST_SSRBASEURL: ${DSPACE_REST_SSRBASEURL:-http://dspace:8080/server}
     image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-angular:${DSPACE_VER:-latest-dist}"
     ports:
     - published: 4000


### PR DESCRIPTION
## Description
**NOTE: This is a port of https://github.com/DSpace/dspace-angular/pull/5280 , where the same changes were applied to `dspace-angular`**

Our existing Docker Compose scripts are not allowing for overriding of environment variables in GitHub CI (or similar) because they **hardcode** a specific environment variable value.

So, for instance, in GitHub CI, we often want to override an environment variable like this:
```
env:
  # REST is running on 127.0.0.1 instead of localhost
  DSPACE_REST_HOST: 127.0.0.1
```

However, the `docker-compose-dist.yml` script hardcodes this environment variable like this:
```
environment:
  DSPACE_REST_HOST: localhost
```

So, in this situation, the variable ends up set to `localhost` (the hardcoded value) when we want it set to `127.0.0.1` (the overriding value).

The fix is to update the Docker Compose script to instead accept a different value but _default_ to `localhost` like this:
```
environment:
   # This syntax tells Docker to use the shell environment variable of the same name. If it doesn't exist, default to `localhost`
  DSPACE_REST_HOST: ${DSPACE_REST_HOST:-localhost}
```

It appears we haven't encountered this flaw simply because our GitHub CI didn't need to override the default values. The first instance of this required override appears to be in #5276 (where I discovered this flaw).

This update to our Docker scripts should be backported to all active branches as other branches include this same flaw.

## Instructions for Reviewers

* Assuming GitHub CI passes, this is likely safe.
* I will admit though that I haven't had a chance to test this on my local machine yet.