### PR TITLE
Improve BitstoreMigrate: skip deleted bitstreams and handle missing files

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
@@ -484,6 +484,12 @@ public class BitstreamServiceImpl extends DSpaceObjectServiceImpl<Bitstream> imp
     }
 
     @Override
+    public Iterator<Bitstream> findByStoreNumber(Context context, Integer storeNumber,
+                                                  boolean excludeDeleted) throws SQLException {
+        return bitstreamDAO.findByStoreNumber(context, storeNumber, excludeDeleted);
+    }
+
+    @Override
     public Long countByStoreNumber(Context context, Integer storeNumber) throws SQLException {
         return bitstreamDAO.countByStoreNumber(context, storeNumber);
     }

--- a/dspace-api/src/main/java/org/dspace/content/dao/BitstreamDAO.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/BitstreamDAO.java
@@ -43,6 +43,9 @@ public interface BitstreamDAO extends DSpaceObjectLegacySupportDAO<Bitstream> {
 
     public Iterator<Bitstream> findByStoreNumber(Context context, Integer storeNumber) throws SQLException;
 
+    public Iterator<Bitstream> findByStoreNumber(Context context, Integer storeNumber,
+                                                  boolean excludeDeleted) throws SQLException;
+
     public Long countByStoreNumber(Context context, Integer storeNumber) throws SQLException;
 
     int countRows(Context context) throws SQLException;

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/BitstreamDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/BitstreamDAOImpl.java
@@ -146,7 +146,17 @@ public class BitstreamDAOImpl extends AbstractHibernateDSODAO<Bitstream> impleme
 
     @Override
     public Iterator<Bitstream> findByStoreNumber(Context context, Integer storeNumber) throws SQLException {
-        Query query = createQuery(context, "select b.id from Bitstream b where b.storeNumber = :storeNumber");
+        return findByStoreNumber(context, storeNumber, false);
+    }
+
+    @Override
+    public Iterator<Bitstream> findByStoreNumber(Context context, Integer storeNumber,
+                                                  boolean excludeDeleted) throws SQLException {
+        String hql = "select b.id from Bitstream b where b.storeNumber = :storeNumber";
+        if (excludeDeleted) {
+            hql += " and b.deleted = false";
+        }
+        Query query = createQuery(context, hql);
         query.setParameter("storeNumber", storeNumber);
         @SuppressWarnings("unchecked")
         List<UUID> uuids = query.getResultList();

--- a/dspace-api/src/main/java/org/dspace/content/service/BitstreamService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/BitstreamService.java
@@ -216,6 +216,18 @@ public interface BitstreamService extends DSpaceObjectService<Bitstream>, DSpace
 
     public Iterator<Bitstream> findByStoreNumber(Context context, Integer storeNumber) throws SQLException;
 
+    /**
+     * Find all bitstreams in the given assetstore, optionally excluding deleted ones.
+     *
+     * @param context        DSpace context object
+     * @param storeNumber    the assetstore number
+     * @param excludeDeleted if true, bitstreams marked as deleted are excluded
+     * @return an iterator over the matching bitstreams
+     * @throws SQLException if database error
+     */
+    public Iterator<Bitstream> findByStoreNumber(Context context, Integer storeNumber,
+                                                  boolean excludeDeleted) throws SQLException;
+
     public Long countByStoreNumber(Context context, Integer storeNumber) throws SQLException;
 
     int countTotal(Context context) throws SQLException;

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/BitStoreMigrate.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/BitStoreMigrate.java
@@ -62,6 +62,10 @@ public class BitStoreMigrate {
                               "Delete file from losing assetstore. (Default: Keep bitstream in old assetstore)");
             options.addOption("p", "print", false, "Print out current assetstore information");
             options.addOption("s", "size", true, "Batch commit size. (Default: 1, commit after each file transfer)");
+            options.addOption(null, "include-deleted", false,
+                              "Include bitstreams marked as deleted. (Default: deleted bitstreams are skipped)");
+            options.addOption(null, "stop-on-error", false,
+                              "Stop migration on first error. (Default: log errors and continue)");
             options.addOption("h", "help", false, "Help");
 
             try {
@@ -93,6 +97,9 @@ public class BitStoreMigrate {
             log.debug("deleteOldAssets = " + deleteOld);
 
 
+            boolean skipDeleted = !line.hasOption("include-deleted");
+            boolean continueOnError = !line.hasOption("stop-on-error");
+
             if (line.hasOption('a') && line.hasOption('b')) {
                 Integer sourceAssetstore = Integer.valueOf(line.getOptionValue('a'));
                 Integer destinationAssetstore = Integer.valueOf(line.getOptionValue('b'));
@@ -104,7 +111,8 @@ public class BitStoreMigrate {
                 }
 
                 bitstreamStorageService
-                    .migrate(context, sourceAssetstore, destinationAssetstore, deleteOld, batchCommitSize);
+                    .migrate(context, sourceAssetstore, destinationAssetstore, deleteOld, batchCommitSize,
+                             skipDeleted, continueOnError);
             } else {
                 printHelp(options);
                 System.exit(0);

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamStorageServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamStorageServiceImpl.java
@@ -401,41 +401,72 @@ public class BitstreamStorageServiceImpl implements BitstreamStorageService, Ini
      */
     @Override
     public void migrate(Context context, Integer assetstoreSource, Integer assetstoreDestination, boolean deleteOld,
-                        Integer batchCommitSize) throws IOException, SQLException, AuthorizeException {
-        //Find all the bitstreams on the old source, copy it to new destination, update store_number, save, remove old
-        Iterator<Bitstream> allBitstreamsInSource = bitstreamService.findByStoreNumber(context, assetstoreSource);
-        int processedCounter = 0;
+                        Integer batchCommitSize, boolean skipDeleted, boolean continueOnError)
+        throws IOException, SQLException, AuthorizeException {
+        Iterator<Bitstream> allBitstreamsInSource =
+            bitstreamService.findByStoreNumber(context, assetstoreSource, skipDeleted);
+        int successCounter = 0;
+        int errorCounter = 0;
+        int skippedCounter = 0;
 
         while (allBitstreamsInSource.hasNext()) {
             Bitstream bitstream = allBitstreamsInSource.next();
-            log.info("Copying bitstream:" + bitstream
-                .getID() + " from assetstore[" + assetstoreSource + "] to assetstore[" + assetstoreDestination + "] " +
-                         "Name:" + bitstream
-                .getName() + ", SizeBytes:" + bitstream.getSizeBytes());
 
-            InputStream inputStream = retrieve(context, bitstream);
-            this.getStore(assetstoreDestination).put(bitstream, inputStream);
-            bitstream.setStoreNumber(assetstoreDestination);
-            bitstreamService.update(context, bitstream);
-
-            if (deleteOld) {
-                log.info("Removing bitstream:" + bitstream.getID() + " from assetstore[" + assetstoreSource + "]");
-                this.getStore(assetstoreSource).remove(bitstream);
+            if (isRegisteredBitstream(bitstream.getInternalId())) {
+                log.info("Skipping registered bitstream:" + bitstream.getID());
+                skippedCounter++;
+                context.uncacheEntity(bitstream);
+                continue;
             }
 
-            processedCounter++;
+            log.info("Copying bitstream:" + bitstream.getID()
+                + " from assetstore[" + assetstoreSource + "] to assetstore[" + assetstoreDestination + "]"
+                + " Name:" + bitstream.getName() + ", SizeBytes:" + bitstream.getSizeBytes());
+
+            try {
+                InputStream inputStream = retrieve(context, bitstream);
+                this.getStore(assetstoreDestination).put(bitstream, inputStream);
+                bitstream.setStoreNumber(assetstoreDestination);
+                bitstreamService.update(context, bitstream);
+
+                if (deleteOld) {
+                    log.info("Removing bitstream:" + bitstream.getID()
+                        + " from assetstore[" + assetstoreSource + "]");
+                    this.getStore(assetstoreSource).remove(bitstream);
+                }
+
+                successCounter++;
+            } catch (IOException e) {
+                errorCounter++;
+                String errorMsg = "Failed to migrate bitstream:" + bitstream.getID()
+                    + " - " + e.getMessage();
+                if (continueOnError) {
+                    log.error(errorMsg, e);
+                    System.err.println("ERROR: " + errorMsg);
+                } else {
+                    throw new IOException(errorMsg, e);
+                }
+            }
+
             context.uncacheEntity(bitstream);
 
-            //modulo
-            if ((processedCounter % batchCommitSize) == 0) {
-                log.info("Migration Commit Checkpoint: " + processedCounter);
+            if (successCounter > 0 && (successCounter % batchCommitSize) == 0) {
+                log.info("Migration Commit Checkpoint: " + successCounter + " migrated"
+                    + (errorCounter > 0 ? ", " + errorCounter + " errors" : ""));
                 context.commit();
             }
         }
 
-        log.info(
-            "Assetstore Migration from assetstore[" + assetstoreSource + "] to assetstore[" + assetstoreDestination +
-                "] completed. " + processedCounter + " objects were transferred.");
+        // Commit any remaining bitstreams from the last partial batch
+        context.commit();
+
+        log.info("Assetstore Migration from assetstore[" + assetstoreSource
+            + "] to assetstore[" + assetstoreDestination + "] completed. "
+            + successCounter + " bitstreams migrated, "
+            + errorCounter + " errors, "
+            + skippedCounter + " skipped (registered).");
+        System.out.println("Migration completed: " + successCounter + " bitstreams migrated, "
+            + errorCounter + " errors, " + skippedCounter + " skipped (registered).");
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/service/BitstreamStorageService.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/service/BitstreamStorageService.java
@@ -165,20 +165,23 @@ public interface BitstreamStorageService {
     public void printStores(Context context) throws SQLException;
 
     /**
-     * Migrate all the assets from assetstoreSource to assetstoreDestination
+     * Migrate all the assets from assetstoreSource to assetstoreDestination.
      *
      * @param context               The relevant DSpace Context.
      * @param assetstoreSource      source assetstore
      * @param assetstoreDestination destination assetstore
      * @param deleteOld             whether to delete files from the source assetstore after migration
      * @param batchCommitSize       batch size
+     * @param skipDeleted           if true, bitstreams marked as deleted in the database are skipped
+     * @param continueOnError       if true, errors on individual bitstreams are logged but do not stop the migration
      * @throws IOException        A general class of exceptions produced by failed or interrupted I/O operations.
      * @throws SQLException       An exception that provides information on a database access error or other errors.
      * @throws AuthorizeException Exception indicating the current user of the context does not have permission
      *                            to perform a particular action.
      */
     public void migrate(Context context, Integer assetstoreSource, Integer assetstoreDestination, boolean deleteOld,
-                        Integer batchCommitSize) throws IOException, SQLException, AuthorizeException;
+                        Integer batchCommitSize, boolean skipDeleted, boolean continueOnError)
+        throws IOException, SQLException, AuthorizeException;
 
 
     /**

--- a/dspace-api/src/test/java/org/dspace/storage/bitstore/BitstreamStorageServiceImplIT.java
+++ b/dspace-api/src/test/java/org/dspace/storage/bitstore/BitstreamStorageServiceImplIT.java
@@ -114,7 +114,7 @@ public class BitstreamStorageServiceImplIT extends AbstractIntegrationTestWithDa
         try {
             bitstreamStorageService.migrate(
                 context, SOURCE_STORE, DEST_STORE, deleteOld,
-                batchCommitSize
+                batchCommitSize, false, false
             );
             fail("IOException should have been thrown");
         } catch (IOException ioe) {
@@ -166,7 +166,7 @@ public class BitstreamStorageServiceImplIT extends AbstractIntegrationTestWithDa
         try {
             bitstreamStorageService.migrate(
                 context, SOURCE_STORE, DEST_STORE, deleteOld,
-                batchCommitSize
+                batchCommitSize, false, false
             );
             fail("IOException should have been thrown");
         } catch (IOException ioe) {


### PR DESCRIPTION
## Summary
- **Skip deleted bitstreams by default** during migration. Bitstreams marked as deleted in the database are now excluded from migration, preventing `FileNotFoundException` when cleanup has already removed the files from storage. Use `--include-deleted` to revert to old behavior. (Fixes #8802)
- **Continue on errors by default** instead of aborting the entire migration on the first missing file. Errors are logged and reported in a final summary. Use `--stop-on-error` to revert to old behavior. (Fixes #8801)
- **Skip registered (external) bitstreams** that are references to files outside the assetstore and should not be migrated.
- **Add explicit final commit** after the migration loop to flush the last partial batch, instead of relying on `context.complete()` in the CLI wrapper.
- **Print migration summary** with success/error/skipped counts at the end.

## Test plan
- [ ] Run `dspace bitstore-migrate -a 0 -b 1` with deleted bitstreams in the source store — verify they are skipped
- [ ] Run `dspace bitstore-migrate -a 0 -b 1 --include-deleted` — verify deleted bitstreams are included
- [ ] Run migration with a missing file in the source store — verify migration continues and error is reported
- [ ] Run migration with `--stop-on-error` and a missing file — verify migration aborts on the error
- [ ] Run migration with registered bitstreams — verify they are skipped
- [ ] Verify final summary output shows correct counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)