### PR TITLE
Fix NPE in ORCID authentication during SWORD request

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authenticate/OrcidAuthenticationBean.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/OrcidAuthenticationBean.java
@@ -130,7 +130,7 @@ public class OrcidAuthenticationBean implements AuthenticationMethod {
 
     @Override
     public boolean isUsed(Context context, HttpServletRequest request) {
-        return request.getAttribute(ORCID_AUTH_ATTRIBUTE) != null;
+        return request != null && request.getAttribute(ORCID_AUTH_ATTRIBUTE) != null;
     }
 
     @Override


### PR DESCRIPTION
## References
* Related to DSpace/DSpace#11633

## Description
Adds a null check to `OrcidAuthenticationBean.isUsed()` to prevent a NullPointerException during SWORD requests.

## Instructions for Reviewers

To reproduce the error:

1. Enable:

```
plugin.sequence.org.dspace.authenticate.AuthenticationMethod = org.dspace.authenticate.OrcidAuthentication,
plugin.sequence.org.dspace.authenticate.AuthenticationMethod = org.dspace.authenticate.PasswordAuthentication
```

2. Perform a valid SWORD servicedocument or deposit request
3. A `NullPointerException` is logged:

`Cannot invoke "jakarta.servlet.http.HttpServletRequest.getAttribute(String)" because "request" is null`

After the fix, the exception is no longer thrown and the SWORD request completes successfully.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
