### PR TITLE
Revert "[10.0 Testathon] Update Docker deployment to only redeploy Sandbox on changes to testathon branch"

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -73,7 +73,7 @@ env:
   REDEPLOY_DEMO_URL: ${{ secrets.REDEPLOY_DEMO_URL }}
   # Current DSpace branches (and architecture) which are deployed to demo.dspace.org & sandbox.dspace.org respectively
   DEPLOY_DEMO_BRANCH: 'dspace-9_x'
-  DEPLOY_SANDBOX_BRANCH: 'dspace-10.0-testathon'
+  DEPLOY_SANDBOX_BRANCH: 'main'
   DEPLOY_ARCH: 'linux/amd64'
   # Registry used during building of Docker images. (All images are later copied to docker.io registry)
   # We use GitHub's Container Registry to avoid aggressive rate limits at DockerHub.


### PR DESCRIPTION

# Description

Reverts DSpace/DSpace#12251

This PR updates our Docker build settings to again redeploy https://sandbox.dspace.org whenever our `main` branch is updated.

This reverts temporary settings that were only applied during [DSpace 10.0 Testathon](https://wiki.lyrasis.org/display/DSPACE/DSpace+Release+10.0+Testathon+Page)