### PR TITLE
Fix non-Latin char in custom url

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/customurl/service/CustomUrlServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/customurl/service/CustomUrlServiceImpl.java
@@ -32,6 +32,7 @@ import org.dspace.discovery.IndexableObject;
 import org.dspace.discovery.SearchService;
 import org.dspace.discovery.SearchServiceException;
 import org.dspace.discovery.indexobject.IndexableItem;
+import org.dspace.validation.util.CustomUrlUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -187,7 +188,13 @@ public class CustomUrlServiceImpl implements CustomUrlService {
         String cleanBase = normalizeUrl(rawInput);
         if (StringUtils.isBlank(cleanBase)) {
             throw new IllegalArgumentException("Input '" + rawInput + "' does not contain any valid " +
-                                                   "alphanumeric characters to generate a URL");
+                                                   "Latin characters to generate a URL");
+        }
+
+        // Verify the normalized result is a valid custom URL (should only contain Latin chars, digits, hyphens)
+        if (CustomUrlUtils.hasInvalidCharacters(cleanBase)) {
+            throw new IllegalArgumentException("Normalized URL '" + cleanBase + "' from input '" + rawInput +
+                                                   "' contains invalid characters");
         }
 
         if (!customUrlExists(context, cleanBase)) {

--- a/dspace-api/src/main/java/org/dspace/app/customurl/service/CustomUrlServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/customurl/service/CustomUrlServiceImpl.java
@@ -198,35 +198,45 @@ public class CustomUrlServiceImpl implements CustomUrlService {
     }
 
     /**
-     * Normalizes a given string into a URL-friendly "slug".
+     * Normalizes a given string into a URL-friendly "slug" containing only Latin characters.
      * <p>
      * The normalization process follows these steps:
      * <ul>
      * <li>Decomposes Unicode characters to remove accents (e.g., "é" becomes "e").</li>
+     * <li>Removes any remaining non-Latin characters (Cyrillic, Arabic, Chinese, etc.).</li>
      * <li>Converts the entire string to lowercase.</li>
      * <li>Replaces all sequences of non-alphanumeric characters with a single hyphen.</li>
      * <li>Trims leading and trailing hyphens.</li>
      * </ul>
      * </p>
-     * * @param text the raw string to be normalized (e.g., an Item title or metadata value).
+     * <p>
+     * Note: This method only preserves Latin letters (a-z, A-Z) and digits (0-9).
+     * Characters from other scripts (Cyrillic, Arabic, Chinese, etc.) are removed
+     * to prevent UI rendering issues.
+     * </p>
      *
+     * @param text the raw string to be normalized (e.g., an Item title or metadata value).
      * @return a sanitized, lowercase, hyphenated string suitable for use in a URL,
-     * or an empty string if the input is {@code null} or blank.
+     *         or an empty string if the input is {@code null}, blank, or contains only non-Latin characters.
      */
     private String normalizeUrl(String text) {
         if (StringUtils.isBlank(text)) {
             return "";
         }
 
-        // 1. Remove accents (Normalize Unicode to ASCII)
+        // 1. Remove accents (Normalize Unicode to decompose accented characters like é -> e + ́)
         String normalized = Normalizer.normalize(text, Normalizer.Form.NFD);
         normalized = normalized.replaceAll("\\p{InCombiningDiacriticalMarks}", "");
 
-        // 2. Lowercase and replace anything NOT alphanumeric with a dash
+        // 2. Remove any remaining non-Latin characters (Cyrillic, Arabic, Chinese, emoji, etc.)
+        //    Keep only Latin letters (a-z, A-Z), digits (0-9), spaces, hyphens, underscores, and dots
+        normalized = normalized.replaceAll("[^a-zA-Z0-9\\s.\\-_]+", "");
+
+        // 3. Lowercase and replace any sequence of non-alphanumeric characters with a single hyphen
         normalized = normalized.toLowerCase()
                                .replaceAll("[^a-z0-9]+", "-");
 
-        // 3. Remove leading/trailing dashes that might result from step 2
+        // 4. Remove leading/trailing dashes that might result from step 3
         normalized = normalized.replaceAll("^-|-$", "");
 
         return normalized;

--- a/dspace-api/src/main/java/org/dspace/validation/CustomUrlValidator.java
+++ b/dspace-api/src/main/java/org/dspace/validation/CustomUrlValidator.java
@@ -15,7 +15,6 @@ import static org.dspace.validation.service.ValidationService.OPERATION_PATH_SEC
 import java.sql.SQLException;
 import java.util.Iterator;
 import java.util.List;
-import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import org.apache.commons.collections4.iterators.IteratorChain;
@@ -27,6 +26,7 @@ import org.dspace.content.Item;
 import org.dspace.content.service.ItemService;
 import org.dspace.core.Context;
 import org.dspace.validation.model.ValidationError;
+import org.dspace.validation.util.CustomUrlUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -43,8 +43,6 @@ public class CustomUrlValidator implements SubmissionStepValidator {
     private static final String ERROR_VALIDATION_INVALID_CHARS = "error.validation.custom-url.invalid-characters";
 
     private static final String ERROR_VALIDATION_CONFLICT = "error.validation.custom-url.conflict";
-
-    private static final Pattern URL_PATH_PATTERN = Pattern.compile("^[.a-zA-Z0-9-_]+$");
 
     @Autowired
     private ItemService itemService;
@@ -82,16 +80,13 @@ public class CustomUrlValidator implements SubmissionStepValidator {
 
     /**
      * Checks if the custom URL contains invalid characters.
-     * The URL must contain only Latin letters (a-z, A-Z), digits (0-9), hyphens (-),
-     * underscores (_), and dots (.).
-     * This prevents URLs with Cyrillic, Arabic, Chinese, or other non-Latin scripts
-     * from being accepted, as they cause UI rendering issues.
+     * Delegates to {@link CustomUrlUtils#hasInvalidCharacters(String)}.
      *
      * @param customUrl the custom URL to check
      * @return true if the URL contains invalid characters, false otherwise
      */
     private boolean hasInvalidCharacters(String customUrl) {
-        return !URL_PATH_PATTERN.matcher(customUrl).matches();
+        return CustomUrlUtils.hasInvalidCharacters(customUrl);
     }
 
     private boolean existsAnotherItemWithSameCustomUrl(Context context, Item item, String customUrl) {

--- a/dspace-api/src/main/java/org/dspace/validation/CustomUrlValidator.java
+++ b/dspace-api/src/main/java/org/dspace/validation/CustomUrlValidator.java
@@ -80,6 +80,16 @@ public class CustomUrlValidator implements SubmissionStepValidator {
         return List.of();
     }
 
+    /**
+     * Checks if the custom URL contains invalid characters.
+     * The URL must contain only Latin letters (a-z, A-Z), digits (0-9), hyphens (-),
+     * underscores (_), and dots (.).
+     * This prevents URLs with Cyrillic, Arabic, Chinese, or other non-Latin scripts
+     * from being accepted, as they cause UI rendering issues.
+     *
+     * @param customUrl the custom URL to check
+     * @return true if the URL contains invalid characters, false otherwise
+     */
     private boolean hasInvalidCharacters(String customUrl) {
         return !URL_PATH_PATTERN.matcher(customUrl).matches();
     }

--- a/dspace-api/src/main/java/org/dspace/validation/util/CustomUrlUtils.java
+++ b/dspace-api/src/main/java/org/dspace/validation/util/CustomUrlUtils.java
@@ -1,0 +1,66 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.validation.util;
+
+import java.util.regex.Pattern;
+
+/**
+ * Utility class for Custom URL validation and processing.
+ * Provides shared logic for validating custom URL format to ensure
+ * URLs contain only Latin characters, preventing UI rendering issues
+ * with non-Latin scripts (Cyrillic, Arabic, Chinese, etc.).
+ *
+ * @author Adamo Fapohunda (adamo.fapohunda at 4science.com)
+ */
+public final class CustomUrlUtils {
+
+    /**
+     * Pattern that defines valid custom URL format.
+     * A valid custom URL must contain only:
+     * - Latin letters (a-z, A-Z)
+     * - Digits (0-9)
+     * - Hyphens (-)
+     * - Underscores (_)
+     * - Dots (.)
+     */
+    private static final Pattern URL_PATH_PATTERN = Pattern.compile("^[.a-zA-Z0-9-_]+$");
+
+    private CustomUrlUtils() {
+        // Private constructor to prevent instantiation
+    }
+
+    /**
+     * Validates if the given custom URL contains only allowed characters.
+     * The URL must contain only Latin letters (a-z, A-Z), digits (0-9),
+     * hyphens (-), underscores (_), and dots (.).
+     * <p>
+     * This validation prevents URLs with Cyrillic, Arabic, Chinese, or other
+     * non-Latin scripts from being accepted, as they cause UI rendering issues.
+     * </p>
+     *
+     * @param customUrl the custom URL to validate
+     * @return true if the URL is valid (contains only allowed characters), false otherwise
+     */
+    public static boolean isValidCustomUrl(String customUrl) {
+        if (customUrl == null) {
+            return false;
+        }
+        return URL_PATH_PATTERN.matcher(customUrl).matches();
+    }
+
+    /**
+     * Checks if the given custom URL contains invalid characters.
+     * This is the inverse of {@link #isValidCustomUrl(String)}.
+     *
+     * @param customUrl the custom URL to check
+     * @return true if the URL contains invalid characters, false otherwise
+     */
+    public static boolean hasInvalidCharacters(String customUrl) {
+        return !isValidCustomUrl(customUrl);
+    }
+}

--- a/dspace-api/src/test/java/org/dspace/app/customurl/consumer/CustomUrlConsumerIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/customurl/consumer/CustomUrlConsumerIT.java
@@ -189,6 +189,63 @@ public class CustomUrlConsumerIT extends AbstractIntegrationTestWithDatabase {
     }
 
     @Test
+    public void testNoCustomUrlAdditionOccursOnItemWithPureNonLatinCharacters() throws SQLException {
+
+        context.turnOffAuthorisationSystem();
+
+        // Test with pure Cyrillic characters - should not generate URL
+        Item cyrillicItem = ItemBuilder.createItem(context, collection)
+                                       .withMetadata("person", "familyName", null, "Тестовый")
+                                       .withMetadata("person", "givenName", null, "Пользователь")
+                                       .build();
+
+        // Test with pure Arabic characters - should not generate URL
+        Item arabicItem = ItemBuilder.createItem(context, collection)
+                                     .withMetadata("person", "familyName", null, "اختبار")
+                                     .build();
+
+        // Test with pure Chinese characters - should not generate URL
+        Item chineseItem = ItemBuilder.createItem(context, collection)
+                                      .withMetadata("person", "familyName", null, "测试")
+                                      .withMetadata("person", "givenName", null, "用户")
+                                      .build();
+
+        context.restoreAuthSystemState();
+        context.commit();
+
+        cyrillicItem = context.reloadEntity(cyrillicItem);
+        arabicItem = context.reloadEntity(arabicItem);
+        chineseItem = context.reloadEntity(chineseItem);
+
+        // All should have no custom URL since normalization would result in empty string
+        assertThat(itemService.getMetadataByMetadataString(cyrillicItem, "dspace.customurl"), empty());
+        assertThat(itemService.getMetadataByMetadataString(arabicItem, "dspace.customurl"), empty());
+        assertThat(itemService.getMetadataByMetadataString(chineseItem, "dspace.customurl"), empty());
+
+    }
+
+    @Test
+    public void testCustomUrlAdditionWithMixedLatinAndNonLatinCharacters() throws SQLException {
+
+        context.turnOffAuthorisationSystem();
+
+        // Test that Latin characters are preserved while non-Latin are stripped
+        Item item = ItemBuilder.createItem(context, collection)
+                               .withMetadata("person", "familyName", null, "Smith")
+                               .withMetadata("person", "givenName", null, "John测试Тест")
+                               .build();
+
+        context.restoreAuthSystemState();
+        context.commit();
+
+        item = context.reloadEntity(item);
+
+        // Non-Latin characters (测试, Тест) should be stripped, leaving only "Smith John"
+        assertThat(item.getMetadata(), hasItem(with("dspace.customurl", "smith-john")));
+
+    }
+
+    @Test
     public void testNoCustomUrlAdditionOccursOnNotSupportedEntities() throws SQLException {
 
         context.turnOffAuthorisationSystem();

--- a/dspace-api/src/test/java/org/dspace/app/customurl/service/CustomUrlServiceImplIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/customurl/service/CustomUrlServiceImplIT.java
@@ -87,7 +87,7 @@ public class CustomUrlServiceImplIT extends AbstractIntegrationTestWithDatabase 
 
     @Test
     public void testGenerateUniqueCustomUrl_MixedScriptAndSpecialCharacters() {
-        // Test mixed scripts and symbols (Preserves Latin and Numbers, strips others)
+        // Test mixed scripts and symbols (Preserves Latin and Numbers, strips non-Latin)
         String mixed = customUrlService.generateUniqueCustomUrl(context, "Study 2024: Étude 数据研究");
         assertEquals("study-2024-etude", mixed);
 
@@ -96,6 +96,14 @@ public class CustomUrlServiceImplIT extends AbstractIntegrationTestWithDatabase 
 
         String emoji = customUrlService.generateUniqueCustomUrl(context, "Climate Change 🌍🌡️");
         assertEquals("climate-change", emoji);
+
+        // Test Cyrillic mixed with Latin
+        String cyrillic = customUrlService.generateUniqueCustomUrl(context, "Test Тестовый Publication");
+        assertEquals("test-publication", cyrillic);
+
+        // Test Arabic mixed with Latin
+        String arabic = customUrlService.generateUniqueCustomUrl(context, "Study اختبار Research");
+        assertEquals("study-research", arabic);
     }
 
     @Test
@@ -119,7 +127,21 @@ public class CustomUrlServiceImplIT extends AbstractIntegrationTestWithDatabase 
 
     @Test(expected = IllegalArgumentException.class)
     public void testGenerateUniqueCustomUrl_ThrowsExceptionOnPureNonLatin() {
-        // This string contains ONLY characters that are stripped by [^a-z0-9]
+        // This string contains ONLY Cyrillic characters
+        // After normalization, all non-Latin characters are stripped, resulting in empty string
+        customUrlService.generateUniqueCustomUrl(context, "Тестовая статья");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGenerateUniqueCustomUrl_ThrowsExceptionOnPureArabic() {
+        // This string contains ONLY Arabic characters
+        // After normalization, all non-Latin characters are stripped, resulting in empty string
+        customUrlService.generateUniqueCustomUrl(context, "اختبار المقالة");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGenerateUniqueCustomUrl_ThrowsExceptionOnPureChinese() {
+        // This string contains ONLY Chinese characters
         // Resulting slug is empty -> Should throw exception
         customUrlService.generateUniqueCustomUrl(context, "测试文章标题");
     }

--- a/dspace-api/src/test/java/org/dspace/validation/util/CustomUrlUtilsTest.java
+++ b/dspace-api/src/test/java/org/dspace/validation/util/CustomUrlUtilsTest.java
@@ -1,0 +1,127 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.validation.util;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link CustomUrlUtils}.
+ *
+ * @author Adamo Fapohunda (adamo.fapohunda at 4science.com)
+ */
+public class CustomUrlUtilsTest {
+
+    @Test
+    public void testIsValidCustomUrl_ValidUrls() {
+        // Valid URLs with only Latin characters, digits, hyphens, underscores, and dots
+        assertTrue(CustomUrlUtils.isValidCustomUrl("valid-url"));
+        assertTrue(CustomUrlUtils.isValidCustomUrl("valid_url"));
+        assertTrue(CustomUrlUtils.isValidCustomUrl("valid.url"));
+        assertTrue(CustomUrlUtils.isValidCustomUrl("ValidUrl123"));
+        assertTrue(CustomUrlUtils.isValidCustomUrl("url-with-many-hyphens"));
+        assertTrue(CustomUrlUtils.isValidCustomUrl("url_with_underscores"));
+        assertTrue(CustomUrlUtils.isValidCustomUrl("url.with.dots"));
+        assertTrue(CustomUrlUtils.isValidCustomUrl("mixed-url_123.test"));
+        assertTrue(CustomUrlUtils.isValidCustomUrl("123-numeric-start"));
+        assertTrue(CustomUrlUtils.isValidCustomUrl("a"));
+        assertTrue(CustomUrlUtils.isValidCustomUrl("1"));
+    }
+
+    @Test
+    public void testIsValidCustomUrl_InvalidUrls_NonLatinCharacters() {
+        // Cyrillic characters
+        assertFalse(CustomUrlUtils.isValidCustomUrl("тестовый-url"));
+        assertFalse(CustomUrlUtils.isValidCustomUrl("url-тест"));
+        assertFalse(CustomUrlUtils.isValidCustomUrl("Москва"));
+
+        // Arabic characters
+        assertFalse(CustomUrlUtils.isValidCustomUrl("اختبار-url"));
+        assertFalse(CustomUrlUtils.isValidCustomUrl("url-اختبار"));
+
+        // Chinese characters
+        assertFalse(CustomUrlUtils.isValidCustomUrl("测试-url"));
+        assertFalse(CustomUrlUtils.isValidCustomUrl("url-测试"));
+        assertFalse(CustomUrlUtils.isValidCustomUrl("测试文章"));
+
+        // Greek characters
+        assertFalse(CustomUrlUtils.isValidCustomUrl("δοκιμή-url"));
+
+        // Hebrew characters
+        assertFalse(CustomUrlUtils.isValidCustomUrl("בדיקה-url"));
+    }
+
+    @Test
+    public void testIsValidCustomUrl_InvalidUrls_SpecialCharacters() {
+        // Special characters that are not allowed
+        assertFalse(CustomUrlUtils.isValidCustomUrl("invalid?url"));
+        assertFalse(CustomUrlUtils.isValidCustomUrl("invalid/url"));
+        assertFalse(CustomUrlUtils.isValidCustomUrl("invalid&url"));
+        assertFalse(CustomUrlUtils.isValidCustomUrl("invalid@url"));
+        assertFalse(CustomUrlUtils.isValidCustomUrl("invalid#url"));
+        assertFalse(CustomUrlUtils.isValidCustomUrl("invalid$url"));
+        assertFalse(CustomUrlUtils.isValidCustomUrl("invalid%url"));
+        assertFalse(CustomUrlUtils.isValidCustomUrl("invalid!url"));
+        assertFalse(CustomUrlUtils.isValidCustomUrl("invalid*url"));
+        assertFalse(CustomUrlUtils.isValidCustomUrl("invalid+url"));
+        assertFalse(CustomUrlUtils.isValidCustomUrl("invalid=url"));
+        assertFalse(CustomUrlUtils.isValidCustomUrl("invalid url")); // space
+        assertFalse(CustomUrlUtils.isValidCustomUrl("invalid,url"));
+        assertFalse(CustomUrlUtils.isValidCustomUrl("invalid;url"));
+    }
+
+    @Test
+    public void testIsValidCustomUrl_InvalidUrls_Emoji() {
+        assertFalse(CustomUrlUtils.isValidCustomUrl("url-🌍"));
+        assertFalse(CustomUrlUtils.isValidCustomUrl("🌍🌡️"));
+        assertFalse(CustomUrlUtils.isValidCustomUrl("test-😊-url"));
+    }
+
+    @Test
+    public void testIsValidCustomUrl_EdgeCases() {
+        // Null and empty
+        assertFalse(CustomUrlUtils.isValidCustomUrl(null));
+        assertFalse(CustomUrlUtils.isValidCustomUrl(""));
+        assertFalse(CustomUrlUtils.isValidCustomUrl("   "));
+
+        // Only special characters
+        assertFalse(CustomUrlUtils.isValidCustomUrl("???"));
+        assertFalse(CustomUrlUtils.isValidCustomUrl("$$$"));
+    }
+
+    @Test
+    public void testHasInvalidCharacters_InverseOfIsValid() {
+        // Valid URLs should NOT have invalid characters
+        assertFalse(CustomUrlUtils.hasInvalidCharacters("valid-url"));
+        assertFalse(CustomUrlUtils.hasInvalidCharacters("valid_url"));
+        assertFalse(CustomUrlUtils.hasInvalidCharacters("valid.url"));
+
+        // Invalid URLs SHOULD have invalid characters
+        assertTrue(CustomUrlUtils.hasInvalidCharacters("invalid?url"));
+        assertTrue(CustomUrlUtils.hasInvalidCharacters("тестовый"));
+        assertTrue(CustomUrlUtils.hasInvalidCharacters("اختبار"));
+        assertTrue(CustomUrlUtils.hasInvalidCharacters(null));
+        assertTrue(CustomUrlUtils.hasInvalidCharacters(""));
+    }
+
+    @Test
+    public void testIsValidCustomUrl_AccentedCharacters() {
+        // Accented characters are NOT valid in the final URL
+        // (they should be normalized first by CustomUrlService)
+        assertFalse(CustomUrlUtils.isValidCustomUrl("café"));
+        assertFalse(CustomUrlUtils.isValidCustomUrl("naïve"));
+        assertFalse(CustomUrlUtils.isValidCustomUrl("résumé"));
+
+        // But the normalized versions ARE valid
+        assertTrue(CustomUrlUtils.isValidCustomUrl("cafe"));
+        assertTrue(CustomUrlUtils.isValidCustomUrl("naive"));
+        assertTrue(CustomUrlUtils.isValidCustomUrl("resume"));
+    }
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CustomUrlStepIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CustomUrlStepIT.java
@@ -244,6 +244,62 @@ public class CustomUrlStepIT extends AbstractControllerIntegrationTest {
     }
 
     @Test
+    public void testNonLatinCharactersRejectedOnWorkspaceItem() throws Exception {
+
+        context.turnOffAuthorisationSystem();
+
+        WorkspaceItem workspaceItem = WorkspaceItemBuilder.createWorkspaceItem(context, collection)
+                                                          .withTitle("Test WorkspaceItem")
+                                                          .withIssueDate("2020")
+                                                          .build();
+
+        context.restoreAuthSystemState();
+
+        // Test Cyrillic characters
+        Operation replaceOperation = new ReplaceOperation("/sections/custom-url/url", "тестовый-url");
+
+        getClient(getAuthToken(eperson.getEmail(), password))
+            .perform(patch("/api/submission/workspaceitems/" + workspaceItem.getID())
+                         .content(getPatchContent(List.of(replaceOperation)))
+                         .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.errors[?(@.message=='error.validation.custom-url.invalid-characters')]",
+                                contains(hasJsonPath("$.paths",
+                                                     contains(hasJsonPath("$", is("/sections/custom-url/url")))))))
+            .andExpect(jsonPath("$.sections.custom-url.url", is("тестовый-url")))
+            .andExpect(jsonPath("$.sections.custom-url.redirected-urls").doesNotExist());
+
+        // Test Arabic characters
+        replaceOperation = new ReplaceOperation("/sections/custom-url/url", "اختبار-url");
+
+        getClient(getAuthToken(eperson.getEmail(), password))
+            .perform(patch("/api/submission/workspaceitems/" + workspaceItem.getID())
+                         .content(getPatchContent(List.of(replaceOperation)))
+                         .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.errors[?(@.message=='error.validation.custom-url.invalid-characters')]",
+                                contains(hasJsonPath("$.paths",
+                                                     contains(hasJsonPath("$", is("/sections/custom-url/url")))))))
+            .andExpect(jsonPath("$.sections.custom-url.url", is("اختبار-url")))
+            .andExpect(jsonPath("$.sections.custom-url.redirected-urls").doesNotExist());
+
+        // Test Chinese characters
+        replaceOperation = new ReplaceOperation("/sections/custom-url/url", "测试-url");
+
+        getClient(getAuthToken(eperson.getEmail(), password))
+            .perform(patch("/api/submission/workspaceitems/" + workspaceItem.getID())
+                         .content(getPatchContent(List.of(replaceOperation)))
+                         .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.errors[?(@.message=='error.validation.custom-url.invalid-characters')]",
+                                contains(hasJsonPath("$.paths",
+                                                     contains(hasJsonPath("$", is("/sections/custom-url/url")))))))
+            .andExpect(jsonPath("$.sections.custom-url.url", is("测试-url")))
+            .andExpect(jsonPath("$.sections.custom-url.redirected-urls").doesNotExist());
+
+    }
+
+    @Test
     public void testAlreadyExistingCustomUrlReplacementOnWorkspaceItem() throws Exception {
 
         context.turnOffAuthorisationSystem();


### PR DESCRIPTION
## References

* Fixes [#5337](https://github.com/DSpace/dspace-angular/issues/5337)

## Description
Restricts Custom URLs in DSpace submissions to Latin characters only, preventing UI rendering issues caused by non-Latin characters (cyrillic, Arabic, Chinese, etc.). The implementation adds validation at both submission entry point and auto-generation to ensure consistent behavior.

## Instructions for Reviewers

### List of changes in this PR:
* **Added `CustomUrlUtils.java`** - New shared utility class in `org.dspace.validation.util` containing validation logic for validating custom URLs contain only Latin characters (a-z, A-Z), digits (0-9), hyphens, underscores, and dots
* **Updated `CustomUrlValidator.java`** - Refactored to use `CustomUrlUtils.hasInvalidCharacters()` instead of inline Pattern matching
* **Updated `CustomUrlServiceImpl.java`** - Added validation call after normalization to ensure auto-generated URLs contain only valid Latin characters, throwing `IllegalArgumentException` if validation fails
* **Added `CustomUrlUtilsTest.java`** - Unit tests for the new utility class covering valid/invalid URLs, edge cases, and various scripts (cyrillic, Arabic, Chinese, emoji)
* **Enhanced integration tests** - Added tests in `CustomUrlConsumerIT`, `CustomUrlServiceImplIT`, and `CustomUrlStepIT` to verify non-Latin character rejection

### How to Test:

1. **Submission Validation**:
   - Configure the submission to use the [custom-url](https://wiki.lyrasis.org/display/DSDOC10x/Custom+URL+for+Entities)
   - Create a workspace item and attempt to set custom URL with Cyrillic/Arabic/Chinese characters
   - Verify error response: `error.validation.custom-url.invalid-characters`

2. **Auto-generation**:
   - Configure the custom [url autogeneration](https://wiki.lyrasis.org/display/DSDOC10x/Custom+URL+for+Entities).
   - Create an item with only non-latin metadata (e.g., pure Cyrillic name)
   - Verify no custom URL is generated (empty string)

3. **Mixed Content**:
   - Create item with mixed Latin + non-latin metadata (e.g., "Smith 测试")
   - Verify only Latin characters are preserved ("smith")

### Key Implementation Details:
- Validation regex: `^[.a-zA-Z0-9-_]+$`
- Applied at two points: `CustomUrlValidator` (submission) and `CustomUrlServiceImpl.generateUniqueCustomUrl()` (auto-generation)
- Non-latin characters are normalized/removed during URL generation to prevent empty URLs

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
