### PR TITLE
[10.0 Testathon] Update Docker deployment to only redeploy Sandbox on changes to testathon branch

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -73,7 +73,7 @@ env:
   REDEPLOY_DEMO_URL: ${{ secrets.REDEPLOY_DEMO_URL }}
   # Current DSpace branches (and architecture) which are deployed to demo.dspace.org & sandbox.dspace.org respectively
   DEPLOY_DEMO_BRANCH: 'dspace-9_x'
-  DEPLOY_SANDBOX_BRANCH: 'main'
+  DEPLOY_SANDBOX_BRANCH: 'dspace-10.0-testathon'
   DEPLOY_ARCH: 'linux/amd64'
   # Registry used during building of Docker images. (All images are later copied to docker.io registry)
   # We use GitHub's Container Registry to avoid aggressive rate limits at DockerHub.


### PR DESCRIPTION
## Description
This small PR updates our Docker redeployment settings to ensure that https://sandbox.dspace.org only redeploys (i.e. restarts) if changes are committed to the `dspace-10.0-testaton` branches.

This is necessary to allow developers to continue to commit changes to `main` _without impacting testers who are actively using https://sandbox.dspace.org during Testathon_ (which takes place from April 6-24). 

**NOTE: This change will be reverted after Testathon.**
