### PR TITLE
[Port dspace-8_x] Fix several bugs in AIP Backup & Restore found when attempting to "round trip" an entire site of AIPs

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/CrosswalkMetadataValidator.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/CrosswalkMetadataValidator.java
@@ -107,9 +107,12 @@ public class CrosswalkMetadataValidator {
                             e.printStackTrace();
                         }
                     } else if (!fieldChoice.equals("ignore")) {
-                        throw new CrosswalkException(
-                            "The '" + element + "." + qualifier + "' element has not been defined in this DSpace " +
-                                "instance. ");
+                        throw new CrosswalkException(String.format(
+                            "The '%s.%s%s' element has not been defined in this DSpace instance.",
+                            mdSchema.getName(),
+                            element,
+                            qualifier == null ? "" : ("." + qualifier)
+                        ));
                     }
                 }
             }

--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/LicenseStreamDisseminationCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/LicenseStreamDisseminationCrosswalk.java
@@ -8,6 +8,7 @@
 package org.dspace.content.crosswalk;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.sql.SQLException;
 
@@ -56,7 +57,12 @@ public class LicenseStreamDisseminationCrosswalk
             Bitstream licenseBs = PackageUtils.findDepositLicense(context, (Item) dso);
 
             if (licenseBs != null) {
-                Utils.copy(bitstreamService.retrieve(context, licenseBs), out);
+                try (final InputStream bitInputStream = bitstreamService.retrieve(context, licenseBs)) {
+                    Utils.copy(bitInputStream, out);
+                } catch (Exception e) {
+                    log.warn("Could not retrieve license file for Item with UUID={}. " +
+                                 "Leaving it out of generated package. Error{}", dso.getID(), e.getMessage());
+                }
             }
         }
     }

--- a/dspace-api/src/main/java/org/dspace/content/packager/AbstractMETSDisseminator.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/AbstractMETSDisseminator.java
@@ -456,17 +456,37 @@ public abstract class AbstractMETSDisseminator
                                 // contents are unchanged
                                 ze.setTime(DEFAULT_MODIFIED_DATE);
                             }
-                            ze.setSize(auth ? bitstream.getSizeBytes() : 0);
-                            zip.putNextEntry(ze);
+
+                            long bitstreamSize = 0;
+                            // If user is authorized to read this bitstream, attempt to retrieve it.
                             if (auth) {
-                                InputStream input = bitstreamService.retrieve(context, bitstream);
-                                Utils.copy(input, zip);
-                                input.close();
+                                try (final InputStream bitstreamInput = bitstreamService.retrieve(context, bitstream)) {
+                                    // Save bitstream size into Zip entry & put entry in Zip file.
+                                    bitstreamSize = bitstream.getSizeBytes();
+                                    ze.setSize(bitstreamSize);
+                                    zip.putNextEntry(ze);
+
+                                    // Copy bitstream contents to Zip file
+                                    Utils.copy(bitstreamInput, zip);
+                                } catch (Exception e) {
+                                    log.warn("Adding zero-length file for Bitstream, uuid={}."
+                                                 + " Bitstream is unable to be retrieved from assetstore."
+                                                 + " Error={}", bitstream.getID(), e.getMessage());
+                                }
                             } else {
-                                log.warn("Adding zero-length file for Bitstream, uuid="
-                                             + String.valueOf(bitstream.getID())
-                                             + ", not authorized for READ.");
+                                log.warn("Adding zero-length file for Bitstream, uuid={}"
+                                             + ", not authorized for READ.", bitstream.getID());
                             }
+
+                            // If bitstreamSize is still zero, that means either we didn't have READ privileges
+                            // or the bitstream could not be retrieved from storage. Either way, write a zero-length
+                            // file into our Zip entry in place of the bitstream.
+                            if (bitstreamSize == 0) {
+                                ze.setSize(0);
+                                zip.putNextEntry(ze);
+                            }
+
+                            // Close our zip entry
                             zip.closeEntry();
                         } else if (unauth != null && unauth.equalsIgnoreCase("skip")) {
                             log.warn("Skipping Bitstream, uuid=" + String
@@ -629,6 +649,13 @@ public abstract class AbstractMETSDisseminator
                         ByteArrayOutputStream disseminateOutput = new ByteArrayOutputStream();
                         sxwalk.disseminate(context, dso, disseminateOutput);
                         disseminateOutput.close();
+
+                        // If our disseminated output has zero size, exit immediately (i.e. return a null mdSec).
+                        // Likely, the outputstream failed to be created, so we cannot include it in this package.
+                        if (disseminateOutput.size() == 0) {
+                            return null;
+                        }
+
                         // Convert output to an inputstream, so we can write to manifest or Zip file
                         ByteArrayInputStream crosswalkedStream = new ByteArrayInputStream(
                             disseminateOutput.toByteArray());

--- a/dspace-api/src/main/java/org/dspace/content/packager/AbstractMETSIngester.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/AbstractMETSIngester.java
@@ -19,6 +19,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.io.input.NullInputStream;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -748,6 +749,14 @@ public abstract class AbstractMETSIngester extends AbstractPackageIngester {
             // externally, if it is an externally referenced file)
             InputStream fileStream = getFileInputStream(pkgFile, params, path);
 
+            // Before proceeding we must ensure we have a non-empty input stream
+            // NOTE: If getFileInputStream encounters a zero-sized file, then it returns NullInputStream
+            if (fileStream == null || fileStream instanceof NullInputStream) {
+                log.warn("Empty InputStream encountered for Bitstream with ID={} in zip file={}. " +
+                             "Skipping adding this empty bitstream to Item={}", mfileID, pkgFile, item.getID());
+                continue;
+            }
+
             // retrieve bundle name from manifest
             String bundleName = METSManifest.getBundleName(mfile);
 
@@ -1324,7 +1333,7 @@ public abstract class AbstractMETSIngester extends AbstractPackageIngester {
      *                zip)
      * @param params  Parameters passed to METSIngester
      * @param path    the File path (either path in Zip package or a URL)
-     * @return the InputStream for the file
+     * @return the InputStream for the file, or NullInputStream if a zero-sized entry is encountered
      * @throws MetadataValidationException if validation error
      * @throws IOException                 if IO error
      */
@@ -1357,12 +1366,13 @@ public abstract class AbstractMETSIngester extends AbstractPackageIngester {
             // Retrieve the manifest file entry by name
             ZipEntry manifestEntry = zipPackage.getEntry(path);
 
-            // Get inputStream associated with this file
-            if (manifestEntry != null) {
+            if (manifestEntry.getSize() > 0) {
+                // Get inputStream associated with this file
                 return zipPackage.getInputStream(manifestEntry);
             } else {
-                throw new MetadataValidationException("Manifest file references file '"
-                                                          + path + "' not included in the zip.");
+                log.warn("Zero-sized file entry={} found in zip file={}. Returning empty InputStream.",
+                         path, pkgFile);
+                return new NullInputStream();
             }
         }
     }

--- a/dspace-api/src/main/java/org/dspace/content/packager/RoleDisseminator.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/RoleDisseminator.java
@@ -310,8 +310,8 @@ public class RoleDisseminator implements PackageDisseminator {
             for (EPerson member : group.getMembers()) {
                 writer.writeEmptyElement(MEMBER);
                 writer.writeAttribute(ID, String.valueOf(member.getID()));
-                if (null != member.getName()) {
-                    writer.writeAttribute(NAME, member.getName());
+                if (null != member.getEmail()) {
+                    writer.writeAttribute(NAME, member.getEmail());
                 }
             }
             writer.writeEndElement();

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -954,6 +954,7 @@ registry.metadata.load = dspace-types.xml
 registry.metadata.load = iiif-types.xml
 registry.metadata.load = datacite-types.xml
 registry.metadata.load = coar-types.xml
+registry.metadata.load = journal-types.xml
 
 #---------------------------------------------------------------#
 #-----------------UI-Related CONFIGURATIONS---------------------#

--- a/dspace/config/registries/journal-types.xml
+++ b/dspace/config/registries/journal-types.xml
@@ -1,0 +1,37 @@
+<dspace-dc-types>
+
+    <!-- These metadata schema are currently only used in virtual-metadata.xml
+         to represent a virtual relationship to a Journal / JournalVolume / JournalIssue Entities -->
+    <!-- TODO: We may want to move these to "relation" schema fields as they are only used by relationships -->
+    <dspace-header>
+        <title>DSpace Journal Types</title>
+    </dspace-header>
+
+
+    <!-- "journal" schema -->
+    <dc-schema>
+        <name>journal</name>
+        <namespace>http://dspace.org/journal</namespace>
+    </dc-schema>
+
+    <dc-type>
+        <schema>journal</schema>
+        <element>title</element>
+        <qualifier></qualifier>
+        <scope_note>The title of the Journal related to this object</scope_note>
+    </dc-type>
+
+    <!-- "journalvolume" schema -->
+    <dc-schema>
+        <name>journalvolume</name>
+        <namespace>http://dspace.org/journalvolume</namespace>
+    </dc-schema>
+
+    <dc-type>
+        <schema>journalvolume</schema>
+        <element>identifier</element>
+        <qualifier>name</qualifier>
+        <scope_note>The identifier name for the Journal Volume related to this object</scope_note>
+    </dc-type>
+
+</dspace-dc-types>

--- a/dspace/config/registries/schema-person-types.xml
+++ b/dspace/config/registries/schema-person-types.xml
@@ -156,4 +156,13 @@
         <scope_note>Full name variant</scope_note>
     </dc-type>
 
+    <!-- NOTE: This field is currently only used by virtual-metadata.xml to respresent the relationship
+         between an OrgUnit and a Person -->
+    <dc-type>
+        <schema>person</schema>
+        <element>contributor</element>
+        <qualifier>other</qualifier>
+        <scope_note></scope_note>
+    </dc-type>
+
 </dspace-dc-types>


### PR DESCRIPTION
Manual port of #12343 to `dspace-8_x`.  

Includes all the commits **except** [6a1bb01](https://github.com/DSpace/DSpace/commit/6a1bb01ca2caa1e2c96f5b5b95c22a4596b0e078), because that commit was specific to changes added in the DSpace-CRIS merger activities.