### PR TITLE
Fix dspace cleanup FK violations from orphaned bundle2bitstream rows

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
@@ -515,6 +515,28 @@ public class BitstreamServiceImpl extends DSpaceObjectServiceImpl<Bitstream> imp
             throw new IllegalStateException("Bitstream " + bitstream.getID().toString()
                     + " must be deleted before it can be removed from the database.");
         }
+
+        // Defensively remove any remaining bundle2bitstream references.
+        // Normally delete() already cleans these up, but orphaned rows from
+        // historical bugs can cause FK constraint violations on hard-delete.
+        final List<Bundle> bundles = bitstream.getBundles();
+        for (Bundle bundle : bundles) {
+            if (bitstream.equals(bundle.getPrimaryBitstream())) {
+                bundle.unsetPrimaryBitstreamID();
+            }
+            bundle.removeBitstream(bitstream);
+        }
+        bundles.clear();
+
+        // Remove any orphaned request items referencing this bitstream
+        Iterator<RequestItem> requestItems = requestItemService.findByBitstreamId(context, bitstream.getID());
+        while (requestItems.hasNext()) {
+            requestItemService.delete(context, requestItems.next());
+        }
+
+        // Remove any remaining authorization policies
+        authorizeService.removeAllPolicies(context, bitstream);
+
         bitstreamDAO.delete(context, bitstream);
     }
 

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamStorageServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamStorageServiceImpl.java
@@ -280,6 +280,13 @@ public class BitstreamStorageServiceImpl implements BitstreamStorageService, Ini
                         continue;
                     }
 
+                    // Check whether the bitstore file should be kept before
+                    // expunging the database record, because expunge() would
+                    // make the bitstream entity stale for subsequent queries.
+                    boolean isRegistered = isRegisteredBitstream(bitstream.getInternalId());
+                    boolean hasDuplicate = !bitstreamService
+                        .findDuplicateInternalIdentifier(context, bitstream).isEmpty();
+
                     if (deleteDbRecords) {
                         log.debug("deleting db record");
                         if (verbose) {
@@ -292,16 +299,15 @@ public class BitstreamStorageServiceImpl implements BitstreamStorageService, Ini
                         bitstreamService.expunge(context, bitstream);
                     }
 
-                    if (isRegisteredBitstream(bitstream.getInternalId())) {
+                    if (isRegistered) {
                         context.uncacheEntity(bitstream);
-                        continue; // do not delete registered bitstreams
+                        continue; // do not delete registered bitstreams from the bitstore
                     }
 
-
-                    // Since versioning allows for multiple bitstreams, check if the internal
-                    // identifier isn't used on
-                    // another place
-                    if (bitstreamService.findDuplicateInternalIdentifier(context, bitstream).isEmpty()) {
+                    // Since versioning allows for multiple bitstreams, only
+                    // remove the file if no other bitstream shares this
+                    // internal identifier
+                    if (!hasDuplicate) {
                         this.getStore(bitstream.getStoreNumber()).remove(bitstream);
 
                         String message = ("Deleted bitstreamID " + bid + ", internalID " + bitstream.getInternalId());

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V8.4_2026.03.28__Fix-bundle2bitstream-with-deleted-bitstreams.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V8.4_2026.03.28__Fix-bundle2bitstream-with-deleted-bitstreams.sql
@@ -1,0 +1,17 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+-- Remove orphaned bundle2bitstream rows that reference deleted bitstreams.
+-- These orphaned rows prevent 'dspace cleanup' from expunging deleted
+-- bitstreams due to FK constraint violations.
+DELETE
+FROM bundle2bitstream
+WHERE bitstream_id IN
+      (SELECT bs.uuid
+       FROM bitstream AS bs
+       WHERE bs.deleted IS TRUE)

--- a/dspace-api/src/test/java/org/dspace/content/BitstreamExpungeIT.java
+++ b/dspace-api/src/test/java/org/dspace/content/BitstreamExpungeIT.java
@@ -1,0 +1,247 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.InputStream;
+import java.util.Iterator;
+import java.util.UUID;
+
+import org.apache.commons.io.IOUtils;
+import org.dspace.AbstractIntegrationTestWithDatabase;
+import org.dspace.app.requestitem.RequestItem;
+import org.dspace.app.requestitem.factory.RequestItemServiceFactory;
+import org.dspace.app.requestitem.service.RequestItemService;
+import org.dspace.authorize.factory.AuthorizeServiceFactory;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.builder.BitstreamBuilder;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.ItemBuilder;
+import org.dspace.builder.RequestItemBuilder;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.BitstreamService;
+import org.dspace.content.service.BundleService;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Integration tests for {@link BitstreamServiceImpl#expunge}.
+ *
+ * Verifies that expunge() defensively cleans up bundle2bitstream, requestitem,
+ * and resourcepolicy references before the hard-delete, so historical orphaned
+ * rows do not cause FK constraint violations.
+ *
+ * @author Bram Luyten (bram at atmire.com)
+ */
+public class BitstreamExpungeIT extends AbstractIntegrationTestWithDatabase {
+
+    private final BitstreamService bitstreamService =
+        ContentServiceFactory.getInstance().getBitstreamService();
+    private final BundleService bundleService =
+        ContentServiceFactory.getInstance().getBundleService();
+    private final RequestItemService requestItemService =
+        RequestItemServiceFactory.getInstance().getRequestItemService();
+    private final AuthorizeService authorizeService =
+        AuthorizeServiceFactory.getInstance().getAuthorizeService();
+
+    private Collection collection;
+
+    @Before
+    public void setup() {
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context).build();
+        collection = CollectionBuilder.createCollection(context, parentCommunity).build();
+        context.restoreAuthSystemState();
+    }
+
+    /**
+     * Smoke test the normal path: a bitstream that has been soft-deleted via
+     * delete() can be expunged. delete() already cleans up FK references, so
+     * expunge() should succeed without any defensive work.
+     */
+    @Test
+    public void testExpungeAfterNormalDelete() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        Item item = ItemBuilder.createItem(context, collection).withTitle("Test item").build();
+        Bitstream bitstream = BitstreamBuilder
+            .createBitstream(context, item, toInputStream("test content"))
+            .build();
+        UUID bitstreamId = bitstream.getID();
+
+        bitstreamService.delete(context, bitstream);
+        context.commit();
+
+        bitstream = bitstreamService.find(context, bitstreamId);
+        assertTrue("Bitstream should be marked as deleted", bitstream.isDeleted());
+
+        bitstreamService.expunge(context, bitstream);
+        context.commit();
+
+        assertNull("Bitstream should not exist after expunge",
+            bitstreamService.find(context, bitstreamId));
+
+        context.restoreAuthSystemState();
+    }
+
+    /**
+     * Simulate the historical bug scenario: a bitstream is marked deleted but
+     * its bundle2bitstream row was never cleaned up. expunge() must remove the
+     * leftover bundle association so the hard-delete does not hit a FK
+     * constraint violation.
+     */
+    @Test
+    public void testExpungeOrphanedBundleReference() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        Item item = ItemBuilder.createItem(context, collection).withTitle("Test item").build();
+        Bitstream bitstream = BitstreamBuilder
+            .createBitstream(context, item, toInputStream("test content"))
+            .build();
+        UUID bitstreamId = bitstream.getID();
+        UUID bundleId = bitstream.getBundles().get(0).getID();
+
+        // Mark the bitstream as deleted WITHOUT going through delete(), so the
+        // bundle relationship stays in place. This is the orphan state the PR
+        // is designed to recover from.
+        bitstream.setDeleted(true);
+        bitstreamService.update(context, bitstream);
+        context.commit();
+
+        bitstream = bitstreamService.find(context, bitstreamId);
+        assertEquals("Bundle association should still exist before expunge",
+            1, bitstream.getBundles().size());
+
+        bitstreamService.expunge(context, bitstream);
+        context.commit();
+
+        assertNull("Bitstream should be removed after expunge",
+            bitstreamService.find(context, bitstreamId));
+
+        Bundle bundle = bundleService.find(context, bundleId);
+        assertFalse("Bundle should no longer reference the bitstream",
+            bundle.getBitstreams().stream().anyMatch(b -> b.getID().equals(bitstreamId)));
+
+        context.restoreAuthSystemState();
+    }
+
+    /**
+     * Variant where the orphaned bitstream is also the bundle's primary
+     * bitstream. expunge() must unset the primary bitstream pointer before
+     * hard-deleting, otherwise the bundle_primary_bitstream_id_fkey constraint
+     * fires.
+     */
+    @Test
+    public void testExpungeOrphanedPrimaryBitstream() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        Item item = ItemBuilder.createItem(context, collection).withTitle("Test item").build();
+        Bitstream bitstream = BitstreamBuilder
+            .createBitstream(context, item, toInputStream("test content"))
+            .build();
+        UUID bitstreamId = bitstream.getID();
+        Bundle bundle = bitstream.getBundles().get(0);
+        UUID bundleId = bundle.getID();
+
+        bundle.setPrimaryBitstreamID(bitstream);
+        bundleService.update(context, bundle);
+
+        bitstream.setDeleted(true);
+        bitstreamService.update(context, bitstream);
+        context.commit();
+
+        // Re-fetch in a fresh session state, simulating the cleanup script
+        // path which iterates deleted bitstreams in a separate session.
+        bitstream = bitstreamService.find(context, bitstreamId);
+        bitstreamService.expunge(context, bitstream);
+        context.commit();
+
+        assertNull("Bitstream should be removed after expunge",
+            bitstreamService.find(context, bitstreamId));
+        assertNull("Bundle should no longer have a primary bitstream",
+            bundleService.find(context, bundleId).getPrimaryBitstream());
+
+        context.restoreAuthSystemState();
+    }
+
+    /**
+     * Variant where a RequestItem references the orphaned bitstream. expunge()
+     * must remove the request item so the requestitem_bitstream_id_fkey
+     * constraint does not fire on the hard-delete.
+     */
+    @Test
+    public void testExpungeOrphanedRequestItem() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        Item item = ItemBuilder.createItem(context, collection).withTitle("Test item").build();
+        Bitstream bitstream = BitstreamBuilder
+            .createBitstream(context, item, toInputStream("test content"))
+            .build();
+        UUID bitstreamId = bitstream.getID();
+
+        RequestItemBuilder.createRequestItem(context, item, bitstream).build();
+
+        bitstream.setDeleted(true);
+        bitstreamService.update(context, bitstream);
+        context.commit();
+
+        Iterator<RequestItem> before = requestItemService.findByBitstreamId(context, bitstreamId);
+        assertTrue("RequestItem should exist before expunge", before.hasNext());
+
+        bitstream = bitstreamService.find(context, bitstreamId);
+        bitstreamService.expunge(context, bitstream);
+        context.commit();
+
+        assertNull("Bitstream should be removed after expunge",
+            bitstreamService.find(context, bitstreamId));
+        assertFalse("RequestItem should be removed after expunge",
+            requestItemService.findByBitstreamId(context, bitstreamId).hasNext());
+
+        context.restoreAuthSystemState();
+    }
+
+    /**
+     * Verify that policies attached to the bitstream are removed by expunge(),
+     * so resource policy rows do not survive the hard-delete.
+     */
+    @Test
+    public void testExpungeRemovesPolicies() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        Item item = ItemBuilder.createItem(context, collection).withTitle("Test item").build();
+        Bitstream bitstream = BitstreamBuilder
+            .createBitstream(context, item, toInputStream("test content"))
+            .build();
+        UUID bitstreamId = bitstream.getID();
+
+        assertFalse("Bitstream should have inherited policies",
+            authorizeService.getPolicies(context, bitstream).isEmpty());
+
+        bitstream.setDeleted(true);
+        bitstreamService.update(context, bitstream);
+        context.commit();
+
+        bitstream = bitstreamService.find(context, bitstreamId);
+        bitstreamService.expunge(context, bitstream);
+        context.commit();
+
+        assertNull("Bitstream should be removed after expunge",
+            bitstreamService.find(context, bitstreamId));
+
+        context.restoreAuthSystemState();
+    }
+
+    private InputStream toInputStream(String content) {
+        return IOUtils.toInputStream(content, "UTF-8");
+    }
+}


### PR DESCRIPTION
## References

Fixes #11009

## Description

The `dspace cleanup` command fails with FK constraint violations when deleted bitstreams still have orphaned rows in `bundle2bitstream`. This has affected multiple institutions and required manual SQL cleanup (see issue discussion). Three distinct FK constraint issues have affected cleanup over the years:

| FK Constraint | Table | Status |
|---|---|---|
| `bundle_primary_bitstream_id_fkey` | `bundle` | Fixed by #9106 (Oct 2023) |
| `requestitem_bitstream_id_fkey` | `requestitem` | Fixed by #11469 (Nov 2025) |
| `bundle2bitstream_bitstream_id_fkey` | `bundle2bitstream` | **Fixed in this PR** |

This PR fixes the remaining `bundle2bitstream` issue with three changes:

**1. Defensive cleanup in `expunge()`**: Before hard-deleting a bitstream, `expunge()` now removes any remaining `bundle2bitstream`, `requestitem`, and `resourcepolicy` references. The soft-delete path (`delete()`) normally handles this, but orphaned rows from historical bugs caused FK violations during the hard-delete. The targeted `RequestItem.findByBitstreamId()` helper used here was added in #12158.

**2. Fix operation ordering in `cleanup()`**: The `isRegisteredBitstream` and `findDuplicateInternalIdentifier` checks were happening *after* `expunge()`, meaning the bitstream entity was already stale when those queries ran. Moved them before `expunge()` to avoid auto-flush triggering the DELETE prematurely.

**3. SQL data migration**: A Flyway migration cleans up existing orphaned `bundle2bitstream` rows on upgrade, following the same pattern as `V7.6_2025.10.29__Fix-request-items-with-deleted-bitstreams.sql`.

The migration is named `V8.4_2026.03.28__Fix-bundle2bitstream-with-deleted-bitstreams.sql` so it can be backported to both `dspace-8_x` and `dspace-9_x` (per @tdonohue's review feedback). A migration starting with `V10.0` would not run on a site upgrading from 8.x or 9.x.

## Instructions for Reviewers

List of changes in this PR:

* `BitstreamServiceImpl.expunge()` — defensive FK cleanup before hard-delete
* `BitstreamStorageServiceImpl.cleanup()` — reorder checks before expunge
* `V8.4_2026.03.28__Fix-bundle2bitstream-with-deleted-bitstreams.sql` — data migration
* `BitstreamExpungeIT` — new integration test

**How to test:**

1. Run `mvn verify -pl dspace-api -DskipIntegrationTests=false -Dit.test=BitstreamExpungeIT` to execute the new test
2. To test on a production-like DB with orphaned rows:
   - Manually insert an orphaned `bundle2bitstream` row referencing a deleted bitstream
   - Run `dspace cleanup -v` and verify it completes without FK violations
3. Verify normal bitstream operations (upload, delete, cleanup) still work as expected

## Checklist

- [x] My PR is **created against the `main` branch** of code.
- [x] My PR is **small in size** (< 150 lines of changes, not including comments & tests).
- [x] My PR **passes Checkstyle** validation.
- [x] My PR **includes Javadoc** for all new public methods.
- [x] My PR **includes a new integration test**.
- [x] My PR **includes details on how to test it**.
- [x] My PR **is linked to issue #11009**.
