### PR TITLE
Fix several bugs in AIP Backup & Restore found when attempting to "round trip" an entire site of AIPs

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/DSpaceObjectServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/DSpaceObjectServiceImpl.java
@@ -1064,7 +1064,8 @@ public abstract class DSpaceObjectServiceImpl<T extends DSpaceObject> implements
     }
 
     private boolean isNonValidAuthority(boolean authorityControlled, List<String> authorities) {
-        return !authorityControlled && authorities != null && authorities.size() > 0 && authorities.get(0) != null;
+        return !authorityControlled && authorities != null && !authorities.isEmpty() &&
+            authorities.get(0) != null && !authorities.get(0).isBlank();
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/CrosswalkMetadataValidator.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/CrosswalkMetadataValidator.java
@@ -108,9 +108,12 @@ public class CrosswalkMetadataValidator {
                             e.printStackTrace();
                         }
                     } else if (!fieldChoice.equals("ignore")) {
-                        throw new CrosswalkException(
-                            "The '" + element + "." + qualifier + "' element has not been defined in this DSpace " +
-                                "instance. ");
+                        throw new CrosswalkException(String.format(
+                            "The '%s.%s%s' element has not been defined in this DSpace instance.",
+                            mdSchema.getName(),
+                            element,
+                            qualifier == null ? "" : ("." + qualifier)
+                        ));
                     }
                 }
             }

--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/LicenseStreamDisseminationCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/LicenseStreamDisseminationCrosswalk.java
@@ -8,6 +8,7 @@
 package org.dspace.content.crosswalk;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.sql.SQLException;
 
@@ -56,7 +57,12 @@ public class LicenseStreamDisseminationCrosswalk
             Bitstream licenseBs = PackageUtils.findDepositLicense(context, (Item) dso);
 
             if (licenseBs != null) {
-                Utils.copy(bitstreamService.retrieve(context, licenseBs), out);
+                try (final InputStream bitInputStream = bitstreamService.retrieve(context, licenseBs)) {
+                    Utils.copy(bitInputStream, out);
+                } catch (Exception e) {
+                    log.warn("Could not retrieve license file for Item with UUID={}. " +
+                                 "Leaving it out of generated package. Error{}", dso.getID(), e.getMessage());
+                }
             }
         }
     }

--- a/dspace-api/src/main/java/org/dspace/content/packager/AbstractMETSDisseminator.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/AbstractMETSDisseminator.java
@@ -456,17 +456,37 @@ public abstract class AbstractMETSDisseminator
                                 // contents are unchanged
                                 ze.setTime(DEFAULT_MODIFIED_DATE);
                             }
-                            ze.setSize(auth ? bitstream.getSizeBytes() : 0);
-                            zip.putNextEntry(ze);
+
+                            long bitstreamSize = 0;
+                            // If user is authorized to read this bitstream, attempt to retrieve it.
                             if (auth) {
-                                InputStream input = bitstreamService.retrieve(context, bitstream);
-                                Utils.copy(input, zip);
-                                input.close();
+                                try (final InputStream bitstreamInput = bitstreamService.retrieve(context, bitstream)) {
+                                    // Save bitstream size into Zip entry & put entry in Zip file.
+                                    bitstreamSize = bitstream.getSizeBytes();
+                                    ze.setSize(bitstreamSize);
+                                    zip.putNextEntry(ze);
+
+                                    // Copy bitstream contents to Zip file
+                                    Utils.copy(bitstreamInput, zip);
+                                } catch (Exception e) {
+                                    log.warn("Adding zero-length file for Bitstream, uuid={}."
+                                                 + " Bitstream is unable to be retrieved from assetstore."
+                                                 + " Error={}", bitstream.getID(), e.getMessage());
+                                }
                             } else {
-                                log.warn("Adding zero-length file for Bitstream, uuid="
-                                             + String.valueOf(bitstream.getID())
-                                             + ", not authorized for READ.");
+                                log.warn("Adding zero-length file for Bitstream, uuid={}"
+                                             + ", not authorized for READ.", bitstream.getID());
                             }
+
+                            // If bitstreamSize is still zero, that means either we didn't have READ privileges
+                            // or the bitstream could not be retrieved from storage. Either way, write a zero-length
+                            // file into our Zip entry in place of the bitstream.
+                            if (bitstreamSize == 0) {
+                                ze.setSize(0);
+                                zip.putNextEntry(ze);
+                            }
+
+                            // Close our zip entry
                             zip.closeEntry();
                         } else if (unauth != null && unauth.equalsIgnoreCase("skip")) {
                             log.warn("Skipping Bitstream, uuid=" + String
@@ -629,6 +649,13 @@ public abstract class AbstractMETSDisseminator
                         ByteArrayOutputStream disseminateOutput = new ByteArrayOutputStream();
                         sxwalk.disseminate(context, dso, disseminateOutput);
                         disseminateOutput.close();
+
+                        // If our disseminated output has zero size, exit immediately (i.e. return a null mdSec).
+                        // Likely, the outputstream failed to be created, so we cannot include it in this package.
+                        if (disseminateOutput.size() == 0) {
+                            return null;
+                        }
+
                         // Convert output to an inputstream, so we can write to manifest or Zip file
                         ByteArrayInputStream crosswalkedStream = new ByteArrayInputStream(
                             disseminateOutput.toByteArray());

--- a/dspace-api/src/main/java/org/dspace/content/packager/AbstractMETSIngester.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/AbstractMETSIngester.java
@@ -19,6 +19,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.io.input.NullInputStream;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -748,6 +749,14 @@ public abstract class AbstractMETSIngester extends AbstractPackageIngester {
             // externally, if it is an externally referenced file)
             InputStream fileStream = getFileInputStream(pkgFile, params, path);
 
+            // Before proceeding we must ensure we have a non-empty input stream
+            // NOTE: If getFileInputStream encounters a zero-sized file, then it returns NullInputStream
+            if (fileStream == null || fileStream instanceof NullInputStream) {
+                log.warn("Empty InputStream encountered for Bitstream with ID={} in zip file={}. " +
+                             "Skipping adding this empty bitstream to Item={}", mfileID, pkgFile, item.getID());
+                continue;
+            }
+
             // retrieve bundle name from manifest
             String bundleName = METSManifest.getBundleName(mfile);
 
@@ -1324,7 +1333,7 @@ public abstract class AbstractMETSIngester extends AbstractPackageIngester {
      *                zip)
      * @param params  Parameters passed to METSIngester
      * @param path    the File path (either path in Zip package or a URL)
-     * @return the InputStream for the file
+     * @return the InputStream for the file, or NullInputStream if a zero-sized entry is encountered
      * @throws MetadataValidationException if validation error
      * @throws IOException                 if IO error
      */
@@ -1357,12 +1366,13 @@ public abstract class AbstractMETSIngester extends AbstractPackageIngester {
             // Retrieve the manifest file entry by name
             ZipEntry manifestEntry = zipPackage.getEntry(path);
 
-            // Get inputStream associated with this file
-            if (manifestEntry != null) {
+            if (manifestEntry.getSize() > 0) {
+                // Get inputStream associated with this file
                 return zipPackage.getInputStream(manifestEntry);
             } else {
-                throw new MetadataValidationException("Manifest file references file '"
-                                                          + path + "' not included in the zip.");
+                log.warn("Zero-sized file entry={} found in zip file={}. Returning empty InputStream.",
+                         path, pkgFile);
+                return new NullInputStream();
             }
         }
     }

--- a/dspace-api/src/main/java/org/dspace/content/packager/RoleDisseminator.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/RoleDisseminator.java
@@ -310,8 +310,8 @@ public class RoleDisseminator implements PackageDisseminator {
             for (EPerson member : group.getMembers()) {
                 writer.writeEmptyElement(MEMBER);
                 writer.writeAttribute(ID, String.valueOf(member.getID()));
-                if (null != member.getName()) {
-                    writer.writeAttribute(NAME, member.getName());
+                if (null != member.getEmail()) {
+                    writer.writeAttribute(NAME, member.getEmail());
                 }
             }
             writer.writeEndElement();

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1273,6 +1273,7 @@ registry.metadata.load = dspace-types.xml
 registry.metadata.load = iiif-types.xml
 registry.metadata.load = datacite-types.xml
 registry.metadata.load = coar-types.xml
+registry.metadata.load = journal-types.xml
 
 #---------------------------------------------------------------#
 #-----------------UI-Related CONFIGURATIONS---------------------#

--- a/dspace/config/registries/journal-types.xml
+++ b/dspace/config/registries/journal-types.xml
@@ -1,0 +1,37 @@
+<dspace-dc-types>
+
+    <!-- These metadata schema are currently only used in virtual-metadata.xml
+         to represent a virtual relationship to a Journal / JournalVolume / JournalIssue Entities -->
+    <!-- TODO: We may want to move these to "relation" schema fields as they are only used by relationships -->
+    <dspace-header>
+        <title>DSpace Journal Types</title>
+    </dspace-header>
+
+
+    <!-- "journal" schema -->
+    <dc-schema>
+        <name>journal</name>
+        <namespace>http://dspace.org/journal</namespace>
+    </dc-schema>
+
+    <dc-type>
+        <schema>journal</schema>
+        <element>title</element>
+        <qualifier></qualifier>
+        <scope_note>The title of the Journal related to this object</scope_note>
+    </dc-type>
+
+    <!-- "journalvolume" schema -->
+    <dc-schema>
+        <name>journalvolume</name>
+        <namespace>http://dspace.org/journalvolume</namespace>
+    </dc-schema>
+
+    <dc-type>
+        <schema>journalvolume</schema>
+        <element>identifier</element>
+        <qualifier>name</qualifier>
+        <scope_note>The identifier name for the Journal Volume related to this object</scope_note>
+    </dc-type>
+
+</dspace-dc-types>

--- a/dspace/config/registries/schema-person-types.xml
+++ b/dspace/config/registries/schema-person-types.xml
@@ -156,4 +156,13 @@
         <scope_note>Full name variant</scope_note>
     </dc-type>
 
+    <!-- NOTE: This field is currently only used by virtual-metadata.xml to respresent the relationship
+         between an OrgUnit and a Person -->
+    <dc-type>
+        <schema>person</schema>
+        <element>contributor</element>
+        <qualifier>other</qualifier>
+        <scope_note></scope_note>
+    </dc-type>
+
 </dspace-dc-types>


### PR DESCRIPTION
## References
* Fixes #3353
* Required for AIP "round trip" testing of #3328.  Without the fixes in this PR, it's not possible to do a full site export and import of Entity AIPs using #3328. 

## Description
While testing #3328, I ran into a number of bugs in attempting to "round trip" AIPs.  Some of these fixes are just making the [AIP backup and restore](https://wiki.lyrasis.org/display/DSDOC9x/AIP+Backup+and+Restore) process more forgiving of bad/sloppy data.

Fixes include:
1. Fix for #3353 .  We have a handful of Entity-related metadata fields that are referenced in `virtual-metadata.xml` but do **not exist** in our Metadata Registry.  These require missing fields have been added in 5ca3c253c35f97ca5f3c086f4bae6e86495a9a3c
2. The current `RoleDisseminator` exports an EPerson's full name to the "Name" field (in the METs export).  But, the `RoleIngester` expects this "Name" field to be an **email** so that it can [locate the EPerson via email](https://github.com/DSpace/DSpace/blob/main/dspace-api/src/main/java/org/dspace/content/packager/RoleIngester.java#L318) in order to add them to the proper groups during ingest. Fixed in 88fe1cbea67a462cbf46a2d24372c92c9da81cc1
3. Encountered a scenario where a single metadata field value had a **space** in the "authority" column.  This caused errors during AIP import because it was seen as a *valid* Authority value. Updated `DSpaceObjectServiceImpl` to ignore this scenario. See 6a1bb01ca2caa1e2c96f5b5b95c22a4596b0e078
4. Encountered scenarios where License bitstreams was missing from the assetstore, throwing errors on export and import.  While this shouldn't be encountered in Production, I've fixed `AbstractMETSDisseminater` and `AbstractMETSIngester` to be _more forgiving_ when they encounter missing or empty Bitstreams. Instead of throwing errors, they now log warnings. See cb844fb17515ba42a90e75924608060a8756367c
5. Finally, a minor update to an exception message to add the Metadata Schema to a message that included only the Metadata element and qualifier. See 43c5c1f7c1dd09978c38aae31946a41d365784da

## Instructions for Reviewers
* Primarily, this needs a **code review** and to ensure that no automated tests fail.
* I've tested these changes thoroughly during my ongoing testing of #3328.  Specifically, I was testing "round-tripping" our Demo Entities Data set by exporting them all to AIP and attempting to restore them all to an empty database.  These are the steps I took in my testing:
    * First, install the [Demo Entities Data](https://github.com/DSpace-Labs/AIP-Files/releases/tag/demo-entities-data) locally. For example in a [Docker instance](https://github.com/DSpace/DSpace/tree/main/dspace/src/main/docker-compose#ingest-entities-test-data)
    * Then, export the entire site to AIPs:
        ```
        [dspace]/bin/dspace packager -d -a -t AIP -e dspacedemo+admin@gmail.com -i 123456789/0 sitewide-aip.zip
        ```
    * Then, either destroy all data, or spin up an empty DSpace instance (again in Docker)
    * Enable Entities on that empty instance:
       ```
       [dspace]/bin/dspace initialize-entities -f [dspace]/config/entities/relationship-types.xml
       ```
    * Copy the AIPs over to that instance and attempt a site-wide restore:
       ```
       # NOTE: You must create the Admin account manually as it needs to exist in order to be passed to the "-e" flag.
       [dspace]/bin/dspace packager -r -a -f -t AIP -e dspacedemo+admin@gmail.com -i 123456789/0 -o skipIfParentMissing=true sitewide-aip_SITE\@123456789-0.zip
       ```