### PR TITLE
[Port dspace-8_x] Fix OpenAIRE integration: null handling and HTTP client lifecycle

### DIFF
--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -8,4 +8,5 @@
          on JMockIt Expectations blocks and similar. See https://github.com/checkstyle/checkstyle/issues/3739 -->
     <suppress checks="Indentation" files="src[/\\]test[/\\]java"/>
     <suppress checks="Regexp" files="DSpaceHttpClientFactory\.java"/>
+    <suppress checks="Regexp" files="OpenAIRERestConnectorTest\.java"/>
 </suppressions>

--- a/dspace-api/src/main/java/org/dspace/external/OpenaireRestConnector.java
+++ b/dspace-api/src/main/java/org/dspace/external/OpenaireRestConnector.java
@@ -206,8 +206,11 @@ public class OpenaireRestConnector {
                         break;
                 }
 
-                // do not close this httpClient
-                result = getResponse.getEntity().getContent();
+                // the client will be closed, we need to copy the response stream to a new one that we can return
+                try (InputStream is = getResponse.getEntity().getContent()) {
+                    byte[] bytes = is.readAllBytes();
+                    result = new java.io.ByteArrayInputStream(bytes);
+                }
             }
         } catch (MalformedURLException e1) {
             getGotError(e1, url + '/' + file);

--- a/dspace-api/src/main/java/org/dspace/external/provider/impl/OpenaireFundingDataProvider.java
+++ b/dspace-api/src/main/java/org/dspace/external/provider/impl/OpenaireFundingDataProvider.java
@@ -29,6 +29,7 @@ import eu.openaire.oaf.model.base.FundingTreeType;
 import eu.openaire.oaf.model.base.FundingType;
 import eu.openaire.oaf.model.base.Project;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.Logger;
 import org.dspace.content.dto.MetadataValueDTO;
 import org.dspace.external.OpenaireRestConnector;
@@ -169,7 +170,19 @@ public class OpenaireFundingDataProvider extends AbstractExternalDataProvider {
         String encodedQuery = encodeValue(query);
 
         Response projectResponse = connector.searchProjectByKeywords(0, 0, encodedQuery);
-        return Integer.parseInt(projectResponse.getHeader().getTotal());
+        if (projectResponse == null || projectResponse.getHeader() == null) {
+            return 0;
+        }
+        String total = projectResponse.getHeader().getTotal();
+        if (StringUtils.isBlank(total)) {
+            return 0;
+        }
+        try {
+            return Integer.parseInt(total);
+        } catch (NumberFormatException e) {
+            log.error("Failed to parse search result count from OpenAIRE: {}", e.getMessage());
+            return 0;
+        }
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/external/provider/impl/OpenaireFundingDataProvider.java
+++ b/dspace-api/src/main/java/org/dspace/external/provider/impl/OpenaireFundingDataProvider.java
@@ -29,7 +29,6 @@ import eu.openaire.oaf.model.base.FundingTreeType;
 import eu.openaire.oaf.model.base.FundingType;
 import eu.openaire.oaf.model.base.Project;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.Logger;
 import org.dspace.content.dto.MetadataValueDTO;
 import org.dspace.external.OpenaireRestConnector;

--- a/dspace-api/src/test/java/org/dspace/external/OpenAIRERestConnectorTest.java
+++ b/dspace-api/src/test/java/org/dspace/external/OpenAIRERestConnectorTest.java
@@ -1,0 +1,61 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.external;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import eu.openaire.jaxb.model.Response;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.dspace.app.client.DSpaceHttpClientFactory;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+
+public class OpenAIRERestConnectorTest {
+
+    @Test
+    public void searchProjectByKeywords() throws IOException {
+        try (InputStream is = this.getClass().getResourceAsStream("openaire-projects.xml");
+               MockWebServer mockServer = new MockWebServer()) {
+            String projects = new String(is.readAllBytes(), StandardCharsets.UTF_8)
+                    .replaceAll("( mushroom)", "( DEADBEEF)");
+            mockServer.enqueue(new MockResponse().setResponseCode(200).setBody(projects));
+
+            // setup mocks so we don't have to set whole DSpace kernel etc.
+            // still, the idea is to test how the get method behaves
+            CloseableHttpClient httpClient = spy(HttpClientBuilder.create().build());
+            doReturn(httpClient.execute(new HttpGet(mockServer.url("").toString())))
+                    .when(httpClient).execute(Mockito.any());
+
+            DSpaceHttpClientFactory mock = Mockito.mock(DSpaceHttpClientFactory.class);
+            when(mock.build()).thenReturn(httpClient);
+
+            try (MockedStatic<DSpaceHttpClientFactory> mockedFactory =
+                         Mockito.mockStatic(DSpaceHttpClientFactory.class)) {
+                mockedFactory.when(DSpaceHttpClientFactory::getInstance).thenReturn(mock);
+                OpenaireRestConnector connector = new OpenaireRestConnector(mockServer.url("").toString());
+                Response response = connector.searchProjectByKeywords(0, 10, "keyword");
+                // Basically check it doesn't throw UnmarshallerException and that we are getting our mocked response
+                assertTrue("Expected the query to contain the replaced keyword",
+                        response.getHeader().getQuery().contains("DEADBEEF"));
+            }
+        }
+    }
+}

--- a/dspace-api/src/test/java/org/dspace/external/provider/impl/OpenaireFundingDataProviderTest.java
+++ b/dspace-api/src/test/java/org/dspace/external/provider/impl/OpenaireFundingDataProviderTest.java
@@ -14,7 +14,9 @@ import static org.junit.Assert.assertTrue;
 import java.util.List;
 import java.util.Optional;
 
+import eu.openaire.jaxb.model.Response;
 import org.dspace.AbstractDSpaceTest;
+import org.dspace.external.OpenaireRestConnector;
 import org.dspace.external.factory.ExternalServiceFactory;
 import org.dspace.external.model.ExternalDataObject;
 import org.dspace.external.provider.ExternalDataProvider;
@@ -101,5 +103,22 @@ public class OpenaireFundingDataProviderTest extends AbstractDSpaceTest {
         Optional<ExternalDataObject> result = openaireFundingDataProvider.getExternalDataObject(id);
 
         assertTrue("openaireFunding.getExternalDataObject.notExists:WRONGID", result.isEmpty());
+    }
+
+    @Test
+    public void testGetNumberOfResultsWhenResponseIsNull() {
+        // Create a mock connector that returns null
+        OpenaireFundingDataProvider provider = new OpenaireFundingDataProvider();
+        provider.setSourceIdentifier("test");
+        provider.setConnector(new OpenaireRestConnector("test") {
+            @Override
+            public Response searchProjectByKeywords(int page, int size, String... keywords) {
+                return null;
+            }
+        });
+
+        // Should return 0 when response is null, not throw NullPointerException
+        int result = provider.getNumberOfResults("test");
+        assertEquals("Should return 0 when response is null", 0, result);
     }
 }


### PR DESCRIPTION
## References
Backport of https://github.com/DSpace/DSpace/pull/11967 to dspace-8_x
The original issue: https://github.com/ufal/clarin-dspace/issues/1329

## Description
OpenAIRE Search API failures (deprecated Dec 2025) caused two exceptions:

NullPointerException in getNumberOfResults() when API unavailable
ConnectionClosedException: Premature end of chunk coded message body during XML unmarshalling

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
