### PR TITLE
Application hardening: filter requests for JSPs and other unwanted patterns

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/GlobalRequestSecurityFilter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/GlobalRequestSecurityFilter.java
@@ -1,0 +1,134 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+
+/**
+ * Global filter acting on all requests (not just /api/) to provide some additional hardening
+ * against common attacks or RCE, if a malicious payload was somehow written to a directory
+ * executable by the servlet container.
+ * The decoding and normalisation is designed to be tolerant of malformed URLs or broken clients, etc.
+ * so that this additional security filter does not introduce false positives or unintended side effects.
+ *
+ * @author Kim Shepherd
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class GlobalRequestSecurityFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        String normalizedPath = normaliseUrl(request.getRequestURI());
+        // Return 403 forbidden if JSP execution or URL traversal is attempted
+        if (isTraversalAttempt(normalizedPath) || isJspExecutionAttempt(normalizedPath)) {
+            response.sendError(HttpServletResponse.SC_FORBIDDEN);
+            return;
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * Normalise the URI similarly to Tomcat, for testing how it will be interpreted
+     * @param rawUrl the unvalidated URL string
+     * @return a decoded, normalise URL
+     */
+    private String normaliseUrl(String rawUrl) throws IOException {
+        if (rawUrl == null || rawUrl.isBlank()) {
+            throw new IOException("Empty URL");
+        }
+        String url = rawUrl.split("\\?")[0];
+        // Strip ;jspsession=... and so on
+        int semicolon = url.indexOf(';');
+        if (semicolon >= 0) {
+            url = url.substring(0, semicolon);
+        }
+        url = decodeUrl(url);
+        if (url == null || url.isBlank()) {
+            throw new IOException("Decoded URL path is empty");
+        }
+        url = normaliseUrlPath(url);
+        if (url == null || url.isBlank()) {
+            throw new IOException("Normalised URL path is empty");
+        }
+        return url.toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * Decode URL, falling back to original URL if it's malformed or undecodable
+     * @param url the encoded / unvalidated URL
+     * @return decoded URL or the original URL on error
+     */
+    private String decodeUrl(String url) {
+        try {
+            return URLDecoder.decode(url, StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException ex) {
+            // if we can't decode it, just return raw string
+            return url;
+        }
+    }
+
+    /**
+     * Normalise the URL path and ensure it ends in a /
+     * @param url the URL path to normalise
+     * @return normalised path or the original parameter on error
+     */
+    private String normaliseUrlPath(String url) {
+        try {
+            if (!url.startsWith("/")) {
+                url = "/" + url;
+            }
+            return new URI(url).normalize().getPath();
+        } catch (Exception e) {
+            // if we can't use or normalise the path, just return the raw string
+            return url;
+        }
+    }
+
+    /**
+     * Detect traversal after normalisation
+     * @param url the URL path to validate
+     * @return true if this looks like a traversal attempt
+     */
+    private boolean isTraversalAttempt(String url) {
+        return url.contains("../")
+                || url.contains("/..")
+                || url.contains("%2e%2e")
+                || url.contains("..");
+    }
+
+    /**
+     * Block JSP execution attempts
+     * @param url the URL path to validate
+     */
+    private boolean isJspExecutionAttempt(String url) {
+        return url.endsWith(".jsp")
+                || url.endsWith(".jspx")
+                || url.contains(".jsp/")
+                || url.contains(".jspx/")
+                || url.contains(".jsp\0")
+                || url.contains(".jspx\0");
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/GlobalRequestSecurityFilter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/GlobalRequestSecurityFilter.java
@@ -43,7 +43,13 @@ public class GlobalRequestSecurityFilter extends OncePerRequestFilter {
     ) throws ServletException, IOException {
         String normalizedPath = normaliseUrl(request.getRequestURI());
         // Return 403 forbidden if JSP execution or URL traversal is attempted
-        if (isTraversalAttempt(normalizedPath) || isJspExecutionAttempt(normalizedPath)) {
+        if (isTraversalAttempt(normalizedPath)) {
+            logger.warn("Path traversal attempt detected. Skipping request: " + request.getRequestURI());
+            response.sendError(HttpServletResponse.SC_FORBIDDEN);
+            return;
+        }
+        if (isJspExecutionAttempt(normalizedPath)) {
+            logger.warn("JSP execution attempt detected. Skipping request: " + request.getRequestURI());
             response.sendError(HttpServletResponse.SC_FORBIDDEN);
             return;
         }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/GlobalRequestSecurityFilter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/GlobalRequestSecurityFilter.java
@@ -7,6 +7,12 @@
  */
 package org.dspace.app.rest.security;
 
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -15,12 +21,6 @@ import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
-
-import java.io.IOException;
-import java.net.URI;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
-import java.util.Locale;
 
 /**
  * Global filter acting on all requests (not just /api/) to provide some additional hardening

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SitemapRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SitemapRestControllerIT.java
@@ -134,7 +134,7 @@ public class SitemapRestControllerIT extends AbstractControllerIntegrationTest {
         //** WHEN **
         //We attempt to use endpoint for malicious file system traversal
         getClient().perform(get("/" + SITEMAPS_ENDPOINT + "/%2e%2e/config/dspace.cfg"))
-                   .andExpect(status().isBadRequest());
+                   .andExpect(status().isForbidden());
     }
 
     @Test
@@ -142,7 +142,7 @@ public class SitemapRestControllerIT extends AbstractControllerIntegrationTest {
         //** WHEN **
         //We attempt to use endpoint for malicious file system traversal
         getClient().perform(get("/" + SITEMAPS_ENDPOINT + "/%2e%2e%2fconfig%2fdspace.cfg"))
-                   .andExpect(status().isBadRequest());
+                   .andExpect(status().isForbidden());
     }
 
     @Test


### PR DESCRIPTION
## Description
This PR introduces a request filter that will return a 403 forbidden if a JSP is requested, or if a resolved URL appears to contain a path traversal attempt

## Instructions for Reviewers
1. Compare requests for /server/anything/something.jsp with and without this patch applied

## Checklist
- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
