### PR TITLE
[dspace-7_x] Support multi-value metadata PATCH add operations

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataAddOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataAddOperation.java
@@ -8,6 +8,7 @@
 package org.dspace.app.rest.repository.patch.operation;
 
 import java.sql.SQLException;
+import java.util.List;
 
 import org.dspace.app.rest.exception.DSpaceBadRequestException;
 import org.dspace.app.rest.model.MetadataValueRest;
@@ -40,11 +41,17 @@ public class DSpaceObjectMetadataAddOperation<R extends DSpaceObject> extends Pa
     @Override
     public R perform(Context context, R resource, Operation operation) throws SQLException {
         DSpaceObjectService dsoService = ContentServiceFactory.getInstance().getDSpaceObjectService(resource);
-        MetadataValueRest metadataValueToAdd = metadataPatchUtils.extractMetadataValueFromOperation(operation);
+        // Atmire modifications START
+        List<MetadataValueRest> metadataValuesToAdd = metadataPatchUtils.extractMetadataValueFromOperation(operation);
+        // Atmire modifications END
         MetadataField metadataField = metadataPatchUtils.getMetadataField(context, operation);
         String indexInPath = metadataPatchUtils.getIndexFromPath(operation.getPath());
 
-        add(context, resource, dsoService, metadataField, metadataValueToAdd, indexInPath);
+        // Atmire modifications START
+        for (MetadataValueRest metadataValue : metadataValuesToAdd) {
+            add(context, resource, dsoService, metadataField, metadataValue, indexInPath);
+        }
+        // Atmire modifications END
         return resource;
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataAddOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataAddOperation.java
@@ -41,17 +41,20 @@ public class DSpaceObjectMetadataAddOperation<R extends DSpaceObject> extends Pa
     @Override
     public R perform(Context context, R resource, Operation operation) throws SQLException {
         DSpaceObjectService dsoService = ContentServiceFactory.getInstance().getDSpaceObjectService(resource);
-        // Atmire modifications START
         List<MetadataValueRest> metadataValuesToAdd = metadataPatchUtils.extractMetadataValueFromOperation(operation);
-        // Atmire modifications END
         MetadataField metadataField = metadataPatchUtils.getMetadataField(context, operation);
         String indexInPath = metadataPatchUtils.getIndexFromPath(operation.getPath());
 
-        // Atmire modifications START
-        for (MetadataValueRest metadataValue : metadataValuesToAdd) {
-            add(context, resource, dsoService, metadataField, metadataValue, indexInPath);
+        if (indexInPath == null && metadataValuesToAdd.size() > 1) {
+            for (int i = metadataValuesToAdd.size() - 1; i >= 0; i--) {
+                add(context, resource, dsoService, metadataField, metadataValuesToAdd.get(i), indexInPath);
+            }
+        } else {
+            for (MetadataValueRest metadataValue : metadataValuesToAdd) {
+                add(context, resource, dsoService, metadataField, metadataValue, indexInPath);
+            }
         }
-        // Atmire modifications END
+
         return resource;
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataPatchUtils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataPatchUtils.java
@@ -9,6 +9,8 @@ package org.dspace.app.rest.repository.patch.operation;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -44,27 +46,38 @@ public final class DSpaceObjectMetadataPatchUtils {
     private DSpaceObjectMetadataPatchUtils() {
     }
 
+    // Atmire modifications START
     /**
      * Extract metadataValue from Operation by parsing the json and mapping it to a MetadataValueRest
      * @param operation     Operation whose value is begin parsed
      * @return MetadataValueRest extracted from json in operation value
      */
-    protected MetadataValueRest extractMetadataValueFromOperation(Operation operation) {
-        MetadataValueRest metadataValue = null;
+    protected List<MetadataValueRest> extractMetadataValueFromOperation(Operation operation) {
+        List<MetadataValueRest> metadataValues = new ArrayList<>();
+
         try {
             if (operation.getValue() != null) {
                 if (operation.getValue() instanceof JsonValueEvaluator) {
                     JsonNode valueNode = ((JsonValueEvaluator) operation.getValue()).getValueNode();
                     if (valueNode.isArray()) {
-                        metadataValue = objectMapper.treeToValue(valueNode.get(0), MetadataValueRest.class);
+                        for (JsonNode node: valueNode) {
+                            MetadataValueRest metadataValue = objectMapper.treeToValue(node, MetadataValueRest.class);
+
+                            if (operation.getValue() instanceof String) {
+                                String valueString = (String) operation.getValue();
+                                metadataValue = new MetadataValueRest();
+                                metadataValue.setValue(valueString);
+                            }
+                            metadataValues.add(metadataValue);
+                        }
                     } else {
-                        metadataValue = objectMapper.treeToValue(valueNode, MetadataValueRest.class);
+                        MetadataValueRest metadataValue = objectMapper.treeToValue(valueNode, MetadataValueRest.class);
+                        if (operation.getValue() instanceof String) {
+                            String valueString = (String) operation.getValue();
+                            metadataValue = new MetadataValueRest();
+                            metadataValue.setValue(valueString);
+                        }
                     }
-                }
-                if (operation.getValue() instanceof String) {
-                    String valueString = (String) operation.getValue();
-                    metadataValue = new MetadataValueRest();
-                    metadataValue.setValue(valueString);
                 }
             }
         } catch (IOException e) {
@@ -72,11 +85,12 @@ public final class DSpaceObjectMetadataPatchUtils {
                     "DspaceObjectMetadataOperation.extractMetadataValueFromOperation trying to map json from " +
                     "operation.value to MetadataValue class.", e);
         }
-        if (metadataValue == null) {
+        if (metadataValues.isEmpty()) {
             throw new DSpaceBadRequestException("Could not extract MetadataValue Object from Operation");
         }
-        return metadataValue;
+        return metadataValues;
     }
+    // Atmire modifications END
 
     /**
      * Extracts the mdField String (schema.element.qualifier) from the operation and returns it

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataPatchUtils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataPatchUtils.java
@@ -72,13 +72,14 @@ public final class DSpaceObjectMetadataPatchUtils {
                         }
                     } else {
                         MetadataValueRest metadataValue = objectMapper.treeToValue(valueNode, MetadataValueRest.class);
-                        if (operation.getValue() instanceof String) {
-                            String valueString = (String) operation.getValue();
-                            metadataValue = new MetadataValueRest();
-                            metadataValue.setValue(valueString);
-                        }
                         metadataValues.add(metadataValue);
                     }
+                }
+                if (operation.getValue() instanceof String) {
+                    String valueString = (String) operation.getValue();
+                    MetadataValueRest metadataValue = new MetadataValueRest();
+                    metadataValue.setValue(valueString);
+                    metadataValues.add(metadataValue);
                 }
             }
         } catch (IOException e) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataPatchUtils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataPatchUtils.java
@@ -77,6 +77,7 @@ public final class DSpaceObjectMetadataPatchUtils {
                             metadataValue = new MetadataValueRest();
                             metadataValue.setValue(valueString);
                         }
+                        metadataValues.add(metadataValue);
                     }
                 }
             }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataReplaceOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataReplaceOperation.java
@@ -49,7 +49,10 @@ public class DSpaceObjectMetadataReplaceOperation<R extends DSpaceObject> extend
         String[] partsOfPath = operation.getPath().split("/");
         // Index of md being patched
         String indexInPath = (partsOfPath.length > 3) ? partsOfPath[3] : null;
-        MetadataValueRest metadataValueToReplace = metadataPatchUtils.extractMetadataValueFromOperation(operation);
+        // Atmire modifications START
+        MetadataValueRest metadataValueToReplace = metadataPatchUtils
+            .extractMetadataValueFromOperation(operation).get(0);
+        // Atmire modifications END
         // Property of md being altered
         String propertyOfMd = metadataPatchUtils.extractPropertyOfMdFromPath(partsOfPath);
         String newValueMdAttribute = metadataPatchUtils.extractNewValueOfMd(operation);

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DSpaceObjectMetadataPatchIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DSpaceObjectMetadataPatchIT.java
@@ -1,0 +1,242 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.ws.rs.core.MediaType;
+
+import org.dspace.app.rest.matcher.MetadataMatcher;
+import org.dspace.app.rest.model.MetadataValueRest;
+import org.dspace.app.rest.model.patch.AddOperation;
+import org.dspace.app.rest.model.patch.Operation;
+import org.dspace.app.rest.test.AbstractEntityIntegrationTest;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.ItemBuilder;
+import org.dspace.content.Collection;
+import org.dspace.content.Item;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Integration tests for metadata PATCH operations on DSpace Objects.
+ * Verifies that single and array values are applied correctly through the core item endpoint.
+ */
+public class DSpaceObjectMetadataPatchIT extends AbstractEntityIntegrationTest {
+
+    private static final String AUTHOR_FIELD = "dc.contributor.author";
+    private static final String AUTHOR_PATH = "/metadata/" + AUTHOR_FIELD;
+
+    private Collection collection;
+    private Item item;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        context.turnOffAuthorisationSystem();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+
+        collection = CollectionBuilder.createCollection(context, parentCommunity)
+                                      .withName("Collection")
+                                      .build();
+
+        context.restoreAuthSystemState();
+    }
+
+    /**
+     * Verifies that adding multiple metadata values without an index inserts them at the front in order.
+     */
+    @Test
+    public void addMultipleMetadataValuesArrayWithoutIndexAddsAtFrontInOrderTest() throws Exception {
+        initItemWithAuthors("Author One");
+
+        List<Operation> operations = List.of(
+            new AddOperation(AUTHOR_PATH, metadataValues("Author Two", "Author Three"))
+        );
+
+        performPatch(operations);
+
+        assertAuthorOrder("Author Two", "Author Three", "Author One");
+    }
+
+    /**
+     * Verifies that adding multiple metadata values at index 0 inserts all values at the front.
+     */
+    @Test
+    public void addMultipleMetadataValuesArrayAtFrontTest() throws Exception {
+        initItemWithAuthors("Author Three");
+
+        List<Operation> operations = List.of(
+            new AddOperation(AUTHOR_PATH + "/0", metadataValues("Author One", "Author Two"))
+        );
+
+        performPatch(operations);
+
+        assertAuthorOrder("Author Two", "Author One", "Author Three");
+    }
+
+    /**
+     * Verifies that adding multiple metadata values at the append index adds all values at the end in order.
+     */
+    @Test
+    public void addMultipleMetadataValuesArrayAtBackKeepsOrderTest() throws Exception {
+        initItemWithAuthors("Author One");
+
+        List<Operation> operations = List.of(
+            new AddOperation(AUTHOR_PATH + "/-", metadataValues("Author Two", "Author Three"))
+        );
+
+        performPatch(operations);
+
+        assertAuthorOrder("Author One", "Author Two", "Author Three");
+    }
+
+    /**
+     * Verifies that adding a single metadata value at index 0 adds it at the front.
+     */
+    @Test
+    public void addSingleMetadataValueAtFrontTest() throws Exception {
+        initItemWithAuthors("Author Two");
+
+        List<Operation> operations = List.of(
+            new AddOperation(AUTHOR_PATH + "/0", metadataValue("Author One"))
+        );
+
+        performPatch(operations);
+
+        assertAuthorOrder("Author One", "Author Two");
+    }
+
+    /**
+     * Verifies that adding a single metadata value at the append index adds it at the back.
+     */
+    @Test
+    public void addSingleMetadataValueAtBackTest() throws Exception {
+        initItemWithAuthors("Author One");
+
+        List<Operation> operations = List.of(
+            new AddOperation(AUTHOR_PATH + "/-", metadataValue("Author Two"))
+        );
+
+        performPatch(operations);
+
+        assertAuthorOrder("Author One", "Author Two");
+    }
+
+    /**
+     * Verifies that adding multiple metadata values to an item without existing values stores all values in order.
+     */
+    @Test
+    public void addMultipleMetadataValuesArrayToEmptyFieldKeepsOrderTest() throws Exception {
+        initItemWithAuthors();
+
+        List<Operation> operations = List.of(
+            new AddOperation(AUTHOR_PATH, metadataValues("Author One", "Author Two"))
+        );
+
+        performPatch(operations);
+
+        assertAuthorOrder("Author One", "Author Two");
+    }
+
+    /**
+     * Creates a test item with the provided author metadata values.
+     *
+     * @param authors author values to add to the item
+     */
+    private void initItemWithAuthors(String... authors) throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        ItemBuilder itemBuilder = ItemBuilder.createItem(context, collection)
+                                             .withTitle("Test Item");
+
+        for (String author : authors) {
+            itemBuilder.withAuthor(author);
+        }
+
+        item = itemBuilder.build();
+
+        context.restoreAuthSystemState();
+    }
+
+    /**
+     * Performs a metadata PATCH request against the test item.
+     *
+     * @param operations patch operations to apply
+     */
+    private void performPatch(List<Operation> operations) throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+
+        getClient(token).perform(patch("/api/core/items/" + item.getID())
+                                     .content(getPatchContent(operations))
+                                     .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                        .andExpect(status().isOk());
+    }
+
+    /**
+     * Creates a single metadata value REST object.
+     *
+     * @param value metadata value
+     * @return metadata value REST object
+     */
+    private MetadataValueRest metadataValue(String value) {
+        MetadataValueRest metadataValueRest = new MetadataValueRest();
+        metadataValueRest.setValue(value);
+        return metadataValueRest;
+    }
+
+    /**
+     * Creates metadata value REST objects for array PATCH values.
+     *
+     * @param values metadata values
+     * @return metadata value REST objects
+     */
+    private List<MetadataValueRest> metadataValues(String... values) {
+        List<MetadataValueRest> metadataValues = new ArrayList<>();
+
+        for (String value : values) {
+            metadataValues.add(metadataValue(value));
+        }
+
+        return metadataValues;
+    }
+
+    /**
+     * Verifies the item author metadata values and their order.
+     *
+     * @param expectedAuthors expected author values in order
+     */
+    private void assertAuthorOrder(String... expectedAuthors) throws Exception {
+        List<org.hamcrest.Matcher<? super Object>> matchers = new ArrayList<>();
+
+        for (int i = 0; i < expectedAuthors.length; i++) {
+            matchers.add(MetadataMatcher.matchMetadata(AUTHOR_FIELD, expectedAuthors[i], i));
+        }
+
+        String token = getAuthToken(admin.getEmail(), password);
+
+        getClient(token).perform(get("/api/core/items/" + item.getID()))
+                        .andExpect(status().isOk())
+                        .andExpect(content().contentType(contentType))
+                        .andExpect(jsonPath("$.metadata", allOf(matchers)));
+    }
+
+}


### PR DESCRIPTION
## References
* Fixes #12419
* Related to [Modifying metadata via Patch](https://github.com/DSpace/RestContract/blob/main/metadata-patch.md)
* PR on `main`: https://github.com/DSpace/DSpace/pull/12467

## Description
Adds support for metadata PATCH `add` operations containing multiple metadata values in a single array. Also adds integration tests covering single-value and multi-value metadata PATCH add scenarios and ordering behavior.

Note: multi-value `replace` behavior is intentionally not changed in this PR and is being discussed separately in the linked issue.

## Instructions for Reviewers
List of changes in this PR:
* Updated `DSpaceObjectMetadataPatchUtils` so `extractMetadataValueFromOperation(...)` returns a list of `MetadataValueRest` values instead of only one value.
* Updated array handling so all values in a metadata PATCH array are extracted, instead of only reading the first array element.
* Updated `DSpaceObjectMetadataAddOperation` to apply all extracted metadata values for `add` operations.
* Added special handling for multi-value `add` operations without an index, so inserted values keep the same order as the provided array.
* Updated `DSpaceObjectMetadataReplaceOperation` to keep its existing single-value behavior by explicitly using the first extracted metadata value.
* Added a new `DSpaceObjectMetadataPatchIT` integration test class covering metadata PATCH `add` operations with single and multiple values, including ordering for front and back insertion.

Review/testing guidance:
- Create or use an existing item through the REST API.
- Send a PATCH request similar to:
```json
[{ "op": "add", "path": "/metadata/dc.contributor.author", "value": [ { "value": "Author One" }, { "value": "Author Two" } ] } ]
```
- Verify that both metadata values are added to the item.


## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
