### PR TITLE
Fix submission with non public items and AccessCondition filters

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/logic/condition/ReadableByGroupCondition.java
+++ b/dspace-api/src/main/java/org/dspace/content/logic/condition/ReadableByGroupCondition.java
@@ -49,7 +49,7 @@ public class ReadableByGroupCondition extends AbstractCondition {
             List<ResourcePolicy> policies = authorizeService
                 .getPoliciesActionFilter(context, item, Constants.getActionID(action));
             for (ResourcePolicy policy : policies) {
-                if (policy.getGroup().getName().equals(group)) {
+                if (policy.getGroup() != null && policy.getGroup().getName().equals(group)) {
                     return true;
                 }
             }

--- a/dspace-api/src/test/java/org/dspace/content/logic/LogicalFilterTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/logic/LogicalFilterTest.java
@@ -626,10 +626,10 @@ public class LogicalFilterTest extends AbstractUnitTest {
                 filter.getResult(context, itemOne));
             // Test the filter on itemTwo - this item has no policies: expect false
             assertFalse("itemTwo unexpectedly matched the 'is readable by Test Group' test",
-                    filter.getResult(context, itemTwo));
+                filter.getResult(context, itemTwo));
             // Test the filter on itemThree - this item has only a person related policy: expect false
             assertFalse("itemThree unexpectedly matched the 'is readable by Test Group' test",
-                    filter.getResult(context, itemThree));
+                filter.getResult(context, itemThree));
         } catch (LogicalStatementException e) {
             log.error(e.getMessage());
             fail("LogicalStatementException thrown testing the ReadableByGroup filter" + e.getMessage());

--- a/dspace-api/src/test/java/org/dspace/content/logic/LogicalFilterTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/logic/LogicalFilterTest.java
@@ -57,8 +57,10 @@ import org.dspace.content.service.MetadataFieldService;
 import org.dspace.content.service.MetadataValueService;
 import org.dspace.content.service.WorkspaceItemService;
 import org.dspace.core.Constants;
+import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
 import org.dspace.eperson.factory.EPersonServiceFactory;
+import org.dspace.eperson.service.EPersonService;
 import org.dspace.eperson.service.GroupService;
 import org.junit.After;
 import org.junit.Before;
@@ -81,6 +83,7 @@ public class LogicalFilterTest extends AbstractUnitTest {
     private MetadataValueService metadataValueService = ContentServiceFactory.getInstance().getMetadataValueService();
     private AuthorizeService authorizeService = AuthorizeServiceFactory.getInstance().getAuthorizeService();
     private GroupService groupService = EPersonServiceFactory.getInstance().getGroupService();
+    private EPersonService epersonService = EPersonServiceFactory.getInstance().getEPersonService();
 
     // Logger
     private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(LogicalFilterTest.class);
@@ -603,6 +606,10 @@ public class LogicalFilterTest extends AbstractUnitTest {
                 groupService.setName(g, "Test Group");
                 groupService.update(context, g);
                 authorizeService.addPolicy(context, itemOne, Constants.READ, g);
+                EPerson e = epersonService.create(context);
+                epersonService.update(context, e);
+                authorizeService.removeAllPolicies(context, itemThree);
+                authorizeService.addPolicy(context, itemThree, Constants.READ, e);
                 context.restoreAuthSystemState();
             } catch (AuthorizeException | SQLException e) {
                 fail("Exception thrown adding group READ policy to item: " + itemOne + ": " + e.getMessage());
@@ -619,7 +626,10 @@ public class LogicalFilterTest extends AbstractUnitTest {
                 filter.getResult(context, itemOne));
             // Test the filter on itemTwo - this item has no policies: expect false
             assertFalse("itemTwo unexpectedly matched the 'is readable by Test Group' test",
-                filter.getResult(context, itemTwo));
+                    filter.getResult(context, itemTwo));
+            // Test the filter on itemThree - this item has only a person related policy: expect false
+            assertFalse("itemThree unexpectedly matched the 'is readable by Test Group' test",
+                    filter.getResult(context, itemThree));
         } catch (LogicalStatementException e) {
             log.error(e.getMessage());
             fail("LogicalStatementException thrown testing the ReadableByGroup filter" + e.getMessage());


### PR DESCRIPTION
## References

* Fixes #12349

## Description
As described in the related issue, a NullPointerException is thrown, if a the _item-is-public_condition_ is enabled for doi registration and someone tries to submit a non-public item.

## Instructions for Reviewers
The reason for the NullPointerException is: all Items have a policy related to the user submitting the item. This policy of course does not have a related EPersonGroup, but only an EPerson. If now the filter check for matching EPersonGroups a NullPointerException is thrown because their is a policy but no EPersonGroup. 
The current tests did not catch the behavior because, they weren't testing items with related EPerson based policies.

List of changes in this PR:
* Checked whether an eperson group exists in the current policy before checking the group's name
* Updated the test to check for an item with only one eperson related policy

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes.

1. Enable doi registration with the doi-filter activated
2. Uncomment the [_itemAccessConditions_ Step](https://github.com/DSpace/DSpace/blob/main/dspace/config/item-submission.xml#L305) in the _traditional_ submission process
3. Start a new submission using the _traditional_ submission process and set the access condition to "administrators"
5. Submit the new item and make sure, it was successful

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] ~If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.~
- [ ] ~If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.~
- [ ] ~If my PR includes new configurations, I've provided basic technical documentation in the PR itself.~
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
