### PR TITLE
Fix empty Javadoc tags in dspace-api (batch 1)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/coarnotify/NotifySubmissionConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/coarnotify/NotifySubmissionConfiguration.java
@@ -57,7 +57,7 @@ public class NotifySubmissionConfiguration {
 
     /**
      * Sets the list of configured COAR Notify Patterns
-     * @param patterns
+     * @param patterns the list of COAR Notify patterns to set
      */
     public void setPatterns(final List<NotifyPattern> patterns) {
         this.patterns = patterns;

--- a/dspace-api/src/main/java/org/dspace/ctask/general/RegisterDOI.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/RegisterDOI.java
@@ -67,7 +67,7 @@ public class RegisterDOI extends AbstractCurationTask {
      * and the original purpose of this task is to essentially implement a "Register DOI" button on the Edit Item page.
      * @param dso DSpaceObject for which to register a DOI (must be item)
      * @return status indicator
-     * @throws IOException
+     * @throws IOException if IO error
      */
     @Override
     public int perform(DSpaceObject dso) throws IOException {

--- a/dspace-api/src/main/java/org/dspace/harvest/HarvestedCollection.java
+++ b/dspace-api/src/main/java/org/dspace/harvest/HarvestedCollection.java
@@ -111,11 +111,10 @@ public class HarvestedCollection implements ReloadableEntity<Integer> {
         setHarvestMetadataConfig(mdConfigId);
     }
 
-    /*
-     * Setters for the appropriate harvesting-related columns
+    /**
+     * Setters for the appropriate harvesting-related columns.
      *
-     * @param type
-     *     harvest type (TYPE_NONE, TYPE_DMD, TYPE_DMDREF, TYPE_FULL
+     * @param type harvest type (TYPE_NONE, TYPE_DMD, TYPE_DMDREF, TYPE_FULL)
      */
     public void setHarvestType(int type) {
         this.harvestType = type;

--- a/dspace-api/src/main/java/org/dspace/harvest/OAIHarvester.java
+++ b/dspace-api/src/main/java/org/dspace/harvest/OAIHarvester.java
@@ -208,8 +208,8 @@ public class OAIHarvester {
     /**
      * Cycle through the options and find the metadata namespace matching the provided key.
      *
-     * @param metadataKey
-     * @return Namespace of the designated metadata format. Returns null of not found.
+     * @param metadataKey the metadata format key (e.g. dc, qdc) as defined in oai.cfg
+     * @return Namespace of the designated metadata format. Returns null if not found.
      */
     public static Namespace getDMDNamespace(String metadataKey) {
         String metadataString = null;

--- a/dspace-api/src/main/java/org/dspace/orcid/dao/OrcidQueueDAO.java
+++ b/dspace-api/src/main/java/org/dspace/orcid/dao/OrcidQueueDAO.java
@@ -58,7 +58,7 @@ public interface OrcidQueueDAO extends GenericDAO<OrcidQueue> {
      * @param  profileItem  the profileItem item
      * @param  entity       the entity item
      * @return              the found orcid queue records
-     * @throws SQLException
+     * @throws SQLException if database error
      */
     public List<OrcidQueue> findByProfileItemAndEntity(Context context, Item profileItem, Item entity)
         throws SQLException;

--- a/dspace-api/src/main/java/org/dspace/service/DSpaceCRUDService.java
+++ b/dspace-api/src/main/java/org/dspace/service/DSpaceCRUDService.java
@@ -29,7 +29,7 @@ public interface DSpaceCRUDService<T> {
     /**
      * Persist a model object.
      *
-     * @param context
+     * @param context DSpace context object
      * @param t object to be persisted.
      * @throws SQLException passed through.
      * @throws AuthorizeException passed through.
@@ -40,7 +40,7 @@ public interface DSpaceCRUDService<T> {
     /**
      * Persist a collection of model objects.
      *
-     * @param context
+     * @param context DSpace context object
      * @param t object to be persisted.
      * @throws SQLException passed through.
      * @throws AuthorizeException passed through.

--- a/dspace-api/src/main/java/org/dspace/subscriptions/SubscriptionEmailNotificationServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/subscriptions/SubscriptionEmailNotificationServiceImpl.java
@@ -154,7 +154,7 @@ public class SubscriptionEmailNotificationServiceImpl implements SubscriptionEma
      * @param context            DSpace context
      * @param subscriptionType   Could be "content" or "statistics". NOTE: in DSpace we have only "content"
      * @param frequency          Could be "D" stand for Day, "W" stand for Week, and "M" stand for Month
-     * @return
+     * @return list of subscriptions matching the given type and frequency
      */
     private List<Subscription> findAllSubscriptionsBySubscriptionTypeAndFrequency(Context context,
              String subscriptionType, String frequency) {

--- a/dspace-api/src/main/java/org/dspace/validation/MetadataValidator.java
+++ b/dspace-api/src/main/java/org/dspace/validation/MetadataValidator.java
@@ -179,7 +179,7 @@ public class MetadataValidator implements SubmissionStepValidator {
      * @param input   input field
      * @param errors  List holding all errors
      * @param config  submission step config
-     * @throws SQLException
+     * @throws SQLException if database error
      */
     private void relationshipRequiredFieldCheck(Context context, Item item, DCInput input, List<ValidationError> errors,
                                                 SubmissionStepConfig config) {

--- a/dspace-api/src/main/java/org/dspace/web/ContextUtil.java
+++ b/dspace-api/src/main/java/org/dspace/web/ContextUtil.java
@@ -141,7 +141,7 @@ public class ContextUtil {
      * Initialize a new Context object
      *
      * @return a DSpace Context Object
-     * @throws SQLException
+     * @throws SQLException if database error
      */
     private static Context initializeContext() throws SQLException {
         // Create a new Context


### PR DESCRIPTION
Relates to https://github.com/DSpace/DSpace/issues/8338 (Partial fix) 

## Summary
- Add missing descriptions to empty `@param`, `@return`, `@throws` Javadoc tags across 8 packages in `dspace-api`
- Fix a block comment (`/*`) that should have been a Javadoc comment (`/**`) in `HarvestedCollection.java`

## Affected packages
`coarnotify`, `ctask`, `harvest`, `orcid`, `service`, `subscriptions`, `validation`, `web`

## Details
This is the first batch of Javadoc warning fixes for #8338. Each package in this batch had only 1–2 warnings, so they are grouped into a single small PR for easier review.

### Changes (9 files, 10 warnings fixed)
| File | Fix |
|------|-----|
| `NotifySubmissionConfiguration.java` | Added `@param patterns` description |
| `RegisterDOI.java` | Added `@throws IOException` description |
| `OrcidQueueDAO.java` | Added `@throws SQLException` description |
| `SubscriptionEmailNotificationServiceImpl.java` | Added `@return` description |
| `MetadataValidator.java` | Added `@throws SQLException` description |
| `ContextUtil.java` | Added `@throws SQLException` description |
| `HarvestedCollection.java` | Fixed block comment to Javadoc + added `@param type` description |
| `OAIHarvester.java` | Added `@param metadataKey` description |
| `DSpaceCRUDService.java` | Added `@param context` description (2 occurrences) |

## Test plan
- [ ] Verify the project compiles without new warnings in these packages
- [ ] No functional changes — Javadoc only

Resolves part of #8338