### PR TITLE
Convert DSpaceObject bag collections to Sets to avoid Hibernate recreation storms

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/CollectionServiceImpl.java
@@ -794,7 +794,7 @@ public class CollectionServiceImpl extends DSpaceObjectServiceImpl<Collection> i
         // Remove any workflow roles
         collectionRoleService.deleteByCollection(context, collection);
 
-        collection.getResourcePolicies().clear();
+        collection.clearResourcePolicies();
 
         // Remove default administrators group
         Group g = collection.getAdministrators();

--- a/dspace-api/src/main/java/org/dspace/content/DSpaceObject.java
+++ b/dspace-api/src/main/java/org/dspace/content/DSpaceObject.java
@@ -9,7 +9,10 @@ package org.dspace.content;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -23,10 +26,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.OneToMany;
-import jakarta.persistence.OrderBy;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
-import org.apache.commons.collections4.CollectionUtils;
 import org.dspace.app.audit.MetadataEvent;
 import org.dspace.authorize.ResourcePolicy;
 import org.dspace.core.ReloadableEntity;
@@ -58,25 +59,30 @@ public abstract class DSpaceObject implements Serializable, ReloadableEntity<jav
     private Set<MetadataEvent> metadataEventDetails;
 
     /**
+     * Using a Set instead of a List avoids Hibernate "bag" semantics, where any change
+     * to a List (without @OrderColumn) triggers a DELETE-all + INSERT-all of every row.
+     * With a Set, Hibernate can track individual element additions and removals.
+     *
      * The same order should be applied inside this comparator
      * {@link MetadataValueComparators#defaultComparator} to preserve
      * ordering while the list has been modified and not yet persisted
      * and reloaded.
      */
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "dSpaceObject", cascade = CascadeType.ALL, orphanRemoval = true)
-    @OrderBy("metadataField, place")
-    private List<MetadataValue> metadata = new ArrayList<>();
+    private Set<MetadataValue> metadata = new LinkedHashSet<>();
 
+    /**
+     * Using a Set avoids Hibernate bag recreation on every change.
+     * The oldest handle (lowest id) is the preferred handle; sorting is done in {@link #getHandle()}.
+     */
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "dso")
-    // OrderBy is here to ensure that the oldest handle is retrieved first.
-    // Multiple handles are assigned to the latest version of an item.
-    // The original handle will have the lowest identifier.  This handle is the
-    // preferred handle.
-    @OrderBy("id ASC")
-    private List<Handle> handles = new ArrayList<>();
+    private Set<Handle> handles = new LinkedHashSet<>();
 
+    /**
+     * Using a Set avoids Hibernate bag recreation on every change.
+     */
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "dSpaceObject", cascade = CascadeType.ALL)
-    private final List<ResourcePolicy> resourcePolicies = new ArrayList<>();
+    private final Set<ResourcePolicy> resourcePolicies = new LinkedHashSet<>();
 
     /**
      * True if anything else was changed since last update()
@@ -195,51 +201,138 @@ public abstract class DSpaceObject implements Serializable, ReloadableEntity<jav
      * one
      */
     public String getHandle() {
-        return CollectionUtils.isNotEmpty(handles) ? handles.get(0).getHandle() : null;
+        return handles.stream()
+            .min(Comparator.comparingInt(Handle::getID))
+            .map(Handle::getHandle)
+            .orElse(null);
     }
 
-    void setHandle(List<Handle> handle) {
+    void setHandle(Set<Handle> handle) {
         this.handles = handle;
     }
 
     /**
-     * Append to this object's list of Handles.
+     * Append to this object's collection of Handles.
+     *
      * @param handle the new Handle to be added.
      */
     public void addHandle(Handle handle) {
         this.handles.add(handle);
     }
 
+    /**
+     * Remove a Handle from this object's collection.
+     *
+     * @param handle the Handle to be removed.
+     */
+    public void removeHandle(Handle handle) {
+        this.handles.remove(handle);
+    }
+
+    /**
+     * Get all Handles associated with this object.
+     * Returns a defensive copy sorted by id ascending (oldest handle first).
+     *
+     * @return sorted list of handles
+     */
     public List<Handle> getHandles() {
-        return handles;
+        List<Handle> sorted = new ArrayList<>(handles);
+        sorted.sort(Comparator.comparingInt(Handle::getID));
+        return sorted;
     }
 
+    /**
+     * Get the metadata values for this object.
+     * Returns a defensive copy sorted by metadata field and place,
+     * matching the previous @OrderBy("metadataField, place") behavior.
+     *
+     * @return sorted list of metadata values
+     */
     public List<MetadataValue> getMetadata() {
-        return metadata;
+        List<MetadataValue> sorted = new ArrayList<>(metadata);
+        sorted.sort(MetadataValueComparators.defaultComparator);
+        return sorted;
     }
 
+    /**
+     * Replace the entire metadata set.
+     *
+     * @param metadata the new metadata values
+     */
     public void setMetadata(List<MetadataValue> metadata) {
-        this.metadata = metadata;
+        this.metadata = new LinkedHashSet<>(metadata);
     }
 
     protected void removeMetadata(MetadataValue metadataValue) {
         setMetadataModified();
-        getMetadata().remove(metadataValue);
+        this.metadata.remove(metadataValue);
     }
 
     protected void removeMetadata(List<MetadataValue> metadataValues) {
         setMetadataModified();
-        getMetadata().removeAll(metadataValues);
+        this.metadata.removeAll(metadataValues);
     }
-
 
     protected void addMetadata(MetadataValue metadataValue) {
         setMetadataModified();
-        getMetadata().add(metadataValue);
+        this.metadata.add(metadataValue);
         addMetadataEventDetails(new MetadataEvent(metadataValue, MetadataEvent.ADD));
     }
 
+    /**
+     * Get the resource policies for this object.
+     * Returns a defensive copy.
+     *
+     * @return list of resource policies
+     */
     public List<ResourcePolicy> getResourcePolicies() {
+        return new ArrayList<>(resourcePolicies);
+    }
+
+    /**
+     * Remove a single resource policy from this object.
+     *
+     * @param policy the resource policy to remove
+     */
+    public void removeResourcePolicy(ResourcePolicy policy) {
+        this.resourcePolicies.remove(policy);
+    }
+
+    /**
+     * Remove multiple resource policies from this object.
+     *
+     * @param policies the resource policies to remove
+     */
+    public void removeResourcePolicies(Collection<ResourcePolicy> policies) {
+        this.resourcePolicies.removeAll(policies);
+    }
+
+    /**
+     * Remove all resource policies from this object.
+     */
+    public void clearResourcePolicies() {
+        this.resourcePolicies.clear();
+    }
+
+    /**
+     * Get the raw backing collection of handles, without creating a defensive copy.
+     * Use this only for Hibernate initialization checks ({@code Hibernate.isInitialized()}).
+     * For normal iteration, use {@link #getHandles()} instead.
+     *
+     * @return the raw handles collection (may be a Hibernate-managed proxy)
+     */
+    public java.util.Collection<Handle> getHandlesInternal() {
+        return handles;
+    }
+
+    /**
+     * Get the raw backing collection of resource policies, without creating a defensive copy.
+     * Use this only for Hibernate initialization checks ({@code Hibernate.isInitialized()}).
+     * For normal iteration, use {@link #getResourcePolicies()} instead.
+     *
+     * @return the raw resource policies collection (may be a Hibernate-managed proxy)
+     */
+    public java.util.Collection<ResourcePolicy> getResourcePoliciesInternal() {
         return resourcePolicies;
     }
 

--- a/dspace-api/src/main/java/org/dspace/content/DSpaceObject.java
+++ b/dspace-api/src/main/java/org/dspace/content/DSpaceObject.java
@@ -26,6 +26,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import org.dspace.app.audit.MetadataEvent;
@@ -80,8 +81,10 @@ public abstract class DSpaceObject implements Serializable, ReloadableEntity<jav
 
     /**
      * Using a Set avoids Hibernate bag recreation on every change.
+     * Ordered by id so that REST responses return access conditions in creation order.
      */
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "dSpaceObject", cascade = CascadeType.ALL)
+    @OrderBy("id")
     private final Set<ResourcePolicy> resourcePolicies = new LinkedHashSet<>();
 
     /**

--- a/dspace-api/src/main/java/org/dspace/content/DSpaceObjectServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/DSpaceObjectServiceImpl.java
@@ -518,31 +518,32 @@ public abstract class DSpaceObjectServiceImpl<T extends DSpaceObject> implements
     @Override
     public void clearMetadata(Context context, T dso, String schema, String element, String qualifier, String lang)
         throws SQLException {
-        Iterator<MetadataValue> metadata = dso.getMetadata().iterator();
-        while (metadata.hasNext()) {
-            MetadataValue metadataValue = metadata.next();
-            // If this value matches, delete it
+        List<MetadataValue> toRemove = new ArrayList<>();
+        for (MetadataValue metadataValue : dso.getMetadata()) {
             if (match(schema, element, qualifier, lang, metadataValue)) {
                 dso.addMetadataEventDetails(new MetadataEvent(metadataValue, MetadataEvent.REMOVE));
-                metadata.remove();
-                metadataValueService.delete(context, metadataValue);
+                toRemove.add(metadataValue);
             }
         }
-        dso.setMetadataModified();
+        dso.removeMetadata(toRemove);
+        for (MetadataValue metadataValue : toRemove) {
+            metadataValueService.delete(context, metadataValue);
+        }
     }
 
     @Override
     public void removeMetadataValues(Context context, T dso, List<MetadataValue> values) throws SQLException {
-        Iterator<MetadataValue> metadata = dso.getMetadata().iterator();
-        while (metadata.hasNext()) {
-            MetadataValue metadataValue = metadata.next();
+        List<MetadataValue> toRemove = new ArrayList<>();
+        for (MetadataValue metadataValue : dso.getMetadata()) {
             if (values.contains(metadataValue)) {
                 dso.addMetadataEventDetails(new MetadataEvent(metadataValue, MetadataEvent.REMOVE));
-                metadata.remove();
-                metadataValueService.delete(context, metadataValue);
+                toRemove.add(metadataValue);
             }
         }
-        dso.setMetadataModified();
+        dso.removeMetadata(toRemove);
+        for (MetadataValue metadataValue : toRemove) {
+            metadataValueService.delete(context, metadataValue);
+        }
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/content/MetadataValueServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/MetadataValueServiceImpl.java
@@ -51,10 +51,10 @@ public class MetadataValueServiceImpl implements MetadataValueService {
         MetadataValue metadataValue = new MetadataValue();
         metadataValue.setMetadataField(metadataField);
         metadataValue.setDSpaceObject(dso);
-        dso.addMetadata(metadataValue);
-//An update here isn't needed, this is persisted upon the merge of the owning object
-//        metadataValueDAO.save(context, metadataValue);
+        // Persist first so that the PK is assigned before adding to the entity's Set.
+        // Adding with id=0 and then mutating the id corrupts the HashSet bucket placement.
         metadataValue = metadataValueDAO.create(context, metadataValue);
+        dso.addMetadata(metadataValue);
         log.info(LogHelper.getHeader(context, "add_metadatavalue",
                                      "metadata_value_id=" + metadataValue.getID()));
 

--- a/dspace-api/src/main/java/org/dspace/core/HibernateDBConnection.java
+++ b/dspace-api/src/main/java/org/dspace/core/HibernateDBConnection.java
@@ -265,7 +265,7 @@ public class HibernateDBConnection implements DBConnection<Session> {
                 // The metadatavalue relation has CascadeType.ALL, so they are evicted automatically
                 // and we don' need to uncache the values explicitly.
 
-                if (Hibernate.isInitialized(dso.getHandles())) {
+                if (Hibernate.isInitialized(dso.getHandlesInternal())) {
                     for (Handle handle : Utils.emptyIfNull(dso.getHandles())) {
                         uncacheEntity(handle);
                     }

--- a/dspace-api/src/main/java/org/dspace/handle/HandleServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/handle/HandleServiceImpl.java
@@ -142,8 +142,9 @@ public class HandleServiceImpl implements HandleService {
 
         handle.setHandle(handleId);
         handle.setDSpaceObject(dso);
-        dso.addHandle(handle);
+        // Set all hashCode-relevant fields before adding to the entity's Set
         handle.setResourceTypeId(dso.getType());
+        dso.addHandle(handle);
         handleDAO.save(context, handle);
 
         log.debug("Created new handle for {} (ID={}) {}",

--- a/dspace-api/src/main/java/org/dspace/handle/HandleServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/handle/HandleServiceImpl.java
@@ -9,7 +9,6 @@ package org.dspace.handle;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -212,17 +211,15 @@ public class HandleServiceImpl implements HandleService {
     @Override
     public void unbindHandle(Context context, DSpaceObject dso)
         throws SQLException {
-        Iterator<Handle> handles = dso.getHandles().iterator();
-        if (handles.hasNext()) {
-            while (handles.hasNext()) {
-                final Handle handle = handles.next();
-                handles.remove();
-                //Only set the "resouce_id" column to null when unbinding a handle.
+        List<Handle> handlesToUnbind = new ArrayList<>(dso.getHandles());
+        if (!handlesToUnbind.isEmpty()) {
+            for (Handle handle : handlesToUnbind) {
+                dso.removeHandle(handle);
+                //Only set the "resource_id" column to null when unbinding a handle.
                 // We want to keep around the "resource_type_id" value, so that we
                 // can verify during a restore whether the same *type* of resource
                 // is reusing this handle!
                 handle.setDSpaceObject(null);
-
 
                 handleDAO.save(context, handle);
 
@@ -315,15 +312,14 @@ public class HandleServiceImpl implements HandleService {
             // or if object is already deleted.
             if (dbHandle.getDSpaceObject() != null) {
                 // Remove the old handle from the current handle list
-                dbHandle.getDSpaceObject().getHandles().remove(dbHandle);
+                dbHandle.getDSpaceObject().removeHandle(dbHandle);
             }
             // Transfer the current handle to the new object
             dbHandle.setDSpaceObject(newOwner);
             dbHandle.setResourceTypeId(newOwner.getType());
-            newOwner.getHandles().add(0, dbHandle);
+            newOwner.addHandle(dbHandle);
             handleDAO.save(context, dbHandle);
         }
-
     }
 
     ////////////////////////////////////////

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/AccessConditionRemovePatchOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/AccessConditionRemovePatchOperation.java
@@ -64,7 +64,7 @@ public class AccessConditionRemovePatchOperation extends RemovePatchOperation<Ac
             }
 
             ResourcePolicy resourcePolicyToDelete = policies.get(idxToDelete);
-            item.getResourcePolicies().remove(resourcePolicyToDelete);
+            item.removeResourcePolicy(resourcePolicyToDelete);
             context.commit();
             resourcePolicyService.delete(context, resourcePolicyToDelete);
         } else {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/AccessConditionReplacePatchOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/AccessConditionReplacePatchOperation.java
@@ -77,7 +77,7 @@ public class AccessConditionReplacePatchOperation extends ReplacePatchOperation<
             // to replace an access condition with a new one
             AccessConditionDTO accessConditionDTO = evaluateSingleObject((LateObjectEvaluator) value);
             if (Objects.nonNull(accessConditionDTO) && Objects.nonNull(getOption(configuration, accessConditionDTO))) {
-                item.getResourcePolicies().remove(policies.get(idxToReplace));
+                item.removeResourcePolicy(policies.get(idxToReplace));
                 resourcePolicyService.delete(context, policies.get(idxToReplace));
                 AccessConditionOption option = getOption(configuration, accessConditionDTO);
                 option.createResourcePolicy(context, item, accessConditionDTO.getName(), null,

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/BitstreamResourcePolicyRemovePatchOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/BitstreamResourcePolicyRemovePatchOperation.java
@@ -71,7 +71,7 @@ public class BitstreamResourcePolicyRemovePatchOperation
                         for (ResourcePolicy policy : policies) {
                             int toDelete = Integer.parseInt(rpIdx);
                             if (index == toDelete) {
-                                b.getResourcePolicies().remove(policy);
+                                b.removeResourcePolicy(policy);
                                 resourcePolicyService.delete(context, policy);
                                 bitstream = b;
                                 break;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/BitstreamResourcePolicyReplacePatchOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/BitstreamResourcePolicyReplacePatchOperation.java
@@ -72,7 +72,7 @@ public class BitstreamResourcePolicyReplacePatchOperation extends ReplacePatchOp
                     for (ResourcePolicy policy : policies) {
                         int toReplace = Integer.parseInt(rpIdx);
                         if (index == toReplace) {
-                            b.getResourcePolicies().remove(policy);
+                            b.removeResourcePolicy(policy);
                             break;
                         }
                         index++;


### PR DESCRIPTION
## References

Fixes https://github.com/DSpace/DSpace/issues/12170

## Description

DSpaceObject's `metadata`, `handles`, and `resourcePolicies` collections were mapped as Hibernate "bags" (List without `@OrderColumn`). Any element change triggered a DELETE-all + INSERT-all of every row. Profiling showed ~97 bag recreations per test method, with `metadata` being the most impactful (21 recreations x 8-15 values = 170-315 wasted SQL operations).

This PR changes the backing type from `List` to `LinkedHashSet`, which lets Hibernate track individual element additions and removals instead of recreating the entire collection. Public getters still return `List` for API compatibility via defensive copies.

## Instructions for Reviewers

List of changes in this PR:

* **`DSpaceObject.java`**: Changed `metadata`, `handles`, and `resourcePolicies` fields from `List` to `LinkedHashSet`. Removed `@OrderBy` annotations (sorting now done in getters). Added mutation methods (`removeHandle`, `removeResourcePolicy`, `removeResourcePolicies`, `clearResourcePolicies`). Added `getHandlesInternal()` / `getResourcePoliciesInternal()` for `Hibernate.isInitialized()` checks.
* **`HandleServiceImpl.java`**: Refactored `unbindHandle()` from iterator-remove pattern to use `removeHandle()`. Changed `modifyHandleDSpaceObject()` to use `removeHandle()` / `addHandle()` instead of mutating the getter's returned list.
* **`DSpaceObjectServiceImpl.java`**: Refactored `clearMetadata()` and `removeMetadataValues()` from iterator-remove on `getMetadata()` to collect-then-remove using the entity's `removeMetadata()` method.
* **`HibernateDBConnection.java`**: Changed `Hibernate.isInitialized()` calls to use `getHandlesInternal()` / `getResourcePoliciesInternal()` to avoid triggering lazy loading through the defensive-copy getters.
* **4 patch operation classes + `CollectionServiceImpl`**: Replaced `getResourcePolicies().remove(policy)` / `.clear()` with the new `removeResourcePolicy()` / `clearResourcePolicies()` entity methods.

**How to test:**

1. Run the full integration test suite -- every IT exercises metadata and resource policies.
2. Verify no regressions in submission (access condition add/replace/remove), handle assignment (versioning, collection move), and collection deletion.
3. Optional: enable Hibernate statistics (`hibernate.generate_statistics=true`) and verify that `CollectionRecreate` count drops to 0.

**Key design decisions:**

* `LinkedHashSet` preserves insertion order, which keeps iteration predictable.
* `MetadataValue.equals()/hashCode()` is PK-based, so Set deduplication is safe.
* `Handle.equals()/hashCode()` uses `id` + `handle` + `resourceTypeId`, also safe.
* `ResourcePolicy.equals()/hashCode()` uses business fields (action, group, ePerson, dates). Two truly identical policies would be deduplicated, which is correct behavior (duplicate policies are bugs, not features).
* No database migrations required -- purely JPA mapping + Java type changes.

## Checklist

- [x] My PR is **created against the `main` branch** of code.
- [x] My PR is **small in size** (142 insertions, 52 deletions across 9 files).
- [x] My PR **passes Checkstyle** validation (0 violations in both dspace-api and dspace-server-webapp).
- [x] My PR **includes Javadoc** for all new public methods and classes.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**.