### PR TITLE
Improve oai.identifier.prefix config documentation

### DIFF
--- a/dspace/config/modules/oai.cfg
+++ b/dspace/config/modules/oai.cfg
@@ -30,9 +30,14 @@ oai.solr.url=${solr.server}/${solr.multicorePrefix}oai
 # This field is used for two purposes:
 #   1. As your OAI-PMH <repositoryIdentifier>
 #   2. As the prefix for all Identifiers in OAI-PMH (Format is "oai:${oai.identifier.prefix}:${handle.prefix}")
-# The OAI-PMH spec requires this prefix to correspond to your site's hostname. Therefore, by default,
-# DSpace will set this configuration to the hostname from your ${dspace.ui.url} configuration.
-# However, you may override that default value by uncommenting this configuration.
+# The OAI-PMH spec requires this prefix to correspond to your site's hostname (without protocol).
+# By default, DSpace automatically extracts the hostname from your ${dspace.ui.url} setting
+# (e.g. "https://demo.dspace.org" becomes "demo.dspace.org").
+#
+# WARNING: Only uncomment this if you need a DIFFERENT hostname than what ${dspace.ui.url} provides.
+# The value must be a plain hostname (e.g. "demo.dspace.org"), NOT a full URL.
+# Do NOT set this to ${dspace.ui.url} -- that would include the protocol (https://) in OAI identifiers,
+# which violates the OAI-PMH specification.
 # oai.identifier.prefix = YOUR_SITE_HOSTNAME
 
 # Base url for bitstreams


### PR DESCRIPTION
## References
* Fixes #12050

## Description
Improves the documentation comments around `oai.identifier.prefix` in `oai.cfg` to make the configuration pitfalls more explicit:
- Clarifies that the value must be a plain hostname (without protocol)
- Explains the default behavior (hostname is automatically extracted from `dspace.ui.url`)
- Warns against setting it to `${dspace.ui.url}`, which would include the protocol in OAI identifiers

## Instructions for Reviewers
Documentation-only change in `dspace/config/modules/oai.cfg`. No code changes.

## Checklist
- [x] My PR is **created against the `main` branch** of code.
- [x] My PR is **small in size**.