### PR TITLE
Fix discover search self link query parameters

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/DiscoveryRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/DiscoveryRestRepository.java
@@ -87,7 +87,11 @@ public class DiscoveryRestRepository extends AbstractDSpaceRestRepository {
         DiscoveryConfiguration discoveryConfiguration = searchConfigurationService
             .getDiscoveryConfigurationByNameOrIndexableObject(context, configuration, scopeObject);
 
-        return discoverConfigurationConverter.convert(discoveryConfiguration, utils.obtainProjection());
+        SearchConfigurationRest searchConfigurationRest = discoverConfigurationConverter
+            .convert(discoveryConfiguration, utils.obtainProjection());
+        searchConfigurationRest.setConfiguration(configuration);
+        searchConfigurationRest.setScope(dsoScope);
+        return searchConfigurationRest;
     }
 
     public SearchResultsRest getSearchObjects(final String query, final List<String> dsoTypes, final String dsoScope,

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -23,6 +23,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyOrNullString;
+import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
@@ -1257,6 +1258,16 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
             SortOptionMatcher.sortOptionMatcher(
                 "dc.date.accessioned", DiscoverySortFieldConfiguration.SORT_ORDER.desc.name())
                    )));
+    }
+
+    @Test
+    public void discoverSearchSelfLinkContainsConfigurationParameterWhenProvided() throws Exception {
+
+        getClient().perform(get("/api/discover/search")
+                   .param("configuration", "default"))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$._links.self.href", endsWith(
+                       "/api/discover/search?configuration=default")));
     }
 
     @Test


### PR DESCRIPTION
# Fix discover search self link query parameters

Fixes #8576

## Description

This PR fixes the self link returned by `/api/discover/search` when the request includes discovery search query parameters such as `configuration=default`.

`SearchConfigurationResourceHalLinkFactory` already knows how to add `configuration` and `scope` to the generated self link, but `DiscoveryRestRepository#getSearchConfiguration()` did not copy those request values onto the converted `SearchConfigurationRest`. As a result, `/api/discover/search?configuration=default` returned a self link without `configuration=default`.

The fix keeps the converted search configuration resource and sets its `configuration` and `scope` from the incoming request before returning it.

## Testing

- `mvn -pl dspace,dspace-server-webapp -am "-DskipIntegrationTests=false" "-DskipUnitTests=true" "-Dit.test=DiscoveryRestControllerIT#discoverSearchSelfLinkContainsConfigurationParameterWhenProvided" verify`
  - Passed.
  - Includes the new REST integration test for the `configuration=default` self link.
  - License and Checkstyle checks passed in the Maven reactor.
- `mvn -pl dspace-server-webapp -am "-DskipUnitTests=true" "-DskipIntegrationTests=true" compile`
  - Passed earlier during local validation.
- `git diff --check`
  - Passed.
- Manual verification
  - Completed locally after backend/API validation.

## Notes

When running this IT locally, include both `dspace` and `dspace-server-webapp` in the Maven reactor. The `dspace` module is needed so the generated test environment contains the default config files such as `config-definition.xml`.
