### PR TITLE
When Custom URLs are enabled, Publication/Person new submissions display errors

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/customurl/consumer/CustomUrlConsumer.java
+++ b/dspace-api/src/main/java/org/dspace/app/customurl/consumer/CustomUrlConsumer.java
@@ -288,18 +288,7 @@ public class CustomUrlConsumer implements Consumer {
      */
     private void assignCustomUrlToItem(Context context, Item item, String customUrl) {
         log.info("Assigning custom URL '{}' to item {}", customUrl, item.getID());
-        // Evict and re-fetch the item to ensure a clean managed entity.
-        // During event dispatch the item may have detached associations
-        // that cause "detached entity passed to persist" errors.
-        try {
-            context.uncacheEntity(item);
-            Item managedItem = itemService.find(context, item.getID());
-            if (managedItem != null) {
-                customUrlService.replaceCustomUrl(context, managedItem, customUrl);
-            }
-        } catch (SQLException e) {
-            throw new RuntimeException("Failed to reload item " + item.getID(), e);
-        }
+        customUrlService.replaceCustomUrl(context, item, customUrl);
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/content/MetadataValue.java
+++ b/dspace-api/src/main/java/org/dspace/content/MetadataValue.java
@@ -8,7 +8,6 @@
 package org.dspace.content;
 
 import jakarta.annotation.Nullable;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -93,7 +92,7 @@ public class MetadataValue implements ReloadableEntity<Integer> {
     @Column(name = "security_level")
     private Integer securityLevel;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST})
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "dspace_object_id")
     protected DSpaceObject dSpaceObject;
 

--- a/dspace-api/src/test/java/org/dspace/app/customurl/consumer/CustomUrlConsumerIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/customurl/consumer/CustomUrlConsumerIT.java
@@ -532,16 +532,6 @@ public class CustomUrlConsumerIT extends AbstractIntegrationTestWithDatabase {
                                        .withTitle("Advanced Algorithms Study")
                                        .build();
 
-        // Commit so the consumer fires and assigns the custom URL to the original item
-        context.restoreAuthSystemState();
-        context.commit();
-
-        originalItem = context.reloadEntity(originalItem);
-        // Verify the original item has the custom URL before versioning
-        assertThat(originalItem.getMetadata(), hasItem(with("dspace.customurl", "advanced-algorithms-study")));
-
-        context.turnOffAuthorisationSystem();
-
         // Create a new version using VersionBuilder (like VersionRestRepositoryIT)
         Version newVersion = VersionBuilder.createVersion(context, originalItem, "Second version").build();
         Item versionedItem = newVersion.getItem();
@@ -558,7 +548,6 @@ public class CustomUrlConsumerIT extends AbstractIntegrationTestWithDatabase {
 
         // The versioned item will have the same title, so it should get the same custom URL
         versionedItem = context.reloadEntity(versionedItem);
-        originalItem = context.reloadEntity(originalItem);
 
         // Verify the versioned item got the same custom URL
         assertThat(versionedItem.getMetadata(), hasItem(with("dspace.customurl", "advanced-algorithms-study")));

--- a/dspace-api/src/test/java/org/dspace/app/customurl/service/CustomUrlServiceImplIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/customurl/service/CustomUrlServiceImplIT.java
@@ -272,7 +272,6 @@ public class CustomUrlServiceImplIT extends AbstractIntegrationTestWithDatabase 
 
     private void reindexItem(Item item) throws SQLException, SearchServiceException {
         context.commit();
-        item = context.reloadEntity(item);
         indexingService.indexContent(context, new IndexableItem(item), true);
         indexingService.commit();
     }

--- a/dspace-server-webapp/src/test/java/org/dspace/authority/CrisConsumerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/authority/CrisConsumerIT.java
@@ -39,6 +39,7 @@ import java.util.UUID;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.codec.digest.DigestUtils;
+import org.dspace.app.customurl.consumer.CustomUrlConsumerConfig;
 import org.dspace.app.rest.model.CollectionRest;
 import org.dspace.app.rest.model.ItemRest;
 import org.dspace.app.rest.model.MetadataValueRest;
@@ -66,6 +67,7 @@ import org.dspace.external.OrcidRestConnector;
 import org.dspace.external.provider.impl.OrcidV3AuthorDataProvider;
 import org.dspace.services.ConfigurationService;
 import org.dspace.util.UUIDUtils;
+import org.dspace.utils.DSpace;
 import org.dspace.xmlworkflow.storedcomponents.PoolTask;
 import org.dspace.xmlworkflow.storedcomponents.service.PoolTaskService;
 import org.junit.Test;
@@ -1304,6 +1306,47 @@ public class CrisConsumerIT extends AbstractControllerIntegrationTest {
         // check that the entity type equals to the entity type of the owning collection
         assertThat(itemService.getEntityType(context.reloadEntity(wsitem.getItem())), is("Publication"));
     }
+
+
+    @Test
+    public void testPublicationSubmissionWithCustomUrl() throws Exception {
+
+        context.turnOffAuthorisationSystem();
+
+        // Create a publication collection
+        Collection publications = CollectionBuilder.createCollection(context, parentCommunity)
+                                                   .withName("Publications Collection")
+                                                   .withEntityType("Publication")
+                                                   .build();
+
+        WorkspaceItem wsitem = WorkspaceItemBuilder.createWorkspaceItem(context, publications)
+                                                   .withTitle("Submission Item")
+                                                   .withIssueDate("2017-10-17")
+                                                   .withFulltext("simple-article.pdf", "/local/path/simple-article.pdf",
+                                                                 InputStream.nullInputStream())
+                                                   .withAuthor("Mario Rossi")
+                                                   .withAuthorAffilitation("4Science")
+                                                   .withEditor("Mario Rossi")
+                                                   .grantLicense()
+                                                   .build();
+
+        new DSpace().getSingletonService(CustomUrlConsumerConfig.class).reload();
+
+        context.restoreAuthSystemState();
+
+        // Configure Publication entity type to use dc.title
+        configurationService.setProperty("dspace.custom-url.consumer.supported-entities", "Publication");
+        configurationService.setProperty("dspace.custom-url.consumer.entity-metadata-mapping.Publication", "dc.title");
+
+
+        String authToken = getAuthToken(submitter.getEmail(), password);
+
+        getClient(authToken).perform(post(BASE_REST_SERVER_URL + "/api/workflow/workflowitems")
+                                         .content("/api/submission/workspaceitems/" + wsitem.getID())
+                                         .contentType(textUriContentType))
+                            .andExpect(status().isCreated());
+    }
+
 
     private ItemRest getItemViaRestByID(String authToken, UUID id) throws Exception {
         MvcResult result = getClient(authToken)


### PR DESCRIPTION
## References
* Fixes #12353

## Description
Fixes `OptimisticLockException` during item submission when Custom URLs are enabled, by removing an unnecessary `CascadeType.PERSIST` from the `MetadataValue.dSpaceObject` JPA mapping and reverting the previous workaround that caused the regression.


## Instructions for Reviewers
### Steps to Reproduce (before fix)

1. Ensure Custom URLs are enabled
2. Find a Collection which has no workflow setup (no approving users)
3. Start a new Publication or Person submission
4. Complete the submission form with all required fields
5. Press "Deposit" button and notice that an error popup appears

### The Problem

When depositing an item with Custom URLs enabled, the `CustomUrlConsumer` fires within the event dispatch phase of `context.commit()`. The previous fix https://github.com/DSpace/DSpace/pull/12326 (commit 6387f1dd) introduced a call to `context.uncacheEntity(item)` followed by `itemService.find()` inside the consumer to work around an `EntityExistsException: detached entity passed to persist`.

However, `HibernateDBConnection.uncacheEntity()` calls `session.flush()` before evicting each entity. During the flush, Hibernate attempts to UPDATE `ResourcePolicy` rows that were already deleted from the database by earlier workflow operations. This results in a `jakarta.persistence.OptimisticLockException: Batch update returned unexpected row count from update[0]; actual row count: 0; expected: 1`.

### Root Cause

The original `EntityExistsException` was caused by a JPA cascade chain:

1. `CustomUrlServiceImpl.replaceCustomUrl()` calls `itemService.addMetadata()` which creates a new `MetadataValue` and calls `session.persist(newMetadataValue)`
2. `MetadataValue.dSpaceObject` was annotated with `@ManyToOne(cascade = {CascadeType.PERSIST})`, so Hibernate transitively cascades PERSIST from the new MetadataValue to the parent Item (`DSpaceObject`)
3. From the Item, Hibernate cascades PERSIST through `DSpaceObject.metadata` (`cascade = ALL`) to all MetadataValues in the collection. Each of those MetadataValues in turn cascades PERSIST back to its own `dSpaceObject` reference
4. If any `DSpaceObject` referenced in this cascade graph is detached (e.g., due to versioning or workflow operations earlier in the same transaction), Hibernate throws `EntityExistsException: detached entity passed to persist: org.dspace.content.DSpaceObject`

The `CascadeType.PERSIST` on `MetadataValue.dSpaceObject` (a child-to-parent relationship) was  unnecessary. The parent Item is always created and persisted before any MetadataValue is added to it. The cascade direction that matters is parent-to-child (`DSpaceObject.metadata` with `cascade = ALL`), not child-to-parent.

### The Fix

List of changes in this PR:

* **Added a test** in `CrisConsumerIT` to reproduce the `OptimisticLockException` that occurs when Custom URLs are enabled during item submission with no workflow
* **Reverted the workaround** from 6387f1dd: removed `context.uncacheEntity(item)` + `itemService.find()` from `CustomUrlConsumer.assignCustomUrlToItem()`, restoring the original simple call to `customUrlService.replaceCustomUrl(context, item, customUrl)`
* **Reverted test changes** from 6387f1dd in `CustomUrlConsumerIT`, `CustomUrlServiceImplIT`, and `ResearcherProfileRestRepositoryIT` that were only needed to accommodate the workaround
* **Removed `CascadeType.PERSIST`** from the `MetadataValue.dSpaceObject` `@ManyToOne` annotation in `MetadataValue.java` — this is the root fix that breaks the problematic cascade chain and eliminates both the original `EntityExistsException` and the `OptimisticLockException` introduced by the workaround.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
