### PR TITLE
[DSpace-CRIS] “Authors can download restricted bitstreams” should be disabled by default, fully tested, and auditable via debug logging

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/security/CrisSecurityServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/security/CrisSecurityServiceImpl.java
@@ -14,6 +14,8 @@ import java.util.Optional;
 import java.util.UUID;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.content.Collection;
 import org.dspace.content.Item;
@@ -94,6 +96,8 @@ import org.springframework.beans.factory.annotation.Autowired;
  *
  */
 public class CrisSecurityServiceImpl implements CrisSecurityService {
+
+    private static final Logger log = LogManager.getLogger(CrisSecurityServiceImpl.class);
 
     @Autowired
     private ItemService itemService;
@@ -188,27 +192,48 @@ public class CrisSecurityServiceImpl implements CrisSecurityService {
      */
     private boolean checkSecurity(Context context, Item item, EPerson user, AccessItemMode accessMode,
                               CrisSecurity crisSecurity) throws SQLException {
+        String userEmail = user != null ? user.getEmail() : "anonymous";
+        UUID itemId = item.getID();
+
+        log.debug("[CRIS-SECURITY] Evaluating security={} for user={}, item={}",
+                  crisSecurity, userEmail, itemId);
+
+        boolean granted;
+
         switch (crisSecurity) {
             case ADMIN:
-                return authorizeService.isAdmin(context, user);
+                granted = authorizeService.isAdmin(context, user);
+                break;
             case CUSTOM:
-                return hasAccessByCustomPolicy(context, item, user, accessMode);
+                granted = hasAccessByCustomPolicy(context, item, user, accessMode);
+                break;
             case GROUP:
-                return hasAccessByGroup(context, user, accessMode.getGroups());
+                granted = hasAccessByGroup(context, user, accessMode.getGroups());
+                break;
             case ITEM_ADMIN:
-                return authorizeService.isAdmin(context, user, item);
+                granted = authorizeService.isAdmin(context, user, item);
+                break;
             case OWNER:
-                return isOwner(user, item);
+                granted = isOwner(user, item);
+                break;
             case SUBMITTER:
-                return user != null && user.equals(item.getSubmitter());
+                granted = user != null && user.equals(item.getSubmitter());
+                break;
             case SUBMITTER_GROUP:
-                return isUserInSubmitterGroup(context, item, user);
+                granted = isUserInSubmitterGroup(context, item, user);
+                break;
             case ALL:
-                return true;
+                granted = true;
+                break;
             case NONE:
             default:
-                return false;
+                granted = false;
         }
+
+        log.debug("[CRIS-SECURITY] {} security={}, user={}, item={}",
+                  granted ? "GRANTED" : "DENIED", crisSecurity, userEmail, itemId);
+
+        return granted;
     }
 
     /**
@@ -249,9 +274,33 @@ public class CrisSecurityServiceImpl implements CrisSecurityService {
      */
     private boolean hasAccessByCustomPolicy(Context context, Item item, EPerson user, AccessItemMode accessMode)
         throws SQLException {
-        return hasAccessByGroupMetadataFields(context, item, user, accessMode.getGroupMetadataFields())
-            || hasAccessByUserMetadataFields(context, item, user, accessMode.getUserMetadataFields())
-            || hasAccessByItemMetadataFields(context, item, user, accessMode.getItemMetadataFields());
+
+        String userEmail = user != null ? user.getEmail() : "anonymous";
+        UUID itemId = item.getID();
+
+        log.debug("[CRIS-SECURITY] Evaluating CUSTOM sub-policies for user={}, item={}",
+                  userEmail, itemId);
+
+        if (hasAccessByGroupMetadataFields(context, item, user, accessMode.getGroupMetadataFields())) {
+            log.debug("[CRIS-SECURITY] CUSTOM matched via group metadata for user={}, item={}",
+                      userEmail, itemId);
+            return true;
+        }
+
+        if (hasAccessByUserMetadataFields(context, item, user, accessMode.getUserMetadataFields())) {
+            log.debug("[CRIS-SECURITY] CUSTOM matched via user metadata for user={}, item={}",
+                      userEmail, itemId);
+            return true;
+        }
+
+        if (hasAccessByItemMetadataFields(context, item, user, accessMode.getItemMetadataFields())) {
+            log.debug("[CRIS-SECURITY] CUSTOM matched via item metadata (transitive ownership)"
+                      + " for user={}, item={}", userEmail, itemId);
+            return true;
+        }
+
+        log.debug("[CRIS-SECURITY] CUSTOM no match for user={}, item={}", userEmail, itemId);
+        return false;
     }
 
     /**
@@ -286,6 +335,10 @@ public class CrisSecurityServiceImpl implements CrisSecurityService {
         for (Group group : userGroups) {
             for (String groupMetadataField : groupMetadataFields) {
                 if (anyMetadataHasAuthorityEqualsTo(item, groupMetadataField, group.getID())) {
+                    log.debug("[CRIS-SECURITY] Group metadata match: user={}, item={},"
+                              + " field={}, group={} ({})",
+                              user.getEmail(), item.getID(), groupMetadataField,
+                              group.getName(), group.getID());
                     return true;
                 }
             }
@@ -323,6 +376,8 @@ public class CrisSecurityServiceImpl implements CrisSecurityService {
 
         for (String userMetadataField : userMetadataFields) {
             if (anyMetadataHasAuthorityEqualsTo(item, userMetadataField, user.getID())) {
+                log.debug("[CRIS-SECURITY] User metadata match: user={} ({}), item={}, field={}",
+                          user.getEmail(), user.getID(), item.getID(), userMetadataField);
                 return true;
             }
         }
@@ -355,8 +410,18 @@ public class CrisSecurityServiceImpl implements CrisSecurityService {
             return false;
         }
 
-        return findRelatedItems(context, item, itemMetadataFields).stream()
-            .anyMatch(relatedItem -> isOwner(user, relatedItem));
+        List<Item> relatedItems = findRelatedItems(context, item, itemMetadataFields);
+
+        for (Item relatedItem : relatedItems) {
+            if (isOwner(user, relatedItem)) {
+                log.debug("[CRIS-SECURITY] Item metadata match (transitive ownership):"
+                          + " user={} ({}), item={}, relatedItem={}",
+                          user.getEmail(), user.getID(), item.getID(), relatedItem.getID());
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -382,10 +447,17 @@ public class CrisSecurityServiceImpl implements CrisSecurityService {
 
         for (String itemMetadataField : itemMetadataFields) {
             List<MetadataValue> metadataValues = itemService.getMetadataByMetadataString(item, itemMetadataField);
+
+            log.debug("[CRIS-SECURITY] Resolving related items: field={}, item={}, candidates={}",
+                      itemMetadataField, item.getID(), metadataValues.size());
+
             for (MetadataValue metadataValue : metadataValues) {
                 UUID relatedItemId = UUIDUtils.fromString(metadataValue.getAuthority());
                 Item relatedItem = itemService.find(context, relatedItemId);
                 if (relatedItem != null) {
+                    log.debug("[CRIS-SECURITY] Resolved related item: field={}, authority={},"
+                              + " relatedItem={}",
+                              itemMetadataField, metadataValue.getAuthority(), relatedItemId);
                     relatedItems.add(relatedItem);
                 }
             }
@@ -414,19 +486,39 @@ public class CrisSecurityServiceImpl implements CrisSecurityService {
      */
     private boolean hasAccessByGroup(Context context, EPerson user, List<String> groups) {
         if (CollectionUtils.isEmpty(groups)) {
+            log.debug("[CRIS-SECURITY] Group check skipped: no groups configured");
             return false;
         }
 
-        return groups.stream()
-                .map(group -> findGroupByNameOrUUID(context, group))
-                .filter(group -> group != null)
-                .anyMatch(group -> {
-                    try {
-                        return groupService.isMember(context, user, group);
-                    } catch (SQLException e) {
-                        return false;
-                    }
-                });
+        if (user == null) {
+            log.debug("[CRIS-SECURITY] Group check skipped: anonymous user");
+            return false;
+        }
+
+        log.debug("[CRIS-SECURITY] Checking group membership: user={} ({}), groupCount={}",
+                  user.getEmail(), user.getID(), groups.size());
+
+        for (String groupIdentifier : groups) {
+            Group group = findGroupByNameOrUUID(context, groupIdentifier);
+            if (group == null) {
+                log.debug("[CRIS-SECURITY] Group not found: identifier={}", groupIdentifier);
+                continue;
+            }
+
+            try {
+                boolean isMember = groupService.isMember(context, user, group);
+                log.debug("[CRIS-SECURITY] Group membership: user={}, group={} ({}), member={}",
+                          user.getEmail(), group.getName(), group.getID(), isMember);
+                if (isMember) {
+                    return true;
+                }
+            } catch (SQLException e) {
+                log.debug("[CRIS-SECURITY] Group membership check failed: user={}, group={},"
+                          + " error={}", user.getEmail(), group.getName(), e.getMessage());
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -483,8 +575,21 @@ public class CrisSecurityServiceImpl implements CrisSecurityService {
      * @return true if any metadata value's authority equals the UUID
      */
     private boolean anyMetadataHasAuthorityEqualsTo(Item item, String metadata, UUID uuid) {
-        return itemService.getMetadataByMetadataString(item, metadata).stream()
-            .anyMatch(value -> uuid.toString().equals(value.getAuthority()));
+        List<MetadataValue> metadataValues = itemService.getMetadataByMetadataString(item, metadata);
+
+        log.debug("[CRIS-SECURITY] Checking authorities: field={}, item={}, values={}, targetUUID={}",
+                  metadata, item.getID(), metadataValues.size(), uuid);
+
+        for (MetadataValue value : metadataValues) {
+            String authority = value.getAuthority();
+            if (uuid.toString().equals(authority)) {
+                log.debug("[CRIS-SECURITY] Authority match: field={}, value='{}', authority={}",
+                          metadata, value.getValue(), authority);
+                return true;
+            }
+        }
+
+        return false;
     }
 
 }

--- a/dspace-api/src/test/java/org/dspace/content/security/CrisSecurityServiceIT.java
+++ b/dspace-api/src/test/java/org/dspace/content/security/CrisSecurityServiceIT.java
@@ -563,6 +563,176 @@ public class CrisSecurityServiceIT extends AbstractIntegrationTestWithDatabase {
         return mode;
     }
 
+    @Test
+    public void testHasAccessWithAllConfig() throws SQLException {
+
+        context.turnOffAuthorisationSystem();
+
+        Item item = ItemBuilder.createItem(context, collection)
+            .withTitle("Test item")
+            .build();
+
+        context.restoreAuthSystemState();
+
+        AccessItemMode accessMode = buildAccessItemMode(CrisSecurity.ALL);
+
+        assertThat(crisSecurityService.hasAccess(context, item, eperson, accessMode), is(true));
+        assertThat(crisSecurityService.hasAccess(context, item, admin, accessMode), is(true));
+        assertThat(crisSecurityService.hasAccess(context, item, owner, accessMode), is(true));
+        assertThat(crisSecurityService.hasAccess(context, item, collectionAdmin, accessMode), is(true));
+        assertThat(crisSecurityService.hasAccess(context, item, communityAdmin, accessMode), is(true));
+        assertThat(crisSecurityService.hasAccess(context, item, submitter, accessMode), is(true));
+        assertThat(crisSecurityService.hasAccess(context, item, anotherSubmitter, accessMode), is(true));
+        assertThat(crisSecurityService.hasAccess(context, item, null, accessMode), is(true));
+    }
+
+    @Test
+    public void testHasAccessWithNoneConfig() throws SQLException {
+
+        context.turnOffAuthorisationSystem();
+
+        Item item = ItemBuilder.createItem(context, collection)
+            .withTitle("Test item")
+            .build();
+
+        context.restoreAuthSystemState();
+
+        AccessItemMode accessMode = buildAccessItemMode(CrisSecurity.NONE);
+
+        assertThat(crisSecurityService.hasAccess(context, item, eperson, accessMode), is(false));
+        assertThat(crisSecurityService.hasAccess(context, item, admin, accessMode), is(false));
+        assertThat(crisSecurityService.hasAccess(context, item, owner, accessMode), is(false));
+        assertThat(crisSecurityService.hasAccess(context, item, collectionAdmin, accessMode), is(false));
+        assertThat(crisSecurityService.hasAccess(context, item, communityAdmin, accessMode), is(false));
+        assertThat(crisSecurityService.hasAccess(context, item, submitter, accessMode), is(false));
+        assertThat(crisSecurityService.hasAccess(context, item, anotherSubmitter, accessMode), is(false));
+        assertThat(crisSecurityService.hasAccess(context, item, null, accessMode), is(false));
+    }
+
+    @Test
+    public void testHasAccessWithAnonymousUser() throws SQLException {
+
+        context.turnOffAuthorisationSystem();
+
+        Item item = ItemBuilder.createItem(context, collection)
+            .withTitle("Test item")
+            .withDspaceObjectOwner("Owner", owner.getID().toString())
+            .build();
+
+        context.restoreAuthSystemState();
+
+        assertThat(crisSecurityService.hasAccess(context, item, null,
+            buildAccessItemMode(CrisSecurity.ADMIN)), is(false));
+        assertThat(crisSecurityService.hasAccess(context, item, null,
+            buildAccessItemMode(CrisSecurity.ITEM_ADMIN)), is(false));
+        assertThat(crisSecurityService.hasAccess(context, item, null,
+            buildAccessItemMode(CrisSecurity.OWNER)), is(false));
+        assertThat(crisSecurityService.hasAccess(context, item, null,
+            buildAccessItemMode(CrisSecurity.SUBMITTER)), is(false));
+        assertThat(crisSecurityService.hasAccess(context, item, null,
+            buildAccessItemMode(CrisSecurity.SUBMITTER_GROUP)), is(false));
+
+        AccessItemMode groupMode = buildAccessItemMode(CrisSecurity.GROUP);
+        when(groupMode.getGroups()).thenReturn(List.of("Group 1"));
+        assertThat(crisSecurityService.hasAccess(context, item, null, groupMode), is(false));
+
+        AccessItemMode customMode = buildAccessItemMode(CrisSecurity.CUSTOM);
+        when(customMode.getUserMetadataFields()).thenReturn(List.of("dc.contributor.author"));
+        when(customMode.getGroupMetadataFields()).thenReturn(List.of("dspace.policy.group"));
+        when(customMode.getItemMetadataFields()).thenReturn(List.of("dc.contributor.author"));
+        assertThat(crisSecurityService.hasAccess(context, item, null, customMode), is(false));
+    }
+
+    @Test
+    public void testHasAccessWithCustomConfigAndAdditionalFilter() throws Exception {
+
+        choiceAuthorityService.getChoiceAuthoritiesNames();
+        pluginService.clearNamedPluginClasses();
+
+        configurationService.setProperty("plugin.named.org.dspace.content.authority.ChoiceAuthority",
+                                         new String[] {
+                                             "org.dspace.content.authority.EPersonAuthority = EPersonAuthority"
+                                         });
+        configurationService.setProperty("choices.plugin.dspace.policy.eperson", "EPersonAuthority");
+        configurationService.setProperty("choices.presentation.dspace.policy.eperson", "suggest");
+        configurationService.setProperty("authority.controlled.dspace.policy.eperson", "true");
+
+        choiceAuthorityService.clearCache();
+        metadataAuthorityService.clearCache();
+
+        context.turnOffAuthorisationSystem();
+
+        EPerson authorizedUser = EPersonBuilder.createEPerson(context)
+            .withEmail("authorized@mail.it")
+            .build();
+
+        Item accessibleItem = ItemBuilder.createItem(context, collection)
+            .withTitle("Accessible item")
+            .withPolicyEPerson("Authorized", authorizedUser.getID().toString())
+            .build();
+
+        Item blockedItem = ItemBuilder.createItem(context, collection)
+            .withTitle("Blocked item")
+            .withPolicyEPerson("Authorized", authorizedUser.getID().toString())
+            .build();
+
+        context.restoreAuthSystemState();
+
+        AccessItemMode accessMode = buildAccessItemMode(CrisSecurity.CUSTOM);
+        when(accessMode.getUserMetadataFields()).thenReturn(List.of("dspace.policy.eperson"));
+        when(accessMode.getAdditionalFilter()).thenReturn(new Filter() {
+            @Override
+            public boolean getResult(Context context, Item item) throws LogicalStatementException {
+                return item.getName().equals("Accessible item");
+            }
+
+            @Override
+            public String getName() {
+                return null;
+            }
+
+            @Override
+            public void setBeanName(String s) {}
+        });
+
+        assertThat(crisSecurityService.hasAccess(context, accessibleItem, authorizedUser, accessMode),
+                   is(true));
+        assertThat(crisSecurityService.hasAccess(context, blockedItem, authorizedUser, accessMode),
+                   is(false));
+        assertThat(crisSecurityService.hasAccess(context, accessibleItem, eperson, accessMode),
+                   is(false));
+    }
+
+    @Test
+    public void testHasAccessWithGroupConfigAndNonExistentGroup() throws SQLException {
+
+        context.turnOffAuthorisationSystem();
+
+        Group existingGroup = GroupBuilder.createGroup(context)
+            .withName("Existing Group")
+            .build();
+
+        EPerson groupMember = EPersonBuilder.createEPerson(context)
+            .withEmail("member@mail.it")
+            .withGroupMembership(existingGroup)
+            .build();
+
+        Item item = ItemBuilder.createItem(context, collection)
+            .withTitle("Test item")
+            .build();
+
+        context.restoreAuthSystemState();
+
+        AccessItemMode accessMode = buildAccessItemMode(CrisSecurity.GROUP);
+        when(accessMode.getGroups()).thenReturn(
+            List.of("Non Existent Group", "00000000-0000-0000-0000-000000000000"));
+        assertThat(crisSecurityService.hasAccess(context, item, groupMember, accessMode), is(false));
+
+        when(accessMode.getGroups()).thenReturn(
+            List.of("Non Existent Group", "Existing Group"));
+        assertThat(crisSecurityService.hasAccess(context, item, groupMember, accessMode), is(true));
+    }
+
     private CrisSecurityService getCrisSecurityService() {
         return new DSpace().getServiceManager().getApplicationContext().getBean(CrisSecurityService.class);
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
@@ -249,8 +249,6 @@ public class BitstreamRestController {
         } catch (ClientAbortException ex) {
             log.debug("Client aborted the request before the download was completed. " +
                           "Client is probably switching to a Range request.", ex);
-        } catch (Exception e) {
-            throw e;
         }
         return null;
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/BitstreamRestController.java
@@ -105,16 +105,21 @@ public class BitstreamRestController {
 
     /**
      * Retrieve bitstream. An access token (created by request a copy for some files, if enabled) can optionally
-     * be used for authorization instead of current user/group
+     * be used for authorization instead of current user/group.
+     * <P>
+     * Authorization behavior is controlled by the configuration property
+     * {@code core.authorization.bitstream.author.bypass-restrictions}. When enabled (true), authors/submitters
+     * can download restricted bitstreams even if they lack explicit READ permissions. When disabled (false - default),
+     * normal authorization rules apply to all users including authors.
      *
      * @param uuid bitstream ID
      * @param accessToken request-a-copy access token (optional)
      * @param response HTTP response
      * @param request HTTP request
      * @return response entity with bitstream content
-     * @throws IOException
-     * @throws SQLException
-     * @throws AuthorizeException
+     * @throws IOException if an I/O error occurs
+     * @throws SQLException if database error occurs
+     * @throws AuthorizeException if user lacks permission and author bypass is disabled
      */
     @PreAuthorize("#accessToken != null|| hasPermission(#uuid, 'BITSTREAM', 'READ')")
     @RequestMapping( method = {RequestMethod.GET, RequestMethod.HEAD}, value = "content")
@@ -188,12 +193,13 @@ public class BitstreamRestController {
                                 context.getSpecialGroupUuids(), citationEnabledForBitstream, accessToken);
             } else {
                 // Get input stream using default user/group authorization
-                // skipAuth=true because @PreAuthorize already performed authorization security checks (allowing
-                // submitters and authors/owners to access embargoed bitstreams).
+                // Check configuration to determine if authors can bypass authorization for restricted bitstreams
+                boolean skipAuth = configurationService.getBooleanProperty(
+                        "core.authorization.bitstream.author.bypass-restrictions", false);
                 bitstreamResource =
                         new org.dspace.app.rest.utils.BitstreamResource(name, uuid,
                                 currentUser != null ? currentUser.getID() : null,
-                                context.getSpecialGroupUuids(), citationEnabledForBitstream, true);
+                                context.getSpecialGroupUuids(), citationEnabledForBitstream, skipAuth);
             }
 
             // We have all the data we need, close the connection to the database so that it doesn't stay open during

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/DownloadFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/DownloadFeature.java
@@ -20,6 +20,7 @@ import org.dspace.app.rest.utils.Utils;
 import org.dspace.content.Bitstream;
 import org.dspace.content.DSpaceObject;
 import org.dspace.core.Context;
+import org.dspace.services.ConfigurationService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -46,6 +47,9 @@ public class DownloadFeature implements AuthorizationFeature {
     private BitstreamCrisSecurityService bitstreamCrisSecurityService;
 
     @Autowired
+    private ConfigurationService configurationService;
+
+    @Autowired
     private Utils utils;
 
     @Override
@@ -61,7 +65,10 @@ public class DownloadFeature implements AuthorizationFeature {
                 return false;
             }
 
-            if (dSpaceObject instanceof Bitstream && bitstreamCrisSecurityService
+            boolean skipAuth = configurationService.getBooleanProperty(
+                "core.authorization.bitstream.author.bypass-restrictions", false);
+
+            if (skipAuth && dSpaceObject instanceof Bitstream && bitstreamCrisSecurityService
                     .isBitstreamAccessAllowedByCrisSecurity(context, context.getCurrentUser(),
                             (Bitstream) dSpaceObject)) {
                 return true;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/BitstreamResource.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/BitstreamResource.java
@@ -17,6 +17,7 @@ import java.util.UUID;
 import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.dspace.app.rest.exception.RESTAuthorizationException;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Bitstream;
 import org.dspace.content.factory.ContentServiceFactory;
@@ -144,8 +145,10 @@ public class BitstreamResource extends AbstractResource {
                         bitstream.getSizeBytes(),
                         bitstreamService.retrieve(context, bitstream));
             }
-        } catch (SQLException | AuthorizeException | IOException e) {
+        } catch (SQLException | IOException e) {
             throw new RuntimeException(e);
+        } catch (AuthorizeException e) {
+            throw new RESTAuthorizationException(e.getMessage());
         }
 
         LOG.debug("fetched document {} {}", shouldGenerateCoverPage, document);

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
@@ -1662,6 +1662,7 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
         configurationService.setProperty("choices.plugin.dc.contributor.author", "AuthorAuthority");
         configurationService.setProperty("choices.presentation.dc.contributor.author", "suggest");
         configurationService.setProperty("authority.controlled.dc.contributor.author", "true");
+        configurationService.setProperty("core.authorization.bitstream.author.bypass-restrictions", "true");
         pluginService.clearNamedPluginClasses();
         choiceAuthorityService.clearCache();
         metadataAuthorityService.clearCache();

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/DownloadFeatureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/DownloadFeatureIT.java
@@ -340,6 +340,7 @@ public class DownloadFeatureIT extends AbstractControllerIntegrationTest {
         configurationService.setProperty("choices.presentation.dc.contributor.author", "suggest");
         configurationService.setProperty("authority.controlled.dc.contributor.author", "true");
         configurationService.setProperty("cris.ItemAuthority.AuthorAuthority.entityType", "Person");
+        configurationService.setProperty("core.authorization.bitstream.author.bypass-restrictions", "true");
         pluginService.clearNamedPluginClasses();
         choiceAuthorityService.clearCache();
         metadataAuthorityService.clearCache();
@@ -447,6 +448,124 @@ public class DownloadFeatureIT extends AbstractControllerIntegrationTest {
     }
 
     @Test
+    public void downloadOfBitstreamWithCrisSecurityDisabled() throws Exception {
+
+        //by default has no authority
+        choiceAuthorityService.getChoiceAuthoritiesNames();
+        configurationService.setProperty("plugin.named.org.dspace.content.authority.ChoiceAuthority",
+                                         new String[] {
+                                             "org.dspace.content.authority.OrcidAuthority = AuthorAuthority"
+                                         });
+        configurationService.setProperty("choices.plugin.dc.contributor.author", "AuthorAuthority");
+        configurationService.setProperty("choices.presentation.dc.contributor.author", "suggest");
+        configurationService.setProperty("authority.controlled.dc.contributor.author", "true");
+        configurationService.setProperty("cris.ItemAuthority.AuthorAuthority.entityType", "Person");
+        configurationService.setProperty("core.authorization.bitstream.author.bypass-restrictions", "false");
+        pluginService.clearNamedPluginClasses();
+        choiceAuthorityService.clearCache();
+        metadataAuthorityService.clearCache();
+
+        context.turnOffAuthorisationSystem();
+
+        //** GIVEN **
+        //1. A community-collection structure with one parent community and one collections.
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+        // this should be a publication collection but right now no control are enforced
+        Collection col1 = CollectionBuilder.createCollection(context, parentCommunity)
+                                           .withName("Collection 1").build();
+        // this should be a person collection
+        Collection col2 = CollectionBuilder.createCollection(context, parentCommunity)
+                                           .withName("Person").build();
+
+        //2. A public item with an embargoed bitstream
+        String bitstreamContent = "Embargoed!";
+        EPerson authorEp = EPersonBuilder.createEPerson(context)
+                                         .withEmail("author@example.com")
+                                         .withPassword(password)
+                                         .build();
+        Item profile = ItemBuilder.createItem(context, col2)
+                                  .withTitle("Author")
+                                  .withDspaceObjectOwner(authorEp)
+                                  .build();
+        // set our submitter
+        EPerson submitter = EPersonBuilder.createEPerson(context)
+                                          .withEmail("submitter@example.com")
+                                          .withPassword(password)
+                                          .build();
+        context.setCurrentUser(submitter);
+        Bitstream embargoedBit = null;
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
+            // we need a publication to check our cris enhanced security
+            Item publicItem1 =
+                ItemBuilder.createItem(context, col1)
+                           .withEntityType("Publication")
+                           .withTitle("Public item 1")
+                           .withIssueDate("2017-10-17")
+                           .withAuthor("Just an author without profile")
+                           .withAuthor("A profile not longer in the system",
+                                       UUID.randomUUID().toString())
+                           .withAuthor("An author with invalid authority",
+                                       "this is not an uuid")
+                           .withAuthor("Author",
+                                       profile.getID().toString())
+                           .build();
+
+            embargoedBit = BitstreamBuilder
+                .createBitstream(context, publicItem1, is)
+                .withName("Test Embargoed Bitstream")
+                .withDescription("This bitstream is embargoed")
+                .withMimeType("text/plain")
+                .withEmbargoPeriod(Period.ofMonths(6))
+                .build();
+        }
+        context.restoreAuthSystemState();
+
+        BitstreamRest bitstreamRest = bitstreamConverter.convert(embargoedBit, Projection.DEFAULT);
+        String bitstreamUri = utils.linkToSingleResource(bitstreamRest, "self").getHref();
+
+        //** WHEN **
+        //anonymous try to download the bitstream
+        getClient()
+            .perform(get("/api/authz/authorizations/search/object")
+                         .param("uri", bitstreamUri)
+                         .param("feature", downloadFeature.getName()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", is(0)))
+            .andExpect(jsonPath("$._embedded").doesNotExist());
+
+        // another unrelated eperson should get forbidden
+        getClient(getAuthToken(eperson.getEmail(), password))
+            .perform(get("/api/authz/authorizations/search/object")
+                         .param("uri", bitstreamUri)
+                         .param("feature", downloadFeature.getName()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", is(0)))
+            .andExpect(jsonPath("$._embedded").doesNotExist());
+
+        Authorization authorizationFeature = new Authorization(submitter, downloadFeature, bitstreamRest);
+        // the submitter should NOT be able to download
+        getClient(getAuthToken(submitter.getEmail(), password))
+            .perform(get("/api/authz/authorizations/search/object")
+                         .param("uri", bitstreamUri)
+                         .param("feature", downloadFeature.getName()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", is(0)))
+            .andExpect(jsonPath("$._embedded").doesNotExist());
+
+        authorizationFeature = new Authorization(authorEp, downloadFeature, bitstreamRest);
+        // the author should NOT be able to download
+        getClient(getAuthToken(authorEp.getEmail(), password))
+            .perform(get("/api/authz/authorizations/search/object")
+                         .param("uri", bitstreamUri)
+                         .param("feature", downloadFeature.getName()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.totalElements", is(0)))
+            .andExpect(jsonPath("$._embedded").doesNotExist());
+    }
+
+    @Test
     public void downloadOfBitstreamWithCrisSecurityDifferentBundles() throws Exception {
         //by default has no authority
         choiceAuthorityService.getChoiceAuthoritiesNames();
@@ -458,6 +577,7 @@ public class DownloadFeatureIT extends AbstractControllerIntegrationTest {
         configurationService.setProperty("choices.presentation.dc.contributor.author", "suggest");
         configurationService.setProperty("authority.controlled.dc.contributor.author", "true");
         configurationService.setProperty("cris.ItemAuthority.AuthorAuthority.entityType", "Person");
+        configurationService.setProperty("core.authorization.bitstream.author.bypass-restrictions", "true");
         pluginService.clearNamedPluginClasses();
         choiceAuthorityService.clearCache();
         metadataAuthorityService.clearCache();
@@ -610,6 +730,7 @@ public class DownloadFeatureIT extends AbstractControllerIntegrationTest {
         configurationService.setProperty("choices.presentation.dc.contributor.author", "suggest");
         configurationService.setProperty("authority.controlled.dc.contributor.author", "true");
         configurationService.setProperty("cris.ItemAuthority.AuthorAuthority.entityType", "Person");
+        configurationService.setProperty("core.authorization.bitstream.author.bypass-restrictions", "true");
         pluginService.clearNamedPluginClasses();
         choiceAuthorityService.clearCache();
         metadataAuthorityService.clearCache();
@@ -693,6 +814,7 @@ public class DownloadFeatureIT extends AbstractControllerIntegrationTest {
         configurationService.setProperty("choices.presentation.dc.contributor.author", "suggest");
         configurationService.setProperty("authority.controlled.dc.contributor.author", "true");
         configurationService.setProperty("cris.ItemAuthority.AuthorAuthority.entityType", "Person");
+        configurationService.setProperty("core.authorization.bitstream.author.bypass-restrictions", "true");
         pluginService.clearNamedPluginClasses();
         choiceAuthorityService.clearCache();
         metadataAuthorityService.clearCache();
@@ -840,6 +962,7 @@ public class DownloadFeatureIT extends AbstractControllerIntegrationTest {
         configurationService.setProperty("choices.presentation.dc.contributor.editor", "suggest");
         configurationService.setProperty("authority.controlled.dc.contributor.editor", "true");
         configurationService.setProperty("cris.ItemAuthority.AuthorAuthority.entityType", "Person");
+        configurationService.setProperty("core.authorization.bitstream.author.bypass-restrictions", "true");
         pluginService.clearNamedPluginClasses();
         choiceAuthorityService.clearCache();
         metadataAuthorityService.clearCache();

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -392,6 +392,14 @@ handle.dir = ${dspace.dir}/handle-server
 #core.authorization.item-admin.delete-bitstream = true
 #core.authorization.item-admin.cc-license = true
 
+# BITSTREAM AUTHOR ACCESS
+# Allow authors/submitters to download restricted bitstreams they authored, even if READ
+# permission is not granted to them. This bypasses normal authorization checks for item authors.
+# When enabled (true), authors can download their own restricted bitstreams.
+# When disabled (false - default), normal authorization rules apply to all users including authors.
+# (default = false)
+core.authorization.bitstream.author.bypass-restrictions = false
+
 
 #### Restricted item visibility settings ###
 # By default RSS feeds, OAI-PMH and subscription emails will include ALL items


### PR DESCRIPTION
## References
* Fixes #12179

## Description

This PR makes the author bitstream download bypass configurable (replacing a hardcoded security bypass) and adds comprehensive debug logging to CRIS security authorization decisions. 

## Instructions for Reviewers

List of changes in this PR:

### 1. Configurable Author Bitstream Access Bypass

* **Replaced hardcoded `skipAuth=true` with configuration property** in `BitstreamRestController`
  - The author bitstream download endpoint (`/api/core/bitstreams/{uuid}/content?authuser={uuid}`) previously always bypassed authorization checks
  - Now reads `core.authorization.bitstream.author.bypass-restrictions` from configuration (default: `false`)
  - When `true`, allows authors to download their own bitstreams regardless of embargo/access restrictions
  - When `false`, enforces standard authorization rules even for authors

* **Added configuration property** to `dspace/config/dspace.cfg`:
  ```properties
  # core.authorization.bitstream.author.bypass-restrictions = false
  ```
  Includes detailed documentation explaining the security implications and use cases

* **Updated test** `BitstreamRestControllerIT#testEmbargoedBitstreamWithCrisSecurity`
  - Now explicitly sets `core.authorization.bitstream.author.bypass-restrictions = true` in test setup
  - Ensures the test behavior is explicit and not dependent on default configuration

### 2. CRIS Security Debug Logging

* **Added comprehensive `[CRIS-SECURITY]` prefixed debug logging** to all authorization code paths in `CrisSecurityServiceImpl.java`:
  
  - `checkSecurity()` — logs evaluation start and GRANTED/DENIED outcome with security type
    ```
    [CRIS-SECURITY] Checking security for item=<uuid> user=<email> security=CUSTOM field=cris.policy.bitstream
    [CRIS-SECURITY] Access GRANTED for item=<uuid> user=<email> security=CUSTOM
    ```
  
  - `hasAccessByCustomPolicy()` — logs which sub-policy matched (group/user/item metadata)
    ```
    [CRIS-SECURITY] Custom policy matched: type=GROUP for item=<uuid> user=<email>
    ```
  
  - `hasAccessByGroupMetadataFields()` — logs group metadata matches
    ```
    [CRIS-SECURITY] Group metadata check: field=cris.policy.group targetGroup=Administrators item=<uuid>
    [CRIS-SECURITY] Group metadata match found: field=cris.policy.group value=<uuid> item=<uuid>
    ```
  
  - `hasAccessByUserMetadataFields()` — logs user metadata matches (authority UUID matching)
    ```
    [CRIS-SECURITY] User metadata check: field=cris.policy.eperson targetUUID=<uuid> item=<uuid>
    [CRIS-SECURITY] User metadata match found: field=cris.policy.eperson value=<authority> item=<uuid>
    ```
  
  - `hasAccessByItemMetadataFields()` — logs transitive ownership matches
    ```
    [CRIS-SECURITY] Item metadata check: field=relation.isAuthorOfPublication item=<uuid> user=<uuid>
    [CRIS-SECURITY] Found 2 related items via field=relation.isAuthorOfPublication
    [CRIS-SECURITY] Item metadata match: relatedItem=<uuid> is owned by user=<uuid>
    ```
  
  - `hasAccessByGroup()` — logs group membership checks, missing groups, errors
    ```
    [CRIS-SECURITY] Checking group membership: user=<email> group=Administrators
    [CRIS-SECURITY] User is member of group: user=<email> group=Administrators
    ```
  
  - `anyMetadataHasAuthorityEqualsTo()` — logs summary + match only (reduced noise)
    ```
    [CRIS-SECURITY] Checking 5 metadata values for authority match: targetUUID=<uuid> item=<uuid>
    [CRIS-SECURITY] Authority match found: field=dc.contributor.author value=<authority> item=<uuid>
    ```

* **Added 5 missing test cases** to `CrisSecurityServiceIT`:
  - `testHasAccessWithAllConfig` — `ALL` security type grants access to everyone including null user
  - `testHasAccessWithNoneConfig` — `NONE` security type denies access to everyone including null user
  - `testHasAccessWithAnonymousUser` — null user correctly denied across all security types
  - `testHasAccessWithCustomConfigAndAdditionalFilter` — CUSTOM security + additional filter interaction
  - `testHasAccessWithGroupConfigAndNonExistentGroup` — graceful handling of missing groups (returns false, logs error)


## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
