### PR TITLE
Refactor ORCID data providers to use OrcidClient instead of OrcidRestConnector

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authority/orcid/Orcidv3SolrAuthorityImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authority/orcid/Orcidv3SolrAuthorityImpl.java
@@ -7,10 +7,6 @@
  */
 package org.dspace.authority.orcid;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -21,90 +17,48 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.authority.AuthorityValue;
 import org.dspace.authority.SolrAuthorityInterface;
-import org.dspace.external.OrcidConnectionException;
-import org.dspace.external.OrcidRestConnector;
-import org.dspace.external.provider.orcid.xml.XMLtoBio;
-import org.dspace.orcid.model.factory.OrcidFactoryUtils;
-import org.orcid.jaxb.model.v3.release.common.OrcidIdentifier;
+import org.dspace.orcid.client.OrcidClient;
+import org.dspace.orcid.client.OrcidConfiguration;
+import org.dspace.orcid.exception.OrcidClientException;
 import org.orcid.jaxb.model.v3.release.record.Person;
-import org.orcid.jaxb.model.v3.release.search.Result;
+import org.orcid.jaxb.model.v3.release.search.expanded.ExpandedResult;
+import org.orcid.jaxb.model.v3.release.search.expanded.ExpandedSearch;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * This class contains all methods for retrieving "Person" objects calling the ORCID (version 3) endpoints.
- * Additionally, this can also create AuthorityValues based on these returned Person objects
+ * Additionally, this can also create AuthorityValues based on these returned Person objects.
+ * Uses the modern {@link OrcidClient} for all ORCID API calls, supporting both
+ * public and member API endpoints based on configuration.
  *
  * @author Jonas Van Goolen (jonas at atmire dot com)
  * @author Andrea Bollini (andrea.bollini at 4science.it)
  */
 public class Orcidv3SolrAuthorityImpl implements SolrAuthorityInterface {
 
-    private final static Logger log = LogManager.getLogger();
+    private static final Logger log = LogManager.getLogger();
 
-    private OrcidRestConnector orcidRestConnector;
-    private String OAUTHUrl;
-    private String clientId;
-    private String clientSecret;
+    @Autowired
+    OrcidClient orcidClient;
 
-    private String accessToken;
-
-    /**
-     * Maximum retries to allow for the access token retrieval
-     */
-    private int maxClientRetries = 3;
-
-    public void setOAUTHUrl(String oAUTHUrl) {
-        OAUTHUrl = oAUTHUrl;
-    }
-
-    public void setClientId(String clientId) {
-        this.clientId = clientId;
-    }
-
-    public void setClientSecret(String clientSecret) {
-        this.clientSecret = clientSecret;
-    }
-
-    public String getAccessToken() {
-        return accessToken;
-    }
-
-    public void setAccessToken(String accessToken) {
-        this.accessToken = accessToken;
-    }
+    @Autowired
+    OrcidConfiguration orcidConfiguration;
 
     /**
-     *  Initialize the accessToken that is required for all subsequent calls to ORCID
+     * No-op initialization — OrcidClient handles token management internally.
      */
     public void init() {
-        // Initialize access token at spring instantiation. If it fails, the access token will be null rather
-        // than causing a fatal Spring startup error
-        initializeAccessToken();
-    }
-
-    public void initializeAccessToken() {
-        // If we have reaches max retries or the access token is already set, return immediately
-        if (maxClientRetries <= 0 || org.apache.commons.lang3.StringUtils.isNotBlank(accessToken)) {
-            return;
-        }
-        try {
-            accessToken = OrcidFactoryUtils.retrieveAccessToken(clientId, clientSecret, OAUTHUrl).orElse(null);
-        } catch (IOException e) {
-            log.error("Error retrieving ORCID access token, {} retries left", --maxClientRetries);
-        }
-    }
-
-    public void setOrcidRestConnector(OrcidRestConnector orcidRestConnector) {
-        this.orcidRestConnector = orcidRestConnector;
+        // No-op: OrcidClient handles token management
     }
 
     /**
      * Makes an instance of the AuthorityValue with the given information.
+     *
      * @param text search string
-     * @return List<AuthorityValue>
+     * @return List of AuthorityValues
      */
     @Override
     public List<AuthorityValue> queryAuthorities(String text, int max) {
-        initializeAccessToken();
         List<Person> bios = queryBio(text, max);
         List<AuthorityValue> result = new ArrayList<>();
         for (Person person : bios) {
@@ -118,107 +72,101 @@ public class Orcidv3SolrAuthorityImpl implements SolrAuthorityInterface {
 
     /**
      * Create an AuthorityValue from a Person retrieved using the given orcid identifier.
+     *
      * @param id orcid identifier
      * @return AuthorityValue
      */
     @Override
     public AuthorityValue queryAuthorityID(String id) {
-        initializeAccessToken();
         Person person = getBio(id);
-        AuthorityValue valueFromPerson = Orcidv3AuthorityValue.create(person);
-        return valueFromPerson;
+        return Orcidv3AuthorityValue.create(person);
     }
 
     /**
-     * Retrieve a Person object based on a given orcid identifier
+     * Retrieve a Person object based on a given orcid identifier.
+     *
      * @param id orcid identifier
      * @return Person
      */
     public Person getBio(String id) {
-        log.debug("getBio called with ID=" + id);
+        log.debug("getBio called with ID={}", id);
         if (!isValid(id)) {
             return null;
         }
-        if (orcidRestConnector == null) {
-            log.error("ORCID REST connector is null, returning null Person");
-            return null;
-        }
-        initializeAccessToken();
-        try (InputStream bioDocument = orcidRestConnector.get(id + ((id.endsWith("/person")) ? "" : "/person"),
-                                                              accessToken)) {
-            XMLtoBio converter = new XMLtoBio();
-            return converter.convertSinglePerson(bioDocument);
-        } catch (OrcidConnectionException | IOException e) {
+        try {
+            if (orcidConfiguration.isApiConfigured()) {
+                return orcidClient.getPerson(getAccessToken(), id);
+            } else {
+                return orcidClient.getPerson(id);
+            }
+        } catch (OrcidClientException e) {
             log.error("Error retrieving ORCID bio for ID={}", id, e);
             return null;
         }
     }
 
-
     /**
      * Retrieve a list of Person objects.
-     * @param text search string
+     *
+     * @param text  search string
      * @param start offset to use
-     * @param rows how many rows to return
-     * @return List<Person>
+     * @param rows  how many rows to return
+     * @return List of Persons
      */
     public List<Person> queryBio(String text, int start, int rows) {
         if (rows > 100) {
             throw new IllegalArgumentException("The maximum number of results to retrieve cannot exceed 100.");
         }
-        // Check REST connector is initialized
-        if (orcidRestConnector == null) {
-            log.error("ORCID REST connector is not initialized, returning empty list");
-            return Collections.emptyList();
-        }
-        // Check / init access token
-        initializeAccessToken();
 
-        String searchPath = "search?q=" + URLEncoder.encode(text, StandardCharsets.UTF_8) + "&start=" + start +
-                                                                                            "&rows=" + rows;
-        log.debug("queryBio searchPath=" + searchPath + " accessToken=" + accessToken);
+        log.debug("queryBio text={} start={} rows={}", text, start, rows);
         try {
-            InputStream bioDocument = orcidRestConnector.get(searchPath, accessToken);
-            XMLtoBio converter = new XMLtoBio();
-            List<Result> results = converter.convert(bioDocument);
+            ExpandedSearch searchResult;
+            if (orcidConfiguration.isApiConfigured()) {
+                searchResult = orcidClient.expandedSearch(getAccessToken(), text, start, rows);
+            } else {
+                searchResult = orcidClient.expandedSearch(text, start, rows);
+            }
+
             List<Person> bios = new LinkedList<>();
-            for (Result result : results) {
-                OrcidIdentifier orcidIdentifier = result.getOrcidIdentifier();
-                if (orcidIdentifier != null) {
-                    log.debug("Found OrcidId=" + orcidIdentifier);
-                    String orcid = orcidIdentifier.getPath();
+            for (ExpandedResult result : searchResult.getResults()) {
+                String orcid = result.getOrcidId();
+                if (orcid != null) {
+                    log.debug("Found OrcidId={}", orcid);
                     Person bio = getBio(orcid);
                     if (bio != null) {
                         bios.add(bio);
                     }
                 }
             }
-            try {
-                bioDocument.close();
-            } catch (IOException e) {
-                log.error(e.getMessage(), e);
-            }
             return bios;
-        } catch (OrcidConnectionException e) {
-            log.error("Error searching ORCID for query=" + text, e);
+        } catch (OrcidClientException e) {
+            log.error("Error searching ORCID for query={}", text, e);
             return Collections.emptyList();
         }
     }
 
     /**
      * Retrieve a list of Person objects.
+     *
      * @param text search string
-     * @param max how many rows to return
-     * @return List<Person>
+     * @param max  how many rows to return
+     * @return List of Persons
      */
     public List<Person> queryBio(String text, int max) {
         return queryBio(text, 0, max);
     }
 
     /**
-     * Check to see if the provided text has the correct ORCID syntax. Since only
-     * searching on ORCID id is allowed, this way, we filter out any queries that
-     * would return a blank result anyway
+     * Retrieve an access token for API calls.
+     *
+     * @return the access token
+     */
+    private String getAccessToken() {
+        return orcidClient.getReadPublicAccessToken().getAccessToken();
+    }
+
+    /**
+     * Check to see if the provided text has the correct ORCID syntax.
      */
     private boolean isValid(String text) {
         return StringUtils.isNotBlank(text) && text.matches(Orcidv3AuthorityValue.ORCID_ID_SYNTAX);

--- a/dspace-api/src/main/java/org/dspace/external/provider/impl/OrcidV3AuthorDataProvider.java
+++ b/dspace-api/src/main/java/org/dspace/external/provider/impl/OrcidV3AuthorDataProvider.java
@@ -7,10 +7,6 @@
  */
 package org.dspace.external.provider.impl;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -24,45 +20,36 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.content.MetadataFieldName;
 import org.dspace.content.dto.MetadataValueDTO;
-import org.dspace.external.OrcidConnectionException;
-import org.dspace.external.OrcidRestConnector;
 import org.dspace.external.model.ExternalDataObject;
 import org.dspace.external.provider.AbstractExternalDataProvider;
-import org.dspace.external.provider.orcid.xml.XMLtoBio;
-import org.dspace.orcid.model.factory.OrcidFactoryUtils;
-import org.orcid.jaxb.model.v3.release.common.OrcidIdentifier;
+import org.dspace.orcid.client.OrcidClient;
+import org.dspace.orcid.client.OrcidConfiguration;
+import org.dspace.orcid.exception.OrcidClientException;
 import org.orcid.jaxb.model.v3.release.record.Email;
 import org.orcid.jaxb.model.v3.release.record.Person;
 import org.orcid.jaxb.model.v3.release.record.Record;
-import org.orcid.jaxb.model.v3.release.search.Result;
+import org.orcid.jaxb.model.v3.release.search.expanded.ExpandedResult;
+import org.orcid.jaxb.model.v3.release.search.expanded.ExpandedSearch;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * This class is the implementation of the ExternalDataProvider interface that will deal with the OrcidV3 External
- * Data lookup
+ * Data lookup. It uses the modern {@link OrcidClient} for all ORCID API calls, supporting both
+ * public and member API endpoints based on configuration.
  */
 public class OrcidV3AuthorDataProvider extends AbstractExternalDataProvider {
 
     private static final Logger log = LogManager.getLogger(OrcidV3AuthorDataProvider.class);
 
-    private OrcidRestConnector orcidRestConnector;
-    private String OAUTHUrl;
+    @Autowired
+    private OrcidClient orcidClient;
 
-    private String clientId;
-    private String clientSecret;
-
-    private String accessToken;
+    @Autowired
+    private OrcidConfiguration orcidConfiguration;
 
     private String sourceIdentifier;
 
     private String orcidUrl;
-
-    private XMLtoBio converter;
-
-    /**
-     * Maximum retries to allow for the access token retrieval
-     */
-    private int maxClientRetries = 3;
 
     private Map<String, String> externalIdentifiers;
 
@@ -75,49 +62,33 @@ public class OrcidV3AuthorDataProvider extends AbstractExternalDataProvider {
     }
 
     public OrcidV3AuthorDataProvider() {
-        converter = new XMLtoBio();
     }
 
     /**
-     * Initialize the accessToken that is required for all subsequent calls to ORCID.
-     *
-     * @throws java.io.IOException passed through from HTTPclient.
+     * Initialization method — no longer needs to retrieve access tokens since
+     * {@link OrcidClient} handles authentication internally.
      */
-    public void init() throws IOException {
-        // Initialize access token at spring instantiation. If it fails, the access token will be null rather
-        // than causing a fatal Spring startup error
-        initializeAccessToken();
-    }
-
-    /**
-     * Initialize access token, logging an error and decrementing remaining retries if an IOException is thrown.
-     * If the optional access token result is empty, set to null instead.
-     */
-    public void initializeAccessToken() {
-        // If we have reaches max retries or the access token is already set, return immediately
-        if (maxClientRetries <= 0 || StringUtils.isNotBlank(accessToken)) {
-            if (maxClientRetries <= 0) {
-                log.warn("Maximum retry attempts reached for ORCID token retrieval");
-            }
-            return;
-        }
-        try {
-            accessToken = OrcidFactoryUtils.retrieveAccessToken(clientId, clientSecret, OAUTHUrl).orElse(null);
-        } catch (IOException e) {
-            log.error("Error retrieving ORCID access token, {} retries left", --maxClientRetries);
-        }
+    public void init() {
+        // No-op: OrcidClient handles token management
     }
 
     @Override
     public Optional<ExternalDataObject> getExternalDataObject(String id) {
-        initializeAccessToken();
         Record record = getRecord(id);
+        if (record == null) {
+            return Optional.empty();
+        }
         ExternalDataObject externalDataObject = convertToExternalDataObject(record);
         return Optional.of(externalDataObject);
     }
 
-    protected ExternalDataObject convertToExternalDataObject(org.orcid.jaxb.model.v3.release.record.Record record) {
-        initializeAccessToken();
+    /**
+     * Convert an ORCID Record to an ExternalDataObject with rich metadata.
+     *
+     * @param record the ORCID Record
+     * @return the ExternalDataObject
+     */
+    protected ExternalDataObject convertToExternalDataObject(Record record) {
         Person person = record.getPerson();
         ExternalDataObject externalDataObject = new ExternalDataObject(sourceIdentifier);
         if (person.getName() != null) {
@@ -268,7 +239,7 @@ public class OrcidV3AuthorDataProvider extends AbstractExternalDataProvider {
 
     private void appendAffiliations(
         ExternalDataObject externalDataObject,
-        org.orcid.jaxb.model.v3.release.record.Record record) {
+        Record record) {
 
         if (record == null) {
             return;
@@ -316,25 +287,35 @@ public class OrcidV3AuthorDataProvider extends AbstractExternalDataProvider {
 
     /**
      * Retrieve a Record object based on a given orcid identifier.
+     *
      * @param id orcid identifier
-     * @return Record
+     * @return Record, or null if invalid or not found
      */
-    public org.orcid.jaxb.model.v3.release.record.Record getRecord(String id) {
+    public Record getRecord(String id) {
         log.debug("getRecord called with ID={}", id);
         if (!isValid(id)) {
             return null;
         }
-        if (orcidRestConnector == null) {
-            log.error("ORCID REST connector is null, returning null ORCID Person Bio");
+        try {
+            if (orcidConfiguration.isApiConfigured()) {
+                return orcidClient.getRecord(getAccessToken(), id);
+            } else {
+                return orcidClient.getRecord(id);
+            }
+        } catch (OrcidClientException e) {
+            log.error("Error retrieving ORCID record for ID={}", id, e);
             return null;
         }
-        initializeAccessToken();
-        try (InputStream bioDocument = orcidRestConnector.get(id, accessToken)) {
-            return converter.convertToRecord(bioDocument);
-        } catch (OrcidConnectionException | IOException e) {
-            log.error("Error retrieving ORCID bio for ID={}", id, e);
-            return null;
-        }
+    }
+
+    /**
+     * Retrieve an access token for API calls. Uses a read-public token obtained
+     * via client credentials.
+     *
+     * @return the access token
+     */
+    private String getAccessToken() {
+        return orcidClient.getReadPublicAccessToken().getAccessToken();
     }
 
     /**
@@ -348,39 +329,29 @@ public class OrcidV3AuthorDataProvider extends AbstractExternalDataProvider {
 
     @Override
     public List<ExternalDataObject> searchExternalDataObjects(String query, int start, int limit) {
-        initializeAccessToken();
         if (limit > 100) {
             throw new IllegalArgumentException("The maximum number of results to retrieve cannot exceed 100.");
         }
         if (start > MAX_INDEX) {
             throw new IllegalArgumentException("The starting number of results to retrieve cannot exceed 10000.");
         }
-        // Check REST connector is initialized
-        if (orcidRestConnector == null) {
-            log.error("ORCID REST connector is not initialized, returning empty list");
-            return Collections.emptyList();
-        }
 
-        String searchPath = "search?q=" + URLEncoder.encode(query, StandardCharsets.UTF_8)
-                + "&start=" + start
-                + "&rows=" + limit;
-        log.debug("queryBio searchPath=" + searchPath + " accessToken=" + accessToken);
-        try (InputStream bioDocument = orcidRestConnector.get(searchPath, accessToken)) {
-            List<Result> results = converter.convert(bioDocument);
-            List<org.orcid.jaxb.model.v3.release.record.Record> bios = new LinkedList<>();
-            for (Result result : results) {
-                OrcidIdentifier orcidIdentifier = result.getOrcidIdentifier();
-                if (orcidIdentifier != null) {
-                    log.debug("Found OrcidId=" + orcidIdentifier.getPath());
-                    String orcid = orcidIdentifier.getPath();
-                    org.orcid.jaxb.model.v3.release.record.Record bio = getRecord(orcid);
-                    if (bio != null) {
-                        bios.add(bio);
+        log.debug("searchExternalDataObjects query={} start={} limit={}", query, start, limit);
+        try {
+            ExpandedSearch searchResult = performSearch(query, start, limit);
+            List<Record> records = new LinkedList<>();
+            for (ExpandedResult result : searchResult.getResults()) {
+                String orcid = result.getOrcidId();
+                if (orcid != null) {
+                    log.debug("Found OrcidId={}", orcid);
+                    Record record = getRecord(orcid);
+                    if (record != null) {
+                        records.add(record);
                     }
                 }
             }
-            return bios.stream().map(bio -> convertToExternalDataObject(bio)).collect(Collectors.toList());
-        } catch (OrcidConnectionException | IOException e) {
+            return records.stream().map(this::convertToExternalDataObject).collect(Collectors.toList());
+        } catch (OrcidClientException e) {
             log.error("Error searching ORCID for query={}", query, e);
             return Collections.emptyList();
         }
@@ -393,27 +364,37 @@ public class OrcidV3AuthorDataProvider extends AbstractExternalDataProvider {
 
     @Override
     public int getNumberOfResults(String query) {
-        if (orcidRestConnector == null) {
-            log.error("ORCID REST connector is null, returning 0");
-            return 0;
-        }
-        initializeAccessToken();
-        String searchPath = "search?q=" + URLEncoder.encode(query, StandardCharsets.UTF_8)
-                + "&start=" + 0
-                + "&rows=" + 0;
-        log.debug("queryBio searchPath=" + searchPath + " accessToken=" + accessToken);
-        try (InputStream bioDocument = orcidRestConnector.get(searchPath, accessToken)) {
-            return Math.min(converter.getNumberOfResultsFromXml(bioDocument), MAX_INDEX);
-        } catch (OrcidConnectionException | IOException e) {
+        log.debug("getNumberOfResults query={}", query);
+        try {
+            ExpandedSearch searchResult = performSearch(query, 0, 0);
+            Long numFound = searchResult.getNumFound();
+            return Math.min(numFound != null ? numFound.intValue() : 0, MAX_INDEX);
+        } catch (OrcidClientException e) {
             log.error("Error getting number of results from ORCID for query={}", query, e);
             return 0;
         }
     }
 
+    /**
+     * Perform an ORCID expanded search, using the member API if configured or the public API otherwise.
+     *
+     * @param query the search query
+     * @param start the start index
+     * @param rows  the number of rows
+     * @return the ExpandedSearch result
+     */
+    private ExpandedSearch performSearch(String query, int start, int rows) {
+        if (orcidConfiguration.isApiConfigured()) {
+            return orcidClient.expandedSearch(getAccessToken(), query, start, rows);
+        } else {
+            return orcidClient.expandedSearch(query, start, rows);
+        }
+    }
 
     /**
-     * Generic setter for the sourceIdentifier
-     * @param sourceIdentifier   The sourceIdentifier to be set on this OrcidV3AuthorDataProvider
+     * Generic setter for the sourceIdentifier.
+     *
+     * @param sourceIdentifier The sourceIdentifier to be set on this OrcidV3AuthorDataProvider
      */
     @Autowired(required = true)
     public void setSourceIdentifier(String sourceIdentifier) {
@@ -421,7 +402,8 @@ public class OrcidV3AuthorDataProvider extends AbstractExternalDataProvider {
     }
 
     /**
-     * Generic getter for the orcidUrl
+     * Generic getter for the orcidUrl.
+     *
      * @return the orcidUrl value of this OrcidV3AuthorDataProvider
      */
     public String getOrcidUrl() {
@@ -429,8 +411,9 @@ public class OrcidV3AuthorDataProvider extends AbstractExternalDataProvider {
     }
 
     /**
-     * Generic setter for the orcidUrl
-     * @param orcidUrl   The orcidUrl to be set on this OrcidV3AuthorDataProvider
+     * Generic setter for the orcidUrl.
+     *
+     * @param orcidUrl The orcidUrl to be set on this OrcidV3AuthorDataProvider
      */
     @Autowired(required = true)
     public void setOrcidUrl(String orcidUrl) {
@@ -438,41 +421,19 @@ public class OrcidV3AuthorDataProvider extends AbstractExternalDataProvider {
     }
 
     /**
-     * Generic setter for the OAUTHUrl
-     * @param OAUTHUrl   The OAUTHUrl to be set on this OrcidV3AuthorDataProvider
+     * Getter for the externalIdentifiers map.
+     *
+     * @return the externalIdentifiers mapping
      */
-    public void setOAUTHUrl(String OAUTHUrl) {
-        this.OAUTHUrl = OAUTHUrl;
-    }
-
-    /**
-     * Generic setter for the clientId
-     * @param clientId   The clientId to be set on this OrcidV3AuthorDataProvider
-     */
-    public void setClientId(String clientId) {
-        this.clientId = clientId;
-    }
-
-    /**
-     * Generic setter for the clientSecret
-     * @param clientSecret   The clientSecret to be set on this OrcidV3AuthorDataProvider
-     */
-    public void setClientSecret(String clientSecret) {
-        this.clientSecret = clientSecret;
-    }
-
-    public OrcidRestConnector getOrcidRestConnector() {
-        return orcidRestConnector;
-    }
-
-    public void setOrcidRestConnector(OrcidRestConnector orcidRestConnector) {
-        this.orcidRestConnector = orcidRestConnector;
-    }
-
     public Map<String, String> getExternalIdentifiers() {
         return externalIdentifiers;
     }
 
+    /**
+     * Setter for the externalIdentifiers map.
+     *
+     * @param externalIdentifiers the mapping of ORCID external ID types to DSpace metadata fields
+     */
     public void setExternalIdentifiers(Map<String, String> externalIdentifiers) {
         this.externalIdentifiers = externalIdentifiers;
     }

--- a/dspace-api/src/main/java/org/dspace/orcid/client/OrcidClient.java
+++ b/dspace-api/src/main/java/org/dspace/orcid/client/OrcidClient.java
@@ -14,6 +14,7 @@ import org.dspace.orcid.OrcidToken;
 import org.dspace.orcid.exception.OrcidClientException;
 import org.dspace.orcid.model.OrcidTokenResponseDTO;
 import org.orcid.jaxb.model.v3.release.record.Person;
+import org.orcid.jaxb.model.v3.release.record.Record;
 import org.orcid.jaxb.model.v3.release.record.WorkBulk;
 import org.orcid.jaxb.model.v3.release.record.summary.Works;
 import org.orcid.jaxb.model.v3.release.search.expanded.ExpandedSearch;
@@ -54,6 +55,36 @@ public interface OrcidClient {
      * @throws OrcidClientException if some error occurs during the search
      */
     Person getPerson(String accessToken, String orcid);
+
+    /**
+     * Retrieves a summary of the ORCID person related to the given orcid
+     * using the public endpoint.
+     *
+     * @param  orcid                the orcid id of the record to retrieve
+     * @return                      the Person
+     * @throws OrcidClientException if some error occurs during the search
+     */
+    Person getPerson(String orcid);
+
+    /**
+     * Retrieves the full ORCID record (person + activities) for the given orcid.
+     *
+     * @param  accessToken          the access token
+     * @param  orcid                the orcid id of the record to retrieve
+     * @return                      the Record
+     * @throws OrcidClientException if some error occurs during the retrieval
+     */
+    Record getRecord(String accessToken, String orcid);
+
+    /**
+     * Retrieves the full ORCID record (person + activities) for the given orcid
+     * using the public endpoint.
+     *
+     * @param  orcid                the orcid id of the record to retrieve
+     * @return                      the Record
+     * @throws OrcidClientException if some error occurs during the retrieval
+     */
+    Record getRecord(String orcid);
 
     /**
      * Retrieves all the works related to the given orcid.

--- a/dspace-api/src/main/java/org/dspace/orcid/client/OrcidClientImpl.java
+++ b/dspace-api/src/main/java/org/dspace/orcid/client/OrcidClientImpl.java
@@ -56,6 +56,7 @@ import org.orcid.jaxb.model.v3.release.record.Keyword;
 import org.orcid.jaxb.model.v3.release.record.OtherName;
 import org.orcid.jaxb.model.v3.release.record.Person;
 import org.orcid.jaxb.model.v3.release.record.PersonExternalIdentifier;
+import org.orcid.jaxb.model.v3.release.record.Record;
 import org.orcid.jaxb.model.v3.release.record.ResearcherUrl;
 import org.orcid.jaxb.model.v3.release.record.Work;
 import org.orcid.jaxb.model.v3.release.record.WorkBulk;
@@ -119,6 +120,24 @@ public class OrcidClientImpl implements OrcidClient {
     public Person getPerson(String accessToken, String orcid) {
         HttpUriRequest httpUriRequest = buildGetUriRequest(accessToken, "/" + orcid + "/person");
         return executeAndUnmarshall(httpUriRequest, false, Person.class);
+    }
+
+    @Override
+    public Person getPerson(String orcid) {
+        HttpUriRequest httpUriRequest = buildGetUriRequestToPublicEndpoint("/" + orcid + "/person");
+        return executeAndUnmarshall(httpUriRequest, false, Person.class);
+    }
+
+    @Override
+    public Record getRecord(String accessToken, String orcid) {
+        HttpUriRequest httpUriRequest = buildGetUriRequest(accessToken, "/" + orcid + "/record");
+        return executeAndUnmarshall(httpUriRequest, false, Record.class);
+    }
+
+    @Override
+    public Record getRecord(String orcid) {
+        HttpUriRequest httpUriRequest = buildGetUriRequestToPublicEndpoint("/" + orcid + "/record");
+        return executeAndUnmarshall(httpUriRequest, false, Record.class);
     }
 
     @Override

--- a/dspace-api/src/test/data/dspaceFolder/config/spring/api/external-services.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/spring/api/external-services.xml
@@ -42,19 +42,11 @@
     <bean class="org.dspace.external.provider.impl.OrcidV3AuthorDataProvider" init-method="init">
         <property name="sourceIdentifier" value="orcid"/>
         <property name="orcidUrl" value="${orcid.domain-url}" />
-        <property name="clientId" value="${orcid.application-client-id}" />
-        <property name="clientSecret" value="${orcid.application-client-secret}" />
-        <property name="OAUTHUrl" value="${orcid.token-url}" />
-        <property name="orcidRestConnector" ref="orcidRestConnector"/>
         <property name="supportedEntityTypes">
             <list>
                 <value>Person</value>
             </list>
         </property>
-    </bean>
-
-    <bean id="orcidRestConnector" class="org.dspace.external.OrcidRestConnector">
-        <constructor-arg value="${orcid.api-url}"/>
     </bean>
 
     <bean id="authorityProjectDataProvider" class="org.dspace.external.provider.impl.AuthorityImportDataProvider">

--- a/dspace-api/src/test/java/org/dspace/authority/orcid/MockOrcid.java
+++ b/dspace-api/src/test/java/org/dspace/authority/orcid/MockOrcid.java
@@ -21,6 +21,7 @@ import org.dspace.orcid.exception.OrcidClientException;
 import org.dspace.orcid.model.OrcidTokenResponseDTO;
 import org.mockito.Mockito;
 import org.orcid.jaxb.model.v3.release.record.Person;
+import org.orcid.jaxb.model.v3.release.search.expanded.ExpandedResult;
 import org.orcid.jaxb.model.v3.release.search.expanded.ExpandedSearch;
 
 /**
@@ -66,13 +67,17 @@ public class MockOrcid extends Orcidv3SolrAuthorityImpl {
      * @throws OrcidClientException if mock setup fails
      */
     public void setupSingleSearch() throws OrcidClientException {
-        // For single search, return empty results (the original mock loaded orcid-search.xml
-        // which contained a single result, but the actual person data is loaded separately)
-        ExpandedSearch emptySearch = new ExpandedSearch();
+        // Return a single search result matching orcid-search.xml (ORCID ID 0000-0002-9029-1854).
+        // This overrides the no-results mock for queries that match "Bollini".
+        ExpandedSearch singleResult = new ExpandedSearch();
+        ExpandedResult result = new ExpandedResult();
+        result.setOrcidId("0000-0002-9029-1854");
+        singleResult.getResults().add(result);
+        singleResult.setNumFound(1L);
         when(mockOrcidClient.expandedSearch(anyString(), anyString(), anyInt(), anyInt()))
-                .thenReturn(emptySearch);
+                .thenReturn(singleResult);
         when(mockOrcidClient.expandedSearch(anyString(), anyInt(), anyInt()))
-                .thenReturn(emptySearch);
+                .thenReturn(singleResult);
     }
 
     /**

--- a/dspace-api/src/test/java/org/dspace/authority/orcid/MockOrcid.java
+++ b/dspace-api/src/test/java/org/dspace/authority/orcid/MockOrcid.java
@@ -9,6 +9,7 @@ package org.dspace.authority.orcid;
 
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import java.io.InputStream;
@@ -39,7 +40,7 @@ public class MockOrcid extends Orcidv3SolrAuthorityImpl {
         // Mock getReadPublicAccessToken to return a mock token
         OrcidTokenResponseDTO mockToken = new OrcidTokenResponseDTO();
         mockToken.setAccessToken("mock-access-token");
-        when(mockOrcidClient.getReadPublicAccessToken()).thenReturn(mockToken);
+        lenient().when(mockOrcidClient.getReadPublicAccessToken()).thenReturn(mockToken);
         // Set via field injection workaround
         this.orcidClient = mockOrcidClient;
     }

--- a/dspace-api/src/test/java/org/dspace/authority/orcid/MockOrcid.java
+++ b/dspace-api/src/test/java/org/dspace/authority/orcid/MockOrcid.java
@@ -7,80 +7,97 @@
  */
 package org.dspace.authority.orcid;
 
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 import java.io.InputStream;
 
-import org.dspace.external.OrcidConnectionException;
-import org.dspace.external.OrcidRestConnector;
-import org.mockito.ArgumentMatchers;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.Unmarshaller;
+import org.dspace.orcid.client.OrcidClient;
+import org.dspace.orcid.exception.OrcidClientException;
+import org.dspace.orcid.model.OrcidTokenResponseDTO;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
+import org.orcid.jaxb.model.v3.release.record.Person;
+import org.orcid.jaxb.model.v3.release.search.expanded.ExpandedSearch;
 
 /**
- * Mock the ORCID source using a mock rest connector so that query will be
- * resolved against static file
- * 
+ * Mock the ORCID source using a mock OrcidClient so that queries will be
+ * resolved against static files.
+ *
  * @author Andrea Bollini (andrea.bollini at 4science.it)
  *
  */
 public class MockOrcid extends Orcidv3SolrAuthorityImpl {
 
-    OrcidRestConnector orcidRestConnector;
+    private OrcidClient mockOrcidClient;
 
     @Override
     public void init() {
-        initializeAccessToken();
-        orcidRestConnector = Mockito.mock(OrcidRestConnector.class);
+        mockOrcidClient = Mockito.mock(OrcidClient.class);
+        // Mock getReadPublicAccessToken to return a mock token
+        OrcidTokenResponseDTO mockToken = new OrcidTokenResponseDTO();
+        mockToken.setAccessToken("mock-access-token");
+        when(mockOrcidClient.getReadPublicAccessToken()).thenReturn(mockToken);
+        // Set via field injection workaround
+        this.orcidClient = mockOrcidClient;
     }
 
     /**
      * Call this to set up mocking for any test classes that need it. We don't set it in init()
-     * or other AbstractIntegrationTest implementations will complain of unnecessary Mockito stubbing
+     * or other AbstractIntegrationTest implementations will complain of unnecessary Mockito stubbing.
+     *
+     * @throws OrcidClientException if mock setup fails
      */
-    public void setupNoResultsSearch() throws OrcidConnectionException {
-        when(orcidRestConnector.get(ArgumentMatchers.startsWith("search?"), ArgumentMatchers.any()))
-                .thenAnswer(new Answer<InputStream>() {
-                    @Override
-                    public InputStream answer(InvocationOnMock invocation) {
-                        return this.getClass().getResourceAsStream("orcid-search-noresults.xml");
-                    }
-                });
-    }
-    /**
-     * Call this to set up mocking for any test classes that need it. We don't set it in init()
-     * or other AbstractIntegrationTest implementations will complain of unnecessary Mockito stubbing
-     */
-    public void setupSingleSearch() throws OrcidConnectionException {
-        when(orcidRestConnector.get(ArgumentMatchers.startsWith("search?q=Bollini"), ArgumentMatchers.any()))
-                .thenAnswer(new Answer<InputStream>() {
-                    @Override
-                    public InputStream answer(InvocationOnMock invocation) {
-                        return this.getClass().getResourceAsStream("orcid-search.xml");
-                    }
-                });
-    }
-    /**
-     * Call this to set up mocking for any test classes that need it. We don't set it in init()
-     * or other AbstractIntegrationTest implementations will complain of unnecessary Mockito stubbing
-     */
-    public void setupSearchWithResults() throws OrcidConnectionException {
-        when(orcidRestConnector.get(ArgumentMatchers.endsWith("/person"), ArgumentMatchers.any()))
-                .thenAnswer(new Answer<InputStream>() {
-                    @Override
-                    public InputStream answer(InvocationOnMock invocation) {
-                        return this.getClass().getResourceAsStream("orcid-person.xml");
-                    }
-                });
-
-        setOrcidRestConnector(orcidRestConnector);
+    public void setupNoResultsSearch() throws OrcidClientException {
+        ExpandedSearch emptySearch = new ExpandedSearch();
+        when(mockOrcidClient.expandedSearch(anyString(), anyString(), anyInt(), anyInt()))
+                .thenReturn(emptySearch);
+        when(mockOrcidClient.expandedSearch(anyString(), anyInt(), anyInt()))
+                .thenReturn(emptySearch);
     }
 
-    @Override
-    public void initializeAccessToken() {
-        if (getAccessToken() == null) {
-            setAccessToken("mock-access-token");
+    /**
+     * Call this to set up mocking for any test classes that need it. We don't set it in init()
+     * or other AbstractIntegrationTest implementations will complain of unnecessary Mockito stubbing.
+     *
+     * @throws OrcidClientException if mock setup fails
+     */
+    public void setupSingleSearch() throws OrcidClientException {
+        // For single search, return empty results (the original mock loaded orcid-search.xml
+        // which contained a single result, but the actual person data is loaded separately)
+        ExpandedSearch emptySearch = new ExpandedSearch();
+        when(mockOrcidClient.expandedSearch(anyString(), anyString(), anyInt(), anyInt()))
+                .thenReturn(emptySearch);
+        when(mockOrcidClient.expandedSearch(anyString(), anyInt(), anyInt()))
+                .thenReturn(emptySearch);
+    }
+
+    /**
+     * Call this to set up mocking for any test classes that need it. We don't set it in init()
+     * or other AbstractIntegrationTest implementations will complain of unnecessary Mockito stubbing.
+     *
+     * @throws OrcidClientException if mock setup fails
+     */
+    public void setupSearchWithResults() throws OrcidClientException {
+        Person person = loadPersonFromXml();
+        when(mockOrcidClient.getPerson(anyString(), anyString())).thenReturn(person);
+        when(mockOrcidClient.getPerson(anyString())).thenReturn(person);
+    }
+
+    /**
+     * Load a Person object from the test XML resource.
+     *
+     * @return the Person object
+     */
+    private Person loadPersonFromXml() {
+        try (InputStream is = this.getClass().getResourceAsStream("orcid-person.xml")) {
+            JAXBContext jaxbContext = JAXBContext.newInstance(Person.class);
+            Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
+            return (Person) unmarshaller.unmarshal(is);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to load mock ORCID person XML", e);
         }
     }
 }

--- a/dspace-api/src/test/java/org/dspace/authority/orcid/MockOrcid.java
+++ b/dspace-api/src/test/java/org/dspace/authority/orcid/MockOrcid.java
@@ -9,6 +9,7 @@ package org.dspace.authority.orcid;
 
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
@@ -68,15 +69,17 @@ public class MockOrcid extends Orcidv3SolrAuthorityImpl {
      */
     public void setupSingleSearch() throws OrcidClientException {
         // Return a single search result matching orcid-search.xml (ORCID ID 0000-0002-9029-1854).
-        // This overrides the no-results mock for queries that match "Bollini".
+        // Only matches queries containing "Bollini", leaving the no-results mock for other queries.
+        // In the 4-arg version (accessToken, query, start, rows) the query is the 2nd arg.
+        // In the 3-arg version (query, start, rows) the query is the 1st arg.
         ExpandedSearch singleResult = new ExpandedSearch();
         ExpandedResult result = new ExpandedResult();
         result.setOrcidId("0000-0002-9029-1854");
         singleResult.getResults().add(result);
         singleResult.setNumFound(1L);
-        when(mockOrcidClient.expandedSearch(anyString(), anyString(), anyInt(), anyInt()))
+        when(mockOrcidClient.expandedSearch(anyString(), contains("Bollini"), anyInt(), anyInt()))
                 .thenReturn(singleResult);
-        when(mockOrcidClient.expandedSearch(anyString(), anyInt(), anyInt()))
+        when(mockOrcidClient.expandedSearch(contains("Bollini"), anyInt(), anyInt()))
                 .thenReturn(singleResult);
     }
 

--- a/dspace-api/src/test/java/org/dspace/external/provider/impl/OrcidV3AuthorDataProviderTest.java
+++ b/dspace-api/src/test/java/org/dspace/external/provider/impl/OrcidV3AuthorDataProviderTest.java
@@ -13,17 +13,26 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.beans.HasPropertyWithValue.hasProperty;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.AllOf.allOf;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.InputStream;
 import java.util.List;
 
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.Unmarshaller;
 import org.dspace.AbstractDSpaceTest;
-import org.dspace.external.OrcidRestConnector;
 import org.dspace.external.model.ExternalDataObject;
+import org.dspace.orcid.client.OrcidClient;
+import org.dspace.orcid.client.OrcidConfiguration;
 import org.junit.Before;
 import org.junit.Test;
+import org.orcid.jaxb.model.v3.release.record.Record;
+import org.orcid.jaxb.model.v3.release.search.expanded.ExpandedResult;
+import org.orcid.jaxb.model.v3.release.search.expanded.ExpandedSearch;
+import org.springframework.test.util.ReflectionTestUtils;
 
 
 /**
@@ -34,10 +43,9 @@ import org.junit.Test;
  */
 public class OrcidV3AuthorDataProviderTest extends AbstractDSpaceTest {
 
-    private static final String SEARCH_XML_PATH = "org/dspace/external/provider/orcid-v3-author/search.xml";
-    private static final String PERSON1_XML_PATH = "org/dspace/external/provider/orcid-v3-author/record1.xml";
-    private static final String PERSON2_XML_PATH = "org/dspace/external/provider/orcid-v3-author/record2.xml";
-    private static final String PERSON3_XML_PATH = "org/dspace/external/provider/orcid-v3-author/record3.xml";
+    private static final String RECORD1_XML_PATH = "org/dspace/external/provider/orcid-v3-author/record1.xml";
+    private static final String RECORD2_XML_PATH = "org/dspace/external/provider/orcid-v3-author/record2.xml";
+    private static final String RECORD3_XML_PATH = "org/dspace/external/provider/orcid-v3-author/record3.xml";
 
     public static final String ORCID_SEARCH_QUERY = "search?q=0000-0000-0000-0000";
 
@@ -46,28 +54,51 @@ public class OrcidV3AuthorDataProviderTest extends AbstractDSpaceTest {
     @Before
     public void setup() throws Exception {
         dataProvider = new OrcidV3AuthorDataProvider();
-
-        OrcidRestConnector mockRestConnector = mock(OrcidRestConnector.class);
-
-        dataProvider.setOrcidRestConnector(mockRestConnector);
         dataProvider.setSourceIdentifier("orcid");
         dataProvider.setOrcidUrl("https://orcid.org");
 
-        dataProvider.setClientId("client-id");
-        dataProvider.setClientSecret("client-secret");
-        dataProvider.setOAUTHUrl("https://orcid.org/oauth");
+        OrcidClient mockOrcidClient = mock(OrcidClient.class);
+        OrcidConfiguration mockConfig = mock(OrcidConfiguration.class);
+        when(mockConfig.isApiConfigured()).thenReturn(false);
 
-        InputStream searchXmlStream = getClass().getClassLoader().getResourceAsStream(SEARCH_XML_PATH);
-        InputStream person1XmlStream = getClass().getClassLoader().getResourceAsStream(PERSON1_XML_PATH);
-        InputStream person2XmlStream = getClass().getClassLoader().getResourceAsStream(PERSON2_XML_PATH);
-        InputStream person3XmlStream = getClass().getClassLoader().getResourceAsStream(PERSON3_XML_PATH);
+        // Inject mocks via reflection since fields are @Autowired
+        ReflectionTestUtils.setField(dataProvider, "orcidClient", mockOrcidClient);
+        ReflectionTestUtils.setField(dataProvider, "orcidConfiguration", mockConfig);
 
-        when(mockRestConnector.get("search?q=search%3Fq%3D0000-0000-0000-0000&start=0&rows=10", null))
-                .thenReturn(searchXmlStream);
-        when(mockRestConnector.get("0000-0000-0000-0001", null)).thenReturn(person1XmlStream);
-        when(mockRestConnector.get("0000-0000-0000-0002", null)).thenReturn(person2XmlStream);
-        when(mockRestConnector.get("0000-0000-0000-0003", null)).thenReturn(person3XmlStream);
+        // Load record XML test data
+        Record record1 = loadRecord(RECORD1_XML_PATH);
+        Record record2 = loadRecord(RECORD2_XML_PATH);
+        Record record3 = loadRecord(RECORD3_XML_PATH);
 
+        // Build ExpandedSearch result with 3 ORCID IDs
+        ExpandedSearch searchResult = new ExpandedSearch();
+        searchResult.setNumFound(3L);
+        ExpandedResult r1 = new ExpandedResult();
+        r1.setOrcidId("0000-0000-0000-0001");
+        ExpandedResult r2 = new ExpandedResult();
+        r2.setOrcidId("0000-0000-0000-0002");
+        ExpandedResult r3 = new ExpandedResult();
+        r3.setOrcidId("0000-0000-0000-0003");
+        searchResult.getResults().add(r1);
+        searchResult.getResults().add(r2);
+        searchResult.getResults().add(r3);
+
+        // Mock search (public API, no token)
+        when(mockOrcidClient.expandedSearch(anyString(), anyInt(), anyInt()))
+                .thenReturn(searchResult);
+
+        // Mock record retrieval (public API, no token)
+        when(mockOrcidClient.getRecord("0000-0000-0000-0001")).thenReturn(record1);
+        when(mockOrcidClient.getRecord("0000-0000-0000-0002")).thenReturn(record2);
+        when(mockOrcidClient.getRecord("0000-0000-0000-0003")).thenReturn(record3);
+    }
+
+    private Record loadRecord(String path) throws Exception {
+        try (InputStream is = getClass().getClassLoader().getResourceAsStream(path)) {
+            JAXBContext jaxbContext = JAXBContext.newInstance(Record.class);
+            Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
+            return (Record) unmarshaller.unmarshal(is);
+        }
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/OrcidExternalSourcesIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/OrcidExternalSourcesIT.java
@@ -9,7 +9,8 @@ package org.dspace.app.rest;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -18,19 +19,21 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.io.InputStream;
 
-import org.apache.commons.lang3.StringUtils;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.Unmarshaller;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
-import org.dspace.external.OrcidRestConnector;
 import org.dspace.external.provider.impl.OrcidV3AuthorDataProvider;
-import org.dspace.services.ConfigurationService;
+import org.dspace.orcid.client.OrcidClient;
+import org.dspace.orcid.client.OrcidConfiguration;
 import org.hamcrest.Matchers;
 import org.junit.Assume;
 import org.junit.Test;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
+import org.orcid.jaxb.model.v3.release.record.Record;
+import org.orcid.jaxb.model.v3.release.search.expanded.ExpandedResult;
+import org.orcid.jaxb.model.v3.release.search.expanded.ExpandedSearch;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.ReflectionTestUtils;
 
 /**
  * This test suite includes static test with mock data and end to end test to
@@ -39,20 +42,19 @@ import org.springframework.beans.factory.annotation.Autowired;
  * orcid.application-client-secret is needed to successful run the tests. This can be enabled
  * setting the orcid credentials via env variables, see the comments in the
  * override section of the config-definition.xml
- * 
+ *
  * @author Mykhaylo Boychuk (4Science.it)
  *
  */
 public class OrcidExternalSourcesIT extends AbstractControllerIntegrationTest {
 
     @Autowired
-    ConfigurationService configurationService;
-
-    @Autowired
     private OrcidV3AuthorDataProvider orcidV3AuthorDataProvider;
 
     public void onlyRunIfConfigExists() {
-        if (StringUtils.isBlank(configurationService.getProperty("orcid.application-client-id"))) {
+        OrcidConfiguration config = (OrcidConfiguration) ReflectionTestUtils
+            .getField(orcidV3AuthorDataProvider, "orcidConfiguration");
+        if (config == null || !config.isApiConfigured()) {
             Assume.assumeNoException(new IllegalStateException("Missing ORCID credentials"));
         }
     }
@@ -83,10 +85,11 @@ public class OrcidExternalSourcesIT extends AbstractControllerIntegrationTest {
                            hasJsonPath("$.externalSource", is("orcid")),
                            hasJsonPath("$.type", is("externalSourceEntry"))
                    )))
-                   .andExpect(jsonPath("$.metadata['dc.identifier.uri'][0].value",is("https://sandbox.orcid.org/" + entry)))
-                   .andExpect(jsonPath("$.metadata['person.familyName'][0].value",is("Bollini")))
-                   .andExpect(jsonPath("$.metadata['person.givenName'][0].value",is("Andrea")))
-                   .andExpect(jsonPath("$.metadata['person.identifier.orcid'][0].value",is(entry)));
+                   .andExpect(jsonPath("$.metadata['dc.identifier.uri'][0].value",
+                       is("https://sandbox.orcid.org/" + entry)))
+                   .andExpect(jsonPath("$.metadata['person.familyName'][0].value", is("Bollini")))
+                   .andExpect(jsonPath("$.metadata['person.givenName'][0].value", is("Andrea")))
+                   .andExpect(jsonPath("$.metadata['person.identifier.orcid'][0].value", is(entry)));
     }
 
     @Test
@@ -140,67 +143,73 @@ public class OrcidExternalSourcesIT extends AbstractControllerIntegrationTest {
                                    is("0000-0002-9029-1854")));
     }
 
-    @Test
     /**
      * This test uses mock data in the orcid-person-record.xml file to simulate the
      * response from ORCID and verify that it is properly consumed and exposed by
-     * the REST API
+     * the REST API.
      *
-     * @throws Exception
+     * @throws Exception if an error occurs
      */
+    @Test
     public void findOneExternalSourcesMockitoTest() throws Exception {
-        OrcidRestConnector orcidConnector = Mockito.mock(OrcidRestConnector.class);
-        OrcidRestConnector realConnector = orcidV3AuthorDataProvider.getOrcidRestConnector();
-        orcidV3AuthorDataProvider.setOrcidRestConnector(orcidConnector);
+        OrcidClient mockOrcidClient = Mockito.mock(OrcidClient.class);
+        OrcidClient realClient = (OrcidClient) ReflectionTestUtils
+            .getField(orcidV3AuthorDataProvider, "orcidClient");
+        OrcidConfiguration realConfig = (OrcidConfiguration) ReflectionTestUtils
+            .getField(orcidV3AuthorDataProvider, "orcidConfiguration");
+        OrcidConfiguration mockConfig = Mockito.mock(OrcidConfiguration.class);
+        when(mockConfig.isApiConfigured()).thenReturn(false);
+
+        ReflectionTestUtils.setField(orcidV3AuthorDataProvider, "orcidClient", mockOrcidClient);
+        ReflectionTestUtils.setField(orcidV3AuthorDataProvider, "orcidConfiguration", mockConfig);
+
         String entry = "0000-0002-9029-1854";
-        when(orcidConnector.get(eq(entry), any()))
-                .thenAnswer(new Answer<InputStream>() {
-                    public InputStream answer(InvocationOnMock invocation) {
-                        return getClass().getResourceAsStream("orcid-person-record.xml");
-                    }
-                });
+        Record mockRecord = loadRecord("orcid-person-record.xml");
+        when(mockOrcidClient.getRecord(eq(entry))).thenReturn(mockRecord);
 
-        getClient().perform(get("/api/integration/externalsources/orcid/entryValues/" + entry))
-                   .andExpect(status().isOk())
-                   .andExpect(jsonPath("$", Matchers.allOf(
-                           hasJsonPath("$.id", is(entry)),
-                           hasJsonPath("$.display", is("Bollini, Andrea")),
-                           hasJsonPath("$.value", is("Bollini, Andrea")),
-                           hasJsonPath("$.externalSource", is("orcid")),
-                           hasJsonPath("$.type", is("externalSourceEntry"))
-                           )));
-
-        orcidV3AuthorDataProvider.setOrcidRestConnector(realConnector);
+        try {
+            getClient().perform(get("/api/integration/externalsources/orcid/entryValues/" + entry))
+                       .andExpect(status().isOk())
+                       .andExpect(jsonPath("$", Matchers.allOf(
+                               hasJsonPath("$.id", is(entry)),
+                               hasJsonPath("$.display", is("Bollini, Andrea")),
+                               hasJsonPath("$.value", is("Bollini, Andrea")),
+                               hasJsonPath("$.externalSource", is("orcid")),
+                               hasJsonPath("$.type", is("externalSourceEntry"))
+                               )));
+        } finally {
+            ReflectionTestUtils.setField(orcidV3AuthorDataProvider, "orcidClient", realClient);
+            ReflectionTestUtils.setField(orcidV3AuthorDataProvider, "orcidConfiguration", realConfig);
+        }
     }
 
-    @Test
     /**
-     * This test uses mock data in the orcid-search.xml and orcid-person-record.xml
-     * file to simulate the response from ORCID and verify that it is properly
-     * consumed and exposed by the REST API. The orcid-search.xml file indeed
-     * contains the ORCID matching the user query, for each of them our integration
-     * need to grab details making a second call to the ORCID profile (this is due
-     * to the ORCID API structure and cannot be avoid)
+     * This test uses mock data in the orcid-person-record.xml file to simulate the
+     * response from ORCID and verify that it is properly consumed and exposed by
+     * the REST API. The search uses the expanded-search endpoint, and for each result
+     * the full record is fetched.
      *
-     * @throws Exception
+     * @throws Exception if an error occurs
      */
+    @Test
     public void findOneExternalSourceEntriesApplicableQueryMockitoTest() throws Exception {
-        OrcidRestConnector orcidConnector = Mockito.mock(OrcidRestConnector.class);
-        OrcidRestConnector realConnector = orcidV3AuthorDataProvider.getOrcidRestConnector();
-        orcidV3AuthorDataProvider.setOrcidRestConnector(orcidConnector);
+        OrcidClient mockOrcidClient = Mockito.mock(OrcidClient.class);
+        OrcidClient realClient = (OrcidClient) ReflectionTestUtils
+            .getField(orcidV3AuthorDataProvider, "orcidClient");
+        OrcidConfiguration realConfig = (OrcidConfiguration) ReflectionTestUtils
+            .getField(orcidV3AuthorDataProvider, "orcidConfiguration");
+        OrcidConfiguration mockConfig = Mockito.mock(OrcidConfiguration.class);
+        when(mockConfig.isApiConfigured()).thenReturn(false);
+
+        ReflectionTestUtils.setField(orcidV3AuthorDataProvider, "orcidClient", mockOrcidClient);
+        ReflectionTestUtils.setField(orcidV3AuthorDataProvider, "orcidConfiguration", mockConfig);
         try {
-            when(orcidConnector.get(ArgumentMatchers.startsWith("search?"), any()))
-                    .thenAnswer(new Answer<InputStream>() {
-                        public InputStream answer(InvocationOnMock invocation) {
-                            return getClass().getResourceAsStream("orcid-search.xml");
-                        }
-                    });
-            when(orcidConnector.get(eq("0000-0002-9029-1854"), ArgumentMatchers.any()))
-                    .thenAnswer(new Answer<InputStream>() {
-                        public InputStream answer(InvocationOnMock invocation) {
-                            return getClass().getResourceAsStream("orcid-person-record.xml");
-                        }
-                    });
+            ExpandedSearch searchResult = buildSearchResult("0000-0002-9029-1854");
+            when(mockOrcidClient.expandedSearch(anyString(), anyInt(), anyInt())).thenReturn(searchResult);
+
+            Record mockRecord = loadRecord("orcid-person-record.xml");
+            when(mockOrcidClient.getRecord(eq("0000-0002-9029-1854"))).thenReturn(mockRecord);
+
             String q = "orcid:0000-0002-9029-1854";
             getClient().perform(get("/api/integration/externalsources/orcid/entries")
                        .param("query", q))
@@ -222,38 +231,38 @@ public class OrcidExternalSourcesIT extends AbstractControllerIntegrationTest {
                             "$._embedded.externalSourceEntries[0].metadata['person.identifier.orcid'][0].value",
                             is("0000-0002-9029-1854")));
         } finally {
-            orcidV3AuthorDataProvider.setOrcidRestConnector(realConnector);
+            ReflectionTestUtils.setField(orcidV3AuthorDataProvider, "orcidClient", realClient);
+            ReflectionTestUtils.setField(orcidV3AuthorDataProvider, "orcidConfiguration", realConfig);
         }
     }
 
-    @Test
     /**
-     * This test uses mock data in the orcid-search.xml and orcid-person-record.xml
-     * file to simulate the response from ORCID and verify that it is properly
-     * consumed and exposed by the REST API. The orcid-search.xml file indeed
-     * contains the ORCID matching the user query, for each of them our integration
-     * need to grab details making a second call to the ORCID profile (this is due
-     * to the ORCID API structure and cannot be avoid)
+     * This test uses mock data in the orcid-person-record.xml file to simulate the
+     * response from ORCID and verify that it is properly consumed and exposed by
+     * the REST API. The search uses the expanded-search endpoint, and for each result
+     * the full record is fetched.
      *
-     * @throws Exception
+     * @throws Exception if an error occurs
      */
+    @Test
     public void findOneExternalSourceEntriesApplicableQueryFamilyNameAndGivenNamesMockitoTest() throws Exception {
-        OrcidRestConnector orcidConnector = Mockito.mock(OrcidRestConnector.class);
-        OrcidRestConnector realConnector = orcidV3AuthorDataProvider.getOrcidRestConnector();
-        orcidV3AuthorDataProvider.setOrcidRestConnector(orcidConnector);
+        OrcidClient mockOrcidClient = Mockito.mock(OrcidClient.class);
+        OrcidClient realClient = (OrcidClient) ReflectionTestUtils
+            .getField(orcidV3AuthorDataProvider, "orcidClient");
+        OrcidConfiguration realConfig = (OrcidConfiguration) ReflectionTestUtils
+            .getField(orcidV3AuthorDataProvider, "orcidConfiguration");
+        OrcidConfiguration mockConfig = Mockito.mock(OrcidConfiguration.class);
+        when(mockConfig.isApiConfigured()).thenReturn(false);
+
+        ReflectionTestUtils.setField(orcidV3AuthorDataProvider, "orcidClient", mockOrcidClient);
+        ReflectionTestUtils.setField(orcidV3AuthorDataProvider, "orcidConfiguration", mockConfig);
         try {
-            when(orcidConnector.get(ArgumentMatchers.startsWith("search?"), any()))
-                    .thenAnswer(new Answer<InputStream>() {
-                        public InputStream answer(InvocationOnMock invocation) {
-                            return getClass().getResourceAsStream("orcid-search.xml");
-                        }
-                    });
-            when(orcidConnector.get(eq("0000-0002-9029-1854"), any()))
-                    .thenAnswer(new Answer<InputStream>() {
-                        public InputStream answer(InvocationOnMock invocation) {
-                            return getClass().getResourceAsStream("orcid-person-record.xml");
-                        }
-                    });
+            ExpandedSearch searchResult = buildSearchResult("0000-0002-9029-1854");
+            when(mockOrcidClient.expandedSearch(anyString(), anyInt(), anyInt())).thenReturn(searchResult);
+
+            Record mockRecord = loadRecord("orcid-person-record.xml");
+            when(mockOrcidClient.getRecord(eq("0000-0002-9029-1854"))).thenReturn(mockRecord);
+
             String q = "family-name:bollini AND given-names:andrea";
             getClient().perform(get("/api/integration/externalsources/orcid/entries")
                        .param("query", q))
@@ -276,8 +285,31 @@ public class OrcidExternalSourcesIT extends AbstractControllerIntegrationTest {
                                 "$._embedded.externalSourceEntries[0].metadata['person.identifier.orcid'][0].value",
                                            is("0000-0002-9029-1854")));
         } finally {
-            orcidV3AuthorDataProvider.setOrcidRestConnector(realConnector);
+            ReflectionTestUtils.setField(orcidV3AuthorDataProvider, "orcidClient", realClient);
+            ReflectionTestUtils.setField(orcidV3AuthorDataProvider, "orcidConfiguration", realConfig);
         }
     }
 
+    /**
+     * Load an ORCID Record from an XML resource on the classpath.
+     */
+    private Record loadRecord(String resourceName) throws Exception {
+        try (InputStream is = getClass().getResourceAsStream(resourceName)) {
+            JAXBContext jaxbContext = JAXBContext.newInstance(Record.class);
+            Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
+            return (Record) unmarshaller.unmarshal(is);
+        }
+    }
+
+    /**
+     * Build an ExpandedSearch result containing a single ORCID ID.
+     */
+    private ExpandedSearch buildSearchResult(String orcidId) {
+        ExpandedSearch searchResult = new ExpandedSearch();
+        searchResult.setNumFound(1L);
+        ExpandedResult result = new ExpandedResult();
+        result.setOrcidId(orcidId);
+        searchResult.getResults().add(result);
+        return searchResult;
+    }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/authority/CrisConsumerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/authority/CrisConsumerIT.java
@@ -20,7 +20,6 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertNull;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -62,8 +61,9 @@ import org.dspace.content.authority.service.MetadataAuthorityService;
 import org.dspace.content.service.ItemService;
 import org.dspace.core.service.PluginService;
 import org.dspace.eperson.EPerson;
-import org.dspace.external.OrcidRestConnector;
 import org.dspace.external.provider.impl.OrcidV3AuthorDataProvider;
+import org.dspace.orcid.client.OrcidClient;
+import org.dspace.orcid.client.OrcidConfiguration;
 import org.dspace.services.ConfigurationService;
 import org.dspace.util.UUIDUtils;
 import org.dspace.xmlworkflow.storedcomponents.PoolTask;
@@ -74,6 +74,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
 import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MvcResult;
 
 /**
@@ -1132,14 +1133,20 @@ public class CrisConsumerIT extends AbstractControllerIntegrationTest {
     public void testOrcidImportFiller() throws Exception {
         // Authority configuration (AuthorAuthority) provided by setUp() method
 
-        OrcidRestConnector mockOrcidConnector = Mockito.mock(OrcidRestConnector.class);
-        OrcidRestConnector orcidConnector = orcidV3AuthorDataProvider.getOrcidRestConnector();
+        OrcidClient mockOrcidClient = Mockito.mock(OrcidClient.class);
+        OrcidClient realOrcidClient = (OrcidClient) ReflectionTestUtils
+            .getField(orcidV3AuthorDataProvider, "orcidClient");
+        OrcidConfiguration realOrcidConfig = (OrcidConfiguration) ReflectionTestUtils
+            .getField(orcidV3AuthorDataProvider, "orcidConfiguration");
+        OrcidConfiguration mockConfig = Mockito.mock(OrcidConfiguration.class);
+        when(mockConfig.isApiConfigured()).thenReturn(false);
 
-        orcidV3AuthorDataProvider.setOrcidRestConnector(mockOrcidConnector);
+        ReflectionTestUtils.setField(orcidV3AuthorDataProvider, "orcidClient", mockOrcidClient);
+        ReflectionTestUtils.setField(orcidV3AuthorDataProvider, "orcidConfiguration", mockConfig);
 
         String orcid = "0000-0002-9029-1854";
-        when(mockOrcidConnector.get(eq(orcid), any()))
-            .thenAnswer(i -> orcidPersonRecord.getInputStream());
+        org.orcid.jaxb.model.v3.release.record.Record mockRecord = loadOrcidRecord(orcidPersonRecord);
+        when(mockOrcidClient.getRecord(eq(orcid))).thenReturn(mockRecord);
 
         try {
 
@@ -1156,8 +1163,8 @@ public class CrisConsumerIT extends AbstractControllerIntegrationTest {
 
             context.restoreAuthSystemState();
 
-            verify(mockOrcidConnector).get(eq(orcid), any());
-            verifyNoMoreInteractions(mockOrcidConnector);
+            verify(mockOrcidClient).getRecord(eq(orcid));
+            verifyNoMoreInteractions(mockOrcidClient);
 
             String authToken = getAuthToken(submitter.getEmail(), password);
             ItemRest item = getItemViaRestByID(authToken, publication.getID());
@@ -1199,7 +1206,7 @@ public class CrisConsumerIT extends AbstractControllerIntegrationTest {
 
             context.restoreAuthSystemState();
 
-            verifyNoMoreInteractions(mockOrcidConnector);
+            verifyNoMoreInteractions(mockOrcidClient);
 
             item = getItemViaRestByID(authToken, anotherPublication.getID());
             authorMetadata = findSingleMetadata(item, "dc.contributor.author");
@@ -1207,9 +1214,22 @@ public class CrisConsumerIT extends AbstractControllerIntegrationTest {
 
 
         } finally {
-            orcidV3AuthorDataProvider.setOrcidRestConnector(orcidConnector);
+            ReflectionTestUtils.setField(orcidV3AuthorDataProvider, "orcidClient", realOrcidClient);
+            ReflectionTestUtils.setField(orcidV3AuthorDataProvider, "orcidConfiguration", realOrcidConfig);
         }
 
+    }
+
+    /**
+     * Load an ORCID Record object from a Spring Resource containing XML.
+     */
+    private org.orcid.jaxb.model.v3.release.record.Record loadOrcidRecord(Resource resource) throws Exception {
+        try (InputStream is = resource.getInputStream()) {
+            jakarta.xml.bind.JAXBContext jaxbContext = jakarta.xml.bind.JAXBContext
+                .newInstance(org.orcid.jaxb.model.v3.release.record.Record.class);
+            jakarta.xml.bind.Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
+            return (org.orcid.jaxb.model.v3.release.record.Record) unmarshaller.unmarshal(is);
+        }
     }
 
     @Test

--- a/dspace/config/spring/api/external-services.xml
+++ b/dspace/config/spring/api/external-services.xml
@@ -258,10 +258,6 @@
     <bean class="org.dspace.external.provider.impl.OrcidV3AuthorDataProvider" init-method="init">
         <property name="sourceIdentifier" value="orcid"/>
         <property name="orcidUrl" value="${orcid.domain-url}" />
-        <property name="clientId" value="${orcid.application-client-id}" />
-        <property name="clientSecret" value="${orcid.application-client-secret}" />
-        <property name="OAUTHUrl" value="${orcid.token-url}" />
-        <property name="orcidRestConnector" ref="orcidRestConnector"/>
         <property name="supportedEntityTypes">
             <list>
                 <value>Person</value>
@@ -273,10 +269,6 @@
                 <entry key="Researcher ID" value="person.identifier.rid"/>
             </map>
         </property>
-    </bean>
-
-    <bean id="orcidRestConnector" class="org.dspace.external.OrcidRestConnector">
-        <constructor-arg value="${orcid.api-url}"/>
     </bean>
 
     <!-- PubMed importers -->

--- a/dspace/config/spring/api/orcid-authority-services.xml
+++ b/dspace/config/spring/api/orcid-authority-services.xml
@@ -17,12 +17,7 @@
 
 <!--
     <alias name="OrcidSource" alias="AuthoritySource"/>
-    <bean name="OrcidSource" class="org.dspace.authority.orcid.Orcidv3SolrAuthorityImpl">
-        <property name="clientId" value="${orcid.application-client-id}" />
-        <property name="clientSecret" value="${orcid.application-client-secret}" />
-        <property name="OAUTHUrl" value="${orcid.token-url}" />
-        <property name="orcidRestConnector" ref="orcidRestConnector"/>
-    </bean>
+    <bean name="OrcidSource" class="org.dspace.authority.orcid.Orcidv3SolrAuthorityImpl"/>
  -->
  
     <bean name="AuthorityTypes" class="org.dspace.authority.AuthorityTypes">


### PR DESCRIPTION
Fixes https://github.com/DSpace/DSpace/issues/12127
Fixes https://github.com/DSpace/DSpace/issues/9333

## Summary
- **Replace the legacy `OrcidRestConnector`** (hardcoded to `orcid.api-url` / member API) with the modern `OrcidClient` in both `OrcidV3AuthorDataProvider` and `Orcidv3SolrAuthorityImpl`. `OrcidClient` properly routes to either the member API or public API based on `OrcidConfiguration.isApiConfigured()`.
- **Add `getRecord()` and public `getPerson()`** methods to `OrcidClient`/`OrcidClientImpl` to support full ORCID record retrieval (person + activities/affiliations) via both public and member endpoints.
- **Remove manual OAuth token management** (`clientId`, `clientSecret`, `OAUTHUrl`, `accessToken`, `initializeAccessToken()`) from both data providers — `OrcidClient` handles this internally.
- **Switch from `/search` to `/expanded-search` endpoint** for ORCID searches, aligning with the pattern used by `OrcidAuthority` (introduced in #11718).
- **Update all integration tests** (`OrcidV3AuthorDataProviderTest`, `OrcidExternalSourcesIT`, `CrisConsumerIT`, `MockOrcid`) to mock `OrcidClient` instead of `OrcidRestConnector`.

### Background

After the DSpace-CRIS authority framework merger (#11718), DSpace had two separate ORCID HTTP client systems: the legacy `OrcidRestConnector` and the modern `OrcidClient`. The legacy system was still actively used by `OrcidV3AuthorDataProvider` (which feeds the `ExternalDataProviderImportFiller` pipeline for auto-populating Person entities) and caused #9333 (ORCID search calls always hitting the member API endpoint, even without credentials).

`OrcidRestConnector` is kept in the codebase for now since the unused `RestSource` abstract class still references it.

## Test plan
- [ ] Verify `mvn install -DskipTests` completes successfully
- [ ] Verify `mvn checkstyle:check` passes on all modules
- [ ] Run `OrcidV3AuthorDataProviderTest` unit test (currently blocked by pre-existing SHERPA bean issue on main)
- [ ] Run `OrcidExternalSourcesIT` integration tests — mock tests should pass, live tests run only with ORCID credentials
- [ ] Run `CrisConsumerIT.testOrcidImportFiller` — verify the CRIS entity creation pipeline still populates Person entities with rich ORCID metadata
- [ ] Manual: author lookup in submission form works without member API credentials (public API)
- [ ] Manual: author lookup works with member API credentials (authenticated API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)