### PR TITLE
[PROFILING] Hibernate statistics comparison for SB4 investigation

### DIFF
--- a/dspace-server-webapp/pom.xml
+++ b/dspace-server-webapp/pom.xml
@@ -183,6 +183,16 @@
                                     <fileset dir="${project.build.directory}" includes="perf-detail.csv" />
                                 </concat>
                                 <echo message="=== END PERF-DETAIL ===" />
+                                <echo message="=== PERF-COLLECTIONS (method;collRecreate;collRemove;collUpdate;mdRecreate;mdRemove;polRecreate;polRemove;hdlRecreate;hdlRemove) ===" />
+                                <concat>
+                                    <fileset dir="${project.build.directory}" includes="perf-collections.csv" />
+                                </concat>
+                                <echo message="=== END PERF-COLLECTIONS ===" />
+                                <echo message="=== PERF-ROLES ===" />
+                                <concat>
+                                    <fileset dir="${project.build.directory}" includes="perf-roles.csv" />
+                                </concat>
+                                <echo message="=== END PERF-ROLES ===" />
                             </target>
                         </configuration>
                     </execution>

--- a/dspace-server-webapp/pom.xml
+++ b/dspace-server-webapp/pom.xml
@@ -161,6 +161,33 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- Print per-class and per-method performance summary after integration tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>print-perf-summary</id>
+                        <phase>post-integration-test</phase>
+                        <goals><goal>run</goal></goals>
+                        <configuration>
+                            <target>
+                                <echo message="=== PERF-SUMMARY (class;tests;wallMs;cpuMs;cpuRatio%;procs) ===" />
+                                <concat>
+                                    <fileset dir="${project.build.directory}" includes="perf-summary.csv" />
+                                </concat>
+                                <echo message="=== END PERF-SUMMARY ===" />
+                                <echo message="=== PERF-DETAIL (method;wallMs;cpuMs;queries;entityLoads;inserts;updates;deletes;flushes;collLoads;maxQMs;maxQuery) ===" />
+                                <concat>
+                                    <fileset dir="${project.build.directory}" includes="perf-detail.csv" />
+                                </concat>
+                                <echo message="=== END PERF-DETAIL ===" />
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/test/AbstractControllerIntegrationTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/test/AbstractControllerIntegrationTest.java
@@ -196,9 +196,38 @@ public class AbstractControllerIntegrationTest extends AbstractIntegrationTestWi
                         new FileWriter("target/perf-detail.csv", true))) {
                     pw.println(detail);
                 }
+
+                // Collection recreation stats (bag hypothesis verification)
+                String collDetail = method
+                    + ";" + stats.getCollectionRecreateCount()
+                    + ";" + stats.getCollectionRemoveCount()
+                    + ";" + stats.getCollectionUpdateCount()
+                    + collStats(stats, "org.dspace.content.DSpaceObject.metadata")
+                    + collStats(stats, "org.dspace.content.DSpaceObject.resourcePolicies")
+                    + collStats(stats, "org.dspace.content.DSpaceObject.handles");
+                try (PrintWriter pw = new PrintWriter(
+                        new FileWriter("target/perf-collections.csv", true))) {
+                    pw.println(collDetail);
+                }
             } catch (Exception e) {
                 // ignore -- stats not available
             }
+        }
+    }
+
+    /**
+     * Get recreation and removal counts for a specific collection role.
+     *
+     * @param stats the Hibernate statistics
+     * @param role the collection role name
+     * @return CSV fragment: ;recreates;removes
+     */
+    private static String collStats(org.hibernate.stat.Statistics stats, String role) {
+        try {
+            org.hibernate.stat.CollectionStatistics cs = stats.getCollectionStatistics(role);
+            return ";" + cs.getRecreateCount() + ";" + cs.getRemoveCount();
+        } catch (Exception e) {
+            return ";-1;-1";
         }
     }
 
@@ -233,6 +262,20 @@ public class AbstractControllerIntegrationTest extends AbstractIntegrationTestWi
             } catch (IOException e) {
                 // silently ignore
             }
+        }
+        // Dump all collection role names (once) so we know what Hibernate tracks
+        try {
+            org.hibernate.SessionFactory sf = DSpaceServicesFactory.getInstance()
+                .getServiceManager()
+                .getServiceByName("sessionFactory", org.hibernate.SessionFactory.class);
+            String[] roles = sf.getStatistics().getCollectionRoleNames();
+            try (PrintWriter pw = new PrintWriter(new FileWriter("target/perf-roles.csv", true))) {
+                for (String role : roles) {
+                    pw.println(role);
+                }
+            }
+        } catch (Exception e) {
+            // ignore
         }
     }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/test/AbstractControllerIntegrationTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/test/AbstractControllerIntegrationTest.java
@@ -12,10 +12,16 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
 
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.lang.management.ManagementFactory;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -30,7 +36,13 @@ import org.dspace.app.rest.model.patch.Operation;
 import org.dspace.app.rest.security.DSpaceCsrfTokenRepository;
 import org.dspace.app.rest.utils.DSpaceConfigurationInitializer;
 import org.dspace.app.rest.utils.DSpaceKernelInitializer;
+import org.dspace.services.factory.DSpaceServicesFactory;
+import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -83,6 +95,20 @@ public class AbstractControllerIntegrationTest extends AbstractIntegrationTestWi
 
     private static final Logger log = org.apache.logging.log4j.LogManager.getLogger();
 
+    // Per-test performance instrumentation (collected per class, printed in @AfterClass)
+    private long perfTestStartNanos;
+    private long perfTestStartCpuNanos;
+    private static final AtomicLong perfTotalWallMs = new AtomicLong();
+    private static final AtomicLong perfTotalCpuMs = new AtomicLong();
+    private static final AtomicInteger perfTestCount = new AtomicInteger();
+    private static final AtomicInteger perfProcs = new AtomicInteger();
+
+    // Per-method Hibernate profiling -- only collected for the target class to keep logs small
+    private static final String PERF_DETAIL_CLASS = "LeftTiltedRelationshipRestRepositoryIT";
+
+    @Rule
+    public TestName perfTestName = new TestName();
+
     protected static final String AUTHORIZATION_HEADER = "Authorization";
     protected static final String AUTHORIZATION_COOKIE = "Authorization-cookie";
 
@@ -118,6 +144,96 @@ public class AbstractControllerIntegrationTest extends AbstractIntegrationTestWi
 
         Assert.assertNotNull("the JSON message converter must not be null",
                              this.mappingJackson2HttpMessageConverter);
+    }
+
+    @Before
+    public void perfTimerStart() {
+        perfTestStartNanos = System.nanoTime();
+        perfTestStartCpuNanos = ManagementFactory.getThreadMXBean().getCurrentThreadCpuTime();
+        if (PERF_DETAIL_CLASS.equals(getClass().getSimpleName())) {
+            try {
+                org.hibernate.SessionFactory sf = DSpaceServicesFactory.getInstance()
+                    .getServiceManager()
+                    .getServiceByName("sessionFactory", org.hibernate.SessionFactory.class);
+                sf.getStatistics().setStatisticsEnabled(true);
+                sf.getStatistics().clear();
+            } catch (Exception e) {
+                // ignore -- stats not available
+            }
+        }
+    }
+
+    @After
+    public void perfTimerEnd() {
+        long wallMs = (System.nanoTime() - perfTestStartNanos) / 1_000_000;
+        long cpuMs = (ManagementFactory.getThreadMXBean().getCurrentThreadCpuTime()
+                      - perfTestStartCpuNanos) / 1_000_000;
+        perfTotalWallMs.addAndGet(wallMs);
+        perfTotalCpuMs.addAndGet(cpuMs);
+        perfTestCount.incrementAndGet();
+        perfProcs.set(Runtime.getRuntime().availableProcessors());
+
+        if (PERF_DETAIL_CLASS.equals(getClass().getSimpleName())) {
+            try {
+                org.hibernate.SessionFactory sf = DSpaceServicesFactory.getInstance()
+                    .getServiceManager()
+                    .getServiceByName("sessionFactory", org.hibernate.SessionFactory.class);
+                org.hibernate.stat.Statistics stats = sf.getStatistics();
+                String method = perfTestName.getMethodName();
+                String detail = method
+                    + ";" + wallMs
+                    + ";" + cpuMs
+                    + ";" + stats.getQueryExecutionCount()
+                    + ";" + stats.getEntityLoadCount()
+                    + ";" + stats.getEntityInsertCount()
+                    + ";" + stats.getEntityUpdateCount()
+                    + ";" + stats.getEntityDeleteCount()
+                    + ";" + stats.getFlushCount()
+                    + ";" + stats.getCollectionLoadCount()
+                    + ";" + stats.getQueryExecutionMaxTime()
+                    + ";" + sanitize(stats.getQueryExecutionMaxTimeQueryString());
+                try (PrintWriter pw = new PrintWriter(
+                        new FileWriter("target/perf-detail.csv", true))) {
+                    pw.println(detail);
+                }
+            } catch (Exception e) {
+                // ignore -- stats not available
+            }
+        }
+    }
+
+    /**
+     * Remove semicolons and newlines from a string to keep CSV output clean.
+     *
+     * @param s the input string (may be null)
+     * @return sanitized string safe for CSV
+     */
+    private static String sanitize(String s) {
+        if (s == null) {
+            return "";
+        }
+        return s.replace(';', ' ').replace('\n', ' ').replace('\r', ' ');
+    }
+
+    @AfterClass
+    public static void perfSummary() {
+        int count = perfTestCount.getAndSet(0);
+        long wallMs = perfTotalWallMs.getAndSet(0);
+        long cpuMs = perfTotalCpuMs.getAndSet(0);
+        int procs = perfProcs.get();
+        if (count > 0) {
+            String summary = "unknown"
+                + ";" + count
+                + ";" + wallMs
+                + ";" + cpuMs
+                + ";" + (wallMs > 0 ? String.format("%.0f", 100.0 * cpuMs / wallMs) : "0")
+                + ";" + procs;
+            try (PrintWriter pw = new PrintWriter(new FileWriter("target/perf-summary.csv", true))) {
+                pw.println(summary);
+            } catch (IOException e) {
+                // silently ignore
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

- Temporary profiling PR to collect Hibernate statistics on `main` (Hibernate 6.4) for comparison with the Spring Boot 4 branch (#11810, Hibernate 7)
- **Not intended to be merged** -- will be closed after collecting CI data

## What it does

- Adds per-class wall/CPU time tracking for all IT classes (PERF-SUMMARY in CI logs)
- Adds per-method Hibernate statistics for `LeftTiltedRelationshipRestRepositoryIT` (PERF-DETAIL in CI logs):
  - Query count, entity loads/inserts/updates/deletes, flush count, collection loads, slowest query

## Why

The SB4 branch ITs take ~110 min on CI vs ~30 min on main. Per-class CPU profiling on SB4 shows CPU is not starved (87-100% utilization) -- the test operations themselves are ~3.6x slower. Local profiling on SB4 shows ~1,777 queries and ~202 flushes per test method in the heaviest IT class. We need the same data from main to determine whether Hibernate 7 is generating more queries/flushes than Hibernate 6.

## Test plan

- [ ] CI runs successfully and PERF-SUMMARY + PERF-DETAIL blocks appear in Integration Test logs
- [ ] Compare PERF-DETAIL numbers with SB4 branch CI data