### PR TITLE
Fix #9114: allow non adminstrator user to import external entities

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/handler/ExternalSourceEntryArchivedItemUriListHandler.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/handler/ExternalSourceEntryArchivedItemUriListHandler.java
@@ -22,7 +22,9 @@ import org.dspace.content.service.CollectionService;
 import org.dspace.content.service.InstallItemService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
+import org.dspace.services.ConfigurationService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Component;
 
 /**
@@ -40,6 +42,9 @@ public class ExternalSourceEntryArchivedItemUriListHandler extends ExternalSourc
 
     @Autowired
     private InstallItemService installItemService;
+
+    @Autowired
+    private ConfigurationService configurationService;
 
     private static final Logger log = org.apache.logging.log4j.LogManager
         .getLogger(ExternalSourceEntryItemUriListHandler.class);
@@ -62,13 +67,20 @@ public class ExternalSourceEntryArchivedItemUriListHandler extends ExternalSourc
             return false;
         }
         try {
-            String owningCollectionUuid = request.getParameter("owningCollection");
-            Collection collection = collectionService.find(context, UUID.fromString(owningCollectionUuid));
-            if (!authorizeService.isAdmin(context) && !authorizeService.authorizeActionBoolean(context, collection,
-                    Constants.ADD)) {
-                throw new AuthorizeException("Only admins/submitters are allowed to create items using external data");
-            }
+            if (this.configurationService.getBooleanProperty("submitter.allow.external.entities", false)) {
+                String owningCollectionUuid = request.getParameter("owningCollection");
+                Collection collection = collectionService.find(context, UUID.fromString(owningCollectionUuid));
+                if (!authorizeService.isAdmin(context) && !authorizeService.authorizeActionBoolean(context, collection,
+                        Constants.ADD)) {
+                    throw new AuthorizeException("Only admins or submitters with at least one collection they have " +
+                            "submitter privileges to, are allowed to create items using external data");
+                }
+            } else {
+                if (!authorizeService.isAdmin(context)) {
+                    throw new AuthorizeException("Only admins are allowed to create items using external data");
 
+                }
+            }
         } catch (SQLException e) {
             log.error("context isAdmin check resulted in an error", e);
             return false;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/handler/ExternalSourceEntryArchivedItemUriListHandler.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/handler/ExternalSourceEntryArchivedItemUriListHandler.java
@@ -24,7 +24,6 @@ import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.services.ConfigurationService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Component;
 
 /**

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/handler/ExternalSourceEntryArchivedItemUriListHandler.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/handler/ExternalSourceEntryArchivedItemUriListHandler.java
@@ -9,14 +9,18 @@ package org.dspace.app.rest.repository.handler;
 
 import java.sql.SQLException;
 import java.util.List;
+import java.util.UUID;
 
 import jakarta.servlet.http.HttpServletRequest;
 import org.apache.logging.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.content.Collection;
 import org.dspace.content.Item;
 import org.dspace.content.WorkspaceItem;
+import org.dspace.content.service.CollectionService;
 import org.dspace.content.service.InstallItemService;
+import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -30,6 +34,9 @@ public class ExternalSourceEntryArchivedItemUriListHandler extends ExternalSourc
 
     @Autowired
     private AuthorizeService authorizeService;
+
+    @Autowired
+    private CollectionService collectionService;
 
     @Autowired
     private InstallItemService installItemService;
@@ -55,9 +62,13 @@ public class ExternalSourceEntryArchivedItemUriListHandler extends ExternalSourc
             return false;
         }
         try {
-            if (!authorizeService.isAdmin(context)) {
-                throw new AuthorizeException("Only admins are allowed to create items using external data");
+            String owningCollectionUuid = request.getParameter("owningCollection");
+            Collection collection = collectionService.find(context, UUID.fromString(owningCollectionUuid));
+            if (!authorizeService.isAdmin(context) && !authorizeService.authorizeActionBoolean(context, collection,
+                    Constants.ADD)) {
+                throw new AuthorizeException("Only admins/submitters are allowed to create items using external data");
             }
+
         } catch (SQLException e) {
             log.error("context isAdmin check resulted in an error", e);
             return false;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/handler/ExternalSourceEntryArchivedItemUriListHandler.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/handler/ExternalSourceEntryArchivedItemUriListHandler.java
@@ -27,8 +27,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /**
- * This class will handle ExternalSourceEntryUriList and it'll create Item objects based on them.
- * This will create Archived items and thus only Admin users can use it
+ * This class will handle ExternalSourceEntryUriList, and it'll create Item objects based on them.
+ * This will create Archived items and thus only Admin users can use it, unless the "submitter.allow.external.entities"
+ * is set to true, allowing submitters with submit permission to the given owning collection to import external items.
  */
 @Component
 public class ExternalSourceEntryArchivedItemUriListHandler extends ExternalSourceEntryItemUriListHandler<Item> {
@@ -71,8 +72,8 @@ public class ExternalSourceEntryArchivedItemUriListHandler extends ExternalSourc
                 Collection collection = collectionService.find(context, UUID.fromString(owningCollectionUuid));
                 if (!authorizeService.isAdmin(context) && !authorizeService.authorizeActionBoolean(context, collection,
                         Constants.ADD)) {
-                    throw new AuthorizeException("Only admins or submitters with at least one collection they have " +
-                            "submitter privileges to, are allowed to create items using external data");
+                    throw new AuthorizeException("Only admins or submitters with submit permission to the given " +
+                            "owning collection parameter, are allowed to create items using external data");
                 }
             } else {
                 if (!authorizeService.isAdmin(context)) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/handler/ExternalSourceEntryArchivedItemUriListHandler.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/handler/ExternalSourceEntryArchivedItemUriListHandler.java
@@ -67,6 +67,7 @@ public class ExternalSourceEntryArchivedItemUriListHandler extends ExternalSourc
             return false;
         }
         try {
+            // TODO: This should be replaced by a solution, which doesn't bypass the submission workflow of the owning collection. See: https://github.com/DSpace/DSpace/issues/9114
             if (this.configurationService.getBooleanProperty("submitter.allow.external.entities", false)) {
                 String owningCollectionUuid = request.getParameter("owningCollection");
                 Collection collection = collectionService.find(context, UUID.fromString(owningCollectionUuid));

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1332,8 +1332,9 @@ metadata.hide.person.email = true
 #cc.license.required = true
 
 # Whether a non-admin user can import external entities into the repository.
-# If this is set to true, a non-admin user can directly import external entites into collections where he has submitter
+# If this is set to true, a non-admin user can directly import external entities into collections where he has submitter
 # privileges during the submission workflow of a related entity.
+# THIS WILL BYPASS THE SUBMISSION WORKFLOW OF THE SPECIFIC COLLECTION, BE CAREFUL WHEN ENABLING THIS.
 submitter.allow.external.entities = false
 
 #### Creative Commons settings ######

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1331,6 +1331,11 @@ metadata.hide.person.email = true
 # Defaults to false; If you set to 'true', submitter needs to provide cclicense
 #cc.license.required = true
 
+# Whether a non-admin user can import external entities into the repository.
+# If this is set to true, a non-admin user can directly import external entites into collections where he has submitter
+# privileges during the submission workflow of a related entity.
+submitter.allow.external.entities = false
+
 #### Creative Commons settings ######
 
 # The url to the web service API


### PR DESCRIPTION
## References
* Fixes #9114

## Description
Currently only side admins can use the external-import functionality in DSpace and standard submitters can't, even if they have submitter privileges on the collection where the external entity should be placed. This PR adds a check to allow non-admin users to directly import external entities into a specified collection to which they have submitter privileges. Because this opens up the possibility of bypassing this collections curation workflow, I made this functionality configurable. You must set  `submitter.allow.external.entities` to _true_ in order to allow this behavior. 

## Instructions for Reviewers

List of changes in this PR:

* included collectionService to _ExternalSourceEntryArchievedItemUriListHandler_ and added check whether the submitting person has the right to _ADD_ an item to the owningCollection.
* created new config parameter `submitter.allow.external.entities` (default: _false_) as a condition for the newly added check


**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes.
1. Activate entities in your DSpace backend
2. Create two collection one for OrgUnit entities and one for research projects (Project entities).
3. Create a submitter user, which has submitter-rights on both collections.
4. Login as the user and start a Submission for a new research project.
5. Search for a new Organization to add via the ROR tab and try to add this organization directly into the OrgUnit collection. -> This should result in an error
6. Set the `submitter.allow.external.entities` on the backend to true and restart tomcat.
7. Retry **4.& 5.** -> now the import should be successful and the new  OrgUnit is archived.

Note: This should also work with other entities such as persons, but the ror import works quite well out-of-the-box.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] ~If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.~
- [ ] ~If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.~
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
