### PR TITLE
Fix #12452, Swordv2 METS ingester: Unrestrict the retrieval of the DMDID attribute to the first <structMap> element as the order of <structMap> elements in a METS file is not strictly fixed by the METS standard

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/packager/METSManifest.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/METSManifest.java
@@ -16,8 +16,10 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.util.XMLUtils;
@@ -927,13 +929,17 @@ public class METSManifest {
     public Element[] getItemDmds()
         throws MetadataValidationException {
         // div@DMDID is actually IDREFS, a space-separated list of IDs:
-        Element objDiv = getObjStructDiv();
-        String dmds = objDiv.getAttributeValue("DMDID");
-        if (dmds == null) {
-            throw new MetadataValidationException(
-                "Invalid METS: Missing reference to Item descriptive metadata, first div on first structmap must have" +
-                    " a DMDID attribute.");
-        }
+        String dmds = mets.getChildren("structMap", metsNS)
+                .stream()
+                .map(e -> e.getChild("div", metsNS))
+                .filter(Objects::nonNull)
+                .map(div -> div.getAttributeValue("DMDID"))
+                .filter(StringUtils::isNotBlank)
+                .findFirst()
+                .orElseThrow(() -> new MetadataValidationException(
+                        "Invalid METS document: Missing reference to Item descriptive metadata. At least one of" +
+                                " the structmap must have a first div with a DMDID attribute."
+                ));
 
         return getDmdElements(dmds);
     }


### PR DESCRIPTION
## References
* Fixes #12452

## Description
Remove the order restriction. The `DMDID` attribute pointing to descriptive metadata (dmdSec) is retrieved from any `<structMap> `element if it exists within the METS file. 

## Instructions for Reviewers
1. Enable swordv2 interface
2. Create a METS file with at least two elements
3. Put the relevant DMDID attribute pointing to descriptive metadata (dmdSec) inside the root <div> of the second <structMap> element
4. Submit it via SWORDv2

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [X] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
