### PR TITLE
[Port dspace-8_x] Disable most file formats for "inline" display (in a user's browser) by default, unless overridden by configuration.

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
@@ -20,7 +20,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.ws.rs.core.Response;
 import org.apache.catalina.connector.ClientAbortException;
-import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.converter.ConverterService;
@@ -153,15 +152,17 @@ public class BitstreamRestController {
                 httpHeadersInitializer.withLastModified(lastModified);
             }
 
-            //Determine if we need to send the file as a download or if the browser can open it inline
-            //The file will be downloaded if its size is larger than the configured threshold,
-            //or if its mimetype/extension appears in the "webui.content_disposition_format" config
-            long dispositionThreshold = configurationService.getLongProperty("webui.content_disposition_threshold");
-            if ((dispositionThreshold >= 0 && filesize > dispositionThreshold)
-                    || checkFormatForContentDisposition(format)) {
-                httpHeadersInitializer.withDisposition(HttpHeadersInitializer.CONTENT_DISPOSITION_ATTACHMENT);
-            } else {
+            // Determine if we need to send the file as a download or if the browser can open it inline.
+            // By default, all files will be downloaded as that is more secure. File formats will only be opened inline
+            // if they are listed in the "webui.content_disposition_inline" config and size is less than the
+            // configured "webui.content_disposition_threshold" (default = 8MB)
+            long dispositionThreshold = configurationService.getLongProperty("webui.content_disposition_threshold",
+                                                                             8388608);
+            if (checkFormatForContentDispositionInline(format) &&
+                filesize <= dispositionThreshold) {
                 httpHeadersInitializer.withDisposition(HttpHeadersInitializer.CONTENT_DISPOSITION_INLINE);
+            } else {
+                httpHeadersInitializer.withDisposition(HttpHeadersInitializer.CONTENT_DISPOSITION_ATTACHMENT);
             }
 
             //We have all the data we need, close the connection to the database so that it doesn't stay open during
@@ -208,48 +209,48 @@ public class BitstreamRestController {
     }
 
     /**
-     * Check if a Bitstream of the specified format should always be downloaded (i.e. "content-disposition: attachment")
-     * or can be opened inline (i.e. "content-disposition: inline").
+     * Check if a Bitstream of the specified format should be opened inline (i.e. "content-disposition: inline")
+     * instead of the default behavior of always downloading (i.e. "content-disposition: attachment").
      * <P>
      * NOTE that downloading via "attachment" is more secure, as the user's browser will not attempt to process or
      * display the file. But, downloading via "inline" may be seen as more user-friendly for common formats.
      * @param format BitstreamFormat
-     * @return true if always download ("attachment"). false if can be opened inline ("inline")
+     * @return true if format is configured to be opened inline ("inline"). false if always download ("attachment")
      */
-    private boolean checkFormatForContentDisposition(BitstreamFormat format) {
+    private boolean checkFormatForContentDispositionInline(BitstreamFormat format) {
         // Undefined or Unknown formats should ALWAYS be downloaded for additional security.
         if (format == null || format.getSupportLevel() == BitstreamFormat.UNKNOWN) {
-            return true;
+            return false;
         }
 
-        // Load additional formats configured to require download
-        List<String> configuredFormats = List.of(configurationService.
-                                                     getArrayProperty("webui.content_disposition_format"));
-
-        // If configuration includes "*", then all formats will always be downloaded.
-        if (configuredFormats.contains("*")) {
-            return true;
+        // Return false for BANNED inline formats. Some formats, especially XML / HTML / Javascript based formats,
+        // when loaded inline may be susceptible to XSS attacks. Therefore, we will refuse to allow those formats to be
+        // displayed inline for security purposes.
+        // NOTE: "+xml" in this list will match any MIME Type that ends in "+xml", as those are XML-based formats.
+        List<String> bannedInlineFormats = List.of("text/html", "text/javascript", "text/xml", "application/xml",
+                                             "+xml");
+        for (String bannedInlineFormat : bannedInlineFormats) {
+            // If our format MIME Type contains one of the banned inline formats, we refuse to display it inline
+            if (format.getMIMEType().contains(bannedInlineFormat)) {
+                return false;
+            }
         }
 
-        // Define a download list of formats which DSpace forces to ALWAYS be downloaded.
-        // These formats can embed JavaScript which may be run in the user's browser if the file is opened inline.
-        // Therefore, DSpace blocks opening these formats inline as it could be used for an XSS attack.
-        List<String> downloadOnlyFormats = List.of("text/html", "text/javascript", "text/xml", "rdf");
-
-        // Combine our two lists
-        List<String> formats = ListUtils.union(downloadOnlyFormats, configuredFormats);
+        // Load formats configured to allow inline display
+        List<String> formats = List.of(configurationService.
+                                                     getArrayProperty("webui.content_disposition_inline"));
 
         // See if the passed in format's MIME type or file extension is listed.
-        boolean download = formats.contains(format.getMIMEType());
-        if (!download) {
+        boolean inline = formats.contains(format.getMIMEType());
+        if (!inline) {
             for (String ext : format.getExtensions()) {
                 if (formats.contains(ext)) {
-                    download = true;
+                    inline = true;
                     break;
                 }
             }
         }
-        return download;
+        return inline;
     }
 
     /**

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
@@ -1261,12 +1261,8 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
 
     @Test
     public void checkContentDispositionOfFormats() throws Exception {
-        configurationService.setProperty("webui.content_disposition_format", new String[] {
-            "text/richtext",
-            "text/xml",
-            "txt"
-        });
-
+        // This test verifies that, by default, common text formats will be downloaded instead of being served inline.
+        // The next two tests will verify behavior of non-default settings of "webui.content_disposition_inline"
         context.turnOffAuthorisationSystem();
         Community community = CommunityBuilder.createCommunity(context).build();
         Collection collection = CollectionBuilder.createCollection(context, community).build();
@@ -1288,18 +1284,26 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
         }
         context.restoreAuthSystemState();
 
-        // these formats are configured and files should be downloaded
+        // Based on default configuration all files should be downloaded
         verifyBitstreamDownload(rtf, "text/richtext;charset=UTF-8", true);
         verifyBitstreamDownload(xml, "text/xml;charset=UTF-8", true);
         verifyBitstreamDownload(txt, "text/plain;charset=UTF-8", true);
-        // this format is not configured and should open inline
-        verifyBitstreamDownload(csv, "text/csv;charset=UTF-8", false);
+        verifyBitstreamDownload(csv, "text/csv;charset=UTF-8", true);
     }
 
     @Test
-    public void checkHardcodedContentDispositionFormats() throws Exception {
-        // This test is similar to the above test, but it verifies that our *hardcoded settings* for
-        // webui.content_disposition_format are protecting us from loading specific formats *inline*.
+    public void checkBannedContentDispositionInlineFormats() throws Exception {
+        configurationService.setProperty("webui.content_disposition_inline", new String[] {
+            "text/html",
+            "text/javascript",
+            "rdf",
+            "text/xml",
+            "image/svg+xml"
+        });
+
+        // This test is similar to the above test, but it verifies that if a site specifies
+        // a banned format (e.g. HTML, XML, etc) in their "webui.content_disposition_inline" setting
+        // DSpace will still protect them by refusing to load the format *inline*.
         context.turnOffAuthorisationSystem();
         Community community = CommunityBuilder.createCommunity(context).build();
         Collection collection = CollectionBuilder.createCollection(context, community).build();
@@ -1329,8 +1333,9 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
         }
         context.restoreAuthSystemState();
 
-        // By default, HTML, JS & XML should all download. This protects us from possible XSS attacks, as
-        // each of these formats can embed JavaScript which may execute when the file is loaded *inline*.
+        // By default, HTML, JS & XML should all download regardless of inline configuration.
+        // This protects us from possible XSS attacks, as each of these formats can embed JavaScript
+        // which may execute when the file is loaded *inline*.
         verifyBitstreamDownload(html, "text/html;charset=UTF-8", true);
         verifyBitstreamDownload(js, "text/javascript;charset=UTF-8", true);
         verifyBitstreamDownload(rdf, "application/rdf+xml;charset=UTF-8", true);
@@ -1343,22 +1348,29 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
     }
 
     @Test
-    public void checkWildcardContentDispositionFormats() throws Exception {
-        // Setting "*" should result in all formats being downloaded (nothing will be opened inline)
-        configurationService.setProperty("webui.content_disposition_format", "*");
-
+    public void checkContentDispositionInlineFormats() throws Exception {
+        // Set PDF and a few image formats to verify they will display inline. But leave off "text/plain"
+        configurationService.setProperty("webui.content_disposition_inline", new String[] {
+            "text/csv",
+            "application/pdf",
+            "image/jpeg",
+            "video/mpeg"
+        });
         context.turnOffAuthorisationSystem();
         Community community = CommunityBuilder.createCommunity(context).build();
         Collection collection = CollectionBuilder.createCollection(context, community).build();
         Item item = ItemBuilder.createItem(context, collection).build();
         String content = "Test Content";
         Bitstream csv;
+        Bitstream txt;
         Bitstream jpg;
         Bitstream mpg;
         Bitstream pdf;
         try (InputStream is = IOUtils.toInputStream(content, CharEncoding.UTF_8)) {
             csv = BitstreamBuilder.createBitstream(context, item, is)
                                   .withMimeType("text/csv").build();
+            txt = BitstreamBuilder.createBitstream(context, item, is)
+                                  .withMimeType("text/plain").build();
             jpg = BitstreamBuilder.createBitstream(context, item, is)
                                    .withMimeType("image/jpeg").build();
             mpg = BitstreamBuilder.createBitstream(context, item, is)
@@ -1368,11 +1380,13 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
         }
         context.restoreAuthSystemState();
 
-        // All formats should be download only
-        verifyBitstreamDownload(csv, "text/csv;charset=UTF-8", true);
-        verifyBitstreamDownload(jpg, "image/jpeg;charset=UTF-8", true);
-        verifyBitstreamDownload(mpg, "video/mpeg;charset=UTF-8", true);
-        verifyBitstreamDownload(pdf, "application/pdf;charset=UTF-8", true);
+        // Only text/plain should download, while other formats should be served inline based on the configuration
+        verifyBitstreamDownload(csv, "text/csv;charset=UTF-8", false);
+        verifyBitstreamDownload(jpg, "image/jpeg;charset=UTF-8", false);
+        verifyBitstreamDownload(mpg, "video/mpeg;charset=UTF-8", false);
+        verifyBitstreamDownload(pdf, "application/pdf;charset=UTF-8", false);
+        // This is the only format not listed in the inline configuration, so it will be downloaded
+        verifyBitstreamDownload(txt, "text/plain;charset=UTF-8", true);
     }
 
 

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1396,8 +1396,9 @@ websvc.opensearch.max_num_of_items_per_request = 100
 # of the settings here. This blocks these formats from executing embedded JavaScript when opened inline, protecting
 # the site from potential XSS attacks.
 #
-# For example: enable PDF and common images formats to be opened in a user's browser.
-#webui.content_disposition_inline = application/pdf, image/gif, image/jpeg, image/png
+# For example: this setting defaults to enabling PDF and common image / audio / video formats to be opened
+# (or potentially streamed) in a user's browser.
+webui.content_disposition_inline = application/pdf, image/gif, image/jpeg, image/png, audio/mpeg, video/mpeg, video/mp4
 
 #
 # Set the max size (in bytes) of a bitstream that can be served inline. This setting only applies to formats

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1390,21 +1390,20 @@ websvc.opensearch.max_num_of_items_per_request = 100
 
 #### Content Inline Disposition Threshold ####
 #
-# Set the max size of a bitstream that can be served inline
-# Use -1 to force all bitstream to be served inline
-webui.content_disposition_threshold = 8388608
-
-#### Content Attachment Disposition Formats ####
-#
-# Set which mimetypes or file extensions will NOT be opened inline.
-# Files with these mimetypes/extensions will always be downloaded, regardless of the threshold above.
+# Set which mimetypes or file extensions are allowed to be opened inline in a user's browser.
+# By default, all files will be downloaded, regardless of the threshold below, unless specified in this configuration.
 # NOTE: For security reasons, some file formats (e.g. HTML, XML, RDF, JS) will always be downloaded regardless
-# of the settings here. This blocks these formats from executing embedded JavaScript when opened inline.
-# For additional security, you may choose to set this to "*" to force all formats to always be downloaded
-# (i.e. disables all formats from opening inline within the user's browser).
+# of the settings here. This blocks these formats from executing embedded JavaScript when opened inline, protecting
+# the site from potential XSS attacks.
 #
-# By default, RTF is always downloaded because most browsers attempt to display it as plain text.
-webui.content_disposition_format = text/richtext
+# For example: enable PDF and common images formats to be opened in a user's browser.
+#webui.content_disposition_inline = application/pdf, image/gif, image/jpeg, image/png
+
+#
+# Set the max size (in bytes) of a bitstream that can be served inline. This setting only applies to formats
+# specified in the "webui.content_disposition_inline" configuration above.
+# Default = 8MB (8388608 bytes). Use -1 to ignore the size of file when serving it inline.
+#webui.content_disposition_threshold = 8388608
 
 #### Multi-file HTML document/site settings #####
 # TODO: UNSUPPORTED in DSpace 7.0. May be re-added in a later release


### PR DESCRIPTION
Manual port of #11956 to `dspace-8_x`