### PR TITLE
Implement Health endpoint for Bitstreams leaks

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/requestitem/RequestItemEmailNotifier.java
+++ b/dspace-api/src/main/java/org/dspace/app/requestitem/RequestItemEmailNotifier.java
@@ -9,9 +9,11 @@
 package org.dspace.app.requestitem;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.sql.SQLException;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.List;
 
 import jakarta.annotation.ManagedBean;
@@ -203,6 +205,7 @@ public class RequestItemEmailNotifier {
         email.setSubject(subject);
         email.addRecipient(ri.getReqEmail());
         // Attach bitstreams.
+        List<InputStream> bitstreamInputStreams = new ArrayList<>();
         try {
             if (ri.isAccept_request()) {
                 if (ri.getAccess_token() != null) {
@@ -229,11 +232,13 @@ public class RequestItemEmailNotifier {
                                     // #8636 Anyone receiving the email can respond to the
                                     // request without authenticating into DSpace
                                     context.turnOffAuthorisationSystem();
+                                    InputStream is = bitstreamService.retrieve(context, bitstream);
                                     email.addAttachment(
-                                            bitstreamService.retrieve(context, bitstream),
+                                            is,
                                             bitstream.getName(),
                                             bitstream.getFormat(context).getMIMEType());
                                     context.restoreAuthSystemState();
+                                    bitstreamInputStreams.add(is);
                                 }
                             }
                         }
@@ -241,10 +246,13 @@ public class RequestItemEmailNotifier {
                         Bitstream bitstream = ri.getBitstream();
                         //#8636 Anyone receiving the email can respond to the request without authenticating into DSpace
                         context.turnOffAuthorisationSystem();
-                        email.addAttachment(bitstreamService.retrieve(context, bitstream),
+                        InputStream is = bitstreamService.retrieve(context, bitstream);
+                        email.addAttachment(
+                                is,
                                 bitstream.getName(),
                                 bitstream.getFormat(context).getMIMEType());
                         context.restoreAuthSystemState();
+                        bitstreamInputStreams.add(is);
                     }
                 }
                 email.send();
@@ -261,6 +269,10 @@ public class RequestItemEmailNotifier {
             LOG.warn(LogHelper.getHeader(context,
                     "error_mailing_requestItem", e.getMessage()));
             throw new IOException("Reply not sent:  " + e.getMessage());
+        } finally {
+            for (InputStream bitstreamInputStream : bitstreamInputStreams) {
+                bitstreamInputStream.close();
+            }
         }
         LOG.info(LogHelper.getHeader(context,
                 "sent_attach_requestItem", "token={}"), ri.getToken());

--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/LicenseStreamDisseminationCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/LicenseStreamDisseminationCrosswalk.java
@@ -8,6 +8,7 @@
 package org.dspace.content.crosswalk;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.sql.SQLException;
 
@@ -56,7 +57,9 @@ public class LicenseStreamDisseminationCrosswalk
             Bitstream licenseBs = PackageUtils.findDepositLicense(context, (Item) dso);
 
             if (licenseBs != null) {
-                Utils.copy(bitstreamService.retrieve(context, licenseBs), out);
+                try (InputStream bitstreamInputStream = bitstreamService.retrieve(context, licenseBs)) {
+                    Utils.copy(bitstreamInputStream, out);
+                }
             }
         }
     }

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamInputStreamOpenInfo.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamInputStreamOpenInfo.java
@@ -18,32 +18,22 @@ import java.util.UUID;
  *
  * @author Kevin Van de Velde (kevin at atmire dot com)
  */
-public final class BitstreamInputstreamOpenInfo {
+public final class BitstreamInputStreamOpenInfo {
 
     private static final int STACK_TRACE_LINES = 30;
 
     private final UUID id;
     private final String kind;
     private final Instant openedAt;
-    private final String threadName;
     private final Throwable openedAtThrowable;
 
-    public BitstreamInputstreamOpenInfo(UUID id,
+    public BitstreamInputStreamOpenInfo(UUID id,
                                         String kind,
                                         Instant openedAt,
-                                        Throwable openedAtThrowable) {
-        this(id, kind, openedAt, Thread.currentThread().getName(), openedAtThrowable);
-    }
-
-    public BitstreamInputstreamOpenInfo(UUID id,
-                                        String kind,
-                                        Instant openedAt,
-                                        String threadName,
                                         Throwable openedAtThrowable) {
         this.id = id;
         this.kind = kind;
         this.openedAt = openedAt;
-        this.threadName = threadName;
         this.openedAtThrowable = openedAtThrowable;
     }
 
@@ -75,15 +65,6 @@ public final class BitstreamInputstreamOpenInfo {
     }
 
     /**
-     * Get the name of the thread were the InputStream was opened
-     *
-     * @return the name of the thread were the InputStream was opened
-     */
-    public String threadName() {
-        return threadName;
-    }
-
-    /**
      * Get the throwable of were the InputStream was opened
      *
      * @return the throwable of were the InputStream was opened
@@ -112,11 +93,10 @@ public final class BitstreamInputstreamOpenInfo {
 
     @Override
     public String toString() {
-        return "OpenInfo{" +
+        return "BitstreamInputStreamOpenInfo{" +
                 "id=" + id +
                 ", kind='" + kind + '\'' +
                 ", openedAt=" + openedAt +
-                ", threadName='" + threadName + '\'' +
                 ", openedAtThrowable=\n" + openedAtStackTrace() +
                 '}';
     }

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamInputstreamOpenInfo.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamInputstreamOpenInfo.java
@@ -1,0 +1,123 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.storage.bitstore;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.UUID;
+
+/**
+ * Class that holds information about an open InputStream
+ *
+ * @author Kevin Van de Velde (kevin at atmire dot com)
+ */
+public final class BitstreamInputstreamOpenInfo {
+
+    private static final int STACK_TRACE_LINES = 30;
+
+    private final UUID id;
+    private final String kind;
+    private final Instant openedAt;
+    private final String threadName;
+    private final Throwable openedAtThrowable;
+
+    public BitstreamInputstreamOpenInfo(UUID id,
+                                        String kind,
+                                        Instant openedAt,
+                                        Throwable openedAtThrowable) {
+        this(id, kind, openedAt, Thread.currentThread().getName(), openedAtThrowable);
+    }
+
+    public BitstreamInputstreamOpenInfo(UUID id,
+                                        String kind,
+                                        Instant openedAt,
+                                        String threadName,
+                                        Throwable openedAtThrowable) {
+        this.id = id;
+        this.kind = kind;
+        this.openedAt = openedAt;
+        this.threadName = threadName;
+        this.openedAtThrowable = openedAtThrowable;
+    }
+
+    /**
+     * Get the ID of this info object
+     *
+     * @return the ID of this info object
+     */
+    public UUID id() {
+        return id;
+    }
+
+    /**
+     * Get the kind of open InputStream, usually the method it was retrieved in
+     *
+     * @return the kind of open InputStream
+     */
+    public String kind() {
+        return kind;
+    }
+
+    /**
+     * Get the Instant the InputStream was opened
+     *
+     * @return the Instant the InputStream was opened
+     */
+    public Instant openedAt() {
+        return openedAt;
+    }
+
+    /**
+     * Get the name of the thread were the InputStream was opened
+     *
+     * @return the name of the thread were the InputStream was opened
+     */
+    public String threadName() {
+        return threadName;
+    }
+
+    /**
+     * Get the throwable of were the InputStream was opened
+     *
+     * @return the throwable of were the InputStream was opened
+     */
+    public Throwable openedAtThrowable() {
+        return openedAtThrowable;
+    }
+
+    /**
+     * Converts openedAtThrowable into a String of the stacktrace and returns the first x amount of lines,
+     * where "x" is configured in STACK_TRACE_LINES
+     *
+     * @return a print of the stacktrace
+     */
+    public String openedAtStackTrace() {
+        if (openedAtThrowable == null) {
+            return "";
+        }
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        openedAtThrowable.printStackTrace(pw);
+        String[] stackTraceLines = sw.toString().split("\n");
+        return String.join("\n", Arrays.copyOfRange(
+                stackTraceLines, 0, Math.min(STACK_TRACE_LINES, stackTraceLines.length)));
+    }
+
+    @Override
+    public String toString() {
+        return "OpenInfo{" +
+                "id=" + id +
+                ", kind='" + kind + '\'' +
+                ", openedAt=" + openedAt +
+                ", threadName='" + threadName + '\'' +
+                ", openedAtThrowable=\n" + openedAtStackTrace() +
+                '}';
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamStorageServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamStorageServiceImpl.java
@@ -217,7 +217,7 @@ public class BitstreamStorageServiceImpl implements BitstreamStorageService, Ini
     public InputStream retrieve(Context context, Bitstream bitstream)
         throws SQLException, IOException {
         Integer storeNumber = bitstream.getStoreNumber();
-        return this.getStore(storeNumber).get(bitstream);
+        return new LeakTrackingInputStream(this.getStore(storeNumber).get(bitstream), "retrieve");
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/LeakTrackingInputStream.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/LeakTrackingInputStream.java
@@ -28,7 +28,7 @@ import org.apache.logging.log4j.Logger;
 public final class LeakTrackingInputStream extends FilterInputStream {
 
     private static final Cleaner CLEANER = Cleaner.create();
-    private static final ConcurrentMap<UUID, BitstreamInputstreamOpenInfo> OPEN = new ConcurrentHashMap<>();
+    private static final ConcurrentMap<UUID, BitstreamInputStreamOpenInfo> OPEN = new ConcurrentHashMap<>();
 
     private final UUID id = UUID.randomUUID();
     private final Cleaner.Cleanable cleanable;
@@ -45,11 +45,11 @@ public final class LeakTrackingInputStream extends FilterInputStream {
      */
     public LeakTrackingInputStream(InputStream in, String kind) {
         super(in);
-        BitstreamInputstreamOpenInfo info =
-                new BitstreamInputstreamOpenInfo(id, kind, Instant.now(), new Exception("Opened here"));
+        BitstreamInputStreamOpenInfo info =
+                new BitstreamInputStreamOpenInfo(id, kind, Instant.now(), new Exception("Opened here"));
         OPEN.put(id, info);
         this.cleanable = CLEANER.register(this, () -> {
-            BitstreamInputstreamOpenInfo leaked = OPEN.remove(id);
+            BitstreamInputStreamOpenInfo leaked = OPEN.remove(id);
             if (leaked != null) {
                 log.error("LEAKED {} stream {}", leaked.kind(), leaked.id(), leaked.openedAtThrowable());
             }
@@ -66,7 +66,7 @@ public final class LeakTrackingInputStream extends FilterInputStream {
         super.close();
     }
 
-    public static Map<UUID, BitstreamInputstreamOpenInfo> snapshotOpenStreams() {
+    public static Map<UUID, BitstreamInputStreamOpenInfo> snapshotOpenStreams() {
         return Map.copyOf(OPEN);
     }
 }

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/LeakTrackingInputStream.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/LeakTrackingInputStream.java
@@ -1,0 +1,72 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.storage.bitstore;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.ref.Cleaner;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Wrapper Class for InputStream
+ * Keeps track of open InputStreams and adds information to be able to track down the origins of the InputStream
+ *
+ * @author Kevin Van de Velde (kevin at atmire dot com)
+ */
+public final class LeakTrackingInputStream extends FilterInputStream {
+
+    private static final Cleaner CLEANER = Cleaner.create();
+    private static final ConcurrentMap<UUID, BitstreamInputstreamOpenInfo> OPEN = new ConcurrentHashMap<>();
+
+    private final UUID id = UUID.randomUUID();
+    private final Cleaner.Cleanable cleanable;
+    private volatile boolean closed = false;
+
+    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(LeakTrackingInputStream.class);
+
+    /**
+     * Constructor of LeakTrackingInputStream
+     * Wraps an InputStream with information to keep track of open InputStreams
+     *
+     * @param in    the InputStream to be wrapped
+     * @param kind  where the InputStream was opened or retrieved
+     */
+    public LeakTrackingInputStream(InputStream in, String kind) {
+        super(in);
+        BitstreamInputstreamOpenInfo info =
+                new BitstreamInputstreamOpenInfo(id, kind, Instant.now(), new Exception("Opened here"));
+        OPEN.put(id, info);
+        this.cleanable = CLEANER.register(this, () -> {
+            BitstreamInputstreamOpenInfo leaked = OPEN.remove(id);
+            if (leaked != null) {
+                log.error("LEAKED {} stream {}", leaked.kind(), leaked.id(), leaked.openedAtThrowable());
+            }
+        });
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (!closed) {
+            closed = true;
+            OPEN.remove(id);
+            cleanable.clean();
+        }
+        super.close();
+    }
+
+    public static Map<UUID, BitstreamInputstreamOpenInfo> snapshotOpenStreams() {
+        return Map.copyOf(OPEN);
+    }
+}

--- a/dspace-api/src/test/java/org/dspace/app/requestitem/RequestItemEmailNotifierTest.java
+++ b/dspace-api/src/test/java/org/dspace/app/requestitem/RequestItemEmailNotifierTest.java
@@ -12,9 +12,15 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.time.Period;
 
 import jakarta.mail.Address;
 import jakarta.mail.Message;
@@ -40,10 +46,14 @@ import org.dspace.handle.factory.HandleServiceFactory;
 import org.dspace.handle.service.HandleService;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.storage.bitstore.factory.StorageServiceFactory;
+import org.dspace.storage.bitstore.service.BitstreamStorageService;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.test.util.ReflectionTestUtils;
 
 
 /**
@@ -306,6 +316,122 @@ public class RequestItemEmailNotifierTest
         String content = (String)myMessage.getContent();
         assertThat("Should contain access link", content, containsString(responseLink));
         assertThat("Should not contain attachment marker", content, not(containsString("Attachment")));
+    }
+
+    @Test
+    public void testEmailGenerationClosesInputStreamsWhenAllFiles() throws Exception {
+        InputStream realStream = new ByteArrayInputStream("abc".getBytes());
+        InputStream spyStream = Mockito.spy(realStream);
+
+        context.turnOffAuthorisationSystem();
+        Community community = CommunityBuilder.createCommunity(context).build();
+        Collection collection = CollectionBuilder.createCollection(context, community).build();
+        Item item = ItemBuilder.createItem(context, collection).build();
+
+        Bitstream bitstream = BitstreamBuilder.createBitstream(context, item, realStream)
+                                              .withName("small.txt")
+                                              .withEmbargoPeriod(Period.ofMonths(6))
+                                              .build();
+        context.restoreAuthSystemState();
+
+        // Make bitstreamService return the spyStream
+        BitstreamStorageService originalService =
+                StorageServiceFactory.getInstance().getBitstreamStorageService();
+        BitstreamStorageService spyService = spy(originalService);
+
+        doReturn(spyStream).when(spyService).retrieve(any(), eq(bitstream));
+
+        ReflectionTestUtils.setField(bitstreamService, "bitstreamStorageService", spyService);
+
+        try {
+            RequestItem request = RequestItemBuilder
+                    .createRequestItem(context, item, bitstream)
+                    .withAllFiles(true)
+                    .withAcceptRequest(true)
+                    .build();
+
+            // Install a fake transport for RFC2822 email addresses.
+            Session session = DSpaceServicesFactory.getInstance().getEmailService().getSession();
+            Provider transportProvider = new Provider(Provider.Type.TRANSPORT,
+                                                      DUMMY_PROTO, JavaMailTestTransport.class.getCanonicalName(),
+                                                      "DSpace", "1.0");
+            session.addProvider(transportProvider);
+            session.setProvider(transportProvider);
+            session.setProtocolForAddress("rfc822", DUMMY_PROTO);
+            requestItemEmailNotifier.sendResponse(context, request, "Subject", "Message");
+
+            boolean bitstreamRetrieved = Mockito.mockingDetails(spyService)
+                                                .getInvocations().stream()
+                                                .filter(i -> i.getMethod().getName().equals("retrieve"))
+                                                .mapToInt(i -> 1)
+                                                .sum() > 0;
+
+            if (bitstreamRetrieved) {
+                Mockito.verify(spyStream, times(1).description(
+                        "InputStream should have been closed after RequestItemEmailNotifier.sendResponse() call"))
+                       .close();
+            }
+        } finally {
+            ReflectionTestUtils.setField(bitstreamService, "bitstreamStorageService", originalService);
+        }
+    }
+
+    @Test
+    public void testEmailGenerationClosesInputStreamsWhenNotAllFiles() throws Exception {
+        InputStream realStream = new ByteArrayInputStream("abc".getBytes());
+        InputStream spyStream = Mockito.spy(realStream);
+
+        context.turnOffAuthorisationSystem();
+        Community community = CommunityBuilder.createCommunity(context).build();
+        Collection collection = CollectionBuilder.createCollection(context, community).build();
+        Item item = ItemBuilder.createItem(context, collection).build();
+
+        Bitstream bitstream = BitstreamBuilder.createBitstream(context, item, realStream)
+                                              .withName("small.txt")
+                                              .withEmbargoPeriod(Period.ofMonths(6))
+                                              .build();
+        context.restoreAuthSystemState();
+
+        // Make bitstreamService return the spyStream
+        BitstreamStorageService originalService =
+                StorageServiceFactory.getInstance().getBitstreamStorageService();
+        BitstreamStorageService spyService = spy(originalService);
+
+        doReturn(spyStream).when(spyService).retrieve(any(), eq(bitstream));
+
+        ReflectionTestUtils.setField(bitstreamService, "bitstreamStorageService", spyService);
+
+        try {
+            RequestItem request = RequestItemBuilder
+                    .createRequestItem(context, item, bitstream)
+                    .withAllFiles(false)
+                    .withAcceptRequest(true)
+                    .build();
+
+            // Install a fake transport for RFC2822 email addresses.
+            Session session = DSpaceServicesFactory.getInstance().getEmailService().getSession();
+            Provider transportProvider = new Provider(Provider.Type.TRANSPORT,
+                                                      DUMMY_PROTO, JavaMailTestTransport.class.getCanonicalName(),
+                                                      "DSpace", "1.0");
+            session.addProvider(transportProvider);
+            session.setProvider(transportProvider);
+            session.setProtocolForAddress("rfc822", DUMMY_PROTO);
+            requestItemEmailNotifier.sendResponse(context, request, "Subject", "Message");
+
+            boolean bitstreamRetrieved = Mockito.mockingDetails(spyService)
+                                                .getInvocations().stream()
+                                                .filter(i -> i.getMethod().getName().equals("retrieve"))
+                                                .mapToInt(i -> 1)
+                                                .sum() > 0;
+
+            if (bitstreamRetrieved) {
+                Mockito.verify(spyStream, times(1).description(
+                        "InputStream should have been closed after RequestItemEmailNotifier.sendResponse() call"))
+                       .close();
+            }
+        } finally {
+            ReflectionTestUtils.setField(bitstreamService, "bitstreamStorageService", originalService);
+        }
     }
 
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/configuration/ActuatorConfiguration.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/configuration/ActuatorConfiguration.java
@@ -13,6 +13,7 @@ import java.util.Arrays;
 
 import org.apache.solr.client.solrj.SolrServerException;
 import org.dspace.app.rest.DiscoverableEndpointsService;
+import org.dspace.app.rest.health.BitstreamStreamAnomaliesHealthIndicator;
 import org.dspace.app.rest.health.GeoIpHealthIndicator;
 import org.dspace.app.rest.health.SEOHealthIndicator;
 import org.dspace.app.rest.health.SolrHealthIndicator;
@@ -93,6 +94,12 @@ public class ActuatorConfiguration {
     @ConditionalOnEnabledHealthIndicator("geoIp")
     public GeoIpHealthIndicator geoIpHealthIndicator() {
         return new GeoIpHealthIndicator();
+    }
+
+    @Bean
+    @ConditionalOnEnabledHealthIndicator("bitstreamStreamAnomalies")
+    public BitstreamStreamAnomaliesHealthIndicator bitstreamStreamAnomaliesHealthIndicator() {
+        return new BitstreamStreamAnomaliesHealthIndicator();
     }
 
     public String getActuatorBasePath() {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/health/BitstreamStreamAnomaliesHealthIndicator.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/health/BitstreamStreamAnomaliesHealthIndicator.java
@@ -1,0 +1,57 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.health;
+
+import static org.dspace.app.rest.configuration.ActuatorConfiguration.UP_WITH_ISSUES_STATUS;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.dspace.storage.bitstore.BitstreamInputStreamOpenInfo;
+import org.dspace.storage.bitstore.LeakTrackingInputStream;
+import org.springframework.boot.actuate.health.AbstractHealthIndicator;
+import org.springframework.boot.actuate.health.Health.Builder;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.actuate.health.Status;
+
+/**
+ * Implementation of {@link HealthIndicator}
+ * to verify that bitstreams are not open longer than a certain amount of time
+ *
+ * @author Bram Maegerman (bram.maegerman at atmire.com)
+ */
+public class BitstreamStreamAnomaliesHealthIndicator extends AbstractHealthIndicator {
+
+    public static final long MAXIMUM_OPEN_MINUTES = 5;
+
+    @Override
+    protected void doHealthCheck(Builder builder) throws Exception {
+        Map<UUID, BitstreamInputStreamOpenInfo> openStreams = LeakTrackingInputStream.snapshotOpenStreams();
+        List<BitstreamInputStreamOpenInfo> leakedStreams = new ArrayList<>();
+        for (BitstreamInputStreamOpenInfo openStream : openStreams.values()) {
+            if (openStream.openedAt().isBefore(
+                    Instant.now().minusSeconds(60 * MAXIMUM_OPEN_MINUTES))) {
+                leakedStreams.add(openStream);
+            }
+        }
+
+        if (!leakedStreams.isEmpty()) {
+            builder.status(UP_WITH_ISSUES_STATUS)
+                   .withDetail("amount",
+                               leakedStreams.size() + " bitstream input streams may not have been properly closed");
+            for (BitstreamInputStreamOpenInfo leakedStream : leakedStreams) {
+                builder.withDetail(leakedStream.id().toString(), leakedStream.toString());
+            }
+        } else {
+            builder.status(Status.UP);
+        }
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/BitstreamResource.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/BitstreamResource.java
@@ -105,7 +105,7 @@ public class BitstreamResource extends AbstractResource {
     public InputStream getInputStream() throws IOException {
         fetchDocument();
 
-        return document.inputStream();
+        return document.getInputstream();
     }
 
     @Override
@@ -123,7 +123,7 @@ public class BitstreamResource extends AbstractResource {
     public String getChecksum() {
         fetchDocument();
 
-        return document.etag();
+        return document.getEtag();
     }
 
     void fetchDocument() {
@@ -136,13 +136,13 @@ public class BitstreamResource extends AbstractResource {
             if (shouldGenerateCoverPage) {
                 var coverPage = getCoverpageByteArray(context, bitstream);
 
-                this.document = new BitstreamDocument(etag(bitstream),
+                this.document = new BitstreamDocumentCoverPage(etag(bitstream),
                         coverPage.length,
                         new ByteArrayInputStream(coverPage));
             } else {
-                this.document = new BitstreamDocument(bitstream.getChecksum(),
+                this.document = new BitstreamDocumentInputstream(bitstream.getChecksum(),
                         bitstream.getSizeBytes(),
-                        bitstreamService.retrieve(context, bitstream));
+                        bitstream.getID());
             }
         } catch (SQLException | AuthorizeException | IOException e) {
             throw new RuntimeException(e);
@@ -190,7 +190,7 @@ public class BitstreamResource extends AbstractResource {
      * @see #skipAuthCheck
      */
     Context initializeContext() throws SQLException {
-        Context context = new Context();
+        Context context = new Context(Context.Mode.READ_ONLY);
         EPerson currentUser = ePersonService.find(context, currentUserUUID);
         context.setCurrentUser(currentUser);
         currentSpecialGroups.forEach(context::setSpecialGroup);
@@ -200,5 +200,56 @@ public class BitstreamResource extends AbstractResource {
         return context;
     }
 
-    record BitstreamDocument(String etag, long length, InputStream inputStream) {}
+    protected abstract class BitstreamDocument {
+        private final String etag;
+        private final long length;
+
+        protected BitstreamDocument(String etag, long length) {
+            this.etag = etag;
+            this.length = length;
+        }
+
+        abstract InputStream getInputstream();
+
+        public String getEtag() {
+            return etag;
+        }
+
+        public long length() {
+            return length;
+        }
+    }
+
+    protected class BitstreamDocumentInputstream extends BitstreamDocument {
+        protected final UUID bitstreamUUID;
+
+        public BitstreamDocumentInputstream(String etag, long length, UUID bitstreamUUID) {
+            super(etag, length);
+            this.bitstreamUUID = bitstreamUUID;
+        }
+
+        @Override
+        public InputStream getInputstream() {
+            try (Context context = initializeContext()) {
+                return bitstreamService.retrieve(context, bitstreamService.find(context, bitstreamUUID));
+            } catch (SQLException | AuthorizeException | IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    protected class BitstreamDocumentCoverPage extends BitstreamDocument {
+        private final ByteArrayInputStream coverpage;
+
+        public BitstreamDocumentCoverPage(String etag, long length, ByteArrayInputStream byteArrayInputStream) {
+            super(etag, length);
+            this.coverpage = byteArrayInputStream;
+        }
+
+        @Override
+        public InputStream getInputstream() {
+            return coverpage;
+        }
+    }
+
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/BitstreamResourceAccessByToken.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/BitstreamResourceAccessByToken.java
@@ -9,6 +9,7 @@ package org.dspace.app.rest.utils;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.sql.SQLException;
 import java.util.Set;
 import java.util.UUID;
@@ -87,19 +88,35 @@ public class BitstreamResourceAccessByToken extends BitstreamResource {
             if (shouldGenerateCoverPage) {
                 var coverPage = getCoverpageByteArray(fileRetrievalContext, bitstream);
 
-                this.document = new BitstreamDocument(etag(bitstream),
+                this.document = new BitstreamDocumentCoverPage(etag(bitstream),
                         coverPage.length,
                         new ByteArrayInputStream(coverPage));
             } else {
-                this.document = new BitstreamDocument(bitstream.getChecksum(),
+                this.document = new BitstreamDocumentAuthorizedAccess(bitstream.getChecksum(),
                         bitstream.getSizeBytes(),
-                        bitstreamService.retrieve(fileRetrievalContext, bitstream));
+                        bitstream.getID());
             }
         } catch (SQLException | AuthorizeException | IOException e) {
             throw new RuntimeException(e);
         }
 
         LOG.debug("fetched document {} {}", shouldGenerateCoverPage, document);
+    }
+
+    private class BitstreamDocumentAuthorizedAccess extends BitstreamDocumentInputstream {
+        public BitstreamDocumentAuthorizedAccess(String etag, long length, UUID bitstreamUUID) {
+            super(etag, length, bitstreamUUID);
+        }
+
+        @Override
+        public InputStream getInputstream() {
+            try (Context context = initializeContext()) {
+                context.turnOffAuthorisationSystem();
+                return bitstreamService.retrieve(context, bitstreamService.find(context, bitstreamUUID));
+            } catch (SQLException | IOException | AuthorizeException e) {
+                throw new RuntimeException(e);
+            }
+        }
     }
 
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
@@ -69,6 +69,7 @@ import org.apache.solr.client.solrj.SolrServerException;
 import org.dspace.app.requestitem.RequestItem;
 import org.dspace.app.requestitem.service.RequestItemService;
 import org.dspace.app.rest.model.RequestItemRest;
+import org.dspace.app.rest.repository.WorkflowItemItemLinkRepository;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
 import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.authorize.service.ResourcePolicyService;
@@ -100,6 +101,7 @@ import org.dspace.statistics.SolrLoggerServiceImpl;
 import org.dspace.statistics.factory.StatisticsServiceFactory;
 import org.dspace.statistics.service.SolrLoggerService;
 import org.dspace.storage.bitstore.factory.StorageServiceFactory;
+import org.dspace.storage.bitstore.service.BitstreamStorageService;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -162,6 +164,8 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
     private BitstreamFormat supportedFormat;
     private BitstreamFormat knownFormat;
     private BitstreamFormat unknownFormat;
+    @Autowired
+    private WorkflowItemItemLinkRepository item;
 
     @BeforeClass
     public static void clearStatistics() throws Exception {
@@ -1749,5 +1753,267 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
 
         // unauthorized request should not log statistics so we have only 2 successful visits
         checkNumberOfStatsRecords(bitstream, 2);
+    }
+
+    @Test
+    public void bitstreamInputStreamClosesWithGetRequestTest() throws Exception {
+        InputStream realStream = new ByteArrayInputStream("abc".getBytes());
+        InputStream spyStream = Mockito.spy(realStream);
+
+        context.turnOffAuthorisationSystem();
+        Community community = CommunityBuilder.createCommunity(context).build();
+        Collection collection = CollectionBuilder.createCollection(context, community).build();
+        Item item = ItemBuilder.createItem(context, collection).build();
+
+        Bitstream bitstream = BitstreamBuilder.createBitstream(context, item, realStream).build();
+        context.restoreAuthSystemState();
+
+        BitstreamStorageService originalService =
+                StorageServiceFactory.getInstance().getBitstreamStorageService();
+        BitstreamStorageService spyService = spy(originalService);
+
+        doReturn(spyStream).when(spyService).retrieve(any(), eq(bitstream));
+
+        ReflectionTestUtils.setField(bitstreamService, "bitstreamStorageService", spyService);
+
+        try {
+            getClient().perform(get("/api/core/bitstreams/" + bitstream.getID() + "/content"))
+                       .andExpect(status().isOk());
+
+            boolean bitstreamRetrieved = Mockito.mockingDetails(spyService)
+                                                .getInvocations().stream()
+                                                .filter(i -> i.getMethod().getName().equals("retrieve"))
+                                                .mapToInt(i -> 1)
+                                                .sum() > 0;
+
+            if (bitstreamRetrieved) {
+                Mockito.verify(spyStream, times(1)
+                               .description("InputStream should have been closed after GET request"))
+                       .close();
+            }
+        } finally {
+            ReflectionTestUtils.setField(bitstreamService, "bitstreamStorageService", originalService);
+        }
+    }
+
+    @Test
+    public void bitstreamInputStreamClosesWithHeadRequestTest() throws Exception {
+        InputStream realStream = new ByteArrayInputStream("abc".getBytes());
+        InputStream spyStream = Mockito.spy(realStream);
+
+        context.turnOffAuthorisationSystem();
+        Community community = CommunityBuilder.createCommunity(context).build();
+        Collection collection = CollectionBuilder.createCollection(context, community).build();
+        Item item = ItemBuilder.createItem(context, collection).build();
+
+        Bitstream bitstream = BitstreamBuilder.createBitstream(context, item, realStream).build();
+        context.restoreAuthSystemState();
+
+        BitstreamStorageService originalService =
+                StorageServiceFactory.getInstance().getBitstreamStorageService();
+        BitstreamStorageService spyService = spy(originalService);
+
+        doReturn(spyStream).when(spyService).retrieve(any(), eq(bitstream));
+
+        ReflectionTestUtils.setField(bitstreamService, "bitstreamStorageService", spyService);
+
+        try {
+            getClient().perform(head("/api/core/bitstreams/" + bitstream.getID() + "/content"))
+                       .andExpect(status().isOk());
+
+            boolean bitstreamRetrieved = Mockito.mockingDetails(spyService)
+                                                .getInvocations().stream()
+                                                .filter(i -> i.getMethod().getName().equals("retrieve"))
+                                                .mapToInt(i -> 1)
+                                                .sum() > 0;
+
+            if (bitstreamRetrieved) {
+                Mockito.verify(spyStream, times(1)
+                               .description("InputStream should have been closed after HEAD request"))
+                       .close();
+            }
+        } finally {
+            ReflectionTestUtils.setField(bitstreamService, "bitstreamStorageService", originalService);
+        }
+    }
+
+    @Test
+    public void bitstreamInputStreamClosesWithGetRequestAndAccessTokenTest() throws Exception {
+        InputStream realStream = new ByteArrayInputStream("abc".getBytes());
+        InputStream spyStream = Mockito.spy(realStream);
+
+        context.turnOffAuthorisationSystem();
+        Community community = CommunityBuilder.createCommunity(context).build();
+        Collection collection = CollectionBuilder.createCollection(context, community).build();
+        Item item = ItemBuilder.createItem(context, collection).build();
+
+        Bitstream bitstream = BitstreamBuilder.createBitstream(context, item, realStream).build();
+
+        RequestItem itemRequest = RequestItemBuilder
+                .createRequestItem(context, item, bitstream)
+                .build();
+        context.restoreAuthSystemState();
+
+        BitstreamStorageService originalService =
+                StorageServiceFactory.getInstance().getBitstreamStorageService();
+        BitstreamStorageService spyService = spy(originalService);
+
+        doReturn(spyStream).when(spyService).retrieve(any(), eq(bitstream));
+
+        ReflectionTestUtils.setField(bitstreamService, "bitstreamStorageService", spyService);
+
+        try {
+            getClient().perform(get("/api/core/bitstreams/" + bitstream.getID() + "/content")
+                                        .param("accessToken", itemRequest.getAccess_token()))
+                       .andExpect(status().isOk());
+
+            boolean bitstreamRetrieved = Mockito.mockingDetails(spyService)
+                                                .getInvocations().stream()
+                                                .filter(i -> i.getMethod().getName().equals("retrieve"))
+                                                .mapToInt(i -> 1)
+                                                .sum() > 0;
+
+            if (bitstreamRetrieved) {
+                Mockito.verify(spyStream, times(1)
+                               .description("InputStream should have been closed after GET request"))
+                       .close();
+            }
+        } finally {
+            ReflectionTestUtils.setField(bitstreamService, "bitstreamStorageService", originalService);
+        }
+    }
+
+    @Test
+    public void bitstreamInputStreamClosesWithHeadRequestAndAccessTokenTest() throws Exception {
+        InputStream realStream = new ByteArrayInputStream("abc".getBytes());
+        InputStream spyStream = Mockito.spy(realStream);
+
+        context.turnOffAuthorisationSystem();
+        Community community = CommunityBuilder.createCommunity(context).build();
+        Collection collection = CollectionBuilder.createCollection(context, community).build();
+        Item item = ItemBuilder.createItem(context, collection).build();
+
+        Bitstream bitstream = BitstreamBuilder.createBitstream(context, item, realStream).build();
+
+        RequestItem itemRequest = RequestItemBuilder
+                .createRequestItem(context, item, bitstream)
+                .build();
+        context.restoreAuthSystemState();
+
+        BitstreamStorageService originalService =
+                StorageServiceFactory.getInstance().getBitstreamStorageService();
+        BitstreamStorageService spyService = spy(originalService);
+
+        doReturn(spyStream).when(spyService).retrieve(any(), eq(bitstream));
+
+        ReflectionTestUtils.setField(bitstreamService, "bitstreamStorageService", spyService);
+
+        try {
+            getClient().perform(head("/api/core/bitstreams/" + bitstream.getID() + "/content")
+                                        .param("accessToken", itemRequest.getAccess_token()))
+                       .andExpect(status().isOk());
+
+            boolean bitstreamRetrieved = Mockito.mockingDetails(spyService)
+                                                .getInvocations().stream()
+                                                .filter(i -> i.getMethod().getName().equals("retrieve"))
+                                                .mapToInt(i -> 1)
+                                                .sum() > 0;
+
+            if (bitstreamRetrieved) {
+                Mockito.verify(spyStream, times(1)
+                               .description("InputStream should have been closed after HEAD request"))
+                       .close();
+            }
+        } finally {
+            ReflectionTestUtils.setField(bitstreamService, "bitstreamStorageService", originalService);
+        }
+    }
+
+    @Test
+    public void bitstreamInputStreamClosesWithGetRequestAndCitationPageEnabledTest() throws Exception {
+        configurationService.setProperty("citation-page.enable_globally", true);
+        citationDocumentService.afterPropertiesSet();
+
+        InputStream realStream = new ByteArrayInputStream("abc".getBytes());
+        InputStream spyStream = Mockito.spy(realStream);
+
+        context.turnOffAuthorisationSystem();
+        Community community = CommunityBuilder.createCommunity(context).build();
+        Collection collection = CollectionBuilder.createCollection(context, community).build();
+        Item item = ItemBuilder.createItem(context, collection).build();
+
+        Bitstream bitstream = BitstreamBuilder.createBitstream(context, item, realStream).build();
+        context.restoreAuthSystemState();
+
+        BitstreamStorageService originalService =
+                StorageServiceFactory.getInstance().getBitstreamStorageService();
+        BitstreamStorageService spyService = spy(originalService);
+
+        doReturn(spyStream).when(spyService).retrieve(any(), eq(bitstream));
+
+        ReflectionTestUtils.setField(bitstreamService, "bitstreamStorageService", spyService);
+
+        try {
+            getClient().perform(get("/api/core/bitstreams/" + bitstream.getID() + "/content"))
+                       .andExpect(status().isOk());
+
+            boolean bitstreamRetrieved = Mockito.mockingDetails(spyService)
+                                                .getInvocations().stream()
+                                                .filter(i -> i.getMethod().getName().equals("retrieve"))
+                                                .mapToInt(i -> 1)
+                                                .sum() > 0;
+
+            if (bitstreamRetrieved) {
+                Mockito.verify(spyStream, times(1)
+                               .description("InputStream should have been closed after GET request"))
+                       .close();
+            }
+        } finally {
+            ReflectionTestUtils.setField(bitstreamService, "bitstreamStorageService", originalService);
+        }
+    }
+
+    @Test
+    public void bitstreamInputStreamClosesWithHeadRequestAndCitationPageEnabledTest() throws Exception {
+        configurationService.setProperty("citation-page.enable_globally", true);
+        citationDocumentService.afterPropertiesSet();
+
+        InputStream realStream = new ByteArrayInputStream("abc".getBytes());
+        InputStream spyStream = Mockito.spy(realStream);
+
+        context.turnOffAuthorisationSystem();
+        Community community = CommunityBuilder.createCommunity(context).build();
+        Collection collection = CollectionBuilder.createCollection(context, community).build();
+        Item item = ItemBuilder.createItem(context, collection).build();
+
+        Bitstream bitstream = BitstreamBuilder.createBitstream(context, item, realStream).build();
+        context.restoreAuthSystemState();
+
+        BitstreamStorageService originalService =
+                StorageServiceFactory.getInstance().getBitstreamStorageService();
+        BitstreamStorageService spyService = spy(originalService);
+
+        doReturn(spyStream).when(spyService).retrieve(any(), eq(bitstream));
+
+        ReflectionTestUtils.setField(bitstreamService, "bitstreamStorageService", spyService);
+
+        try {
+            getClient().perform(head("/api/core/bitstreams/" + bitstream.getID() + "/content"))
+                       .andExpect(status().isOk());
+
+            boolean bitstreamRetrieved = Mockito.mockingDetails(spyService)
+                                                .getInvocations().stream()
+                                                .filter(i -> i.getMethod().getName().equals("retrieve"))
+                                                .mapToInt(i -> 1)
+                                                .sum() > 0;
+
+            if (bitstreamRetrieved) {
+                Mockito.verify(spyStream, times(1)
+                               .description("InputStream should have been closed after HEAD request"))
+                       .close();
+            }
+        } finally {
+            ReflectionTestUtils.setField(bitstreamService, "bitstreamStorageService", originalService);
+        }
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/health/BitstreamStreamAnomaliesHealthIndicatorTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/health/BitstreamStreamAnomaliesHealthIndicatorTest.java
@@ -1,0 +1,162 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.health;
+
+import static org.dspace.app.rest.health.BitstreamStreamAnomaliesHealthIndicator.MAXIMUM_OPEN_MINUTES;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+
+import org.dspace.app.rest.configuration.ActuatorConfiguration;
+import org.dspace.storage.bitstore.BitstreamInputStreamOpenInfo;
+import org.dspace.storage.bitstore.LeakTrackingInputStream;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+
+/**
+ * Unit tests for {@link BitstreamStreamAnomaliesHealthIndicator}.
+ *
+ * @author Bram Maegerman (bram.maegerman at atmire.com)
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class BitstreamStreamAnomaliesHealthIndicatorTest {
+
+    @InjectMocks
+    private BitstreamStreamAnomaliesHealthIndicator bitstreamStreamAnomaliesHealthIndicator;
+
+    @Test
+    public void testWithoutLeakedBitstream() {
+        try (MockedStatic<LeakTrackingInputStream> mockedStatic = Mockito.mockStatic(LeakTrackingInputStream.class)) {
+            mockedStatic.when(LeakTrackingInputStream::snapshotOpenStreams).thenReturn(Collections.emptyMap());
+
+            Health health = bitstreamStreamAnomaliesHealthIndicator.health();
+
+            assertEquals(Status.UP, health.getStatus());
+            assertEquals(Collections.emptyMap(), health.getDetails());
+        }
+    }
+
+    @Test
+    public void testWithOneLeakedBitstream() {
+        try (MockedStatic<LeakTrackingInputStream> mockedStatic = Mockito.mockStatic(LeakTrackingInputStream.class)) {
+            UUID bitstreamInfoId = UUID.randomUUID();
+            mockedStatic.when(LeakTrackingInputStream::snapshotOpenStreams)
+                        .thenReturn(Map.of(
+                                UUID.randomUUID(),
+                                new BitstreamInputStreamOpenInfo(
+                                        bitstreamInfoId,
+                                        "kind1",
+                                        Instant.now().minusSeconds(60 * (MAXIMUM_OPEN_MINUTES * 2)),
+                                        new Exception("test")
+                                )
+                        ));
+
+            Health health = bitstreamStreamAnomaliesHealthIndicator.health();
+
+            assertEquals(ActuatorConfiguration.UP_WITH_ISSUES_STATUS, health.getStatus());
+
+            assertEquals(2, health.getDetails().size());
+
+            assertTrue(health.getDetails().containsKey("amount"));
+            assertTrue(health.getDetails().get("amount").toString().contains("1"));
+
+            assertTrue(health.getDetails().containsKey(bitstreamInfoId.toString()));
+            assertTrue(health.getDetails().get(bitstreamInfoId.toString()).toString().contains("kind1"));
+        }
+    }
+
+    @Test
+    public void testWithMultipleLeakedBitstreams() {
+        try (MockedStatic<LeakTrackingInputStream> mockedStatic = Mockito.mockStatic(LeakTrackingInputStream.class)) {
+            UUID bitstreamInfoId1 = UUID.randomUUID();
+            UUID bitstreamInfoId2 = UUID.randomUUID();
+            mockedStatic.when(LeakTrackingInputStream::snapshotOpenStreams)
+                        .thenReturn(Map.of(
+                                UUID.randomUUID(),
+                                new BitstreamInputStreamOpenInfo(
+                                        bitstreamInfoId1,
+                                        "kind1",
+                                        Instant.now().minusSeconds(60 * (MAXIMUM_OPEN_MINUTES * 2)),
+                                        new Exception("test")
+                                ),
+                                UUID.randomUUID(),
+                                new BitstreamInputStreamOpenInfo(
+                                        bitstreamInfoId2,
+                                        "kind2",
+                                        Instant.now().minusSeconds(60 * (MAXIMUM_OPEN_MINUTES * 2)),
+                                        new Exception("test")
+                                )
+                        ));
+
+            Health health = bitstreamStreamAnomaliesHealthIndicator.health();
+
+            assertEquals(ActuatorConfiguration.UP_WITH_ISSUES_STATUS, health.getStatus());
+
+            assertEquals(3, health.getDetails().size());
+
+            assertTrue(health.getDetails().containsKey("amount"));
+            assertTrue(health.getDetails().get("amount").toString().contains("2"));
+
+            assertTrue(health.getDetails().containsKey(bitstreamInfoId1.toString()));
+            assertTrue(health.getDetails().get(bitstreamInfoId1.toString()).toString().contains("kind1"));
+
+            assertTrue(health.getDetails().containsKey(bitstreamInfoId2.toString()));
+            assertTrue(health.getDetails().get(bitstreamInfoId2.toString()).toString().contains("kind2"));
+        }
+    }
+
+    @Test
+    public void testWithOneLeakedAndOneRegularBitstream() {
+        try (MockedStatic<LeakTrackingInputStream> mockedStatic = Mockito.mockStatic(LeakTrackingInputStream.class)) {
+            UUID bitstreamInfoId1 = UUID.randomUUID();
+            UUID bitstreamInfoId2 = UUID.randomUUID();
+            mockedStatic.when(LeakTrackingInputStream::snapshotOpenStreams)
+                        .thenReturn(Map.of(
+                                UUID.randomUUID(),
+                                new BitstreamInputStreamOpenInfo(
+                                        bitstreamInfoId1,
+                                        "kind1",
+                                        Instant.now().minusSeconds(60 * (MAXIMUM_OPEN_MINUTES * 2)),
+                                        new Exception("test")
+                                ),
+                                UUID.randomUUID(),
+                                new BitstreamInputStreamOpenInfo(
+                                        bitstreamInfoId2,
+                                        "kind2",
+                                        Instant.now(),
+                                        new Exception("test")
+                                )
+                        ));
+
+            Health health = bitstreamStreamAnomaliesHealthIndicator.health();
+
+            assertEquals(ActuatorConfiguration.UP_WITH_ISSUES_STATUS, health.getStatus());
+
+            assertEquals(2, health.getDetails().size());
+
+            assertTrue(health.getDetails().containsKey("amount"));
+            assertTrue(health.getDetails().get("amount").toString().contains("1"));
+
+            assertTrue(health.getDetails().containsKey(bitstreamInfoId1.toString()));
+            assertTrue(health.getDetails().get(bitstreamInfoId1.toString()).toString().contains("kind1"));
+
+            assertFalse(health.getDetails().containsKey(bitstreamInfoId2.toString()));
+        }
+    }
+}


### PR DESCRIPTION
## References
Fixes #12277 
Builds on https://github.com/DSpace/DSpace/pull/12249
Angular PR: [#5456](https://github.com/DSpace/dspace-angular/pull/5456)

## Description
This PR implements a health endpoint that detects if a bitstream input stream is open for longer than a certain amount of time.

## Instructions for Reviewers
- Revert the commit that fixed retrieved input streams staying open (d5aefecbe5f7273c40c89e1ba62a63e21b8d3bf8)
- Open a few bitstream input streams using `curl --head http://localhost:8080/server/api/core/bitstreams/{uuid}/content`
- Wait 5 minutes
- Call the `/server/actuator/health` endpoint
- Verify the opened bitstreams are returned in the endpoint's response

List of changes in this PR:
- Adds a health endpoint to check for leaked bitstream input streams.
- Wraps all retrieved input streams in a newly added wrapper class to keep track of when and where they were opened.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
