### PR TITLE
Allow claiming of researcher profile by Item object in ResearcherProfileService

### DIFF
--- a/dspace-api/src/main/java/org/dspace/profile/ResearcherProfileServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/profile/ResearcherProfileServiceImpl.java
@@ -193,6 +193,13 @@ public class ResearcherProfileServiceImpl implements ResearcherProfileService {
         Item item = findItemByURI(context, uri)
             .orElseThrow(() -> new IllegalArgumentException("No item found by URI " + uri));
 
+        return claim(context, ePerson, item);
+    }
+
+    @Override
+    public ResearcherProfile claim(Context context, EPerson ePerson, Item item)
+        throws SQLException, AuthorizeException {
+
         if (!item.isArchived() || item.isWithdrawn()) {
             throw new IllegalArgumentException(
                 "Only archived items can be claimed to create a researcher profile. Item ID: " + item.getID());

--- a/dspace-api/src/main/java/org/dspace/profile/ResearcherProfileServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/profile/ResearcherProfileServiceImpl.java
@@ -200,6 +200,10 @@ public class ResearcherProfileServiceImpl implements ResearcherProfileService {
     public ResearcherProfile claim(Context context, EPerson ePerson, Item item)
         throws SQLException, AuthorizeException {
 
+        if (item == null) {
+            throw new IllegalArgumentException("The provided item is null");
+        }
+
         if (!item.isArchived() || item.isWithdrawn()) {
             throw new IllegalArgumentException(
                 "Only archived items can be claimed to create a researcher profile. Item ID: " + item.getID());

--- a/dspace-api/src/main/java/org/dspace/profile/service/ResearcherProfileService.java
+++ b/dspace-api/src/main/java/org/dspace/profile/service/ResearcherProfileService.java
@@ -94,6 +94,18 @@ public interface ResearcherProfileService {
         throws SQLException, AuthorizeException, SearchServiceException;
 
     /**
+     * Claims and links an eperson to an existing DSpaceObject directly, without
+     * resolving a URI to an object
+     * @param  context                  the relevant DSpace Context.
+     * @param  ePerson                  the ePerson
+     * @param  item                     DSpace item to convert to a researcher profile
+     * @return                          the created profile
+     * @throws IllegalArgumentException if the given dso is null or cannot be claimed
+     */
+    ResearcherProfile claim(Context context, EPerson ePerson, Item item)
+            throws SQLException, AuthorizeException;
+
+    /**
      * Check if the given item has an entity type compatible with that of the
      * researcher profile. If the given item does not have an entity type, the check
      * returns false.


### PR DESCRIPTION
## Description
The `ResearcherProfileService#claim` method currently only supports URI as a parameter for the target item to use as a profile. That's fine for the REST API implementation, but when using this service in the core Java API (for example, curation tasks, workflow actions and so on), it introduces unwanted complexity and the URI as a value only makes sense to the spring boot REST API.

This small change just adds another claim method to allow an Item object to be passed as a parameter, and modifies the original claim method to call this once after the URI has been resolved to an Item.

## Instructions for Reviewers
Inspection and existing test coverage should hopefully prove this change is sound.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).