### PR TITLE
[DURACOM-473] Fix on vocabulary browse with anonymous

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/authority/DCInputAuthority.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/DCInputAuthority.java
@@ -217,6 +217,19 @@ public class DCInputAuthority extends SelfNamedPlugin implements ChoiceAuthority
         }
     }
 
+    /**
+     * Value-pairs from submission forms are always considered public.
+     * They contain static, non-sensitive dropdown options (e.g., document
+     * types, languages, OpenAIRE vocabularies) that must be browsable
+     * by anonymous users in submission vocabulary lookups.
+     *
+     * @return always {@code true}
+     */
+    @Override
+    public boolean isPublic() {
+        return true;
+    }
+
     @Override
     public boolean isScrollable() {
         return true;

--- a/dspace-api/src/main/java/org/dspace/content/authority/DSpaceControlledVocabulary.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/DSpaceControlledVocabulary.java
@@ -87,6 +87,19 @@ public class DSpaceControlledVocabulary extends SelfNamedPlugin implements Hiera
         super();
     }
 
+    /**
+     * Controlled vocabulary XML files are always considered public.
+     * They contain static, non-sensitive classification data (e.g., subject
+     * taxonomies like SRSC or NSI) that must be browsable by anonymous users
+     * in submission vocabulary lookups.
+     *
+     * @return always {@code true}
+     */
+    @Override
+    public boolean isPublic() {
+        return true;
+    }
+
     @Override
     public boolean storeAuthorityInMetadata() {
         init(null);

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/VocabularyRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/VocabularyRestRepositoryIT.java
@@ -213,6 +213,59 @@ public class VocabularyRestRepositoryIT extends AbstractControllerIntegrationTes
                 .andExpect(jsonPath("$.page.size", Matchers.is(2)));
     }
 
+    /**
+     * Verifies that anonymous users can browse entries from a
+     * {@link org.dspace.content.authority.DSpaceControlledVocabulary}-backed
+     * vocabulary (XML hierarchical taxonomy like SRSC).
+     * These vocabularies are public and must not require authentication.
+     */
+    @Test
+    public void correctSrscQueryAnonymousUserTest() throws Exception {
+        getClient().perform(
+                            get("/api/submission/vocabularies/srsc/entries")
+                                .param("filter", "Research")
+                                .param("size", "2"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$._embedded.entries", Matchers.containsInAnyOrder(
+                            VocabularyMatcher.matchVocabularyEntry(
+                                "Research Subject Categories", "", "vocabularyEntry"),
+                            VocabularyMatcher.matchVocabularyEntry(
+                                "Family research",
+                                "SOCIAL SCIENCES::Social sciences::Social work"
+                                    + "::Family research",
+                                "vocabularyEntry"))))
+                        .andExpect(jsonPath("$.page.totalElements", Matchers.is(26)))
+                        .andExpect(jsonPath("$.page.totalPages", Matchers.is(13)))
+                        .andExpect(jsonPath("$.page.size", Matchers.is(2)));
+    }
+
+    /**
+     * Verifies that anonymous users can browse entries from a
+     * {@link DCInputAuthority}-backed vocabulary (value-pairs).
+     * These vocabularies are public and must not require authentication.
+     */
+    @Test
+    public void correctCommonTypesQueryAnonymousUserTest() throws Exception {
+        getClient().perform(
+                        get("/api/submission/vocabularies/common_types/entries")
+                            .param("filter", "Book")
+                            .param("size", "2"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$._embedded.entries",
+                            Matchers.containsInAnyOrder(
+                                VocabularyMatcher.matchVocabularyEntry(
+                                    "Book", "Book", "vocabularyEntry"),
+                                VocabularyMatcher.matchVocabularyEntry(
+                                    "Book chapter", "Book chapter",
+                                    "vocabularyEntry"))))
+                        .andExpect(jsonPath("$.page.totalElements",
+                            Matchers.is(2)))
+                        .andExpect(jsonPath("$.page.totalPages",
+                            Matchers.is(1)))
+                        .andExpect(jsonPath("$.page.size",
+                            Matchers.is(2)));
+    }
+
     @Test
     public void notScrollableVocabularyRequiredQueryTest() throws Exception {
         String token = getAuthToken(admin.getEmail(), password);


### PR DESCRIPTION
## References

* Fixes [#5450](https://github.com/DSpace/dspace-angular/issues/5450)


## Description

This PR fixes a regression where static vocabularies (XML taxonomies like SRSC and value-pair dropdowns like common_types) became inaccessible to anonymous users after changing `VocabularyEntryLinkRepository`'s `@PreAuthorize` annotation from `permitAll()` to `@vocabularySecurity.isVocabularyPublic(#name) || hasAuthority('AUTHENTICATED')`.

## Instructions for Reviewers

List of changes in this PR:

### Root Cause

After changing the `@PreAuthorize` annotation on `VocabularyEntryLinkRepository.getVocabularyEntryValues()` to check `isVocabularyPublic()`, all static vocabularies became blocked for anonymous users because:

1. The security check delegates to `ChoiceAuthority.isPublic()`
2. The default implementation checks the config property `authority.<pluginName>.public`
3. When the property is absent, it returns `false`
4. `DSpaceControlledVocabulary` and `DCInputAuthority` had **missing `isPublic()` overrides** that were present in the `main-cris` branch

This broke anonymous access to 13 vocabularies used in submission forms:
- **XML taxonomies** (DSpaceControlledVocabulary): `srsc`, `nsi`
- **Value-pair dropdowns** (DCInputAuthority): `common_types`, `common_identifiers`, `common_iso_languages`, `openaire_license_types`, `openaire_types`, `openaire_version_types`, `openaire_rights`, `openaire_author_identifier_types`, `openaire_organization_identifier_types`, `openaire_organization_types`

### Changes

1. **Added `isPublic()` override to `DSpaceControlledVocabulary.java`** (line 90)
   ```java
   @Override
   public boolean isPublic() {
       return true;
   }
   ```
   - XML vocabulary files contain static, non-sensitive classification data (subject taxonomies)
   - Must be browsable by anonymous users in submission vocabulary lookups
   - Includes comprehensive Javadoc explaining the rationale

2. **Added `isPublic()` override to `DCInputAuthority.java`** (line 220)
   ```java
   @Override
   public boolean isPublic() {
       return true;
   }
   ```
   - Value-pairs from `submission-forms.xml` contain static dropdown options (document types, languages, OpenAIRE vocabularies)
   - Must be browsable by anonymous users in submission vocabulary lookups
   - Includes comprehensive Javadoc explaining the rationale

3. **Added test `correctSrscQueryAnonymousUserTest`** in `VocabularyRestRepositoryIT.java` (line 216)
   - Verifies anonymous users can browse SRSC (DSpaceControlledVocabulary) entries
   - Tests `/api/submission/vocabularies/srsc/entries?filter=Research&size=2`
   - Expects HTTP 200 and correct vocabulary entries returned

4. **Added test `correctCommonTypesQueryAnonymousUserTest`** in `VocabularyRestRepositoryIT.java` (line 239)
   - Verifies anonymous users can browse common_types (DCInputAuthority) entries
   - Tests `/api/submission/vocabularies/common_types/entries?filter=Book&size=2`
   - Expects HTTP 200 and correct vocabulary entries returned

### Security Considerations

**Sensitive authorities remain protected:**
- `EPersonAuthority`, `GroupAuthority`, `ItemAuthority` do **NOT** have `isPublic()` overrides
- They correctly fall through to the default implementation checking the config property
- Without explicit `authority.<name>.public = true` configuration, they remain blocked for anonymous users

**Only static, non-sensitive vocabularies are public:**
- XML taxonomies (SRSC, NSI) — subject classifications, no personal data
- Value-pairs (common_types, languages) — static dropdowns from config files, no personal data

**How to test**
    1. Go to http://localhost/browse/srsc (frontend)
    2. Type in the input
    3. Click "Search"
    4. Verify no 401 appear in Network tab


## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
