### PR TITLE
Deduplicate OpenPolicyFinder performRequest / performPublisherRequest

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/openpolicyfinder/OpenPolicyFinderService.java
+++ b/dspace-api/src/main/java/org/dspace/app/openpolicyfinder/OpenPolicyFinderService.java
@@ -12,6 +12,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import java.util.function.Function;
 
 import jakarta.annotation.PostConstruct;
 import org.apache.commons.io.IOUtils;
@@ -56,6 +57,16 @@ public class OpenPolicyFinderService {
 
     @Autowired
     ConfigurationService configurationService;
+
+    /**
+     * Parses a successful HTTP response body into an Open Policy Finder response object.
+     * Lets {@link #performRequest} and {@link #performPublisherRequest} share a single retry
+     * loop while constructing different response types.
+     */
+    @FunctionalInterface
+    private interface ResponseParser<T> {
+        T parse(InputStream input) throws IOException;
+    }
 
     /**
      * Complete initialization of the Bean.
@@ -117,104 +128,11 @@ public class OpenPolicyFinderService {
     public OpenPolicyFinderPublisherResponse performPublisherRequest(
             String type, String field, String predicate, String value,
             int start, int limit) {
-        // API Key is *required* for API calls
-        if (null == apiKey) {
-            log.error("Open Policy Finder API Key missing: "
-                + "please register for an API key and set openpolicyfinder.apikey");
-            return new OpenPolicyFinderPublisherResponse("Open Policy Finder configuration invalid or missing");
-        }
-
-        HttpGet method = null;
-        OpenPolicyFinderPublisherResponse opfResponse = null;
-        int numberOfTries = 0;
-
-        while (numberOfTries < maxNumberOfTries && opfResponse == null) {
-            numberOfTries++;
-
-            log.debug(String.format(
-                "Trying to contact Open Policy Finder - attempt %d of %d; timeout is %d; "
-                    + "sleep between timeouts is %d",
-                numberOfTries,
-                maxNumberOfTries,
-                timeout,
-                sleepBetweenTimeouts));
-
-            try (CloseableHttpClient client = DSpaceHttpClientFactory.getInstance().buildWithoutAutomaticRetries(5)) {
-                if (numberOfTries > 1) {
-                    Thread.sleep(sleepBetweenTimeouts);
-                }
-
-                // Construct a default HTTP method (first result)
-                method = constructHttpGet(type, field, predicate, value, start, limit);
-
-                // Execute the method
-                try (CloseableHttpResponse response = client.execute(method)) {
-                    int statusCode = response.getStatusLine().getStatusCode();
-
-                    log.debug(response.getStatusLine().getStatusCode() + ": "
-                            + response.getStatusLine().getReasonPhrase());
-
-                    if (statusCode != HttpStatus.SC_OK) {
-                        opfResponse = new OpenPolicyFinderPublisherResponse(
-                            "Open Policy Finder return not OK status: " + statusCode);
-                        String errorBody = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
-                        log.error("Error from Open Policy Finder HTTP request: " + errorBody);
-                        // The error body has consumed the response stream; skip the JSON parsing block
-                        // below (which would otherwise throw "Attempted read from closed stream").
-                        continue;
-                    }
-
-                    HttpEntity responseBody = response.getEntity();
-
-                    // If the response body is valid, pass to OpenPolicyFinderResponse for parsing as JSON
-                    if (null != responseBody) {
-                        log.debug("Non-null response received for query of " + value);
-                        InputStream content = null;
-                        try {
-                            content = responseBody.getContent();
-                            opfResponse = new OpenPolicyFinderPublisherResponse(
-                                    content,
-                                    OpenPolicyFinderPublisherResponse.ResponseFormat.JSON);
-                        } catch (IOException e) {
-                            log.error("Encountered exception while contacting Open Policy Finder: "
-                                + e.getMessage(), e);
-                        } finally {
-                            if (content != null) {
-                                content.close();
-                            }
-                        }
-                    } else {
-                        log.debug("Empty response body for query on " + value);
-                        opfResponse = new OpenPolicyFinderPublisherResponse("Open Policy Finder returned no response");
-                    }
-                }
-            } catch (URISyntaxException e) {
-                String errorMessage = "Error building Open Policy Finder API URI: " + e.getMessage();
-                log.error(errorMessage, e);
-                opfResponse = new OpenPolicyFinderPublisherResponse(errorMessage);
-            } catch (IOException e) {
-                String errorMessage = "Encountered exception while contacting Open Policy Finder: " + e.getMessage();
-                log.error(errorMessage, e);
-                opfResponse = new OpenPolicyFinderPublisherResponse(errorMessage);
-            }  catch (InterruptedException e) {
-                String errorMessage = "Encountered exception while sleeping thread: " + e.getMessage();
-                log.error(errorMessage, e);
-                opfResponse = new OpenPolicyFinderPublisherResponse(errorMessage);
-            } finally {
-                if (method != null) {
-                    method.releaseConnection();
-                }
-            }
-        }
-
-        if (opfResponse == null) {
-            log.debug("Response is still null");
-            opfResponse = new OpenPolicyFinderPublisherResponse(
-                "Error processing the Open Policy Finder answer");
-        }
-
-        // Return the final response
-        return opfResponse;
+        return executeRequest(
+            type, field, predicate, value, start, limit,
+            input -> new OpenPolicyFinderPublisherResponse(
+                input, OpenPolicyFinderPublisherResponse.ResponseFormat.JSON),
+            OpenPolicyFinderPublisherResponse::new);
     }
 
     /**
@@ -230,15 +148,39 @@ public class OpenPolicyFinderService {
      */
     public OpenPolicyFinderResponse performRequest(String type, String field, String predicate, String value,
                                          int start, int limit) {
+        return executeRequest(
+            type, field, predicate, value, start, limit,
+            input -> new OpenPolicyFinderResponse(input, OpenPolicyFinderResponse.ResponseFormat.JSON),
+            OpenPolicyFinderResponse::new);
+    }
+
+    /**
+     * Shared HTTP-execution and retry loop for {@link #performRequest} and
+     * {@link #performPublisherRequest}. The two callers differ only in how they parse the
+     * successful response body and how they package an error message, so those two pieces are
+     * supplied as functions.
+     *
+     * <p>Behaviour matches the previous duplicated implementations: a non-200 status, an
+     * IOException from the HTTP layer, a URI build error, or a thread interruption produces an
+     * error response and exits the loop. A parse-time IOException leaves the response unset so
+     * the loop can retry up to {@code maxNumberOfTries}. The first attempt does not pay the
+     * configured {@code sleepBetweenTimeouts}.</p>
+     *
+     * @param successParser  parses a successful response InputStream into the response object
+     * @param errorBuilder   builds an error response object from a message string
+     */
+    private <T> T executeRequest(String type, String field, String predicate, String value,
+                                 int start, int limit,
+                                 ResponseParser<T> successParser, Function<String, T> errorBuilder) {
         // API Key is *required* for API calls
         if (null == apiKey) {
             log.error("Open Policy Finder API Key missing: "
                 + "please register for an API key and set openpolicyfinder.apikey");
-            return new OpenPolicyFinderResponse("Open Policy Finder configuration invalid or missing");
+            return errorBuilder.apply("Open Policy Finder configuration invalid or missing");
         }
 
         HttpGet method = null;
-        OpenPolicyFinderResponse opfResponse = null;
+        T opfResponse = null;
         int numberOfTries = 0;
 
         while (numberOfTries < maxNumberOfTries && opfResponse == null) {
@@ -252,7 +194,7 @@ public class OpenPolicyFinderService {
                 timeout,
                 sleepBetweenTimeouts));
 
-            try (CloseableHttpClient client = DSpaceHttpClientFactory.getInstance().buildWithoutAutomaticRetries(5)) {
+            try (CloseableHttpClient client = newHttpClient()) {
                 if (numberOfTries > 1) {
                     Thread.sleep(sleepBetweenTimeouts);
                 }
@@ -268,7 +210,7 @@ public class OpenPolicyFinderService {
                             + response.getStatusLine().getReasonPhrase());
 
                     if (statusCode != HttpStatus.SC_OK) {
-                        opfResponse = new OpenPolicyFinderResponse(
+                        opfResponse = errorBuilder.apply(
                             "Open Policy Finder return not OK status: " + statusCode);
                         String errorBody = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
                         log.error("Error from Open Policy Finder HTTP request: " + errorBody);
@@ -279,39 +221,33 @@ public class OpenPolicyFinderService {
 
                     HttpEntity responseBody = response.getEntity();
 
-                    // If the response body is valid, pass to OpenPolicyFinderResponse for parsing as JSON
+                    // If the response body is valid, pass to the success parser for parsing as JSON
                     if (null != responseBody) {
                         log.debug("Non-null response received for query of " + value);
-                        InputStream content = null;
-                        try {
-                            content = responseBody.getContent();
-                            opfResponse = new OpenPolicyFinderResponse(
-                                    content, OpenPolicyFinderResponse.ResponseFormat.JSON);
+                        try (InputStream content = responseBody.getContent()) {
+                            opfResponse = successParser.parse(content);
                         } catch (IOException e) {
                             log.error("Encountered exception while contacting Open Policy Finder: "
                                 + e.getMessage(), e);
-                        } finally {
-                            if (content != null) {
-                                content.close();
-                            }
+                            // opfResponse stays null so the loop retries if attempts remain.
                         }
                     } else {
                         log.debug("Empty response body for query on " + value);
-                        opfResponse = new OpenPolicyFinderResponse("Open Policy Finder returned no response");
+                        opfResponse = errorBuilder.apply("Open Policy Finder returned no response");
                     }
                 }
             } catch (URISyntaxException e) {
                 String errorMessage = "Error building Open Policy Finder API URI: " + e.getMessage();
                 log.error(errorMessage, e);
-                opfResponse = new OpenPolicyFinderResponse(errorMessage);
+                opfResponse = errorBuilder.apply(errorMessage);
             } catch (IOException e) {
                 String errorMessage = "Encountered exception while contacting Open Policy Finder: " + e.getMessage();
                 log.error(errorMessage, e);
-                opfResponse = new OpenPolicyFinderResponse(errorMessage);
+                opfResponse = errorBuilder.apply(errorMessage);
             } catch (InterruptedException e) {
                 String errorMessage = "Encountered exception while sleeping thread: " + e.getMessage();
                 log.error(errorMessage, e);
-                opfResponse = new OpenPolicyFinderResponse(errorMessage);
+                opfResponse = errorBuilder.apply(errorMessage);
             } finally {
                 if (method != null) {
                     method.releaseConnection();
@@ -321,12 +257,19 @@ public class OpenPolicyFinderService {
 
         if (opfResponse == null) {
             log.debug("Response is still null");
-            opfResponse = new OpenPolicyFinderResponse(
-                "Error processing the Open Policy Finder answer");
+            opfResponse = errorBuilder.apply("Error processing the Open Policy Finder answer");
         }
 
         // Return the final response
         return opfResponse;
+    }
+
+    /**
+     * Build an {@link CloseableHttpClient} for one HTTP attempt against the Open Policy Finder API.
+     * Extracted as a protected method so that unit tests can override it to inject a mocked client.
+     */
+    protected CloseableHttpClient newHttpClient() throws IOException {
+        return DSpaceHttpClientFactory.getInstance().buildWithoutAutomaticRetries(5);
     }
 
     /**

--- a/dspace-api/src/test/java/org/dspace/app/openpolicyfinder/OpenPolicyFinderServiceUnitTest.java
+++ b/dspace-api/src/test/java/org/dspace/app/openpolicyfinder/OpenPolicyFinderServiceUnitTest.java
@@ -11,7 +11,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;

--- a/dspace-api/src/test/java/org/dspace/app/openpolicyfinder/OpenPolicyFinderServiceUnitTest.java
+++ b/dspace-api/src/test/java/org/dspace/app/openpolicyfinder/OpenPolicyFinderServiceUnitTest.java
@@ -1,0 +1,206 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.openpolicyfinder;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.dspace.app.openpolicyfinder.v2.OpenPolicyFinderResponse;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Focused unit tests for {@link OpenPolicyFinderService#performRequest}, exercising the shared
+ * retry/error-handling loop in {@code executeRequest}. The existing
+ * {@link OpenPolicyFinderServiceTest} uses {@link MockOpenPolicyFinderService} which overrides
+ * {@code performRequest} entirely, so it cannot exercise the HTTP retry logic. These tests inject
+ * a mocked {@link CloseableHttpClient} via the protected {@link OpenPolicyFinderService#newHttpClient()}
+ * hook.
+ *
+ * <p>Note: this test does not extend {@code AbstractDSpaceTest} so it does not start the DSpace
+ * kernel. Configuration is supplied by writing the {@code endpoint} and {@code apiKey} fields
+ * directly via {@link ReflectionTestUtils}.</p>
+ */
+public class OpenPolicyFinderServiceUnitTest {
+
+    private TestableOpenPolicyFinderService service;
+    private CloseableHttpClient mockClient;
+
+    @Before
+    public void setUp() {
+        mockClient = mock(CloseableHttpClient.class);
+        service = new TestableOpenPolicyFinderService(mockClient);
+        service.setMaxNumberOfTries(3);
+        service.setSleepBetweenTimeouts(0L);
+        service.setTimeout(1000);
+        ReflectionTestUtils.setField(service, "endpoint", "https://api.openpolicyfinder.jisc.ac.uk/retrieve");
+        ReflectionTestUtils.setField(service, "apiKey", "test-api-key");
+    }
+
+    @Test
+    public void missingApiKey_returnsErrorImmediatelyAndDoesNotCallHttp() throws Exception {
+        ReflectionTestUtils.setField(service, "apiKey", null);
+
+        OpenPolicyFinderResponse response = service.performRequest(
+            "publication", "issn", "equals", "0140-6736", 0, 1);
+
+        assertTrue("Expected isError when API key is missing", response.isError());
+        assertEquals("Open Policy Finder configuration invalid or missing", response.getMessage());
+        verify(mockClient, times(0)).execute(any(HttpUriRequest.class));
+    }
+
+    @Test
+    public void non200_returnsErrorAndDoesNotRetry() throws Exception {
+        CloseableHttpResponse stub = stubResponse(401, "{\"message\":\"unauthorized\"}");
+        when(mockClient.execute(any(HttpUriRequest.class))).thenReturn(stub);
+
+        OpenPolicyFinderResponse response = service.performRequest(
+            "publication", "issn", "equals", "0140-6736", 0, 1);
+
+        assertTrue("Expected isError on non-200 status", response.isError());
+        assertEquals("Open Policy Finder return not OK status: 401", response.getMessage());
+        // Reviewer M2 fix: a non-200 should fail fast, not retry the configured maxNumberOfTries
+        verify(mockClient, times(1)).execute(any(HttpUriRequest.class));
+    }
+
+    @Test
+    public void networkError_returnsErrorWithExceptionMessage() throws Exception {
+        when(mockClient.execute(any(HttpUriRequest.class)))
+            .thenThrow(new IOException("connection refused"));
+
+        OpenPolicyFinderResponse response = service.performRequest(
+            "publication", "issn", "equals", "0140-6736", 0, 1);
+
+        assertTrue("Expected isError on IOException", response.isError());
+        assertTrue("Error message should mention connection failure: " + response.getMessage(),
+            response.getMessage().contains("connection refused"));
+        verify(mockClient, times(1)).execute(any(HttpUriRequest.class));
+    }
+
+    @Test
+    public void emptyResponseBody_returnsError() throws Exception {
+        CloseableHttpResponse httpResponse = mock(CloseableHttpResponse.class);
+        StatusLine statusLine = stubStatusLine(200, "OK");
+        when(httpResponse.getStatusLine()).thenReturn(statusLine);
+        when(httpResponse.getEntity()).thenReturn(null);
+        when(mockClient.execute(any(HttpUriRequest.class))).thenReturn(httpResponse);
+
+        OpenPolicyFinderResponse response = service.performRequest(
+            "publication", "issn", "equals", "0140-6736", 0, 1);
+
+        assertTrue("Expected isError when response body is null", response.isError());
+        assertEquals("Open Policy Finder returned no response", response.getMessage());
+    }
+
+    @Test
+    public void retryAfterContentReadFailure_returnsSuccessOnSecondAttempt() throws Exception {
+        // First attempt: HTTP 200, but reading the response body throws IOException.
+        // The shared executeRequest catches that IOException, leaves opfResponse null and the
+        // retry loop iterates. Second attempt returns valid JSON.
+        CloseableHttpResponse firstAttempt = mock(CloseableHttpResponse.class);
+        StatusLine firstStatusLine = stubStatusLine(200, "OK");
+        when(firstAttempt.getStatusLine()).thenReturn(firstStatusLine);
+        HttpEntity firstEntity = mock(HttpEntity.class);
+        when(firstEntity.getContent()).thenThrow(new IOException("simulated content read failure"));
+        when(firstAttempt.getEntity()).thenReturn(firstEntity);
+
+        CloseableHttpResponse secondAttempt = stubResponse(200, lancetSuccessJson());
+        when(mockClient.execute(any(HttpUriRequest.class)))
+            .thenReturn(firstAttempt)
+            .thenReturn(secondAttempt);
+
+        OpenPolicyFinderResponse response = service.performRequest(
+            "publication", "issn", "equals", "0140-6736", 0, 1);
+
+        assertFalse("Expected non-error response after retry: " + response.getMessage(),
+            response.isError());
+        verify(mockClient, atLeastOnce()).execute(any(HttpUriRequest.class));
+        verify(mockClient, times(2)).execute(any(HttpUriRequest.class));
+    }
+
+    private CloseableHttpResponse stubResponse(int statusCode, String body) {
+        return stubResponseWithStream(statusCode,
+            new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    private CloseableHttpResponse stubResponseWithStream(int statusCode, InputStream body) {
+        CloseableHttpResponse response = mock(CloseableHttpResponse.class);
+        StatusLine statusLine = stubStatusLine(statusCode, reason(statusCode));
+        when(response.getStatusLine()).thenReturn(statusLine);
+        HttpEntity entity = mock(HttpEntity.class);
+        try {
+            when(entity.getContent()).thenReturn(body);
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+        when(response.getEntity()).thenReturn(entity);
+        return response;
+    }
+
+    private StatusLine stubStatusLine(int code, String reason) {
+        StatusLine line = mock(StatusLine.class);
+        when(line.getStatusCode()).thenReturn(code);
+        when(line.getReasonPhrase()).thenReturn(reason);
+        return line;
+    }
+
+    private String reason(int code) {
+        switch (code) {
+            case 200: return "OK";
+            case 401: return "Unauthorized";
+            case 500: return "Internal Server Error";
+            default: return "";
+        }
+    }
+
+    /**
+     * Minimum-viable JSON for {@code OpenPolicyFinderResponse} JSON parsing to produce a
+     * non-error response. The parser sets {@code error=true} only when {@code items} is empty
+     * or JSON parsing throws, so we just need a single item-shaped object.
+     */
+    private String lancetSuccessJson() {
+        return "{\"items\":[{}]}";
+    }
+
+    /**
+     * Subclass that injects a fixed {@link CloseableHttpClient} for HTTP execution. Mockito's
+     * default no-op {@code close()} on the mock is harmless; reusing the same mock across
+     * iterations is intentional so tests can chain {@code thenReturn(...)} stubs across retries.
+     */
+    private static final class TestableOpenPolicyFinderService extends OpenPolicyFinderService {
+        private final CloseableHttpClient httpClient;
+
+        TestableOpenPolicyFinderService(CloseableHttpClient httpClient) {
+            this.httpClient = httpClient;
+        }
+
+        @Override
+        protected CloseableHttpClient newHttpClient() {
+            return httpClient;
+        }
+    }
+}


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/DSpace/issues/12429
* Stacked on top of https://github.com/DSpace/DSpace/pull/12005 — until that PR merges, the diff against `main` here will also include the SHERPA → Open Policy Finder migration.

## Description
Deduplicates `OpenPolicyFinderService.performRequest` and `performPublisherRequest` into a single shared `executeRequest` method, addressing the structural feedback from @Micheleboychuk's review of #12005. Behaviour is unchanged; the only added test seam is a protected `newHttpClient()` that allows unit tests to inject a mocked HttpClient.

## Instructions for Reviewers

The two `perform*` methods previously contained ~100 lines of duplicated HTTP / retry / error-handling code, differing only in the response object they constructed at success and at error. They are now both one-liner delegates to a private generic `executeRequest` that takes:

- a `ResponseParser<T>` (a small functional interface) for the success path
- a `Function<String, T>` for the error-message path

### List of changes
* Extract the shared HTTP loop into `OpenPolicyFinderService.executeRequest(...)`. Both `performRequest` and `performPublisherRequest` are now one-liner delegates.
* Introduce a private `ResponseParser<T>` functional interface so the success constructor of either response type (which throws `IOException`) can be passed as a lambda.
* Add a protected `newHttpClient()` factory method so unit tests can inject a mocked `CloseableHttpClient`. Production behaviour is identical (it still calls `DSpaceHttpClientFactory.getInstance().buildWithoutAutomaticRetries(5)`).
* Add `OpenPolicyFinderServiceUnitTest`, a focused JUnit class that mocks `CloseableHttpClient` and covers:
  - missing API key returns an error response without making any HTTP call
  - non-200 status returns the documented error message and does not retry
  - network `IOException` returns an error response with the underlying message
  - empty response body returns the documented "no response" error
  - `IOException` while reading the response body triggers a retry, and the second attempt's parsed response is returned

The existing `OpenPolicyFinderServiceTest` continues to pass; it uses `MockOpenPolicyFinderService` which overrides `performRequest`/`performPublisherRequest` entirely, so it never exercised the retry loop. The new test class fills that gap.

### Why this PR does NOT adopt LiveImportClient

@Micheleboychuk's original review also suggested injecting `LiveImportClient` to replace the `DSpaceHttpClientFactory` HttpClient usage. I started down that path and stepped back: `LiveImportClientImpl.executeHttpGetRequest` has a `catch (Exception)` block that swallows every error and returns `StringUtils.EMPTY` ([impl link](https://github.com/DSpace/DSpace/blob/main/dspace-api/src/main/java/org/dspace/importer/external/liveimportclient/service/LiveImportClientImpl.java#L80-L87)). Routing OPF through it would lose the user-visible error reporting that today produces messages like `Open Policy Finder return not OK status: 401` and degrade them to `Error processing the Open Policy Finder answer`.

The deduplication win is delivered here without that regression. If reviewers prefer the full `LiveImportClient` adoption despite the error-fidelity tradeoff, it is a small follow-up on top of this change and I am happy to do it.

### How to test
1. The 5 new unit tests are deterministic and run in milliseconds:
   ```
   mvn test -pl dspace-api -DskipUnitTests=false -Dtest='OpenPolicyFinderServiceUnitTest'
   ```
2. The full pre-existing OPF test set continues to pass (12 tests across 3 classes):
   ```
   mvn test -pl dspace-api -DskipUnitTests=false -Dtest='OpenPolicyFinder*'
   ```
3. Manual smoke (with an API key set in `local.cfg`) — the public surface is unchanged so the same checks as PR #12005 apply:
   - `GET /api/integration/externalsources/opfJournal/entries?query=Lancet`
   - the `opfPolicies` step in the submission UI

## Checklist
- [x] My PR is **created against the `main` branch** of code.
- [x] My PR is **small in size** (~150 lines of net change to production code, plus 167 lines of new unit tests).
- [x] My PR **passes Checkstyle** validation.
- [x] My PR **includes Javadoc** for all new (or modified) public/protected methods and classes; the new `executeRequest` private method has explanatory Javadoc covering the parser/error-builder contract.
- [x] My PR **passes all tests and includes new Unit Tests** for the shared retry loop.
- [x] My PR **includes details on how to test it**.
- [x] No new libraries/dependencies.
- [x] No REST API changes.
- [x] No new configurations.
- [x] My PR fixes an issue ticket and the link is at the top.
