### PR TITLE
Improve openaire mappings for default dc.types

### DIFF
--- a/dspace/config/crosswalks/oai/metadataFormats/oai_openaire.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/oai_openaire.xsl
@@ -1691,6 +1691,12 @@
             <xsl:when test="$lc_dc_type = 'research article'">
                 <xsl:text>http://purl.org/coar/resource_type/c_2df8fbb1</xsl:text>
             </xsl:when>
+            <xsl:when test="$lc_dc_type = 'conference presentation'">
+                <xsl:text>http://purl.org/coar/resource_type/R60J-J5BD</xsl:text>
+            </xsl:when>
+            <xsl:when test="$lc_dc_type = 'learning object'">
+                <xsl:text>http://purl.org/coar/resource_type/c_e059</xsl:text>
+            </xsl:when>
             <!-- other -->
             <xsl:otherwise>
                 <xsl:text>http://purl.org/coar/resource_type/c_1843</xsl:text>

--- a/dspace/config/crosswalks/oai/transformers/openaire4.xsl
+++ b/dspace/config/crosswalks/oai/transformers/openaire4.xsl
@@ -158,6 +158,10 @@
                 <xsl:text>book part</xsl:text>
             </xsl:when>
             <xsl:when
+                test="$lc_dc_type = 'book chapter' or $lc_dc_type = 'bookchapter'">
+            <xsl:text>book part</xsl:text>
+            </xsl:when>
+            <xsl:when
                 test="$lc_dc_type = 'book review' or $lc_dc_type = 'bookreview' or $dc_type = 'http://purl.org/coar/resource_type/c_ba08'">
                 <xsl:text>book review</xsl:text>
             </xsl:when>
@@ -214,6 +218,10 @@
             </xsl:when>
             <xsl:when
                 test="$lc_dc_type = 'moving image' or $lc_dc_type = 'movingimage' or $dc_type = 'http://purl.org/coar/resource_type/c_8a7e'">
+                <xsl:text>moving image</xsl:text>
+            </xsl:when>
+            <xsl:when
+                test="$lc_dc_type = 'animation'">
                 <xsl:text>moving image</xsl:text>
             </xsl:when>
             <xsl:when
@@ -336,6 +344,14 @@
             <xsl:when
                 test="$lc_dc_type = 'research article' or $lc_dc_type = 'researcharticle' or $dc_type = 'http://purl.org/coar/resource_type/c_2df8fbb1'">
                 <xsl:text>research article</xsl:text>
+            </xsl:when>
+            <xsl:when
+                test="$lc_dc_type = 'presentation' or $dc_type = 'http://purl.org/coar/resource_type/R60J-J5BD'">
+            <xsl:text>conference presentation</xsl:text>
+            </xsl:when>
+            <xsl:when
+                test="$lc_dc_type = 'learning object' or $lc_dc_type = 'learningobject' or $dc_type = 'http://purl.org/coar/resource_type/c_e059'">
+            <xsl:text>learning object</xsl:text>
             </xsl:when>
             <xsl:otherwise>
                 <xsl:text>other</xsl:text>


### PR DESCRIPTION
## References
Fixes #12171

## Description
Adds default OpenAIRE crosswalk for types Animation, Book chapter, Learning Object, and Presentation

## Instructions for Reviewers

Create items with the above dc.type values and expect the following mapping.

1. Animation: moving image (http://purl.org/coar/resource_type/c_8a7e)
2. Book chapter: book part (http://purl.org/coar/resource_type/c_3248)
3. Learning Object: learning object (http://purl.org/coar/resource_type/c_e059)
4. Presentation: conference presentation (http://purl.org/coar/resource_type/R60J-J5BD)

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
