### PR TITLE
Contain IT teardown failures so one flaky cleanup doesn't cascade

### DIFF
--- a/dspace-api/src/test/java/org/dspace/AbstractIntegrationTestWithDatabase.java
+++ b/dspace-api/src/test/java/org/dspace/AbstractIntegrationTestWithDatabase.java
@@ -179,15 +179,40 @@ public class AbstractIntegrationTestWithDatabase extends AbstractDSpaceIntegrati
      */
     @After
     public void destroy() throws Exception {
-        // Cleanup our global context object
+        // Contain the blast radius of teardown failures: the shared static state (Solr cores, authority
+        // cache, configuration, builder cache) must be reset regardless of whether builder cleanup threw.
+        // Otherwise a single flake in one test's teardown poisons every subsequent test in the class.
+        Exception primaryFailure = null;
         try {
             AbstractBuilder.cleanupObjects();
             parentCommunity = null;
             cleanupContext();
         } catch (Exception e) {
-            throw new RuntimeException("Error cleaning up builder objects & context object", e);
+            primaryFailure = new RuntimeException("Error cleaning up builder objects & context object", e);
+        } finally {
+            try {
+                resetSharedState();
+            } catch (Exception e) {
+                if (primaryFailure == null) {
+                    primaryFailure = e;
+                } else {
+                    primaryFailure.addSuppressed(e);
+                }
+            }
         }
+        if (primaryFailure != null) {
+            throw primaryFailure;
+        }
+    }
 
+    /**
+     * Reset all shared static state between tests: Solr cores, authority cache, QA events, configuration
+     * service, and the builder cache. Called from {@link #destroy()} inside a finally block so this always
+     * runs, even if earlier teardown steps failed.
+     *
+     * @throws Exception if reloading configuration or resetting the builder cache fails
+     */
+    private void resetSharedState() throws Exception {
         ServiceManager serviceManager = DSpaceServicesFactory.getInstance().getServiceManager();
 
         // Clear the search core.

--- a/dspace-api/src/test/java/org/dspace/builder/util/AbstractBuilderCleanupUtil.java
+++ b/dspace-api/src/test/java/org/dspace/builder/util/AbstractBuilderCleanupUtil.java
@@ -12,6 +12,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.dspace.builder.AbstractBuilder;
 import org.dspace.builder.BitstreamBuilder;
 import org.dspace.builder.BitstreamFormatBuilder;
@@ -44,6 +46,8 @@ import org.dspace.builder.WorkspaceItemBuilder;
  * builders.
  */
 public class AbstractBuilderCleanupUtil {
+
+    private static final Logger log = LogManager.getLogger(AbstractBuilderCleanupUtil.class);
 
     private final LinkedHashMap<String, List<AbstractBuilder>> map
             = new LinkedHashMap<>();
@@ -98,14 +102,33 @@ public class AbstractBuilderCleanupUtil {
     /**
      * This method takes care of iterating over all the AbstractBuilders in the predefined order and calls
      * the cleanup method to delete the objects from the database.
-     * @throws Exception    If something goes wrong
+     * <p>
+     * Each builder is cleaned up inside its own try/catch so that a single failure (e.g. the intermittent
+     * Hibernate {@link java.util.ConcurrentModificationException} in resource registry cleanup) does not
+     * abort cleanup of the remaining builders. The first failure is rethrown at the end with any subsequent
+     * failures attached as suppressed exceptions, so nothing is silently swallowed.
+     * </p>
+     * @throws Exception    If one or more builders fail to clean up
      */
     public void cleanupBuilders() throws Exception {
+        Exception firstFailure = null;
         for (Map.Entry<String, List<AbstractBuilder>> entry : map.entrySet()) {
             List<AbstractBuilder> list = entry.getValue();
             for (AbstractBuilder abstractBuilder : list) {
-                abstractBuilder.cleanup();
+                try {
+                    abstractBuilder.cleanup();
+                } catch (Exception e) {
+                    log.error("Error cleaning up builder {}", abstractBuilder.getClass().getName(), e);
+                    if (firstFailure == null) {
+                        firstFailure = e;
+                    } else {
+                        firstFailure.addSuppressed(e);
+                    }
+                }
             }
+        }
+        if (firstFailure != null) {
+            throw firstFailure;
         }
     }
 


### PR DESCRIPTION
## References

Fixes #12324

## Description

Contain the blast radius of flaky integration-test teardowns. Today, when one test's `@After` → `AbstractIntegrationTestWithDatabase.destroy()` throws (most visibly the intermittent Hibernate `ConcurrentModificationException` in `ResourceRegistryStandardImpl.releaseResources()` — see #7933), the exception skips the Solr cores, authority cache, QA events, configuration, and builder-cache resets that sit after the try/catch. Every subsequent test in the class then starts from a poisoned static state and cascades into follow-up errors (typically `CommunityBuilder.createCommunity(...)` returning null). A single flake becomes ~70 reported failures and reruns only partially recover.

This PR makes teardown resilient without changing production code:

1. **`AbstractBuilderCleanupUtil.cleanupBuilders()`** — each `abstractBuilder.cleanup()` is now wrapped in its own try/catch. Per-builder failures are logged; the first is rethrown at the end with subsequent failures attached as suppressed exceptions. Previously, the first exception aborted the rest of the loop, leaving hundreds of objects un-deleted.

2. **`AbstractIntegrationTestWithDatabase.destroy()`** — the shared-state resets are moved into a new `resetSharedState()` helper that is always invoked from a `finally` block, so Solr cores, authority cache, QA events, configuration, and builder cache are reset regardless of whether builder cleanup threw. The original cleanup exception is preserved as the primary failure; any reset-path failures are attached via `addSuppressed`.

Result: a future teardown flake fails exactly one test instead of cascading to ~70.

Production code is unchanged — this is purely test-infrastructure.

## Instructions for Reviewers

Please ensure:
- The original exception contract is preserved: if builder cleanup throws, the test still fails with the same root cause; nothing is silently swallowed.
- The `finally` block's `resetSharedState()` runs even when builder cleanup throws, so the next test in the class starts from clean shared state.
- No changes to cleanup *order* in `AbstractBuilderCleanupUtil` — the order from #7933 is preserved.

Manually verified locally: full `GenericAuthorizationFeatureIT` (20 tests) passes cleanly with these changes.

## Checklist

- [x] My PR is small in size (e.g., less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes [Javadoc](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide#CodeStyleGuide-Javadocs) for *all new (or modified) public methods and classes*. Includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide). *N/A — this PR hardens the test infrastructure itself; existing ITs continue to pass.*
- [x] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation. *No new dependencies.*