### PR TITLE
Adjust S3 Settings to overcome OOM During Download of a Bitstream

### DIFF
--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/S3BitStoreService.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/S3BitStoreService.java
@@ -94,7 +94,8 @@ public class S3BitStoreService extends BaseBitStoreService {
     private long minPartSizeBytes = 8 * 1024 * 1024L;
     private ChecksumAlgorithm s3ChecksumAlgorithm = ChecksumAlgorithm.CRC32;
     private Integer maxConcurrency;
-    private double memoryUsageFactor = 0.1;
+    private Double memoryUsageFactor;
+    private Long initialReadBufferSizeInBytes;
 
     /**
      * container for all the assets
@@ -124,6 +125,8 @@ public class S3BitStoreService extends BaseBitStoreService {
      * @param minPartSize minimum part size in bytes
      * @param concurrency maximum number of concurrent requests
      * @param memoryUsageFactor factor to determine memory usage for read buffer size, as a percentage of max memory.
+     * @param initialReadBufferSizeInBytes initial read buffer size in bytes,
+     *                                     used if memoryUsageFactor is not set or out of bounds
      * @return builder with the specified parameters
      */
     protected static Supplier<S3AsyncClient> amazonClientBuilderBy(
@@ -133,10 +136,14 @@ public class S3BitStoreService extends BaseBitStoreService {
         double targetThroughput,
         long minPartSize,
         Integer concurrency,
-        double memoryUsageFactor
+        Double memoryUsageFactor,
+        Long initialReadBufferSizeInBytes
     ) {
         return () -> {
-            S3CrtAsyncClientBuilder crtBuilder = S3AsyncClient.crtBuilder();
+            S3CrtAsyncClientBuilder crtBuilder =
+                S3AsyncClient.crtBuilder()
+                             .targetThroughputInGbps(targetThroughput)
+                             .minimumPartSizeInBytes(minPartSize);
 
             if (credentialsProvider != null) {
                 crtBuilder.credentialsProvider(credentialsProvider);
@@ -151,6 +158,20 @@ public class S3BitStoreService extends BaseBitStoreService {
                 crtBuilder.forcePathStyle(true);
             }
 
+            if (memoryUsageFactor == null) {
+                log.warn("custom heuristic cannot be applied!");
+
+                if (initialReadBufferSizeInBytes != null) {
+                    crtBuilder.initialReadBufferSizeInBytes(initialReadBufferSizeInBytes);
+                }
+
+                if (concurrency != null) {
+                    crtBuilder.maxConcurrency(concurrency);
+                }
+
+                return crtBuilder.build();
+            }
+
             int maxConcurrency;
             if (concurrency == null) {
                 log.warn("maxConcurrency is not set, defaulting to number of available processors");
@@ -159,7 +180,14 @@ public class S3BitStoreService extends BaseBitStoreService {
                 maxConcurrency = concurrency;
             }
 
-            final long maxMemory = Math.round(Math.floor(Runtime.getRuntime().maxMemory() * memoryUsageFactor));
+            long maxMemory;
+            if (memoryUsageFactor <= 0 || memoryUsageFactor > 1) {
+                log.warn("memoryUsageFactor is not set or out of bounds (0,1], defaulting to 0.1");
+                maxMemory = Math.round(Math.floor(Runtime.getRuntime().maxMemory() * 0.1));
+            } else {
+                maxMemory = Math.round(Math.floor(Runtime.getRuntime().maxMemory() * memoryUsageFactor));
+            }
+
             final long readBuffer = Math.round(
                 Math.floor((((double) maxMemory / maxConcurrency / minPartSize) - 1) * minPartSize)
             );
@@ -167,7 +195,8 @@ public class S3BitStoreService extends BaseBitStoreService {
             final long maxReadBuffer;
             if (readBuffer < minPartSize) {
                 log.warn(
-                    "Calculated read buffer size is less than the minimum part size. Adjusting to minimum part size."
+                    "Calculated read buffer size is less than the minimum part size. Adjusting to minimum part " +
+                    "size."
                 );
                 maxReadBuffer = minPartSize;
                 maxConcurrency = Math.max((int) Math.floor((double) maxMemory / (maxReadBuffer + minPartSize)), 1);
@@ -176,9 +205,13 @@ public class S3BitStoreService extends BaseBitStoreService {
                 maxReadBuffer = readBuffer;
             }
 
+            log.info(
+                "Calculated read buffer size: {} bytes, max concurrency: {}, based on memory usage factor: {} " +
+                "and max memory: {} bytes",
+                maxReadBuffer, maxConcurrency, memoryUsageFactor, maxMemory
+            );
+
             return crtBuilder.maxConcurrency(maxConcurrency)
-                             .targetThroughputInGbps(targetThroughput)
-                             .minimumPartSizeInBytes(minPartSize)
                              .initialReadBufferSizeInBytes(maxReadBuffer)
                              .build();
         };
@@ -231,17 +264,23 @@ public class S3BitStoreService extends BaseBitStoreService {
                         this.s3AsyncClient,
                         amazonClientBuilderBy(
                             region,
-                            StaticCredentialsProvider.create(AwsBasicCredentials.create(getAwsAccessKey(),
-                                        getAwsSecretKey())), endpoint, targetThroughputGbps,
-                            minPartSizeBytes, maxConcurrency, memoryUsageFactor)
-                        );
+                            StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(getAwsAccessKey(), getAwsSecretKey())
+                            ),
+                            endpoint, targetThroughputGbps, minPartSizeBytes, maxConcurrency, memoryUsageFactor,
+                            initialReadBufferSizeInBytes
+                        )
+                );
                 log.warn("S3 Region set to: " + region.id());
             } else {
                 log.info("Using a IAM role or aws environment credentials");
                 s3AsyncClient = FunctionalUtils.getDefaultOrBuild(
                         this.s3AsyncClient,
-                        amazonClientBuilderBy(null, null , endpoint, targetThroughputGbps,
-                                              minPartSizeBytes, maxConcurrency, memoryUsageFactor));
+                        amazonClientBuilderBy(
+                            null, null, endpoint, targetThroughputGbps,
+                            minPartSizeBytes, maxConcurrency, memoryUsageFactor, initialReadBufferSizeInBytes
+                        )
+                );
             }
 
             // bucket name
@@ -581,13 +620,20 @@ public class S3BitStoreService extends BaseBitStoreService {
         this.endpoint = endpoint;
     }
 
-    public double getMemoryUsageFactor() {
+    public Double getMemoryUsageFactor() {
         return memoryUsageFactor;
     }
 
-    public S3BitStoreService setMemoryUsageFactor(double memoryUsageFactor) {
+    public void setMemoryUsageFactor(Double memoryUsageFactor) {
         this.memoryUsageFactor = memoryUsageFactor;
-        return this;
+    }
+
+    public Long getInitialReadBufferSizeInBytes() {
+        return initialReadBufferSizeInBytes;
+    }
+
+    public void setInitialReadBufferSizeInBytes(Long initialReadBufferSizeInBytes) {
+        this.initialReadBufferSizeInBytes = initialReadBufferSizeInBytes;
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/S3BitStoreService.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/S3BitStoreService.java
@@ -93,7 +93,8 @@ public class S3BitStoreService extends BaseBitStoreService {
     private double targetThroughputGbps = 10.0;
     private long minPartSizeBytes = 8 * 1024 * 1024L;
     private ChecksumAlgorithm s3ChecksumAlgorithm = ChecksumAlgorithm.CRC32;
-    private Integer maxConcurrency = null;
+    private Integer maxConcurrency;
+    private double memoryUsageFactor = 0.1;
 
     /**
      * container for all the assets
@@ -116,21 +117,23 @@ public class S3BitStoreService extends BaseBitStoreService {
     /**
      * Utility method for generate AmazonS3 builder
      *
-     * @param regions wanted regions in client
-     * @param awsCredentials credentials of the client
+     * @param region wanted regions in client
+     * @param credentialsProvider credentials of the client
      * @param endpoint custom AWS endpoint
      * @param targetThroughput target throughput in Gbps
      * @param minPartSize minimum part size in bytes
-     * @param maxConcurrency maximum number of concurrent requests
+     * @param concurrency maximum number of concurrent requests
+     * @param memoryUsageFactor factor to determine memory usage for read buffer size, as a percentage of max memory.
      * @return builder with the specified parameters
      */
     protected static Supplier<S3AsyncClient> amazonClientBuilderBy(
-            Region region,
-            AwsCredentialsProvider credentialsProvider,
-            String endpoint,
-            double targetThroughput,
-            long minPartSize,
-            Integer maxConcurrency
+        Region region,
+        AwsCredentialsProvider credentialsProvider,
+        String endpoint,
+        double targetThroughput,
+        long minPartSize,
+        Integer concurrency,
+        double memoryUsageFactor
     ) {
         return () -> {
             S3CrtAsyncClientBuilder crtBuilder = S3AsyncClient.crtBuilder();
@@ -143,16 +146,41 @@ public class S3BitStoreService extends BaseBitStoreService {
                 crtBuilder.region(region);
             }
 
-            if (maxConcurrency != null) {
-                crtBuilder.maxConcurrency(maxConcurrency);
-            }
-
             if (StringUtils.isNotBlank(endpoint)) {
                 crtBuilder.endpointOverride(URI.create(endpoint));
                 crtBuilder.forcePathStyle(true);
             }
 
-            return crtBuilder.targetThroughputInGbps(targetThroughput).minimumPartSizeInBytes(minPartSize).build();
+            int maxConcurrency;
+            if (concurrency == null) {
+                log.warn("maxConcurrency is not set, defaulting to number of available processors");
+                maxConcurrency = Runtime.getRuntime().availableProcessors();
+            } else {
+                maxConcurrency = concurrency;
+            }
+
+            final long maxMemory = Math.round(Math.floor(Runtime.getRuntime().maxMemory() * memoryUsageFactor));
+            final long readBuffer = Math.round(
+                Math.floor((((double) maxMemory / maxConcurrency / minPartSize) - 1) * minPartSize)
+            );
+
+            final long maxReadBuffer;
+            if (readBuffer < minPartSize) {
+                log.warn(
+                    "Calculated read buffer size is less than the minimum part size. Adjusting to minimum part size."
+                );
+                maxReadBuffer = minPartSize;
+                maxConcurrency = Math.max((int) Math.floor((double) maxMemory / (maxReadBuffer + minPartSize)), 1);
+                log.warn("Adjusted maxConcurrency to {} to fit memory constraints.", maxConcurrency);
+            } else {
+                maxReadBuffer = readBuffer;
+            }
+
+            return crtBuilder.maxConcurrency(maxConcurrency)
+                             .targetThroughputInGbps(targetThroughput)
+                             .minimumPartSizeInBytes(minPartSize)
+                             .initialReadBufferSizeInBytes(maxReadBuffer)
+                             .build();
         };
     }
 
@@ -202,10 +230,10 @@ public class S3BitStoreService extends BaseBitStoreService {
                 s3AsyncClient = FunctionalUtils.getDefaultOrBuild(
                         this.s3AsyncClient,
                         amazonClientBuilderBy(
-                                region,
-                                StaticCredentialsProvider.create(AwsBasicCredentials.create(getAwsAccessKey(),
+                            region,
+                            StaticCredentialsProvider.create(AwsBasicCredentials.create(getAwsAccessKey(),
                                         getAwsSecretKey())), endpoint, targetThroughputGbps,
-                                minPartSizeBytes, maxConcurrency)
+                            minPartSizeBytes, maxConcurrency, memoryUsageFactor)
                         );
                 log.warn("S3 Region set to: " + region.id());
             } else {
@@ -213,7 +241,7 @@ public class S3BitStoreService extends BaseBitStoreService {
                 s3AsyncClient = FunctionalUtils.getDefaultOrBuild(
                         this.s3AsyncClient,
                         amazonClientBuilderBy(null, null , endpoint, targetThroughputGbps,
-                                minPartSizeBytes, maxConcurrency));
+                                              minPartSizeBytes, maxConcurrency, memoryUsageFactor));
             }
 
             // bucket name
@@ -551,6 +579,15 @@ public class S3BitStoreService extends BaseBitStoreService {
 
     public void setEndpoint(String endpoint) {
         this.endpoint = endpoint;
+    }
+
+    public double getMemoryUsageFactor() {
+        return memoryUsageFactor;
+    }
+
+    public S3BitStoreService setMemoryUsageFactor(double memoryUsageFactor) {
+        this.memoryUsageFactor = memoryUsageFactor;
+        return this;
     }
 
     /**

--- a/dspace/config/modules/assetstore.cfg
+++ b/dspace/config/modules/assetstore.cfg
@@ -65,13 +65,20 @@ assetstore.s3.awsRegionName =
 # The target throughput for transfer requests in Gbps. Higher value means more connections will be established with S3.
 assetstore.s3.targetThroughputGbps = 10.0
 
-# Sets the minimum part size for transfer parts. Decreasing the minimum part size causes multipart transfer to be split
-# into a larger number of smaller parts.
+# Sets the minimum part size for transfer parts.
+# Decreasing the minimum part size causes multipart transfer to be split into a larger number of smaller parts.
+# Increase also the number of maxConcurrency if you want to maxout the throughput with smaller part sizes.
 assetstore.s3.minPartSizeBytes = 8388608
 
 # Specifies the maximum number of S3 connections that should be established during a transfer.
-# If not provided, it will be based on targetThroughputGbps
-assetstore.s3.maxConcurrency = 
+# If not provided, it will be used a proper value depending on the machine capabilities (CPU cores and available memory).
+# assetstore.s3.maxConcurrency =
+
+# The amount of maximum memory used during data transfers, as a percentage of the total available memory.
+# Default is 0.1 (10% of total memory - Xmx). Adjust this value based on the available memory and expected transfer sizes.
+# This value should be set between 0 and 1, where 0 means no memory usage limit and 1 means using all available memory.
+# BE careful with this value, since it can cause OOM - especially for lower Xmx values ( 256m / 512m )
+# assetstore.s3.memoryUsageFactor=0.1
 
 # The algorithm the S3 client will use to create a checksum when doing putObject.
 assetstore.s3.s3ChecksumAlgorithm = CRC32

--- a/dspace/config/modules/assetstore.cfg
+++ b/dspace/config/modules/assetstore.cfg
@@ -78,7 +78,16 @@ assetstore.s3.minPartSizeBytes = 8388608
 # Default is 0.1 (10% of total memory - Xmx). Adjust this value based on the available memory and expected transfer sizes.
 # This value should be set between 0 and 1, where 0 means no memory usage limit and 1 means using all available memory.
 # BE careful with this value, since it can cause OOM - especially for lower Xmx values ( 256m / 512m )
-# assetstore.s3.memoryUsageFactor=0.1
+# If not set, there is no memory usage limit and the S3 client will use as much memory as needed for transfers,
+# which may lead to OutOfMemory errors if the transfer sizes are large and the available memory is limited.
+assetstore.s3.memoryUsageFactor=0.1
+
+
+# The size of the buffer used for reading data from S3 during transfers, in bytes.
+# Default is 16KB (16384 bytes). Adjust this value based on the expected transfer sizes and available memory.
+# A larger buffer size may improve performance for larger transfers, but it also increases memory usage.
+# If not set, the S3 client will use a default buffer size of 16KB (16384 bytes) for reading data from S3 during transfers.
+#assetstore.s3.initialReadBufferSizeInBytes=
 
 # The algorithm the S3 client will use to create a checksum when doing putObject.
 assetstore.s3.s3ChecksumAlgorithm = CRC32

--- a/dspace/config/spring/api/bitstore.xml
+++ b/dspace/config/spring/api/bitstore.xml
@@ -52,8 +52,15 @@
         -->
         <property name="maxConcurrency" value="${assetstore.s3.maxConcurrency:}"/>
 
-        <!-- The factor of available memory to use for calculating the maximum concurrency. Default is 0.1 (10%). -->
-        <property name="memoryUsageFactor" value="${assetstore.s3.memoryUsageFactor:0.1}"/>
+        <!-- The factor of available memory to use for calculating the maximum concurrency.
+             Uses custom heuristics to determine the maximum concurrency based on the available memory and the configured memory usage factor.
+             If not provided, it will use parameters from the AWS SDK defaults, which are based on the available processors and memory.
+             Be careful when changing this value, as setting it too high or not setting at all may cause out of memory errors.
+        -->
+        <property name="memoryUsageFactor" value="${assetstore.s3.memoryUsageFactor:}"/>
+
+        <!-- The initial buffer size in bytes for reading from S3. If not specified it will be determined by AWS SDK-->
+        <property name="initialReadBufferSizeInBytes" value="${assetstore.s3.initialReadBufferSizeInBytes:}"/>
 
         <!-- The algorithm the S3 client will use to create a checksum when doing putObject. -->
         <property name="s3ChecksumAlgorithm" value="${assetstore.s3.s3ChecksumAlgorithm}"/>

--- a/dspace/config/spring/api/bitstore.xml
+++ b/dspace/config/spring/api/bitstore.xml
@@ -48,9 +48,12 @@
         <property name="minPartSizeBytes" value="${assetstore.s3.minPartSizeBytes}"/>
 
         <!-- Specifies the maximum number of S3 connections that should be established during a transfer.
-             If not provided, it will be based on targetThroughputGbps
+             If not provided, it will be based on the machines available processors and memory.
         -->
-        <property name="maxConcurrency" value="${assetstore.s3.maxConcurrency}"/>
+        <property name="maxConcurrency" value="${assetstore.s3.maxConcurrency:}"/>
+
+        <!-- The factor of available memory to use for calculating the maximum concurrency. Default is 0.1 (10%). -->
+        <property name="memoryUsageFactor" value="${assetstore.s3.memoryUsageFactor:0.1}"/>
 
         <!-- The algorithm the S3 client will use to create a checksum when doing putObject. -->
         <property name="s3ChecksumAlgorithm" value="${assetstore.s3.s3ChecksumAlgorithm}"/>


### PR DESCRIPTION
## References
* Fixes #12468

## Description
The S3 CRT client (`S3CrtAsyncClientBuilder`) does not constrain its internal read buffer by default. When downloading files larger than the available heap (e.g., a 256MB file on -Xmx256m), the JVM hits `OutOfMemoryError` with `SdkClientException`: Failed to send the request: `OutOfMemoryError` has been raised from JVM. The server returns a broken HTTP 500 response.

## Instructions for Reviewers
Review code changes on configuration, and check the behavior of these changes on your local machine / remote server with bounded Xmx settigs:
1. Configure limited heap (-Xmx256m)
2. Upload a file ≥100MB and download via /content endpoint
3. Verify no OOM - using single `--limit-rate` to ensure that the memory won't be filled ( `curl --limit-rate 10M -o /dev/null {content-endpoint-bitstream}` )
4. Stress Test using multiple parallel requests - This is an example for 100 requests `seq 1 100 | xargs -P 100 -I {} curl -o /dev/null {content-endpoint-bitstream}`.

List of changes in this PR:
Added a `memoryUsageFactor` configuration parameter (`assetstore.s3.memoryUsageFactor`, default 0.1) that caps the CRT client's per-transfer memory consumption to a percentage of `Runtime.getRuntime().maxMemory()`.

Key changes in `S3BitStoreService.java`:
1. `memoryUsageFactor` — defines what fraction of max heap the S3 client may use for all concurrent transfers (default 10%).
2. `initialReadBufferSizeInBytes` — calculated as `((maxMemory / maxConcurrency / minPartSize) - 1) * minPartSize`, ensuring the CRT client doesn't allocate more than the budget per concurrent request.
3. Adaptive `maxConcurrency` — if the calculated read buffer would be smaller than `minPartSize`, `maxConcurrency` is automatically reduced to fit within the memory budget, emitting a warning.
5. When `maxConcurrency` is not configured, it defaults to `Runtime.getRuntime().availableProcessors()` instead of letting the CRT client pick its own (possibly unbounded) default.

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
