### PR TITLE
Support redirect parameter in SAML login filter

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/SamlLoginFilter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/SamlLoginFilter.java
@@ -8,13 +8,14 @@
 package org.dspace.app.rest.security;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.stream.Stream;
+import java.util.ArrayList;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.authenticate.SamlAuthentication;
@@ -88,32 +89,39 @@ public class SamlLoginFilter extends StatelessLoginFilter {
     }
 
     /**
-     * After successful login, redirect to the configured UI URL. If that URL is not allowed for
-     * this DSpace site, return a 400 error.
+     * After successful login, redirect to the DSpace URL specified by this SAML
+     * request (in the "redirectUrl" request parameter). If that 'redirectUrl' is
+     * not valid or trusted for this DSpace site, then return a 400 error.
      *
      * @param request
      * @param response
      * @throws IOException
      */
     private void redirectAfterSuccess(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        String redirectUrl = configurationService.getProperty("dspace.ui.url");
+        // Get redirect URL from request parameter
+        String redirectUrl = request.getParameter("redirectUrl");
+
+        // If redirectUrl unspecified, default to the configured UI
+        if (StringUtils.isEmpty(redirectUrl)) {
+            redirectUrl = configurationService.getProperty("dspace.ui.url");
+        }
+
+        // Validate that the redirectURL matches either the server or UI hostname. It *cannot* be an arbitrary URL.
         String redirectHostName = Utils.getHostName(redirectUrl);
-        String serverUrl = configurationService.getProperty("dspace.server.url");
+        String serverHostName = Utils.getHostName(configurationService.getProperty("dspace.server.url"));
+        ArrayList<String> allowedHostNames = new ArrayList<>();
+        allowedHostNames.add(serverHostName);
+        String[] allowedUrls = configurationService.getArrayProperty("rest.cors.allowed-origins");
+        for (String url : allowedUrls) {
+            allowedHostNames.add(Utils.getHostName(url));
+        }
 
-        boolean isRedirectAllowed = Stream.concat(
-                Stream.of(serverUrl),
-                Arrays.stream(configurationService.getArrayProperty("rest.cors.allowed-origins")))
-            .map(url -> Utils.getHostName(url))
-            .anyMatch(hostName -> hostName.equalsIgnoreCase(redirectHostName));
-
-        if (isRedirectAllowed) {
+        if (Strings.CI.equalsAny(redirectHostName, allowedHostNames.toArray(new String[0]))) {
             logger.debug("SAML redirecting to " + redirectUrl);
-
             response.sendRedirect(redirectUrl);
         } else {
             logger.error("SAML redirect URL {} is not allowed" + redirectUrl);
-
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST,"SAML redirect URL not allowed");
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "SAML redirect URL not allowed");
         }
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/SamlLoginFilterTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/SamlLoginFilterTest.java
@@ -115,6 +115,36 @@ public class SamlLoginFilterTest extends AbstractDSpaceTest {
     }
 
     @Test
+    public void testRedirectWithRedirectUrlParam() throws Exception {
+        configurationService.setProperty("plugin.sequence.org.dspace.authenticate.AuthenticationMethod",
+            "org.dspace.authenticate.SamlAuthentication");
+
+        configurationService.setProperty("dspace.ui.url","http://dspace.example.org");
+        configurationService.setProperty("dspace.server.url","http://dspace.example.org/server");
+
+        ((MockHttpServletRequest) request).setParameter("redirectUrl", "http://dspace.example.org/collections/123");
+
+        filter.doFilter(request, response, filterChain);
+
+        verify(response).sendRedirect("http://dspace.example.org/collections/123");
+    }
+
+    @Test
+    public void testRedirectWithInvalidRedirectUrlParam() throws Exception {
+        configurationService.setProperty("plugin.sequence.org.dspace.authenticate.AuthenticationMethod",
+            "org.dspace.authenticate.SamlAuthentication");
+
+        configurationService.setProperty("dspace.ui.url","http://dspace.example.org");
+        configurationService.setProperty("dspace.server.url","http://dspace.example.org/server");
+
+        ((MockHttpServletRequest) request).setParameter("redirectUrl", "http://evil.host.bad/steal");
+
+        filter.doFilter(request, response, filterChain);
+
+        verify(response).sendError(eq(400), anyString());
+    }
+
+    @Test
     public void testSamlAuthenticationNotEnabled() throws Exception {
         assertThrows(ProviderNotFoundException.class, () -> filter.attemptAuthentication(request, response));
     }


### PR DESCRIPTION
Fixes #12309

## References
#12309

## Description
The SAML login was always redirecting to the configured dspace.ui.url after auth, regardless of where you actually wanted to go. This adds support for a redirectUrl parameter so you can specify where to redirect, with the same origin checks to keep things secure.

## Instructions for Reviewers
Main change is in redirectAfterSuccess(). It now checks for a redirectUrl parameter first, defaults to dspace.ui.url if not provided, and validates the hostname just like before.

To test, try logging in with ?redirectUrl=http://localhost:4000/some/page and verify it redirects there. Without the parameter it should use the configured URL. Try an external URL and it should return a 400. Added tests covering the new parameter and validation edge cases.

## Checklist
- [x] Tests added
- [x] Checkstyle passing
- [x] Javadoc updated
- [x] No license issues
- [x] No REST API docs needed
- [x] No config changes
- [x] Issue #12309 linked