### PR TITLE
Fix Creating Researcher Profile fails when Custom URLs are enabled.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/customurl/consumer/CustomUrlConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/app/customurl/consumer/CustomUrlConsumer.java
@@ -288,7 +288,18 @@ public class CustomUrlConsumer implements Consumer {
      */
     private void assignCustomUrlToItem(Context context, Item item, String customUrl) {
         log.info("Assigning custom URL '{}' to item {}", customUrl, item.getID());
-        customUrlService.replaceCustomUrl(context, item, customUrl);
+        // Evict and re-fetch the item to ensure a clean managed entity.
+        // During event dispatch the item may have detached associations
+        // that cause "detached entity passed to persist" errors.
+        try {
+            context.uncacheEntity(item);
+            Item managedItem = itemService.find(context, item.getID());
+            if (managedItem != null) {
+                customUrlService.replaceCustomUrl(context, managedItem, customUrl);
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to reload item " + item.getID(), e);
+        }
     }
 
     /**

--- a/dspace-api/src/test/java/org/dspace/app/customurl/consumer/CustomUrlConsumerIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/customurl/consumer/CustomUrlConsumerIT.java
@@ -475,6 +475,16 @@ public class CustomUrlConsumerIT extends AbstractIntegrationTestWithDatabase {
                                        .withTitle("Advanced Algorithms Study")
                                        .build();
 
+        // Commit so the consumer fires and assigns the custom URL to the original item
+        context.restoreAuthSystemState();
+        context.commit();
+
+        originalItem = context.reloadEntity(originalItem);
+        // Verify the original item has the custom URL before versioning
+        assertThat(originalItem.getMetadata(), hasItem(with("dspace.customurl", "advanced-algorithms-study")));
+
+        context.turnOffAuthorisationSystem();
+
         // Create a new version using VersionBuilder (like VersionRestRepositoryIT)
         Version newVersion = VersionBuilder.createVersion(context, originalItem, "Second version").build();
         Item versionedItem = newVersion.getItem();
@@ -491,6 +501,7 @@ public class CustomUrlConsumerIT extends AbstractIntegrationTestWithDatabase {
 
         // The versioned item will have the same title, so it should get the same custom URL
         versionedItem = context.reloadEntity(versionedItem);
+        originalItem = context.reloadEntity(originalItem);
 
         // Verify the versioned item got the same custom URL
         assertThat(versionedItem.getMetadata(), hasItem(with("dspace.customurl", "advanced-algorithms-study")));

--- a/dspace-api/src/test/java/org/dspace/app/customurl/service/CustomUrlServiceImplIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/customurl/service/CustomUrlServiceImplIT.java
@@ -250,6 +250,7 @@ public class CustomUrlServiceImplIT extends AbstractIntegrationTestWithDatabase 
 
     private void reindexItem(Item item) throws SQLException, SearchServiceException {
         context.commit();
+        item = context.reloadEntity(item);
         indexingService.indexContent(context, new IndexableItem(item), true);
         indexingService.commit();
     }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResearcherProfileRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResearcherProfileRestRepositoryIT.java
@@ -56,6 +56,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 
 import com.jayway.jsonpath.JsonPath;
+import org.dspace.app.customurl.consumer.CustomUrlConsumerConfig;
 import org.dspace.app.rest.model.patch.AddOperation;
 import org.dspace.app.rest.model.patch.Operation;
 import org.dspace.app.rest.model.patch.RemoveOperation;
@@ -88,6 +89,7 @@ import org.dspace.orcid.service.OrcidSynchronizationService;
 import org.dspace.orcid.service.OrcidTokenService;
 import org.dspace.services.ConfigurationService;
 import org.dspace.util.UUIDUtils;
+import org.dspace.utils.DSpace;
 import org.junit.After;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -322,6 +324,13 @@ public class ResearcherProfileRestRepositoryIT extends AbstractControllerIntegra
      */
     @Test
     public void testCreateAndReturn() throws Exception {
+        CustomUrlConsumerConfig customUrlConsumerConfig = new DSpace()
+            .getSingletonService(CustomUrlConsumerConfig.class);
+
+        configurationService.setProperty("dspace.custom-url.consumer.supported-entities", "Person");
+        configurationService.setProperty("dspace.custom-url.consumer.entity-metadata-mapping.Person",
+                                         "person.familyName,person.givenName");
+        customUrlConsumerConfig.reload();
 
         String id = user.getID().toString();
         String name = user.getFullName();


### PR DESCRIPTION
## References
* Fixes #12280

## Description
When creating a researcher profile with Custom URLs enabled, the request fails with a 500 Internal Server Error. This occurs because the `replaceCustomUrl` method receives a detached Hibernate entity from event consumers, causing a "detached entity passed to persist" error when trying to add metadata.


## Instructions for Reviewers

List of changes in this PR:
* Modified `CustomUrlServiceImpl.replaceCustomUrl()` to evict the item from the Hibernate session and re-fetch it using `itemService.find()` to obtain a fully managed entity before performing metadata operations.
* Added test coverage in `ResearcherProfileRestRepositoryIT.java` to verify the profile creation works with Custom URLs enabled.

**Include guidance for how to test or review your PR:**
1. Enable Custom URLs in the [DSpace configuration](https://wiki.lyrasis.org/display/DSDOC10x/Custom+URL+for+Entities#CustomURLforEntities-CustomURLautogeneration)
2. As a registered user, navigate to the Profile screen
3. Click "Create new" in the Researcher Profile section
4. Verify the profile is created successfully without a 500 error

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
