### PR TITLE
Fix "can execute" auth check in DSpace Delete DSO script

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/DSpaceObjectUtilsImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/DSpaceObjectUtilsImpl.java
@@ -8,15 +8,23 @@
 package org.dspace.app.util;
 
 import java.sql.SQLException;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.dspace.app.util.service.DSpaceObjectUtils;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
 import org.dspace.content.DSpaceObject;
+import org.dspace.content.Item;
 import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.CollectionService;
+import org.dspace.content.service.CommunityService;
 import org.dspace.content.service.DSpaceObjectService;
+import org.dspace.content.service.ItemService;
 import org.dspace.core.Context;
 import org.dspace.handle.service.HandleService;
 import org.springframework.beans.factory.annotation.Autowired;
+
 
 public class DSpaceObjectUtilsImpl implements DSpaceObjectUtils {
 
@@ -24,6 +32,12 @@ public class DSpaceObjectUtilsImpl implements DSpaceObjectUtils {
     private ContentServiceFactory contentServiceFactory;
     @Autowired
     private HandleService handleService;
+    @Autowired
+    private ItemService itemService;
+    @Autowired
+    private CollectionService collectionService;
+    @Autowired
+    private CommunityService communityService;
 
     /**
      * Retrieve a DSpaceObject from its uuid. As this method need to iterate over all the different services that
@@ -74,5 +88,41 @@ public class DSpaceObjectUtilsImpl implements DSpaceObjectUtils {
             }
         }
         return dso;
+    }
+
+    /**
+     * Resolves a handle or UUID identifier to a basic handle-addressable DSpace Object
+     * (Item, Collection, or Community) and returns it as Optional/empty.
+     *
+     * @param identifier   The UUID or handle of the DSpace object.
+     * @return An Optional containing the DSpaceObject if found.
+     * @throws SQLException If database error occurs.
+     */
+    @Override
+    public Optional<DSpaceObject> resolveBasicDSpaceObject(Context context, String identifier)
+            throws SQLException {
+        UUID uuid = null;
+        try {
+            uuid = UUID.fromString(identifier);
+        } catch (Exception e) {
+            // It's not a UUID, proceed to treat it as a handle.
+        }
+
+        if (uuid != null) {
+            Item item = itemService.find(context, uuid);
+            if (item != null) {
+                return Optional.of(item);
+            }
+            Community community = communityService.find(context, uuid);
+            if (community != null) {
+                return Optional.of(community);
+            }
+            Collection collection = collectionService.find(context, uuid);
+            if (collection != null) {
+                return Optional.of(collection);
+            }
+        }
+        DSpaceObject dso = handleService.resolveToObject(context, identifier);
+        return dso != null ? Optional.of(dso) : Optional.empty();
     }
 }

--- a/dspace-api/src/main/java/org/dspace/app/util/service/DSpaceObjectUtils.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/service/DSpaceObjectUtils.java
@@ -8,6 +8,7 @@
 package org.dspace.app.util.service;
 
 import java.sql.SQLException;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.dspace.content.DSpaceObject;
@@ -43,4 +44,15 @@ public interface DSpaceObjectUtils {
      * @throws SQLException
      */
     public DSpaceObject findDSpaceObject(Context context, String id) throws SQLException;
+
+    /**
+     * Resolves a handle or UUID identifier to a basic handle-addressable DSpace Object
+     * (Item, Collection, or Community) and returns it as Optional/empty.
+     *
+     * @param identifier   The UUID or handle of the DSpace object.
+     * @return An Optional containing the DSpaceObject if found.
+     * @throws SQLException If database error occurs.
+     */
+    Optional<DSpaceObject> resolveBasicDSpaceObject(Context context, String identifier)
+            throws SQLException;
 }

--- a/dspace-api/src/main/java/org/dspace/deletion/process/DSpaceObjectDeletionProcess.java
+++ b/dspace-api/src/main/java/org/dspace/deletion/process/DSpaceObjectDeletionProcess.java
@@ -14,24 +14,16 @@ import java.util.Optional;
 import java.util.UUID;
 
 import org.apache.commons.cli.ParseException;
+import org.dspace.app.util.service.DSpaceObjectUtils;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.factory.AuthorizeServiceFactory;
 import org.dspace.authorize.service.AuthorizeService;
-import org.dspace.content.Collection;
-import org.dspace.content.Community;
 import org.dspace.content.DSpaceObject;
-import org.dspace.content.Item;
-import org.dspace.content.factory.ContentServiceFactory;
-import org.dspace.content.service.CollectionService;
-import org.dspace.content.service.CommunityService;
-import org.dspace.content.service.ItemService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.deletion.process.strategies.DSpaceObjectDeletionStrategy;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.factory.EPersonServiceFactory;
-import org.dspace.handle.factory.HandleServiceFactory;
-import org.dspace.handle.service.HandleService;
 import org.dspace.kernel.ServiceManager;
 import org.dspace.scripts.DSpaceRunnable;
 import org.dspace.utils.DSpace;
@@ -48,11 +40,8 @@ public class DSpaceObjectDeletionProcess
 
     public static final String OBJECT_DELETION_SCRIPT = "object-deletion";
 
-    private ItemService itemService;
-    private HandleService handleService;
-    private CommunityService communityService;
     private AuthorizeService authorizeService;
-    private CollectionService collectionService;
+    private DSpaceObjectUtils dspaceObjectUtils;
 
     private String id;
     private Context context;
@@ -62,10 +51,6 @@ public class DSpaceObjectDeletionProcess
     @Override
     public void setup() throws ParseException {
         ServiceManager serviceManager = new DSpace().getServiceManager();
-        itemService = ContentServiceFactory.getInstance().getItemService();
-        handleService = HandleServiceFactory.getInstance().getHandleService();
-        communityService = ContentServiceFactory.getInstance().getCommunityService();
-        collectionService = ContentServiceFactory.getInstance().getCollectionService();
         authorizeService = AuthorizeServiceFactory.getInstance().getAuthorizeService();
         deletionStrategies.addAll(serviceManager.getServicesByType(DSpaceObjectDeletionStrategy.class));
 
@@ -91,7 +76,7 @@ public class DSpaceObjectDeletionProcess
     @Override
     public void internalRun() throws Exception {
         assignCurrentUserInContext();
-        Optional<DSpaceObject> dSpaceObjectOptional = resolveDSpaceObject(this.id);
+        Optional<DSpaceObject> dSpaceObjectOptional = dspaceObjectUtils.resolveBasicDSpaceObject(context, this.id);
 
         if (dSpaceObjectOptional.isEmpty()) {
             var error = String.format("DSpaceObject for provided identifier:%s doesn't exist!", this.id);
@@ -125,39 +110,6 @@ public class DSpaceObjectDeletionProcess
             EPerson ePerson = EPersonServiceFactory.getInstance().getEPersonService().find(context, uuid);
             context.setCurrentUser(ePerson);
         }
-    }
-
-    /**
-     * Resolves the identifier (Item, Collection, or Community).
-     *
-     * @param identifier   The UUID or handle of the DSpace object.
-     * @return An Optional containing the DSpaceObject if found.
-     * @throws SQLException If database error occurs.
-     */
-    private Optional<DSpaceObject> resolveDSpaceObject(String identifier) throws SQLException {
-        UUID uuid = null;
-        try {
-            uuid = UUID.fromString(identifier);
-        } catch (Exception e) {
-            // It's not a UUID, proceed to treat it as a handle.
-        }
-
-        if (uuid != null) {
-            Item item = itemService.find(context, uuid);
-            if (item != null) {
-                return Optional.of(item);
-            }
-            Community community = communityService.find(context, uuid);
-            if (community != null) {
-                return Optional.of(community);
-            }
-            Collection collection = collectionService.find(context, uuid);
-            if (collection != null) {
-                return Optional.of(collection);
-            }
-        }
-        DSpaceObject dso = handleService.resolveToObject(context, identifier);
-        return dso != null ? Optional.of(dso) : Optional.empty();
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/deletion/process/DSpaceObjectDeletionProcessScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/deletion/process/DSpaceObjectDeletionProcessScriptConfiguration.java
@@ -85,26 +85,28 @@ public class DSpaceObjectDeletionProcessScriptConfiguration<T extends DSpaceObje
      * and REST usage: hasPermission('DELETE') for the DSO, with inherit = true
      * @param context DSpace context of the current user
      * @param commandLineParameters command line parameters, required to parse and resolve the DSO identifier
-     * @return result of authorize delete check, default false
+     * @return result of authorize delete check, default is to call super method
      * @throws IllegalArgumentException if the identifier cannot be resolved
      * @throws SQLException if the DAO operation for the authZ check fails
      */
     @Override
     public boolean isAllowedToExecute(Context context, List<DSpaceCommandLineParameter> commandLineParameters) {
-        try {
-            for (DSpaceCommandLineParameter parameter : commandLineParameters) {
-                if ("-i".equals(parameter.getName())) {
-                    DSpaceObject dso = resolveDSpaceObject(context, parameter.getValue())
-                        .orElseThrow(() -> new IllegalArgumentException("Could not resolve %s to DSpace Object"
-                                    .formatted(parameter.getValue())));
-                    return authorizeService.authorizeActionBoolean(context, dso, Constants.DELETE, true);
+        if (null != commandLineParameters) {
+            try {
+                for (DSpaceCommandLineParameter parameter : commandLineParameters) {
+                    if ("-i".equals(parameter.getName())) {
+                        DSpaceObject dso = resolveDSpaceObject(context, parameter.getValue())
+                                .orElseThrow(() -> new IllegalArgumentException("Could not resolve %s to DSpace Object"
+                                        .formatted(parameter.getValue())));
+                        return authorizeService.authorizeActionBoolean(context, dso, Constants.DELETE, true);
+                    }
                 }
+            } catch (IllegalArgumentException | SQLException e) {
+                log.error(e.getMessage());
             }
-        } catch (IllegalArgumentException | SQLException e) {
-            log.error(e.getMessage());
         }
-        return false;
 
+        return super.isAllowedToExecute(context, commandLineParameters);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/deletion/process/DSpaceObjectDeletionProcessScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/deletion/process/DSpaceObjectDeletionProcessScriptConfiguration.java
@@ -7,8 +7,27 @@
  */
 package org.dspace.deletion.process;
 
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
 import org.apache.commons.cli.Options;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.DSpaceObject;
+import org.dspace.content.Item;
+import org.dspace.content.service.CollectionService;
+import org.dspace.content.service.CommunityService;
+import org.dspace.content.service.ItemService;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+import org.dspace.handle.service.HandleService;
+import org.dspace.scripts.DSpaceCommandLineParameter;
 import org.dspace.scripts.configuration.ScriptConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * Script configuration for the batch deletion process of DSpace objects (Item, Collection, Community).
@@ -21,6 +40,17 @@ import org.dspace.scripts.configuration.ScriptConfiguration;
  */
 public class DSpaceObjectDeletionProcessScriptConfiguration<T extends DSpaceObjectDeletionProcess>
         extends ScriptConfiguration<T> {
+
+    @Autowired
+    ItemService itemService;
+    @Autowired
+    HandleService handleService;
+    @Autowired
+    CommunityService communityService;
+    @Autowired
+    CollectionService collectionService;
+
+    Logger log = LogManager.getLogger();
 
     private Class<T> dspaceRunnableClass;
 
@@ -50,6 +80,33 @@ public class DSpaceObjectDeletionProcessScriptConfiguration<T extends DSpaceObje
         return options;
     }
 
+    /**
+     * Match the authorization check implemented in AuthorizeServicePermissionEvaluatorPlugin
+     * and REST usage: hasPermission('DELETE') for the DSO, with inherit = true
+     * @param context DSpace context of the current user
+     * @param commandLineParameters command line parameters, required to parse and resolve the DSO identifier
+     * @return result of authorize delete check, default false
+     * @throws IllegalArgumentException if the identifier cannot be resolved
+     * @throws SQLException if the DAO operation for the authZ check fails
+     */
+    @Override
+    public boolean isAllowedToExecute(Context context, List<DSpaceCommandLineParameter> commandLineParameters) {
+        try {
+            for (DSpaceCommandLineParameter parameter : commandLineParameters) {
+                if ("-i".equals(parameter.getName())) {
+                    DSpaceObject dso = resolveDSpaceObject(context, parameter.getValue())
+                        .orElseThrow(() -> new IllegalArgumentException("Could not resolve %s to DSpace Object"
+                                    .formatted(parameter.getValue())));
+                    return authorizeService.authorizeActionBoolean(context, dso, Constants.DELETE, true);
+                }
+            }
+        } catch (IllegalArgumentException | SQLException e) {
+            log.error(e.getMessage());
+        }
+        return false;
+
+    }
+
     @Override
     public Class<T> getDspaceRunnableClass() {
         return this.dspaceRunnableClass;
@@ -59,5 +116,37 @@ public class DSpaceObjectDeletionProcessScriptConfiguration<T extends DSpaceObje
     public void setDspaceRunnableClass(Class<T> dspaceRunnableClass) {
         this.dspaceRunnableClass = dspaceRunnableClass;
     }
+    /**
+     * Resolves the identifier (Item, Collection, or Community).
+     *
+     * @param identifier   The UUID or handle of the DSpace object.
+     * @return An Optional containing the DSpaceObject if found.
+     * @throws SQLException If database error occurs.
+     */
+    private Optional<DSpaceObject> resolveDSpaceObject(Context context, String identifier)
+            throws SQLException {
+        UUID uuid = null;
+        try {
+            uuid = UUID.fromString(identifier);
+        } catch (Exception e) {
+            // It's not a UUID, proceed to treat it as a handle.
+        }
 
+        if (uuid != null) {
+            Item item = itemService.find(context, uuid);
+            if (item != null) {
+                return Optional.of(item);
+            }
+            Community community = communityService.find(context, uuid);
+            if (community != null) {
+                return Optional.of(community);
+            }
+            Collection collection = collectionService.find(context, uuid);
+            if (collection != null) {
+                return Optional.of(collection);
+            }
+        }
+        DSpaceObject dso = handleService.resolveToObject(context, identifier);
+        return dso != null ? Optional.of(dso) : Optional.empty();
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/deletion/process/DSpaceObjectDeletionProcessScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/deletion/process/DSpaceObjectDeletionProcessScriptConfiguration.java
@@ -9,22 +9,14 @@ package org.dspace.deletion.process;
 
 import java.sql.SQLException;
 import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
 
 import org.apache.commons.cli.Options;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.dspace.content.Collection;
-import org.dspace.content.Community;
+import org.dspace.app.util.service.DSpaceObjectUtils;
 import org.dspace.content.DSpaceObject;
-import org.dspace.content.Item;
-import org.dspace.content.service.CollectionService;
-import org.dspace.content.service.CommunityService;
-import org.dspace.content.service.ItemService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
-import org.dspace.handle.service.HandleService;
 import org.dspace.scripts.DSpaceCommandLineParameter;
 import org.dspace.scripts.configuration.ScriptConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,13 +34,7 @@ public class DSpaceObjectDeletionProcessScriptConfiguration<T extends DSpaceObje
         extends ScriptConfiguration<T> {
 
     @Autowired
-    ItemService itemService;
-    @Autowired
-    HandleService handleService;
-    @Autowired
-    CommunityService communityService;
-    @Autowired
-    CollectionService collectionService;
+    DSpaceObjectUtils dspaceObjectUtils;
 
     Logger log = LogManager.getLogger();
 
@@ -95,7 +81,7 @@ public class DSpaceObjectDeletionProcessScriptConfiguration<T extends DSpaceObje
             try {
                 for (DSpaceCommandLineParameter parameter : commandLineParameters) {
                     if ("-i".equals(parameter.getName())) {
-                        DSpaceObject dso = resolveDSpaceObject(context, parameter.getValue())
+                        DSpaceObject dso = dspaceObjectUtils.resolveBasicDSpaceObject(context, parameter.getValue())
                                 .orElseThrow(() -> new IllegalArgumentException("Could not resolve %s to DSpace Object"
                                         .formatted(parameter.getValue())));
                         return authorizeService.authorizeActionBoolean(context, dso, Constants.DELETE, true);
@@ -118,37 +104,5 @@ public class DSpaceObjectDeletionProcessScriptConfiguration<T extends DSpaceObje
     public void setDspaceRunnableClass(Class<T> dspaceRunnableClass) {
         this.dspaceRunnableClass = dspaceRunnableClass;
     }
-    /**
-     * Resolves the identifier (Item, Collection, or Community).
-     *
-     * @param identifier   The UUID or handle of the DSpace object.
-     * @return An Optional containing the DSpaceObject if found.
-     * @throws SQLException If database error occurs.
-     */
-    private Optional<DSpaceObject> resolveDSpaceObject(Context context, String identifier)
-            throws SQLException {
-        UUID uuid = null;
-        try {
-            uuid = UUID.fromString(identifier);
-        } catch (Exception e) {
-            // It's not a UUID, proceed to treat it as a handle.
-        }
 
-        if (uuid != null) {
-            Item item = itemService.find(context, uuid);
-            if (item != null) {
-                return Optional.of(item);
-            }
-            Community community = communityService.find(context, uuid);
-            if (community != null) {
-                return Optional.of(community);
-            }
-            Collection collection = collectionService.find(context, uuid);
-            if (collection != null) {
-                return Optional.of(collection);
-            }
-        }
-        DSpaceObject dso = handleService.resolveToObject(context, identifier);
-        return dso != null ? Optional.of(dso) : Optional.empty();
-    }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/deletionprocess/DSpaceObjectDeletionProcessIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/deletionprocess/DSpaceObjectDeletionProcessIT.java
@@ -139,7 +139,7 @@ public class DSpaceObjectDeletionProcessIT extends AbstractControllerIntegration
     }
 
     @Test
-    public void asyncDetetionOfItemTest() throws Exception {
+    public void asyncDeletionOfItemTest() throws Exception {
         // verify that item with bitstreams exist
         String tokenAdmin = getAuthToken(admin.getEmail(), password);
         getClient(tokenAdmin).perform(get("/api/core/items/" + item1.getID()))
@@ -207,7 +207,7 @@ public class DSpaceObjectDeletionProcessIT extends AbstractControllerIntegration
     }
 
     @Test
-    public void asyncDetetionOfCollectionTest() throws Exception {
+    public void asyncDeletionOfCollectionTest() throws Exception {
 
         // verify that collection with items/bitstreams exists
         String tokenAdmin = getAuthToken(admin.getEmail(), password);
@@ -299,7 +299,7 @@ public class DSpaceObjectDeletionProcessIT extends AbstractControllerIntegration
     }
 
     @Test
-    public void asyncDetetionOfCommunityTest() throws Exception {
+    public void asyncDeletionOfCommunityTest() throws Exception {
 
         // verify that community with collections/items/bitstreams exists
         String tokenAdmin = getAuthToken(admin.getEmail(), password);
@@ -399,7 +399,7 @@ public class DSpaceObjectDeletionProcessIT extends AbstractControllerIntegration
     }
 
     @Test
-    public void asyncDetetionOfUnsupportedObjectTest() throws Exception {
+    public void asyncDeletionOfUnsupportedObjectTest() throws Exception {
 
         String tokenAdmin = getAuthToken(admin.getEmail(), password);
         getClient(tokenAdmin).perform(get("/api/core/bitstreams/" + bitstream1.getID()))
@@ -423,7 +423,7 @@ public class DSpaceObjectDeletionProcessIT extends AbstractControllerIntegration
     }
 
     @Test
-    public void asyncDetetionOfItemByHandleTest() throws Exception {
+    public void asyncDeletionOfItemByHandleTest() throws Exception {
         // verify that item with bitstreams exist
         AtomicReference<String> idRef = new AtomicReference<>();
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/deletionprocess/DSpaceObjectDeletionProcessIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/deletionprocess/DSpaceObjectDeletionProcessIT.java
@@ -29,6 +29,7 @@ import org.dspace.builder.BitstreamBuilder;
 import org.dspace.builder.BundleBuilder;
 import org.dspace.builder.CollectionBuilder;
 import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.EPersonBuilder;
 import org.dspace.builder.EntityTypeBuilder;
 import org.dspace.builder.ItemBuilder;
 import org.dspace.builder.RelationshipBuilder;
@@ -42,7 +43,9 @@ import org.dspace.content.Item;
 import org.dspace.content.MetadataValue;
 import org.dspace.content.RelationshipType;
 import org.dspace.content.service.ItemService;
+import org.dspace.core.I18nUtil;
 import org.dspace.deletion.process.DSpaceObjectDeletionProcess;
+import org.dspace.eperson.EPerson;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -64,6 +67,7 @@ public class DSpaceObjectDeletionProcessIT extends AbstractControllerIntegration
     private Bitstream bitstream5;
     private Bitstream bitstream6;
     private Collection collection;
+    private EPerson communityAdmin;
 
     @Autowired
     private ItemService itemService;
@@ -72,8 +76,17 @@ public class DSpaceObjectDeletionProcessIT extends AbstractControllerIntegration
     public void setUp() throws Exception {
         super.setUp();
         context.turnOffAuthorisationSystem();
+
+        communityAdmin = EPersonBuilder.createEPerson(context)
+                              .withNameInMetadata("first (admin)", "last (admin)")
+                              .withEmail("admin@email.com")
+                              .withCanLogin(true)
+                              .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
+                              .withPassword(password)
+                              .build();
         community = CommunityBuilder.createCommunity(context)
                                     .withName("My community")
+                                    .withAdminGroup(communityAdmin)
                                     .build();
         collection = CollectionBuilder.createCollection(context, community)
                                       .withName("Publication collection")
@@ -136,6 +149,22 @@ public class DSpaceObjectDeletionProcessIT extends AbstractControllerIntegration
         }
 
         context.restoreAuthSystemState();
+    }
+
+    /**
+     * A user with delete permission (e.g. admin) on a parent object, but not the
+     * object itself, should be allowed to run the script to delete by inheriteance
+     */
+    @Test
+    public void testScriptConfigurationAuthorizeAllowsParentAdmin() throws Exception {
+        String tokenCommunityAdmin = getAuthToken(communityAdmin.getEmail(), password);
+        String[] args = new String[]{ OBJECT_DELETION_SCRIPT, "-i", collection.getID().toString() };
+        TestDSpaceRunnableHandler handler = new TestDSpaceRunnableHandler();
+        DSpaceObjectDeletionProcess deletionProcess = new DSpaceObjectDeletionProcess();
+        deletionProcess.initialize(args, handler, admin);
+        deletionProcess.run();
+        getClient(tokenCommunityAdmin).perform(get("/api/core/collections/" + collection.getID()))
+                             .andExpect(status().isNotFound());
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/deletionprocess/DSpaceObjectDeletionProcessIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/deletionprocess/DSpaceObjectDeletionProcessIT.java
@@ -68,6 +68,8 @@ public class DSpaceObjectDeletionProcessIT extends AbstractControllerIntegration
     private Bitstream bitstream6;
     private Collection collection;
     private EPerson communityAdmin;
+    private Community adminCommunity;
+    private Collection collInAdminCommunity;
 
     @Autowired
     private ItemService itemService;
@@ -77,16 +79,8 @@ public class DSpaceObjectDeletionProcessIT extends AbstractControllerIntegration
         super.setUp();
         context.turnOffAuthorisationSystem();
 
-        communityAdmin = EPersonBuilder.createEPerson(context)
-                              .withNameInMetadata("first (admin)", "last (admin)")
-                              .withEmail("admin@email.com")
-                              .withCanLogin(true)
-                              .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
-                              .withPassword(password)
-                              .build();
         community = CommunityBuilder.createCommunity(context)
                                     .withName("My community")
-                                    .withAdminGroup(communityAdmin)
                                     .build();
         collection = CollectionBuilder.createCollection(context, community)
                                       .withName("Publication collection")
@@ -157,13 +151,32 @@ public class DSpaceObjectDeletionProcessIT extends AbstractControllerIntegration
      */
     @Test
     public void testScriptConfigurationAuthorizeAllowsParentAdmin() throws Exception {
+
+        context.turnOffAuthorisationSystem();
+        communityAdmin = EPersonBuilder.createEPerson(context)
+                .withNameInMetadata("first (community admin)", "last (community admin)")
+                .withEmail("communityadmin@email.com")
+                .withCanLogin(true)
+                .withLanguage(I18nUtil.getDefaultLocale().getLanguage())
+                .withPassword(password)
+                .build();
+
+        adminCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Community with an administrator")
+                .withAdminGroup(communityAdmin).build();
+
+        collInAdminCommunity = CollectionBuilder.createCollection(context, adminCommunity)
+                .withName("Collection beneath community with an administrator")
+                .build();
+        context.restoreAuthSystemState();
+
         String tokenCommunityAdmin = getAuthToken(communityAdmin.getEmail(), password);
-        String[] args = new String[]{ OBJECT_DELETION_SCRIPT, "-i", collection.getID().toString() };
+        String[] args = new String[]{ OBJECT_DELETION_SCRIPT, "-i", collInAdminCommunity.getID().toString() };
         TestDSpaceRunnableHandler handler = new TestDSpaceRunnableHandler();
         DSpaceObjectDeletionProcess deletionProcess = new DSpaceObjectDeletionProcess();
         deletionProcess.initialize(args, handler, admin);
         deletionProcess.run();
-        getClient(tokenCommunityAdmin).perform(get("/api/core/collections/" + collection.getID()))
+        getClient(tokenCommunityAdmin).perform(get("/api/core/collections/" + collInAdminCommunity.getID()))
                              .andExpect(status().isNotFound());
     }
 


### PR DESCRIPTION
## References
* Fixes [DSpace-angular#5477](https://github.com/DSpace/dspace-angular/issues/5477)

## Description
The DSO delete process script introduced with #10964 does not override `isAllowedToExecute` - this means that all DSO deletions using that process are restricted to site admins only.

This was originally picked up through collection deletion testing but possibly affects a lot of other areas as well.

The solution was to implement an `isAllowedToExecute` for the script configuration, which resolved the `-i` parameter to a DSO and then calls the same `authorizeAction(context, dso, DELETE, true)` check that the REST authorize hasPermission plugin calls.

I traced back the previous `hasPermission` logic used, and that REST permission evaluator plugin does indeed pass `true` to `useInheritence` but if I've overlooked something I welcome feedback or questions.

New test added to prove an ordinary community admin can delete a collection.

## Instructions for Reviewers

List of changes in this PR:
* New override for `isAllowedToExecute` in `DSpaceObjectDeletionProcessScriptConfiguration` to properly check for DELETE permission on the target object by the current user (using inheritence)
* Fixed some spelling errors in the integration tests
* Added a new test: `testScriptConfigurationAuthorizeAllowsParentAdmin`

To test this PR, first try the current main branch:

* Create an ordinary user and make them an administrator of a community in your test instance (no site admin permission)
* Log in as that user and try to delete a collection. Note the error.

Then check out this PR branch and try again. It should now succeed. 

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
