### PR TITLE
DSpace#12402 Fix duplicate submit.type-bind.field refs in dspace.cfg

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1322,9 +1322,11 @@ metadata.hide.person.email = true
 #webui.submit.upload.required = true
 
 # Which field should be used for type-bind
-# Defaults to 'dc.type'; If changing this value, you must also update the related
-# dspace-angular environment configuration property submission.typeBind.field
-#submit.type-bind.field = dc.type
+# If changing this value, you must also update the related
+# dspace-angular environment configuration property submission.typeBind.field.
+# This property should not be left commented out, or the REST configuration
+# exposure will fail
+submit.type-bind.field = dc.type
 
 # Wheter or not we REQUIRE that the cclicense is provided
 # during the cclicense step in the submission process
@@ -1870,12 +1872,6 @@ log.report.dir = ${dspace.dir}/log
 # Set config to 'none' to disable GA4 bitstream events, eg:
 # google-analytics.bundles = none
 google-analytics.bundles = ORIGINAL
-
-#------------------------------------------------------------------#
-#------------------SUBMISSION CONFIGURATION------------------------#
-#------------------------------------------------------------------#
-# Field to use for type binding, default dc.type
-submit.type-bind.field = dc.type
 
 #---------------------------------------------------------------#
 #----------SOLR DATABASE RESYNC SCRIPT CONFIGURATION------------#


### PR DESCRIPTION
Removed the second instance of `submit.type-bind.field` configuration property from dspace.cfg

I kept the first instance, as it was better documented and was grouped with other submission changes. Left it *not* commented out as the rest.cfg property exposure can't do real 'defaults' and expects to see it with some value set in the configuration properties.

## References
* Fixes https://github.com/DSpace/DSpace/issues/12402

## Instructions for Reviewers

Test that type bind still works as expected. I don't expect any issues here, as in the default code, one instance was commented out and one was not.

List of changes in this PR:
* Removed the duplicate reference to `submit.type-bind.field`
* Added an extra line of doc to the remaining instance
* Uncommented the remaining instance with "dc.type" value

## Checklist
- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
