### PR TITLE
Switch all Solr hard commits to soft commits for faster indexing

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/audit/AuditSolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/audit/AuditSolrServiceImpl.java
@@ -498,7 +498,7 @@ public class AuditSolrServiceImpl implements AuditService {
 
     public void commit() {
         try {
-            getSolr().commit();
+            getSolr().commit(true, true, true);
         } catch (SolrServerException | IOException e) {
             throw new RuntimeException(e.getMessage(), e);
         }

--- a/dspace-api/src/main/java/org/dspace/app/suggestion/SolrSuggestionStorageServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/suggestion/SolrSuggestionStorageServiceImpl.java
@@ -106,14 +106,14 @@ public class SolrSuggestionStorageServiceImpl implements SolrSuggestionStorageSe
             document.addField(EVIDENCES, jsonMapper.writeValueAsString(suggestion.getEvidences()));
             getSolr().add(document);
             if (commit) {
-                getSolr().commit();
+                getSolr().commit(true, true, true);
             }
         }
     }
 
     @Override
     public void commit() throws SolrServerException, IOException {
-        getSolr().commit();
+        getSolr().commit(true, true, true);
     }
 
     private List<String> getAllValues(Suggestion suggestion, String schema, String element, String qualifier) {
@@ -143,7 +143,7 @@ public class SolrSuggestionStorageServiceImpl implements SolrSuggestionStorageSe
     @Override
     public void deleteSuggestion(Suggestion suggestion) throws SolrServerException, IOException {
         getSolr().deleteById(suggestion.getID());
-        getSolr().commit();
+        getSolr().commit(true, true, true);
     }
 
     @Override
@@ -154,7 +154,7 @@ public class SolrSuggestionStorageServiceImpl implements SolrSuggestionStorageSe
         fieldModifier.put("set", true);
         sdoc.addField(PROCESSED, fieldModifier); // add the map as the field value
         getSolr().add(sdoc);
-        getSolr().commit();
+        getSolr().commit(true, true, true);
     }
 
     @Override
@@ -173,14 +173,14 @@ public class SolrSuggestionStorageServiceImpl implements SolrSuggestionStorageSe
                 getSolr().add(sdoc);
             }
         }
-        getSolr().commit();
+        getSolr().commit(true, true, true);
     }
 
     @Override
     public void deleteTarget(SuggestionTarget target) throws SolrServerException, IOException {
         getSolr().deleteByQuery(
                 SOURCE + ":" + target.getSource() + " AND " + TARGET_ID + ":" + target.getTarget().getID().toString());
-        getSolr().commit();
+        getSolr().commit(true, true, true);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/authority/AuthoritySolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authority/AuthoritySolrServiceImpl.java
@@ -103,7 +103,7 @@ public class AuthoritySolrServiceImpl implements AuthorityIndexingService, Autho
     @Override
     public void commit() {
         try {
-            getSolr().commit();
+            getSolr().commit(true, true, true);
         } catch (SolrServerException e) {
             log.error("Error while committing authority solr server", e);
         } catch (IOException e) {

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -224,7 +224,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
             log.info("Try to delete uniqueID:" + uniqueID);
             indexObjectServiceFactory.getIndexableObjectFactory(indexableObject).delete(indexableObject);
             if (commit) {
-                solrSearchCore.getSolr().commit();
+                solrSearchCore.getSolr().commit(true, true, true);
             }
         } catch (IOException | SolrServerException exception) {
             log.error(exception.getMessage(), exception);
@@ -265,7 +265,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
                     log.warn("Object not found in Solr index: " + searchUniqueID);
                 }
                 if (commit) {
-                    solrSearchCore.getSolr().commit();
+                    solrSearchCore.getSolr().commit(true, true, true);
                 }
             }
         } catch (SolrServerException e) {
@@ -359,7 +359,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
                 }
             }
             if (solrSearchCore.getSolr() != null) {
-                solrSearchCore.getSolr().commit();
+                solrSearchCore.getSolr().commit(true, true, true);
             }
 
         } catch (IOException | SQLException | SolrServerException e) {
@@ -1076,7 +1076,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
                 log.info("ZombieDocs ");
                 zombieDocs.forEach(log::info);
                 solrSearchCore.getSolr().deleteById(zombieDocs);
-                solrSearchCore.getSolr().commit();
+                solrSearchCore.getSolr().commit(true, true, true);
             } else {
                 valid = true;
             }
@@ -1596,7 +1596,10 @@ public class SolrServiceImpl implements SearchService, IndexingService {
     public void commit() throws SearchServiceException {
         try {
             if (solrSearchCore.getSolr() != null) {
-                solrSearchCore.getSolr().commit();
+                // Use soft commit to make documents visible without the expensive
+                // fsync + new searcher overhead of a hard commit. Solr's autoCommit
+                // (configured in solrconfig.xml) handles durability on its own schedule.
+                solrSearchCore.getSolr().commit(true, true, true);
             }
         } catch (IOException | SolrServerException e) {
             throw new SearchServiceException(e.getMessage(), e);

--- a/dspace-api/src/main/java/org/dspace/qaevent/service/impl/QAEventServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/qaevent/service/impl/QAEventServiceImpl.java
@@ -221,7 +221,7 @@ public class QAEventServiceImpl implements QAEventService {
     public void deleteEventByEventId(String id) {
         try {
             getSolr().deleteById(id);
-            getSolr().commit();
+            getSolr().commit(true, true, true);
         } catch (SolrServerException | IOException e) {
             throw new RuntimeException(e);
         }
@@ -231,7 +231,7 @@ public class QAEventServiceImpl implements QAEventService {
     public void deleteEventsByTargetId(UUID targetId) {
         try {
             getSolr().deleteByQuery(RESOURCE_UUID + ":" + targetId.toString());
-            getSolr().commit();
+            getSolr().commit(true, true, true);
         } catch (SolrServerException | IOException e) {
             throw new RuntimeException(e);
         }
@@ -347,7 +347,7 @@ public class QAEventServiceImpl implements QAEventService {
                 updateRequest.add(doc);
                 updateRequest.process(getSolr());
 
-                getSolr().commit();
+                getSolr().commit(true, true, true);
 
                 performAutomaticProcessingIfNeeded(context, dto);
             }

--- a/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java
@@ -680,7 +680,7 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
     public void removeIndex(String query) throws IOException,
         SolrServerException {
         solr.deleteByQuery(query);
-        solr.commit();
+        solr.commit(true, true, true);
     }
 
     @Override
@@ -751,7 +751,7 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
         }
 
         public void commit() throws IOException, SolrServerException {
-            solr.commit();
+            solr.commit(true, true, true);
         }
 
         /**
@@ -802,7 +802,7 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
 
         try {
             processor.execute("-isBot:true");
-            solr.commit();
+            solr.commit(true, true, true);
         } catch (SolrServerException | IOException ex) {
             log.error("Failed while marking robot accesses.", ex);
         }
@@ -1250,12 +1250,12 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
                 statisticsYearServer.request(contentStreamUpdateRequest);
             }
 
-            statisticsYearServer.commit(true, true);
+            statisticsYearServer.commit(true, true, true);
 
 
             //Delete contents of this year from our year query !
             solr.deleteByQuery(filterQuery.toString());
-            solr.commit(true, true);
+            solr.commit(true, true, true);
 
             log.info("Moved {} records into core: {}", totalRecords, coreName);
         }
@@ -1440,7 +1440,7 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
             //Now that all our new bitstream stats are in place, delete all the old ones !
             solr.deleteByQuery("-bundleName:[* TO *] AND type:" + Constants.BITSTREAM);
             //Commit everything to wrap up
-            solr.commit(true, true);
+            solr.commit(true, true, true);
             //Clean up our directory !
             FileUtils.deleteDirectory(tempDirectory);
         } catch (Exception e) {
@@ -1497,7 +1497,7 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
 
     @Override
     public void commit() throws IOException, SolrServerException {
-        solr.commit();
+        solr.commit(true, true, true);
     }
 
     protected void addDocumentsToFile(Context context, SolrDocumentList docs, File exportOutput)

--- a/dspace-api/src/main/java/org/dspace/statistics/util/StatisticsImporter.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/util/StatisticsImporter.java
@@ -386,7 +386,7 @@ public class StatisticsImporter {
 
             // Commit at the end because it takes a while
             try {
-                solr.commit();
+                solr.commit(true, true, true);
             } catch (SolrServerException sse) {
                 System.err.println("Error committing statistics to solr server!");
                 sse.printStackTrace();

--- a/dspace-api/src/main/java/org/dspace/util/SolrImportExport.java
+++ b/dspace-api/src/main/java/org/dspace/util/SolrImportExport.java
@@ -318,7 +318,7 @@ public class SolrImportExport {
 
             // commit changes
             HttpSolrClient origSolr = new HttpSolrClient.Builder(origSolrUrl).build();
-            origSolr.commit();
+            origSolr.commit(true, true, true);
 
             // swap back (statistics now going to actual core name in actual data dir)
             swapRequest = new CoreAdminRequest();
@@ -335,7 +335,7 @@ public class SolrImportExport {
             importIndex(tempIndexName, exportDir, origSolrUrl, false);
 
             // commit changes
-            origSolr.commit();
+            origSolr.commit(true, true, true);
 
             // unload now-temp core (temp core name)
             CoreAdminRequest.unloadCore(tempIndexName, false, false, adminSolr);
@@ -436,7 +436,7 @@ public class SolrImportExport {
             solr.request(contentStreamUpdateRequest);
         }
 
-        solr.commit(true, true);
+        solr.commit(true, true, true);
     }
 
     /**
@@ -473,7 +473,7 @@ public class SolrImportExport {
     public static void clearIndex(String solrUrl) throws IOException, SolrServerException {
         HttpSolrClient solr = new HttpSolrClient.Builder(solrUrl).build();
         solr.deleteByQuery("*:*");
-        solr.commit();
+        solr.commit(true, true, true);
         solr.optimize();
     }
 

--- a/dspace-api/src/main/java/org/dspace/util/SolrUpgradePre6xStatistics.java
+++ b/dspace-api/src/main/java/org/dspace/util/SolrUpgradePre6xStatistics.java
@@ -160,7 +160,7 @@ public class SolrUpgradePre6xStatistics {
     private void batchUpdateStats() throws SolrServerException, IOException {
         if (docs.size() > 0) {
             server.add(docs);
-            server.commit(true, true);
+            server.commit(true, true, true);
             docs.clear();
         }
     }

--- a/dspace-api/src/test/java/org/dspace/qaevent/MockQAEventService.java
+++ b/dspace-api/src/test/java/org/dspace/qaevent/MockQAEventService.java
@@ -33,7 +33,7 @@ public class MockQAEventService extends QAEventServiceImpl implements Initializi
     public void reset() {
         mockSolrServer.reset();
         try {
-            mockSolrServer.getSolrServer().commit();
+            mockSolrServer.getSolrServer().commit(true, true, true);
         } catch (SolrServerException | IOException e) {
             throw new RuntimeException(e);
         }

--- a/dspace-api/src/test/java/org/dspace/statistics/AnonymizeStatisticsIT.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/AnonymizeStatisticsIT.java
@@ -142,7 +142,7 @@ public class AnonymizeStatisticsIT
                 Pair.of("time", getTimeNDaysAgo(500))
         ));
 
-        solrStatisticsCore.getSolr().commit();
+        solrStatisticsCore.getSolr().commit(true, true, true);
 
         runDSpaceScript("anonymize-statistics");
 

--- a/dspace-api/src/test/java/org/dspace/statistics/SolrLoggerServiceImplIT.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/SolrLoggerServiceImplIT.java
@@ -327,7 +327,7 @@ public class SolrLoggerServiceImplIT
                 .getServiceByName(SolrStatisticsCore.class.getName(), MockSolrStatisticsCore.class);
 
         solrStatisticsCore.getSolr().deleteByQuery("*:*");
-        solrStatisticsCore.getSolr().commit();
+        solrStatisticsCore.getSolr().commit(true, true, true);
 
         context.turnOffAuthorisationSystem();
         Community community = CommunityBuilder
@@ -352,7 +352,7 @@ public class SolrLoggerServiceImplIT
         solrLoggerService.postView(originalBitstream, null, eperson);
         solrLoggerService.postView(thumbnailBitstream, null, eperson);
 
-        solrStatisticsCore.getSolr().commit();
+        solrStatisticsCore.getSolr().commit(true, true, true);
 
         SolrQuery thumbnailQuery = new SolrQuery("id:" + thumbnailBitstream.getID().toString());
         QueryResponse thumbnailResponse = solrStatisticsCore.getSolr().query(thumbnailQuery);

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
@@ -172,7 +172,7 @@ public class XOAI {
                 }
 
             }
-            solrServerResolver.getServer().commit();
+            solrServerResolver.getServer().commit(true, true, true);
 
             // Set last compilation date
             xoaiLastCompilationCacheService.put(Instant.now());
@@ -336,7 +336,7 @@ public class XOAI {
                 if (i % batchSize == 0) {
                     System.out.println(i + " items imported so far...");
                     server.add(list);
-                    server.commit();
+                    server.commit(true, true, true);
                     list.clear();
                     try {
                         context.uncacheEntities();
@@ -564,7 +564,7 @@ public class XOAI {
         try {
             System.out.println("Clearing index");
             solrServerResolver.getServer().deleteByQuery("*:*");
-            solrServerResolver.getServer().commit();
+            solrServerResolver.getServer().commit(true, true, true);
             System.out.println("Index cleared");
         } catch (SolrServerException | IOException ex) {
             throw new DSpaceSolrIndexerException(ex.getMessage(), ex);

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ViewEventRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ViewEventRestRepositoryIT.java
@@ -511,7 +511,7 @@ public class ViewEventRestRepositoryIT extends AbstractControllerIntegrationTest
                         .content(mapper.writeValueAsBytes(viewEventRest))
                         .contentType(contentType))
                 .andExpect(status().isCreated());
-        solrStatisticsCore.getSolr().commit();
+        solrStatisticsCore.getSolr().commit(true, true, true);
 
         // Query all statistics and verify it contains a document with the correct referrer
         SolrQuery solrQuery = new SolrQuery("*:*");


### PR DESCRIPTION
## References
Fixes https://github.com/DSpace/DSpace/issues/12153

## Description
Replace all hard commit calls (`solr.commit()`) with soft commits (`solr.commit(true, true, true)`) across all Solr services to eliminate expensive fsync + new searcher overhead.

## Instructions for Reviewers

List of changes in this PR:
* Switched all `solr.commit()` and `solr.commit(true, true)` calls to `solr.commit(true, true, true)` (soft commit with waitFlush + waitSearcher)
* Affected services: SolrServiceImpl, SolrLoggerServiceImpl, AuthoritySolrServiceImpl, QAEventServiceImpl, SolrSuggestionStorageServiceImpl, AuditSolrServiceImpl, SolrImportExport, StatisticsImporter, SolrUpgradePre6xStatistics, XOAI
* Also updated direct `getSolr().commit()` calls in test files

**Background**: Hard commits perform an fsync to disk and open a new IndexSearcher (re-opening all Lucene segments). Soft commits make documents visible in search results via a lightweight NRT (Near Real-Time) searcher without the fsync overhead. Solr's `autoCommit` (already configured in all DSpace solrconfig.xml files with `maxTime=10000`) handles writing data to disk on a 10-second schedule, providing durability automatically.

This is the [recommended Solr pattern](https://solr.apache.org/guide/solr/latest/indexing-guide/commits-and-transaction-logs.html): frequent soft commits for visibility, infrequent hard commits for durability.

**How to test**: Run the integration test suite and compare total execution time against a run without this change. On the Spring Boot 4 branch (Solr 10 / Lucene 10.3.2), this change reduced DiscoveryRestControllerIT (83 tests) from 70s to 43s locally. The improvement should also be significant on main (Solr 8).

## Checklist
- [x] My PR is **created against the `main` branch** of code.
- [x] My PR is **small in size** (less than 1,000 lines of code).
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_.
- [x] My PR **includes details on how to test it**.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).