### PR TITLE
Replace several `javax.annotation` dependencies with their `jakarta.annotation` equivalent

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -414,6 +414,11 @@
                     <groupId>org.bouncycastle</groupId>
                     <artifactId>bcprov-jdk15on</artifactId>
                 </exclusion>
+                <!-- Excluded because this library is incompatible with Jakarta EE. -->
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/dspace-api/src/main/java/org/dspace/identifier/doi/crossref/BaseHttpClient.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/doi/crossref/BaseHttpClient.java
@@ -8,8 +8,8 @@
 package org.dspace.identifier.doi.crossref;
 
 import java.io.IOException;
-import javax.annotation.Nullable;
 
+import jakarta.annotation.Nullable;
 import org.apache.http.HttpHeaders;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/JCloudBitStoreService.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/JCloudBitStoreService.java
@@ -20,6 +20,7 @@ import com.google.common.hash.HashCode;
 import com.google.common.io.ByteSource;
 import com.google.common.io.Files;
 import com.google.common.net.MediaType;
+import jakarta.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -38,7 +39,6 @@ import org.jclouds.blobstore.domain.BlobMetadata;
 import org.jclouds.blobstore.options.ListContainerOptions;
 import org.jclouds.blobstore.options.PutOptions.Builder;
 import org.jclouds.io.ContentMetadata;
-import org.jclouds.javax.annotation.Nullable;
 
 /**
  * JCloudBitstream asset store service

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/EditItemCollectionLinkRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/EditItemCollectionLinkRestRepository.java
@@ -7,8 +7,7 @@
  */
 package org.dspace.app.rest.repository;
 
-import javax.annotation.Nullable;
-
+import jakarta.annotation.Nullable;
 import jakarta.servlet.http.HttpServletRequest;
 import org.dspace.app.rest.model.CollectionRest;
 import org.dspace.app.rest.model.EditItemRest;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/EditItemItemLinkRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/EditItemItemLinkRestRepository.java
@@ -7,8 +7,7 @@
  */
 package org.dspace.app.rest.repository;
 
-import javax.annotation.Nullable;
-
+import jakarta.annotation.Nullable;
 import jakarta.servlet.http.HttpServletRequest;
 import org.dspace.app.rest.model.EditItemRest;
 import org.dspace.app.rest.model.ItemRest;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ItemSubmitterLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ItemSubmitterLinkRepository.java
@@ -9,8 +9,8 @@ package org.dspace.app.rest.repository;
 
 import java.sql.SQLException;
 import java.util.UUID;
-import javax.annotation.Nullable;
 
+import jakarta.annotation.Nullable;
 import jakarta.servlet.http.HttpServletRequest;
 import org.dspace.app.rest.model.EPersonRest;
 import org.dspace.app.rest.model.ItemRest;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkflowItemCollectionLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkflowItemCollectionLinkRepository.java
@@ -8,8 +8,8 @@
 package org.dspace.app.rest.repository;
 
 import java.sql.SQLException;
-import javax.annotation.Nullable;
 
+import jakarta.annotation.Nullable;
 import jakarta.servlet.http.HttpServletRequest;
 import org.dspace.app.rest.model.CollectionRest;
 import org.dspace.app.rest.model.WorkflowItemRest;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkflowItemItemLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkflowItemItemLinkRepository.java
@@ -8,8 +8,8 @@
 package org.dspace.app.rest.repository;
 
 import java.sql.SQLException;
-import javax.annotation.Nullable;
 
+import jakarta.annotation.Nullable;
 import jakarta.servlet.http.HttpServletRequest;
 import org.dspace.app.rest.model.ItemRest;
 import org.dspace.app.rest.model.WorkflowItemRest;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkflowItemSubmitterLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkflowItemSubmitterLinkRepository.java
@@ -8,8 +8,8 @@
 package org.dspace.app.rest.repository;
 
 import java.sql.SQLException;
-import javax.annotation.Nullable;
 
+import jakarta.annotation.Nullable;
 import jakarta.servlet.http.HttpServletRequest;
 import org.dspace.app.rest.model.EPersonRest;
 import org.dspace.app.rest.model.WorkflowItemRest;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkspaceItemCollectionLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkspaceItemCollectionLinkRepository.java
@@ -8,8 +8,8 @@
 package org.dspace.app.rest.repository;
 
 import java.sql.SQLException;
-import javax.annotation.Nullable;
 
+import jakarta.annotation.Nullable;
 import jakarta.servlet.http.HttpServletRequest;
 import org.dspace.app.rest.model.CollectionRest;
 import org.dspace.app.rest.model.WorkspaceItemRest;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkspaceItemItemLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkspaceItemItemLinkRepository.java
@@ -8,8 +8,8 @@
 package org.dspace.app.rest.repository;
 
 import java.sql.SQLException;
-import javax.annotation.Nullable;
 
+import jakarta.annotation.Nullable;
 import jakarta.servlet.http.HttpServletRequest;
 import org.dspace.app.rest.model.ItemRest;
 import org.dspace.app.rest.model.WorkspaceItemRest;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkspaceItemSubmitterLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkspaceItemSubmitterLinkRepository.java
@@ -8,8 +8,8 @@
 package org.dspace.app.rest.repository;
 
 import java.sql.SQLException;
-import javax.annotation.Nullable;
 
+import jakarta.annotation.Nullable;
 import jakarta.servlet.http.HttpServletRequest;
 import org.dspace.app.rest.model.EPersonRest;
 import org.dspace.app.rest.model.WorkspaceItemRest;

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,16 @@
                                 <rules>
                                     <bannedDependencies>
                                         <excludes>
+                                            <!-- Ban usage of Log4j v1 -->
                                             <exclude>log4j:log4j</exclude>
+                                            <!-- Ban usage of Javax dependencies. We use Jakarta equivalents -->
+                                            <exclude>javax.annotation:javax.annotation-api</exclude>
+                                            <exclude>javax.inject:javax.inject</exclude>
+                                            <exclude>javax.mail:mail</exclude>
+                                            <exclude>com.sun.mail:javax.mail</exclude>
+                                            <exclude>javax.persistence:javax.persistence-api</exclude>
+                                            <exclude>javax.servlet:servlet-api</exclude>
+                                            <exclude>javax.validation:validation-api</exclude>
                                         </excludes>
                                     </bannedDependencies>
                                 </rules>


### PR DESCRIPTION

## References
* Discovered during analysis of compilation failures in #12412

## Description
Several of our classes are accidentally using `javax.annotation.*` dependencies when we should be using `jakarta.annotation.*` dependencies (since DSpace 8.x).

This small PR corrects that issue & helps ensure we don't encounter it again by **banning** various `javax.*` dependencies from being included/used in our codebase. (See the new exclusions added to `pom.xml` in this PR)

## Instructions for Reviewers
* Provide code review
* Verify all automated tests still pass.  This is a simple swap of dependencies.