### PR TITLE
"Shared Submissions" feature update for authors

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/EditItemFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/EditItemFeature.java
@@ -17,10 +17,14 @@ import org.dspace.app.rest.model.SiteRest;
 import org.dspace.app.rest.utils.Utils;
 import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.content.Item;
+import org.dspace.content.WorkspaceItem;
 import org.dspace.content.service.ItemService;
+import org.dspace.content.service.WorkspaceItemService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.discovery.SearchServiceException;
+import org.dspace.eperson.EPerson;
+import org.dspace.profile.service.ResearcherProfileService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -35,6 +39,12 @@ public class EditItemFeature implements AuthorizationFeature {
     ItemService itemService;
 
     @Autowired
+    WorkspaceItemService workspaceItemService;
+
+    @Autowired
+    ResearcherProfileService researcherProfileService;
+
+    @Autowired
     Utils utils;
 
     @Override
@@ -43,9 +53,28 @@ public class EditItemFeature implements AuthorizationFeature {
             return itemService.countItemsWithEdit(context, "") > 0;
         } else if (object instanceof ItemRest) {
             Item item = (Item) utils.getDSpaceAPIObjectFromRest(context, object);
-            return authService.authorizeActionBoolean(context, item, Constants.WRITE);
+            if (authService.authorizeActionBoolean(context, item, Constants.WRITE)) {
+                return true;
+            }
+            EPerson ePerson = context.getCurrentUser();
+            return canEditWorkspaceItem(context, item, ePerson);
         }
         return false;
+    }
+
+    private boolean canEditWorkspaceItem(Context context, Item item, EPerson ePerson) throws SQLException {
+        if (ePerson == null) {
+            return false;
+        }
+        WorkspaceItem workspaceItem = workspaceItemService.findByItem(context, item);
+        if (workspaceItem == null) {
+            return false;
+        }
+        EPerson submitter = workspaceItem.getSubmitter();
+        if (submitter != null && submitter.getID().equals(ePerson.getID())) {
+            return true;
+        }
+        return researcherProfileService.isAuthorOf(context, ePerson, item);
     }
 
     @Override

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkflowItemRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkflowItemRestRepository.java
@@ -162,13 +162,14 @@ public class WorkflowItemRestRepository extends DSpaceRestRepository<WorkflowIte
     }
 
     @Override
+    @PreAuthorize("hasPermission(@workflowSecurityUtils.parseIdFromUriList(#stringList), 'WORKFLOWITEM', 'WRITE')")
     protected WorkflowItemRest createAndReturn(Context context, List<String> stringList) {
         XmlWorkflowItem source;
-        if (stringList == null || stringList.isEmpty() || stringList.size() > 1) {
+        if (stringList == null || stringList.size() != 1) {
             throw new UnprocessableEntityException("The given URI list could not be properly parsed to one result");
         }
         try {
-            source = submissionService.createWorkflowItem(context, stringList.get(0));
+            source = submissionService.createWorkflowItem(context, stringList.getFirst());
         } catch (AuthorizeException e) {
             throw new RESTAuthorizationException(e);
         } catch (WorkflowException e) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/AuthorizeServicePermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/AuthorizeServicePermissionEvaluatorPlugin.java
@@ -25,6 +25,7 @@ import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.service.EPersonService;
+import org.dspace.profile.service.ResearcherProfileService;
 import org.dspace.services.RequestService;
 import org.dspace.services.model.Request;
 import org.dspace.util.UUIDUtils;
@@ -44,6 +45,9 @@ public class AuthorizeServicePermissionEvaluatorPlugin extends RestObjectPermiss
 
     @Autowired
     private AuthorizeService authorizeService;
+
+    @Autowired
+    private ResearcherProfileService researcherProfileService;
 
     @Autowired
     private RequestService requestService;
@@ -125,6 +129,13 @@ public class AuthorizeServicePermissionEvaluatorPlugin extends RestObjectPermiss
                         if (!DSpaceRestPermission.READ.equals(restPermission) &&
                                    !item.isArchived() && !item.isWithdrawn()) {
                             return false;
+                        }
+
+                        if (DSpaceRestPermission.READ.equals(restPermission)
+                            && !item.isArchived()
+                            && !item.isWithdrawn()
+                            && researcherProfileService.isAuthorOf(context, ePerson, item)) {
+                            return true;
                         }
                     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/DepositRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/DepositRestPermissionEvaluatorPlugin.java
@@ -1,0 +1,109 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.security;
+
+import java.io.Serializable;
+import java.sql.SQLException;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.dspace.app.rest.exception.UnprocessableEntityException;
+import org.dspace.app.rest.model.WorkflowItemRest;
+import org.dspace.app.rest.utils.ContextUtil;
+import org.dspace.content.WorkspaceItem;
+import org.dspace.content.service.WorkspaceItemService;
+import org.dspace.core.Context;
+import org.dspace.eperson.EPerson;
+import org.dspace.eperson.service.EPersonService;
+import org.dspace.profile.service.ResearcherProfileService;
+import org.dspace.services.RequestService;
+import org.dspace.services.model.Request;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+/**
+ * Evaluates WRITE (deposit) permission on the WORKFLOWITEM target type.
+ * <p>
+ * During deposit, the {@code @PreAuthorize} annotation on
+ * {@link org.dspace.app.rest.repository.WorkflowItemRestRepository#createAndReturn}
+ * passes a workspace item ID as the target ID with target type WORKFLOWITEM and
+ * permission WRITE.
+ * </p>
+ * <p>
+ * This plugin loads the workspace item by that ID and checks:
+ * <ul>
+ *   <li>If the current user is the author of the item, deposit is denied.</li>
+ *   <li>Otherwise, deposit is allowed if the current user is the submitter.</li>
+ * </ul>
+ * </p>
+ *
+ * @author Adamo Fapohunda (adamo.fapohunda at 4science.com)
+ */
+@Component
+public class DepositRestPermissionEvaluatorPlugin extends RestObjectPermissionEvaluatorPlugin {
+
+    private static final Logger log = LogManager.getLogger();
+
+    @Autowired
+    private RequestService requestService;
+
+    @Autowired
+    private EPersonService ePersonService;
+
+    @Autowired
+    private WorkspaceItemService workspaceItemService;
+
+    @Autowired
+    private ResearcherProfileService researcherProfileService;
+
+    @Override
+    public boolean hasDSpacePermission(Authentication authentication, Serializable targetId,
+                                       String targetType, DSpaceRestPermission permission) {
+
+        DSpaceRestPermission restPermission = DSpaceRestPermission.convert(permission);
+        if (!DSpaceRestPermission.WRITE.equals(restPermission)
+                || !StringUtils.equalsIgnoreCase(WorkflowItemRest.NAME, targetType)) {
+            return false;
+        }
+
+        if (targetId == null) {
+            throw new UnprocessableEntityException("The given WorkSpaceItem id is not valid");
+        }
+
+        Request request = requestService.getCurrentRequest();
+        Context context = ContextUtil.obtainContext(request.getHttpServletRequest());
+
+        try {
+            EPerson ePerson = ePersonService.findByEmail(context,
+                    (String) authentication.getPrincipal());
+            if (ePerson == null) {
+                return false;
+            }
+
+            int dsoId = Integer.parseInt(targetId.toString());
+            WorkspaceItem workspaceItem = workspaceItemService.find(context, dsoId);
+            if (workspaceItem == null) {
+                return false;
+            }
+
+            // Authors of the item cannot deposit it
+            if (researcherProfileService.isAuthorOf(context, ePerson, workspaceItem.getItem())) {
+                return false;
+            }
+
+            // Non-author submitters are allowed to deposit
+            return ePerson.equals(workspaceItem.getSubmitter());
+        } catch (SQLException e) {
+            log.error(e.getMessage(), e);
+        }
+
+        return false;
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/DepositRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/DepositRestPermissionEvaluatorPlugin.java
@@ -16,12 +16,14 @@ import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.exception.UnprocessableEntityException;
 import org.dspace.app.rest.model.WorkflowItemRest;
 import org.dspace.app.rest.utils.ContextUtil;
+import org.dspace.content.Collection;
 import org.dspace.content.WorkspaceItem;
 import org.dspace.content.service.WorkspaceItemService;
 import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
+import org.dspace.eperson.Group;
 import org.dspace.eperson.service.EPersonService;
-import org.dspace.profile.service.ResearcherProfileService;
+import org.dspace.eperson.service.GroupService;
 import org.dspace.services.RequestService;
 import org.dspace.services.model.Request;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,10 +39,14 @@ import org.springframework.stereotype.Component;
  * permission WRITE.
  * </p>
  * <p>
- * This plugin loads the workspace item by that ID and checks:
+ * This plugin loads the workspace item by that ID and allows deposit if
+ * the current user is either the original submitter or a member of the
+ * collection's submitters group. This means:
  * <ul>
- *   <li>If the current user is the author of the item, deposit is denied.</li>
- *   <li>Otherwise, deposit is allowed if the current user is the submitter.</li>
+ *   <li>The original submitter can always deposit.</li>
+ *   <li>Any submitter of the same collection (shared workspace) can deposit.</li>
+ *   <li>Authors who are also submitters of the same collection can deposit.</li>
+ *   <li>Authors who are not submitters of the collection cannot deposit.</li>
  * </ul>
  * </p>
  *
@@ -61,7 +67,7 @@ public class DepositRestPermissionEvaluatorPlugin extends RestObjectPermissionEv
     private WorkspaceItemService workspaceItemService;
 
     @Autowired
-    private ResearcherProfileService researcherProfileService;
+    private GroupService groupService;
 
     @Override
     public boolean hasDSpacePermission(Authentication authentication, Serializable targetId,
@@ -93,13 +99,19 @@ public class DepositRestPermissionEvaluatorPlugin extends RestObjectPermissionEv
                 return false;
             }
 
-            // Authors of the item cannot deposit it
-            if (researcherProfileService.isAuthorOf(context, ePerson, workspaceItem.getItem())) {
-                return false;
+            // Allow deposit if the user is the original submitter
+            if (ePerson.equals(workspaceItem.getSubmitter())) {
+                return true;
             }
 
-            // Non-author submitters are allowed to deposit
-            return ePerson.equals(workspaceItem.getSubmitter());
+            // Allow deposit if the user is in the collection's submitters group
+            Collection collection = workspaceItem.getCollection();
+            if (collection != null) {
+                Group submitters = collection.getSubmitters();
+                return submitters != null && groupService.isMember(context, ePerson, submitters);
+            }
+
+            return false;
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
         }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/DepositRestPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/DepositRestPermissionEvaluatorPlugin.java
@@ -16,12 +16,13 @@ import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.exception.UnprocessableEntityException;
 import org.dspace.app.rest.model.WorkflowItemRest;
 import org.dspace.app.rest.utils.ContextUtil;
+import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.content.Collection;
 import org.dspace.content.WorkspaceItem;
 import org.dspace.content.service.WorkspaceItemService;
+import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
-import org.dspace.eperson.Group;
 import org.dspace.eperson.service.EPersonService;
 import org.dspace.eperson.service.GroupService;
 import org.dspace.services.RequestService;
@@ -67,6 +68,9 @@ public class DepositRestPermissionEvaluatorPlugin extends RestObjectPermissionEv
     private WorkspaceItemService workspaceItemService;
 
     @Autowired
+    private AuthorizeService authorizeService;
+
+    @Autowired
     private GroupService groupService;
 
     @Override
@@ -75,7 +79,7 @@ public class DepositRestPermissionEvaluatorPlugin extends RestObjectPermissionEv
 
         DSpaceRestPermission restPermission = DSpaceRestPermission.convert(permission);
         if (!DSpaceRestPermission.WRITE.equals(restPermission)
-                || !StringUtils.equalsIgnoreCase(WorkflowItemRest.NAME, targetType)) {
+            || !StringUtils.equalsIgnoreCase(WorkflowItemRest.NAME, targetType)) {
             return false;
         }
 
@@ -88,7 +92,7 @@ public class DepositRestPermissionEvaluatorPlugin extends RestObjectPermissionEv
 
         try {
             EPerson ePerson = ePersonService.findByEmail(context,
-                    (String) authentication.getPrincipal());
+                                                         (String) authentication.getPrincipal());
             if (ePerson == null) {
                 return false;
             }
@@ -107,8 +111,7 @@ public class DepositRestPermissionEvaluatorPlugin extends RestObjectPermissionEv
             // Allow deposit if the user is in the collection's submitters group
             Collection collection = workspaceItem.getCollection();
             if (collection != null) {
-                Group submitters = collection.getSubmitters();
-                return submitters != null && groupService.isMember(context, ePerson, submitters);
+                return authorizeService.authorizeActionBoolean(context, collection, Constants.ADD);
             }
 
             return false;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/WorkflowSecurityUtils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/WorkflowSecurityUtils.java
@@ -1,0 +1,89 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.security;
+
+import java.util.List;
+
+import com.apicatalog.jsonld.StringUtils;
+import org.dspace.app.rest.model.WorkspaceItemRest;
+import org.springframework.stereotype.Component;
+
+/**
+ * Utility component for extracting workspace item identifiers from REST API URIs.
+ * <p>
+ * This bean is registered as {@code workflowSecurityUtils} so that it can be
+ * referenced in Spring Security SpEL expressions (e.g.
+ * {@code @PreAuthorize("hasPermission(@workflowSecurityUtils.parseIdFromUriList(#stringList), ...)")})
+ * to resolve workspace item IDs before permission evaluation.
+ * </p>
+ * <p>
+ * It is also injected into
+ * {@link org.dspace.app.rest.submit.SubmissionService#createWorkflowItem} to
+ * extract the workspace item ID from the URI provided in the request body.
+ * </p>
+ *
+ * @author Adamo Fapohunda (adamo.fapohunda at 4science.com)
+ */
+@Component("workflowSecurityUtils")
+public class WorkflowSecurityUtils {
+
+    /**
+     * Parse a workspace item integer ID from a full REST API URI.
+     * <p>
+     * The method expects a URI matching the pattern
+     * {@code /api/submission/workspaceitems/{id}} and returns the trailing
+     * numeric segment. If the URI is blank, does not match the expected
+     * pattern, or contains a non-numeric ID, {@code null} is returned.
+     * </p>
+     *
+     * @param requestUri the full REST API URI containing the workspace item ID
+     *                   (e.g. {@code "/api/submission/workspaceitems/42"})
+     * @return the parsed workspace item ID, or {@code null} if the URI is
+     *         invalid or cannot be parsed
+     */
+    public Integer parseIdFromUri(String requestUri) {
+        if (StringUtils.isBlank(requestUri)) {
+            return null;
+        }
+
+        String regex = "/api/" + WorkspaceItemRest.CATEGORY + "/" + WorkspaceItemRest.PLURAL_NAME + "/";
+        String[] split = requestUri.split(regex, 2);
+
+        if (split.length != 2) {
+            return null;
+        }
+
+        try {
+            return Integer.parseInt(split[1]);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Parse a workspace item ID from the first element of a URI list.
+     * <p>
+     * This convenience method is designed for use in Spring Security SpEL
+     * expressions where the request body is bound as a {@code List<String>}.
+     * It delegates to {@link #parseIdFromUri(String)} using the first element
+     * of the list.
+     * </p>
+     *
+     * @param uriList the list of URIs from the request body; only the first
+     *                element is used
+     * @return the parsed workspace item ID, or {@code null} if the list is
+     *         {@code null}, empty, or the first URI cannot be parsed
+     * @see #parseIdFromUri(String)
+     */
+    public Integer parseIdFromUriList(List<String> uriList) {
+        if (uriList == null || uriList.isEmpty()) {
+            return null;
+        }
+        return parseIdFromUri(uriList.getFirst());
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/SubmissionService.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/SubmissionService.java
@@ -38,6 +38,7 @@ import org.dspace.app.rest.model.step.UploadBitstreamRest;
 import org.dspace.app.rest.projection.Projection;
 import org.dspace.app.rest.repository.WorkflowItemRestRepository;
 import org.dspace.app.rest.repository.WorkspaceItemRestRepository;
+import org.dspace.app.rest.security.WorkflowSecurityUtils;
 import org.dspace.app.rest.submit.step.UploadStep;
 import org.dspace.app.rest.utils.ContextUtil;
 import org.dspace.app.util.SubmissionConfig;
@@ -115,6 +116,8 @@ public class SubmissionService {
     private SubmissionConfigService submissionConfigService;
     @Autowired
     private DuplicateDetectionService duplicateDetectionService;
+    @Autowired
+    private WorkflowSecurityUtils workflowSecurityUtils;
 
     public SubmissionService() throws SubmissionConfigReaderException {
         submissionConfigService = SubmissionServiceFactory.getInstance().getSubmissionConfigService();
@@ -250,41 +253,29 @@ public class SubmissionService {
      */
     public XmlWorkflowItem createWorkflowItem(Context context, String requestUriListString)
             throws SQLException, AuthorizeException, WorkflowException {
-        XmlWorkflowItem wi = null;
-        if (StringUtils.isBlank(requestUriListString)) {
-            throw new UnprocessableEntityException("Malformed body..." + requestUriListString);
+        Integer id = workflowSecurityUtils.parseIdFromUri(requestUriListString);
+        if (id == null) {
+            throw new UnprocessableEntityException("The provided workspaceitem URI is not valid: " +
+                                                       requestUriListString);
         }
-        String regex = "\\/api\\/" + WorkspaceItemRest.CATEGORY + "\\/" + WorkspaceItemRest.PLURAL_NAME
-                + "\\/";
-        String[] split = requestUriListString.split(regex, 2);
-        if (split.length != 2) {
-            throw new UnprocessableEntityException("Malformed body..." + requestUriListString);
-        }
-        WorkspaceItem wsi = null;
-        int id = 0;
-        try {
-            id = Integer.parseInt(split[1]);
-            wsi = workspaceItemService.find(context, id);
-        } catch (NumberFormatException e) {
-            throw new UnprocessableEntityException("The provided workspaceitem URI is not valid", e);
-        }
+
+        WorkspaceItem wsi = workspaceItemService.find(context, id);
         if (wsi == null) {
-            throw new UnprocessableEntityException("Workspace item is not found");
+            throw new UnprocessableEntityException("Workspace item not found with id: " + id);
         }
+
         WorkspaceItemRest wsiRest = converter.toRest(wsi, utils.obtainProjection());
-        if (!wsiRest.getErrors().isEmpty()) {
+        if (wsiRest != null && !wsiRest.getErrors().isEmpty()) {
             throw new UnprocessableEntityException(
                     "Start workflow failed due to validation error on workspaceitem");
         }
 
         try {
-            wi = workflowService.start(context, wsi);
+            return workflowService.start(context, wsi);
         } catch (IOException e) {
             throw new RuntimeException("The workflow could not be started for workspaceItem with" +
                                                " id:  " + id, e);
         }
-
-        return wi;
     }
 
     private AccessConditionDTO createAccessConditionFromResourcePolicy(ResourcePolicy rp) {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkspaceItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkspaceItemRestRepositoryIT.java
@@ -24,6 +24,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -64,16 +65,20 @@ import jakarta.ws.rs.core.MediaType;
 import org.apache.commons.codec.CharEncoding;
 import org.apache.commons.io.IOUtils;
 import org.dspace.app.ldn.NotifyServiceEntity;
+import org.dspace.app.rest.converter.ItemConverter;
 import org.dspace.app.rest.matcher.CollectionMatcher;
 import org.dspace.app.rest.matcher.ItemMatcher;
 import org.dspace.app.rest.matcher.MetadataMatcher;
 import org.dspace.app.rest.matcher.ResourcePolicyMatcher;
 import org.dspace.app.rest.matcher.WorkspaceItemMatcher;
+import org.dspace.app.rest.model.ItemRest;
 import org.dspace.app.rest.model.patch.AddOperation;
 import org.dspace.app.rest.model.patch.Operation;
 import org.dspace.app.rest.model.patch.RemoveOperation;
 import org.dspace.app.rest.model.patch.ReplaceOperation;
+import org.dspace.app.rest.projection.Projection;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.app.rest.utils.Utils;
 import org.dspace.authorize.ResourcePolicy;
 import org.dspace.authorize.factory.AuthorizeServiceFactory;
 import org.dspace.authorize.service.AuthorizeService;
@@ -156,6 +161,10 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
     private ChoiceAuthorityService choiceAuthorityService;
     @Autowired
     private MetadataAuthorityService metadataAuthorityService;
+    @Autowired
+    private ItemConverter itemConverter;
+    @Autowired
+    private Utils utils;
 
     @Autowired
     private ObjectMapper mapper;
@@ -5981,7 +5990,6 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
         choiceAuthorityService.clearCache();
         metadataAuthorityService.clearCache();
 
-        // DSC-2728 - Case 2: Author (non-submitter) can modify workspace item when configured
         context.turnOffAuthorisationSystem();
 
         EPerson submitter = EPersonBuilder.createEPerson(context)
@@ -6033,6 +6041,12 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
             WorkspaceItem workspaceItem = workspaceItemService.find(context, idRef.get());
             assertThat(workspaceItem, notNullValue());
 
+            // Fetch item and force initialization while session is still active
+            Item item = workspaceItem.getItem();
+            item.getID(); // Force Hibernate to initialize the proxy
+            // Pre-compute URI while session is active
+            String itemUri = uri(item);
+
             // Before adding author metadata, author should NOT be able to modify
             Operation addOperation = new AddOperation("/sections/traditionalpageone/dc.contributor.author",
                                                       List.of(Map.of("value", "Test Author")));
@@ -6080,6 +6094,21 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.sections.traditionalpageone['dc.title'][0].value",
                                     is("Title by author")));
+
+            getClient(getAuthToken(author.getEmail(), password))
+                .perform(get("/api/discover/search/objects")
+                             .param("configuration", "otherWorkspace"))
+                .andExpect(status().isOk());
+
+
+            getClient(getAuthToken(author.getEmail(), password))
+                .perform(get("/api/authz/authorizations/search/object")
+                             .param("uri", itemUri)
+                             .param("feature", "canEditItem")
+                             .param("embed", "feature"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded").exists())
+                .andExpect(jsonPath("$.page.totalElements", greaterThanOrEqualTo(1)));
 
         } finally {
             WorkspaceItemBuilder.deleteWorkspaceItem(idRef.get());
@@ -6363,6 +6392,102 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
         } finally {
             if (idRef.get() != null) {
                 WorkspaceItemBuilder.deleteWorkspaceItem(idRef.get());
+            }
+        }
+    }
+
+    @Test
+    public void testCollectionAdminCanAccessAllWorkspaceItemsInSharedSubmissions() throws Exception {
+        // Verify that collection admins can see ALL workspace items (not just shared ones) in shared submissions view
+        // This is expected behavior - admins have broader permissions via authorizeActionBoolean with checkAdmin=true
+        context.turnOffAuthorisationSystem();
+
+        EPerson submitter1 = EPersonBuilder.createEPerson(context)
+                                           .withEmail("submitter1@test.com")
+                                           .withPassword(password)
+                                           .build();
+
+        EPerson submitter2 = EPersonBuilder.createEPerson(context)
+                                           .withEmail("submitter2@test.com")
+                                           .withPassword(password)
+                                           .build();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                       .withName("Parent Community")
+                                       .build();
+
+        // Collection WITHOUT shared workspace - submitter1 is admin
+        Collection nonSharedCol = CollectionBuilder.createCollection(context, parentCommunity)
+                                       .withName("Non-Shared Collection")
+                                       .withEntityType("Publication")
+                                       .withSubmitterGroup(submitter1, submitter2)
+                                       .withAdminGroup(submitter1)
+                                       .build();
+
+        // Collection WITH shared workspace
+        Collection sharedCol = CollectionBuilder.createCollection(context, parentCommunity)
+                                       .withName("Shared Collection")
+                                       .withEntityType("Publication")
+                                       .withSubmitterGroup(submitter1, submitter2)
+                                       .withSharedWorkspace()
+                                       .build();
+
+        context.restoreAuthSystemState();
+
+        AtomicReference<Integer> idRefNonShared = new AtomicReference<>();
+        AtomicReference<Integer> idRefShared = new AtomicReference<>();
+        try {
+            // Submitter2 creates a workspace item in NON-SHARED collection
+            getClient(getAuthToken(submitter2.getEmail(), password))
+                .perform(post("/api/submission/workspaceitems")
+                             .param("owningCollection", nonSharedCol.getID().toString())
+                             .contentType(org.springframework.http.MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andDo(result -> idRefNonShared.set(
+                    read(result.getResponse().getContentAsString(), "$.id")));
+
+            // Submitter2 creates a workspace item in SHARED collection
+            getClient(getAuthToken(submitter2.getEmail(), password))
+                .perform(post("/api/submission/workspaceitems")
+                             .param("owningCollection", sharedCol.getID().toString())
+                             .contentType(org.springframework.http.MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andDo(result -> idRefShared.set(
+                    read(result.getResponse().getContentAsString(), "$.id")));
+
+            // Submitter1 (collection admin of non-shared collection) can see BOTH workspace items
+            // This is expected behavior - admins have broader permissions
+            getClient(getAuthToken(submitter1.getEmail(), password))
+                .perform(get("/api/submission/workspaceitems/" + idRefNonShared.get()))
+                .andExpect(status().isOk());
+
+            getClient(getAuthToken(submitter1.getEmail(), password))
+                .perform(get("/api/submission/workspaceitems/" + idRefShared.get()))
+                .andExpect(status().isOk());
+
+            // Collection Admin can also EDIT both workspace items (expected behavior)
+            Operation addOperation = new AddOperation("/sections/traditionalpageone/dc.contributor.author",
+                                                  List.of(Map.of("value", "Modified by admin")));
+            String patchBody = getPatchContent(List.of(addOperation));
+
+            getClient(getAuthToken(submitter1.getEmail(), password))
+                .perform(patch("/api/submission/workspaceitems/" + idRefNonShared.get())
+                             .content(patchBody)
+                             .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .andExpect(status().isOk());
+
+            getClient(getAuthToken(submitter1.getEmail(), password))
+                .perform(patch("/api/submission/workspaceitems/" + idRefShared.get())
+                             .content(patchBody)
+                             .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .andExpect(status().isOk());
+
+        } finally {
+            if (idRefNonShared.get() != null) {
+                WorkspaceItemBuilder.deleteWorkspaceItem(idRefNonShared.get());
+            }
+            if (idRefShared.get() != null) {
+                WorkspaceItemBuilder.deleteWorkspaceItem(idRefShared.get());
             }
         }
     }
@@ -11028,4 +11153,9 @@ ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup)
             .andExpect(status().isForbidden());
     }
 
+
+    private String uri(Item item) {
+        ItemRest itemRest = itemConverter.convert(item, Projection.DEFAULT);
+        return utils.linkToSingleResource(itemRest, "self").getHref();
+    }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkspaceItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkspaceItemRestRepositoryIT.java
@@ -6002,11 +6002,6 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
                                        .withPassword(password)
                                        .build();
 
-        EPerson anotherEperson = EPersonBuilder.createEPerson(context)
-                                       .withEmail("anothereperson@test.com")
-                                       .withPassword(password)
-                                       .build();
-
         parentCommunity = CommunityBuilder.createCommunity(context)
                                           .withName("Parent Community")
                                           .build();
@@ -6081,7 +6076,9 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
                 .perform(patch("/api/submission/workspaceitems/" + workspaceItem.getID())
                              .content(addAuthorPatchBody)
                              .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.sections.traditionalpageone['dc.contributor.author'][0].authority",
+                                    is(authorProfile.getID().toString())));
 
             // Author should now be able to access (Solr permissions are indexed based on metadata with authorities)
             getClient(getAuthToken(author.getEmail(), password))
@@ -6119,8 +6116,12 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
             getClient(submitterToken)
                 .perform(multipart("/api/submission/workspaceitems/" + workspaceItem.getID()).file(pdfFile))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.sections.upload.files[0].accessConditions", empty()));
+                .andExpect(jsonPath("$.sections.upload.files", hasSize(1)));
 
+            getClient(getAuthToken(author.getEmail(), password))
+                .perform(multipart("/api/submission/workspaceitems/" + workspaceItem.getID()).file(pdfFile))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.errors", hasSize(1)));
 
             getClient(getAuthToken(author.getEmail(), password))
                 .perform(get("/api/discover/search/objects")

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkspaceItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkspaceItemRestRepositoryIT.java
@@ -11190,6 +11190,505 @@ ResourcePolicyBuilder.createResourcePolicy(context, null, adminGroup)
     }
 
 
+    /**
+     * Scenario 1: Any submitter of a shared-workspace collection can View, Edit, Delete, and Deposit
+     * workspace items created by other submitters.
+     */
+    @Test
+    public void testSubmitterCanViewEditDeleteDepositInSharedWorkspace() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        EPerson submitter1 = EPersonBuilder.createEPerson(context)
+                                           .withEmail("submitter1@test.com")
+                                           .withPassword(password)
+                                           .build();
+
+        EPerson submitter2 = EPersonBuilder.createEPerson(context)
+                                           .withEmail("submitter2@test.com")
+                                           .withPassword(password)
+                                           .build();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+
+        Collection pubCollection = CollectionBuilder.createCollection(context, parentCommunity)
+                                                    .withName("Publication Collection")
+                                                    .withEntityType("Publication")
+                                                    .withSubmitterGroup(submitter1, submitter2)
+                                                    .withSharedWorkspace()
+                                                    .build();
+
+        context.restoreAuthSystemState();
+
+        AtomicReference<Integer> idRef1 = new AtomicReference<>();
+        AtomicReference<Integer> idRef2 = new AtomicReference<>();
+        try {
+            String submitter1Token = getAuthToken(submitter1.getEmail(), password);
+            String submitter2Token = getAuthToken(submitter2.getEmail(), password);
+
+            // Submitter1 creates workspace item for view/edit/deposit test
+            getClient(submitter1Token)
+                .perform(post("/api/submission/workspaceitems")
+                             .param("owningCollection", pubCollection.getID().toString())
+                             .contentType(org.springframework.http.MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andDo(result -> idRef1.set(
+                    read(result.getResponse().getContentAsString(), "$.id")));
+
+            // Submitter1 creates another workspace item for delete test
+            getClient(submitter1Token)
+                .perform(post("/api/submission/workspaceitems")
+                             .param("owningCollection", pubCollection.getID().toString())
+                             .contentType(org.springframework.http.MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andDo(result -> idRef2.set(
+                    read(result.getResponse().getContentAsString(), "$.id")));
+
+            // Submitter2 CAN view
+            getClient(submitter2Token)
+                .perform(get("/api/submission/workspaceitems/" + idRef1.get()))
+                .andExpect(status().isOk());
+
+            // Submitter2 CAN edit (add title and date for deposit validation)
+            List<Operation> editOps = List.of(
+                new AddOperation("/sections/traditionalpageone/dc.title",
+                                  List.of(Map.of("value", "Title by submitter2"))),
+                new AddOperation("/sections/traditionalpageone/dc.date.issued",
+                                  List.of(Map.of("value", "2026")))
+            );
+            getClient(submitter2Token)
+                .perform(patch("/api/submission/workspaceitems/" + idRef1.get())
+                             .content(getPatchContent(editOps))
+                             .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .andExpect(status().isOk());
+
+            // Grant license (needed for deposit validation)
+            List<Operation> licenseOps = List.of(
+                new AddOperation("/sections/license/granted", true));
+            getClient(submitter1Token)
+                .perform(patch("/api/submission/workspaceitems/" + idRef1.get())
+                             .content(getPatchContent(licenseOps))
+                             .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .andExpect(status().isOk());
+
+            // Upload a file (needed for deposit validation)
+            InputStream pdf = InputStream.nullInputStream();
+            MockMultipartFile pdfFile = new MockMultipartFile("file", "/local/path/simple-article.pdf",
+                                                              "application/pdf", pdf);
+            getClient(submitter1Token)
+                .perform(multipart("/api/submission/workspaceitems/" + idRef1.get()).file(pdfFile))
+                .andExpect(status().isCreated());
+
+            // Submitter2 CAN deposit
+            getClient(submitter2Token)
+                .perform(post("/api/workflow/workflowitems")
+                             .content("/api/submission/workspaceitems/" + idRef1.get())
+                             .contentType(textUriContentType))
+                .andExpect(status().is2xxSuccessful());
+
+            // Submitter2 CAN delete (using second workspace item)
+            getClient(submitter2Token)
+                .perform(delete("/api/submission/workspaceitems/" + idRef2.get()))
+                .andExpect(status().isNoContent());
+
+        } finally {
+            if (idRef1.get() != null) {
+                WorkspaceItemBuilder.deleteWorkspaceItem(idRef1.get());
+            }
+            if (idRef2.get() != null) {
+                WorkspaceItemBuilder.deleteWorkspaceItem(idRef2.get());
+            }
+        }
+    }
+
+    /**
+     * Scenario 2: Authors/Co-authors who are also in the Submitter group of the same collection
+     * can View, Edit, Delete, and Deposit.
+     */
+    @Test
+    public void testAuthorSubmitterSameCollectionCanViewEditDeleteDeposit() throws Exception {
+        // Configure authority control for dc.contributor.author
+        configurationService.setProperty("choices.plugin.dc.contributor.author", "AuthorAuthority");
+        configurationService.setProperty("choices.presentation.dc.contributor.author", "suggest");
+        configurationService.setProperty("authority.controlled.dc.contributor.author", "true");
+
+        // Clear authority caches BEFORE entity creation (required for authority-controlled fields)
+        pluginService.clearNamedPluginClasses();
+        choiceAuthorityService.clearCache();
+        metadataAuthorityService.clearCache();
+
+        context.turnOffAuthorisationSystem();
+
+        EPerson submitter = EPersonBuilder.createEPerson(context)
+                                          .withEmail("submitter@test.com")
+                                          .withPassword(password)
+                                          .build();
+
+        EPerson authorSubmitter = EPersonBuilder.createEPerson(context)
+                                                .withEmail("authorsubmitter@test.com")
+                                                .withPassword(password)
+                                                .build();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+
+        // Person collection for researcher profiles
+        Collection personCollection = CollectionBuilder.createCollection(context, parentCommunity)
+                                                       .withName("Person Collection")
+                                                       .withEntityType("Person")
+                                                       .build();
+
+        // Publication collection with BOTH submitter AND authorSubmitter in submitter group
+        Collection pubCollection = CollectionBuilder.createCollection(context, parentCommunity)
+                                                    .withName("Publication Collection")
+                                                    .withEntityType("Publication")
+                                                    .withSubmitterGroup(submitter, authorSubmitter)
+                                                    .withSharedWorkspace()
+                                                    .build();
+
+        // Create a researcher profile (Person entity) owned by authorSubmitter
+        Item authorProfile = ItemBuilder.createItem(context, personCollection)
+                                        .withTitle("Author Submitter")
+                                        .withIssueDate("2020-01-01")
+                                        .withDspaceObjectOwner(authorSubmitter)
+                                        .build();
+
+        context.restoreAuthSystemState();
+
+        AtomicReference<Integer> idRef1 = new AtomicReference<>();
+        AtomicReference<Integer> idRef2 = new AtomicReference<>();
+        try {
+            String submitterToken = getAuthToken(submitter.getEmail(), password);
+            String authorSubmitterToken = getAuthToken(authorSubmitter.getEmail(), password);
+
+            // Submitter creates workspace item for view/edit/deposit test
+            getClient(submitterToken)
+                .perform(post("/api/submission/workspaceitems")
+                             .param("owningCollection", pubCollection.getID().toString())
+                             .contentType(org.springframework.http.MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andDo(result -> idRef1.set(
+                    read(result.getResponse().getContentAsString(), "$.id")));
+
+            // Submitter creates another workspace item for delete test
+            getClient(submitterToken)
+                .perform(post("/api/submission/workspaceitems")
+                             .param("owningCollection", pubCollection.getID().toString())
+                             .contentType(org.springframework.http.MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andDo(result -> idRef2.set(
+                    read(result.getResponse().getContentAsString(), "$.id")));
+
+            // Add author metadata pointing to authorSubmitter's profile
+            Map<String, String> authorValue = new HashMap<>();
+            authorValue.put("value", "Author Submitter");
+            authorValue.put("authority", authorProfile.getID().toString());
+            authorValue.put("display", "Author Submitter");
+            authorValue.put("confidence", String.valueOf(Choices.CF_ACCEPTED));
+
+            List<Operation> addAuthorOps = List.of(
+                new AddOperation("/sections/traditionalpageone/dc.contributor.author",
+                                  List.of(authorValue)));
+            getClient(submitterToken)
+                .perform(patch("/api/submission/workspaceitems/" + idRef1.get())
+                             .content(getPatchContent(addAuthorOps))
+                             .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .andExpect(status().isOk());
+
+            // Also add author to workspace item 2 for delete test
+            getClient(submitterToken)
+                .perform(patch("/api/submission/workspaceitems/" + idRef2.get())
+                             .content(getPatchContent(addAuthorOps))
+                             .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .andExpect(status().isOk());
+
+            // AuthorSubmitter CAN view
+            getClient(authorSubmitterToken)
+                .perform(get("/api/submission/workspaceitems/" + idRef1.get()))
+                .andExpect(status().isOk());
+
+            // AuthorSubmitter CAN edit (add title and date for deposit)
+            List<Operation> editOps = List.of(
+                new AddOperation("/sections/traditionalpageone/dc.title",
+                                  List.of(Map.of("value", "Title by author-submitter"))),
+                new AddOperation("/sections/traditionalpageone/dc.date.issued",
+                                  List.of(Map.of("value", "2026")))
+            );
+            getClient(authorSubmitterToken)
+                .perform(patch("/api/submission/workspaceitems/" + idRef1.get())
+                             .content(getPatchContent(editOps))
+                             .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .andExpect(status().isOk());
+
+            // Grant license
+            List<Operation> licenseOps = List.of(
+                new AddOperation("/sections/license/granted", true));
+            getClient(submitterToken)
+                .perform(patch("/api/submission/workspaceitems/" + idRef1.get())
+                             .content(getPatchContent(licenseOps))
+                             .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .andExpect(status().isOk());
+
+            // Upload a file (needed for deposit validation)
+            InputStream pdf = InputStream.nullInputStream();
+            MockMultipartFile pdfFile = new MockMultipartFile("file", "/local/path/simple-article.pdf",
+                                                              "application/pdf", pdf);
+            getClient(submitterToken)
+                .perform(multipart("/api/submission/workspaceitems/" + idRef1.get()).file(pdfFile))
+                .andExpect(status().isCreated());
+
+            // AuthorSubmitter CAN deposit (is author BUT also submitter of same collection)
+            getClient(authorSubmitterToken)
+                .perform(post("/api/workflow/workflowitems")
+                             .content("/api/submission/workspaceitems/" + idRef1.get())
+                             .contentType(textUriContentType))
+                .andExpect(status().is2xxSuccessful());
+
+            // AuthorSubmitter CAN delete (using second workspace item)
+            getClient(authorSubmitterToken)
+                .perform(delete("/api/submission/workspaceitems/" + idRef2.get()))
+                .andExpect(status().isNoContent());
+
+        } finally {
+            if (idRef1.get() != null) {
+                WorkspaceItemBuilder.deleteWorkspaceItem(idRef1.get());
+            }
+            if (idRef2.get() != null) {
+                WorkspaceItemBuilder.deleteWorkspaceItem(idRef2.get());
+            }
+        }
+    }
+
+    /**
+     * Scenario 3: Authors/Co-authors in a different collection's submitter group
+     * can View and Edit, but CANNOT Deposit.
+     */
+    @Test
+    public void testAuthorSubmitterDifferentCollectionCannotDeposit() throws Exception {
+        // Configure authority control for dc.contributor.author
+        configurationService.setProperty("choices.plugin.dc.contributor.author", "AuthorAuthority");
+        configurationService.setProperty("choices.presentation.dc.contributor.author", "suggest");
+        configurationService.setProperty("authority.controlled.dc.contributor.author", "true");
+
+        // Clear authority caches BEFORE entity creation (required for authority-controlled fields)
+        pluginService.clearNamedPluginClasses();
+        choiceAuthorityService.clearCache();
+        metadataAuthorityService.clearCache();
+
+        context.turnOffAuthorisationSystem();
+
+        EPerson submitter = EPersonBuilder.createEPerson(context)
+                                          .withEmail("submitter@test.com")
+                                          .withPassword(password)
+                                          .build();
+
+        EPerson author = EPersonBuilder.createEPerson(context)
+                                       .withEmail("author@test.com")
+                                       .withPassword(password)
+                                       .build();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+
+        // Person collection for researcher profiles
+        Collection personCollection = CollectionBuilder.createCollection(context, parentCommunity)
+                                                       .withName("Person Collection")
+                                                       .withEntityType("Person")
+                                                       .build();
+
+        // Publication collection 1: submitter only (author is NOT in this submitter group)
+        Collection pubCollection1 = CollectionBuilder.createCollection(context, parentCommunity)
+                                                     .withName("Publication Collection 1")
+                                                     .withEntityType("Publication")
+                                                     .withSubmitterGroup(submitter)
+                                                     .withSharedWorkspace()
+                                                     .build();
+
+        // Publication collection 2: author is in THIS submitter group (different collection)
+        Collection pubCollection2 = CollectionBuilder.createCollection(context, parentCommunity)
+                                                     .withName("Publication Collection 2")
+                                                     .withEntityType("Publication")
+                                                     .withSubmitterGroup(author)
+                                                     .withSharedWorkspace()
+                                                     .build();
+
+        // Create researcher profile for author
+        Item authorProfile = ItemBuilder.createItem(context, personCollection)
+                                        .withTitle("Author Person")
+                                        .withIssueDate("2020-01-01")
+                                        .withDspaceObjectOwner(author)
+                                        .build();
+
+        context.restoreAuthSystemState();
+
+        AtomicReference<Integer> idRef = new AtomicReference<>();
+        try {
+            String submitterToken = getAuthToken(submitter.getEmail(), password);
+            String authorToken = getAuthToken(author.getEmail(), password);
+
+            // Submitter creates workspace item in pubCollection1
+            getClient(submitterToken)
+                .perform(post("/api/submission/workspaceitems")
+                             .param("owningCollection", pubCollection1.getID().toString())
+                             .contentType(org.springframework.http.MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andDo(result -> idRef.set(
+                    read(result.getResponse().getContentAsString(), "$.id")));
+
+            // Add author metadata pointing to author's profile
+            Map<String, String> authorValue = new HashMap<>();
+            authorValue.put("value", "Author Person");
+            authorValue.put("authority", authorProfile.getID().toString());
+            authorValue.put("display", "Author Person");
+            authorValue.put("confidence", String.valueOf(Choices.CF_ACCEPTED));
+
+            List<Operation> addAuthorOps = List.of(
+                new AddOperation("/sections/traditionalpageone/dc.contributor.author",
+                                  List.of(authorValue)));
+            getClient(submitterToken)
+                .perform(patch("/api/submission/workspaceitems/" + idRef.get())
+                             .content(getPatchContent(addAuthorOps))
+                             .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .andExpect(status().isOk());
+
+            // Author CAN view (is co-author, shared workspace grants access)
+            getClient(authorToken)
+                .perform(get("/api/submission/workspaceitems/" + idRef.get()))
+                .andExpect(status().isOk());
+
+            // Author CAN edit
+            List<Operation> editOps = List.of(
+                new AddOperation("/sections/traditionalpageone/dc.title",
+                                  List.of(Map.of("value", "Title by author"))));
+            getClient(authorToken)
+                .perform(patch("/api/submission/workspaceitems/" + idRef.get())
+                             .content(getPatchContent(editOps))
+                             .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .andExpect(status().isOk());
+
+            // Author CANNOT deposit (submitter of DIFFERENT collection, not this one)
+            getClient(authorToken)
+                .perform(post("/api/workflow/workflowitems")
+                             .content("/api/submission/workspaceitems/" + idRef.get())
+                             .contentType(textUriContentType))
+                .andExpect(status().isForbidden());
+
+        } finally {
+            if (idRef.get() != null) {
+                WorkspaceItemBuilder.deleteWorkspaceItem(idRef.get());
+            }
+        }
+    }
+
+    /**
+     * Scenario 5: The specific submitter who started the item submission
+     * can View, Edit, Delete, and Deposit.
+     */
+    @Test
+    public void testOriginalSubmitterCanViewEditDeleteDepositInSharedWorkspace() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        EPerson submitter = EPersonBuilder.createEPerson(context)
+                                          .withEmail("submitter@test.com")
+                                          .withPassword(password)
+                                          .build();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+
+        Collection pubCollection = CollectionBuilder.createCollection(context, parentCommunity)
+                                                    .withName("Publication Collection")
+                                                    .withEntityType("Publication")
+                                                    .withSubmitterGroup(submitter)
+                                                    .withSharedWorkspace()
+                                                    .build();
+
+        context.restoreAuthSystemState();
+
+        AtomicReference<Integer> idRef1 = new AtomicReference<>();
+        AtomicReference<Integer> idRef2 = new AtomicReference<>();
+        try {
+            String submitterToken = getAuthToken(submitter.getEmail(), password);
+
+            // Original submitter creates workspace item for view/edit/deposit test
+            getClient(submitterToken)
+                .perform(post("/api/submission/workspaceitems")
+                             .param("owningCollection", pubCollection.getID().toString())
+                             .contentType(org.springframework.http.MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andDo(result -> idRef1.set(
+                    read(result.getResponse().getContentAsString(), "$.id")));
+
+            // Original submitter creates another workspace item for delete test
+            getClient(submitterToken)
+                .perform(post("/api/submission/workspaceitems")
+                             .param("owningCollection", pubCollection.getID().toString())
+                             .contentType(org.springframework.http.MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andDo(result -> idRef2.set(
+                    read(result.getResponse().getContentAsString(), "$.id")));
+
+            // Original submitter CAN view
+            getClient(submitterToken)
+                .perform(get("/api/submission/workspaceitems/" + idRef1.get()))
+                .andExpect(status().isOk());
+
+            // Original submitter CAN edit (add title and date for deposit)
+            List<Operation> editOps = List.of(
+                new AddOperation("/sections/traditionalpageone/dc.title",
+                                  List.of(Map.of("value", "Title by original submitter"))),
+                new AddOperation("/sections/traditionalpageone/dc.date.issued",
+                                  List.of(Map.of("value", "2026")))
+            );
+            getClient(submitterToken)
+                .perform(patch("/api/submission/workspaceitems/" + idRef1.get())
+                             .content(getPatchContent(editOps))
+                             .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .andExpect(status().isOk());
+
+            // Grant license
+            List<Operation> licenseOps = List.of(
+                new AddOperation("/sections/license/granted", true));
+            getClient(submitterToken)
+                .perform(patch("/api/submission/workspaceitems/" + idRef1.get())
+                             .content(getPatchContent(licenseOps))
+                             .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .andExpect(status().isOk());
+
+            // Upload a file (needed for deposit validation)
+            InputStream pdf = InputStream.nullInputStream();
+            MockMultipartFile pdfFile = new MockMultipartFile("file", "/local/path/simple-article.pdf",
+                                                              "application/pdf", pdf);
+            getClient(submitterToken)
+                .perform(multipart("/api/submission/workspaceitems/" + idRef1.get()).file(pdfFile))
+                .andExpect(status().isCreated());
+
+            // Original submitter CAN deposit
+            getClient(submitterToken)
+                .perform(post("/api/workflow/workflowitems")
+                             .content("/api/submission/workspaceitems/" + idRef1.get())
+                             .contentType(textUriContentType))
+                .andExpect(status().is2xxSuccessful());
+
+            // Original submitter CAN delete (using second workspace item)
+            getClient(submitterToken)
+                .perform(delete("/api/submission/workspaceitems/" + idRef2.get()))
+                .andExpect(status().isNoContent());
+
+        } finally {
+            if (idRef1.get() != null) {
+                WorkspaceItemBuilder.deleteWorkspaceItem(idRef1.get());
+            }
+            if (idRef2.get() != null) {
+                WorkspaceItemBuilder.deleteWorkspaceItem(idRef2.get());
+            }
+        }
+    }
+
     private String uri(Item item) {
         ItemRest itemRest = itemConverter.convert(item, Projection.DEFAULT);
         return utils.linkToSingleResource(itemRest, "self").getHref();

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkspaceItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkspaceItemRestRepositoryIT.java
@@ -6002,6 +6002,11 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
                                        .withPassword(password)
                                        .build();
 
+        EPerson anotherEperson = EPersonBuilder.createEPerson(context)
+                                       .withEmail("anothereperson@test.com")
+                                       .withPassword(password)
+                                       .build();
+
         parentCommunity = CommunityBuilder.createCommunity(context)
                                           .withName("Parent Community")
                                           .build();
@@ -6084,9 +6089,11 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
                 .andExpect(status().isOk());
 
             // Verify author can also PATCH (modify) the workspace item
-            Operation authorPatchOperation = new AddOperation("/sections/traditionalpageone/dc.title",
-                                                              List.of(Map.of("value", "Title by author")));
-            String authorPatchBody = getPatchContent(List.of(authorPatchOperation));
+            List<Operation> ops = List.of(
+                new AddOperation("/sections/traditionalpageone/dc.title", List.of(Map.of("value", "Title by author"))),
+                new AddOperation("/sections/traditionalpageone/dc.date.issued", List.of(Map.of("value", "2026")))
+            );
+            String authorPatchBody = getPatchContent(ops);
             getClient(getAuthToken(author.getEmail(), password))
                 .perform(patch("/api/submission/workspaceitems/" + workspaceItem.getID())
                              .content(authorPatchBody)
@@ -6094,6 +6101,26 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.sections.traditionalpageone['dc.title'][0].value",
                                     is("Title by author")));
+
+            // only submitter can update license
+            List<Operation> addGrant = new ArrayList<Operation>();
+            addGrant.add(new AddOperation("/sections/license/granted", true));
+            String submitterPatchBody = getPatchContent(addGrant);
+            getClient(submitterToken)
+                .perform(patch("/api/submission/workspaceitems/" + workspaceItem.getID())
+                             .content(submitterPatchBody)
+                             .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                .andExpect(status().isOk());
+
+            // only submitter can upload a file
+            InputStream pdf = InputStream.nullInputStream();
+            final MockMultipartFile pdfFile = new MockMultipartFile("file", "/local/path/simple-article.pdf",
+                                                                    "application/pdf", pdf);
+            getClient(submitterToken)
+                .perform(multipart("/api/submission/workspaceitems/" + workspaceItem.getID()).file(pdfFile))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.sections.upload.files[0].accessConditions", empty()));
+
 
             getClient(getAuthToken(author.getEmail(), password))
                 .perform(get("/api/discover/search/objects")
@@ -6109,6 +6136,15 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$._embedded").exists())
                 .andExpect(jsonPath("$.page.totalElements", greaterThanOrEqualTo(1)));
+
+            context.commit();
+
+            // author cannot deposit
+            getClient(getAuthToken(author.getEmail(), password))
+                .perform(post("/api/workflow/workflowitems")
+                             .content("/api/submission/workspaceitems/" + workspaceItem.getID())
+                             .contentType(textUriContentType))
+                .andExpect(status().isForbidden());
 
         } finally {
             WorkspaceItemBuilder.deleteWorkspaceItem(idRef.get());

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -20,7 +20,7 @@
            http://www.springframework.org/schema/context/spring-context-3.0.xsd
            http://www.springframework.org/schema/util
            http://www.springframework.org/schema/util/spring-util-3.0.xsd"
-    default-autowire-candidates="*Service,*DAO,javax.sql.DataSource,*Plugin" default-lazy-init="true">
+    default-autowire-candidates="*Service,*DAO,javax.sql.DataSource,*Plugin,sharedWorkspaceAuthorMetadataFields" default-lazy-init="true">
 
     <context:annotation-config /> <!-- allows us to use spring annotations in beans -->
 
@@ -58,6 +58,15 @@
     <bean id="solrServiceBestMatchIndexingPlugin" class="org.dspace.discovery.SolrServiceBestMatchIndexingPlugin"/>
     <bean id="solrServiceBestMatchStrictIndexingPlugin"
           class="org.dspace.discovery.SolrServiceStrictBestMatchIndexingPlugin"/>
+
+    <bean id="sharedWorkspaceSolrIndexPlugin" class="org.dspace.discovery.SharedWorkspaceSolrIndexPlugin">
+        <constructor-arg name="additionalReadMetadata" ref="sharedWorkspaceAuthorMetadataFields"/>
+    </bean>
+
+    <util:list id="sharedWorkspaceAuthorMetadataFields" value-type="java.lang.String">
+        <value>dc.contributor.author</value>
+        <value>dc.contributor.editor</value>
+    </util:list>
 
     <alias name="solrServiceResourceIndexPlugin" alias="org.dspace.discovery.SolrServiceResourceRestrictionPlugin"/>
 


### PR DESCRIPTION
## References
* Related to [#5384](https://github.com/DSpace/dspace-angular/issues/5384)
* Related to [DSpace/DSpace#5145](https://github.com/DSpace/dspace-angular/pull/5145) (Shared Submissions feature)
* Related to https://github.com/DSpace/dspace-angular/pull/5630


## Description
Restrict authors from depositing (submitting to workflow) workspace items they co-authored but do not have submitter rights on, while preserving their ability to view and edit those items in shared workspace collections.


## Instructions for Reviewers
In shared workspace collections, authors/co-authors of a workspace item could deposit (start workflow) even when they were not submitters of that collection. The deposit permission check did not exist on the `WorkflowItemRestRepository.createAndReturn` endpoint, meaning any user with access to a shared workspace item could push it into the workflow.

Additionally, the bug report describing that "submissions which are not shared also appear" for collection admins in the Shared Submissions view is **not a bug** -- it is expected behavior. The test `testCollectionAdminCanAccessAllWorkspaceItemsInSharedSubmissions` demonstrates that collection admins have broader permissions (via `authorizeActionBoolean` with `checkAdmin=true`) and can legitimately see and edit all workspace items, including those from non-shared collections.

Furthermore, we should consider updating the MyDSpace dashboard labels and [official documentation](https://www.google.com/search?q=https://wiki.lyrasis.org/spaces/DSDOC10x/pages/438698001/Shared%2Bsubmission%2Bother%2Bworkspace%2Bsubmission%25E2%2580%258B) to better align with these established permission structures and reduce ambiguity regarding visibility.


### List of changes in this PR:

* **`DepositRestPermissionEvaluatorPlugin.java`** (NEW) -- A dedicated `RestObjectPermissionEvaluatorPlugin` that evaluates WRITE permission on the WORKFLOWITEM target type. During deposit, the workspace item ID is passed as target ID. The plugin loads the workspace item and allows deposit only if the user is:
  1. The original submitter of the workspace item, OR
  2. Authorized to ADD to the workspace item's collection (covers submitter group membership, community-level permissions, and admin rights).

* **`WorkflowSecurityUtils.java`** (NEW) -- A `@Component("workflowSecurityUtils")` utility that parses workspace item IDs from REST API URIs (`/api/submission/workspaceitems/{id}`). Used in `@PreAuthorize` SpEL expressions and by `SubmissionService`.

* **`WorkflowItemRestRepository.java`** -- Added `@PreAuthorize("hasPermission(@workflowSecurityUtils.parseIdFromUriList(#stringList), 'WORKFLOWITEM', 'WRITE')")` on `createAndReturn` to enforce deposit permission before workflow creation.

* **`SubmissionService.java`** -- Refactored `createWorkflowItem` to use `WorkflowSecurityUtils.parseIdFromUri` for URI parsing instead of inline regex logic. Improved error messages.

* **`EditItemFeature.java`** -- Extended the `canEditItem` authorization feature to grant edit access to workspace item submitters and co-authors (via `ResearcherProfileService.isAuthorOf`), enabling the frontend to correctly show edit capabilities.

* **`AuthorizeServicePermissionEvaluatorPlugin.java`** -- Added a check so that co-authors (identified via `ResearcherProfileService.isAuthorOf`) can READ non-archived, non-withdrawn items they co-authored. This enables authors to view workspace items in shared submissions.

* **`discovery.xml`** -- Added `sharedWorkspaceSolrIndexPlugin` bean with `sharedWorkspaceAuthorMetadataFields` (`dc.contributor.author`, `dc.contributor.editor`) to support Solr-based discovery of shared workspace items by co-authors.

* **`WorkspaceItemRestRepositoryIT.java`** -- Added comprehensive test coverage for five deposit permission scenarios:
  1. **Any submitter** of a shared workspace collection CAN View, Edit, Delete, and Deposit workspace items created by other submitters.
  2. **Authors who are also submitters** of the same collection CAN View, Edit, Delete, and Deposit.
  3. **Authors in a different collection's submitter group** CAN View and Edit but CANNOT Deposit.
  4. **Authors not in any submitter group** CAN View and Edit but CANNOT Deposit (existing `testAuthorCanAccessSharedWorkspaceItem`).
  5. **The original submitter** CAN View, Edit, Delete, and Deposit.
  6. **Collection admins** CAN access all workspace items including non-shared ones (expected behavior, `testCollectionAdminCanAccessAllWorkspaceItemsInSharedSubmissions`).

### How to test

1. Create a community with two Publication collections, both with "Shared Workspace" enabled.
2. Create three users: `submitter1` (submitter of Collection A), `submitter2` (submitter of Collection A), `author` (submitter of Collection B only).
3. As `submitter1`, create a workspace item in Collection A and add `author` as co-author (using authority-controlled `dc.contributor.author` pointing to the author's researcher profile).
4. Verify:
   - `submitter2` CAN view, edit, delete, and deposit the workspace item (same collection submitter group).
   - `author` CAN view and edit the workspace item but CANNOT deposit (submitter of different collection).
   - `submitter1` (original submitter) CAN view, edit, delete, and deposit.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
