### PR TITLE
[Docker] Ensure `docker-deploy` waits for the backend to fully initialize before creating test content

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -185,8 +185,11 @@ jobs:
           sleep 10
           docker container ls
       # Create a test admin account. Load test data from a simple set of AIPs as defined in cli.ingest.yml
+      # NOTE: Before creating test data, we wait for the backend to become responsive by requesting it every 10 sec.
+      # Timeout after 5 minutes. This is done to ensure the backend is fully initialized before we create test data.
       - name: Load test data into Backend
         run: |
+          timeout 5m wget --retry-connrefused -t 0 --waitretry=10 http://127.0.0.1:8080/server/api
           docker compose -f docker-compose-cli.yml run --rm dspace-cli create-administrator -e test@test.edu -f admin -l user -p admin -c en
           docker compose -f docker-compose-cli.yml -f dspace/src/main/docker-compose/cli.ingest.yml run --rm dspace-cli
       # Verify backend started successfully.


### PR DESCRIPTION

## References
* Possible fix for the errors in the `docker-deploy` job that are occurring in #10554

## Description
This small change to `docker-deploy` job ensures that we are waiting for the REST API backend to **fully initialize** before we create any test/demo content (like admin accounts or importing AIP data).

I believe a race condition may be occurring in the build of #10554...where the database is not fully initialized at the point where `./dspace create-administrator` is called.  This results in odd errors.

**Assuming this fixes the issues in #10554, then this should also be ported to `dspace-angular` as it's possible the same race condition could occur in the `docker-deploy` job there.**  I can create a manual port once we verify whether this is working.

## Instructions for Reviewers
* Verify that this passes all automated tests in GitHub