### PR TITLE
Fix empty Javadoc tags in dspace-api (batch 2)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/browse/BrowseIndex.java
+++ b/dspace-api/src/main/java/org/dspace/browse/BrowseIndex.java
@@ -379,10 +379,10 @@ public class BrowseIndex {
     /**
      * Generate a sequence name from the given base
      *
-     * @param baseName
-     * @param isDistinct
-     * @param isMap
-     * @return
+     * @param baseName   the base name of the sequence
+     * @param isDistinct is a distinct table
+     * @param isMap      is a map table
+     * @return the name of the sequence
      */
     private static String getSequenceName(String baseName, boolean isDistinct, boolean isMap) {
         if (isDistinct) {

--- a/dspace-api/src/main/java/org/dspace/browse/BrowseInfo.java
+++ b/dspace-api/src/main/java/org/dspace/browse/BrowseInfo.java
@@ -764,8 +764,8 @@ public class BrowseInfo {
      * A utility method for generating a string to represent a single item's
      * entry in the browse
      *
-     * @param config
-     * @return
+     * @param config the item list configuration
+     * @return string representation of the full item listing
      * @throws SQLException if database error
      */
     private String fullListingString(ItemListConfig config)
@@ -813,7 +813,7 @@ public class BrowseInfo {
     /**
      * A utility method for representing a single value in the browse
      *
-     * @return
+     * @return string representation of the value listing
      */
     private String valueListingString() {
         // report on all the results contained herein

--- a/dspace-api/src/main/java/org/dspace/browse/CrossLinks.java
+++ b/dspace-api/src/main/java/org/dspace/browse/CrossLinks.java
@@ -64,7 +64,7 @@ public class CrossLinks {
 
     /**
      * Is there a link for the given browse name (eg 'author')
-     * @param browseIndexName
+     * @param browseIndexName the browse index name to check
      * @return true/false
      */
     public boolean hasBrowseName(String browseIndexName) {
@@ -83,7 +83,7 @@ public class CrossLinks {
 
     /**
      * Get full map of field->indexname link configurations
-     * @return
+     * @return map of metadata field to browse index name
      */
     public Map<String, String> getLinks() {
         return links;
@@ -93,8 +93,8 @@ public class CrossLinks {
      * Find and return the browse name for a given metadata field.
      * If the link key contains a wildcard eg dc.subject.*, it should
      * match dc.subject.other, etc.
-     * @param metadata
-     * @return
+     * @param metadata the metadata field to find the link type for
+     * @return the browse name for the given metadata, or null if not found
      */
     public String findLinkType(String metadata) {
         // Resolve wildcards properly, eg. dc.subject.other matches a configuration for dc.subject.*

--- a/dspace-api/src/main/java/org/dspace/external/OpenaireRestToken.java
+++ b/dspace-api/src/main/java/org/dspace/external/OpenaireRestToken.java
@@ -52,7 +52,7 @@ public class OpenaireRestToken {
      * If the existing token has an expiration date and if it is at a minute of
      * expiring
      *
-     * @return true if the token is valid and not near expiration, false otherwise
+     * @return true if the token is present and not near expiration, false otherwise
      */
     public boolean isValidToken() {
         if (this.accessToken == null) {

--- a/dspace-api/src/main/java/org/dspace/external/OpenaireRestToken.java
+++ b/dspace-api/src/main/java/org/dspace/external/OpenaireRestToken.java
@@ -31,8 +31,8 @@ public class OpenaireRestToken {
     /**
      * Stores the grabbed token
      * 
-     * @param accessToken
-     * @param expiresIn
+     * @param accessToken the access token string
+     * @param expiresIn   the token expiration period in seconds
      */
     public OpenaireRestToken(String accessToken, Long expiresIn) {
         this.accessToken = accessToken;
@@ -51,8 +51,8 @@ public class OpenaireRestToken {
     /**
      * If the existing token has an expiration date and if it is at a minute of
      * expiring
-     * 
-     * @return
+     *
+     * @return true if the token is valid and not near expiration, false otherwise
      */
     public boolean isValidToken() {
         if (this.accessToken == null) {

--- a/dspace-api/src/main/java/org/dspace/external/model/ExternalDataObject.java
+++ b/dspace-api/src/main/java/org/dspace/external/model/ExternalDataObject.java
@@ -151,7 +151,7 @@ public class ExternalDataObject {
 
     /**
      * Sort metadata before printing, to help with comparison by eye
-     * @return
+     * @return  sorted string representation of this ExternalDataObject
      */
     @Override
     public String toString() {
@@ -200,7 +200,7 @@ public class ExternalDataObject {
 
     /**
      * Explicit override of Object hashCode()
-     * @return
+     * @return  hash code based on id, value, source, metadata, and displayValue
      */
     @Override
     public int hashCode() {

--- a/dspace-api/src/main/java/org/dspace/external/provider/impl/LiveImportDataProvider.java
+++ b/dspace-api/src/main/java/org/dspace/external/provider/impl/LiveImportDataProvider.java
@@ -124,8 +124,8 @@ public class LiveImportDataProvider extends AbstractExternalDataProvider {
      * FIXME it would be useful to remove ImportRecord at all in favor of the
      * ExternalDataObject
      * 
-     * @param record
-     * @return
+     * @param record the ImportRecord to convert
+     * @return the converted ExternalDataObject
      */
     private ExternalDataObject getExternalDataObject(ImportRecord record) {
         //return 400 if no record were found

--- a/dspace-api/src/main/java/org/dspace/handle/hdlresolver/HdlResolverDTO.java
+++ b/dspace-api/src/main/java/org/dspace/handle/hdlresolver/HdlResolverDTO.java
@@ -58,8 +58,8 @@ public class HdlResolverDTO {
 
     /**
      * Returns the split String of the resource-path
-     * 
-     * @return
+     *
+     * @return split string array of the resource path
      */
     public final String[] getSplittedString() {
         return this.splittedString;
@@ -67,8 +67,8 @@ public class HdlResolverDTO {
 
     /**
      * Returns the handle identifier
-     * 
-     * @return
+     *
+     * @return handle identifier string
      */
     public final String getHandle() {
         return this.handle;
@@ -76,8 +76,8 @@ public class HdlResolverDTO {
 
     /**
      * Checks if the handle identifier is valid.
-     * 
-     * @return
+     *
+     * @return true if handle identifier is valid, false otherwise
      */
     public boolean isValid() {
         return Objects.nonNull(this.handle) &&

--- a/dspace-api/src/main/java/org/dspace/handle/service/HandleService.java
+++ b/dspace-api/src/main/java/org/dspace/handle/service/HandleService.java
@@ -188,8 +188,8 @@ public interface HandleService {
      *   - info:hdl/123456789/1                -> 123456789/1
      *   - https://hdl.handle.net/123456789/1  -> 123456789/1
      *
-     * @param identifier
-     * @return
+     * @param identifier the handle identifier to parse
+     * @return The canonical form of the handle
      */
     String parseHandle(String identifier);
 


### PR DESCRIPTION
## References
* Related to #8338 (Partial fix)
* Continuation of #12248 (batch 1)

## Description
Fix EmptyBlockTag Javadoc warnings in `browse`, `handle`, and `external` packages by adding descriptions to empty `@param` and `@return` tags.

## Instructions for Reviewers
List of changes in this PR:
* Added descriptions to empty `@param`, `@return` tags in 8 files across 3 packages
* Each description follows the existing convention in its respective file (verified via `grep`)

| File | Fix |
|------|-----|
| `BrowseInfo.java` | `@param config`, `@return` (×2) |
| `BrowseIndex.java` | `@param baseName`, `@param isDistinct`, `@param isMap`, `@return` — matched public overload at lines 355-357 |
| `CrossLinks.java` | `@param browseIndexName`, `@param metadata`, `@return` (×2) |
| `HdlResolverDTO.java` | `@return` (×3) — matched `@return decoded URL` style at line 31 |
| `HandleService.java` | `@param identifier`, `@return` — matched `@return The canonical form` style |
| `OpenaireRestToken.java` | `@param accessToken`, `@param expiresIn`, `@return` |
| `ExternalDataObject.java` | `@return` (×2) — matched double-space `@return  ` style |
| `LiveImportDataProvider.java` | `@param record`, `@return` |

**Total: 8 files, 20 empty Javadoc tags fixed across 3 packages**

**How to test:** Build with `mvn install -DskipTests` and verify reduced EmptyBlockTag warnings. Javadoc-only changes — no functional impact.

## Checklist
- [x] My PR is **created against the `main` branch** of code.
- [x] My PR is **small in size** (8 files, 27 lines changed).
- [x] My PR **passes Checkstyle** validation.
- [x] My PR **includes Javadoc** for all new (or modified) public methods and classes.
- [x] My PR **includes details on how to test it**.
- [x] If my PR fixes an issue ticket, I've linked them together.