### PR TITLE
DSpace#12470 Force each JWT handler to fall back to documented defaults

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/jwt/JWTTokenHandler.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/jwt/JWTTokenHandler.java
@@ -65,7 +65,7 @@ public abstract class JWTTokenHandler {
     private List<JWTClaimProvider> jwtClaimProviders;
 
     @Autowired
-    private ConfigurationService configurationService;
+    protected ConfigurationService configurationService;
 
     @Autowired
     private EPersonClaimProvider ePersonClaimProvider;
@@ -78,6 +78,13 @@ public abstract class JWTTokenHandler {
 
     private String generatedJwtKey;
     private String generatedEncryptionKey;
+
+    /**
+     * Get the default expiration period for this handler if not
+     * defined in configuration.
+     * @return default expiration period if not explicitly defined in configuration
+     */
+    public abstract long getExpirationPeriod();
 
     /**
      * Get the configuration property key for the token secret.
@@ -218,10 +225,6 @@ public abstract class JWTTokenHandler {
         }
 
         return secret;
-    }
-
-    public long getExpirationPeriod() {
-        return configurationService.getLongProperty(getTokenExpirationConfigurationKey(), 1800000);
     }
 
     public boolean isEncryptionEnabled() {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/jwt/LoginJWTTokenHandler.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/jwt/LoginJWTTokenHandler.java
@@ -15,6 +15,17 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class LoginJWTTokenHandler extends JWTTokenHandler {
+
+    /**
+     * Default expiration period for login tokens in milliseconds
+     */
+    private static final long DEFAULT_EXPIRATION_PERIOD = 1800000;
+
+    @Override
+    public long getExpirationPeriod() {
+        return configurationService.getLongProperty(getTokenExpirationConfigurationKey(), DEFAULT_EXPIRATION_PERIOD);
+    }
+
     @Override
     protected String getTokenSecretConfigurationKey() {
         return "jwt.login.token.secret";

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/jwt/ShortLivedJWTTokenHandler.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/jwt/ShortLivedJWTTokenHandler.java
@@ -40,6 +40,11 @@ public class ShortLivedJWTTokenHandler extends JWTTokenHandler {
     private static final Logger log = LogManager.getLogger(ShortLivedJWTTokenHandler.class);
 
     /**
+     * Default expiration period for short-lived tokens in milliseconds
+     */
+    private static final long DEFAULT_EXPIRATION_PERIOD = 2000;
+
+    /**
      * Determine if current JWT is valid for the given EPerson object.
      * To be valid, current JWT *must* have been signed by the EPerson and not be expired.
      * If EPerson is null or does not have a known active session, false is returned immediately.
@@ -88,6 +93,11 @@ public class ShortLivedJWTTokenHandler extends JWTTokenHandler {
             }
         }
         return ePerson;
+    }
+
+    @Override
+    public long getExpirationPeriod() {
+        return configurationService.getLongProperty(getTokenExpirationConfigurationKey(), DEFAULT_EXPIRATION_PERIOD);
     }
 
     @Override

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/jwt/ShortLivedJWTTokenHandlerTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/jwt/ShortLivedJWTTokenHandlerTest.java
@@ -80,8 +80,7 @@ public class ShortLivedJWTTokenHandlerTest extends JWTTokenHandlerTest {
     //temporary set a negative expiration time so the token is invalid immediately
     @Test
     public void testExpiredToken() throws Exception {
-        when(configurationService.getLongProperty("jwt.shortLived.token.expiration", 1800000))
-            .thenReturn(-99999999L);
+        when(shortLivedJWTTokenHandler.getExpirationPeriod()).thenReturn(-99999999L);
         when(ePersonClaimProvider.getEPerson(any(Context.class), any(JWTClaimsSet.class))).thenReturn(ePerson);
         Instant previous = Instant.now().minus(10000000000L, ChronoUnit.MILLIS);
         String token = shortLivedJWTTokenHandler

--- a/dspace/config/modules/authentication.cfg
+++ b/dspace/config/modules/authentication.cfg
@@ -84,8 +84,9 @@ jwt.login.encryption.enabled = false
 # of some performance, this setting WILL ONLY BE used when encrypting the jwt.
 jwt.login.compression.enabled = true
 
-# Expiration time of a token in milliseconds
-jwt.login.token.expiration = 1800000
+# Expiration time of a login token in milliseconds
+# Default: 1800000 (30 minutes)
+#jwt.login.token.expiration = 1800000
 
 #---------------------------------------------------------------#
 #---Stateless JWT Authentication for downloads of bitstreams----#
@@ -109,5 +110,6 @@ jwt.shortLived.encryption.enabled = false
 # of some performance, this setting WILL ONLY BE used when encrypting the jwt.
 jwt.shortLived.compression.enabled = true
 
-# Expiration time of a token in milliseconds
-jwt.shortLived.token.expiration = 2000
+# Expiration time of a short-lived token in milliseconds
+# Default: 2000 (2 seconds)
+#jwt.shortLived.token.expiration = 2000


### PR DESCRIPTION
## References
* Fixes #12470 

## Description
Refactor `JWTTokenHandler#getExpirationPeriod` to become an abstract method and implement it in both `ShortLived...` and `Login...` classes with their own default values that match the documented defaults.

This means that even if configured expiration periods are missing from configuration, sensible / documented defaults will be used instead of using the "login" default of 1800000 milliseconds (30 minutes) for both handlers.

This also makes it safe to supply `authentication.cfg` with the default values documented and commented out.

## Instructions for Reviewers

List of changes in this PR:
* Make `configurationService` access protected in `JWTTokenHandler` so extending classes can access it
* Make `JWTTokenHanlder#getExpirationPeriod()` a public abstract method (no body, requires impl in extending classes)
* Define `DEFAULT_EXPIRATION_PERIOD` for each handler with values matching the defaults in `authentication.cfg`
* Override `getExpirationPeriod()` in the short-lived and login token handlers so they return 2000 and 1800000 respectively
* Document default and comment out default values in authentication.cfg to make this behaviour very clear

### Testing instructions

One or all of the following tests are useful:

1. Make sure logins and downloads work as expected - logins should not expire before 30 minutes, download short-lived tokens should be unusable after 2 seconds, and no side-effects should be introduced
2. Try some different configured values to make sure they're picked up and taking priority as expected (e.g. set login to 10000)
3. Debug (debugger or insert logging) the expiration periods or calculated expiration times in `JWTTokenHandler@createTokenForEPerson` (look at `claimsSet.getExpirationTime()`) and confirm they match expectations

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
