### PR TITLE
Curation framework improvements

### DIFF
--- a/dspace-api/src/main/java/org/dspace/ctask/general/AbstractTranslator.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/AbstractTranslator.java
@@ -15,6 +15,7 @@ import org.apache.logging.log4j.Logger;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataValue;
+import org.dspace.core.Context;
 import org.dspace.curate.AbstractCurationTask;
 import org.dspace.curate.Curator;
 import org.dspace.curate.Distributive;
@@ -72,7 +73,7 @@ public abstract class AbstractTranslator extends AbstractCurationTask {
     }
 
     @Override
-    public int perform(DSpaceObject dso) throws IOException {
+    public int perform(Context context, DSpaceObject dso) throws IOException {
 
         if (dso instanceof Item) {
             Item item = (Item) dso;
@@ -145,15 +146,15 @@ public abstract class AbstractTranslator extends AbstractCurationTask {
                                 try {
                                     // Add the new metadata
                                     if (fieldSegments.length > 2) {
-                                        itemService.addMetadata(Curator.curationContext(), item, fieldSegments[0],
+                                        itemService.addMetadata(context, item, fieldSegments[0],
                                                                 fieldSegments[1], fieldSegments[2], lang,
                                                                 translatedText);
                                     } else {
-                                        itemService.addMetadata(Curator.curationContext(), item, fieldSegments[0],
+                                        itemService.addMetadata(context, item, fieldSegments[0],
                                                                 fieldSegments[1], null, lang, translatedText);
                                     }
 
-                                    itemService.update(Curator.curationContext(), item);
+                                    itemService.update(context, item);
                                     results
                                         .add(handle + ": Translated " + authLang + " -> " + lang + " (" + field + ")");
                                 } catch (Exception e) {

--- a/dspace-api/src/main/java/org/dspace/ctask/general/AbstractTranslator.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/AbstractTranslator.java
@@ -50,8 +50,8 @@ public abstract class AbstractTranslator extends AbstractCurationTask {
 
 
     @Override
-    public void init(Curator curator, String taskId) throws IOException {
-        super.init(curator, taskId);
+    public void init(Context ctx, Curator curator, String taskId) throws IOException {
+        super.init(ctx, curator, taskId);
 
         // Load configuration
         authLang = configurationService.getProperty("default.locale");

--- a/dspace-api/src/main/java/org/dspace/ctask/general/BasicLinkChecker.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/BasicLinkChecker.java
@@ -24,6 +24,7 @@ import org.dspace.app.client.DSpaceHttpClientFactory;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataValue;
+import org.dspace.core.Context;
 import org.dspace.curate.AbstractCurationTask;
 import org.dspace.curate.Curator;
 import org.dspace.services.ConfigurationService;
@@ -58,12 +59,13 @@ public class BasicLinkChecker extends AbstractCurationTask {
     /**
      * Perform the link checking.
      *
+     * @param context The DSpace Context
      * @param dso The DSpaaceObject to be checked
      * @return The curation task status of the checking
      * @throws java.io.IOException THrown if something went wrong
      */
     @Override
-    public int perform(DSpaceObject dso) throws IOException {
+    public int perform(Context context, DSpaceObject dso) throws IOException {
         // The results that we'll return
         StringBuilder results = new StringBuilder();
 

--- a/dspace-api/src/main/java/org/dspace/ctask/general/BitstreamsIntoMetadata.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/BitstreamsIntoMetadata.java
@@ -16,6 +16,7 @@ import org.dspace.content.Bitstream;
 import org.dspace.content.Bundle;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
+import org.dspace.core.Context;
 import org.dspace.curate.AbstractCurationTask;
 import org.dspace.curate.Curator;
 
@@ -43,7 +44,7 @@ public class BitstreamsIntoMetadata extends AbstractCurationTask {
      * @return The curation task status of the checking
      */
     @Override
-    public int perform(DSpaceObject dso) {
+    public int perform(Context context, DSpaceObject dso) {
         // The results that we'll return
         StringBuilder results = new StringBuilder();
 
@@ -54,24 +55,24 @@ public class BitstreamsIntoMetadata extends AbstractCurationTask {
         if (dso instanceof Item) {
             try {
                 Item item = (Item) dso;
-                itemService.clearMetadata(Curator.curationContext(), item, "dc", "format", Item.ANY, Item.ANY);
+                itemService.clearMetadata(context, item, "dc", "format", Item.ANY, Item.ANY);
                 for (Bundle bundle : item.getBundles()) {
                     if ("ORIGINAL".equals(bundle.getName())) {
                         for (Bitstream bitstream : bundle.getBitstreams()) {
                             // Add the metadata and update the item
-                            addMetadata(item, bitstream, "original");
+                            addMetadata(context, item, bitstream, "original");
                             changed = true;
                         }
                     } else if ("THUMBNAIL".equals(bundle.getName())) {
                         for (Bitstream bitstream : bundle.getBitstreams()) {
                             // Add the metadata and update the item
-                            addMetadata(item, bitstream, "thumbnail");
+                            addMetadata(context, item, bitstream, "thumbnail");
                             changed = true;
                         }
                     }
 
                     if (changed) {
-                        itemService.update(Curator.curationContext(), item);
+                        itemService.update(context, item);
                         status = Curator.CURATE_SUCCESS;
                     }
                 }
@@ -113,8 +114,8 @@ public class BitstreamsIntoMetadata extends AbstractCurationTask {
      * @param type      The type of bitstream
      * @throws SQLException An exception that provides information on a database access error or other errors.
      */
-    protected void addMetadata(Item item, Bitstream bitstream, String type) throws SQLException {
-        String value = bitstream.getFormat(Curator.curationContext()).getMIMEType() + "##";
+    protected void addMetadata(Context context, Item item, Bitstream bitstream, String type) throws SQLException {
+        String value = bitstream.getFormat(context).getMIMEType() + "##";
         value += bitstream.getName() + "##";
         value += bitstream.getSizeBytes() + "##";
         value += item.getHandle() + "##";
@@ -123,6 +124,6 @@ public class BitstreamsIntoMetadata extends AbstractCurationTask {
         if (bitstream.getDescription() != null) {
             value += bitstream.getDescription();
         }
-        itemService.addMetadata(Curator.curationContext(), item, "dc", "format", type, "en", value);
+        itemService.addMetadata(context, item, "dc", "format", type, "en", value);
     }
 }

--- a/dspace-api/src/main/java/org/dspace/ctask/general/CitationPage.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/CitationPage.java
@@ -82,14 +82,14 @@ public class CitationPage extends AbstractCurationTask {
     /**
      * {@inheritDoc}
      *
-     * @see CurationTask#perform(DSpaceObject)
+     * @see AbstractCurationTask#perform(Context, DSpaceObject)
      */
     @Override
-    public int perform(DSpaceObject dso) throws IOException {
+    public int perform(Context context, DSpaceObject dso) throws IOException {
 
         // Deal with status and result as well as call distribute.
         this.resBuilder = new StringBuilder();
-        this.distribute(dso);
+        this.distribute(context, dso);
         this.result = this.resBuilder.toString();
         this.setResult(this.result);
         this.report(this.result);
@@ -100,19 +100,19 @@ public class CitationPage extends AbstractCurationTask {
     /**
      * {@inheritDoc}
      *
-     * @see AbstractCurationTask#performItem(Item)
+     * @see AbstractCurationTask#performItem(Context, Item)
      */
     @Override
-    protected void performItem(Item item) throws SQLException {
+    protected void performItem(Context context, Item item) throws SQLException {
         //Determine if the DISPLAY bundle exits. If not, create it.
         List<Bundle> dBundles = itemService.getBundles(item, CitationPage.DISPLAY_BUNDLE_NAME);
         Bundle original = itemService.getBundles(item, "ORIGINAL").get(0);
         Bundle dBundle = null;
         if (dBundles == null || dBundles.isEmpty()) {
             try {
-                dBundle = bundleService.create(Curator.curationContext(), item, CitationPage.DISPLAY_BUNDLE_NAME);
+                dBundle = bundleService.create(context, item, CitationPage.DISPLAY_BUNDLE_NAME);
                 // don't inherit now otherwise they will be copied over the moved bitstreams
-                resourcePolicyService.removeAllPolicies(Curator.curationContext(), dBundle);
+                resourcePolicyService.removeAllPolicies(context, dBundle);
             } catch (AuthorizeException e) {
                 log.error("User not authorized to create bundle on item \"{}\": {}",
                         item::getName, e::getMessage);
@@ -140,9 +140,9 @@ public class CitationPage extends AbstractCurationTask {
             bundles.addAll(pBundles);
         } else {
             try {
-                pBundle = bundleService.create(Curator.curationContext(), item, CitationPage.PRESERVATION_BUNDLE_NAME);
+                pBundle = bundleService.create(context, item, CitationPage.PRESERVATION_BUNDLE_NAME);
                 // don't inherit now otherwise they will be copied over the moved bitstreams
-                resourcePolicyService.removeAllPolicies(Curator.curationContext(), pBundle);
+                resourcePolicyService.removeAllPolicies(context, pBundle);
             } catch (AuthorizeException e) {
                 log.error("User not authorized to create bundle on item \""
                               + item.getName() + "\": " + e.getMessage());
@@ -163,7 +163,7 @@ public class CitationPage extends AbstractCurationTask {
                 CitationDocumentService citationDocument = DisseminateServiceFactory.getInstance()
                                                                                     .getCitationDocumentService();
 
-                if (citationDocument.canGenerateCitationVersion(Curator.curationContext(), bitstream)) {
+                if (citationDocument.canGenerateCitationVersion(context, bitstream)) {
                     this.resBuilder.append(item.getHandle())
                             .append(" - ")
                             .append(bitstream.getName())
@@ -172,13 +172,13 @@ public class CitationPage extends AbstractCurationTask {
                         //Create the cited document
                         InputStream citedInputStream =
                             new ByteArrayInputStream(
-                                citationDocument.makeCitedDocument(Curator.curationContext(), bitstream).getLeft());
+                                citationDocument.makeCitedDocument(context, bitstream).getLeft());
                         //Add the cited document to the appropriate bundle
-                        this.addCitedPageToItem(citedInputStream, bundle, pBundle,
+                        this.addCitedPageToItem(context, citedInputStream, bundle, pBundle,
                                                 dBundle, item, bitstream);
                         // now set the policies of the preservation and display bundle
-                        clonePolicies(Curator.curationContext(), original, pBundle);
-                        clonePolicies(Curator.curationContext(), original, dBundle);
+                        clonePolicies(context, original, pBundle);
+                        clonePolicies(context, original, dBundle);
                     } catch (Exception e) {
                         //Could be many things, but nothing that should be
                         //expected.
@@ -213,7 +213,7 @@ public class CitationPage extends AbstractCurationTask {
     }
 
     /**
-     * A helper function for {@link CitationPage#performItem(Item)}. This function takes in the
+     * A helper function for {@link CitationPage#performItem(Context, Item)}. This function takes in the
      * cited document as a File and adds it to DSpace properly.
      *
      * @param citedDoc The inputstream that is the cited document.
@@ -227,12 +227,11 @@ public class CitationPage extends AbstractCurationTask {
      * @throws AuthorizeException if authorization error
      * @throws IOException        if IO error
      */
-    protected void addCitedPageToItem(InputStream citedDoc, Bundle bundle, Bundle pBundle,
+    protected void addCitedPageToItem(Context context, InputStream citedDoc, Bundle bundle, Bundle pBundle,
                                       Bundle dBundle, Item item,
                                       Bitstream bitstream) throws SQLException, AuthorizeException, IOException {
         //If we are modifying a file that is not in the
         //preservation bundle then we have to move it there.
-        Context context = Curator.curationContext();
         if (!bundle.getID().equals(pBundle.getID())) {
             bundleService.addBitstream(context, pBundle, bitstream);
             bundleService.removeBitstream(context, bundle, bitstream);
@@ -254,7 +253,7 @@ public class CitationPage extends AbstractCurationTask {
         //Setup a good name for our bitstream and make
         //it the same format as the source document.
         citedBitstream.setName(context, bitstream.getName());
-        bitstreamService.setFormat(context, citedBitstream, bitstream.getFormat(Curator.curationContext()));
+        bitstreamService.setFormat(context, citedBitstream, bitstream.getFormat(context));
         citedBitstream.setDescription(context, bitstream.getDescription());
         displayMap.put(bitstream.getName(), citedBitstream);
         clonePolicies(context, bitstream, citedBitstream);

--- a/dspace-api/src/main/java/org/dspace/ctask/general/ClamScan.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/ClamScan.java
@@ -27,6 +27,7 @@ import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.BitstreamService;
+import org.dspace.core.Context;
 import org.dspace.curate.AbstractCurationTask;
 import org.dspace.curate.Curator;
 import org.dspace.curate.Suspendable;
@@ -82,7 +83,7 @@ public class ClamScan extends AbstractCurationTask {
     }
 
     @Override
-    public int perform(DSpaceObject dso) throws IOException {
+    public int perform(Context context, DSpaceObject dso) throws IOException {
         status = Curator.CURATE_SKIP;
         logDebugMessage("The target dso is " + dso.getName());
         if (dso instanceof Item) {
@@ -106,7 +107,7 @@ public class ClamScan extends AbstractCurationTask {
                 Bundle bundle = bundles.get(0);
                 results = new ArrayList<String>();
                 for (Bitstream bitstream : bundle.getBitstreams()) {
-                    InputStream inputstream = bitstreamService.retrieve(Curator.curationContext(), bitstream);
+                    InputStream inputstream = bitstreamService.retrieve(context, bitstream);
                     logDebugMessage("Scanning " + bitstream.getName() + " . . . ");
                     int bstatus = scan(bitstream, inputstream, getItemHandle(item));
                     inputstream.close();

--- a/dspace-api/src/main/java/org/dspace/ctask/general/ClamScan.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/ClamScan.java
@@ -73,8 +73,8 @@ public class ClamScan extends AbstractCurationTask {
     protected BitstreamService bitstreamService;
 
     @Override
-    public void init(Curator curator, String taskId) throws IOException {
-        super.init(curator, taskId);
+    public void init(Context ctx, Curator curator, String taskId) throws IOException {
+        super.init(ctx, curator, taskId);
         host = configurationService.getProperty(PLUGIN_PREFIX + ".service.host");
         port = configurationService.getIntProperty(PLUGIN_PREFIX + ".service.port");
         timeout = configurationService.getIntProperty(PLUGIN_PREFIX + ".socket.timeout");

--- a/dspace-api/src/main/java/org/dspace/ctask/general/CreateMissingIdentifiers.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/CreateMissingIdentifiers.java
@@ -38,7 +38,7 @@ public class CreateMissingIdentifiers
     private static final Logger LOG = LogManager.getLogger();
 
     @Override
-    public int perform(DSpaceObject dso)
+    public int perform(Context context, DSpaceObject dso)
             throws IOException {
         // Only some kinds of model objects get identifiers
         if (!(dso instanceof Item)) {
@@ -46,15 +46,6 @@ public class CreateMissingIdentifiers
         }
 
         String typeText = Constants.typeText[dso.getType()];
-
-        // Get a Context
-        Context context;
-        try {
-            context = Curator.curationContext();
-        } catch (SQLException ex) {
-            report("Could not get the curation Context:  " + ex.getMessage());
-            return Curator.CURATE_ERROR;
-        }
 
         // Find the IdentifierService implementation
         IdentifierService identifierService = IdentifierServiceFactory

--- a/dspace-api/src/main/java/org/dspace/ctask/general/MetadataWebService.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/MetadataWebService.java
@@ -171,8 +171,8 @@ public class MetadataWebService extends AbstractCurationTask implements Namespac
      * @throws IOException if the parser could not be configured, or passed through.
      */
     @Override
-    public void init(Curator curator, String taskId) throws IOException {
-        super.init(curator, taskId);
+    public void init(Context ctx, Curator curator, String taskId) throws IOException {
+        super.init(ctx, curator, taskId);
         lang = configurationService.getProperty("default.language");
         String fldSep = taskProperty("separator");
         fieldSeparator = (fldSep != null) ? fldSep : " ";

--- a/dspace-api/src/main/java/org/dspace/ctask/general/MetadataWebService.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/MetadataWebService.java
@@ -43,6 +43,7 @@ import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataValue;
 import org.dspace.core.Constants;
+import org.dspace.core.Context;
 import org.dspace.curate.AbstractCurationTask;
 import org.dspace.curate.Curator;
 import org.dspace.curate.Mutative;
@@ -217,7 +218,7 @@ public class MetadataWebService extends AbstractCurationTask implements Namespac
     }
 
     @Override
-    public int perform(DSpaceObject dso) throws IOException {
+    public int perform(Context context, DSpaceObject dso) throws IOException {
 
         int status = Curator.CURATE_SKIP;
         StringBuilder resultSb = new StringBuilder();
@@ -238,7 +239,7 @@ public class MetadataWebService extends AbstractCurationTask implements Namespac
             List<MetadataValue> dcVals = itemService.getMetadataByMetadataString(item, lookupField);
             if (dcVals.size() > 0 && dcVals.get(0).getValue().length() > 0) {
                 String value = transform(dcVals.get(0).getValue(), lookupTransform);
-                status = callService(value, item, resultSb);
+                status = callService(context, value, item, resultSb);
             } else {
                 resultSb.append(" lacks metadata value required for service: ").append(lookupField);
                 status = Curator.CURATE_FAIL;
@@ -251,7 +252,7 @@ public class MetadataWebService extends AbstractCurationTask implements Namespac
         return status;
     }
 
-    protected int callService(String value, Item item, StringBuilder resultSb) throws IOException {
+    protected int callService(Context context, String value, Item item, StringBuilder resultSb) throws IOException {
         String callUrl = urlTemplate.replaceAll("\\{" + templateParam + "\\}", value);
         try (CloseableHttpClient client = DSpaceHttpClientFactory.getInstance().build()) {
             HttpGet req = new HttpGet(callUrl);
@@ -270,7 +271,7 @@ public class MetadataWebService extends AbstractCurationTask implements Namespac
                             // This next line triggers a false-positive XXE warning from LGTM, even though
                             // we disallow DTD parsing during initialization of docBuilder in init()
                             Document doc = docBuilder.parse(instream);  // lgtm [java/xxe]
-                            status = processResponse(doc, item, resultSb);
+                            status = processResponse(context, doc, item, resultSb);
                         } catch (SAXException saxE) {
                             log.error("caught exception: " + saxE);
                             resultSb.append(" unable to read response document");
@@ -298,7 +299,7 @@ public class MetadataWebService extends AbstractCurationTask implements Namespac
         }
     }
 
-    protected int processResponse(Document doc, Item item, StringBuilder resultSb) throws IOException {
+    protected int processResponse(Context context, Document doc, Item item, StringBuilder resultSb) throws IOException {
         boolean update = false;
         int status = Curator.CURATE_ERROR;
         List<String> values = new ArrayList<>();
@@ -310,7 +311,7 @@ public class MetadataWebService extends AbstractCurationTask implements Namespac
                 // if data found and we are mapping, check assignment policy
                 if (nodes.getLength() > 0 && info.getMapping() != null) {
                     if ("=>".equals(info.getMapping())) {
-                        itemService.clearMetadata(Curator.curationContext(), item, info.getSchema(), info.getElement(),
+                        itemService.clearMetadata(context, item, info.getSchema(), info.getElement(),
                                                   info.getQualifier(), Item.ANY);
                     } else if ("~>".equals(info.getMapping())) {
                         if (itemService
@@ -331,7 +332,7 @@ public class MetadataWebService extends AbstractCurationTask implements Namespac
                     String tvalue = transform(node.getFirstChild().getNodeValue(), info.getTransform());
                     // assign to metadata field if mapped && not present
                     if (info.getMapping() != null && !values.contains(tvalue)) {
-                        itemService.addMetadata(Curator.curationContext(), item, info.getSchema(), info.getElement(),
+                        itemService.addMetadata(context, item, info.getSchema(), info.getElement(),
                                                 info.getQualifier(), lang, tvalue);
                         update = true;
                     }
@@ -341,7 +342,7 @@ public class MetadataWebService extends AbstractCurationTask implements Namespac
             }
             // update Item if it has changed
             if (update) {
-                itemService.update(Curator.curationContext(), item);
+                itemService.update(context, item);
             }
             status = Curator.CURATE_SUCCESS;
         } catch (AuthorizeException authE) {

--- a/dspace-api/src/main/java/org/dspace/ctask/general/NoOpCurationDistributeTask.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/NoOpCurationDistributeTask.java
@@ -8,32 +8,33 @@
 package org.dspace.ctask.general;
 
 import java.io.IOException;
+import java.sql.SQLException;
 
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
 import org.dspace.curate.AbstractCurationTask;
 import org.dspace.curate.Curator;
+import org.dspace.curate.Distributive;
 
-public class NoOpCurationTask extends AbstractCurationTask {
+@Distributive
+public class NoOpCurationDistributeTask extends AbstractCurationTask {
 
     protected int status = Curator.CURATE_UNSET;
     protected String result = null;
 
     @Override
     public int perform(Context context, DSpaceObject dso) throws IOException {
-
-        if (dso instanceof Item) {
-            Item item = (Item) dso;
-            status = Curator.CURATE_SUCCESS;
-            result = "No operation performed on " + item.getHandle();
-
-            setResult(result);
-            report(result);
-        }
-
+        distribute(context, dso);
         return status;
     }
 
+    @Override
+    protected void performItem(Context context, Item item) throws SQLException, IOException {
+        status = Curator.CURATE_SUCCESS;
+        result = "No operation performed on " + item.getHandle();
 
+        setResult(result);
+        report(result);
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/ctask/general/ProfileFormats.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/ProfileFormats.java
@@ -19,6 +19,7 @@ import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.BitstreamFormatService;
+import org.dspace.core.Context;
 import org.dspace.curate.AbstractCurationTask;
 import org.dspace.curate.Curator;
 import org.dspace.curate.Distributive;
@@ -43,18 +44,18 @@ public class ProfileFormats extends AbstractCurationTask {
      * @throws IOException if IO error
      */
     @Override
-    public int perform(DSpaceObject dso) throws IOException {
+    public int perform(Context context, DSpaceObject dso) throws IOException {
         fmtTable.clear();
-        distribute(dso);
-        formatResults();
+        distribute(context, dso);
+        formatResults(context);
         return Curator.CURATE_SUCCESS;
     }
 
     @Override
-    protected void performItem(Item item) throws SQLException, IOException {
+    protected void performItem(Context context, Item item) throws SQLException, IOException {
         for (Bundle bundle : item.getBundles()) {
             for (Bitstream bs : bundle.getBitstreams()) {
-                String fmt = bs.getFormat(Curator.curationContext()).getShortDescription();
+                String fmt = bs.getFormat(context).getShortDescription();
                 Integer count = fmtTable.get(fmt);
                 if (count == null) {
                     count = 1;
@@ -66,11 +67,11 @@ public class ProfileFormats extends AbstractCurationTask {
         }
     }
 
-    private void formatResults() throws IOException {
+    private void formatResults(Context context) throws IOException {
         try {
             StringBuilder sb = new StringBuilder();
             for (String fmt : fmtTable.keySet()) {
-                BitstreamFormat bsf = bitstreamFormatService.findByShortDescription(Curator.curationContext(), fmt);
+                BitstreamFormat bsf = bitstreamFormatService.findByShortDescription(context, fmt);
                 sb.append(String.format("%6d", fmtTable.get(fmt))).append(" (").
                     append(bitstreamFormatService.getSupportLevelText(bsf).charAt(0)).append(") ").
                       append(bsf.getDescription()).append("\n");

--- a/dspace-api/src/main/java/org/dspace/ctask/general/RegisterDOI.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/RegisterDOI.java
@@ -49,8 +49,8 @@ public class RegisterDOI extends AbstractCurationTask {
      * Initialise the curation task and read configuration, instantiate the DOI provider
      */
     @Override
-    public void init(Curator curator, String taskId) throws IOException {
-        super.init(curator, taskId);
+    public void init(Context ctx, Curator curator, String taskId) throws IOException {
+        super.init(ctx, curator, taskId);
         // Get distribution behaviour from configuration, with a default value of 'false'
         distributed = configurationService.getBooleanProperty(PLUGIN_PREFIX + ".distributed", false);
         log.debug("PLUGIN_PREFIX = " + PLUGIN_PREFIX + ", skipFilter = " + skipFilter +

--- a/dspace-api/src/main/java/org/dspace/ctask/general/RegisterDOI.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/RegisterDOI.java
@@ -8,7 +8,6 @@
 package org.dspace.ctask.general;
 
 import java.io.IOException;
-import java.sql.SQLException;
 
 import org.apache.logging.log4j.Logger;
 import org.dspace.content.DSpaceObject;
@@ -16,6 +15,7 @@ import org.dspace.content.Item;
 import org.dspace.content.logic.Filter;
 import org.dspace.content.logic.FilterUtils;
 import org.dspace.content.logic.TrueFilter;
+import org.dspace.core.Context;
 import org.dspace.curate.AbstractCurationTask;
 import org.dspace.curate.Curator;
 import org.dspace.identifier.DOIIdentifierProvider;
@@ -70,17 +70,17 @@ public class RegisterDOI extends AbstractCurationTask {
      * @throws IOException if IO error
      */
     @Override
-    public int perform(DSpaceObject dso) throws IOException {
+    public int perform(Context context, DSpaceObject dso) throws IOException {
         // Check distribution configuration
         if (distributed) {
             // This task is configured for distributed use. Call distribute() and let performItem handle
             // the main processing.
-            distribute(dso);
+            distribute(context, dso);
         } else {
             // This task is NOT configured for distributed use (default). Instead process a single item directly
             if (dso instanceof Item) {
                 Item item = (Item) dso;
-                performRegistration(item);
+                performRegistration(context, item);
             } else {
                 log.warn("DOI registration attempted on non-item DSpace Object: " + dso.getID());
             }
@@ -94,17 +94,17 @@ public class RegisterDOI extends AbstractCurationTask {
      * @param item the DSpace Item
      */
     @Override
-    protected void performItem(Item item) {
-        performRegistration(item);
+    protected void performItem(Context context, Item item) {
+        performRegistration(context, item);
     }
 
     /**
      * Shared 'perform' code between perform() and performItem() - a curation wrapper for the register() method
      * @param item the item for which to register a DOI
      */
-    private void performRegistration(Item item) {
+    private void performRegistration(Context context, Item item) {
         // Request DOI registration and report results
-        String doi = register(item);
+        String doi = register(context, item);
         String result = "DOI registration task performed on " + item.getHandle() + ".";
         if (doi != null) {
             result += " DOI: (" + doi + ")";
@@ -119,13 +119,13 @@ public class RegisterDOI extends AbstractCurationTask {
      * Perform the DOIIdentifierProvider.register call, with skipFilter passed as per config and defaults
      * @param item The item for which to register a DOI
      */
-    private String register(Item item) {
+    private String register(Context context, Item item) {
         String doi = null;
         // Attempt DOI registration and report successes and failures
         try {
             Filter filter = FilterUtils.getFilterFromConfiguration("identifiers.submission.filter.curation",
                     trueFilter);
-            doi = provider.register(Curator.curationContext(), item, filter);
+            doi = provider.register(context, item, filter);
             if (doi != null) {
                 String message = "New DOI minted in database for item " + item.getHandle() + ": " + doi
                     + ". This DOI will be registered online with the DOI provider when the queue is next run";
@@ -133,10 +133,6 @@ public class RegisterDOI extends AbstractCurationTask {
             } else {
                 log.error("Got a null DOI after registering...");
             }
-        } catch (SQLException e) {
-            // Exception obtaining context
-            log.error("Error obtaining curator context: " + e.getMessage());
-            status = Curator.CURATE_ERROR;
         } catch (DOIIdentifierNotApplicableException e) {
             // Filter returned 'false' so DOI was not registered. This is normal behaviour when filter is running.
             log.info("Item was filtered from DOI registration: " + e.getMessage());

--- a/dspace-api/src/main/java/org/dspace/ctask/general/RequiredMetadata.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/RequiredMetadata.java
@@ -22,6 +22,7 @@ import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataValue;
 import org.dspace.core.Constants;
+import org.dspace.core.Context;
 import org.dspace.curate.AbstractCurationTask;
 import org.dspace.curate.Curator;
 import org.dspace.curate.Suspendable;
@@ -58,7 +59,7 @@ public class RequiredMetadata extends AbstractCurationTask {
      * @throws IOException if IO error
      */
     @Override
-    public int perform(DSpaceObject dso) throws IOException {
+    public int perform(Context context, DSpaceObject dso) throws IOException {
         if (dso.getType() == Constants.ITEM) {
             Item item = (Item) dso;
             int count = 0;

--- a/dspace-api/src/main/java/org/dspace/ctask/general/RequiredMetadata.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/RequiredMetadata.java
@@ -43,8 +43,8 @@ public class RequiredMetadata extends AbstractCurationTask {
     protected Map<String, List<String>> reqMap = new HashMap<String, List<String>>();
 
     @Override
-    public void init(Curator curator, String taskId) throws IOException {
-        super.init(curator, taskId);
+    public void init(Context ctx, Curator curator, String taskId) throws IOException {
+        super.init(ctx, curator, taskId);
         try {
             reader = new DCInputsReader();
         } catch (DCInputsReaderException dcrE) {

--- a/dspace-api/src/main/java/org/dspace/ctask/test/WorkflowReportTest.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/test/WorkflowReportTest.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.content.DSpaceObject;
+import org.dspace.core.Context;
 import org.dspace.curate.AbstractCurationTask;
 import org.dspace.curate.Curator;
 
@@ -27,7 +28,7 @@ public class WorkflowReportTest
     private static final Logger LOG = LogManager.getLogger();
 
     @Override
-    public int perform(DSpaceObject dso)
+    public int perform(Context context, DSpaceObject dso)
             throws IOException {
         LOG.info("Class {} as task {} received 'perform' for object {}",
                 WorkflowReportTest.class::getSimpleName, () -> taskId, () -> dso);

--- a/dspace-api/src/main/java/org/dspace/ctask/testing/PropertyParameterTestingTask.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/testing/PropertyParameterTestingTask.java
@@ -35,9 +35,9 @@ public class PropertyParameterTestingTask
     private static final Logger LOG = LogManager.getLogger();
 
     @Override
-    public void init(Curator curator, String taskId)
+    public void init(Context ctx, Curator curator, String taskId)
             throws IOException {
-        super.init(curator, taskId);
+        super.init(ctx, curator, taskId);
         LOG.info("Received 'init' on task {}", taskId);
         // Display some properties.
         LOG.info("taskProperty = '{}'; runParameter = '{}'",

--- a/dspace-api/src/main/java/org/dspace/ctask/testing/PropertyParameterTestingTask.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/testing/PropertyParameterTestingTask.java
@@ -45,7 +45,7 @@ public class PropertyParameterTestingTask
     }
 
     @Override
-    public int perform(DSpaceObject dso)
+    public int perform(Context ctx, DSpaceObject dso)
             throws IOException {
         LOG.info("Received 'perform' on {}", dso);
         return Curator.CURATE_SUCCESS;

--- a/dspace-api/src/main/java/org/dspace/curate/AbstractCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/curate/AbstractCurationTask.java
@@ -9,9 +9,7 @@ package org.dspace.curate;
 
 import java.io.IOException;
 import java.sql.SQLException;
-import java.text.DecimalFormat;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
@@ -87,30 +85,14 @@ public abstract class AbstractCurationTask implements CurationTask {
      * @param dso current DSpaceObject
      * @throws IOException if IO error
      */
-    private Integer total = null;
-    private int current = 0;
-    private Date start = null;
-    private Date last = null;
-    private final DecimalFormat df = new DecimalFormat("0.00");
-    private final int PAGE_SIZE = 100;
     protected void distribute(Context context, DSpaceObject dso) throws IOException {
         try {
-            if (total == null) {
-                total = itemService.countTotal(context);
-                start = new Date();
-                last = start;
-            }
             //perform task on this current object
             performObject(context, dso);
 
             //next, we'll try to distribute to all child objects, based on container type
             int type = dso.getType();
             if (Constants.COLLECTION == type) {
-                Collection collection = (Collection) dso;
-                System.out.println();
-                System.out.println("NEW COLLECTION: " + itemService.countItems(context, collection));
-                System.out.println();
-
                 Iterator<Item> iter = itemService.findByCollection(context,
                         (Collection) context.reloadEntity(dso));
                 List<UUID> uuids = new ArrayList<>();
@@ -122,18 +104,6 @@ public abstract class AbstractCurationTask implements CurationTask {
                 context.commit();
                 for (UUID uuid : uuids) {
                     Item item = itemService.find(context, uuid);
-                    if (++current % 1000 == 0) {
-                        Date now = new Date();
-                        float ms = (float) (now.getTime() - last.getTime());
-                        float avgSeconds = (float) (now.getTime() - start.getTime()) / 1000 / (current / 1000);
-                        Runtime runtime = Runtime.getRuntime();
-                        long usedMemory = runtime.totalMemory() - runtime.freeMemory();
-
-                        System.out.println(current + " / " + total + " -- " + ms +
-                                "ms - (avg " + df.format(avgSeconds) + "s per 1000) - Used memory: " +
-                                (usedMemory / (1024 * 1024)) + "MB");
-                        last = now;
-                    }
                     performObject(context, item);
                     context.commit();
                 }

--- a/dspace-api/src/main/java/org/dspace/curate/AbstractCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/curate/AbstractCurationTask.java
@@ -54,7 +54,7 @@ public abstract class AbstractCurationTask implements CurationTask {
     protected EPersonService ePersonService;
 
     @Override
-    public void init(Curator curator, String taskId) throws IOException {
+    public void init(Context ctx, Curator curator, String taskId) throws IOException {
         this.curator = curator;
         this.taskId = taskId;
         communityService = ContentServiceFactory.getInstance().getCommunityService();

--- a/dspace-api/src/main/java/org/dspace/curate/AbstractCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/curate/AbstractCurationTask.java
@@ -9,8 +9,12 @@ package org.dspace.curate;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
+import java.util.UUID;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -26,6 +30,8 @@ import org.dspace.content.service.CommunityService;
 import org.dspace.content.service.ItemService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
+import org.dspace.eperson.factory.EPersonServiceFactory;
+import org.dspace.eperson.service.EPersonService;
 import org.dspace.handle.factory.HandleServiceFactory;
 import org.dspace.handle.service.HandleService;
 import org.dspace.services.ConfigurationService;
@@ -47,7 +53,7 @@ public abstract class AbstractCurationTask implements CurationTask {
     protected HandleService handleService;
     protected ConfigurationService configurationService;
     protected DSpaceObjectUtils dspaceObjectUtils;
-    private static final Logger log = LogManager.getLogger();
+    protected EPersonService ePersonService;
 
     @Override
     public void init(Curator curator, String taskId) throws IOException {
@@ -58,10 +64,11 @@ public abstract class AbstractCurationTask implements CurationTask {
         handleService = HandleServiceFactory.getInstance().getHandleService();
         configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
         dspaceObjectUtils = UtilServiceFactory.getInstance().getDSpaceObjectUtils();
+        ePersonService = EPersonServiceFactory.getInstance().getEPersonService();
     }
 
     @Override
-    public abstract int perform(DSpaceObject dso) throws IOException;
+    public abstract int perform(Context context, DSpaceObject dso) throws IOException;
 
     /**
      * Distributes a task through a DSpace container - a convenience method
@@ -80,32 +87,73 @@ public abstract class AbstractCurationTask implements CurationTask {
      * @param dso current DSpaceObject
      * @throws IOException if IO error
      */
-    protected void distribute(DSpaceObject dso) throws IOException {
+    private Integer total = null;
+    private int current = 0;
+    private Date start = null;
+    private Date last = null;
+    private final DecimalFormat df = new DecimalFormat("0.00");
+    private final int PAGE_SIZE = 100;
+    protected void distribute(Context context, DSpaceObject dso) throws IOException {
         try {
+            if (total == null) {
+                total = itemService.countTotal(context);
+                start = new Date();
+                last = start;
+            }
             //perform task on this current object
-            performObject(dso);
+            performObject(context, dso);
 
             //next, we'll try to distribute to all child objects, based on container type
             int type = dso.getType();
             if (Constants.COLLECTION == type) {
-                Iterator<Item> iter = itemService.findByCollection(Curator.curationContext(), (Collection) dso);
+                Collection collection = (Collection) dso;
+                System.out.println();
+                System.out.println("NEW COLLECTION: " + itemService.countItems(context, collection));
+                System.out.println();
+
+                Iterator<Item> iter = itemService.findByCollection(context,
+                        (Collection) context.reloadEntity(dso));
+                List<UUID> uuids = new ArrayList<>();
                 while (iter.hasNext()) {
-                    Item item = iter.next();
-                    performObject(item);
-                    Curator.curationContext().uncacheEntity(item);
+                    Item next = iter.next();
+                    uuids.add(next.getID());
+                    context.uncacheEntity(next);
+                }
+                context.commit();
+                for (UUID uuid : uuids) {
+                    Item item = itemService.find(context, uuid);
+                    if (++current % 1000 == 0) {
+                        Date now = new Date();
+                        float ms = (float) (now.getTime() - last.getTime());
+                        float avgSeconds = (float) (now.getTime() - start.getTime()) / 1000 / (current / 1000);
+                        Runtime runtime = Runtime.getRuntime();
+                        long usedMemory = runtime.totalMemory() - runtime.freeMemory();
+
+                        System.out.println(current + " / " + total + " -- " + ms +
+                                "ms - (avg " + df.format(avgSeconds) + "s per 1000) - Used memory: " +
+                                (usedMemory / (1024 * 1024)) + "MB");
+                        last = now;
+                    }
+                    performObject(context, item);
+                    context.commit();
                 }
             } else if (Constants.COMMUNITY == type) {
-                Community comm = (Community) dso;
+                Community comm = (Community) context.reloadEntity(dso);
                 for (Community subcomm : comm.getSubcommunities()) {
-                    distribute(subcomm);
+                    distribute(context, subcomm);
+                    context.uncacheEntity(subcomm);
                 }
+                comm = context.reloadEntity(comm);
                 for (Collection coll : comm.getCollections()) {
-                    distribute(coll);
+                    distribute(context, coll);
+                    context.uncacheEntity(coll);
                 }
+                context.uncacheEntity(comm);
             } else if (Constants.SITE == type) {
-                List<Community> topComm = communityService.findAllTop(Curator.curationContext());
+                List<Community> topComm = communityService.findAllTop(context);
                 for (Community comm : topComm) {
-                    distribute(comm);
+                    distribute(context, comm);
+                    context.uncacheEntity(comm);
                 }
             }
         } catch (SQLException sqlE) {
@@ -130,11 +178,11 @@ public abstract class AbstractCurationTask implements CurationTask {
      * @throws SQLException if database error
      * @throws IOException  if IO error
      */
-    protected void performObject(DSpaceObject dso) throws SQLException, IOException {
+    protected void performObject(Context context, DSpaceObject dso) throws SQLException, IOException {
         // By default this method only performs tasks on Items
         // (You should override this method if you want to perform task on all objects)
         if (dso.getType() == Constants.ITEM) {
-            performItem((Item) dso);
+            performItem(context, (Item) dso);
         }
 
         //no-op for all other types of DSpace Objects
@@ -154,19 +202,19 @@ public abstract class AbstractCurationTask implements CurationTask {
      * @throws SQLException if database error
      * @throws IOException  if IO error
      */
-    protected void performItem(Item item) throws SQLException, IOException {
+    protected void performItem(Context context, Item item) throws SQLException, IOException {
         // no-op - override when using 'distribute' method
     }
 
     @Override
     public int perform(Context ctx, String id) throws IOException {
-        DSpaceObject dso = null;
+        DSpaceObject dso;
         try {
             dso = dspaceObjectUtils.findDSpaceObject(ctx, id);
         } catch (SQLException sqlE) {
             throw new IOException(sqlE.getMessage(), sqlE);
         }
-        return (dso != null) ? perform(dso) : Curator.CURATE_FAIL;
+        return (dso != null) ? perform(ctx, dso) : Curator.CURATE_FAIL;
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/curate/AbstractCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/curate/AbstractCurationTask.java
@@ -15,8 +15,6 @@ import java.util.List;
 import java.util.UUID;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.dspace.app.util.factory.UtilServiceFactory;
 import org.dspace.app.util.service.DSpaceObjectUtils;
 import org.dspace.content.Collection;

--- a/dspace-api/src/main/java/org/dspace/curate/Curation.java
+++ b/dspace-api/src/main/java/org/dspace/curate/Curation.java
@@ -106,7 +106,7 @@ public class Curation extends DSpaceRunnable<CurationScriptConfiguration> {
             if (verbose) {
                 handler.logInfo("Adding task: " + this.task);
             }
-            curator.addTask(this.task);
+            curator.addTask(context, this.task);
             if (verbose && !curator.hasTask(this.task)) {
                 handler.logInfo("Task: " + this.task + " not resolved");
             }
@@ -119,7 +119,7 @@ public class Curation extends DSpaceRunnable<CurationScriptConfiguration> {
                     if (verbose) {
                         super.handler.logInfo("Adding task: " + taskName);
                     }
-                    curator.addTask(taskName);
+                    curator.addTask(context, taskName);
                 }
             } finally {
                 if (reader != null) {
@@ -159,7 +159,7 @@ public class Curation extends DSpaceRunnable<CurationScriptConfiguration> {
             }
             curator.clear();
             for (String taskName : entry.getTaskNames()) {
-                curator.addTask(taskName);
+                curator.addTask(context, taskName);
             }
             curator.curate(context, entry.getObjectId());
         }

--- a/dspace-api/src/main/java/org/dspace/curate/CurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/curate/CurationTask.java
@@ -24,11 +24,12 @@ public interface CurationTask {
      * Since the curator can provide services to the task, this represents
      * curation DI.
      *
+     * @param ctx DSpace context object
      * @param curator the Curator controlling this task
      * @param taskId  identifier task should use in invoking services
      * @throws IOException if error
      */
-    void init(Curator curator, String taskId) throws IOException;
+    void init(Context ctx, Curator curator, String taskId) throws IOException;
 
     /**
      * Perform the curation task upon passed DSO

--- a/dspace-api/src/main/java/org/dspace/curate/CurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/curate/CurationTask.java
@@ -33,11 +33,12 @@ public interface CurationTask {
     /**
      * Perform the curation task upon passed DSO
      *
+     * @param ctx DSpace context object
      * @param dso the DSpace object
      * @return status code
      * @throws IOException if error
      */
-    int perform(DSpaceObject dso) throws IOException;
+    int perform(Context ctx, DSpaceObject dso) throws IOException;
 
     /**
      * Perform the curation task for passed id

--- a/dspace-api/src/main/java/org/dspace/curate/Curator.java
+++ b/dspace-api/src/main/java/org/dspace/curate/Curator.java
@@ -9,15 +9,14 @@ package org.dspace.curate;
 
 import java.io.IOException;
 import java.sql.SQLException;
-import java.text.DecimalFormat;
 import java.text.MessageFormat;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -37,7 +36,6 @@ import org.dspace.core.factory.CoreServiceFactory;
 import org.dspace.handle.factory.HandleServiceFactory;
 import org.dspace.handle.service.HandleService;
 import org.dspace.scripts.handler.DSpaceRunnableHandler;
-import org.dspace.services.factory.DSpaceServicesFactory;
 
 /**
  * Curator orchestrates and manages the application of a one or more curation
@@ -98,8 +96,6 @@ public class Curator {
     protected ItemService itemService;
     protected HandleService handleService;
     protected DSpaceRunnableHandler handler;
-    protected int batchSize =
-            DSpaceServicesFactory.getInstance().getConfigurationService().getIntProperty("curate.batch.size");
 
     /**
      * constructor that uses an handler for logging
@@ -475,46 +471,29 @@ public class Curator {
      * @return true if successful, false otherwise
      * @throws IOException if IO error
      */
-    private Integer total = null;
-    private int current = 0;
-    private Date start = null;
-    private Date last = null;
-    private final DecimalFormat df = new DecimalFormat("0.00");
     protected boolean doCollection(Context context, TaskRunner tr, Collection coll) throws IOException {
         try {
             if (!tr.run(context, coll)) {
                 return false;
             }
-            if (total == null) {
-                total = itemService.countTotal(context);
-                start = new Date();
-                last = start;
-            }
 
-            int offset = 0;
-            boolean hasNext;
-            do {
-                coll = context.reloadEntity(coll);
-                Iterator<Item> iter = itemService.findByCollection(context, coll, batchSize, offset);
-                hasNext = iter.hasNext();
-                while (iter.hasNext()) {
-                    Item item = iter.next();
-                    offset++;
-                    boolean shouldContinue = tr.run(context, item);
-                    if (!shouldContinue) {
-                        return false;
-                    }
-                    if (++current % 100 == 0) {
-                        Date now = new Date();
-                        float ms = (float) (now.getTime() - last.getTime());
-                        float avgSeconds = (float) (now.getTime() - start.getTime()) / 1000 / (current / 100);
-                        System.out.println(current + " / " + total + " -- " + ms +
-                                "ms - (avg " + df.format(avgSeconds) + "s per 100)");
-                        last = now;
-                    }
+            coll = context.reloadEntity(coll);
+            Iterator<Item> iter = itemService.findByCollection(context, coll);
+            List<UUID> uuids = new ArrayList<>();
+            while (iter.hasNext()) {
+                Item next = iter.next();
+                uuids.add(next.getID());
+                context.uncacheEntity(next);
+            }
+            context.commit();
+            for (UUID uuid : uuids) {
+                Item item = itemService.find(context, uuid);
+                boolean shouldContinue = tr.run(context, item);
+                if (!shouldContinue) {
+                    return false;
                 }
                 context.commit();
-            } while (hasNext);
+            }
         } catch (SQLException sqlE) {
             throw new IOException(sqlE.getMessage(), sqlE);
         }

--- a/dspace-api/src/main/java/org/dspace/curate/Curator.java
+++ b/dspace-api/src/main/java/org/dspace/curate/Curator.java
@@ -148,14 +148,15 @@ public class Curator {
      * Add a task to the set to be performed. Caller should make no assumptions
      * on execution ordering.
      *
+     * @param ctx DSpace context object
      * @param taskName - logical name of task
      * @return this curator - to support concatenating invocation style
      */
-    public Curator addTask(String taskName) {
+    public Curator addTask(Context ctx, String taskName) {
         ResolvedTask task = resolver.resolveTask(taskName);
         if (task != null) {
             try {
-                task.init(this);
+                task.init(ctx, this);
                 trMap.put(taskName, new TaskRunner(task));
                 // performance order currently FIFO - to be revisited
                 perfList.add(taskName);

--- a/dspace-api/src/main/java/org/dspace/curate/Curator.java
+++ b/dspace-api/src/main/java/org/dspace/curate/Curator.java
@@ -9,9 +9,11 @@ package org.dspace.curate;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.text.DecimalFormat;
 import java.text.MessageFormat;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -35,6 +37,7 @@ import org.dspace.core.factory.CoreServiceFactory;
 import org.dspace.handle.factory.HandleServiceFactory;
 import org.dspace.handle.service.HandleService;
 import org.dspace.scripts.handler.DSpaceRunnableHandler;
+import org.dspace.services.factory.DSpaceServicesFactory;
 
 /**
  * Curator orchestrates and manages the application of a one or more curation
@@ -82,8 +85,6 @@ public class Curator {
 
     private static final Logger log = LogManager.getLogger();
 
-    protected static final ThreadLocal<Context> curationCtx = new ThreadLocal<>();
-
     protected final Map<String, String> runParameters = new HashMap<>();
     protected Map<String, TaskRunner> trMap = new HashMap<>();
     protected List<String> perfList = new ArrayList<>();
@@ -97,6 +98,8 @@ public class Curator {
     protected ItemService itemService;
     protected HandleService handleService;
     protected DSpaceRunnableHandler handler;
+    protected int batchSize =
+            DSpaceServicesFactory.getInstance().getConfigurationService().getIntProperty("curate.batch.size");
 
     /**
      * constructor that uses an handler for logging
@@ -250,12 +253,9 @@ public class Curator {
             throw new IOException("Cannot perform curation task(s) on a null object identifier!");
         }
         try {
-            //Save the context on current execution thread
-            curationCtx.set(c);
-
             DSpaceObject dso = dspaceObjectUtils.findDSpaceObject(c,id);
             if (dso != null) {
-                curate(dso);
+                curate(c, dso);
             } else {
                 for (String taskName : perfList) {
                     trMap.get(taskName).run(c, id);
@@ -263,15 +263,12 @@ public class Curator {
             }
             // if curation scoped, commit transaction
             if (txScope.equals(TxScope.CURATION)) {
-                Context ctx = curationCtx.get();
-                if (ctx != null) {
-                    ctx.complete();
+                if (c != null) {
+                    c.complete();
                 }
             }
         } catch (SQLException sqlE) {
             throw new IOException(sqlE.getMessage(), sqlE);
-        } finally {
-            curationCtx.remove();
         }
     }
 
@@ -281,7 +278,7 @@ public class Curator {
      * @param dso the DSpace object
      * @throws IOException if IO error
      */
-    public void curate(DSpaceObject dso) throws IOException {
+    public void curate(Context c, DSpaceObject dso) throws IOException {
         if (dso == null) {
             throw new IOException("Cannot perform curation task(s) on a null DSpaceObject!");
         }
@@ -290,33 +287,15 @@ public class Curator {
             TaskRunner tr = trMap.get(taskName);
             // do we need to iterate over the object ?
             if (type == Constants.ITEM || tr.task.isDistributive()) {
-                tr.run(dso);
+                tr.run(c, dso);
             } else if (type == Constants.COLLECTION) {
-                doCollection(tr, (Collection) dso);
+                doCollection(c, tr, (Collection) dso);
             } else if (type == Constants.COMMUNITY) {
-                doCommunity(tr, (Community) dso);
+                doCommunity(c, tr, (Community) dso);
             } else if (type == Constants.SITE) {
-                doSite(tr, (Site) dso);
+                doSite(c, tr, (Site) dso);
             }
         }
-    }
-
-    /**
-     * Performs all configured tasks upon DSpace object
-     * (Community, Collection or Item).
-     *
-     * <p>
-     * Note:  this method has the side-effect of setting this instance's Context
-     * reference.  The setting is retained on return.
-     *
-     * @param c   session context in which curation takes place.
-     * @param dso the single object to be curated.
-     * @throws java.io.IOException passed through.
-     */
-    public void curate(Context c, DSpaceObject dso)
-        throws IOException {
-        curationCtx.set(c);
-        curate(dso);
     }
 
     /**
@@ -403,29 +382,6 @@ public class Curator {
     }
 
     /**
-     * Returns the context object used in the current curation thread.
-     * This is primarily a utility method to allow tasks access to the context when necessary.
-     * <p>
-     * If the context is null or not set, then this just returns
-     * a brand new Context object representing an Anonymous User.
-     *
-     * @return curation thread's Context object (or a new, anonymous Context if no curation Context exists)
-     * @throws SQLException An exception that provides information on a database access error or other errors.
-     */
-    public static Context curationContext() throws SQLException {
-        // Return curation context or new context if undefined/invalid
-        Context curCtx = curationCtx.get();
-
-        if (curCtx == null || !curCtx.isValid()) {
-            //Create a new context (represents an Anonymous User)
-            curCtx = new Context();
-            //Save it to current execution thread
-            curationCtx.set(curCtx);
-        }
-        return curCtx;
-    }
-
-    /**
      * Returns whether a given DSO is a 'container' - collection or community
      *
      * @param dso a DSpace object
@@ -444,15 +400,12 @@ public class Curator {
      * @return true if successful, false otherwise
      * @throws IOException if IO error
      */
-    protected boolean doSite(TaskRunner tr, Site site) throws IOException {
-        Context ctx = null;
+    protected boolean doSite(Context context, TaskRunner tr, Site site) throws IOException {
         try {
-            //get access to the curation thread's current context
-            ctx = curationContext();
 
             // Site-wide Tasks really should have an EPerson performer associated with them,
             // otherwise they are run as an "anonymous" user with limited access rights.
-            if (ctx.getCurrentUser() == null && !ctx.ignoreAuthorization()) {
+            if (context.getCurrentUser() == null && !context.ignoreAuthorization()) {
                 logWarning("You are running one or more Site-Wide curation tasks in ANONYMOUS USER mode," +
                              " as there is no EPerson 'performer' associated with this task. To associate an EPerson " +
                              "'performer' " +
@@ -460,16 +413,18 @@ public class Curator {
             }
 
             //Run task for the Site object itself
-            if (!tr.run(site)) {
+            if (!tr.run(context, site)) {
                 return false;
             }
 
             //Then, perform this task for all Top-Level Communities in the Site
             // (this will recursively perform task for all objects in DSpace)
-            for (Community subcomm : communityService.findAllTop(ctx)) {
-                if (!doCommunity(tr, subcomm)) {
+            for (Community subcomm : communityService.findAllTop(context)) {
+                subcomm = context.reloadEntity(subcomm);
+                if (!doCommunity(context, tr, subcomm)) {
                     return false;
                 }
+                context.commit();
             }
         } catch (SQLException sqlE) {
             throw new IOException(sqlE);
@@ -486,19 +441,28 @@ public class Curator {
      * @return true if successful, false otherwise
      * @throws IOException if IO error
      */
-    protected boolean doCommunity(TaskRunner tr, Community comm) throws IOException {
-        if (!tr.run(comm)) {
-            return false;
-        }
-        for (Community subcomm : comm.getSubcommunities()) {
-            if (!doCommunity(tr, subcomm)) {
+    protected boolean doCommunity(Context context, TaskRunner tr, Community comm) throws IOException {
+        try {
+            if (!tr.run(context, comm)) {
                 return false;
             }
-        }
-        for (Collection coll : comm.getCollections()) {
-            if (!doCollection(tr, coll)) {
-                return false;
+            for (Community subcomm : comm.getSubcommunities()) {
+                subcomm = context.reloadEntity(subcomm);
+                if (!doCommunity(context, tr, subcomm)) {
+                    return false;
+                }
+                context.commit();
             }
+            comm = context.reloadEntity(comm);
+            for (Collection coll : comm.getCollections()) {
+                coll = context.reloadEntity(coll);
+                if (!doCollection(context, tr, coll)) {
+                    return false;
+                }
+                context.commit();
+            }
+        }  catch (SQLException sqlE) {
+            throw new IOException(sqlE.getMessage(), sqlE);
         }
         return true;
     }
@@ -511,21 +475,46 @@ public class Curator {
      * @return true if successful, false otherwise
      * @throws IOException if IO error
      */
-    protected boolean doCollection(TaskRunner tr, Collection coll) throws IOException {
+    private Integer total = null;
+    private int current = 0;
+    private Date start = null;
+    private Date last = null;
+    private final DecimalFormat df = new DecimalFormat("0.00");
+    protected boolean doCollection(Context context, TaskRunner tr, Collection coll) throws IOException {
         try {
-            if (!tr.run(coll)) {
+            if (!tr.run(context, coll)) {
                 return false;
             }
-            Context context = curationContext();
-            Iterator<Item> iter = itemService.findByCollection(context, coll);
-            while (iter.hasNext()) {
-                Item item = iter.next();
-                boolean shouldContinue = tr.run(item);
-                context.uncacheEntity(item);
-                if (!shouldContinue) {
-                    return false;
-                }
+            if (total == null) {
+                total = itemService.countTotal(context);
+                start = new Date();
+                last = start;
             }
+
+            int offset = 0;
+            boolean hasNext;
+            do {
+                coll = context.reloadEntity(coll);
+                Iterator<Item> iter = itemService.findByCollection(context, coll, batchSize, offset);
+                hasNext = iter.hasNext();
+                while (iter.hasNext()) {
+                    Item item = iter.next();
+                    offset++;
+                    boolean shouldContinue = tr.run(context, item);
+                    if (!shouldContinue) {
+                        return false;
+                    }
+                    if (++current % 100 == 0) {
+                        Date now = new Date();
+                        float ms = (float) (now.getTime() - last.getTime());
+                        float avgSeconds = (float) (now.getTime() - start.getTime()) / 1000 / (current / 100);
+                        System.out.println(current + " / " + total + " -- " + ms +
+                                "ms - (avg " + df.format(avgSeconds) + "s per 100)");
+                        last = now;
+                    }
+                }
+                context.commit();
+            } while (hasNext);
         } catch (SQLException sqlE) {
             throw new IOException(sqlE.getMessage(), sqlE);
         }
@@ -536,14 +525,12 @@ public class Curator {
      * Record a 'visit' to a DSpace object and enforce any policies set
      * on this curator.
      *
-     * @param dso the DSpace object
      * @throws IOException A general class of exceptions produced by failed or interrupted I/O operations.
      */
-    protected void visit(DSpaceObject dso) throws IOException {
-        Context curCtx = curationCtx.get();
-        if (curCtx != null) {
+    protected void visit(Context context) throws IOException {
+        if (context != null) {
             if (txScope.equals(TxScope.OBJECT)) {
-                curCtx.dispatchEvents();
+                context.dispatchEvents();
             }
         }
     }
@@ -557,15 +544,15 @@ public class Curator {
             this.task = task;
         }
 
-        public boolean run(DSpaceObject dso) throws IOException {
+        public boolean run(Context context, DSpaceObject dso) throws IOException {
             try {
                 if (dso == null) {
                     throw new IOException("DSpaceObject is null");
                 }
-                statusCode = task.perform(dso);
                 String id = (dso.getHandle() != null) ? dso.getHandle() : "workflow item: " + dso.getID();
+                statusCode = task.perform(context, dso);
                 logInfo(logMessage(id));
-                visit(dso);
+                visit(context);
                 return !suspend(statusCode);
             } catch (IOException ioe) {
                 //log error & pass exception upwards
@@ -574,14 +561,14 @@ public class Curator {
             }
         }
 
-        public boolean run(Context c, String id) throws IOException {
+        public boolean run(Context context, String id) throws IOException {
             try {
-                if (c == null || id == null) {
+                if (context == null || id == null) {
                     throw new IOException("Context or identifier is null");
                 }
-                statusCode = task.perform(c, id);
+                statusCode = task.perform(context, id);
                 logInfo(logMessage(id));
-                visit(null);
+                visit(context);
                 return !suspend(statusCode);
             } catch (IOException ioe) {
                 //log error & pass exception upwards

--- a/dspace-api/src/main/java/org/dspace/curate/ResolvedTask.java
+++ b/dspace-api/src/main/java/org/dspace/curate/ResolvedTask.java
@@ -57,20 +57,22 @@ public class ResolvedTask {
      * Since the curator can provide services to the task, this represents
      * curation DI.
      *
+     * @param ctx DSpace context object
      * @param curator the Curator controlling this task
      * @throws IOException if IO error
      */
-    public void init(Curator curator) throws IOException {
+    public void init(Context ctx, Curator curator) throws IOException {
         if (unscripted()) {
-            cTask.init(curator, taskName);
+            cTask.init(ctx, curator, taskName);
         } else {
-            sTask.init(curator, taskName);
+            sTask.init(ctx, curator, taskName);
         }
     }
 
     /**
      * Perform the curation task upon passed DSO
      *
+     * @param ctx DSpace context object
      * @param dso the DSpace object
      * @return status code
      * @throws IOException if error

--- a/dspace-api/src/main/java/org/dspace/curate/ResolvedTask.java
+++ b/dspace-api/src/main/java/org/dspace/curate/ResolvedTask.java
@@ -75,8 +75,8 @@ public class ResolvedTask {
      * @return status code
      * @throws IOException if error
      */
-    public int perform(DSpaceObject dso) throws IOException {
-        return unscripted() ? cTask.perform(dso) : sTask.performDso(dso);
+    public int perform(Context ctx, DSpaceObject dso) throws IOException {
+        return unscripted() ? cTask.perform(ctx, dso) : sTask.performDso(ctx, dso);
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/curate/ScriptedTask.java
+++ b/dspace-api/src/main/java/org/dspace/curate/ScriptedTask.java
@@ -27,15 +27,17 @@ public interface ScriptedTask {
      * Since the curator can provide services to the task, this represents
      * curation DI.
      *
+     * @param ctx DSpace context object
      * @param curator the Curator controlling this task
      * @param taskId  identifier task should use in invoking services
      * @throws IOException if IO error
      */
-    public void init(Curator curator, String taskId) throws IOException;
+    public void init(Context ctx, Curator curator, String taskId) throws IOException;
 
     /**
      * Perform the curation task upon passed DSO
      *
+     * @param ctx DSpace context object
      * @param dso the DSpace object
      * @return status code
      * @throws IOException if IO error

--- a/dspace-api/src/main/java/org/dspace/curate/ScriptedTask.java
+++ b/dspace-api/src/main/java/org/dspace/curate/ScriptedTask.java
@@ -40,7 +40,7 @@ public interface ScriptedTask {
      * @return status code
      * @throws IOException if IO error
      */
-    public int performDso(DSpaceObject dso) throws IOException;
+    public int performDso(Context ctx, DSpaceObject dso) throws IOException;
 
     /**
      * Perform the curation task for passed id

--- a/dspace-api/src/main/java/org/dspace/curate/XmlWorkflowCuratorServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/curate/XmlWorkflowCuratorServiceImpl.java
@@ -139,7 +139,7 @@ public class XmlWorkflowCuratorServiceImpl
             Item item = wfi.getItem();
             item.setOwningCollection(wfi.getCollection());
             for (Task task : step.tasks) {
-                curator.addTask(task.name);
+                curator.addTask(c, task.name);
             }
 
             if (StringUtils.isNotEmpty(step.queue)) { // Step's tasks are to be queued.

--- a/dspace-api/src/test/data/dspaceFolder/config/modules/curate.cfg
+++ b/dspace-api/src/test/data/dspaceFolder/config/modules/curate.cfg
@@ -9,7 +9,6 @@
 # NOTE: Other configurations can append to this list of default tasks by simply
 # adding their own additional values of "plugin.named.org.dspace.curate.CurationTask"
 plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.NoOpCurationTask = noop
-plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.NoOpCurationDistributeTask = noopdis
 plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.ProfileFormats = profileformats
 plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.RequiredMetadata = requiredmetadata
 #plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.ClamScan = vscan
@@ -28,6 +27,3 @@ curate.taskqueue.dir = ${dspace.dir}/ctqueues
 
 # (optional) directory location of scripted (non-java) tasks
 # curate.script.dir = ${dspace.dir}/ctscripts
-
-# How many items to process before committing the context
-curate.batch.size = 10

--- a/dspace-api/src/test/data/dspaceFolder/config/modules/curate.cfg
+++ b/dspace-api/src/test/data/dspaceFolder/config/modules/curate.cfg
@@ -9,6 +9,7 @@
 # NOTE: Other configurations can append to this list of default tasks by simply
 # adding their own additional values of "plugin.named.org.dspace.curate.CurationTask"
 plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.NoOpCurationTask = noop
+plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.NoOpCurationDistributeTask = noopdis
 plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.ProfileFormats = profileformats
 plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.RequiredMetadata = requiredmetadata
 #plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.ClamScan = vscan
@@ -27,3 +28,6 @@ curate.taskqueue.dir = ${dspace.dir}/ctqueues
 
 # (optional) directory location of scripted (non-java) tasks
 # curate.script.dir = ${dspace.dir}/ctscripts
+
+# How many items to process before committing the context
+curate.batch.size = 10

--- a/dspace-api/src/test/java/org/dspace/ctask/general/CreateMissingIdentifiersIT.java
+++ b/dspace-api/src/test/java/org/dspace/ctask/general/CreateMissingIdentifiersIT.java
@@ -55,7 +55,7 @@ public class CreateMissingIdentifiersIT
                 CreateMissingIdentifiers.class.getCanonicalName() + " = " + TASK_NAME);
 
         Curator curator = new Curator();
-        curator.addTask(TASK_NAME);
+        curator.addTask(context, TASK_NAME);
 
         context.setCurrentUser(admin);
         parentCommunity = CommunityBuilder.createCommunity(context)

--- a/dspace-api/src/test/java/org/dspace/ctask/general/CreateMissingIdentifiersIT.java
+++ b/dspace-api/src/test/java/org/dspace/ctask/general/CreateMissingIdentifiersIT.java
@@ -122,7 +122,7 @@ public class CreateMissingIdentifiersIT
 
             // setup the curator
             Curator curator = new Curator();
-            curator.addTask(TASK_NAME);
+            curator.addTask(context, TASK_NAME);
 
             // register the default Handle Provider
             registerProvider(VersionedHandleIdentifierProvider.class);

--- a/dspace-api/src/test/java/org/dspace/ctask/testing/MarkerTask.java
+++ b/dspace-api/src/test/java/org/dspace/ctask/testing/MarkerTask.java
@@ -32,16 +32,9 @@ public class MarkerTask
     public static final String LANGUAGE = null;
 
     @Override
-    public int perform(DSpaceObject dso)
+    public int perform(Context context, DSpaceObject dso)
             throws IOException {
         if (dso instanceof Item) {
-            Context context;
-            try {
-                context = Curator.curationContext();
-            } catch (SQLException ex) {
-                throw new IOException("Failed to get a Context:", ex);
-            }
-
             Item item = (Item) dso;
             String marker = String.format("Marked by %s on %s",
                     MarkerTask.class.getCanonicalName(),

--- a/dspace-api/src/test/java/org/dspace/curate/CuratorReportTest.java
+++ b/dspace-api/src/test/java/org/dspace/curate/CuratorReportTest.java
@@ -22,6 +22,7 @@ import org.dspace.content.Community;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Site;
 import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.core.Context;
 import org.dspace.services.ConfigurationService;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -138,7 +139,7 @@ public class CuratorReportTest
         }
 
         @Override
-        public int perform(DSpaceObject dso)
+        public int perform(Context context, DSpaceObject dso)
                 throws IOException {
             curator.report(String.format(
                     "Task1 received 'perform' on taskId '%s' for object '%s'%n",
@@ -157,7 +158,7 @@ public class CuratorReportTest
         }
 
         @Override
-        public int perform(DSpaceObject dso) throws IOException {
+        public int perform(Context context, DSpaceObject dso) throws IOException {
             curator.report(String.format(
                     "Task2 received 'perform' on taskId '%s' for object '%s'%n",
                     taskId, dso.getHandle()));

--- a/dspace-api/src/test/java/org/dspace/curate/CuratorReportTest.java
+++ b/dspace-api/src/test/java/org/dspace/curate/CuratorReportTest.java
@@ -89,8 +89,8 @@ public class CuratorReportTest
         ListReporter reporter = new ListReporter();
         Curator curator = new Curator();
         curator.setReporter(reporter);
-        curator.addTask("task1");
-        curator.addTask("task2");
+        curator.addTask(context, "task1");
+        curator.addTask(context, "task2");
         curator.curate(context, site);
 
         // Validate the results.

--- a/dspace-api/src/test/java/org/dspace/curate/CuratorTest.java
+++ b/dspace-api/src/test/java/org/dspace/curate/CuratorTest.java
@@ -67,7 +67,7 @@ public class CuratorTest extends AbstractUnitTest {
         // Get and configure a Curator.
         Curator instance = new Curator();
         instance.setReporter(System.out); // Send any report to standard out.
-        instance.addTask(TASK_NAME);
+        instance.addTask(context, TASK_NAME);
 
         // Configure the run.
         Map<String, String> parameters = new HashMap<>();
@@ -107,7 +107,7 @@ public class CuratorTest extends AbstractUnitTest {
         StringBuilder reporterOutput = new StringBuilder();
         curator.setReporter(reporterOutput); // Send any report to our StringBuilder.
 
-        curator.addTask(TASK_NAME);
+        curator.addTask(context, TASK_NAME);
         Item item = mock(Item.class);
         when(item.getType()).thenReturn(2);
         when(item.getHandle()).thenReturn("testHandle");

--- a/dspace-api/src/test/java/org/dspace/curate/DummyTask.java
+++ b/dspace-api/src/test/java/org/dspace/curate/DummyTask.java
@@ -10,6 +10,7 @@ package org.dspace.curate;
 import java.io.IOException;
 
 import org.dspace.content.DSpaceObject;
+import org.dspace.core.Context;
 
 /**
  * Makes no model changes, but records certain property values for inspection.
@@ -21,7 +22,7 @@ public class DummyTask
     }
 
     @Override
-    public int perform(DSpaceObject dso)
+    public int perform(Context context, DSpaceObject dso)
             throws IOException {
         CuratorTest.runParameter = taskProperty(CuratorTest.RUN_PARAMETER_NAME);
         CuratorTest.taskProperty = taskProperty(CuratorTest.TASK_PROPERTY_NAME);

--- a/dspace/config/modules/curate.cfg
+++ b/dspace/config/modules/curate.cfg
@@ -9,6 +9,7 @@
 # NOTE: Other configurations can append to this list of default tasks by simply
 # adding their own additional values of "plugin.named.org.dspace.curate.CurationTask"
 plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.NoOpCurationTask = noop
+plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.NoOpCurationDistributeTask = noopdis
 plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.ProfileFormats = profileformats
 plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.RequiredMetadata = requiredmetadata
 #plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.ClamScan = vscan
@@ -29,6 +30,3 @@ curate.taskqueue.dir = ${dspace.dir}/ctqueues
 
 # Maximum amount of redirects set to 0 for none and -1 for unlimited
 curate.checklinks.max-redirect = 0
-
-# How many items to process before committing the context
-curate.batch.size = 10

--- a/dspace/config/modules/curate.cfg
+++ b/dspace/config/modules/curate.cfg
@@ -29,3 +29,6 @@ curate.taskqueue.dir = ${dspace.dir}/ctqueues
 
 # Maximum amount of redirects set to 0 for none and -1 for unlimited
 curate.checklinks.max-redirect = 0
+
+# How many items to process before committing the context
+curate.batch.size = 10


### PR DESCRIPTION
## Description

This PR is focussed on improving the performance of the curation framework.

Currently, the lack of regular commits during the curation process can make it impossible to complete jobs on very large repositories in any reasonable amount of time. In addition, the use iteration implementations and use of `curationContext()` needlessly slow-down the process as well.

## Details

The memory-leak and resulting slow-down of the curation framework means, on repositories with millions of items, the `noop` curation job effectively **never finishes**.

Instead, we tried a strategy of paging through Collection items, and committing every page (using 100 items per page). However, we still observed a memory leak. For some 4 million+ items, it took 13.14 hours to process with an average of ~1.09s per 100 items.

Still unhappy with this result, we instead built a list of UUIDs within the collection and iterate over the list of UUIDs instead, committing every item. This has a profound improvement in the performance of the script, with only a modest increase in memory use. For some 4 million+ items, it took just 21.7 minutes to process with an average of ~0.03s per 100 items.

In addition to this, the use of the `curationContext()` static object only seems to introduce additional slow-down to this process. So, it has been replaced by passing the `Context` object as is done through all other parts of DSpace.

## Instructions for Reviewers

The main changes in this PR involve the iteration strategies in `AbstractCurationTask` (used for `@Distributive` tasks) and `Curator` (used for non-`@Distributive` tasks). This involves building a list of UUIDs for each `Collection`, and iterating through them while committing every Item.

The other changes in this PR concern method signature changes so that `Context` can be properly passed into curation tasks (and the existing tasks have been modified with this new signature)

The most import testing will be performance comparisons with the existing code. And to ensure changes don't break existing curation tasks.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
