### PR TITLE
Fixes Solr date bug in LogAnalyser.java

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/statistics/LogAnalyser.java
+++ b/dspace-api/src/main/java/org/dspace/app/statistics/LogAnalyser.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
@@ -1083,13 +1084,13 @@ public class LogAnalyser {
 
 
     /**
-     * Take the date object and convert it into a string of the form YYYY-MM-DD
+     * Take the date object and convert it into an Instant datetime object of the form YYYY-MM-DDTHH:MM:SSZ
      *
      * @param date the date to be converted
-     * @return A string of the form YYYY-MM-DD
+     * @return An Instant datetime object of the form YYYY-MM-DDTHH:MM:SSZ
      */
-    public static String unParseDate(LocalDate date) {
-        return DateTimeFormatter.ISO_LOCAL_DATE.format(date);
+    public static Instant convertDate(LocalDate date) {
+        return date.atStartOfDay(ZoneId.systemDefault()).toInstant();
     }
 
 
@@ -1219,13 +1220,13 @@ public class LogAnalyser {
         StringBuilder accessionedQuery = new StringBuilder();
         accessionedQuery.append("dc.date.accessioned_dt:[");
         if (startDate != null) {
-            accessionedQuery.append(unParseDate(startDate));
+            accessionedQuery.append(convertDate(startDate));
         } else {
             accessionedQuery.append("*");
         }
         accessionedQuery.append(" TO ");
         if (endDate != null) {
-            accessionedQuery.append(unParseDate(endDate));
+            accessionedQuery.append(convertDate(endDate));
         } else {
             accessionedQuery.append("*");
         }

--- a/dspace-api/src/main/java/org/dspace/app/statistics/LogAnalyser.java
+++ b/dspace-api/src/main/java/org/dspace/app/statistics/LogAnalyser.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -1089,8 +1090,12 @@ public class LogAnalyser {
      * @param date the date to be converted
      * @return An Instant datetime object of the form YYYY-MM-DDTHH:MM:SSZ
      */
-    public static Instant convertDate(LocalDate date) {
-        return date.atStartOfDay(ZoneId.systemDefault()).toInstant();
+    public static Instant convertDate(LocalDate date, boolean startOfDay) {
+        if (startOfDay) {
+            return date.atStartOfDay(ZoneId.systemDefault()).toInstant();
+        } else {
+            return date.atTime(LocalTime.MAX).atZone(ZoneId.systemDefault()).toInstant();
+        }
     }
 
 
@@ -1220,13 +1225,13 @@ public class LogAnalyser {
         StringBuilder accessionedQuery = new StringBuilder();
         accessionedQuery.append("dc.date.accessioned_dt:[");
         if (startDate != null) {
-            accessionedQuery.append(convertDate(startDate));
+            accessionedQuery.append(convertDate(startDate, true));
         } else {
             accessionedQuery.append("*");
         }
         accessionedQuery.append(" TO ");
         if (endDate != null) {
-            accessionedQuery.append(convertDate(endDate));
+            accessionedQuery.append(convertDate(endDate, false));
         } else {
             accessionedQuery.append("*");
         }


### PR DESCRIPTION
## References
* Fixes #10805

## Description
This small PR fixes the date range query in `getNumItems()` for Solr 9 by adding the time.

To reproduce the bug, run `bin/dspace healthcheck` and observe the following error:

> #### Log Analyser Check [took: 0s] [# lines: 3]
> ====
> Exception occurred!
> org.dspace.discovery.SearchServiceException: Error from server at http://localhost:8983/solr/search: Invalid Date String:'2026-03-24'

Deploy this PR and check that the bug is fixed.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [X] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [X] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [X] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
