### PR TITLE
[Port dspace-7_x] pom.xml: bump postgresql.driver.version to 42.7.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <spring-security.version>5.7.14</spring-security.version> <!-- sync with version used by spring-boot-->
         <hibernate.version>5.6.15.Final</hibernate.version>
         <hibernate-validator.version>6.2.5.Final</hibernate-validator.version>
-        <postgresql.driver.version>42.7.10</postgresql.driver.version>
+        <postgresql.driver.version>42.7.11</postgresql.driver.version>
         <solr.client.version>8.11.4</solr.client.version>
 
         <ehcache.version>3.11.1</ehcache.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1804,7 +1804,7 @@
                 <artifactId>guava</artifactId>
                 <version>32.1.3-jre</version>
                 <exclusions>
-                    <!-- Use version provided by Solr / Postgres -->
+                    <!-- Use version provided by solr-core -->
                     <exclusion>
                         <groupId>org.checkerframework</groupId>
                         <artifactId>checker-qual</artifactId>


### PR DESCRIPTION
Manual port of #12403 to `dspace-7_x`.

Note that this is only a partial port, as DSpace 7.x didn't have the explicit pinning of `org.checkerframework:checker-qual`, so we didn't need to remove that.