### PR TITLE
Fix IndexEventConsumer commit condition and remove redundant Solr commits from builders

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/IndexEventConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexEventConsumer.java
@@ -240,7 +240,8 @@ public class IndexEventConsumer implements Consumer {
                 indexObject(ctx, iu, true);
             }
         } finally {
-            if (!objectsToUpdate.isEmpty() || !uniqueIdsToDelete.isEmpty()) {
+            if (!objectsToUpdate.isEmpty() || !uniqueIdsToDelete.isEmpty()
+                || !createdItemsToUpdate.isEmpty()) {
 
                 indexer.commit();
 

--- a/dspace-api/src/test/java/org/dspace/builder/AbstractCRUDBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/AbstractCRUDBuilder.java
@@ -38,7 +38,6 @@ public abstract class AbstractCRUDBuilder<T extends ReloadableEntity> extends Ab
             c.complete();
         }
 
-        indexingService.commit();
     }
 
 }

--- a/dspace-api/src/test/java/org/dspace/builder/AbstractDSpaceObjectBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/AbstractDSpaceObjectBuilder.java
@@ -287,6 +287,5 @@ public abstract class AbstractDSpaceObjectBuilder<T extends DSpaceObject>
             getService().delete(c, dso);
         }
         c.complete();
-        indexingService.commit();
     }
 }

--- a/dspace-api/src/test/java/org/dspace/builder/BitstreamBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/BitstreamBuilder.java
@@ -255,7 +255,6 @@ public class BitstreamBuilder extends AbstractDSpaceObjectBuilder<Bitstream> {
 
             context.dispatchEvents();
 
-            indexingService.commit();
 
         } catch (Exception e) {
             return null;

--- a/dspace-api/src/test/java/org/dspace/builder/BitstreamFormatBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/BitstreamFormatBuilder.java
@@ -14,7 +14,6 @@ import org.apache.logging.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.BitstreamFormat;
 import org.dspace.core.Context;
-import org.dspace.discovery.SearchServiceException;
 import org.dspace.service.DSpaceCRUDService;
 
 /**
@@ -42,7 +41,6 @@ public class BitstreamFormatBuilder extends AbstractCRUDBuilder<BitstreamFormat>
                 delete(c, bitstreamFormat);
             }
             c.complete();
-            indexingService.commit();
         }
     }
 
@@ -65,12 +63,7 @@ public class BitstreamFormatBuilder extends AbstractCRUDBuilder<BitstreamFormat>
             bitstreamFormatService.update(context, bitstreamFormat);
             context.dispatchEvents();
 
-            indexingService.commit();
-        } catch (SearchServiceException e) {
-            log.error(e);
-        } catch (SQLException e) {
-            log.error(e);
-        } catch (AuthorizeException e) {
+        } catch (Exception e) {
             log.error(e);
         }
         return bitstreamFormat;

--- a/dspace-api/src/test/java/org/dspace/builder/ClaimedTaskBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/ClaimedTaskBuilder.java
@@ -97,7 +97,6 @@ public class ClaimedTaskBuilder extends AbstractBuilder<ClaimedTask, ClaimedTask
             // restore the submitter as current user
             context.setCurrentUser(submitter);
             context.dispatchEvents();
-            indexingService.commit();
             return claimedTask;
         } catch (Exception e) {
             return handleException(e);

--- a/dspace-api/src/test/java/org/dspace/builder/CollectionBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/CollectionBuilder.java
@@ -266,7 +266,6 @@ public class CollectionBuilder extends AbstractDSpaceObjectBuilder<Collection> {
         try {
             collectionService.update(context, collection);
             context.dispatchEvents();
-            indexingService.commit();
 
         } catch (Exception e) {
             return handleException(e);
@@ -367,7 +366,6 @@ public class CollectionBuilder extends AbstractDSpaceObjectBuilder<Collection> {
                 }
             }
             c.complete();
-            indexingService.commit();
        }
     }
 

--- a/dspace-api/src/test/java/org/dspace/builder/CommunityBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/CommunityBuilder.java
@@ -121,7 +121,6 @@ public class CommunityBuilder extends AbstractDSpaceObjectBuilder<Community> {
             communityService.update(context, community);
             context.dispatchEvents();
 
-            indexingService.commit();
         } catch (Exception e) {
             e.printStackTrace();
             return null;

--- a/dspace-api/src/test/java/org/dspace/builder/EPersonBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/EPersonBuilder.java
@@ -16,7 +16,6 @@ import org.apache.logging.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.service.DSpaceObjectService;
 import org.dspace.core.Context;
-import org.dspace.discovery.SearchServiceException;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
 
@@ -52,8 +51,7 @@ public class EPersonBuilder extends AbstractDSpaceObjectBuilder<EPerson> {
     public EPerson build() {
         try {
             ePersonService.update(context, ePerson);
-            indexingService.commit();
-        } catch (SearchServiceException | SQLException | AuthorizeException e) {
+        } catch (SQLException | AuthorizeException e) {
             LOG.warn("Failed to complete the EPerson", e);
         }
         return ePerson;

--- a/dspace-api/src/test/java/org/dspace/builder/EntityTypeBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/EntityTypeBuilder.java
@@ -15,7 +15,6 @@ import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.EntityType;
 import org.dspace.content.service.EntityTypeService;
 import org.dspace.core.Context;
-import org.dspace.discovery.SearchServiceException;
 
 public class EntityTypeBuilder extends AbstractBuilder<EntityType, EntityTypeService> {
 
@@ -44,7 +43,6 @@ public class EntityTypeBuilder extends AbstractBuilder<EntityType, EntityTypeSer
                 delete(entityType);
             }
             c.complete();
-            indexingService.commit();
         }
     }
 
@@ -62,8 +60,7 @@ public class EntityTypeBuilder extends AbstractBuilder<EntityType, EntityTypeSer
             entityTypeService.update(context, entityType);
             context.dispatchEvents();
 
-            indexingService.commit();
-        } catch (SearchServiceException | SQLException | AuthorizeException e) {
+        } catch (SQLException | AuthorizeException e) {
             log.error(e);
         }
         return entityType;
@@ -79,7 +76,6 @@ public class EntityTypeBuilder extends AbstractBuilder<EntityType, EntityTypeSer
             c.complete();
         }
 
-        indexingService.commit();
     }
 
     public static EntityTypeBuilder createEntityTypeBuilder(Context context, String entityType) {

--- a/dspace-api/src/test/java/org/dspace/builder/ItemBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/ItemBuilder.java
@@ -510,7 +510,6 @@ public class ItemBuilder extends AbstractDSpaceObjectBuilder<Item> {
                 item.setArchived(inArchive);
             }
             context.dispatchEvents();
-            indexingService.commit();
             return item;
         } catch (Exception e) {
             return handleException(e);

--- a/dspace-api/src/test/java/org/dspace/builder/LDNMessageBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/LDNMessageBuilder.java
@@ -15,7 +15,6 @@ import org.dspace.app.ldn.LDNMessageEntity;
 import org.dspace.app.ldn.model.Notification;
 import org.dspace.app.ldn.service.LDNMessageService;
 import org.dspace.core.Context;
-import org.dspace.discovery.SearchServiceException;
 
 /**
  * Builder for {@link LDNMessageEntity} entities.
@@ -50,7 +49,6 @@ public class LDNMessageBuilder extends AbstractBuilder<LDNMessageEntity, LDNMess
                 delete(ldnMessageEntity);
             }
             c.complete();
-            indexingService.commit();
         }
     }
 
@@ -68,8 +66,7 @@ public class LDNMessageBuilder extends AbstractBuilder<LDNMessageEntity, LDNMess
             ldnMessageService.update(context, ldnMessageEntity);
             context.dispatchEvents();
 
-            indexingService.commit();
-        } catch (SearchServiceException | SQLException e) {
+        } catch (SQLException e) {
             log.error(e);
         }
         return ldnMessageEntity;
@@ -85,7 +82,6 @@ public class LDNMessageBuilder extends AbstractBuilder<LDNMessageEntity, LDNMess
             c.complete();
         }
 
-        indexingService.commit();
     }
 
     public static LDNMessageBuilder createNotifyServiceBuilder(Context context, String id) {

--- a/dspace-api/src/test/java/org/dspace/builder/MetadataFieldBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/MetadataFieldBuilder.java
@@ -17,7 +17,6 @@ import org.dspace.content.MetadataSchema;
 import org.dspace.content.NonUniqueMetadataException;
 import org.dspace.content.service.MetadataFieldService;
 import org.dspace.core.Context;
-import org.dspace.discovery.SearchServiceException;
 
 public class MetadataFieldBuilder extends AbstractBuilder<MetadataField, MetadataFieldService> {
 
@@ -46,7 +45,6 @@ public class MetadataFieldBuilder extends AbstractBuilder<MetadataField, Metadat
                 delete(c, metadataField);
             }
             c.complete();
-            indexingService.commit();
         }
     }
 
@@ -64,8 +62,7 @@ public class MetadataFieldBuilder extends AbstractBuilder<MetadataField, Metadat
             metadataFieldService.update(context, metadataField);
             context.dispatchEvents();
 
-            indexingService.commit();
-        } catch (SearchServiceException | SQLException | AuthorizeException
+        } catch (SQLException | AuthorizeException
                 | NonUniqueMetadataException | IOException e) {
             log.error("Failed to complete MetadataField", e);
         }
@@ -82,7 +79,6 @@ public class MetadataFieldBuilder extends AbstractBuilder<MetadataField, Metadat
             c.complete();
         }
 
-        indexingService.commit();
     }
 
     /**

--- a/dspace-api/src/test/java/org/dspace/builder/MetadataSchemaBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/MetadataSchemaBuilder.java
@@ -16,7 +16,6 @@ import org.dspace.content.MetadataSchema;
 import org.dspace.content.NonUniqueMetadataException;
 import org.dspace.content.service.MetadataSchemaService;
 import org.dspace.core.Context;
-import org.dspace.discovery.SearchServiceException;
 
 public class MetadataSchemaBuilder extends AbstractBuilder<MetadataSchema, MetadataSchemaService> {
 
@@ -45,7 +44,6 @@ public class MetadataSchemaBuilder extends AbstractBuilder<MetadataSchema, Metad
                 delete(c, metadataSchema);
             }
             c.complete();
-            indexingService.commit();
         }
     }
 
@@ -63,8 +61,7 @@ public class MetadataSchemaBuilder extends AbstractBuilder<MetadataSchema, Metad
             metadataSchemaService.update(context, metadataSchema);
             context.dispatchEvents();
 
-            indexingService.commit();
-        } catch (SearchServiceException | SQLException | AuthorizeException e) {
+        } catch (SQLException | AuthorizeException e) {
             log.error(e);
         } catch (NonUniqueMetadataException e) {
             log.error("Failed to complete MetadataSchema", e);
@@ -82,7 +79,6 @@ public class MetadataSchemaBuilder extends AbstractBuilder<MetadataSchema, Metad
             c.complete();
         }
 
-        indexingService.commit();
     }
 
     /**

--- a/dspace-api/src/test/java/org/dspace/builder/NotifyServiceBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/NotifyServiceBuilder.java
@@ -15,7 +15,6 @@ import org.apache.logging.log4j.Logger;
 import org.dspace.app.ldn.NotifyServiceEntity;
 import org.dspace.app.ldn.service.NotifyService;
 import org.dspace.core.Context;
-import org.dspace.discovery.SearchServiceException;
 
 /**
  * Builder for {@link NotifyServiceEntity} entities.
@@ -50,7 +49,6 @@ public class NotifyServiceBuilder extends AbstractBuilder<NotifyServiceEntity, N
                 delete(notifyServiceEntity);
             }
             c.complete();
-            indexingService.commit();
         }
     }
 
@@ -68,8 +66,7 @@ public class NotifyServiceBuilder extends AbstractBuilder<NotifyServiceEntity, N
             notifyService.update(context, notifyServiceEntity);
             context.dispatchEvents();
 
-            indexingService.commit();
-        } catch (SearchServiceException | SQLException e) {
+        } catch (SQLException e) {
             log.error(e);
         }
         return notifyServiceEntity;
@@ -85,7 +82,6 @@ public class NotifyServiceBuilder extends AbstractBuilder<NotifyServiceEntity, N
             c.complete();
         }
 
-        indexingService.commit();
     }
 
     public static NotifyServiceBuilder createNotifyServiceBuilder(Context context, String name) {

--- a/dspace-api/src/test/java/org/dspace/builder/NotifyServiceInboundPatternBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/NotifyServiceInboundPatternBuilder.java
@@ -15,7 +15,6 @@ import org.dspace.app.ldn.NotifyServiceEntity;
 import org.dspace.app.ldn.NotifyServiceInboundPattern;
 import org.dspace.app.ldn.service.NotifyServiceInboundPatternService;
 import org.dspace.core.Context;
-import org.dspace.discovery.SearchServiceException;
 
 /**
  * Builder for {@link NotifyServiceInboundPattern} entities.
@@ -51,7 +50,6 @@ public class NotifyServiceInboundPatternBuilder
                 delete(notifyServiceInboundPattern);
             }
             c.complete();
-            indexingService.commit();
         }
     }
 
@@ -69,8 +67,7 @@ public class NotifyServiceInboundPatternBuilder
             inboundPatternService.update(context, notifyServiceInboundPattern);
             context.dispatchEvents();
 
-            indexingService.commit();
-        } catch (SearchServiceException | SQLException e) {
+        } catch (SQLException e) {
             log.error(e);
         }
         return notifyServiceInboundPattern;
@@ -86,7 +83,6 @@ public class NotifyServiceInboundPatternBuilder
             c.complete();
         }
 
-        indexingService.commit();
     }
 
     public static NotifyServiceInboundPatternBuilder createNotifyServiceInboundPatternBuilder(

--- a/dspace-api/src/test/java/org/dspace/builder/OrcidHistoryBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/OrcidHistoryBuilder.java
@@ -64,7 +64,6 @@ public class OrcidHistoryBuilder extends  AbstractBuilder<OrcidHistory, OrcidHis
             getService().update(context, orcidHistory);
             context.dispatchEvents();
 
-            indexingService.commit();
         } catch (Exception e) {
             log.error("Error in OrcidHistoryBuilder.build(), error: ", e);
         }
@@ -108,7 +107,6 @@ public class OrcidHistoryBuilder extends  AbstractBuilder<OrcidHistory, OrcidHis
             }
             c.complete();
         }
-        indexingService.commit();
     }
 
     public OrcidHistoryBuilder withResponseMessage(String responseMessage) throws SQLException {

--- a/dspace-api/src/test/java/org/dspace/builder/OrcidQueueBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/OrcidQueueBuilder.java
@@ -92,7 +92,6 @@ public class OrcidQueueBuilder extends  AbstractBuilder<OrcidQueue, OrcidQueueSe
             getService().update(context, orcidQueue);
             context.dispatchEvents();
 
-            indexingService.commit();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -140,7 +139,6 @@ public class OrcidQueueBuilder extends  AbstractBuilder<OrcidQueue, OrcidQueueSe
             }
             c.complete();
         }
-        indexingService.commit();
     }
 
 }

--- a/dspace-api/src/test/java/org/dspace/builder/PoolTaskBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/PoolTaskBuilder.java
@@ -77,7 +77,6 @@ public class PoolTaskBuilder extends AbstractBuilder<PoolTask, PoolTaskService> 
             workspaceItem = null;
             poolTask = getService().findByWorkflowIdAndEPerson(context, workflowItem, user);
             context.dispatchEvents();
-            indexingService.commit();
             return poolTask;
         } catch (Exception e) {
             return handleException(e);
@@ -117,7 +116,6 @@ public class PoolTaskBuilder extends AbstractBuilder<PoolTask, PoolTaskService> 
             WorkflowItemBuilder.deleteWorkflowItem(workflowItem.getID());
             }
             c.complete();
-            indexingService.commit();
         }
     }
 

--- a/dspace-api/src/test/java/org/dspace/builder/ProcessBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/ProcessBuilder.java
@@ -91,7 +91,6 @@ public class ProcessBuilder extends AbstractBuilder<Process, ProcessService> {
                 delete(c, process);
             }
             c.complete();
-            indexingService.commit();
         }
     }
 
@@ -100,7 +99,6 @@ public class ProcessBuilder extends AbstractBuilder<Process, ProcessService> {
         try {
             processService.update(context, process);
             context.dispatchEvents();
-            indexingService.commit();
         } catch (Exception e) {
             return null;
         }

--- a/dspace-api/src/test/java/org/dspace/builder/QAEventBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/QAEventBuilder.java
@@ -66,7 +66,6 @@ public class QAEventBuilder extends AbstractBuilder<QAEvent, QAEventService> {
             item = itemBuilder.build();
             this.title = name;
             context.dispatchEvents();
-            indexingService.commit();
         } catch (Exception e) {
             return handleException(e);
         }

--- a/dspace-api/src/test/java/org/dspace/builder/RelationshipBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/RelationshipBuilder.java
@@ -18,7 +18,6 @@ import org.dspace.content.Relationship;
 import org.dspace.content.RelationshipType;
 import org.dspace.content.service.RelationshipService;
 import org.dspace.core.Context;
-import org.dspace.discovery.SearchServiceException;
 
 public class RelationshipBuilder extends AbstractBuilder<Relationship, RelationshipService> {
 
@@ -47,7 +46,6 @@ public class RelationshipBuilder extends AbstractBuilder<Relationship, Relations
                 delete(c, relationship);
             }
             c.complete();
-            indexingService.commit();
         }
     }
 
@@ -65,8 +63,7 @@ public class RelationshipBuilder extends AbstractBuilder<Relationship, Relations
             relationshipService.update(context, relationship);
             context.dispatchEvents();
 
-            indexingService.commit();
-        } catch (SearchServiceException | SQLException | AuthorizeException e) {
+        } catch (SQLException | AuthorizeException e) {
             log.error(e);
         }
         return relationship;
@@ -82,7 +79,6 @@ public class RelationshipBuilder extends AbstractBuilder<Relationship, Relations
             c.complete();
         }
 
-        indexingService.commit();
     }
 
     /**

--- a/dspace-api/src/test/java/org/dspace/builder/RelationshipTypeBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/RelationshipTypeBuilder.java
@@ -16,7 +16,6 @@ import org.dspace.content.EntityType;
 import org.dspace.content.RelationshipType;
 import org.dspace.content.service.RelationshipTypeService;
 import org.dspace.core.Context;
-import org.dspace.discovery.SearchServiceException;
 
 public class RelationshipTypeBuilder extends AbstractBuilder<RelationshipType, RelationshipTypeService> {
 
@@ -45,7 +44,6 @@ public class RelationshipTypeBuilder extends AbstractBuilder<RelationshipType, R
                 delete(c, relationshipType);
             }
             c.complete();
-            indexingService.commit();
         }
 
     }
@@ -64,8 +62,7 @@ public class RelationshipTypeBuilder extends AbstractBuilder<RelationshipType, R
             relationshipTypeService.update(context, relationshipType);
             context.dispatchEvents();
 
-            indexingService.commit();
-        } catch (SearchServiceException | SQLException | AuthorizeException e) {
+        } catch (SQLException | AuthorizeException e) {
             log.error(e);
         }
         return relationshipType;
@@ -81,7 +78,6 @@ public class RelationshipTypeBuilder extends AbstractBuilder<RelationshipType, R
             c.complete();
         }
 
-        indexingService.commit();
     }
 
     public static RelationshipTypeBuilder createRelationshipTypeBuilder(Context context, EntityType leftType,

--- a/dspace-api/src/test/java/org/dspace/builder/ResourcePolicyBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/ResourcePolicyBuilder.java
@@ -18,7 +18,6 @@ import org.dspace.authorize.ResourcePolicy;
 import org.dspace.authorize.service.ResourcePolicyService;
 import org.dspace.content.DSpaceObject;
 import org.dspace.core.Context;
-import org.dspace.discovery.SearchServiceException;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
 
@@ -49,7 +48,6 @@ public class ResourcePolicyBuilder extends AbstractBuilder<ResourcePolicy, Resou
                 delete(c, resourcePolicy);
             }
             c.complete();
-            indexingService.commit();
         }
     }
 
@@ -67,14 +65,8 @@ public class ResourcePolicyBuilder extends AbstractBuilder<ResourcePolicy, Resou
             resourcePolicyService.update(context, resourcePolicy);
             context.dispatchEvents();
 
-            indexingService.commit();
-        } catch (SearchServiceException e) {
+        } catch (Exception e) {
             log.error(e);
-        } catch (SQLException e) {
-            log.error(e);
-        } catch (AuthorizeException e) {
-            log.error(e);
-            ;
         }
         return resourcePolicy;
     }
@@ -90,11 +82,10 @@ public class ResourcePolicyBuilder extends AbstractBuilder<ResourcePolicy, Resou
             c.complete();
         }
 
-        indexingService.commit();
     }
 
     public static void delete(Integer id)
-            throws SQLException, IOException, SearchServiceException {
+            throws SQLException, IOException {
         try (Context c = new Context()) {
             c.turnOffAuthorisationSystem();
             ResourcePolicy rp = resourcePolicyService.find(c, id);
@@ -107,7 +98,6 @@ public class ResourcePolicyBuilder extends AbstractBuilder<ResourcePolicy, Resou
             }
             c.complete();
         }
-        indexingService.commit();
     }
 
     public static ResourcePolicyBuilder createResourcePolicy(Context context, EPerson ePerson,

--- a/dspace-api/src/test/java/org/dspace/builder/SiteBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/SiteBuilder.java
@@ -36,7 +36,6 @@ public class SiteBuilder extends AbstractDSpaceObjectBuilder<Site> {
 
             context.dispatchEvents();
 
-            indexingService.commit();
             return site;
         } catch (Exception e) {
             return handleException(e);

--- a/dspace-api/src/test/java/org/dspace/builder/SubscribeBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/SubscribeBuilder.java
@@ -16,7 +16,6 @@ import org.apache.logging.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.DSpaceObject;
 import org.dspace.core.Context;
-import org.dspace.discovery.SearchServiceException;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Subscription;
 import org.dspace.eperson.SubscriptionParameter;
@@ -48,7 +47,6 @@ public class SubscribeBuilder extends AbstractBuilder<Subscription, SubscribeSer
                 delete(c, subscription);
             }
             c.complete();
-            indexingService.commit();
         }
     }
 
@@ -65,19 +63,11 @@ public class SubscribeBuilder extends AbstractBuilder<Subscription, SubscribeSer
             }
             c.complete();
         }
-        indexingService.commit();
     }
 
     @Override
     public Subscription build() {
-        try {
-
-            context.dispatchEvents();
-
-            indexingService.commit();
-        } catch (SearchServiceException  e) {
-            log.error(e);
-        }
+        context.dispatchEvents();
         return subscription;
     }
 

--- a/dspace-api/src/test/java/org/dspace/builder/SuggestionTargetBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/SuggestionTargetBuilder.java
@@ -71,7 +71,6 @@ public class SuggestionTargetBuilder extends AbstractBuilder<SuggestionTarget, S
             }
             item = itemBuilder.build();
             context.dispatchEvents();
-            indexingService.commit();
         } catch (Exception e) {
             return handleException(e);
         }

--- a/dspace-api/src/test/java/org/dspace/builder/SupervisionOrderBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/SupervisionOrderBuilder.java
@@ -60,7 +60,6 @@ public class SupervisionOrderBuilder
         try {
             getService().update(context, supervisionOrder);
             context.dispatchEvents();
-            indexingService.commit();
         } catch (Exception e) {
             log.error("Error in SupervisionOrderBuilder.build(), error: ", e);
         }
@@ -88,7 +87,6 @@ public class SupervisionOrderBuilder
                 getService().delete(context, attached);
             }
             context.complete();
-            indexingService.commit();
         }
     }
 }

--- a/dspace-api/src/test/java/org/dspace/builder/SystemWideAlertBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/SystemWideAlertBuilder.java
@@ -64,7 +64,6 @@ public class SystemWideAlertBuilder extends AbstractBuilder<SystemWideAlert, Sys
                 delete(c, systemWideAlert);
             }
             c.complete();
-            indexingService.commit();
         }
     }
 
@@ -73,7 +72,6 @@ public class SystemWideAlertBuilder extends AbstractBuilder<SystemWideAlert, Sys
         try {
             systemWideAlertService.update(context, systemWideAlert);
             context.dispatchEvents();
-            indexingService.commit();
         } catch (Exception e) {
             return null;
         }

--- a/dspace-api/src/test/java/org/dspace/builder/VersionBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/VersionBuilder.java
@@ -59,7 +59,6 @@ public class VersionBuilder extends AbstractBuilder<Version, VersioningService> 
         try {
             getService().update(context, version);
             context.dispatchEvents();
-            indexingService.commit();
         } catch (Exception e) {
             log.error("Error in VersionBuilder.build(), error: ", e);
         }
@@ -93,7 +92,6 @@ public class VersionBuilder extends AbstractBuilder<Version, VersioningService> 
             }
             context.complete();
         }
-        indexingService.commit();
     }
 
     public static void delete(Integer id)
@@ -106,7 +104,6 @@ public class VersionBuilder extends AbstractBuilder<Version, VersioningService> 
             }
             context.complete();
         }
-        indexingService.commit();
     }
 
 }

--- a/dspace-api/src/test/java/org/dspace/builder/WorkflowItemBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/WorkflowItemBuilder.java
@@ -77,7 +77,6 @@ public class WorkflowItemBuilder extends AbstractBuilder<XmlWorkflowItem, XmlWor
             workflowItem = workflowService.start(context, workspaceItem);
             workspaceItem = null;
             context.dispatchEvents();
-            indexingService.commit();
             return workflowItem;
         } catch (Exception e) {
             return handleException(e);
@@ -132,7 +131,6 @@ public class WorkflowItemBuilder extends AbstractBuilder<XmlWorkflowItem, XmlWor
                 deleteItem(c, item);
             }
             c.complete();
-            indexingService.commit();
         }
     }
 
@@ -342,7 +340,6 @@ public class WorkflowItemBuilder extends AbstractBuilder<XmlWorkflowItem, XmlWor
             }
             c.complete();
         }
-        indexingService.commit();
     }
 
 }

--- a/dspace-api/src/test/java/org/dspace/builder/WorkspaceItemBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/WorkspaceItemBuilder.java
@@ -83,7 +83,6 @@ public class WorkspaceItemBuilder extends AbstractBuilder<WorkspaceItem, Workspa
     public WorkspaceItem build() {
         try {
             context.dispatchEvents();
-            indexingService.commit();
             return workspaceItem;
         } catch (Exception e) {
             return handleException(e);
@@ -152,7 +151,6 @@ public class WorkspaceItemBuilder extends AbstractBuilder<WorkspaceItem, Workspa
                 deleteItem(c, item);
             }
             c.complete();
-            indexingService.commit();
         }
     }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/CanSubscribeFeatureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/CanSubscribeFeatureIT.java
@@ -42,7 +42,6 @@ import org.dspace.content.Community;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.core.Constants;
-import org.dspace.discovery.SearchServiceException;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
 import org.hamcrest.Matchers;
@@ -301,7 +300,7 @@ public class CanSubscribeFeatureIT extends AbstractControllerIntegrationTest {
             for (ResourcePolicy resourcePolicy : resourcePolicies) {
                 ResourcePolicyBuilder.delete(resourcePolicy.getID());
             }
-        } catch (SQLException | SearchServiceException | IOException sqlException) {
+        } catch (SQLException | IOException sqlException) {
             log.error(sqlException.getMessage());
         }
     }


### PR DESCRIPTION
## References
Fixes https://github.com/DSpace/DSpace/issues/12156

## Description
Fix a bug in IndexEventConsumer where `createdItemsToUpdate` was not checked in the commit condition, and remove ~65 redundant `indexingService.commit()` calls from test builder classes.

## Instructions for Reviewers

List of changes in this PR:

* **Bug fix**: `IndexEventConsumer.end()` now checks `createdItemsToUpdate` in addition to `objectsToUpdate` and `uniqueIdsToDelete` before deciding to commit. Previously, documents indexed via the `createdItemsToUpdate` path (Collection ADD events with Item objects) could be left uncommitted.

* **Remove redundant builder commits**: Every builder's `build()` method called `context.dispatchEvents()` (which triggers `IndexEventConsumer.end()` -> `indexer.commit()`) and then immediately called `indexingService.commit()` again. The second commit was redundant. Removed from all 31 builder classes.

* **Remove per-object delete commits**: `AbstractDSpaceObjectBuilder.delete()` called `indexingService.commit()` after each deleted object during test teardown. Since `MockSolrServer.reset()` (called later in the teardown) clears the entire index via `deleteByQuery("*:*")`, individual delete commits are wasteful.

* **Cleanup**: Removed now-unused `SearchServiceException` catch blocks and imports from affected builders and one test class.

**How to test**: Run the full integration test suite. All tests should pass. The number of Solr commits per test class should be reduced by approximately 50% (from ~1,966 to ~1,000 for DiscoveryRestControllerIT).

## Checklist
- [x] My PR is **created against the `main` branch** of code.
- [x] My PR is **small in size** (108 lines removed, 16 added).
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes details on how to test it**.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).