### PR TITLE
Fix SAF export bypassing file size limits

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExport.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExport.java
@@ -13,6 +13,7 @@ import java.io.InputStream;
 import java.nio.file.Path;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
@@ -22,6 +23,7 @@ import org.apache.commons.io.file.PathUtils;
 import org.dspace.app.itemexport.factory.ItemExportServiceFactory;
 import org.dspace.app.itemexport.service.ItemExportService;
 import org.dspace.content.Collection;
+import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.CollectionService;
@@ -203,6 +205,18 @@ public class ItemExport extends DSpaceRunnable<ItemExportScriptConfiguration> {
         setEPerson(context);
         setDestDirName(context, itemExportService);
         setZip(context);
+
+        // Phase 1: lightweight item count check
+        DSpaceObject exportObject = item != null ? item : collection;
+        List<DSpaceObject> dsoList = Collections.<DSpaceObject>singletonList(exportObject);
+        int itemCount = itemExportService.countExportItems(context, dsoList);
+        itemExportService.validateExportItemCount(itemCount);
+
+        // Phase 2: size + disk space check (only when bitstreams included)
+        if (!excludeBitstreams) {
+            long estimatedSize = itemExportService.estimateExportSize(context, dsoList);
+            itemExportService.validateExportSize(estimatedSize);
+        }
 
         Iterator<Item> items;
         if (item != null) {

--- a/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExportCLI.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExportCLI.java
@@ -13,6 +13,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.dspace.app.itemexport.service.ItemExportService;
+import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
 
@@ -44,6 +45,18 @@ public class ItemExportCLI extends ItemExport {
     @Override
     protected void process(Context context, ItemExportService itemExportService) throws Exception {
         setZip(context);
+
+        // Phase 1: lightweight item count check
+        DSpaceObject exportObject = item != null ? item : collection;
+        List<DSpaceObject> dsoList = Collections.<DSpaceObject>singletonList(exportObject);
+        int itemCount = itemExportService.countExportItems(context, dsoList);
+        itemExportService.validateExportItemCount(itemCount);
+
+        // Phase 2: size + disk space check (only when bitstreams included)
+        if (!excludeBitstreams) {
+            long estimatedSize = itemExportService.estimateExportSize(context, dsoList);
+            itemExportService.validateExportSize(estimatedSize);
+        }
 
         if (zip) {
             Iterator<Item> items;

--- a/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExportServiceImpl.java
@@ -484,6 +484,143 @@ public class ItemExportServiceImpl implements ItemExportService {
     }
 
     @Override
+    public long estimateExportSize(Context context, List<DSpaceObject> dsObjects) throws SQLException {
+        long size = 0;
+        for (DSpaceObject dso : dsObjects) {
+            if (dso.getType() == Constants.COMMUNITY) {
+                Community community = (Community) dso;
+                List<Collection> collections = communityService.getAllCollections(context, community);
+                for (Collection collection : collections) {
+                    Iterator<Item> iitems = itemService.findByCollection(context, collection);
+                    while (iitems.hasNext()) {
+                        size += getItemBitstreamSize(iitems.next());
+                    }
+                }
+            } else if (dso.getType() == Constants.COLLECTION) {
+                Collection collection = (Collection) dso;
+                Iterator<Item> iitems = itemService.findByCollection(context, collection);
+                while (iitems.hasNext()) {
+                    size += getItemBitstreamSize(iitems.next());
+                }
+            } else if (dso.getType() == Constants.ITEM) {
+                size += getItemBitstreamSize((Item) dso);
+            }
+        }
+        return size;
+    }
+
+    /**
+     * Sum the sizes of all bitstreams in an item's bundles.
+     *
+     * @param item the item
+     * @return total bitstream size in bytes
+     */
+    private long getItemBitstreamSize(Item item) {
+        long size = 0;
+        for (Bundle bundle : item.getBundles()) {
+            for (Bitstream bitstream : bundle.getBitstreams()) {
+                size += bitstream.getSizeBytes();
+            }
+        }
+        return size;
+    }
+
+    @Override
+    public void validateExportSize(long estimatedSize) throws ItemExportException, Exception {
+        // Check against configured maximum size
+        String megaBytes = configurationService
+            .getProperty("org.dspace.app.itemexport.max.size");
+        if (megaBytes != null) {
+            float maxSize = 0;
+            try {
+                maxSize = Float.parseFloat(megaBytes);
+            } catch (NumberFormatException e) {
+                // ignore invalid configuration
+            }
+
+            if (maxSize > 0 && maxSize < (estimatedSize / 1048576.00)) {
+                throw new ItemExportException(ItemExportException.EXPORT_TOO_LARGE,
+                    String.format(
+                        "The export is too large. Estimated size: %s, configured maximum: %.0f MB. "
+                            + "Consider using the exclude bitstreams (-x) option for a metadata-only export.",
+                        formatSize(estimatedSize), maxSize));
+            }
+        }
+
+        // Check against available disk space.
+        // The export writes bitstreams to a temp directory and then zips them,
+        // so peak disk usage is roughly 2x the bitstream size.
+        int minFreeSpaceMB = configurationService
+            .getIntProperty("org.dspace.app.itemexport.min.free.space", 500);
+        if (minFreeSpaceMB > 0) {
+            String exportDir = getExportWorkDirectory();
+            File workDir = new File(exportDir);
+            if (!workDir.exists()) {
+                workDir.mkdirs();
+            }
+            long usableSpace = workDir.getUsableSpace();
+            long minFreeSpaceBytes = (long) minFreeSpaceMB * 1048576L;
+            long peakDiskUsage = estimatedSize * 2;
+            if (peakDiskUsage > (usableSpace - minFreeSpaceBytes)) {
+                throw new ItemExportException(ItemExportException.EXPORT_TOO_LARGE,
+                    String.format(
+                        "Insufficient disk space for export. Estimated size: %s "
+                            + "(peak disk usage ~%s due to temp files), "
+                            + "available space: %s, required reserve: %d MB. "
+                            + "Consider using the exclude bitstreams (-x) option for a metadata-only export.",
+                        formatSize(estimatedSize), formatSize(peakDiskUsage),
+                        formatSize(usableSpace), minFreeSpaceMB));
+            }
+        }
+    }
+
+    @Override
+    public int countExportItems(Context context, List<DSpaceObject> dsObjects) throws SQLException {
+        int count = 0;
+        for (DSpaceObject dso : dsObjects) {
+            if (dso.getType() == Constants.COMMUNITY) {
+                count += itemService.countItems(context, (Community) dso);
+            } else if (dso.getType() == Constants.COLLECTION) {
+                count += itemService.countItems(context, (Collection) dso);
+            } else if (dso.getType() == Constants.ITEM) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    @Override
+    public void validateExportItemCount(int itemCount) throws ItemExportException {
+        int maxItems = configurationService
+            .getIntProperty("org.dspace.app.itemexport.max.items", 0);
+        if (maxItems > 0 && itemCount > maxItems) {
+            throw new ItemExportException(ItemExportException.EXPORT_TOO_LARGE,
+                String.format(
+                    "The export contains too many items. Item count: %d, configured maximum: %d. "
+                        + "Consider exporting a smaller collection or individual items.",
+                    itemCount, maxItems));
+        }
+    }
+
+    /**
+     * Format a byte size as a human-readable string (e.g., "2.3 GB", "150 MB").
+     *
+     * @param bytes the size in bytes
+     * @return formatted string
+     */
+    private String formatSize(long bytes) {
+        if (bytes >= 1073741824L) {
+            return String.format("%.1f GB", bytes / 1073741824.0);
+        } else if (bytes >= 1048576L) {
+            return String.format("%.1f MB", bytes / 1048576.0);
+        } else if (bytes >= 1024L) {
+            return String.format("%.1f KB", bytes / 1024.0);
+        } else {
+            return bytes + " bytes";
+        }
+    }
+
+    @Override
     public void exportAsZip(Context context, Iterator<Item> items,
                             String destDirName, String zipFileName,
                             int seqStart, boolean migrate,
@@ -570,103 +707,45 @@ public class ItemExportServiceImpl implements ItemExportService {
         //deleteOldExportArchives(eperson.getID());
         deleteOldExportArchives();
 
-        // keep track of the commulative size of all bitstreams in each of the
-        // items
-        // it will be checked against the config file entry
-        double size = 0;
+        // Phase 1: lightweight item count check
+        int itemCount = countExportItems(context, dsObjects);
+        validateExportItemCount(itemCount);
+
+        // Phase 2: size + disk space check
+        long estimatedSize = estimateExportSize(context, dsObjects);
+        validateExportSize(estimatedSize);
+
+        // Build itemsMap for the export thread
         final HashMap<String, List<UUID>> itemsMap = new HashMap<>();
         for (DSpaceObject dso : dsObjects) {
             if (dso.getType() == Constants.COMMUNITY) {
                 Community community = (Community) dso;
-                // get all the collections in the community
                 List<Collection> collections = communityService.getAllCollections(context, community);
                 for (Collection collection : collections) {
                     ArrayList<UUID> items = new ArrayList<>();
-                    // get all the items in each collection
                     Iterator<Item> iitems = itemService.findByCollection(context, collection);
-                    try {
-                        while (iitems.hasNext()) {
-                            Item item = iitems.next();
-                            // get all the bundles in the item
-                            List<Bundle> bundles = item.getBundles();
-                            for (Bundle bundle : bundles) {
-                                // get all the bitstreams in each bundle
-                                List<Bitstream> bitstreams = bundle.getBitstreams();
-                                for (Bitstream bitstream : bitstreams) {
-                                    // add up the size
-                                    size += bitstream.getSizeBytes();
-                                }
-                            }
-                            items.add(item.getID());
-                        }
-                    } finally {
-                        if (items.size() > 0) {
-                            itemsMap.put("collection_" + collection.getID(), items);
-                        }
+                    while (iitems.hasNext()) {
+                        items.add(iitems.next().getID());
+                    }
+                    if (!items.isEmpty()) {
+                        itemsMap.put("collection_" + collection.getID(), items);
                     }
                 }
             } else if (dso.getType() == Constants.COLLECTION) {
                 Collection collection = (Collection) dso;
                 ArrayList<UUID> items = new ArrayList<>();
-
-                // get all the items in the collection
                 Iterator<Item> iitems = itemService.findByCollection(context, collection);
-                try {
-                    while (iitems.hasNext()) {
-                        Item item = iitems.next();
-                        // get all thebundles in the item
-                        List<Bundle> bundles = item.getBundles();
-                        for (Bundle bundle : bundles) {
-                            // get all the bitstreams in the bundle
-                            List<Bitstream> bitstreams = bundle.getBitstreams();
-                            for (Bitstream bitstream : bitstreams) {
-                                // add up the size
-                                size += bitstream.getSizeBytes();
-                            }
-                        }
-                        items.add(item.getID());
-                    }
-                } finally {
-                    if (items.size() > 0) {
-                        itemsMap.put("collection_" + collection.getID(), items);
-                    }
+                while (iitems.hasNext()) {
+                    items.add(iitems.next().getID());
+                }
+                if (!items.isEmpty()) {
+                    itemsMap.put("collection_" + collection.getID(), items);
                 }
             } else if (dso.getType() == Constants.ITEM) {
                 Item item = (Item) dso;
-                // get all the bundles in the item
-                List<Bundle> bundles = item.getBundles();
-                for (Bundle bundle : bundles) {
-                    // get all the bitstreams in the bundle
-                    List<Bitstream> bitstreams = bundle.getBitstreams();
-                    for (Bitstream bitstream : bitstreams) {
-                        // add up the size
-                        size += bitstream.getSizeBytes();
-                    }
-                }
                 ArrayList<UUID> items = new ArrayList<>();
                 items.add(item.getID());
                 itemsMap.put("item_" + item.getID(), items);
-            } else {
-                // nothing to do just ignore this type of DSpaceObject
-            }
-        }
-
-        // check the size of all the bitstreams against the configuration file
-        // entry if it exists
-        String megaBytes = configurationService
-            .getProperty("org.dspace.app.itemexport.max.size");
-        if (megaBytes != null) {
-            float maxSize = 0;
-            try {
-                maxSize = Float.parseFloat(megaBytes);
-            } catch (Exception e) {
-                // ignore...configuration entry may not be present
-            }
-
-            if (maxSize > 0 && maxSize < (size / 1048576.00)) { // a megabyte
-                throw new ItemExportException(ItemExportException.EXPORT_TOO_LARGE,
-                                              "The overall size of this export is too large.  Please contact your " +
-                                                  "administrator for more information.");
             }
         }
 

--- a/dspace-api/src/main/java/org/dspace/app/itemexport/service/ItemExportService.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemexport/service/ItemExportService.java
@@ -8,11 +8,13 @@
 package org.dspace.app.itemexport.service;
 
 import java.io.InputStream;
+import java.sql.SQLException;
 import java.time.LocalDate;
 import java.util.Iterator;
 import java.util.List;
 
 import jakarta.mail.MessagingException;
+import org.dspace.app.itemexport.ItemExportException;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
@@ -267,6 +269,47 @@ public interface ItemExportService {
      * @throws Exception if error
      */
     public void zip(String strSource, String target) throws Exception;
+
+    /**
+     * Estimate the total size of an export by summing bitstream sizes for the given items.
+     *
+     * @param context   DSpace context
+     * @param dsObjects List of DSpaceObjects (Items, Collections, or Communities) to estimate
+     * @return estimated total size in bytes
+     * @throws SQLException if a database error occurs
+     */
+    public long estimateExportSize(Context context, List<DSpaceObject> dsObjects) throws SQLException;
+
+    /**
+     * Validate that the estimated export size does not exceed the configured maximum
+     * and that sufficient disk space is available in the export work directory.
+     *
+     * @param estimatedSize estimated export size in bytes
+     * @throws ItemExportException if the export exceeds configured limits or available disk space
+     * @throws Exception           if the export work directory cannot be determined
+     */
+    public void validateExportSize(long estimatedSize) throws ItemExportException, Exception;
+
+    /**
+     * Count the total number of items that would be included in an export
+     * of the given DSpaceObjects. Uses efficient COUNT queries rather than
+     * loading Item entities.
+     *
+     * @param context   DSpace context
+     * @param dsObjects List of DSpaceObjects (Items, Collections, or Communities) to count
+     * @return total item count
+     * @throws SQLException if a database error occurs
+     */
+    public int countExportItems(Context context, List<DSpaceObject> dsObjects) throws SQLException;
+
+    /**
+     * Validate that the item count does not exceed the configured maximum
+     * ({@code org.dspace.app.itemexport.max.items}). A configured value of 0 disables the check.
+     *
+     * @param itemCount the number of items in the export
+     * @throws ItemExportException if the item count exceeds the configured limit
+     */
+    public void validateExportItemCount(int itemCount) throws ItemExportException;
 
     /**
      * Set the DSpace Runnable Handler

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1207,6 +1207,16 @@ org.dspace.app.itemexport.life.span.hours = 48
 # cumulative sizes are more than this entry the export is not kicked off
 org.dspace.app.itemexport.max.size = 200
 
+# Minimum free disk space (in MB) to preserve after export. Export will be
+# rejected if estimated size would leave less than this amount free.
+# Set to 0 to disable disk space checking.
+org.dspace.app.itemexport.min.free.space = 500
+
+# Maximum number of items allowed in a single SAF export.
+# This is a lightweight check (uses COUNT query) performed before the more
+# expensive size estimation. Set to 0 to disable this check (no item count limit).
+org.dspace.app.itemexport.max.items = 0
+
 ### Batch Item import settings ###
 # The directory where the results of imports will be placed (mapfile, upload file)
 org.dspace.app.batchitemimport.work.dir = ${dspace.dir}/imports


### PR DESCRIPTION
## Summary

Fixes #9389

- **Item count guard**: adds a lightweight `SELECT COUNT(*)` check (`org.dspace.app.itemexport.max.items`) before the expensive size estimation, catching oversized exports early. Default: 0 (disabled).
- **Size & disk space validation**: enforces the existing `org.dspace.app.itemexport.max.size` config and a new `org.dspace.app.itemexport.min.free.space` config (default: 500 MB) across all three export code paths (`ItemExport`, `ItemExportCLI`, `processDownloadableExport`).
- **Consistent enforcement**: previously, the `max.size` check only ran in `processDownloadableExport()` and the inline size calculation didn't actually prevent the export. Now all entry points validate consistently.

### New configuration properties

| Property | Default | Description |
|----------|---------|-------------|
| `org.dspace.app.itemexport.max.items` | `0` | Maximum item count per export (0 = disabled) |
| `org.dspace.app.itemexport.min.free.space` | `500` | Minimum free disk space in MB to preserve after export (0 = disabled) |

### New service methods

- `countExportItems(Context, List<DSpaceObject>)` — uses efficient `itemService.countItems()` COUNT queries
- `validateExportItemCount(int)` — checks count against config limit
- `estimateExportSize(Context, List<DSpaceObject>)` — sums bitstream sizes across items
- `validateExportSize(long)` — checks size against config limit and available disk space

## Test plan

- [ ] Set `max.items = 5`, export a collection with >5 items → should fail with clear error message
- [ ] Set `max.items = 0` → count check should be skipped (backward compatible)
- [ ] Set `max.size = 1` (1 MB), export collection with large bitstreams → should fail
- [ ] Export with `-x` (exclude bitstreams) → size check skipped, count check still applies
- [ ] Verify all three export paths: webapp download, CLI with zip, CLI without zip
- [ ] `mvn compile -pl dspace-api -DskipTests` passes
- [ ] `mvn checkstyle:check -pl dspace-api` passes with 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)