### PR TITLE
Use UTF-8 explicitly when indexing items in XOAI

### DIFF
--- a/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
@@ -17,6 +17,7 @@ import static org.dspace.xoai.util.ItemUtils.retrieveMetadata;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.ConnectException;
+import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -504,7 +505,7 @@ public class XOAI {
         metadata.write(xmlContext);
         xmlContext.getWriter().flush();
         xmlContext.getWriter().close();
-        doc.addField("item.compile", out.toString());
+        doc.addField("item.compile", out.toString(StandardCharsets.UTF_8));
 
         if (verbose) {
             println(String.format("Item %s with handle %s indexed", item.getID().toString(), handle));


### PR DESCRIPTION
## References
Fixes #12298

## Description
When indexing items in XOAI, the code was implicitly using the JVM's default encoding. Now explicitly using UTF-8 to avoid encoding mismatches.

## Instructions for Reviewers
Adds StandardCharsets import and explicitly specifies UTF-8 when converting the XML buffer to string. One line changed in XOAI.java. Existing XOAI tests cover this code path.

## Checklist
- [x] PR against `main` branch
- [x] Small in size (<1000 lines)
- [x] Passes Checkstyle
- [x] Javadoc not applicable (no new public APIs)
- [x] Passes all tests
- [x] Test instructions not applicable (existing tests cover this)
- [x] No new dependencies
- [x] No REST API changes
- [x] No new configs
- [x] Issue linked