### PR TITLE
Properly configure the object-deletion scripts to be run in CLI

### DIFF
--- a/dspace-api/src/main/java/org/dspace/deletion/process/DSpaceObjectDeletionProcess.java
+++ b/dspace-api/src/main/java/org/dspace/deletion/process/DSpaceObjectDeletionProcess.java
@@ -55,7 +55,7 @@ public class DSpaceObjectDeletionProcess
     private CollectionService collectionService;
 
     private String id;
-    private Context context;
+    protected Context context;
     private String[] copyVirtualMetadata;
     private List<DSpaceObjectDeletionStrategy> deletionStrategies = new ArrayList<>();
 
@@ -91,23 +91,40 @@ public class DSpaceObjectDeletionProcess
     @Override
     public void internalRun() throws Exception {
         assignCurrentUserInContext();
-        Optional<DSpaceObject> dSpaceObjectOptional = resolveDSpaceObject(this.id);
+        try {
+            Optional<DSpaceObject> dSpaceObjectOptional = resolveDSpaceObject(this.id);
 
-        if (dSpaceObjectOptional.isEmpty()) {
-            var error = String.format("DSpaceObject for provided identifier:%s doesn't exist!", this.id);
-            throw new IllegalArgumentException(error);
+            if (dSpaceObjectOptional.isEmpty()) {
+                var error = String.format("DSpaceObject for provided identifier:%s doesn't exist!", this.id);
+                throw new IllegalArgumentException(error);
+            }
+
+            DSpaceObject dso = dSpaceObjectOptional.get();
+
+            if (!authorizeService.isAdmin(context, dso)) {
+                throw new AuthorizeException("Current user is not eligible to execute script: " +
+                                                 "'" + OBJECT_DELETION_SCRIPT + "'");
+            }
+
+            var info = "Performing deletion of DSpaceObject (and all child objects) for type=%s and uuid=%s";
+            handler.logInfo(String.format(info, Constants.typeText[dso.getType()], dso.getID().toString()));
+            getStrategy(dso).delete(this.context, dso, this.copyVirtualMetadata);
+
+            handleCompletion();
+            handler.logInfo("Deletion completed!");
+        } catch (Exception e) {
+            handler.handleException("Error during deletion process: " + e.getMessage(), e);
+        } finally {
+            if (context != null && context.isValid()) {
+                context.abort();
+            }
         }
+    }
 
-        DSpaceObject dso = dSpaceObjectOptional.get();
-
-        if (!authorizeService.isAdmin(context, dso)) {
-            throw new AuthorizeException("Current user is not eligible to execute script: " + OBJECT_DELETION_SCRIPT);
+    private void handleCompletion() throws SQLException {
+        if (context != null) {
+            context.complete();
         }
-
-        var info = "Performing deletion of DSpaceObject (and all child objects) for type=%s and uuid=%s";
-        handler.logInfo(String.format(info, Constants.typeText[dso.getType()], dso.getID().toString()));
-        getStrategy(dso).delete(this.context, dso, this.copyVirtualMetadata);
-        handler.logInfo("Deletion completed!");
     }
 
     private DSpaceObjectDeletionStrategy getStrategy(DSpaceObject dso) {
@@ -118,11 +135,34 @@ public class DSpaceObjectDeletionProcess
                                  .orElseThrow(() -> new IllegalArgumentException(error));
     }
 
-    private void assignCurrentUserInContext() throws SQLException {
+    /**
+     * Assigns the current user to the context for script execution.
+     * 
+     * This method creates a new DSpace context and sets the current user based on the
+     * EPerson identifier obtained from the script handler. This method is protected to
+     * allow CLI extensions (like {@link DSpaceObjectDeletionProcessCli}) to override
+     * the user assignment logic and use alternative methods such as email-based lookup.
+     * 
+     * Default behavior:
+     * <ul>
+     *   <li>Creates a new Context instance</li>
+     *   <li>Retrieves the EPerson UUID from the script handler via {@link #getEpersonIdentifier()}</li>
+     *   <li>If UUID is present, looks up the EPerson and sets them as current user</li>
+     *   <li>If UUID is null, context remains without a current user (anonymous)</li>
+     * </ul>
+     *
+     * @throws SQLException if a database error occurs during EPerson lookup
+     * @throws ParseException if command line parsing fails (used by CLI extensions)
+     */
+    protected void assignCurrentUserInContext() throws SQLException, ParseException {
         this.context = new Context();
         UUID uuid = getEpersonIdentifier();
         if (uuid != null) {
             EPerson ePerson = EPersonServiceFactory.getInstance().getEPersonService().find(context, uuid);
+            if (ePerson == null) {
+                handler.logError("EPerson not found for UUID: " + uuid);
+                throw new IllegalArgumentException("Unable to find a user with UUID: " + uuid);
+            }
             context.setCurrentUser(ePerson);
         }
     }

--- a/dspace-api/src/main/java/org/dspace/deletion/process/DSpaceObjectDeletionProcessCli.java
+++ b/dspace-api/src/main/java/org/dspace/deletion/process/DSpaceObjectDeletionProcessCli.java
@@ -1,0 +1,75 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.deletion.process;
+
+import java.sql.SQLException;
+
+import org.apache.commons.cli.ParseException;
+import org.dspace.eperson.EPerson;
+import org.dspace.eperson.factory.EPersonServiceFactory;
+
+/**
+ * Extension of {@link DSpaceObjectDeletionProcess} for CLI execution.
+ * This class enables command-line execution of the deletion process with
+ * explicit user specification via the -e (email) parameter.
+ *
+ * @author Adamo Fapohunda (adamo.fapohunda at 4science.com)
+ *
+ */
+public class DSpaceObjectDeletionProcessCli extends DSpaceObjectDeletionProcess {
+
+    /**
+     * Assigns the current user to the context based on the email parameter for CLI execution.
+     *
+     * This method overrides the parent implementation to support command-line execution
+     * with explicit user specification via the -e (email) parameter. This is required for
+     * CLI scenarios where the script is invoked directly from the command line rather than
+     * through the REST API or other programmatic interfaces.
+     *
+     * Process:
+     * <ul>
+     *   <li>Creates a new DSpace Context instance</li>
+     *   <li>Validates that the -e (email) parameter is provided</li>
+     *   <li>Looks up the EPerson by email address using EPersonService</li>
+     *   <li>Validates that the EPerson exists in the system</li>
+     *   <li>Sets the found EPerson as the current user in the context</li>
+     * </ul>
+     *
+     * Usage Example:
+     * <pre>
+     * ./dspace object-deletion -e admin@example.com -i [object-uuid]
+     * </pre>
+     *
+     * @throws SQLException             if a database error occurs during EPerson lookup
+     * @throws ParseException           if the required -e parameter is missing from command line
+     * @throws IllegalArgumentException if the provided email address doesn't match any existing EPerson
+     */
+    @Override
+    protected void assignCurrentUserInContext() throws SQLException, ParseException {
+        this.context = new org.dspace.core.Context();
+        if (commandLine.hasOption('e')) {
+            String ePersonEmail = commandLine.getOptionValue('e');
+            EPerson ePerson =
+                EPersonServiceFactory.getInstance().getEPersonService().findByEmail(context, ePersonEmail);
+            if (ePerson == null) {
+                super.handler.logError("EPerson not found: " + ePersonEmail);
+                throw new IllegalArgumentException("Unable to find a user with email: " + ePersonEmail);
+            }
+            context.setCurrentUser(ePerson);
+        } else {
+            throw new ParseException("Required parameter -e missing!");
+        }
+    }
+
+    @Override
+    public DSpaceObjectDeletionProcessScriptConfiguration<DSpaceObjectDeletionProcess> getScriptConfiguration() {
+        org.dspace.kernel.ServiceManager sm = new org.dspace.utils.DSpace().getServiceManager();
+        return sm.getServiceByName(OBJECT_DELETION_SCRIPT, DSpaceObjectDeletionProcessCliScriptConfiguration.class);
+    }
+
+}

--- a/dspace-api/src/main/java/org/dspace/deletion/process/DSpaceObjectDeletionProcessCliScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/deletion/process/DSpaceObjectDeletionProcessCliScriptConfiguration.java
@@ -1,0 +1,31 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.deletion.process;
+
+import org.apache.commons.cli.Options;
+
+/**
+ * Extension of {@link DSpaceObjectDeletionProcessScriptConfiguration} for CLI execution.
+ * Adds the -e (email) option to specify the user executing the deletion from command line.
+ *
+ * @author Adamo Fapohunda (adamo.fapohunda at 4science.com)
+ *
+ */
+public class DSpaceObjectDeletionProcessCliScriptConfiguration<T extends DSpaceObjectDeletionProcessCli>
+    extends DSpaceObjectDeletionProcessScriptConfiguration<T> {
+
+    @Override
+    public Options getOptions() {
+        Options options = super.getOptions();
+        options.addOption("e", "email", true, "email address of user");
+        options.getOption("e").setRequired(true);
+        super.options = options;
+        return options;
+    }
+
+}

--- a/dspace-api/src/main/java/org/dspace/deletion/process/DSpaceObjectDeletionProcessScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/deletion/process/DSpaceObjectDeletionProcessScriptConfiguration.java
@@ -7,7 +7,12 @@
  */
 package org.dspace.deletion.process;
 
+import java.sql.SQLException;
+import java.util.List;
+
 import org.apache.commons.cli.Options;
+import org.dspace.core.Context;
+import org.dspace.scripts.DSpaceCommandLineParameter;
 import org.dspace.scripts.configuration.ScriptConfiguration;
 
 /**
@@ -20,7 +25,7 @@ import org.dspace.scripts.configuration.ScriptConfiguration;
  * @author Mykhaylo Boychuk (mykhaylo.boychuk@4science.com)
  */
 public class DSpaceObjectDeletionProcessScriptConfiguration<T extends DSpaceObjectDeletionProcess>
-        extends ScriptConfiguration<T> {
+    extends ScriptConfiguration<T> {
 
     private Class<T> dspaceRunnableClass;
 
@@ -60,4 +65,33 @@ public class DSpaceObjectDeletionProcessScriptConfiguration<T extends DSpaceObje
         this.dspaceRunnableClass = dspaceRunnableClass;
     }
 
+    /**
+     * Determines if the current user is allowed to execute the deletion script.
+     *
+     * This method implements a granular permission model that allows execution by:
+     * <ul>
+     *   <li>Repository administrators (full admin rights)</li>
+     *   <li>Community or Collection administrators (can delete objects they administer)</li>
+     *   <li>Item administrators (can delete items they administer)</li>
+     * </ul>
+     *
+     * Note: This method checks if the user has ANY of these admin roles. The actual
+     * authorization to delete a specific object is verified separately in the deletion
+     * process based on the user's permissions for that particular object.
+     *
+     * @param context               the DSpace context containing the current user
+     * @param commandLineParameters the command line parameters (not used in this implementation)
+     * @return true if the current user is a repository admin, community/collection admin,
+     * or item admin; false otherwise
+     * @throws RuntimeException if a SQLException occurs during permission checking
+     */
+    @Override
+    public boolean isAllowedToExecute(Context context, List<DSpaceCommandLineParameter> commandLineParameters) {
+        try {
+            return authorizeService.isAdmin(context) || authorizeService.isComColAdmin(context)
+                || authorizeService.isItemAdmin(context);
+        } catch (SQLException e) {
+            throw new RuntimeException("SQLException occurred when checking if the current user is an admin", e);
+        }
+    }
 }

--- a/dspace-api/src/test/data/dspaceFolder/config/spring/api/scripts.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/spring/api/scripts.xml
@@ -64,7 +64,7 @@
         <property name="description" value="Mocking a script for testing purposes" />
         <property name="dspaceRunnableClass" value="org.dspace.scripts.impl.MockDSpaceRunnableScript"/>
     </bean>
-    
+
     <bean id="orcid-bulk-push" class="org.dspace.orcid.script.OrcidBulkPushScriptConfiguration">
         <property name="description" value="Perform the bulk synchronization of all the BATCH configured ORCID entities placed in the ORCID queue"/>
         <property name="dspaceRunnableClass" value="org.dspace.orcid.script.OrcidBulkPush"/>
@@ -101,9 +101,9 @@
         <property name="dspaceRunnableClass" value="org.dspace.app.bulkaccesscontrol.BulkAccessControlCli"/>
     </bean>
 
-    <bean id="object-deletion" class="org.dspace.deletion.process.DSpaceObjectDeletionProcessScriptConfiguration" primary="true">
+    <bean id="object-deletion" class="org.dspace.deletion.process.DSpaceObjectDeletionProcessCliScriptConfiguration" primary="true">
         <property name="description" value="Permanently delete the given object along with all child objects. WARNING: This action cannot be undone." />
-        <property name="dspaceRunnableClass" value="org.dspace.deletion.process.DSpaceObjectDeletionProcess"/>
+        <property name="dspaceRunnableClass" value="org.dspace.deletion.process.DSpaceObjectDeletionProcessCli"/>
     </bean>
 
     <bean id="itemDeletionStrategy" class="org.dspace.deletion.process.strategies.ItemDeletionStrategy" />

--- a/dspace-api/src/test/java/org/dspace/app/deletionprocess/DSpaceObjectDeletionProcessCliIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/deletionprocess/DSpaceObjectDeletionProcessCliIT.java
@@ -1,0 +1,852 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.deletionprocess;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.UUID;
+
+import org.apache.commons.codec.CharEncoding;
+import org.apache.commons.io.IOUtils;
+import org.dspace.AbstractIntegrationTestWithDatabase;
+import org.dspace.builder.BitstreamBuilder;
+import org.dspace.builder.BundleBuilder;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.EPersonBuilder;
+import org.dspace.builder.EntityTypeBuilder;
+import org.dspace.builder.ItemBuilder;
+import org.dspace.builder.RelationshipBuilder;
+import org.dspace.builder.RelationshipTypeBuilder;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Bundle;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.EntityType;
+import org.dspace.content.Item;
+import org.dspace.content.MetadataValue;
+import org.dspace.content.RelationshipType;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.BitstreamService;
+import org.dspace.content.service.CollectionService;
+import org.dspace.content.service.CommunityService;
+import org.dspace.content.service.ItemService;
+import org.dspace.eperson.EPerson;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Integration tests for {@link org.dspace.deletion.process.DSpaceObjectDeletionProcessCli}.
+ * Tests CLI execution with the -e (email) parameter to specify different users.
+ *
+ * @author Mykhaylo Boychuk (mykhaylo.boychuk@4science.com)
+ */
+public class DSpaceObjectDeletionProcessCliIT extends AbstractIntegrationTestWithDatabase {
+
+
+    private ItemService itemService = ContentServiceFactory.getInstance().getItemService();
+    private CollectionService collectionService = ContentServiceFactory.getInstance().getCollectionService();
+    private CommunityService communityService = ContentServiceFactory.getInstance().getCommunityService();
+    private BitstreamService bitstreamService = ContentServiceFactory.getInstance().getBitstreamService();
+
+    private Community community;
+    private Collection collection;
+    private Item item1;
+    private Item item2;
+    private Bitstream bitstream1;
+    private Bitstream bitstream2;
+    private Bitstream bitstream3;
+    private Bitstream bitstream4;
+    private Bitstream bitstream5;
+    private Bitstream bitstream6;
+
+    private EPerson comAdmin;
+    private EPerson colAdmin;
+    private EPerson itemAdmin;
+    private EPerson regularUser;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        context.turnOffAuthorisationSystem();
+
+        // Create test users
+        comAdmin = EPersonBuilder.createEPerson(context)
+                                 .withEmail("comadmin@example.com")
+                                 .withPassword(password)
+                                 .build();
+
+        colAdmin = EPersonBuilder.createEPerson(context)
+                                 .withEmail("coladmin@example.com")
+                                 .withPassword(password)
+                                 .build();
+
+        itemAdmin = EPersonBuilder.createEPerson(context)
+                                  .withEmail("itemadmin@example.com")
+                                  .withPassword(password)
+                                  .build();
+
+        regularUser = EPersonBuilder.createEPerson(context)
+                                    .withEmail("regularuser@example.com")
+                                    .withPassword(password)
+                                    .build();
+
+        // Create test hierarchy
+        community = CommunityBuilder.createCommunity(context)
+                                    .withName("Test Community")
+                                    .withAdminGroup(comAdmin)
+                                    .build();
+
+        collection = CollectionBuilder.createCollection(context, community)
+                                      .withName("Publication collection")
+                                      .withEntityType("Publication")
+                                      .withAdminGroup(colAdmin)
+                                      .build();
+
+        item1 = ItemBuilder.createItem(context, collection)
+                           .withTitle("Publication item TEST 1")
+                           .withType("TEST")
+                           .withAdminUser(itemAdmin)
+                           .build();
+
+        item2 = ItemBuilder.createItem(context, collection)
+                           .withTitle("Publication title test")
+                           .withAuthor("Misha, Boychuk")
+                           .withType("website_content")
+                           .build();
+
+        Bundle bundleOfItem1 = BundleBuilder.createBundle(context, item1)
+                                            .withName("ORIGINAL")
+                                            .build();
+
+        try (InputStream is = IOUtils.toInputStream("Dummy content 1", CharEncoding.UTF_8)) {
+            bitstream1 = BitstreamBuilder.createBitstream(context, bundleOfItem1, is)
+                                         .withName("bitstream 1")
+                                         .build();
+        }
+
+        try (InputStream is = IOUtils.toInputStream("Dummy content 2", CharEncoding.UTF_8)) {
+            bitstream2 = BitstreamBuilder.createBitstream(context, bundleOfItem1, is)
+                                         .withName("bitstream 2")
+                                         .build();
+        }
+
+        try (InputStream is = IOUtils.toInputStream("Dummy content 3", CharEncoding.UTF_8)) {
+            bitstream3 = BitstreamBuilder.createBitstream(context, bundleOfItem1, is)
+                                         .withName("bitstream 3")
+                                         .build();
+        }
+
+        try (InputStream is = IOUtils.toInputStream("Dummy content 4", CharEncoding.UTF_8)) {
+            bitstream4 = BitstreamBuilder.createBitstream(context, bundleOfItem1, is)
+                                         .withName("bitstream 4")
+                                         .build();
+        }
+
+        Bundle bundleOfItem2 = BundleBuilder.createBundle(context, item2)
+                                            .withName("ORIGINAL")
+                                            .build();
+
+        try (InputStream is = IOUtils.toInputStream("TEST 1", CharEncoding.UTF_8)) {
+            bitstream5 = BitstreamBuilder.createBitstream(context, bundleOfItem2, is)
+                                         .withName("test title 1 item2")
+                                         .build();
+        }
+
+        try (InputStream is = IOUtils.toInputStream("TEST 2", CharEncoding.UTF_8)) {
+            bitstream6 = BitstreamBuilder.createBitstream(context, bundleOfItem2, is)
+                                         .withName("test title 2 item2")
+                                         .build();
+        }
+
+        context.commit();
+        context.restoreAuthSystemState();
+    }
+
+    /**
+     * Test deletion of an item with admin user specified via -e parameter.
+     * Verifies that item and associated bitstreams are properly deleted.
+     */
+    @Test
+    public void cliDeletionOfItemWithAdminTest() throws Exception {
+        runDSpaceScript("object-deletion", "-e", admin.getEmail(), "-i", item1.getID().toString());
+        context.commit();
+
+        // verify that item with bitstreams was deleted
+        assertThat("Item expected to be deleted", itemService.find(context, item1.getID()), nullValue());
+        assertThat("Bitstream expected to be soft-deleted",
+                   bitstreamService.find(context, bitstream1.getID()).isDeleted(), is(true));
+        assertThat("Bitstream expected to be soft-deleted",
+                   bitstreamService.find(context, bitstream2.getID()).isDeleted(), is(true));
+        assertThat("Bitstream expected to be soft-deleted",
+                   bitstreamService.find(context, bitstream3.getID()).isDeleted(), is(true));
+        assertThat("Bitstream expected to be soft-deleted",
+                   bitstreamService.find(context, bitstream4.getID()).isDeleted(), is(true));
+
+        // verify item2 still exists
+        Item item2Found = itemService.find(context, item2.getID());
+        assertThat("Item expected to exist", item2Found, notNullValue());
+        assertThat(item2Found.getName(), is(item2.getName()));
+
+        Bitstream bitstream5Found = bitstreamService.find(context, bitstream5.getID());
+        assertThat("Bitstream expected to exist", bitstream5Found, notNullValue());
+        assertThat(bitstream5Found.getName(), is(bitstream5.getName()));
+        assertThat("Bitstream expected to NOT be deleted", bitstream5Found.isDeleted(), is(false));
+
+        Bitstream bitstream6Found = bitstreamService.find(context, bitstream6.getID());
+        assertThat("Bitstream expected to exist", bitstream6Found, notNullValue());
+        assertThat(bitstream6Found.getName(), is(bitstream6.getName()));
+        assertThat("Bitstream expected to NOT be deleted", bitstream6Found.isDeleted(), is(false));
+    }
+
+    /**
+     * Test deletion of a collection with admin user specified via -e parameter.
+     * Verifies cascading deletion of collection, items, and bitstreams.
+     */
+    @Test
+    public void cliDeletionOfCollectionWithAdminTest() throws Exception {
+        // verify that collection with items/bitstreams exists
+        assertThat("Collection expected to exist", collectionService.find(context, collection.getID()), notNullValue());
+        assertThat("Item expected to exist", itemService.find(context, item1.getID()), notNullValue());
+        assertThat("Bitstream expected to exist", bitstreamService.find(context, bitstream1.getID()), notNullValue());
+        assertThat("Bitstream expected to exist", bitstreamService.find(context, bitstream2.getID()), notNullValue());
+        assertThat("Bitstream expected to exist", bitstreamService.find(context, bitstream3.getID()), notNullValue());
+        assertThat("Bitstream expected to exist", bitstreamService.find(context, bitstream4.getID()), notNullValue());
+        assertThat("Item expected to exist", itemService.find(context, item2.getID()), notNullValue());
+        assertThat("Bitstream expected to exist", bitstreamService.find(context, bitstream5.getID()), notNullValue());
+        assertThat("Bitstream expected to exist", bitstreamService.find(context, bitstream6.getID()), notNullValue());
+
+        runDSpaceScript("object-deletion", "-e", admin.getEmail(), "-i", collection.getID().toString());
+        context.commit();
+
+        // verify that collection with items/bitstreams was deleted
+        assertThat("Collection expected to be deleted", collectionService.find(context, collection.getID()),
+                   nullValue());
+        assertThat("Item expected to be deleted", itemService.find(context, item1.getID()), nullValue());
+        assertThat("Item expected to be deleted", itemService.find(context, item2.getID()), nullValue());
+        assertThat("Bitstream expected to be soft-deleted",
+                   bitstreamService.find(context, bitstream1.getID()).isDeleted(), is(true));
+        assertThat("Bitstream expected to be soft-deleted",
+                   bitstreamService.find(context, bitstream2.getID()).isDeleted(), is(true));
+        assertThat("Bitstream expected to be soft-deleted",
+                   bitstreamService.find(context, bitstream3.getID()).isDeleted(), is(true));
+        assertThat("Bitstream expected to be soft-deleted",
+                   bitstreamService.find(context, bitstream4.getID()).isDeleted(), is(true));
+        assertThat("Bitstream expected to be soft-deleted",
+                   bitstreamService.find(context, bitstream5.getID()).isDeleted(), is(true));
+        assertThat("Bitstream expected to be soft-deleted",
+                   bitstreamService.find(context, bitstream6.getID()).isDeleted(), is(true));
+    }
+
+    /**
+     * Test that deletion of unsupported objects (like bitstreams) fails properly.
+     */
+    @Test
+    public void cliDeletionOfUnsupportedObjectTest() throws Exception {
+        // verify that bitstream exists
+        assertThat("Bitstream expected to exist", bitstreamService.find(context, bitstream1.getID()), notNullValue());
+
+        try {
+            runDSpaceScript("object-deletion", "-e", admin.getEmail(), "-i", bitstream1.getID().toString());
+            fail("Expected IllegalArgumentException for unsupported object type");
+        } catch (IllegalArgumentException e) {
+            var expectedMessage = String.format("DSpaceObject for provided identifier:%s doesn't exist!",
+                                                bitstream1.getID());
+            assertTrue(e.getMessage().contains(expectedMessage));
+        }
+
+        // verify that bitstream still exists (not deleted)
+        assertThat("Bitstream expected to still exist", bitstreamService.find(context, bitstream1.getID()),
+                   notNullValue());
+    }
+
+    /**
+     * Test deletion of an item by handle with admin user specified via -e parameter.
+     */
+    @Test
+    public void cliDeletionOfItemByHandleTest() throws Exception {
+        // verify that item with bitstreams exist
+        assertThat("Item expected to exist", itemService.find(context, item1.getID()), notNullValue());
+        assertThat("Bitstream expected to exist", bitstreamService.find(context, bitstream1.getID()), notNullValue());
+        assertThat("Bitstream expected to exist", bitstreamService.find(context, bitstream2.getID()), notNullValue());
+        assertThat("Bitstream expected to exist", bitstreamService.find(context, bitstream3.getID()), notNullValue());
+        assertThat("Bitstream expected to exist", bitstreamService.find(context, bitstream4.getID()), notNullValue());
+
+        runDSpaceScript("object-deletion", "-e", admin.getEmail(), "-i", item1.getHandle());
+        context.commit();
+
+        // verify that item with bitstreams was deleted
+        assertThat("Item expected to be deleted", itemService.find(context, item1.getID()), nullValue());
+        assertThat("Bitstream expected to be soft-deleted",
+                   bitstreamService.find(context, bitstream1.getID()).isDeleted(), is(true));
+        assertThat("Bitstream expected to be soft-deleted",
+                   bitstreamService.find(context, bitstream2.getID()).isDeleted(), is(true));
+        assertThat("Bitstream expected to be soft-deleted",
+                   bitstreamService.find(context, bitstream3.getID()).isDeleted(), is(true));
+        assertThat("Bitstream expected to be soft-deleted",
+                   bitstreamService.find(context, bitstream4.getID()).isDeleted(), is(true));
+    }
+
+    /**
+     * Test that CLI deletion works with item admin user specified via -e parameter.
+     */
+    @Test
+    public void cliDeletionWithItemAdminUserTest() throws Exception {
+        runDSpaceScript("object-deletion", "-e", itemAdmin.getEmail(), "-i", item1.getID().toString());
+        context.commit();
+
+        // Verify deletion was successful
+        assertThat("Item expected to be deleted", itemService.find(context, item1.getID()), nullValue());
+        assertThat("Bitstream expected to be soft-deleted",
+                   bitstreamService.find(context, bitstream1.getID()).isDeleted(), is(true));
+    }
+
+    /**
+     * Test that CLI deletion works with collection admin user specified via -e parameter.
+     */
+    @Test
+    public void cliDeletionWithCollectionAdminUserTest() throws Exception {
+        runDSpaceScript("object-deletion", "-e", colAdmin.getEmail(), "-i", collection.getID().toString());
+        context.commit();
+
+        // Verify deletion was successful
+        assertThat("Collection expected to be deleted",
+                   collectionService.find(context, collection.getID()), nullValue());
+        assertThat("Item1 expected to be deleted", itemService.find(context, item1.getID()), nullValue());
+        assertThat("Item2 expected to be deleted", itemService.find(context, item2.getID()), nullValue());
+        assertThat("Bitstream1 expected to be soft-deleted",
+                   bitstreamService.find(context, bitstream1.getID()).isDeleted(), is(true));
+        assertThat("Bitstream2 expected to be soft-deleted",
+                   bitstreamService.find(context, bitstream2.getID()).isDeleted(), is(true));
+    }
+
+    /**
+     * Test that CLI deletion works with community admin user specified via -e parameter.
+     */
+    @Test
+    public void cliDeletionWithCommunityAdminUserTest() throws Exception {
+        runDSpaceScript("object-deletion", "-e", comAdmin.getEmail(), "-i", community.getID().toString());
+        context.commit();
+
+        // Verify deletion was successful
+        assertThat("Community expected to be deleted",
+                   communityService.find(context, community.getID()), nullValue());
+        assertThat("Collection expected to be deleted",
+                   collectionService.find(context, collection.getID()), nullValue());
+        assertThat("Item1 expected to be deleted", itemService.find(context, item1.getID()), nullValue());
+        assertThat("Item2 expected to be deleted", itemService.find(context, item2.getID()), nullValue());
+    }
+
+    /**
+     * Test that CLI deletion fails when regular user (non-admin) is specified.
+     */
+    @Test
+    public void cliDeletionWithRegularUserFailsTest() throws Exception {
+        try {
+            runDSpaceScript("object-deletion", "-e", regularUser.getEmail(), "-i", item2.getID().toString());
+            fail("Expected exception for unauthorized user");
+        } catch (Exception e) {
+            assertThat(e.getMessage(), containsString("not eligible to execute script: 'object-deletion'"));
+        }
+
+        // Verify item was NOT deleted
+        assertThat("Item expected to still exist", itemService.find(context, item2.getID()), notNullValue());
+        assertThat("Bitstream expected to still exist and not be soft-deleted",
+                   bitstreamService.find(context, bitstream5.getID()).isDeleted(), is(false));
+    }
+
+    /**
+     * Test that CLI deletion fails when item admin tries to delete an item they don't administer.
+     */
+    @Test
+    public void cliDeletionWithItemAdminOnUnauthorizedItemFailsTest() throws Exception {
+        try {
+            runDSpaceScript("object-deletion", "-e", itemAdmin.getEmail(),
+                            "-i", item2.getID().toString());  // item2 is NOT administered by itemAdmin
+            fail("Expected exception for unauthorized item");
+        } catch (Exception e) {
+            assertThat(e.getMessage(), containsString("not eligible to execute script: 'object-deletion'"));
+        }
+
+        // Verify item was NOT deleted
+        assertThat("Item expected to still exist", itemService.find(context, item2.getID()), notNullValue());
+    }
+
+    /**
+     * Test that CLI deletion fails when -e parameter is missing.
+     */
+    @Test
+    public void cliDeletionWithMissingEmailParameterFailsTest() throws Exception {
+        try {
+            runDSpaceScript("object-deletion", "-i", item1.getID().toString());
+            fail("Expected ParseException for missing -e parameter");
+        } catch (Exception e) {
+            assertThat(e.getMessage(), containsString("Required parameter -e missing!"));
+        }
+
+        // Verify item was NOT deleted
+        assertThat("Item expected to still exist", itemService.find(context, item1.getID()), notNullValue());
+    }
+
+    /**
+     * Test that CLI deletion fails when invalid email is provided.
+     */
+    @Test
+    public void cliDeletionWithInvalidEmailFailsTest() throws Exception {
+        try {
+            runDSpaceScript("object-deletion", "-e", "nonexistent@example.com", "-i", item1.getID().toString());
+            fail("Expected IllegalArgumentException for invalid email");
+        } catch (Exception e) {
+            assertThat(e.getMessage(), containsString("Unable to find a user with email: nonexistent@example.com"));
+        }
+
+        // Verify item was NOT deleted
+        assertThat("Item expected to still exist", itemService.find(context, item1.getID()), notNullValue());
+    }
+
+    /**
+     * Test that CLI deletion fails when non-existent UUID is provided.
+     */
+    @Test
+    public void cliDeletionWithNonExistentUUIDTest() throws Exception {
+        UUID fakeUuid = UUID.randomUUID();
+        try {
+            runDSpaceScript("object-deletion", "-e", admin.getEmail(), "-i", fakeUuid.toString());
+            fail("Expected IllegalArgumentException for non-existent UUID");
+        } catch (Exception e) {
+            var expectedMessage = String.format("DSpaceObject for provided identifier:%s doesn't exist!", fakeUuid);
+            assertThat(e.getMessage(), containsString(expectedMessage));
+        }
+    }
+
+    /**
+     * Test that CLI deletion fails when invalid handle is provided.
+     */
+    @Test
+    public void cliDeletionWithInvalidHandleTest() throws Exception {
+        try {
+            runDSpaceScript("object-deletion", "-e", admin.getEmail(), "-i", "123456789/invalid");
+            fail("Expected IllegalArgumentException for invalid handle");
+        } catch (IllegalArgumentException e) {
+            // Expected exception
+            assertThat(e.getMessage(), notNullValue());
+        }
+    }
+
+    /**
+     * Test deletion of an Item with the -c all (copyVirtualMetadata=all) option.
+     * This test verifies that when deleting an Item with relationships, the virtual metadata
+     * generated by those relationships is copied as physical metadata to the related items
+     * before the deletion occurs.
+     *
+     * Case:
+     * 1. Create a Person item and a Publication item with a relationship between them
+     * 2. Verify the Publication has NO physical dc.contributor.author metadata (only virtual)
+     * 3. Delete the Person item using -c all option
+     * 4. Verify the Person is deleted
+     * 5. Verify the Publication still exists AND now has physical dc.contributor.author metadata
+     *
+     * This ensures that the virtual metadata (e.g., "Smith, John") is preserved as permanent
+     * physical metadata in the Publication item after the related Person item is deleted.
+     *
+     * @throws Exception if an error occurs during the test
+     */
+    @Test
+    public void cliDeletionOfItemWithCopyVirtualMetadataAllTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        Community reloadedCommunity = context.reloadEntity(community);
+
+        // Create entity types and relationship type
+        EntityType publicationEntityType = EntityTypeBuilder.createEntityTypeBuilder(context, "Publication").build();
+        EntityType personEntityType = EntityTypeBuilder.createEntityTypeBuilder(context, "Person").build();
+
+        RelationshipType isAuthorOfPublication = RelationshipTypeBuilder.createRelationshipTypeBuilder(
+                context, publicationEntityType, personEntityType,
+                "isAuthorOfPublication", "isPublicationOfAuthor", 0, null, 0, null
+        ).withCopyToLeft(true).build();
+
+        Collection publicationCollection = CollectionBuilder.createCollection(context, reloadedCommunity)
+                                                            .withName("Publication collection")
+                                                            .withEntityType("Publication")
+                                                            .build();
+        Collection personCollection = CollectionBuilder.createCollection(context, reloadedCommunity)
+                                                       .withName("Person collection")
+                                                       .withEntityType("Person")
+                                                       .build();
+
+        // Create Person item with metadata
+        Item personItem = ItemBuilder.createItem(context, personCollection)
+                                     .withTitle("John Smith")
+                                     .withPersonIdentifierFirstName("John")
+                                     .withPersonIdentifierLastName("Smith")
+                                     .build();
+
+        Item publicationItem = ItemBuilder.createItem(context, publicationCollection)
+                                          .withTitle("Quantum Computing Research")
+                                          .build();
+
+        // Create relationship between publication and person
+        RelationshipBuilder.createRelationshipBuilder(context, publicationItem, personItem, isAuthorOfPublication)
+                           .build();
+
+        context.commit();
+        context.restoreAuthSystemState();
+
+        // Check that publication has NO physical dc.contributor.author metadata
+        // (only virtual metadata from relationship should be visible via REST API)
+        context.turnOffAuthorisationSystem();
+        publicationItem = context.reloadEntity(publicationItem);
+        List<MetadataValue> physicalAuthorMetadata = itemService.getMetadata(
+            publicationItem, "dc", "contributor", "author", Item.ANY, false
+        );
+        assertTrue("Publication should have NO physical dc.contributor.author metadata initially",
+                   physicalAuthorMetadata.isEmpty());
+        context.restoreAuthSystemState();
+
+        // Delete person item with -c all option
+        runDSpaceScript("object-deletion", "-e", admin.getEmail(),
+                "-i", personItem.getID().toString(), "-c", "all");
+        context.commit();
+
+        // Verify that person item was deleted
+        assertThat("Person item expected to be deleted", itemService.find(context, personItem.getID()), nullValue());
+
+        // Verify that publication item still exists
+        assertThat("Publication item expected to still exist",
+                   itemService.find(context, publicationItem.getID()), notNullValue());
+
+        // Check that publication NOW HAS physical dc.contributor.author metadata
+        // (copied from virtual metadata before deletion)
+        context.turnOffAuthorisationSystem();
+        publicationItem = context.reloadEntity(publicationItem);
+        List<MetadataValue> physicalAuthorMetadataAfter = itemService.getMetadata(
+            publicationItem, "dc", "contributor", "author", Item.ANY, false
+        );
+        assertFalse("Publication should have physical dc.contributor.author metadata after deletion with -c all",
+                    physicalAuthorMetadataAfter.isEmpty());
+        assertEquals("Physical metadata should contain the copied author name", 1, physicalAuthorMetadataAfter.size());
+        String authorValue = physicalAuthorMetadataAfter.get(0).getValue();
+        assertTrue("Author metadata should contain 'Smith'", authorValue.contains("Smith"));
+        assertTrue("Author metadata should contain 'John'", authorValue.contains("John"));
+        context.restoreAuthSystemState();
+    }
+
+    /**
+     * Test deletion of an Item with the -c configured (copyVirtualMetadata=configured) option.
+     * This test verifies that when deleting an Item with multiple relationships, only the virtual
+     * metadata from relationships configured with copyToLeft/copyToRight=true are copied as
+     * physical metadata to the related items.
+     *
+     * Case:
+     * 1. Create a Publication with two relationships: one with copyToRight=true, one with copyToRight=false
+     * 2. Verify the related items (Person, Project) have NO physical metadata initially
+     * 3. Delete the Publication using -c configured option
+     * 4. Verify the Publication is deleted
+     * 5. Verify that ONLY the Person (copyToRight=true) received physical metadata
+     * 6. Verify that the Project (copyToRight=false) did NOT receive physical metadata
+     *
+     * This ensures that only relationships configured to copy metadata actually do so when the
+     * left item (Publication) is deleted.
+     *
+     * @throws Exception if an error occurs during the test
+     */
+    @Test
+    public void cliDeletionOfItemWithCopyVirtualMetadataConfiguredTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        Community reloadedCommunity = context.reloadEntity(community);
+
+        // Create entity types and relationship type
+        EntityType publicationEntityType = EntityTypeBuilder.createEntityTypeBuilder(context, "Publication").build();
+        EntityType personEntityType = EntityTypeBuilder.createEntityTypeBuilder(context, "Person").build();
+        EntityType projectEntityType = EntityTypeBuilder.createEntityTypeBuilder(context, "Project").build();
+
+        // Create relationship type with copyToRight=true (person will receive metadata from publication)
+        RelationshipType isAuthorOfPublication = RelationshipTypeBuilder.createRelationshipTypeBuilder(
+                context, publicationEntityType, personEntityType,
+                "isAuthorOfPublication", "isPublicationOfAuthor", 0, null, 0, null
+        ).withCopyToRight(true).build();
+
+        // Create relationship type with copyToRight=false (project will NOT receive metadata)
+        RelationshipType isProjectOfPublication = RelationshipTypeBuilder.createRelationshipTypeBuilder(
+                context, publicationEntityType, projectEntityType,
+                "isProjectOfPublication", "isPublicationOfProject", 0, null, 0, null
+        ).withCopyToRight(false).build();
+
+        Collection publicationCollection = CollectionBuilder.createCollection(context, reloadedCommunity)
+                                                            .withName("Publication collection")
+                                                            .withEntityType("Publication")
+                                                            .build();
+        Collection personCollection = CollectionBuilder.createCollection(context, reloadedCommunity)
+                                                       .withName("Person collection")
+                                                       .withEntityType("Person")
+                                                       .build();
+        Collection projectCollection = CollectionBuilder.createCollection(context, reloadedCommunity)
+                                                        .withName("Project collection")
+                                                        .withEntityType("Project")
+                                                        .build();
+
+        // Create Publication item with title
+        Item publicationItem = ItemBuilder.createItem(context, publicationCollection)
+                                          .withTitle("Advanced Quantum Research")
+                                          .build();
+
+        // Create Person item
+        Item personItem = ItemBuilder.createItem(context, personCollection)
+                                     .withTitle("Jane Doe")
+                                     .withPersonIdentifierFirstName("Jane")
+                                     .withPersonIdentifierLastName("Doe")
+                                     .build();
+
+        // Create Project item
+        Item projectItem = ItemBuilder.createItem(context, projectCollection)
+                                      .withTitle("Quantum Computing Project")
+                                      .build();
+
+        // Create relationships
+        RelationshipBuilder.createRelationshipBuilder(context, publicationItem, personItem, isAuthorOfPublication)
+                           .build();
+        RelationshipBuilder.createRelationshipBuilder(context, publicationItem, projectItem, isProjectOfPublication)
+                           .build();
+
+        context.commit();
+        context.restoreAuthSystemState();
+
+        // Check that person has NO physical relation.isPublicationOfAuthor metadata
+        context.turnOffAuthorisationSystem();
+        personItem = context.reloadEntity(personItem);
+        List<MetadataValue> personPhysicalMetadata = itemService.getMetadata(
+            personItem, "relation", "isPublicationOfAuthor", null, Item.ANY, false
+        );
+        assertTrue("Person should have NO physical relation.isPublicationOfAuthor metadata initially",
+                   personPhysicalMetadata.isEmpty());
+
+        // Check that project has NO physical relation.isPublicationOfProject metadata
+        projectItem = context.reloadEntity(projectItem);
+        List<MetadataValue> projectPhysicalMetadata = itemService.getMetadata(
+            projectItem, "relation", "isPublicationOfProject", null, Item.ANY, false
+        );
+        assertTrue("Project should have NO physical relation.isPublicationOfProject metadata initially",
+                   projectPhysicalMetadata.isEmpty());
+        context.restoreAuthSystemState();
+
+        // Delete publication item with -c configured option
+        runDSpaceScript("object-deletion", "-e", admin.getEmail(),
+                       "-i", publicationItem.getID().toString(), "-c", "configured");
+        context.commit();
+
+        // Verify that publication item was deleted
+        assertThat("Publication item expected to be deleted",
+                   itemService.find(context, publicationItem.getID()), nullValue());
+
+        // Check that person NOW HAS physical relation.isPublicationOfAuthor metadata (copyToRight=true)
+        context.turnOffAuthorisationSystem();
+        personItem = context.reloadEntity(personItem);
+        List<MetadataValue> personPhysicalMetadataAfter = itemService.getMetadata(
+            personItem, "relation", "isPublicationOfAuthor", null, Item.ANY, false
+        );
+        assertFalse("Person should have physical relation.isPublicationOfAuthor metadata after deletion with " +
+                        "-c configured (copyToRight=true)",
+                    personPhysicalMetadataAfter.isEmpty());
+        assertEquals("Person should have one relation metadata value", 1, personPhysicalMetadataAfter.size());
+        assertEquals("Person metadata should reference the deleted publication UUID",
+                     publicationItem.getID().toString(),
+                     personPhysicalMetadataAfter.get(0).getValue());
+
+        // Check that project STILL HAS NO physical relation.isPublicationOfProject metadata (copyToRight=false)
+        projectItem = context.reloadEntity(projectItem);
+        List<MetadataValue> projectPhysicalMetadataAfter = itemService.getMetadata(
+            projectItem, "relation", "isPublicationOfProject", null, Item.ANY, false
+        );
+        assertTrue("Project should NOT have physical relation.isPublicationOfProject metadata after deletion " +
+                       "with -c configured (copyToRight=false)",
+                   projectPhysicalMetadataAfter.isEmpty());
+        context.restoreAuthSystemState();
+    }
+
+    /**
+     * Test deletion of an Item with the -c option using specific RelationshipType IDs.
+     * This test verifies that when deleting an Item with multiple relationships, only the virtual
+     * metadata from the specified RelationshipType IDs are copied as physical metadata to the
+     * related items, regardless of the copyToLeft/copyToRight configuration.
+     *
+     * Case:
+     * 1. Create a Publication with three relationships (Person, Project, OrgUnit)
+     * 2. Verify the related items have NO physical metadata initially
+     * 3. Delete the Publication using -c with only the Person and OrgUnit relationship IDs
+     * 4. Verify the Publication is deleted
+     * 5. Verify that ONLY Person and OrgUnit received physical metadata (specified IDs)
+     * 6. Verify that Project did NOT receive physical metadata (ID not specified)
+     *
+     * This ensures that the -c option with numeric IDs allows granular control over which
+     * virtual metadata to copy, independent of the relationship type configuration.
+     *
+     * @throws Exception if an error occurs during the test
+     */
+    @Test
+    public void cliDeletionOfItemWithCopyVirtualMetadataByRelationshipTypeIdsTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        Community reloadedCommunity = context.reloadEntity(community);
+
+        // Create entity types
+        EntityType personEntityType = EntityTypeBuilder.createEntityTypeBuilder(context, "Person").build();
+        EntityType projectEntityType = EntityTypeBuilder.createEntityTypeBuilder(context, "Project").build();
+        EntityType orgUnitEntityType = EntityTypeBuilder.createEntityTypeBuilder(context, "OrgUnit").build();
+        EntityType publicationEntityType = EntityTypeBuilder.createEntityTypeBuilder(context, "Publication").build();
+
+        // Create three relationship types (all with copyToRight=false to ensure IDs override config)
+        RelationshipType isAuthorOfPublication = RelationshipTypeBuilder.createRelationshipTypeBuilder(
+                context, publicationEntityType, personEntityType,
+                "isAuthorOfPublication", "isPublicationOfAuthor", 0, null, 0, null
+        ).withCopyToRight(false).build();
+
+        RelationshipType isProjectOfPublication = RelationshipTypeBuilder.createRelationshipTypeBuilder(
+                context, publicationEntityType, projectEntityType,
+                "isProjectOfPublication", "isPublicationOfProject", 0, null, 0, null
+        ).withCopyToRight(false).build();
+
+        RelationshipType isOrgUnitOfPublication = RelationshipTypeBuilder.createRelationshipTypeBuilder(
+                context, publicationEntityType, orgUnitEntityType,
+                "isOrgUnitOfPublication", "isPublicationOfOrgUnit", 0, null, 0, null
+        ).withCopyToRight(false).build();
+
+        Collection publicationCollection = CollectionBuilder.createCollection(context, reloadedCommunity)
+                                                            .withName("Publication collection")
+                                                            .withEntityType("Publication")
+                                                            .build();
+        Collection personCollection = CollectionBuilder.createCollection(context, reloadedCommunity)
+                                                       .withName("Person collection")
+                                                       .withEntityType("Person")
+                                                       .build();
+        Collection projectCollection = CollectionBuilder.createCollection(context, reloadedCommunity)
+                                                        .withName("Project collection")
+                                                        .withEntityType("Project")
+                                                        .build();
+        Collection orgUnitCollection = CollectionBuilder.createCollection(context, reloadedCommunity)
+                                                        .withName("OrgUnit collection")
+                                                        .withEntityType("OrgUnit")
+                                                        .build();
+
+        Item publicationItem = ItemBuilder.createItem(context, publicationCollection)
+                                          .withTitle("Comprehensive Study on AI")
+                                          .build();
+
+        Item personItem = ItemBuilder.createItem(context, personCollection)
+                                     .withTitle("Alice Johnson")
+                                     .withPersonIdentifierFirstName("Alice")
+                                     .withPersonIdentifierLastName("Johnson")
+                                     .build();
+
+        Item projectItem = ItemBuilder.createItem(context, projectCollection)
+                                      .withTitle("AI Research Initiative")
+                                      .build();
+
+        Item orgUnitItem = ItemBuilder.createItem(context, orgUnitCollection)
+                                      .withTitle("Computer Science Department")
+                                      .build();
+
+        // Create relationships
+        RelationshipBuilder.createRelationshipBuilder(context, publicationItem, personItem, isAuthorOfPublication)
+                           .build();
+        RelationshipBuilder.createRelationshipBuilder(context, publicationItem, projectItem, isProjectOfPublication)
+                           .build();
+        RelationshipBuilder.createRelationshipBuilder(context, publicationItem, orgUnitItem, isOrgUnitOfPublication)
+                           .build();
+
+        context.commit();
+        context.restoreAuthSystemState();
+
+        // Check that person has NO physical relation.isPublicationOfAuthor metadata
+        context.turnOffAuthorisationSystem();
+        personItem = context.reloadEntity(personItem);
+        List<MetadataValue> personPhysicalMetadata = itemService.getMetadata(
+            personItem, "relation", "isPublicationOfAuthor", null, Item.ANY, false
+        );
+        assertTrue("Person should have NO physical relation.isPublicationOfAuthor metadata initially",
+                   personPhysicalMetadata.isEmpty());
+
+        // Check that project has NO physical relation.isPublicationOfProject metadata
+        projectItem = context.reloadEntity(projectItem);
+        List<MetadataValue> projectPhysicalMetadata = itemService.getMetadata(
+            projectItem, "relation", "isPublicationOfProject", null, Item.ANY, false
+        );
+        assertTrue("Project should have NO physical relation.isPublicationOfProject metadata initially",
+                   projectPhysicalMetadata.isEmpty());
+
+        // Check that orgUnit has NO physical relation.isPublicationOfOrgUnit metadata
+        orgUnitItem = context.reloadEntity(orgUnitItem);
+        List<MetadataValue> orgUnitPhysicalMetadata = itemService.getMetadata(
+            orgUnitItem, "relation", "isPublicationOfOrgUnit", null, Item.ANY, false
+        );
+        assertTrue("OrgUnit should have NO physical relation.isPublicationOfOrgUnit metadata initially",
+                   orgUnitPhysicalMetadata.isEmpty());
+        context.restoreAuthSystemState();
+
+        // Delete publication item with -c specifying only Person and OrgUnit relationship type IDs
+        // We exclude the Project relationship type ID
+        String relationshipTypeIds = isAuthorOfPublication.getID() + "," + isOrgUnitOfPublication.getID();
+        runDSpaceScript("object-deletion", "-e", admin.getEmail(),
+                       "-i", publicationItem.getID().toString(), "-c", relationshipTypeIds);
+        context.commit();
+
+        // Verify that publication item was deleted
+        assertThat("Publication item expected to be deleted",
+                   itemService.find(context, publicationItem.getID()), nullValue());
+
+        // Check that person NOW HAS physical relation.isPublicationOfAuthor metadata (ID was specified)
+        context.turnOffAuthorisationSystem();
+        personItem = context.reloadEntity(personItem);
+        List<MetadataValue> personPhysicalMetadataAfter = itemService.getMetadata(
+            personItem, "relation", "isPublicationOfAuthor", null, Item.ANY, false
+        );
+        assertFalse("Person should have physical relation.isPublicationOfAuthor metadata after deletion " +
+                        "with -c using its relationship type ID",
+                    personPhysicalMetadataAfter.isEmpty());
+        assertEquals("Person should have one relation metadata value", 1, personPhysicalMetadataAfter.size());
+        assertEquals("Person metadata should reference the deleted publication UUID",
+                     publicationItem.getID().toString(),
+                     personPhysicalMetadataAfter.get(0).getValue());
+
+        // Check that orgUnit NOW HAS physical relation.isPublicationOfOrgUnit metadata (ID was specified)
+        orgUnitItem = context.reloadEntity(orgUnitItem);
+        List<MetadataValue> orgUnitPhysicalMetadataAfter = itemService.getMetadata(
+            orgUnitItem, "relation", "isPublicationOfOrgUnit", null, Item.ANY, false
+        );
+        assertFalse("OrgUnit should have physical relation.isPublicationOfOrgUnit metadata after deletion " +
+                        "with -c using its relationship type ID",
+                    orgUnitPhysicalMetadataAfter.isEmpty());
+        assertEquals("OrgUnit should have one relation metadata value", 1, orgUnitPhysicalMetadataAfter.size());
+        assertEquals("OrgUnit metadata should reference the deleted publication UUID",
+                     publicationItem.getID().toString(),
+                     orgUnitPhysicalMetadataAfter.get(0).getValue());
+
+        // Check that project STILL HAS NO physical relation.isPublicationOfProject metadata (ID was NOT specified)
+        projectItem = context.reloadEntity(projectItem);
+        List<MetadataValue> projectPhysicalMetadataAfter = itemService.getMetadata(
+            projectItem, "relation", "isPublicationOfProject", null, Item.ANY, false
+        );
+        assertTrue("Project should NOT have physical relation.isPublicationOfProject metadata after deletion " +
+                       "because its relationship type ID was not included in -c parameter",
+                   projectPhysicalMetadataAfter.isEmpty());
+        context.restoreAuthSystemState();
+    }
+
+}

--- a/dspace-server-webapp/src/test/data/dspaceFolder/config/spring/rest/scripts.xml
+++ b/dspace-server-webapp/src/test/data/dspaceFolder/config/spring/rest/scripts.xml
@@ -48,4 +48,9 @@
         <property name="dspaceRunnableClass" value="org.dspace.app.bulkaccesscontrol.BulkAccessControl"/>
     </bean>
 
+    <bean id="object-deletion" class="org.dspace.deletion.process.DSpaceObjectDeletionProcessScriptConfiguration" primary="true">
+        <property name="description" value="Permanently delete the given object along with all child objects. WARNING: This action cannot be undone." />
+        <property name="dspaceRunnableClass" value="org.dspace.deletion.process.DSpaceObjectDeletionProcess"/>
+    </bean>
+
 </beans>

--- a/dspace-server-webapp/src/test/java/org/dspace/app/deletionprocess/DSpaceObjectDeletionProcessIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/deletionprocess/DSpaceObjectDeletionProcessIT.java
@@ -8,906 +8,387 @@
 package org.dspace.app.deletionprocess;
 
 import static com.jayway.jsonpath.JsonPath.read;
-import static org.dspace.deletion.process.DSpaceObjectDeletionProcess.OBJECT_DELETION_SCRIPT;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.dspace.builder.CollectionBuilder.createCollection;
+import static org.dspace.builder.CommunityBuilder.createCommunity;
+import static org.dspace.builder.ItemBuilder.createItem;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.io.InputStream;
+import java.sql.SQLException;
+import java.util.LinkedList;
 import java.util.List;
-import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
-import org.apache.commons.codec.CharEncoding;
-import org.apache.commons.io.IOUtils;
-import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
-import org.dspace.app.scripts.handler.impl.TestDSpaceRunnableHandler;
-import org.dspace.builder.BitstreamBuilder;
-import org.dspace.builder.BundleBuilder;
-import org.dspace.builder.CollectionBuilder;
-import org.dspace.builder.CommunityBuilder;
-import org.dspace.builder.EntityTypeBuilder;
-import org.dspace.builder.ItemBuilder;
-import org.dspace.builder.RelationshipBuilder;
-import org.dspace.builder.RelationshipTypeBuilder;
-import org.dspace.content.Bitstream;
-import org.dspace.content.Bundle;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.dspace.app.rest.converter.DSpaceRunnableParameterConverter;
+import org.dspace.app.rest.model.ParameterValueRest;
+import org.dspace.app.rest.projection.Projection;
+import org.dspace.app.rest.test.AbstractEntityIntegrationTest;
+import org.dspace.builder.EPersonBuilder;
+import org.dspace.builder.ProcessBuilder;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
-import org.dspace.content.EntityType;
+import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
-import org.dspace.content.MetadataValue;
-import org.dspace.content.RelationshipType;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.CollectionService;
+import org.dspace.content.service.CommunityService;
 import org.dspace.content.service.ItemService;
-import org.dspace.deletion.process.DSpaceObjectDeletionProcess;
-import org.hamcrest.Matchers;
+import org.dspace.discovery.IndexingService;
+import org.dspace.eperson.EPerson;
+import org.dspace.scripts.DSpaceCommandLineParameter;
+import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 
 /**
- * This class handles ITs for { @link DSpaceObjectDeletionProcess }.
+ * Integration tests for DSpaceObjectDeletionProcess run through the ScriptRestRepository.
+ * Tests deletion permissions for community admin, collection admin, and item admin.
  *
  * @author Mykhaylo Boychuk (mykhaylo.boychuk@4science.com)
  */
-public class DSpaceObjectDeletionProcessIT extends AbstractControllerIntegrationTest {
-
-    private Item item1;
-    private Item item2;
-    private Community community;
-    private Bitstream bitstream1;
-    private Bitstream bitstream2;
-    private Bitstream bitstream3;
-    private Bitstream bitstream4;
-    private Bitstream bitstream5;
-    private Bitstream bitstream6;
-    private Collection collection;
+public class DSpaceObjectDeletionProcessIT extends AbstractEntityIntegrationTest {
 
     @Autowired
-    private ItemService itemService;
+    private DSpaceRunnableParameterConverter dSpaceRunnableParameterConverter;
 
+    @Autowired
+    private IndexingService indexingService;
+
+    private ItemService itemService = ContentServiceFactory.getInstance().getItemService();
+    private CollectionService collectionService = ContentServiceFactory.getInstance().getCollectionService();
+    private CommunityService communityService = ContentServiceFactory.getInstance().getCommunityService();
+
+    private Community community;
+    private Collection collection;
+    private Item item;
+
+    private EPerson comAdmin;
+    private EPerson colAdmin;
+    private EPerson itemAdmin;
+
+    @Before
     @Override
     public void setUp() throws Exception {
         super.setUp();
         context.turnOffAuthorisationSystem();
-        community = CommunityBuilder.createCommunity(context)
-                                    .withName("My community")
-                                    .build();
-        collection = CollectionBuilder.createCollection(context, community)
-                                      .withName("Publication collection")
-                                      .withEntityType("Publication")
-                                      .build();
 
-        item1 = ItemBuilder.createItem(context, collection)
-                           .withTitle("Publication item TEST 1")
-                           .withType("TEST")
-                           .build();
+        comAdmin = EPersonBuilder.createEPerson(context)
+                                 .withEmail("comAdmin@example.com")
+                                 .withPassword(password).build();
 
-        item2 = ItemBuilder.createItem(context, collection)
-                           .withTitle("Publication title test")
-                           .withAuthor("Misha, Boychuk")
-                           .withType("website_content")
-                           .build();
+        colAdmin = EPersonBuilder.createEPerson(context)
+                                 .withEmail("colAdmin@example.com")
+                                 .withPassword(password).build();
 
-        Bundle bundleOfItem1 = BundleBuilder.createBundle(context, item1)
-                                            .withName("ORIGINAL")
-                                            .build();
+        itemAdmin = EPersonBuilder.createEPerson(context)
+                                  .withEmail("itemAdmin@example.com")
+                                  .withPassword(password).build();
 
-        try (InputStream is = IOUtils.toInputStream("Dummy content 1", CharEncoding.UTF_8)) {
-            bitstream1 = BitstreamBuilder.createBitstream(context, bundleOfItem1, is)
-                                         .withName("bitstream 1")
-                                         .build();
-        }
-
-        try (InputStream is = IOUtils.toInputStream("Dummy content 2", CharEncoding.UTF_8)) {
-            bitstream2 = BitstreamBuilder.createBitstream(context, bundleOfItem1, is)
-                                         .withName("bitstream 2")
-                                         .build();
-        }
-
-        try (InputStream is = IOUtils.toInputStream("Dummy content 3", CharEncoding.UTF_8)) {
-            bitstream3 = BitstreamBuilder.createBitstream(context, bundleOfItem1, is)
-                                         .withName("bitstream 3")
-                                         .build();
-        }
-
-        try (InputStream is = IOUtils.toInputStream("Dummy content 4", CharEncoding.UTF_8)) {
-            bitstream4 = BitstreamBuilder.createBitstream(context, bundleOfItem1, is)
-                                         .withName("bitstream 4")
-                                         .build();
-        }
-
-        Bundle bundleOfItem2 = BundleBuilder.createBundle(context, item2)
-                                            .withName("ORIGINAL")
-                                            .build();
-
-        try (InputStream is = IOUtils.toInputStream("TEST 1", CharEncoding.UTF_8)) {
-            bitstream5 = BitstreamBuilder.createBitstream(context, bundleOfItem2, is)
-                                         .withName("test title 1 item2")
-                                         .build();
-        }
-
-        try (InputStream is = IOUtils.toInputStream("TEST 2", CharEncoding.UTF_8)) {
-            bitstream6 = BitstreamBuilder.createBitstream(context, bundleOfItem2, is)
-                                         .withName("test title 2 item2")
-                                         .build();
-        }
-
+        context.commit();
         context.restoreAuthSystemState();
-    }
 
-    @Test
-    public void asyncDetetionOfItemTest() throws Exception {
-        // verify that item with bitstreams exist
-        String tokenAdmin = getAuthToken(admin.getEmail(), password);
-        getClient(tokenAdmin).perform(get("/api/core/items/" + item1.getID()))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("$.id", Matchers.is(item1.getID().toString())))
-                             .andExpect(jsonPath("$.name", Matchers.is(item1.getName())));
-
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream1.getID()))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("$.id", Matchers.is(bitstream1.getID().toString())))
-                             .andExpect(jsonPath("$.name", Matchers.is(bitstream1.getName())));
-
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream2.getID()))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("$.id", Matchers.is(bitstream2.getID().toString())))
-                             .andExpect(jsonPath("$.name", Matchers.is(bitstream2.getName())));
-
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream3.getID()))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("$.id", Matchers.is(bitstream3.getID().toString())))
-                             .andExpect(jsonPath("$.name", Matchers.is(bitstream3.getName())));
-
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream4.getID()))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("$.id", Matchers.is(bitstream4.getID().toString())))
-                             .andExpect(jsonPath("$.name", Matchers.is(bitstream4.getName())));
-
-        String[] args = new String[]{ OBJECT_DELETION_SCRIPT, "-i", item1.getID().toString() };
-        TestDSpaceRunnableHandler handler = new TestDSpaceRunnableHandler();
-        DSpaceObjectDeletionProcess deletionProcess = new DSpaceObjectDeletionProcess();
-        deletionProcess.initialize(args, handler, admin);
-        deletionProcess.run();
-
-        // // verify that item with bitstreams was deleted
-        getClient(tokenAdmin).perform(get("/api/core/items/" + item1.getID()))
-                             .andExpect(status().isNotFound());
-
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream1.getID()))
-                             .andExpect(status().isNotFound());
-
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream2.getID()))
-                             .andExpect(status().isNotFound());
-
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream3.getID()))
-                             .andExpect(status().isNotFound());
-
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream4.getID()))
-                             .andExpect(status().isNotFound());
-
-        // check item2
-        getClient(tokenAdmin).perform(get("/api/core/items/" + item2.getID()))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("$.id", Matchers.is(item2.getID().toString())))
-                             .andExpect(jsonPath("$.name", Matchers.is(item2.getName())));
-
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream5.getID()))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("$.id", Matchers.is(bitstream5.getID().toString())))
-                             .andExpect(jsonPath("$.name", Matchers.is(bitstream5.getName())));
-
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream6.getID()))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("$.id", Matchers.is(bitstream6.getID().toString())))
-                             .andExpect(jsonPath("$.name", Matchers.is(bitstream6.getName())));
-    }
-
-    @Test
-    public void asyncDetetionOfCollectionTest() throws Exception {
-
-        // verify that collection with items/bitstreams exists
-        String tokenAdmin = getAuthToken(admin.getEmail(), password);
-        getClient(tokenAdmin).perform(get("/api/core/collections/" + collection.getID()))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("$.id", Matchers.is(collection.getID().toString())))
-                             .andExpect(jsonPath("$.name", Matchers.is(collection.getName())));
-
-        // check item1
-        getClient(tokenAdmin).perform(get("/api/core/items/" + item1.getID()))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("$.id", Matchers.is(item1.getID().toString())))
-                             .andExpect(jsonPath("$.name", Matchers.is(item1.getName())));
-
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream1.getID()))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("$.id", Matchers.is(bitstream1.getID().toString())))
-                             .andExpect(jsonPath("$.name", Matchers.is(bitstream1.getName())));
-
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream2.getID()))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("$.id", Matchers.is(bitstream2.getID().toString())))
-                             .andExpect(jsonPath("$.name", Matchers.is(bitstream2.getName())));
-
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream3.getID()))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("$.id", Matchers.is(bitstream3.getID().toString())))
-                             .andExpect(jsonPath("$.name", Matchers.is(bitstream3.getName())));
-
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream4.getID()))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("$.id", Matchers.is(bitstream4.getID().toString())))
-                             .andExpect(jsonPath("$.name", Matchers.is(bitstream4.getName())));
-
-        getClient(tokenAdmin).perform(get("/api/core/collections/" + collection.getID()))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("$.id", Matchers.is(collection.getID().toString())))
-                             .andExpect(jsonPath("$.name", Matchers.is(collection.getName())));
-
-        // check item2
-        getClient(tokenAdmin).perform(get("/api/core/items/" + item2.getID()))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("$.id", Matchers.is(item2.getID().toString())))
-                             .andExpect(jsonPath("$.name", Matchers.is(item2.getName())));
-
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream5.getID()))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("$.id", Matchers.is(bitstream5.getID().toString())))
-                             .andExpect(jsonPath("$.name", Matchers.is(bitstream5.getName())));
-
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream6.getID()))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("$.id", Matchers.is(bitstream6.getID().toString())))
-                             .andExpect(jsonPath("$.name", Matchers.is(bitstream6.getName())));
-
-        String[] args = new String[]{ OBJECT_DELETION_SCRIPT, "-i", collection.getID().toString() };
-        TestDSpaceRunnableHandler handler = new TestDSpaceRunnableHandler();
-        DSpaceObjectDeletionProcess deletionProcess = new DSpaceObjectDeletionProcess();
-        deletionProcess.initialize(args, handler, admin);
-        deletionProcess.run();
-
-        // // verify that collection with items/bitstreams was deleted
-        getClient(tokenAdmin).perform(get("/api/core/collections/" + collection.getID()))
-                             .andExpect(status().isNotFound());
-
-        getClient(tokenAdmin).perform(get("/api/core/items/" + item1.getID()))
-                             .andExpect(status().isNotFound());
-
-        getClient(tokenAdmin).perform(get("/api/core/items/" + item2.getID()))
-                             .andExpect(status().isNotFound());
-
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream1.getID()))
-                             .andExpect(status().isNotFound());
-
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream2.getID()))
-                             .andExpect(status().isNotFound());
-
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream3.getID()))
-                             .andExpect(status().isNotFound());
-
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream4.getID()))
-                             .andExpect(status().isNotFound());
-
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream5.getID()))
-                             .andExpect(status().isNotFound());
-
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream6.getID()))
-                             .andExpect(status().isNotFound());
-    }
-
-    @Test
-    public void asyncDetetionOfCommunityTest() throws Exception {
-
-        // verify that community with collections/items/bitstreams exists
-        String tokenAdmin = getAuthToken(admin.getEmail(), password);
-        getClient(tokenAdmin).perform(get("/api/core/communities/" + community.getID()))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("$.id", Matchers.is(community.getID().toString())))
-                             .andExpect(jsonPath("$.name", Matchers.is(community.getName())));
-
-        getClient(tokenAdmin).perform(get("/api/core/collections/" + collection.getID()))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("$.id", Matchers.is(collection.getID().toString())))
-                             .andExpect(jsonPath("$.name", Matchers.is(collection.getName())));
-
-        // check item1
-        getClient(tokenAdmin).perform(get("/api/core/items/" + item1.getID()))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("$.id", Matchers.is(item1.getID().toString())))
-                             .andExpect(jsonPath("$.name", Matchers.is(item1.getName())));
-
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream1.getID()))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("$.id", Matchers.is(bitstream1.getID().toString())))
-                             .andExpect(jsonPath("$.name", Matchers.is(bitstream1.getName())));
-
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream2.getID()))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("$.id", Matchers.is(bitstream2.getID().toString())))
-                             .andExpect(jsonPath("$.name", Matchers.is(bitstream2.getName())));
-
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream3.getID()))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("$.id", Matchers.is(bitstream3.getID().toString())))
-                             .andExpect(jsonPath("$.name", Matchers.is(bitstream3.getName())));
-
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream4.getID()))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("$.id", Matchers.is(bitstream4.getID().toString())))
-                             .andExpect(jsonPath("$.name", Matchers.is(bitstream4.getName())));
-
-        getClient(tokenAdmin).perform(get("/api/core/collections/" + collection.getID()))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("$.id", Matchers.is(collection.getID().toString())))
-                             .andExpect(jsonPath("$.name", Matchers.is(collection.getName())));
-
-        // check item2
-        getClient(tokenAdmin).perform(get("/api/core/items/" + item2.getID()))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("$.id", Matchers.is(item2.getID().toString())))
-                             .andExpect(jsonPath("$.name", Matchers.is(item2.getName())));
-
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream5.getID()))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("$.id", Matchers.is(bitstream5.getID().toString())))
-                             .andExpect(jsonPath("$.name", Matchers.is(bitstream5.getName())));
-
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream6.getID()))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("$.id", Matchers.is(bitstream6.getID().toString())))
-                             .andExpect(jsonPath("$.name", Matchers.is(bitstream6.getName())));
-
-        String[] args = new String[]{ OBJECT_DELETION_SCRIPT, "-i", community.getID().toString() };
-        TestDSpaceRunnableHandler handler = new TestDSpaceRunnableHandler();
-        DSpaceObjectDeletionProcess deletionProcess = new DSpaceObjectDeletionProcess();
-        deletionProcess.initialize(args, handler, admin);
-        deletionProcess.run();
-
-        // // verify that collection with items/bitstreams was deleted
-        getClient(tokenAdmin).perform(get("/api/core/communities/" + community.getID()))
-                             .andExpect(status().isNotFound());
-
-        getClient(tokenAdmin).perform(get("/api/core/collections/" + collection.getID()))
-                             .andExpect(status().isNotFound());
-
-        getClient(tokenAdmin).perform(get("/api/core/items/" + item1.getID()))
-                             .andExpect(status().isNotFound());
-
-        getClient(tokenAdmin).perform(get("/api/core/items/" + item2.getID()))
-                             .andExpect(status().isNotFound());
-
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream1.getID()))
-                             .andExpect(status().isNotFound());
-
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream2.getID()))
-                             .andExpect(status().isNotFound());
-
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream3.getID()))
-                             .andExpect(status().isNotFound());
-
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream4.getID()))
-                             .andExpect(status().isNotFound());
-
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream5.getID()))
-                             .andExpect(status().isNotFound());
-
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream6.getID()))
-                             .andExpect(status().isNotFound());
-    }
-
-    @Test
-    public void asyncDetetionOfUnsupportedObjectTest() throws Exception {
-
-        String tokenAdmin = getAuthToken(admin.getEmail(), password);
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream1.getID()))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("$.id", Matchers.is(bitstream1.getID().toString())))
-                             .andExpect(jsonPath("$.name", Matchers.is(bitstream1.getName())));
-
-        String[] args = new String[]{ OBJECT_DELETION_SCRIPT, "-i", bitstream1.getID().toString() };
-        TestDSpaceRunnableHandler handler = new TestDSpaceRunnableHandler();
-        DSpaceObjectDeletionProcess deletionProcess = new DSpaceObjectDeletionProcess();
-        deletionProcess.initialize(args, handler, admin);
-        deletionProcess.run();
-
-        var message = String.format("DSpaceObject for provided identifier:%s doesn't exist!", bitstream1.getID());
-        assertTrue(handler.getException().getMessage().contains(message));
-
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream1.getID()))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("$.id", Matchers.is(bitstream1.getID().toString())))
-                             .andExpect(jsonPath("$.name", Matchers.is(bitstream1.getName())));
-    }
-
-    @Test
-    public void asyncDetetionOfItemByHandleTest() throws Exception {
-        // verify that item with bitstreams exist
-        AtomicReference<String> idRef = new AtomicReference<>();
-
-        String tokenAdmin = getAuthToken(admin.getEmail(), password);
-        getClient(tokenAdmin).perform(get("/api/core/items/" + item1.getID()))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("$.id", Matchers.is(item1.getID().toString())))
-                             .andExpect(jsonPath("$.name", Matchers.is(item1.getName())))
-                             .andDo(result -> idRef.set(read(result.getResponse().getContentAsString(),
-                            "$.handle")));
-
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream1.getID()))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("$.id", Matchers.is(bitstream1.getID().toString())))
-                             .andExpect(jsonPath("$.name", Matchers.is(bitstream1.getName())));
-
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream2.getID()))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("$.id", Matchers.is(bitstream2.getID().toString())))
-                             .andExpect(jsonPath("$.name", Matchers.is(bitstream2.getName())));
-
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream3.getID()))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("$.id", Matchers.is(bitstream3.getID().toString())))
-                             .andExpect(jsonPath("$.name", Matchers.is(bitstream3.getName())));
-
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream4.getID()))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("$.id", Matchers.is(bitstream4.getID().toString())))
-                             .andExpect(jsonPath("$.name", Matchers.is(bitstream4.getName())));
-
-        String[] args = new String[]{ OBJECT_DELETION_SCRIPT, "-i", idRef.get() };
-        TestDSpaceRunnableHandler handler = new TestDSpaceRunnableHandler();
-        DSpaceObjectDeletionProcess deletionProcess = new DSpaceObjectDeletionProcess();
-        deletionProcess.initialize(args, handler, admin);
-        deletionProcess.run();
-
-        // verify that item with bitstreams was deleted
-        getClient(tokenAdmin).perform(get("/api/core/items/" + item1.getID()))
-                             .andExpect(status().isNotFound());
-
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream1.getID()))
-                             .andExpect(status().isNotFound());
-
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream2.getID()))
-                             .andExpect(status().isNotFound());
-
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream3.getID()))
-                             .andExpect(status().isNotFound());
-
-        getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream4.getID()))
-                             .andExpect(status().isNotFound());
-    }
-
-    @Test
-    public void asyncDeletionWithNonExistentUUIDTest() throws Exception {
-        UUID fakeUuid = UUID.randomUUID();
-        String[] args = new String[]{ OBJECT_DELETION_SCRIPT, "-i", fakeUuid.toString() };
-        TestDSpaceRunnableHandler handler = new TestDSpaceRunnableHandler();
-        DSpaceObjectDeletionProcess deletionProcess = new DSpaceObjectDeletionProcess();
-        deletionProcess.initialize(args, handler, admin);
-        deletionProcess.run();
-
-        var expectedMessage = String.format("DSpaceObject for provided identifier:%s doesn't exist!", fakeUuid);
-        assertTrue(handler.getException().getMessage().contains(expectedMessage));
-    }
-
-    @Test
-    public void asyncDeletionWithInvalidHandleTest() throws Exception {
-        String[] args = new String[]{ OBJECT_DELETION_SCRIPT, "-i", "123456789/invalid" };
-        TestDSpaceRunnableHandler handler = new TestDSpaceRunnableHandler();
-        DSpaceObjectDeletionProcess deletionProcess = new DSpaceObjectDeletionProcess();
-        deletionProcess.initialize(args, handler, admin);
-        deletionProcess.run();
-
-        assertTrue(handler.getException() instanceof IllegalArgumentException);
+        // Commit to Solr so that isComColAdmin() and isItemAdmin() can find the objects
+        indexingService.commit();
     }
 
     /**
-     * Test deletion of an Item with the -c all (copyVirtualMetadata=all) option.
-     * This test verifies that when deleting an Item with relationships, the virtual metadata
-     * generated by those relationships is copied as physical metadata to the related items
-     * before the deletion occurs.
-     *
-     * Case:
-     * 1. Create a Person item and a Publication item with a relationship between them
-     * 2. Verify the Publication has NO physical dc.contributor.author metadata (only virtual)
-     * 3. Delete the Person item using -c all option
-     * 4. Verify the Person is deleted
-     * 5. Verify the Publication still exists AND now has physical dc.contributor.author metadata
-     *
-     * This ensures that the virtual metadata (e.g., "Smith, John") is preserved as permanent
-     * physical metadata in the Publication item after the related Person item is deleted.
-     *
-     * @throws Exception if an error occurs during the test
+     * Test that repository admin can delete a community.
      */
     @Test
-    public void asyncDeletionOfItemWithCopyVirtualMetadataAllTest() throws Exception {
+    public void testAdminCanDeleteCommunity() throws Exception {
         context.turnOffAuthorisationSystem();
-
-        // Create entity types and relationship type
-        EntityType publicationEntityType = EntityTypeBuilder.createEntityTypeBuilder(context, "Publication").build();
-        EntityType personEntityType = EntityTypeBuilder.createEntityTypeBuilder(context, "Person").build();
-
-        RelationshipType isAuthorOfPublication = RelationshipTypeBuilder.createRelationshipTypeBuilder(context,
-              publicationEntityType, personEntityType,"isAuthorOfPublication", "isPublicationOfAuthor",0, null, 0,null
-        ).withCopyToLeft(true)
-         .build();
-
-        Collection publicationCollection = CollectionBuilder.createCollection(context, community)
-                                                            .withName("Publication collection")
-                                                            .withEntityType("Publication")
-                                                            .build();
-        Collection personCollection = CollectionBuilder.createCollection(context, community)
-                                                       .withName("Person collection")
-                                                       .withEntityType("Person")
-                                                       .build();
-
-        // Create Person item with metadata
-        Item personItem = ItemBuilder.createItem(context, personCollection)
-                                     .withTitle("John Smith")
-                                     .withPersonIdentifierFirstName("John")
-                                     .withPersonIdentifierLastName("Smith")
-                                     .build();
-
-        Item publicationItem = ItemBuilder.createItem(context, publicationCollection)
-                                          .withTitle("Quantum Computing Research")
-                                          .build();
-
-        // Create relationship between publication and person
-        RelationshipBuilder.createRelationshipBuilder(context, publicationItem, personItem, isAuthorOfPublication)
-                           .build();
-
+        Community communityToDelete = createCommunity(context)
+            .withName("Community To Delete")
+            .build();
+        context.commit();
         context.restoreAuthSystemState();
 
-        // Check that publication has NO physical dc.contributor.author metadata
-        // (only virtual metadata from relationship should be visible via REST API)
-        context.turnOffAuthorisationSystem();
-        publicationItem = context.reloadEntity(publicationItem);
-        List<MetadataValue> physicalAuthorMetadata = itemService.getMetadata(
-            publicationItem, "dc", "contributor", "author", Item.ANY, false
-        );
-        assertTrue("Publication should have NO physical dc.contributor.author metadata initially",
-                   physicalAuthorMetadata.isEmpty());
-        context.restoreAuthSystemState();
+        LinkedList<DSpaceCommandLineParameter> parameters = new LinkedList<>();
+        parameters.add(new DSpaceCommandLineParameter("-i", communityToDelete.getID().toString()));
 
-        // Delete person item with -c all option
-        String[] args = new String[]{ OBJECT_DELETION_SCRIPT, "-i", personItem.getID().toString(), "-c", "all" };
-        TestDSpaceRunnableHandler handler = new TestDSpaceRunnableHandler();
-        DSpaceObjectDeletionProcess deletionProcess = new DSpaceObjectDeletionProcess();
-        deletionProcess.initialize(args, handler, admin);
-        deletionProcess.run();
-
-        // Verify that person item was deleted
-        String tokenAdmin = getAuthToken(admin.getEmail(), password);
-        getClient(tokenAdmin).perform(get("/api/core/items/" + personItem.getID()))
-                             .andExpect(status().isNotFound());
-
-        // Verify that publication item still exists
-        getClient(tokenAdmin).perform(get("/api/core/items/" + publicationItem.getID()))
-                             .andExpect(status().isOk())
-                             .andExpect(jsonPath("$.id", Matchers.is(publicationItem.getID().toString())));
-
-        // Check that publication NOW HAS physical dc.contributor.author metadata
-        // (copied from virtual metadata before deletion)
-        context.turnOffAuthorisationSystem();
-        publicationItem = context.reloadEntity(publicationItem);
-        List<MetadataValue> physicalAuthorMetadataAfter = itemService.getMetadata(
-            publicationItem, "dc", "contributor", "author", Item.ANY, false
-        );
-        assertFalse("Publication should have physical dc.contributor.author metadata after deletion with -c all",
-                    physicalAuthorMetadataAfter.isEmpty());
-        assertEquals("Physical metadata should contain the copied author name", 1, physicalAuthorMetadataAfter.size());
-        String authorValue = physicalAuthorMetadataAfter.get(0).getValue();
-        assertTrue("Author metadata should contain 'Smith'", authorValue.contains("Smith"));
-        assertTrue("Author metadata should contain 'John'", authorValue.contains("John"));
-        context.restoreAuthSystemState();
+        performDeletionScript(parameters, admin, HttpStatus.ACCEPTED, communityToDelete);
     }
 
     /**
-     * Test deletion of an Item with the -c configured (copyVirtualMetadata=configured) option.
-     * This test verifies that when deleting an Item with multiple relationships, only the virtual
-     * metadata from relationships configured with copyToLeft/copyToRight=true are copied as
-     * physical metadata to the related items.
-     *
-     * Case:
-     * 1. Create a Publication with two relationships: one with copyToRight=true, one with copyToRight=false
-     * 2. Verify the related items (Person, Project) have NO physical metadata initially
-     * 3. Delete the Publication using -c configured option
-     * 4. Verify the Publication is deleted
-     * 5. Verify that ONLY the Person (copyToRight=true) received physical metadata
-     * 6. Verify that the Project (copyToRight=false) did NOT receive physical metadata
-     *
-     * This ensures that only relationships configured to copy metadata actually do so when the
-     * left item (Publication) is deleted.
-     *
-     * @throws Exception if an error occurs during the test
+     * Test that community admin can delete a community.
      */
     @Test
-    public void asyncDeletionOfItemWithCopyVirtualMetadataConfiguredTest() throws Exception {
+    public void testCommunityAdminCanDeleteCommunity() throws Exception {
         context.turnOffAuthorisationSystem();
-
-        // Create entity types
-        EntityType personEntityType = EntityTypeBuilder.createEntityTypeBuilder(context, "Person").build();
-        EntityType projectEntityType = EntityTypeBuilder.createEntityTypeBuilder(context, "Project").build();
-        EntityType publicationEntityType = EntityTypeBuilder.createEntityTypeBuilder(context, "Publication").build();
-
-        // Create relationship type with copyToRight=true (person will receive metadata from publication)
-        RelationshipType isAuthorOfPublication = RelationshipTypeBuilder.createRelationshipTypeBuilder(context,
-              publicationEntityType, personEntityType, "isAuthorOfPublication", "isPublicationOfAuthor", 0, null, 0,null
-        ).withCopyToRight(true)
-         .build();
-
-        // Create relationship type with copyToRight=false (project will NOT receive metadata)
-        RelationshipType isProjectOfPublication = RelationshipTypeBuilder.createRelationshipTypeBuilder(context,
-              publicationEntityType, projectEntityType, "isProjectOfPublication", "isPublicationOfProject",
-              0, null, 0, null
-        ).withCopyToRight(false)
-         .build();
-
-        Collection publicationCollection = CollectionBuilder.createCollection(context, community)
-                                                            .withName("Publication collection")
-                                                            .withEntityType("Publication")
-                                                            .build();
-        Collection personCollection = CollectionBuilder.createCollection(context, community)
-                                                       .withName("Person collection")
-                                                       .withEntityType("Person")
-                                                       .build();
-        Collection projectCollection = CollectionBuilder.createCollection(context, community)
-                                                        .withName("Project collection")
-                                                        .withEntityType("Project")
-                                                        .build();
-
-        // Create Publication item with title
-        Item publicationItem = ItemBuilder.createItem(context, publicationCollection)
-                                          .withTitle("Advanced Quantum Research")
-                                          .build();
-
-        // Create Person item
-        Item personItem = ItemBuilder.createItem(context, personCollection)
-                                     .withTitle("Jane Doe")
-                                     .withPersonIdentifierFirstName("Jane")
-                                     .withPersonIdentifierLastName("Doe")
-                                     .build();
-
-        // Create Project item
-        Item projectItem = ItemBuilder.createItem(context, projectCollection)
-                                      .withTitle("Quantum Computing Project")
-                                      .build();
-
-        // Create relationships
-        RelationshipBuilder.createRelationshipBuilder(context, publicationItem, personItem, isAuthorOfPublication)
-                           .build();
-        RelationshipBuilder.createRelationshipBuilder(context, publicationItem, projectItem, isProjectOfPublication)
-                           .build();
-
+        Community communityToDelete = createCommunity(context)
+            .withName("Community To Delete")
+            .withAdminGroup(comAdmin)
+            .build();
+        context.commit();
         context.restoreAuthSystemState();
+        indexingService.commit();
 
-        // Check that person has NO physical relation.isPublicationOfAuthor metadata
-        context.turnOffAuthorisationSystem();
-        personItem = context.reloadEntity(personItem);
-        List<MetadataValue> personPhysicalMetadata = itemService.getMetadata(
-            personItem, "relation", "isPublicationOfAuthor", null, Item.ANY, false
-        );
-        assertTrue("Person should have NO physical relation.isPublicationOfAuthor metadata initially",
-                   personPhysicalMetadata.isEmpty());
+        LinkedList<DSpaceCommandLineParameter> parameters = new LinkedList<>();
+        parameters.add(new DSpaceCommandLineParameter("-i", communityToDelete.getID().toString()));
 
-        // Check that project has NO physical relation.isPublicationOfProject metadata
-        projectItem = context.reloadEntity(projectItem);
-        List<MetadataValue> projectPhysicalMetadata = itemService.getMetadata(
-            projectItem, "relation", "isPublicationOfProject", null, Item.ANY, false
-        );
-        assertTrue("Project should have NO physical relation.isPublicationOfProject metadata initially",
-                   projectPhysicalMetadata.isEmpty());
-        context.restoreAuthSystemState();
-
-        // Delete publication item with -c configured option
-        String[] args = new String[]{ OBJECT_DELETION_SCRIPT, "-i", publicationItem.getID().toString(),
-                                                              "-c", "configured" };
-        TestDSpaceRunnableHandler handler = new TestDSpaceRunnableHandler();
-        DSpaceObjectDeletionProcess deletionProcess = new DSpaceObjectDeletionProcess();
-        deletionProcess.initialize(args, handler, admin);
-        deletionProcess.run();
-
-        String tokenAdmin = getAuthToken(admin.getEmail(), password);
-        // Verify that publication item was deleted
-        getClient(tokenAdmin).perform(get("/api/core/items/" + publicationItem.getID()))
-                             .andExpect(status().isNotFound());
-
-        // Check that person NOW HAS physical relation.isPublicationOfAuthor metadata (copyToRight=true)
-        context.turnOffAuthorisationSystem();
-        personItem = context.reloadEntity(personItem);
-        List<MetadataValue> personPhysicalMetadataAfter = itemService.getMetadata(
-            personItem, "relation", "isPublicationOfAuthor", null, Item.ANY, false
-        );
-        assertFalse("Person should have physical relation.isPublicationOfAuthor metadata after deletion with " +
-                    "-c configured (copyToRight=true)",
-                    personPhysicalMetadataAfter.isEmpty());
-        assertEquals("Person should have one relation metadata value", 1, personPhysicalMetadataAfter.size());
-        assertEquals("Person metadata should reference the deleted publication UUID",
-                     publicationItem.getID().toString(),
-                     personPhysicalMetadataAfter.get(0).getValue());
-
-        // Check that project STILL HAS NO physical relation.isPublicationOfProject metadata (copyToRight=false)
-        projectItem = context.reloadEntity(projectItem);
-        List<MetadataValue> projectPhysicalMetadataAfter = itemService.getMetadata(
-            projectItem, "relation", "isPublicationOfProject", null, Item.ANY, false
-        );
-        assertTrue("Project should NOT have physical relation.isPublicationOfProject metadata after deletion " +
-                   "with -c configured (copyToRight=false)",
-                   projectPhysicalMetadataAfter.isEmpty());
-        context.restoreAuthSystemState();
+        performDeletionScript(parameters, comAdmin, HttpStatus.ACCEPTED, communityToDelete);
     }
 
     /**
-     * Test deletion of an Item with the -c option using specific RelationshipType IDs.
-     * This test verifies that when deleting an Item with multiple relationships, only the virtual
-     * metadata from the specified RelationshipType IDs are copied as physical metadata to the
-     * related items, regardless of the copyToLeft/copyToRight configuration.
-     *
-     * Case:
-     * 1. Create a Publication with three relationships (Person, Project, OrgUnit)
-     * 2. Verify the related items have NO physical metadata initially
-     * 3. Delete the Publication using -c with only the Person and OrgUnit relationship IDs
-     * 4. Verify the Publication is deleted
-     * 5. Verify that ONLY Person and OrgUnit received physical metadata (specified IDs)
-     * 6. Verify that Project did NOT receive physical metadata (ID not specified)
-     *
-     * This ensures that the -c option with numeric IDs allows granular control over which
-     * virtual metadata to copy, independent of the relationship type configuration.
-     *
-     * @throws Exception if an error occurs during the test
+     * Test that collection admin can delete a collection.
      */
     @Test
-    public void asyncDeletionOfItemWithCopyVirtualMetadataByRelationshipTypeIdsTest() throws Exception {
+    public void testCollectionAdminCanDeleteCollection() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Community tempCommunity = createCommunity(context)
+            .withName("Temp Community for Collection")
+            .build();
+        Collection collectionToDelete = createCollection(context, tempCommunity)
+            .withName("Collection To Delete")
+            .withAdminGroup(colAdmin)
+            .build();
+        context.commit();
+        context.restoreAuthSystemState();
+        indexingService.commit();
+
+        LinkedList<DSpaceCommandLineParameter> parameters = new LinkedList<>();
+        parameters.add(new DSpaceCommandLineParameter("-i", collectionToDelete.getID().toString()));
+
+        performDeletionScript(parameters, colAdmin, HttpStatus.ACCEPTED, collectionToDelete);
+    }
+
+    /**
+     * Test that item admin can delete an item.
+     */
+    @Test
+    public void testItemAdminCanDeleteItem() throws Exception {
+        context.turnOffAuthorisationSystem();
+        community = createCommunity(context)
+            .withName("Test Community")
+            .build();
+
+        collection = createCollection(context, community)
+            .withName("Test Collection")
+            .build();
+
+        Item itemToDelete = createItem(context, collection)
+            .withTitle("Item To Delete")
+            .withAdminUser(itemAdmin)
+            .build();
+        context.commit();
+        context.restoreAuthSystemState();
+        indexingService.commit();
+
+        LinkedList<DSpaceCommandLineParameter> parameters = new LinkedList<>();
+        parameters.add(new DSpaceCommandLineParameter("-i", itemToDelete.getID().toString()));
+
+        performDeletionScript(parameters, itemAdmin, HttpStatus.ACCEPTED, itemToDelete);
+    }
+
+    /**
+     * Test that community admin cannot delete a collection they don't administer.
+     */
+    @Test
+    public void testCommunityAdminCannotDeleteCollection() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Community otherCommunity = createCommunity(context)
+            .withName("Other Community")
+            .build();
+        Collection otherCollection = createCollection(context, otherCommunity)
+            .withName("Other Collection")
+            .build();
+        context.commit();
+        context.restoreAuthSystemState();
+        indexingService.commit();
+
+        LinkedList<DSpaceCommandLineParameter> parameters = new LinkedList<>();
+        parameters.add(new DSpaceCommandLineParameter("-i", otherCollection.getID().toString()));
+
+        // Community admin can execute the script (they are a ComColAdmin)
+        // but the deletion should fail because they don't administer this specific collection
+        performDeletionScript(parameters, comAdmin, HttpStatus.FORBIDDEN, otherCollection);
+    }
+
+    /**
+     * Test that collection admin cannot delete an item they don't administer.
+     */
+    @Test
+    public void testCollectionAdminCannotDeleteItem() throws Exception {
         context.turnOffAuthorisationSystem();
 
-        // Create entity types
-        EntityType personEntityType = EntityTypeBuilder.createEntityTypeBuilder(context, "Person").build();
-        EntityType projectEntityType = EntityTypeBuilder.createEntityTypeBuilder(context, "Project").build();
-        EntityType orgUnitEntityType = EntityTypeBuilder.createEntityTypeBuilder(context, "OrgUnit").build();
-        EntityType publicationEntityType = EntityTypeBuilder.createEntityTypeBuilder(context, "Publication").build();
+        Community community = createCommunity(context)
+            .withName("Test Community")
+            .withAdminGroup(comAdmin)
+            .build();
 
-        // Create three relationship types (all with copyToRight=false to ensure IDs override config)
-        RelationshipType isAuthorOfPublication = RelationshipTypeBuilder.createRelationshipTypeBuilder(context,
-              publicationEntityType, personEntityType, "isAuthorOfPublication", "isPublicationOfAuthor",
-              0, null, 0, null
-        ).withCopyToRight(false)
-         .build();
-
-        RelationshipType isProjectOfPublication = RelationshipTypeBuilder.createRelationshipTypeBuilder(context,
-              publicationEntityType, projectEntityType, "isProjectOfPublication", "isPublicationOfProject",
-              0, null, 0, null
-        ).withCopyToRight(false)
-         .build();
-
-        RelationshipType isOrgUnitOfPublication = RelationshipTypeBuilder.createRelationshipTypeBuilder(context,
-              publicationEntityType, orgUnitEntityType, "isOrgUnitOfPublication", "isPublicationOfOrgUnit",
-              0, null, 0, null
-        ).withCopyToRight(false)
-         .build();
-
-        Collection publicationCollection = CollectionBuilder.createCollection(context, community)
-                                                            .withName("Publication collection")
-                                                            .withEntityType("Publication")
-                                                            .build();
-        Collection personCollection = CollectionBuilder.createCollection(context, community)
-                                                       .withName("Person collection")
-                                                       .withEntityType("Person")
-                                                       .build();
-        Collection projectCollection = CollectionBuilder.createCollection(context, community)
-                                                        .withName("Project collection")
-                                                        .withEntityType("Project")
-                                                        .build();
-        Collection orgUnitCollection = CollectionBuilder.createCollection(context, community)
-                                                        .withName("OrgUnit collection")
-                                                        .withEntityType("OrgUnit")
-                                                        .build();
-
-        Item publicationItem = ItemBuilder.createItem(context, publicationCollection)
-                                          .withTitle("Comprehensive Study on AI")
-                                          .build();
-
-        Item personItem = ItemBuilder.createItem(context, personCollection)
-                                     .withTitle("Alice Johnson")
-                                     .withPersonIdentifierFirstName("Alice")
-                                     .withPersonIdentifierLastName("Johnson")
-                                     .build();
-
-        Item projectItem = ItemBuilder.createItem(context, projectCollection)
-                                      .withTitle("AI Research Initiative")
-                                      .build();
-
-        Item orgUnitItem = ItemBuilder.createItem(context, orgUnitCollection)
-                                      .withTitle("Computer Science Department")
-                                      .build();
-
-        // Create relationships
-        RelationshipBuilder.createRelationshipBuilder(context, publicationItem, personItem, isAuthorOfPublication)
-                           .build();
-        RelationshipBuilder.createRelationshipBuilder(context, publicationItem, projectItem, isProjectOfPublication)
-                           .build();
-        RelationshipBuilder.createRelationshipBuilder(context, publicationItem, orgUnitItem, isOrgUnitOfPublication)
-                           .build();
-
+        Collection otherCollection = createCollection(context, community)
+            .withName("Other Collection")
+            .build();
+        Item otherItem = createItem(context, otherCollection)
+            .withTitle("Other Item")
+            .build();
+        context.commit();
         context.restoreAuthSystemState();
+        indexingService.commit();
 
-        // Check that person has NO physical relation.isPublicationOfAuthor metadata
+        LinkedList<DSpaceCommandLineParameter> parameters = new LinkedList<>();
+        parameters.add(new DSpaceCommandLineParameter("-i", otherItem.getID().toString()));
+
+        // Collection admin can execute the script (they are a ComColAdmin)
+        // but the deletion should fail because they don't administer this specific item
+        performDeletionScript(parameters, colAdmin, HttpStatus.FORBIDDEN, otherItem);
+    }
+
+    /**
+     * Test that item admin cannot delete another item they don't administer.
+     */
+    @Test
+    public void testItemAdminCannotDeleteAnotherItem() throws Exception {
         context.turnOffAuthorisationSystem();
-        personItem = context.reloadEntity(personItem);
-        List<MetadataValue> personPhysicalMetadata = itemService.getMetadata(
-            personItem, "relation", "isPublicationOfAuthor", null, Item.ANY, false
-        );
-        assertTrue("Person should have NO physical relation.isPublicationOfAuthor metadata initially",
-                   personPhysicalMetadata.isEmpty());
-
-        // Check that project has NO physical relation.isPublicationOfProject metadata
-        projectItem = context.reloadEntity(projectItem);
-        List<MetadataValue> projectPhysicalMetadata = itemService.getMetadata(
-            projectItem, "relation", "isPublicationOfProject", null, Item.ANY, false
-        );
-        assertTrue("Project should have NO physical relation.isPublicationOfProject metadata initially",
-                   projectPhysicalMetadata.isEmpty());
-
-        // Check that orgUnit has NO physical relation.isPublicationOfOrgUnit metadata
-        orgUnitItem = context.reloadEntity(orgUnitItem);
-        List<MetadataValue> orgUnitPhysicalMetadata = itemService.getMetadata(
-            orgUnitItem, "relation", "isPublicationOfOrgUnit", null, Item.ANY, false
-        );
-        assertTrue("OrgUnit should have NO physical relation.isPublicationOfOrgUnit metadata initially",
-                   orgUnitPhysicalMetadata.isEmpty());
+        community = createCommunity(context)
+            .withName("Test Community")
+            .build();
+        collection = createCollection(context, community)
+            .withName("Test Collection")
+            .build();
+        Item otherItem = createItem(context, collection)
+            .withTitle("Other Item")
+            .build();
         context.restoreAuthSystemState();
+        indexingService.commit();
 
-        // Delete publication item with -c specifying only Person and OrgUnit relationship type IDs
-        // We exclude the Project relationship type ID
-        String relationshipTypeIds = isAuthorOfPublication.getID() + "," + isOrgUnitOfPublication.getID();
-        String[] args = new String[]{ OBJECT_DELETION_SCRIPT, "-i", publicationItem.getID().toString(),
-                                                              "-c", relationshipTypeIds };
-        TestDSpaceRunnableHandler handler = new TestDSpaceRunnableHandler();
-        DSpaceObjectDeletionProcess deletionProcess = new DSpaceObjectDeletionProcess();
-        deletionProcess.initialize(args, handler, admin);
-        deletionProcess.run();
+        LinkedList<DSpaceCommandLineParameter> parameters = new LinkedList<>();
+        parameters.add(new DSpaceCommandLineParameter("-i", otherItem.getID().toString()));
 
-        // Verify that publication item was deleted
-        String tokenAdmin = getAuthToken(admin.getEmail(), password);
-        getClient(tokenAdmin).perform(get("/api/core/items/" + publicationItem.getID()))
-                             .andExpect(status().isNotFound());
+        // Item admin can execute the script (they are an ItemAdmin)
+        // but the deletion should fail because they don't administer this specific item
+        performDeletionScript(parameters, itemAdmin, HttpStatus.FORBIDDEN, otherItem);
+    }
 
-        // Check that person NOW HAS physical relation.isPublicationOfAuthor metadata (ID was specified)
+    /**
+     * Test that regular eperson cannot delete any object.
+     */
+    @Test
+    public void testRegularEPersonCannotDelete() throws Exception {
         context.turnOffAuthorisationSystem();
-        personItem = context.reloadEntity(personItem);
-        List<MetadataValue> personPhysicalMetadataAfter = itemService.getMetadata(
-            personItem, "relation", "isPublicationOfAuthor", null, Item.ANY, false
-        );
-        assertFalse("Person should have physical relation.isPublicationOfAuthor metadata after deletion " +
-                    "with -c using its relationship type ID",
-                    personPhysicalMetadataAfter.isEmpty());
-        assertEquals("Person should have one relation metadata value", 1, personPhysicalMetadataAfter.size());
-        assertEquals("Person metadata should reference the deleted publication UUID",
-                     publicationItem.getID().toString(),
-                     personPhysicalMetadataAfter.get(0).getValue());
+        community = createCommunity(context)
+            .withName("Test Community")
+            .build();
 
-        // Check that orgUnit NOW HAS physical relation.isPublicationOfOrgUnit metadata (ID was specified)
-        orgUnitItem = context.reloadEntity(orgUnitItem);
-        List<MetadataValue> orgUnitPhysicalMetadataAfter = itemService.getMetadata(
-            orgUnitItem, "relation", "isPublicationOfOrgUnit", null, Item.ANY, false
-        );
-        assertFalse("OrgUnit should have physical relation.isPublicationOfOrgUnit metadata after deletion " +
-                    "with -c using its relationship type ID",
-                    orgUnitPhysicalMetadataAfter.isEmpty());
-        assertEquals("OrgUnit should have one relation metadata value", 1, orgUnitPhysicalMetadataAfter.size());
-        assertEquals("OrgUnit metadata should reference the deleted publication UUID",
-                     publicationItem.getID().toString(),
-                     orgUnitPhysicalMetadataAfter.get(0).getValue());
+        collection = createCollection(context, community)
+            .withName("Test Collection")
+            .build();
 
-        // Check that project STILL HAS NO physical relation.isPublicationOfProject metadata (ID was NOT specified)
-        projectItem = context.reloadEntity(projectItem);
-        List<MetadataValue> projectPhysicalMetadataAfter = itemService.getMetadata(
-            projectItem, "relation", "isPublicationOfProject", null, Item.ANY, false
-        );
-        assertTrue("Project should NOT have physical relation.isPublicationOfProject metadata after deletion " +
-                   "because its relationship type ID was not included in -c parameter",
-                   projectPhysicalMetadataAfter.isEmpty());
+        item = createItem(context, collection)
+            .withTitle("Test Item")
+            .build();
         context.restoreAuthSystemState();
+
+        LinkedList<DSpaceCommandLineParameter> parameters = new LinkedList<>();
+        parameters.add(new DSpaceCommandLineParameter("-i", item.getID().toString()));
+
+        performDeletionScript(parameters, eperson, HttpStatus.FORBIDDEN, item);
+    }
+
+    /**
+     * Test that anonymous user cannot delete any object.
+     */
+    @Test
+    public void testAnonymousCannotDelete() throws Exception {
+
+        context.turnOffAuthorisationSystem();
+        community = createCommunity(context)
+            .withName("Test Community")
+            .build();
+
+        collection = createCollection(context, community)
+            .withName("Test Collection")
+            .build();
+
+        item = createItem(context, collection)
+            .withTitle("Test Item")
+            .build();
+        context.restoreAuthSystemState();
+
+        LinkedList<DSpaceCommandLineParameter> parameters = new LinkedList<>();
+        parameters.add(new DSpaceCommandLineParameter("-i", item.getID().toString()));
+
+        List<ParameterValueRest> list = convertParameters(parameters);
+
+        getClient()
+            .perform(multipart("/api/system/scripts/object-deletion/processes")
+                         .param("properties", new ObjectMapper().writeValueAsString(list)))
+            .andExpect(status().isUnauthorized());
+
+        // Verify item still exists
+        assertThat("Item should still exist", itemService.find(context, item.getID()), notNullValue());
+    }
+
+    private void performDeletionScript(
+        LinkedList<DSpaceCommandLineParameter> parameters, EPerson user, HttpStatus expectedHttpStatus,
+        DSpaceObject objectToDelete) throws Exception {
+
+        List<ParameterValueRest> list = convertParameters(parameters);
+        AtomicReference<Integer> idRef = new AtomicReference<>();
+
+        try {
+            String token = getAuthToken(user.getEmail(), password);
+
+            getClient(token)
+                .perform(multipart("/api/system/scripts/object-deletion/processes")
+                             .param("properties", new ObjectMapper().writeValueAsString(list)))
+                .andExpect(status().is(expectedHttpStatus.value()))
+                .andDo(result -> {
+                    if (expectedHttpStatus == HttpStatus.ACCEPTED) {
+                        idRef.set(read(result.getResponse().getContentAsString(), "$.processId"));
+                    }
+                });
+
+            // Verify deletion status based on expected HTTP status
+            if (expectedHttpStatus == HttpStatus.ACCEPTED) {
+                // Object should be deleted
+                verifyObjectDeleted(objectToDelete);
+            } else {
+                // Object should still exist
+                verifyObjectExists(objectToDelete);
+            }
+        } finally {
+            if (idRef.get() != null) {
+                ProcessBuilder.deleteProcess(idRef.get());
+            }
+        }
+    }
+
+    private void verifyObjectDeleted(DSpaceObject object) throws SQLException {
+        if (object instanceof Item) {
+            assertThat("Item expected to be deleted", itemService.find(context, object.getID()), nullValue());
+        } else if (object instanceof Collection) {
+            assertThat("Collection expected to be deleted", collectionService.find(context, object.getID()),
+                       nullValue());
+        } else if (object instanceof Community) {
+            assertThat("Community expected to be deleted", communityService.find(context, object.getID()), nullValue());
+        }
+    }
+
+    private void verifyObjectExists(DSpaceObject object) throws SQLException {
+        if (object instanceof Item) {
+            assertThat("Item expected to still exist", itemService.find(context, object.getID()), notNullValue());
+        } else if (object instanceof Collection) {
+            assertThat("Collection expected to still exist", collectionService.find(context, object.getID()),
+                       notNullValue());
+        } else if (object instanceof Community) {
+            assertThat("Community expected to still exist", communityService.find(context, object.getID()),
+                       notNullValue());
+        }
+    }
+
+    private List<ParameterValueRest> convertParameters(LinkedList<DSpaceCommandLineParameter> parameters) {
+        return parameters.stream()
+                         .map(dSpaceCommandLineParameter ->
+                                  dSpaceRunnableParameterConverter.convert(dSpaceCommandLineParameter,
+                                                                           Projection.DEFAULT))
+                         .collect(Collectors.toList());
     }
 
 }

--- a/dspace/config/spring/api/scripts.xml
+++ b/dspace/config/spring/api/scripts.xml
@@ -61,7 +61,7 @@
         <property name="description" value="Manage the OAI-PMH harvesting of external collections"/>
         <property name="dspaceRunnableClass" value="org.dspace.app.harvest.HarvestCli"/>
     </bean>
-        
+
     <bean id="process-cleaner" class="org.dspace.administer.ProcessCleanerCliConfiguration">
         <property name="description" value="Cleanup all the old processes in the specified state"/>
         <property name="dspaceRunnableClass" value="org.dspace.administer.ProcessCleanerCli"/>
@@ -71,12 +71,12 @@
         <property name="description" value="Perform the media filtering to extract full text from documents and to create thumbnails"/>
         <property name="dspaceRunnableClass" value="org.dspace.app.mediafilter.MediaFilterScript"/>
     </bean>
-    
+
     <bean id="orcid-bulk-push" class="org.dspace.orcid.script.OrcidBulkPushScriptConfiguration">
         <property name="description" value="Perform the bulk synchronization of all the BATCH configured ORCID entities placed in the ORCID queue"/>
         <property name="dspaceRunnableClass" value="org.dspace.orcid.script.OrcidBulkPush"/>
     </bean>
-    
+
     <bean id="solr-database-resync" class="org.dspace.app.solrdatabaseresync.SolrDatabaseResyncCliScriptConfiguration">
         <property name="description" value="Update the database status of Items in solr"/>
         <property name="dspaceRunnableClass" value="org.dspace.app.solrdatabaseresync.SolrDatabaseResyncCli"/>
@@ -114,9 +114,9 @@
         <property name="isVisibleFromUI" value="false"/>
     </bean>
 
-    <bean id="object-deletion" class="org.dspace.deletion.process.DSpaceObjectDeletionProcessScriptConfiguration" primary="true">
+    <bean id="object-deletion" class="org.dspace.deletion.process.DSpaceObjectDeletionProcessCliScriptConfiguration" primary="true">
         <property name="description" value="Permanently delete the given object along with all child objects. WARNING: This action cannot be undone." />
-        <property name="dspaceRunnableClass" value="org.dspace.deletion.process.DSpaceObjectDeletionProcess"/>
+        <property name="dspaceRunnableClass" value="org.dspace.deletion.process.DSpaceObjectDeletionProcessCli"/>
     </bean>
 
     <bean id="itemDeletionStrategy" class="org.dspace.deletion.process.strategies.ItemDeletionStrategy" />

--- a/dspace/config/spring/rest/scripts.xml
+++ b/dspace/config/spring/rest/scripts.xml
@@ -85,4 +85,9 @@
         <property name="isVisibleFromUI" value="false"/>
     </bean>
 
+    <bean id="object-deletion" class="org.dspace.deletion.process.DSpaceObjectDeletionProcessScriptConfiguration" primary="true">
+        <property name="description" value="Permanently delete the given object along with all child objects. WARNING: This action cannot be undone." />
+        <property name="dspaceRunnableClass" value="org.dspace.deletion.process.DSpaceObjectDeletionProcess"/>
+    </bean>
+
 </beans>


### PR DESCRIPTION
## References
* Fixes #12136

## Description
This PR introduces a CLI-specific variant of the `object-deletion` script that allows command-line execution with explicit user specification via the `-e` (email) parameter, and expands authorization to allow community/collection/item administrators to execute the deletion command.

## Instructions for Reviewers


List of changes in this PR:
* **Created `DSpaceObjectDeletionProcessCli`**: A new CLI-specific extension that overrides the `assignCurrentUserInContext()` method to accept a `-e` (email) parameter for user specification
* **Created `DSpaceObjectDeletionProcessCliScriptConfiguration`**: Configuration class that adds the required `-e` (email) command-line option to the CLI variant
* **Modified `DSpaceObjectDeletionProcess`**: Changed `context` field visibility from `private` to `protected` to allow CLI extension to override context initialization; added comprehensive Javadoc for the `assignCurrentUserInContext()` method; improved error message formatting
* **Enhanced `DSpaceObjectDeletionProcessScriptConfiguration`**: Overrode `isAllowedToExecute()` method to expand authorization from admin-only to include community administrators, collection administrators, and item administrators (granular permission model)
* **Updated Spring configuration files**: Modified `scripts.xml` files in `dspace-api/src/test/data/dspaceFolder/config/spring/api/` and `dspace/config/spring/api/` to use the new CLI-specific bean configuration
* **Moved and expanded integration tests**: Moved `DSpaceObjectDeletionProcessIT` from REST module to API module as `DSpaceObjectDeletionProcessCliIT` with significantly expanded test coverage (8 comprehensive tests)
* **Added REST bean configuration**: Added `object-deletion` bean definition to REST `scripts.xml` to maintain REST API functionality with the original implementation


1. **Test CLI execution with admin user:**
   ```bash
   ./dspace object-deletion -e admin@example.com -i [item-uuid]
   ```
   Expected: Item and associated bitstreams are deleted successfully

2. **Test CLI execution with granular admin roles:**
   ```bash
   ./dspace object-deletion -e itemadmin@example.com -i [item-uuid]
   ./dspace object-deletion -e coladmin@example.com -i [collection-uuid]
   ./dspace object-deletion -e comadmin@example.com -i [community-uuid]
   ```
   Expected: Deletion succeeds when user has appropriate admin privileges for the object

3. **Test CLI execution without -e parameter:**
   ```bash
   ./dspace object-deletion -i [item-uuid]
   ```
   Expected: Fails with "Required parameter -e missing!"

4. **Test CLI execution with invalid email:**
   ```bash
   ./dspace object-deletion -e nonexistent@example.com -i [item-uuid]
   ```
   Expected: Fails with "Unable to find a user with email: nonexistent@example.com"

5. **Test CLI execution with unauthorized user:**
   ```bash
   ./dspace object-deletion -e regularuser@example.com -i [item-uuid]
   ```
   Expected: Fails with authorization exception

6. **Verify REST API still works:** The REST API endpoint for object deletion should continue working as before (uses the original `DSpaceObjectDeletionProcess` class with the `dspace-object-deletion` bean)


## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
